### PR TITLE
test: Add preinstalled Snap E2E

### DIFF
--- a/e2e/pages/Browser/TestSnaps.ts
+++ b/e2e/pages/Browser/TestSnaps.ts
@@ -24,7 +24,7 @@ import { RetryOptions } from '../../framework';
 import { Json } from '@metamask/utils';
 
 export const TEST_SNAPS_URL =
-  'https://metamask.github.io/snaps/test-snaps/2.25.0/';
+  'https://metamask.github.io/snaps/test-snaps/2.28.1/';
 
 class TestSnaps {
   get getConnectSnapButton(): DetoxElement {

--- a/e2e/selectors/Browser/TestSnaps.selectors.ts
+++ b/e2e/selectors/Browser/TestSnaps.selectors.ts
@@ -54,12 +54,17 @@ export const TestSnapViewSelectorWebIDS = {
   stopWebSocket: 'stopWebSocket',
   showSVGImage: 'showSVGImage',
   showPNGImage: 'showPNGImage',
+  showPreinstalledDialogButton: 'showPreinstalledDialog',
   getWebSocketState: 'getWebSocketState',
   getChainIdButton: 'sendEthprovider',
   getAccountsButton: 'sendEthproviderAccounts',
   personalSignButton: 'signPersonalSignMessage',
   sendWasmMessageButton: 'sendWasmMessage',
   signTypedDataButton: 'signTypedDataButton',
+  trackErrorButton: 'trackError',
+  trackEventButton: 'trackEvent',
+  startTraceButton: 'start-trace',
+  endTraceButton: 'end-trace',
 };
 
 export const TestSnapInputSelectorWebIDS = {

--- a/e2e/specs/snaps/test-snap-preinstalled.spec.ts
+++ b/e2e/specs/snaps/test-snap-preinstalled.spec.ts
@@ -1,0 +1,72 @@
+import { FlaskBuildTests } from '../../tags';
+import { loginToApp } from '../../viewHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import TabBarComponent from '../../pages/wallet/TabBarComponent';
+import TestSnaps from '../../pages/Browser/TestSnaps';
+import Assertions from '../../framework/Assertions';
+import { mockEvents } from '../../api-mocking/mock-config/mock-events';
+import { getEventsPayloads } from '../analytics/helpers';
+import TestHelpers from '../../helpers';
+
+jest.setTimeout(150_000);
+
+describe(FlaskBuildTests('Preinstalled Snap Tests'), () => {
+  it.todo('displays the Snap settings page');
+
+  it('uses `initialConnections` to allow JSON-RPC', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().withMetaMetricsOptIn().build(),
+        restartDevice: true,
+      },
+      async () => {
+        await loginToApp();
+        await TabBarComponent.tapBrowser();
+        await TestSnaps.navigateToTestSnap();
+
+        await TestSnaps.tapButton('showPreinstalledDialogButton');
+
+        await Assertions.expectTextDisplayed(
+          'This is a custom dialog. It has a custom footer and can be resolved to any value.',
+        );
+
+        await TestSnaps.tapCancelButton();
+      },
+    );
+  });
+
+  it.todo('tracks an error in Sentry with `snap_trackError`');
+
+  it('tracks an event in Segment with `snap_trackEvent`', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().withMetaMetricsOptIn().build(),
+        testSpecificMock: { POST: [mockEvents.POST.segmentTrack] },
+      },
+      async ({ mockServer }) => {
+        if (!mockServer) {
+          throw new Error(
+            'Mock server is not defined, check testSpecificMock setup',
+          );
+        }
+
+        await TestSnaps.tapButton('trackEventButton');
+        await TestHelpers.delay(1000);
+
+        const events = await getEventsPayloads(mockServer);
+
+        await Assertions.checkIfObjectsMatch(events[0], {
+          event: 'Test Event',
+          properties: {
+            test_property: 'test value',
+          },
+        });
+      },
+    );
+  });
+
+  it.todo(
+    'starts and ends a performance trace in Sentry with `snap_startTrace` and `snap_endTrace`',
+  );
+});

--- a/package.json
+++ b/package.json
@@ -253,7 +253,7 @@
     "@metamask/post-message-stream": "^10.0.0",
     "@metamask/ppom-validator": "0.36.0",
     "@metamask/preferences-controller": "^18.4.0",
-    "@metamask/preinstalled-example-snap": "^0.6.0",
+    "@metamask/preinstalled-example-snap": "^0.7.1",
     "@metamask/profile-sync-controller": "^23.0.0",
     "@metamask/react-native-acm": "^1.0.1",
     "@metamask/react-native-actionsheet": "2.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5891,12 +5891,12 @@
     "@metamask/base-controller" "^8.0.1"
     "@metamask/controller-utils" "^11.10.0"
 
-"@metamask/preinstalled-example-snap@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@metamask/preinstalled-example-snap/-/preinstalled-example-snap-0.6.0.tgz#eb5932f0d9df0e36e17b360bdcefa1d0ee92c467"
-  integrity sha512-4m+nxSjBAu7V8XqCos8fYFgBNdnXLgcbfUGDnDewPwRP6z1HgTJ46V/wEwYUEXdLT9uRWULzWeABMQVOJrRCbA==
+"@metamask/preinstalled-example-snap@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@metamask/preinstalled-example-snap/-/preinstalled-example-snap-0.7.1.tgz#add0efccd62cbcb3402f18ab263a8f9ef389c73f"
+  integrity sha512-DZLlpp0ms5qd4DiJ6Adtpi+2QY6W9j8kIMQ4jwxurd3iGXJQny6CHSChwsQAf4WkxKObuhknNit5JQP/MmiTbA==
   dependencies:
-    "@metamask/snaps-sdk" "^9.1.0"
+    "@metamask/snaps-sdk" "^9.3.0"
 
 "@metamask/profile-sync-controller@^23.0.0":
   version "23.0.0"
@@ -6179,7 +6179,7 @@
     "@metamask/superstruct" "^3.2.1"
     "@metamask/utils" "^11.4.0"
 
-"@metamask/snaps-sdk@^9.0.0", "@metamask/snaps-sdk@^9.1.0", "@metamask/snaps-sdk@^9.3.0":
+"@metamask/snaps-sdk@^9.0.0", "@metamask/snaps-sdk@^9.3.0":
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/@metamask/snaps-sdk/-/snaps-sdk-9.3.0.tgz#5c3858a5a247bf8c25c444b4bc8ecd4cbbfbf875"
   integrity sha512-o/XxzQNl59HjsesNAAK1UqVNQmujloAxCNfIii/z4wLFNe7+sg7Swsw4My5jR6xRLgzSaSBwW3dczYdVTpA06g==


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Port preinstalled Snap E2E from extension. This has a few remaining tests to add in the future, once the missing features are implemented and Sentry is mockable in E2E.

## **Related issues**

Closes: https://github.com/MetaMask/snaps/issues/3558
