### PR TITLE
chore: add variant prop to BottomSheetHeader

### DIFF
--- a/app/component-library/components/BottomSheets/BottomSheetHeader/BottomSheetHeader.constants.ts
+++ b/app/component-library/components/BottomSheets/BottomSheetHeader/BottomSheetHeader.constants.ts
@@ -1,0 +1,11 @@
+import { HeaderBaseVariant } from '../../HeaderBase/HeaderBase.types';
+import { BottomSheetHeaderVariant } from './BottomSheetHeader.types';
+
+// Mapping between BottomSheetHeaderVariant and HeaderBaseVariant
+export const BOTTOM_SHEET_HEADER_VARIANT_MAP: Record<
+  BottomSheetHeaderVariant,
+  HeaderBaseVariant
+> = {
+  [BottomSheetHeaderVariant.Display]: HeaderBaseVariant.Display,
+  [BottomSheetHeaderVariant.Compact]: HeaderBaseVariant.Compact,
+};

--- a/app/component-library/components/BottomSheets/BottomSheetHeader/BottomSheetHeader.stories.tsx
+++ b/app/component-library/components/BottomSheets/BottomSheetHeader/BottomSheetHeader.stories.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 // Internal dependencies.
 import { default as BottomSheetHeader } from './BottomSheetHeader';
-import { BottomSheetHeaderProps } from './BottomSheetHeader.types';
+import { BottomSheetHeaderVariant } from './BottomSheetHeader.types';
 
 const BottomSheetHeaderMeta = {
   title: 'Component Library / BottomSheets / BottomSheetHeader',
@@ -16,21 +16,48 @@ export default BottomSheetHeaderMeta;
 export const Default = {
   args: {
     children: 'Super Long BottomSheetHeader Title that may span 3 lines',
+    onBack: () => {
+      console.log('Back button clicked');
+    },
+    onClose: () => {
+      console.log('Close button clicked');
+    },
   },
-  // TODO: Replace "any" with type
-  render: function Render(args: BottomSheetHeaderProps) {
+};
+
+export const Variant = {
+  render: function Render() {
     return (
-      <BottomSheetHeader
-        {...args}
-        onBack={() => {
-          console.log('Back button clicked');
-        }}
-        onClose={() => {
-          console.log('Close button clicked');
-        }}
-      >
-        {args.children}
-      </BottomSheetHeader>
+      <>
+        <BottomSheetHeader variant={BottomSheetHeaderVariant.Compact}>
+          BottomSheetHeader Variant: Compact with a long title
+        </BottomSheetHeader>
+        <BottomSheetHeader
+          variant={BottomSheetHeaderVariant.Compact}
+          onBack={() => {
+            console.log('Back button clicked');
+          }}
+          onClose={() => {
+            console.log('Close button clicked');
+          }}
+        >
+          BottomSheetHeader Variant: Compact with accessories
+        </BottomSheetHeader>
+        <BottomSheetHeader variant={BottomSheetHeaderVariant.Display}>
+          BottomSheetHeader Variant: Display with a long title
+        </BottomSheetHeader>
+        <BottomSheetHeader
+          variant={BottomSheetHeaderVariant.Display}
+          onBack={() => {
+            console.log('Back button clicked');
+          }}
+          onClose={() => {
+            console.log('Close button clicked');
+          }}
+        >
+          BottomSheetHeader Variant: Display with accessories
+        </BottomSheetHeader>
+      </>
     );
   },
 };

--- a/app/component-library/components/BottomSheets/BottomSheetHeader/BottomSheetHeader.test.tsx
+++ b/app/component-library/components/BottomSheets/BottomSheetHeader/BottomSheetHeader.test.tsx
@@ -4,11 +4,154 @@ import { render } from '@testing-library/react-native';
 
 // Internal dependencies.
 import BottomSheetHeader from './BottomSheetHeader';
+import { BottomSheetHeaderVariant } from './BottomSheetHeader.types';
 
 describe('BottomSheetHeader', () => {
   it('should render snapshot correctly', () => {
     const wrapper = render(
       <BottomSheetHeader>Sample Header Title</BottomSheetHeader>,
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders with back button when onBack is provided', () => {
+    const onBackMock = jest.fn();
+    const { getByTestId } = render(
+      <BottomSheetHeader
+        onBack={onBackMock}
+        backButtonProps={{ testID: 'back-button' }}
+        testID="header"
+      >
+        Header Content
+      </BottomSheetHeader>,
+    );
+
+    // The back button should be rendered and accessible via testID
+    expect(getByTestId('back-button')).toBeTruthy();
+    expect(getByTestId('header-title')).toBeTruthy();
+  });
+
+  it('renders with close button when onClose is provided', () => {
+    const onCloseMock = jest.fn();
+    const { getByTestId } = render(
+      <BottomSheetHeader
+        onClose={onCloseMock}
+        closeButtonProps={{ testID: 'close-button' }}
+        testID="header"
+      >
+        Header Content
+      </BottomSheetHeader>,
+    );
+
+    // The close button should be rendered and accessible via testID
+    expect(getByTestId('close-button')).toBeTruthy();
+    expect(getByTestId('header-title')).toBeTruthy();
+  });
+
+  it('renders with both back and close buttons using button props', () => {
+    const onBackMock = jest.fn();
+    const onCloseMock = jest.fn();
+    const { getByTestId } = render(
+      <BottomSheetHeader
+        onBack={onBackMock}
+        backButtonProps={{
+          testID: 'custom-back-btn',
+          accessibilityLabel: 'Go back',
+        }}
+        onClose={onCloseMock}
+        closeButtonProps={{
+          testID: 'custom-close-btn',
+          accessibilityLabel: 'Close modal',
+        }}
+        testID="header"
+      >
+        Header Content
+      </BottomSheetHeader>,
+    );
+
+    const backButton = getByTestId('custom-back-btn');
+    const closeButton = getByTestId('custom-close-btn');
+
+    expect(backButton).toBeTruthy();
+    expect(closeButton).toBeTruthy();
+    expect(backButton.props.accessibilityLabel).toBe('Go back');
+    expect(closeButton.props.accessibilityLabel).toBe('Close modal');
+  });
+
+  it('passes additional props to button components', () => {
+    const onBackMock = jest.fn();
+    const { getByTestId } = render(
+      <BottomSheetHeader
+        onBack={onBackMock}
+        backButtonProps={{
+          testID: 'styled-back-btn',
+          isDisabled: true,
+          style: { opacity: 0.5 },
+        }}
+        testID="header"
+      >
+        Header Content
+      </BottomSheetHeader>,
+    );
+
+    const backButton = getByTestId('styled-back-btn');
+    expect(backButton).toBeTruthy();
+    expect(backButton.props.style).toMatchObject(
+      expect.objectContaining({ opacity: 0.5 }),
+    );
+  });
+
+  it('applies compact variant by default', () => {
+    const { getByTestId } = render(
+      <BottomSheetHeader testID="header">Header Content</BottomSheetHeader>,
+    );
+
+    const titleElement = getByTestId('header-title');
+    expect(titleElement.props.style.textAlign).toBe('center');
+  });
+
+  it('applies display variant when variant prop is set to Display', () => {
+    const { getByTestId } = render(
+      <BottomSheetHeader
+        variant={BottomSheetHeaderVariant.Display}
+        testID="header"
+      >
+        Header Content
+      </BottomSheetHeader>,
+    );
+
+    const titleElement = getByTestId('header-title');
+    expect(titleElement.props.style.textAlign).toBe('left');
+  });
+
+  it('applies compact variant when variant prop is set to Compact', () => {
+    const { getByTestId } = render(
+      <BottomSheetHeader
+        variant={BottomSheetHeaderVariant.Compact}
+        testID="header"
+      >
+        Header Content
+      </BottomSheetHeader>,
+    );
+
+    const titleElement = getByTestId('header-title');
+    expect(titleElement.props.style.textAlign).toBe('center');
+  });
+
+  it('renders snapshot correctly with Display variant', () => {
+    const wrapper = render(
+      <BottomSheetHeader variant={BottomSheetHeaderVariant.Display}>
+        Sample Header Title
+      </BottomSheetHeader>,
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders snapshot correctly with Compact variant', () => {
+    const wrapper = render(
+      <BottomSheetHeader variant={BottomSheetHeaderVariant.Compact}>
+        Sample Header Title
+      </BottomSheetHeader>,
     );
     expect(wrapper).toMatchSnapshot();
   });

--- a/app/component-library/components/BottomSheets/BottomSheetHeader/BottomSheetHeader.tsx
+++ b/app/component-library/components/BottomSheets/BottomSheetHeader/BottomSheetHeader.tsx
@@ -6,18 +6,27 @@ import React from 'react';
 // External dependencies.
 import { useStyles } from '../../../hooks';
 import HeaderBase from '../../HeaderBase';
+
 import ButtonIcon from '../../Buttons/ButtonIcon';
 import { IconName, IconColor } from '../../Icons/Icon';
 
 // Internal dependencies.
 import styleSheet from './BottomSheetHeader.styles';
-import { BottomSheetHeaderProps } from './BottomSheetHeader.types';
+
+import { BOTTOM_SHEET_HEADER_VARIANT_MAP } from './BottomSheetHeader.constants';
+import {
+  BottomSheetHeaderProps,
+  BottomSheetHeaderVariant,
+} from './BottomSheetHeader.types';
 
 const BottomSheetHeader: React.FC<BottomSheetHeaderProps> = ({
   style,
   children,
   onBack,
+  backButtonProps,
   onClose,
+  closeButtonProps,
+  variant = BottomSheetHeaderVariant.Compact,
   ...props
 }) => {
   const { styles } = useStyles(styleSheet, { style });
@@ -26,6 +35,7 @@ const BottomSheetHeader: React.FC<BottomSheetHeaderProps> = ({
       iconName={IconName.ArrowLeft}
       iconColor={IconColor.Default}
       onPress={onBack}
+      {...backButtonProps}
     />
   );
 
@@ -34,14 +44,18 @@ const BottomSheetHeader: React.FC<BottomSheetHeaderProps> = ({
       iconName={IconName.Close}
       iconColor={IconColor.Default}
       onPress={onClose}
+      {...closeButtonProps}
     />
   );
+
+  const headerBaseVariant = BOTTOM_SHEET_HEADER_VARIANT_MAP[variant];
 
   return (
     <HeaderBase
       style={styles.base}
       startAccessory={startAccessory}
       endAccessory={endAccessory}
+      variant={headerBaseVariant}
       {...props}
     >
       {children}

--- a/app/component-library/components/BottomSheets/BottomSheetHeader/BottomSheetHeader.types.ts
+++ b/app/component-library/components/BottomSheets/BottomSheetHeader/BottomSheetHeader.types.ts
@@ -1,18 +1,44 @@
-// External dependencies.
 import { HeaderBaseProps } from '../../HeaderBase/HeaderBase.types';
+import { ButtonIconProps } from '../../Buttons/ButtonIcon/ButtonIcon.types';
+
+// Enums
+export enum BottomSheetHeaderVariant {
+  Display = 'display',
+  Compact = 'compact',
+}
 
 /**
  * BottomSheetHeader component props.
  */
-export interface BottomSheetHeaderProps extends HeaderBaseProps {
+export interface BottomSheetHeaderProps
+  extends Omit<HeaderBaseProps, 'variant'> {
   /**
    * Optional function to trigger when pressing the back button.
    */
   onBack?: () => void;
   /**
+   * Optional props to pass to the back button component.
+   */
+  backButtonProps?: Partial<
+    Omit<ButtonIconProps, 'iconName' | 'iconColor' | 'onPress'>
+  >;
+  /**
    * Optional function to trigger when pressing the close button.
    */
   onClose?: () => void;
+  /**
+   * Optional props to pass to the close button component.
+   */
+  closeButtonProps?: Partial<
+    Omit<ButtonIconProps, 'iconName' | 'iconColor' | 'onPress'>
+  >;
+  /**
+   * Optional prop to set the variant of the header (controls alignment and text size).
+   * Display: left aligned with HeadingLG text.
+   * Compact: center aligned with HeadingSM text.
+   * @default BottomSheetHeaderVariant.Compact
+   */
+  variant?: BottomSheetHeaderVariant;
 }
 
 /**

--- a/app/component-library/components/BottomSheets/BottomSheetHeader/__snapshots__/BottomSheetHeader.test.tsx.snap
+++ b/app/component-library/components/BottomSheets/BottomSheetHeader/__snapshots__/BottomSheetHeader.test.tsx.snap
@@ -1,5 +1,91 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`BottomSheetHeader renders snapshot correctly with Compact variant 1`] = `
+<View
+  style={
+    [
+      {
+        "backgroundColor": "#ffffff",
+        "flexDirection": "row",
+        "gap": 16,
+        "padding": 16,
+      },
+      false,
+    ]
+  }
+  testID="header"
+>
+  <View
+    style={
+      {
+        "alignItems": "center",
+        "flex": 1,
+      }
+    }
+  >
+    <Text
+      accessibilityRole="text"
+      style={
+        {
+          "color": "#121314",
+          "fontFamily": "Geist Bold",
+          "fontSize": 16,
+          "letterSpacing": 0,
+          "lineHeight": 24,
+          "textAlign": "center",
+        }
+      }
+      testID="header-title"
+    >
+      Sample Header Title
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`BottomSheetHeader renders snapshot correctly with Display variant 1`] = `
+<View
+  style={
+    [
+      {
+        "backgroundColor": "#ffffff",
+        "flexDirection": "row",
+        "gap": 16,
+        "padding": 16,
+      },
+      false,
+    ]
+  }
+  testID="header"
+>
+  <View
+    style={
+      {
+        "alignItems": "flex-start",
+        "flex": 1,
+      }
+    }
+  >
+    <Text
+      accessibilityRole="text"
+      style={
+        {
+          "color": "#121314",
+          "fontFamily": "Geist Bold",
+          "fontSize": 24,
+          "letterSpacing": 0,
+          "lineHeight": 32,
+          "textAlign": "left",
+        }
+      }
+      testID="header-title"
+    >
+      Sample Header Title
+    </Text>
+  </View>
+</View>
+`;
+
 exports[`BottomSheetHeader should render snapshot correctly 1`] = `
 <View
   style={

--- a/app/component-library/components/BottomSheets/BottomSheetHeader/index.ts
+++ b/app/component-library/components/BottomSheets/BottomSheetHeader/index.ts
@@ -1,1 +1,2 @@
 export { default } from './BottomSheetHeader';
+export { BottomSheetHeaderVariant } from './BottomSheetHeader.types';


### PR DESCRIPTION
## **Description**

This PR updates the `BottomSheetHeader` component to align with the new `HeaderBase` variant system introduced in [PR #18314](https://github.com/MetaMask/metamask-mobile/pull/18314) and supports the swaps redesign requirements. Following the HeaderBase migration from `align` to `variant`, this ensures our bottom sheet headers maintain consistency with the MetaMask Design System and enables the new swaps flow UI.

### What is the reason for the change?

1. The parent `HeaderBase` component has migrated from an `align` prop to a more comprehensive `variant` prop system
2. The swaps redesign requires flexible bottom sheet header configurations with different alignment and text size options
3. The `BottomSheetHeader` component needs to be updated to use this new variant system to maintain compatibility and support the swaps redesign

### What is the improvement/solution?

1. **Added variant prop to BottomSheetHeader**: Introduced `BottomSheetHeaderVariant` enum with `Display` and `Compact` options to support different swaps flow screens
2. **Created proper variant mapping**: Maps `BottomSheetHeaderVariant` to `HeaderBaseVariant` for seamless integration
3. **Added button props support**: Enhanced with `backButtonProps` and `closeButtonProps` for better customization in swaps flow
4. **Aligned with Figma specifications**: Ensures consistency with the [Bottom Sheet design specs](https://www.figma.com/design/9lcBHFcMLu4jQaywrMlDTr/Bottom-sheet?node-id=0-1&t=SxXHNJ624mEPdvCy-1) for swaps redesign

## **Changelog**

CHANGELOG entry: Updated BottomSheetHeader component to use the new variant system from HeaderBase, adding support for Display and Compact variants needed for swaps redesign

## **Related issues**

Fixes: [DSYS-83](https://consensyssoftware.atlassian.net/browse/DSYS-83)
Builds upon: [PR #18314](https://github.com/MetaMask/metamask-mobile/pull/18314)
Supports: Swaps redesign bottom sheet requirements

## **Manual testing steps**

```gherkin
Feature: BottomSheetHeader updates

  Scenario: User view bottom sheet header in storybook
    Given the user opens the storybook and sees different bottom sheet header variants
```

## **Screenshots/Recordings**

### **Before**
- BottomSheetHeader had no variant control needed for swaps redesign
- Fixed center alignment couldn't support different swaps screens
- No alignment with updated HeaderBase component

### **After**
- Full variant support matching HeaderBase updates and swaps redesign needs
- Display variant: left-aligned with HeadingLG text (for primary swaps screens)
- Compact variant: center-aligned with HeadingSM text (for secondary swaps modals)
- Proper integration with new HeaderBase variant system
- Enhanced button customization for swaps flow navigation

https://github.com/user-attachments/assets/458b97f9-2579-4352-88ac-ff34c869450d

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[DSYS-83]: https://consensyssoftware.atlassian.net/browse/DSYS-83?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ