### PR TITLE
fix: Fix send flow hang on custom RPC by signaling blocked XHR

### DIFF
--- a/app/store/sagas/xmlHttpRequestOverride.test.ts
+++ b/app/store/sagas/xmlHttpRequestOverride.test.ts
@@ -83,3 +83,102 @@ describe('restoreXMLHttpRequest', () => {
     }),
   );
 });
+
+describe('handleBlockedRequest behavior', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('calls onerror handler when blocking a request', (done) => {
+    const mockOnerror = jest.fn();
+    overrideXMLHttpRequest();
+    const req = new global.XMLHttpRequest();
+    req.onerror = mockOnerror;
+
+    req.open('POST', 'https://example.com/gas-api');
+    req.send();
+
+    setImmediate(() => {
+      expect(mockOnerror).toHaveBeenCalledTimes(1);
+      expect(mockOnerror).toHaveBeenCalledWith(expect.any(Error));
+      done();
+    });
+  });
+
+  it('calls abort method when blocking a request', (done) => {
+    const mockAbort = jest.fn();
+    overrideXMLHttpRequest();
+    const req = new global.XMLHttpRequest();
+    req.abort = mockAbort;
+
+    req.open('POST', 'https://example.com/gas-api');
+    req.send();
+
+    setImmediate(() => {
+      expect(mockAbort).toHaveBeenCalledTimes(1);
+      done();
+    });
+  });
+
+  it('calls onloadend handler when blocking a request', (done) => {
+    const mockOnloadend = jest.fn();
+    overrideXMLHttpRequest();
+    const req = new global.XMLHttpRequest();
+    req.onloadend = mockOnloadend;
+
+    req.open('POST', 'https://example.com/gas-api');
+    req.send();
+
+    setImmediate(() => {
+      expect(mockOnloadend).toHaveBeenCalledTimes(1);
+      done();
+    });
+  });
+
+  it('handles missing handlers gracefully when blocking a request', (done) => {
+    const logSpy = jest.spyOn(console, 'error');
+    overrideXMLHttpRequest();
+    const req = new global.XMLHttpRequest();
+    // Explicitly set handlers to null
+    req.onerror = null;
+    req.onloadend = null;
+    req.abort = () => {
+      /* no-op */
+    };
+
+    req.open('POST', 'https://example.com/gas-api');
+    req.send();
+
+    setImmediate(() => {
+      // Should still log the error even without handlers
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(logSpy.mock.calls[0][0].message).toMatch(
+        'Disallowed URL: https://example.com/gas-api',
+      );
+      done();
+    });
+  });
+
+  it('continues blocking when handler throws an error', (done) => {
+    const logSpy = jest.spyOn(console, 'error');
+    const throwingHandler = jest.fn(() => {
+      throw new Error('Handler failed');
+    });
+    overrideXMLHttpRequest();
+    const req = new global.XMLHttpRequest();
+    req.onerror = throwingHandler;
+
+    req.open('POST', 'https://example.com/gas-api');
+    req.send();
+
+    setImmediate(() => {
+      expect(throwingHandler).toHaveBeenCalledTimes(1);
+      // Should still log the original blocking error despite handler failure
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      expect(logSpy.mock.calls[0][0].message).toMatch(
+        'Disallowed URL: https://example.com/gas-api',
+      );
+      done();
+    });
+  });
+});

--- a/app/store/sagas/xmlHttpRequestOverride.ts
+++ b/app/store/sagas/xmlHttpRequestOverride.ts
@@ -41,12 +41,41 @@ export function overrideXMLHttpRequest() {
       url.includes(blockedUrl),
     );
 
-  const handleError = () =>
-    Promise.reject(new Error(`Disallowed URL: ${currentUrl}`)).catch(
-      (error) => {
-        console.error(error);
-      },
-    );
+  const handleBlockedRequest = (xhr: XMLHttpRequest) => {
+    const error = new Error(`Disallowed URL: ${currentUrl}`);
+    // Keep existing logging behavior (relied upon by tests)
+    console.error(error);
+
+    // Proactively notify consumers so promises (e.g., fetch) do not hang.
+    try {
+      // Inform listeners that an error occurred
+      const onerror = xhr.onerror;
+      if (typeof onerror === 'function') {
+        onerror(error);
+      }
+    } catch {
+      // no-op
+    }
+
+    try {
+      // Abort to ensure any consumers listening for abort are notified
+      if (typeof xhr.abort === 'function') {
+        xhr.abort();
+      }
+    } catch {
+      // no-op
+    }
+
+    try {
+      // Fire loadend if present to complete any pending listeners
+      const onloadend = xhr.onloadend;
+      if (typeof onloadend === 'function') {
+        onloadend();
+      }
+    } catch {
+      // no-op
+    }
+  };
 
   // Override the 'open' method to capture the request URL
   global.XMLHttpRequest.prototype.open = function (
@@ -72,7 +101,7 @@ export function overrideXMLHttpRequest() {
   ) {
     // Check if the current request should be blocked
     if (shouldBlockRequest(currentUrl)) {
-      handleError(); // Trigger an error callback or handle the blocked request as needed
+      handleBlockedRequest(this as XMLHttpRequest); // Trigger error/abort so callers don't hang
       return; // Do not proceed with the request
     }
     // For non-blocked requests, proceed as normal

--- a/app/store/sagas/xmlHttpRequestOverride.ts
+++ b/app/store/sagas/xmlHttpRequestOverride.ts
@@ -51,6 +51,7 @@ export function overrideXMLHttpRequest() {
       // Inform listeners that an error occurred
       const onerror = xhr.onerror;
       if (typeof onerror === 'function') {
+        // @ts-expect-error - ProgressEvent is not supported by React Native and we don't need it
         onerror(error);
       }
     } catch {
@@ -70,6 +71,7 @@ export function overrideXMLHttpRequest() {
       // Fire loadend if present to complete any pending listeners
       const onloadend = xhr.onloadend;
       if (typeof onloadend === 'function') {
+        // @ts-expect-error - ProgressEvent is not supported by React Native and we don't need it
         onloadend();
       }
     } catch {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Switching basic functionality on or off was introduced on [#9208](https://github.com/MetaMask/metamask-mobile/pull/9208/). However, it seems that the send flow with a custom RPC endpoint (for local nodes) wasn't properly tested.

When the transaction reaches `addTransaction` function in the transaction controller, `updateGasProperties` is eventually called, inside which `updateGasFees` is called, inside which `getSuggestedGasFees` is called, inside which `getGasFeeEstimates` which comes from the gas fees controller is called. This function calls `fetchGasFeeEstimates` inside the Gas Fee controller, and calls `_fetchGasFeeEstimateData`, which calls `determineGasFeeCalculations` which calls `getEstimatesUsingFallbacks` which calls `getEstimatesUsingFeeMarketEndpoint` which calls `fetchGasEstimates`, which calls `handleFetch` from the controller utils.

However, in `app/store/sagas/xmlHttpRequestOverride.ts`, `handleError` is called inside the `global.XMLHttpRequest.prototype.send` override, and the request is blocked. This makes it so the `getGasFeeEstimates` call on `getSuggestedGasFees` never resolves or rejects, causing the execution of `addTransaction` in the transaction controller to hang indefinetely. In other words, the override is blocking and returning early without signaling an error to consumers, so promises originating from fetch never settled and `addTransaction` hangs.

The fix is to update the XHR override so that when a URL is blocked it triggers `onerror`/`abort`/`onloadend` on the `XMLHttpRequest` instance. That makes fetch reject quickly and allows the gas-fee controller to proceed to its fallbacks, unblocking `addTransaction` even when 3rd party requests are blocked.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/17800

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
