### PR TITLE
chore: HeaderBase component improvements

### DIFF
--- a/app/component-library/components/BottomSheets/BottomSheetHeader/__snapshots__/BottomSheetHeader.test.tsx.snap
+++ b/app/component-library/components/BottomSheets/BottomSheetHeader/__snapshots__/BottomSheetHeader.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`BottomSheetHeader should render snapshot correctly 1`] = `
       {
         "backgroundColor": "#ffffff",
         "flexDirection": "row",
+        "gap": 16,
         "padding": 16,
       },
       false,
@@ -17,20 +18,8 @@ exports[`BottomSheetHeader should render snapshot correctly 1`] = `
   <View
     style={
       {
-        "width": undefined,
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    />
-  </View>
-  <View
-    style={
-      {
         "alignItems": "center",
         "flex": 1,
-        "marginHorizontal": 16,
       }
     }
   >
@@ -50,17 +39,6 @@ exports[`BottomSheetHeader should render snapshot correctly 1`] = `
     >
       Sample Header Title
     </Text>
-  </View>
-  <View
-    style={
-      {
-        "width": undefined,
-      }
-    }
-  >
-    <View
-      onLayout={[Function]}
-    />
   </View>
 </View>
 `;

--- a/app/component-library/components/HeaderBase/HeaderBase.constants.ts
+++ b/app/component-library/components/HeaderBase/HeaderBase.constants.ts
@@ -1,17 +1,14 @@
-/* eslint-disable import/prefer-default-export */
-
 // External dependencies.
 import { TextVariant } from '../Texts/Text';
 
-// Enums
-export enum HeaderBaseAlign {
-  Left = 'left',
-  Center = 'center',
-}
+// Internal dependencies.
+import { HeaderBaseVariant } from './HeaderBase.types';
 
-// Defaults
-export const DEFAULT_HEADERBASE_TITLE_TEXTVARIANT = TextVariant.HeadingSM;
-export const DEFAULT_HEADERBASE_ALIGN = HeaderBaseAlign.Center;
+// Text variants for different header variants
+export const HEADERBASE_VARIANT_TEXT_VARIANTS = {
+  [HeaderBaseVariant.Display]: TextVariant.HeadingLG,
+  [HeaderBaseVariant.Compact]: TextVariant.HeadingSM,
+};
 
 // Test IDs
 export const HEADERBASE_TEST_ID = 'header';

--- a/app/component-library/components/HeaderBase/HeaderBase.stories.tsx
+++ b/app/component-library/components/HeaderBase/HeaderBase.stories.tsx
@@ -43,12 +43,12 @@ export const HeaderBase = {
         />
       }
     >
-      Super Long HeaderBase Title that may span 3 lines
+      Super long HeaderBase title that may span 3 lines
     </HeaderBaseComponent>
   ),
 };
 
-export const HeaderBaseDisplayVariant = {
+export const HeaderBaseVariantDisplay = {
   render: () => (
     <HeaderBaseComponent
       variant={HeaderBaseVariant.Display}
@@ -99,7 +99,7 @@ export const HeaderBaseCompactVariant = {
         />
       }
     >
-      Compact Variant - Center Aligned & Small Text
+      Compact variant - center aligned & small text
     </HeaderBaseComponent>
   ),
 };
@@ -107,7 +107,7 @@ export const HeaderBaseCompactVariant = {
 export const HeaderBaseDisplayVariantWithoutAccessories = {
   render: () => (
     <HeaderBaseComponent variant={HeaderBaseVariant.Display}>
-      Display Variant Without Accessories
+      Display variant without accessories
     </HeaderBaseComponent>
   ),
 };
@@ -115,7 +115,7 @@ export const HeaderBaseDisplayVariantWithoutAccessories = {
 export const HeaderBaseCompactVariantWithoutAccessories = {
   render: () => (
     <HeaderBaseComponent variant={HeaderBaseVariant.Compact}>
-      Compact Variant Without Accessories
+      Compact variant without accessories stretches full width of header
     </HeaderBaseComponent>
   ),
 };

--- a/app/component-library/components/HeaderBase/HeaderBase.stories.tsx
+++ b/app/component-library/components/HeaderBase/HeaderBase.stories.tsx
@@ -12,7 +12,7 @@ import { IconName, IconColor } from '../Icons/Icon';
 
 // Internal dependencies.
 import { default as HeaderBaseComponent } from './HeaderBase';
-import { HeaderBaseAlign } from './HeaderBase.constants';
+import { HeaderBaseVariant } from './HeaderBase.types';
 
 const HeaderBaseStoryMeta = {
   title: 'Component Library / HeaderBase',
@@ -48,10 +48,10 @@ export const HeaderBase = {
   ),
 };
 
-export const HeaderBaseCenterAligned = {
+export const HeaderBaseDisplayVariant = {
   render: () => (
     <HeaderBaseComponent
-      align={HeaderBaseAlign.Center}
+      variant={HeaderBaseVariant.Display}
       startAccessory={
         <ButtonIcon
           iconColor={IconColor.Default}
@@ -71,15 +71,15 @@ export const HeaderBaseCenterAligned = {
         />
       }
     >
-      Center Aligned Title
+      Display Variant - Left Aligned & Large Text
     </HeaderBaseComponent>
   ),
 };
 
-export const HeaderBaseLeftAligned = {
+export const HeaderBaseCompactVariant = {
   render: () => (
     <HeaderBaseComponent
-      align={HeaderBaseAlign.Left}
+      variant={HeaderBaseVariant.Compact}
       startAccessory={
         <ButtonIcon
           iconColor={IconColor.Default}
@@ -99,23 +99,23 @@ export const HeaderBaseLeftAligned = {
         />
       }
     >
-      Left Aligned Title
+      Compact Variant - Center Aligned & Small Text
     </HeaderBaseComponent>
   ),
 };
 
-export const HeaderBaseLeftAlignedWithoutAccessories = {
+export const HeaderBaseDisplayVariantWithoutAccessories = {
   render: () => (
-    <HeaderBaseComponent align={HeaderBaseAlign.Left}>
-      Left Aligned Title Without Accessories
+    <HeaderBaseComponent variant={HeaderBaseVariant.Display}>
+      Display Variant Without Accessories
     </HeaderBaseComponent>
   ),
 };
 
-export const HeaderBaseCenterAlignedWithoutAccessories = {
+export const HeaderBaseCompactVariantWithoutAccessories = {
   render: () => (
-    <HeaderBaseComponent align={HeaderBaseAlign.Center}>
-      Center Aligned Title Without Accessories
+    <HeaderBaseComponent variant={HeaderBaseVariant.Compact}>
+      Compact Variant Without Accessories
     </HeaderBaseComponent>
   ),
 };

--- a/app/component-library/components/HeaderBase/HeaderBase.styles.ts
+++ b/app/component-library/components/HeaderBase/HeaderBase.styles.ts
@@ -5,8 +5,10 @@ import { StyleSheet, ViewStyle } from 'react-native';
 import { Theme } from '../../../util/theme/models';
 
 // Internal dependencies.
-import { HeaderBaseStyleSheetVars } from './HeaderBase.types';
-import { HeaderBaseAlign } from './HeaderBase.constants';
+import {
+  HeaderBaseStyleSheetVars,
+  HeaderBaseVariant,
+} from './HeaderBase.types';
 
 /**
  * Style sheet function for HeaderBase component.
@@ -21,14 +23,9 @@ const styleSheet = (params: {
   vars: HeaderBaseStyleSheetVars;
 }) => {
   const { vars, theme } = params;
-  const {
-    style,
-    startAccessorySize,
-    endAccessorySize,
-    align = HeaderBaseAlign.Center,
-  } = vars;
+  const { style, startAccessorySize, endAccessorySize, variant } = vars;
 
-  const isLeftAligned = align === HeaderBaseAlign.Left;
+  const isLeftAligned = variant === HeaderBaseVariant.Display;
 
   // Only calculate accessoryWidth for center alignment to ensure visual centering
   let accessoryWidth;
@@ -41,13 +38,13 @@ const styleSheet = (params: {
       {
         backgroundColor: theme.colors.background.default,
         flexDirection: 'row',
+        gap: 16,
       } as ViewStyle,
       style,
     ) as ViewStyle,
     titleWrapper: {
       flex: 1,
       alignItems: isLeftAligned ? 'flex-start' : 'center',
-      marginHorizontal: accessoryWidth ? 0 : 16,
     },
     title: {
       textAlign: isLeftAligned ? 'left' : 'center',

--- a/app/component-library/components/HeaderBase/HeaderBase.test.tsx
+++ b/app/component-library/components/HeaderBase/HeaderBase.test.tsx
@@ -10,11 +10,11 @@ import { useComponentSize } from '../../hooks';
 // Internal dependencies.
 import HeaderBase from './HeaderBase';
 import {
-  DEFAULT_HEADERBASE_TITLE_TEXTVARIANT,
-  HeaderBaseAlign,
+  HEADERBASE_VARIANT_TEXT_VARIANTS,
   HEADERBASE_TEST_ID,
   HEADERBASE_TITLE_TEST_ID,
 } from './HeaderBase.constants';
+import { HeaderBaseVariant } from './HeaderBase.types';
 
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: jest.fn(),
@@ -24,6 +24,7 @@ jest.mock('../../hooks', () => ({
   ...jest.requireActual('../../hooks'),
   useComponentSize: jest.fn(),
 }));
+
 describe('HeaderBase', () => {
   const mockInsets = { top: 20, bottom: 0, left: 0, right: 0 };
   const mockUseComponentSize = useComponentSize as jest.Mock;
@@ -36,28 +37,55 @@ describe('HeaderBase', () => {
     });
   });
 
-  it('should render snapshot correctly', () => {
-    const wrapper = render(<HeaderBase>Sample HeaderBase Title</HeaderBase>);
+  it('should render snapshot correctly with Compact variant', () => {
+    const wrapper = render(
+      <HeaderBase variant={HeaderBaseVariant.Compact}>
+        Sample HeaderBase Title
+      </HeaderBase>,
+    );
     expect(wrapper).toMatchSnapshot();
   });
+
   it('should render HeaderBase', () => {
     const { queryByTestId } = render(
       <HeaderBase>Sample HeaderBase Title</HeaderBase>,
     );
     expect(queryByTestId(HEADERBASE_TEST_ID)).not.toBe(null);
   });
+
+  it('should render HeaderBase with default Compact variant when no variant is provided', () => {
+    const { getByTestId, getByRole } = render(
+      <HeaderBase>Default Variant Header</HeaderBase>,
+    );
+
+    const titleElement = getByTestId(HEADERBASE_TITLE_TEST_ID);
+    const textElement = getByRole('text');
+    const fontFamily = getFontFamily(
+      HEADERBASE_VARIANT_TEXT_VARIANTS[HeaderBaseVariant.Compact],
+    );
+
+    // Should default to Compact variant (center aligned with HeadingSM text)
+    expect(titleElement.props.style.textAlign).toBe('center');
+    expect(textElement.props.style.fontFamily).toBe(fontFamily);
+  });
+
   it('should render Header with the right text variant if typeof children === string', () => {
     const { getByRole } = render(
-      <HeaderBase>Sample HeaderBase Title</HeaderBase>,
+      <HeaderBase variant={HeaderBaseVariant.Compact}>
+        Sample HeaderBase Title
+      </HeaderBase>,
     );
-    const fontFamily = getFontFamily(DEFAULT_HEADERBASE_TITLE_TEXTVARIANT);
+    const fontFamily = getFontFamily(
+      HEADERBASE_VARIANT_TEXT_VARIANTS[HeaderBaseVariant.Compact],
+    );
 
     expect(getByRole('text').props.style.fontFamily).toBe(fontFamily);
   });
+
   it('should render Header with the custom node if typeof children !== string', () => {
     const testTextVariant = TextVariant.DisplayMD;
     const { getByRole } = render(
-      <HeaderBase>
+      <HeaderBase variant={HeaderBaseVariant.Compact}>
         <Text variant={testTextVariant} testID={HEADERBASE_TITLE_TEST_ID}>
           Sample HeaderBase Title
         </Text>
@@ -71,7 +99,9 @@ describe('HeaderBase', () => {
 
   it('applies marginTop when includesTopInset is true', () => {
     const { getByTestId } = render(
-      <HeaderBase includesTopInset>Header Content</HeaderBase>,
+      <HeaderBase variant={HeaderBaseVariant.Compact} includesTopInset>
+        Header Content
+      </HeaderBase>,
     );
 
     const headerBase = getByTestId(HEADERBASE_TEST_ID);
@@ -83,7 +113,9 @@ describe('HeaderBase', () => {
 
   it('does not apply marginTop when includesTopInset is false', () => {
     const { getByTestId } = render(
-      <HeaderBase includesTopInset={false}>Header Content</HeaderBase>,
+      <HeaderBase variant={HeaderBaseVariant.Compact} includesTopInset={false}>
+        Header Content
+      </HeaderBase>,
     );
 
     const headerBase = getByTestId(HEADERBASE_TEST_ID);
@@ -93,53 +125,156 @@ describe('HeaderBase', () => {
     );
   });
 
-  it('defaults to center alignment', () => {
-    const { getByTestId } = render(<HeaderBase>Header Content</HeaderBase>);
+  describe('variant functionality', () => {
+    it('applies Display variant correctly - left alignment and HeadingLG text', () => {
+      const { getByTestId, getByRole } = render(
+        <HeaderBase variant={HeaderBaseVariant.Display}>
+          Header Content
+        </HeaderBase>,
+      );
 
-    const titleElement = getByTestId(HEADERBASE_TITLE_TEST_ID);
-    expect(titleElement.props.style.textAlign).toBe('center');
+      const titleElement = getByTestId(HEADERBASE_TITLE_TEST_ID);
+      const textElement = getByRole('text');
+      const fontFamily = getFontFamily(
+        HEADERBASE_VARIANT_TEXT_VARIANTS[HeaderBaseVariant.Display],
+      );
+
+      // Check alignment
+      expect(titleElement.props.style.textAlign).toBe('left');
+      // Check text variant
+      expect(textElement.props.style.fontFamily).toBe(fontFamily);
+    });
+
+    it('applies Compact variant correctly - center alignment and HeadingSM text', () => {
+      const { getByTestId, getByRole } = render(
+        <HeaderBase variant={HeaderBaseVariant.Compact}>
+          Header Content
+        </HeaderBase>,
+      );
+
+      const titleElement = getByTestId(HEADERBASE_TITLE_TEST_ID);
+      const textElement = getByRole('text');
+      const fontFamily = getFontFamily(
+        HEADERBASE_VARIANT_TEXT_VARIANTS[HeaderBaseVariant.Compact],
+      );
+
+      // Check alignment
+      expect(titleElement.props.style.textAlign).toBe('center');
+      // Check text variant
+      expect(textElement.props.style.fontFamily).toBe(fontFamily);
+    });
+
+    it('renders snapshot correctly with Display variant', () => {
+      const wrapper = render(
+        <HeaderBase variant={HeaderBaseVariant.Display}>
+          Display Variant Header
+        </HeaderBase>,
+      );
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('renders snapshot correctly with Compact variant', () => {
+      const wrapper = render(
+        <HeaderBase variant={HeaderBaseVariant.Compact}>
+          Compact Variant Header
+        </HeaderBase>,
+      );
+      expect(wrapper).toMatchSnapshot();
+    });
   });
 
-  it('applies center alignment when align prop is set to center', () => {
-    const { getByTestId } = render(
-      <HeaderBase align={HeaderBaseAlign.Center}>Header Content</HeaderBase>,
-    );
+  describe('variant functionality with accessories', () => {
+    const mockAccessoryComponent = <Text>Test Accessory</Text>;
 
-    const titleElement = getByTestId(HEADERBASE_TITLE_TEST_ID);
-    expect(titleElement.props.style.textAlign).toBe('center');
-  });
+    describe('Display variant (left alignment)', () => {
+      it('only renders start accessory wrapper when start accessory exists', () => {
+        const startAccessoryTestId = 'start-accessory-wrapper';
+        const endAccessoryTestId = 'end-accessory-wrapper';
 
-  it('applies left alignment when align prop is set to left', () => {
-    const { getByTestId } = render(
-      <HeaderBase align={HeaderBaseAlign.Left}>Header Content</HeaderBase>,
-    );
+        const { queryByTestId } = render(
+          <HeaderBase
+            variant={HeaderBaseVariant.Display}
+            startAccessory={mockAccessoryComponent}
+            startAccessoryWrapperProps={{ testID: startAccessoryTestId }}
+            endAccessoryWrapperProps={{ testID: endAccessoryTestId }}
+          >
+            Header Content
+          </HeaderBase>,
+        );
 
-    const titleElement = getByTestId(HEADERBASE_TITLE_TEST_ID);
-    expect(titleElement.props.style.textAlign).toBe('left');
-  });
+        // Display variant acts like left alignment
+        expect(queryByTestId(startAccessoryTestId)).toBeTruthy();
+        expect(queryByTestId(endAccessoryTestId)).toBeFalsy();
+      });
 
-  it('renders snapshot correctly with left alignment', () => {
-    const wrapper = render(
-      <HeaderBase align={HeaderBaseAlign.Left}>
-        Sample HeaderBase Title
-      </HeaderBase>,
-    );
-    expect(wrapper).toMatchSnapshot();
-  });
+      it('renders both wrappers when both accessories exist', () => {
+        const startAccessoryTestId = 'start-accessory-wrapper';
+        const endAccessoryTestId = 'end-accessory-wrapper';
 
-  it('renders snapshot correctly with center alignment', () => {
-    const wrapper = render(
-      <HeaderBase align={HeaderBaseAlign.Center}>
-        Sample HeaderBase Title
-      </HeaderBase>,
-    );
-    expect(wrapper).toMatchSnapshot();
+        const { queryByTestId } = render(
+          <HeaderBase
+            variant={HeaderBaseVariant.Display}
+            startAccessory={mockAccessoryComponent}
+            endAccessory={mockAccessoryComponent}
+            startAccessoryWrapperProps={{ testID: startAccessoryTestId }}
+            endAccessoryWrapperProps={{ testID: endAccessoryTestId }}
+          >
+            Header Content
+          </HeaderBase>,
+        );
+
+        // Both wrappers should be rendered when both accessories exist
+        expect(queryByTestId(startAccessoryTestId)).toBeTruthy();
+        expect(queryByTestId(endAccessoryTestId)).toBeTruthy();
+      });
+    });
+
+    describe('Compact variant (center alignment)', () => {
+      it('renders both accessory wrappers when any accessory exists', () => {
+        const startAccessoryTestId = 'start-accessory-wrapper';
+        const endAccessoryTestId = 'end-accessory-wrapper';
+
+        const { queryByTestId } = render(
+          <HeaderBase
+            variant={HeaderBaseVariant.Compact}
+            startAccessory={mockAccessoryComponent}
+            startAccessoryWrapperProps={{ testID: startAccessoryTestId }}
+            endAccessoryWrapperProps={{ testID: endAccessoryTestId }}
+          >
+            Header Content
+          </HeaderBase>,
+        );
+
+        // Compact variant acts like center alignment
+        expect(queryByTestId(startAccessoryTestId)).toBeTruthy();
+        expect(queryByTestId(endAccessoryTestId)).toBeTruthy();
+      });
+
+      it('does not render accessory wrappers when no accessories exist', () => {
+        const startAccessoryTestId = 'start-accessory-wrapper';
+        const endAccessoryTestId = 'end-accessory-wrapper';
+
+        const { queryByTestId } = render(
+          <HeaderBase
+            variant={HeaderBaseVariant.Compact}
+            startAccessoryWrapperProps={{ testID: startAccessoryTestId }}
+            endAccessoryWrapperProps={{ testID: endAccessoryTestId }}
+          >
+            Header Content
+          </HeaderBase>,
+        );
+
+        // No wrappers should be rendered when no accessories exist
+        expect(queryByTestId(startAccessoryTestId)).toBeFalsy();
+        expect(queryByTestId(endAccessoryTestId)).toBeFalsy();
+      });
+    });
   });
 
   describe('accessory width calculations', () => {
     const mockAccessoryComponent = <Text>Test Accessory</Text>;
 
-    it('calculates accessoryWidth when both start and end accessories have sizes for center alignment', () => {
+    it('calculates accessoryWidth when both start and end accessories have sizes for Compact variant', () => {
       // Mock useComponentSize to return different sizes for each call
       mockUseComponentSize
         .mockReturnValueOnce({
@@ -153,7 +288,7 @@ describe('HeaderBase', () => {
 
       const { getByTestId } = render(
         <HeaderBase
-          align={HeaderBaseAlign.Center}
+          variant={HeaderBaseVariant.Compact}
           startAccessory={mockAccessoryComponent}
           endAccessory={mockAccessoryComponent}
         >
@@ -162,11 +297,11 @@ describe('HeaderBase', () => {
       );
 
       const headerBase = getByTestId(HEADERBASE_TEST_ID);
-      // The accessoryWidth should be calculated and applied to titleWrapper
+      // The accessoryWidth should be calculated and applied for center alignment
       expect(headerBase).toBeTruthy();
     });
 
-    it('does not calculate accessoryWidth for left alignment even with accessories', () => {
+    it('does not calculate accessoryWidth for Display variant', () => {
       mockUseComponentSize
         .mockReturnValueOnce({
           size: { width: 50, height: 30 },
@@ -179,7 +314,7 @@ describe('HeaderBase', () => {
 
       const { getByTestId } = render(
         <HeaderBase
-          align={HeaderBaseAlign.Left}
+          variant={HeaderBaseVariant.Display}
           startAccessory={mockAccessoryComponent}
           endAccessory={mockAccessoryComponent}
         >
@@ -189,81 +324,6 @@ describe('HeaderBase', () => {
 
       const titleElement = getByTestId(HEADERBASE_TITLE_TEST_ID);
       expect(titleElement.props.style.textAlign).toBe('left');
-    });
-
-    it('handles case when only start accessory has size', () => {
-      mockUseComponentSize
-        .mockReturnValueOnce({
-          size: { width: 50, height: 30 },
-          onLayout: jest.fn(),
-        })
-        .mockReturnValueOnce({
-          size: null,
-          onLayout: jest.fn(),
-        });
-
-      const { getByTestId } = render(
-        <HeaderBase
-          align={HeaderBaseAlign.Center}
-          startAccessory={mockAccessoryComponent}
-          endAccessory={mockAccessoryComponent}
-        >
-          Header Content
-        </HeaderBase>,
-      );
-
-      const headerBase = getByTestId(HEADERBASE_TEST_ID);
-      expect(headerBase).toBeTruthy();
-    });
-
-    it('handles case when only end accessory has size', () => {
-      mockUseComponentSize
-        .mockReturnValueOnce({
-          size: null,
-          onLayout: jest.fn(),
-        })
-        .mockReturnValueOnce({
-          size: { width: 40, height: 25 },
-          onLayout: jest.fn(),
-        });
-
-      const { getByTestId } = render(
-        <HeaderBase
-          align={HeaderBaseAlign.Center}
-          startAccessory={mockAccessoryComponent}
-          endAccessory={mockAccessoryComponent}
-        >
-          Header Content
-        </HeaderBase>,
-      );
-
-      const headerBase = getByTestId(HEADERBASE_TEST_ID);
-      expect(headerBase).toBeTruthy();
-    });
-
-    it('handles case when neither accessory has size', () => {
-      mockUseComponentSize
-        .mockReturnValueOnce({
-          size: null,
-          onLayout: jest.fn(),
-        })
-        .mockReturnValueOnce({
-          size: null,
-          onLayout: jest.fn(),
-        });
-
-      const { getByTestId } = render(
-        <HeaderBase
-          align={HeaderBaseAlign.Center}
-          startAccessory={mockAccessoryComponent}
-          endAccessory={mockAccessoryComponent}
-        >
-          Header Content
-        </HeaderBase>,
-      );
-
-      const headerBase = getByTestId(HEADERBASE_TEST_ID);
-      expect(headerBase).toBeTruthy();
     });
   });
 });

--- a/app/component-library/components/HeaderBase/HeaderBase.tsx
+++ b/app/component-library/components/HeaderBase/HeaderBase.tsx
@@ -11,10 +11,9 @@ import Text from '../Texts/Text';
 
 // Internal dependencies.
 import styleSheet from './HeaderBase.styles';
-import { HeaderBaseProps } from './HeaderBase.types';
+import { HeaderBaseProps, HeaderBaseVariant } from './HeaderBase.types';
 import {
-  DEFAULT_HEADERBASE_TITLE_TEXTVARIANT,
-  DEFAULT_HEADERBASE_ALIGN,
+  HEADERBASE_VARIANT_TEXT_VARIANTS,
   HEADERBASE_TEST_ID,
   HEADERBASE_TITLE_TEST_ID,
 } from './HeaderBase.constants';
@@ -25,7 +24,9 @@ const HeaderBase: React.FC<HeaderBaseProps> = ({
   startAccessory,
   endAccessory,
   includesTopInset = false,
-  align = DEFAULT_HEADERBASE_ALIGN,
+  variant = HeaderBaseVariant.Compact,
+  startAccessoryWrapperProps,
+  endAccessoryWrapperProps,
 }) => {
   const { size: startAccessorySize, onLayout: startAccessoryOnLayout } =
     useComponentSize();
@@ -33,25 +34,43 @@ const HeaderBase: React.FC<HeaderBaseProps> = ({
     useComponentSize();
   const insets = useSafeAreaInsets();
 
+  // Determine text variant based on variant prop
+  const textVariant = HEADERBASE_VARIANT_TEXT_VARIANTS[variant];
+
+  // Determine alignment based on variant
+  const isLeftAligned = variant === HeaderBaseVariant.Display;
+
   const { styles } = useStyles(styleSheet, {
     style,
     startAccessorySize,
     endAccessorySize,
-    align,
+    variant,
   });
+  const hasAnyAccessory = startAccessory || endAccessory;
+
+  // Determine when to render accessory wrappers based on alignment
+  const shouldRenderStartAccessoryWrapper = isLeftAligned
+    ? !!startAccessory // Left aligned: only render if startAccessory exists
+    : hasAnyAccessory; // Center aligned: render if any accessory exists
+
+  const shouldRenderEndAccessoryWrapper = isLeftAligned
+    ? !!endAccessory // Left aligned: only render if endAccessory exists
+    : hasAnyAccessory; // Center aligned: render if any accessory exists
 
   return (
     <View
       style={[styles.base, includesTopInset && { marginTop: insets.top }]}
       testID={HEADERBASE_TEST_ID}
     >
-      <View style={styles.accessoryWrapper}>
-        <View onLayout={startAccessoryOnLayout}>{startAccessory}</View>
-      </View>
+      {shouldRenderStartAccessoryWrapper ? (
+        <View style={styles.accessoryWrapper} {...startAccessoryWrapperProps}>
+          <View onLayout={startAccessoryOnLayout}>{startAccessory}</View>
+        </View>
+      ) : null}
       <View style={styles.titleWrapper}>
         {typeof children === 'string' ? (
           <Text
-            variant={DEFAULT_HEADERBASE_TITLE_TEXTVARIANT}
+            variant={textVariant}
             style={styles.title}
             testID={HEADERBASE_TITLE_TEST_ID}
           >
@@ -61,9 +80,11 @@ const HeaderBase: React.FC<HeaderBaseProps> = ({
           children
         )}
       </View>
-      <View style={styles.accessoryWrapper}>
-        <View onLayout={endAccessoryOnLayout}>{endAccessory}</View>
-      </View>
+      {shouldRenderEndAccessoryWrapper ? (
+        <View style={styles.accessoryWrapper} {...endAccessoryWrapperProps}>
+          <View onLayout={endAccessoryOnLayout}>{endAccessory}</View>
+        </View>
+      ) : null}
     </View>
   );
 };

--- a/app/component-library/components/HeaderBase/HeaderBase.types.ts
+++ b/app/component-library/components/HeaderBase/HeaderBase.types.ts
@@ -1,8 +1,11 @@
 // Third party dependencies.
 import { ViewProps } from 'react-native';
 
-// Internal dependencies.
-import { HeaderBaseAlign } from './HeaderBase.constants';
+// Enums
+export enum HeaderBaseVariant {
+  Display = 'display',
+  Compact = 'compact',
+}
 
 /**
  * HeaderBase component props.
@@ -27,10 +30,20 @@ export interface HeaderBaseProps extends ViewProps {
    */
   includesTopInset?: boolean;
   /**
-   * Optional prop to set the alignment of the header title.
-   * @default: HeaderBaseAlign.Center
+   * Optional prop to set the variant of the header (controls alignment and text size).
+   * Display: left aligned with HeadingLG text.
+   * Compact: center aligned with HeadingSM text.
+   * @default HeaderBaseVariant.Compact
    */
-  align?: HeaderBaseAlign;
+  variant?: HeaderBaseVariant;
+  /**
+   * Optional props to pass to the start accessory wrapper View.
+   */
+  startAccessoryWrapperProps?: ViewProps;
+  /**
+   * Optional props to pass to the end accessory wrapper View.
+   */
+  endAccessoryWrapperProps?: ViewProps;
 }
 
 /**
@@ -38,7 +51,7 @@ export interface HeaderBaseProps extends ViewProps {
  */
 export type HeaderBaseStyleSheetVars = Pick<
   HeaderBaseProps,
-  'style' | 'align'
+  'style' | 'variant'
 > & {
   startAccessorySize: { width: number; height: number } | null;
   endAccessorySize: { width: number; height: number } | null;

--- a/app/component-library/components/HeaderBase/__snapshots__/HeaderBase.test.tsx.snap
+++ b/app/component-library/components/HeaderBase/__snapshots__/HeaderBase.test.tsx.snap
@@ -1,12 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HeaderBase renders snapshot correctly with center alignment 1`] = `
+exports[`HeaderBase should render snapshot correctly with Compact variant 1`] = `
 <View
   style={
     [
       {
         "backgroundColor": "#ffffff",
         "flexDirection": "row",
+        "gap": 16,
       },
       false,
     ]
@@ -16,20 +17,8 @@ exports[`HeaderBase renders snapshot correctly with center alignment 1`] = `
   <View
     style={
       {
-        "width": undefined,
-      }
-    }
-  >
-    <View
-      onLayout={[MockFunction]}
-    />
-  </View>
-  <View
-    style={
-      {
         "alignItems": "center",
         "flex": 1,
-        "marginHorizontal": 16,
       }
     }
   >
@@ -50,27 +39,17 @@ exports[`HeaderBase renders snapshot correctly with center alignment 1`] = `
       Sample HeaderBase Title
     </Text>
   </View>
-  <View
-    style={
-      {
-        "width": undefined,
-      }
-    }
-  >
-    <View
-      onLayout={[MockFunction]}
-    />
-  </View>
 </View>
 `;
 
-exports[`HeaderBase renders snapshot correctly with left alignment 1`] = `
+exports[`HeaderBase variant functionality renders snapshot correctly with Compact variant 1`] = `
 <View
   style={
     [
       {
         "backgroundColor": "#ffffff",
         "flexDirection": "row",
+        "gap": 16,
       },
       false,
     ]
@@ -80,20 +59,50 @@ exports[`HeaderBase renders snapshot correctly with left alignment 1`] = `
   <View
     style={
       {
-        "width": undefined,
+        "alignItems": "center",
+        "flex": 1,
       }
     }
   >
-    <View
-      onLayout={[MockFunction]}
-    />
+    <Text
+      accessibilityRole="text"
+      style={
+        {
+          "color": "#121314",
+          "fontFamily": "Geist Bold",
+          "fontSize": 16,
+          "letterSpacing": 0,
+          "lineHeight": 24,
+          "textAlign": "center",
+        }
+      }
+      testID="header-title"
+    >
+      Compact Variant Header
+    </Text>
   </View>
+</View>
+`;
+
+exports[`HeaderBase variant functionality renders snapshot correctly with Display variant 1`] = `
+<View
+  style={
+    [
+      {
+        "backgroundColor": "#ffffff",
+        "flexDirection": "row",
+        "gap": 16,
+      },
+      false,
+    ]
+  }
+  testID="header"
+>
   <View
     style={
       {
         "alignItems": "flex-start",
         "flex": 1,
-        "marginHorizontal": 16,
       }
     }
   >
@@ -103,91 +112,16 @@ exports[`HeaderBase renders snapshot correctly with left alignment 1`] = `
         {
           "color": "#121314",
           "fontFamily": "Geist Bold",
-          "fontSize": 16,
+          "fontSize": 24,
           "letterSpacing": 0,
-          "lineHeight": 24,
+          "lineHeight": 32,
           "textAlign": "left",
         }
       }
       testID="header-title"
     >
-      Sample HeaderBase Title
+      Display Variant Header
     </Text>
-  </View>
-  <View
-    style={
-      {
-        "width": undefined,
-      }
-    }
-  >
-    <View
-      onLayout={[MockFunction]}
-    />
-  </View>
-</View>
-`;
-
-exports[`HeaderBase should render snapshot correctly 1`] = `
-<View
-  style={
-    [
-      {
-        "backgroundColor": "#ffffff",
-        "flexDirection": "row",
-      },
-      false,
-    ]
-  }
-  testID="header"
->
-  <View
-    style={
-      {
-        "width": undefined,
-      }
-    }
-  >
-    <View
-      onLayout={[MockFunction]}
-    />
-  </View>
-  <View
-    style={
-      {
-        "alignItems": "center",
-        "flex": 1,
-        "marginHorizontal": 16,
-      }
-    }
-  >
-    <Text
-      accessibilityRole="text"
-      style={
-        {
-          "color": "#121314",
-          "fontFamily": "Geist Bold",
-          "fontSize": 16,
-          "letterSpacing": 0,
-          "lineHeight": 24,
-          "textAlign": "center",
-        }
-      }
-      testID="header-title"
-    >
-      Sample HeaderBase Title
-    </Text>
-  </View>
-  <View
-    style={
-      {
-        "width": undefined,
-      }
-    }
-  >
-    <View
-      onLayout={[MockFunction]}
-    />
   </View>
 </View>
 `;

--- a/app/component-library/components/HeaderBase/index.ts
+++ b/app/component-library/components/HeaderBase/index.ts
@@ -1,2 +1,1 @@
 export { default } from './HeaderBase';
-export { HeaderBaseAlign } from './HeaderBase.constants';

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
@@ -775,6 +775,7 @@ exports[`SnapUIForm will render with fields 1`] = `
                               {
                                 "backgroundColor": "#ffffff",
                                 "flexDirection": "row",
+                                "gap": 16,
                                 "padding": 16,
                               },
                               false,
@@ -831,7 +832,6 @@ exports[`SnapUIForm will render with fields 1`] = `
                               {
                                 "alignItems": "center",
                                 "flex": 1,
-                                "marginHorizontal": 16,
                               }
                             }
                           >

--- a/app/components/UI/Bridge/components/BridgeDestNetworkSelector/__snapshots__/BridgeDestNetworkSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeDestNetworkSelector/__snapshots__/BridgeDestNetworkSelector.test.tsx.snap
@@ -458,6 +458,7 @@ exports[`BridgeDestNetworkSelector renders with initial state and displays netwo
                                     {
                                       "backgroundColor": "#ffffff",
                                       "flexDirection": "row",
+                                      "gap": 16,
                                       "padding": 16,
                                     },
                                     false,
@@ -468,20 +469,8 @@ exports[`BridgeDestNetworkSelector renders with initial state and displays netwo
                                 <View
                                   style={
                                     {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <View
-                                    onLayout={[Function]}
-                                  />
-                                </View>
-                                <View
-                                  style={
-                                    {
                                       "alignItems": "center",
                                       "flex": 1,
-                                      "marginHorizontal": 16,
                                     }
                                   }
                                 >
@@ -552,17 +541,6 @@ exports[`BridgeDestNetworkSelector renders with initial state and displays netwo
                                       </TouchableOpacity>
                                     </View>
                                   </View>
-                                </View>
-                                <View
-                                  style={
-                                    {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <View
-                                    onLayout={[Function]}
-                                  />
                                 </View>
                               </View>
                             </View>

--- a/app/components/UI/Bridge/components/BridgeDestTokenSelector/__snapshots__/BridgeDestTokenSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeDestTokenSelector/__snapshots__/BridgeDestTokenSelector.test.tsx.snap
@@ -442,6 +442,7 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                                   {
                                     "backgroundColor": "#ffffff",
                                     "flexDirection": "row",
+                                    "gap": 16,
                                     "padding": 16,
                                   },
                                   false,
@@ -452,20 +453,8 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                               <View
                                 style={
                                   {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <View
-                                  onLayout={[Function]}
-                                />
-                              </View>
-                              <View
-                                style={
-                                  {
                                     "alignItems": "center",
                                     "flex": 1,
-                                    "marginHorizontal": 16,
                                   }
                                 }
                               >
@@ -536,17 +525,6 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                                     </TouchableOpacity>
                                   </View>
                                 </View>
-                              </View>
-                              <View
-                                style={
-                                  {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <View
-                                  onLayout={[Function]}
-                                />
                               </View>
                             </View>
                           </View>

--- a/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/__snapshots__/BridgeSourceNetworkSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/__snapshots__/BridgeSourceNetworkSelector.test.tsx.snap
@@ -458,6 +458,7 @@ exports[`BridgeSourceNetworkSelector renders with initial state and displays net
                                     {
                                       "backgroundColor": "#ffffff",
                                       "flexDirection": "row",
+                                      "gap": 16,
                                       "padding": 16,
                                     },
                                     false,
@@ -468,20 +469,8 @@ exports[`BridgeSourceNetworkSelector renders with initial state and displays net
                                 <View
                                   style={
                                     {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <View
-                                    onLayout={[Function]}
-                                  />
-                                </View>
-                                <View
-                                  style={
-                                    {
                                       "alignItems": "center",
                                       "flex": 1,
-                                      "marginHorizontal": 16,
                                     }
                                   }
                                 >
@@ -552,17 +541,6 @@ exports[`BridgeSourceNetworkSelector renders with initial state and displays net
                                       </TouchableOpacity>
                                     </View>
                                   </View>
-                                </View>
-                                <View
-                                  style={
-                                    {
-                                      "width": undefined,
-                                    }
-                                  }
-                                >
-                                  <View
-                                    onLayout={[Function]}
-                                  />
                                 </View>
                               </View>
                             </View>

--- a/app/components/UI/Bridge/components/BridgeSourceTokenSelector/__snapshots__/BridgeSourceTokenSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeSourceTokenSelector/__snapshots__/BridgeSourceTokenSelector.test.tsx.snap
@@ -442,6 +442,7 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                   {
                                     "backgroundColor": "#ffffff",
                                     "flexDirection": "row",
+                                    "gap": 16,
                                     "padding": 16,
                                   },
                                   false,
@@ -452,20 +453,8 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                               <View
                                 style={
                                   {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <View
-                                  onLayout={[Function]}
-                                />
-                              </View>
-                              <View
-                                style={
-                                  {
                                     "alignItems": "center",
                                     "flex": 1,
-                                    "marginHorizontal": 16,
                                   }
                                 }
                               >
@@ -536,17 +525,6 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                     </TouchableOpacity>
                                   </View>
                                 </View>
-                              </View>
-                              <View
-                                style={
-                                  {
-                                    "width": undefined,
-                                  }
-                                }
-                              >
-                                <View
-                                  onLayout={[Function]}
-                                />
                               </View>
                             </View>
                           </View>

--- a/app/components/UI/Bridge/components/QuoteExpiredModal/__snapshots__/QuoteExpiredModal.test.tsx.snap
+++ b/app/components/UI/Bridge/components/QuoteExpiredModal/__snapshots__/QuoteExpiredModal.test.tsx.snap
@@ -135,6 +135,7 @@ exports[`QuoteExpiredModal renders correctly 1`] = `
               {
                 "backgroundColor": "#ffffff",
                 "flexDirection": "row",
+                "gap": 16,
                 "padding": 16,
               },
               false,
@@ -158,7 +159,6 @@ exports[`QuoteExpiredModal renders correctly 1`] = `
               {
                 "alignItems": "center",
                 "flex": 1,
-                "marginHorizontal": 16,
               }
             }
           >

--- a/app/components/UI/Bridge/components/QuoteInfoModal/__snapshots__/QuoteInfoModal.test.tsx.snap
+++ b/app/components/UI/Bridge/components/QuoteInfoModal/__snapshots__/QuoteInfoModal.test.tsx.snap
@@ -135,6 +135,7 @@ exports[`QuoteInfoModal renders correctly 1`] = `
               {
                 "backgroundColor": "#ffffff",
                 "flexDirection": "row",
+                "gap": 16,
                 "padding": 16,
               },
               false,
@@ -158,7 +159,6 @@ exports[`QuoteInfoModal renders correctly 1`] = `
               {
                 "alignItems": "center",
                 "flex": 1,
-                "marginHorizontal": 16,
               }
             }
           >

--- a/app/components/UI/Bridge/components/SlippageModal/__snapshots__/SlippageModal.test.tsx.snap
+++ b/app/components/UI/Bridge/components/SlippageModal/__snapshots__/SlippageModal.test.tsx.snap
@@ -135,6 +135,7 @@ exports[`SlippageModal renders all UI elements with the proper slippage options 
               {
                 "backgroundColor": "#ffffff",
                 "flexDirection": "row",
+                "gap": 16,
                 "padding": 16,
               },
               false,
@@ -158,7 +159,6 @@ exports[`SlippageModal renders all UI elements with the proper slippage options 
               {
                 "alignItems": "center",
                 "flex": 1,
-                "marginHorizontal": 16,
               }
             }
           >

--- a/app/components/UI/Card/components/AddFundsBottomSheet/__snapshots__/AddFundsBottomSheet.test.tsx.snap
+++ b/app/components/UI/Card/components/AddFundsBottomSheet/__snapshots__/AddFundsBottomSheet.test.tsx.snap
@@ -436,6 +436,7 @@ exports[`AddFundsBottomSheet renders with both options enabled and matches snaps
                                 {
                                   "backgroundColor": "#ffffff",
                                   "flexDirection": "row",
+                                  "gap": 16,
                                   "padding": 16,
                                 },
                                 false,
@@ -459,7 +460,6 @@ exports[`AddFundsBottomSheet renders with both options enabled and matches snaps
                                 {
                                   "alignItems": "center",
                                   "flex": 1,
-                                  "marginHorizontal": 16,
                                 }
                               }
                             >
@@ -1247,6 +1247,7 @@ exports[`AddFundsBottomSheet renders with no options when both are disabled and 
                                 {
                                   "backgroundColor": "#ffffff",
                                   "flexDirection": "row",
+                                  "gap": 16,
                                   "padding": 16,
                                 },
                                 false,
@@ -1270,7 +1271,6 @@ exports[`AddFundsBottomSheet renders with no options when both are disabled and 
                                 {
                                   "alignItems": "center",
                                   "flex": 1,
-                                  "marginHorizontal": 16,
                                 }
                               }
                             >
@@ -1842,6 +1842,7 @@ exports[`AddFundsBottomSheet renders with only deposit option when swaps are not
                                 {
                                   "backgroundColor": "#ffffff",
                                   "flexDirection": "row",
+                                  "gap": 16,
                                   "padding": 16,
                                 },
                                 false,
@@ -1865,7 +1866,6 @@ exports[`AddFundsBottomSheet renders with only deposit option when swaps are not
                                 {
                                   "alignItems": "center",
                                   "flex": 1,
-                                  "marginHorizontal": 16,
                                 }
                               }
                             >
@@ -2545,6 +2545,7 @@ exports[`AddFundsBottomSheet renders with only swap option when deposit is disab
                                 {
                                   "backgroundColor": "#ffffff",
                                   "flexDirection": "row",
+                                  "gap": 16,
                                   "padding": 16,
                                 },
                                 false,
@@ -2568,7 +2569,6 @@ exports[`AddFundsBottomSheet renders with only swap option when deposit is disab
                                 {
                                   "alignItems": "center",
                                   "flex": 1,
-                                  "marginHorizontal": 16,
                                 }
                               }
                             >
@@ -3248,6 +3248,7 @@ exports[`AddFundsBottomSheet renders with only swap option when token is not USD
                                 {
                                   "backgroundColor": "#ffffff",
                                   "flexDirection": "row",
+                                  "gap": 16,
                                   "padding": 16,
                                 },
                                 false,
@@ -3271,7 +3272,6 @@ exports[`AddFundsBottomSheet renders with only swap option when token is not USD
                                 {
                                   "alignItems": "center",
                                   "flex": 1,
-                                  "marginHorizontal": 16,
                                 }
                               }
                             >

--- a/app/components/UI/Earn/LendingLearnMoreModal/__snapshots__/LendingLearnMoreModal.test.tsx.snap
+++ b/app/components/UI/Earn/LendingLearnMoreModal/__snapshots__/LendingLearnMoreModal.test.tsx.snap
@@ -115,6 +115,7 @@ exports[`LendingLearnMoreModal render lending history apy chart 1`] = `
               {
                 "backgroundColor": "#ffffff",
                 "flexDirection": "row",
+                "gap": 16,
                 "padding": 16,
               },
               false,
@@ -138,7 +139,6 @@ exports[`LendingLearnMoreModal render lending history apy chart 1`] = `
               {
                 "alignItems": "center",
                 "flex": 1,
-                "marginHorizontal": 16,
               }
             }
           >

--- a/app/components/UI/Earn/components/EarnTokenList/__snapshots__/EarnTokenList.test.tsx.snap
+++ b/app/components/UI/Earn/components/EarnTokenList/__snapshots__/EarnTokenList.test.tsx.snap
@@ -135,6 +135,7 @@ exports[`EarnTokenList render matches snapshot 1`] = `
               {
                 "backgroundColor": "#ffffff",
                 "flexDirection": "row",
+                "gap": 16,
                 "padding": 16,
               },
               false,
@@ -145,20 +146,8 @@ exports[`EarnTokenList render matches snapshot 1`] = `
           <View
             style={
               {
-                "width": undefined,
-              }
-            }
-          >
-            <View
-              onLayout={[Function]}
-            />
-          </View>
-          <View
-            style={
-              {
                 "alignItems": "center",
                 "flex": 1,
-                "marginHorizontal": 16,
               }
             }
           >
@@ -176,17 +165,6 @@ exports[`EarnTokenList render matches snapshot 1`] = `
             >
               Select a token to deposit
             </Text>
-          </View>
-          <View
-            style={
-              {
-                "width": undefined,
-              }
-            }
-          >
-            <View
-              onLayout={[Function]}
-            />
           </View>
         </View>
         <View

--- a/app/components/UI/Earn/components/MaxInputModal/__snapshots__/MaxInputModal.test.tsx.snap
+++ b/app/components/UI/Earn/components/MaxInputModal/__snapshots__/MaxInputModal.test.tsx.snap
@@ -442,6 +442,7 @@ exports[`MaxInputModal render matches snapshot 1`] = `
                                   {
                                     "backgroundColor": "#ffffff",
                                     "flexDirection": "row",
+                                    "gap": 16,
                                     "padding": 16,
                                   },
                                   false,
@@ -465,7 +466,6 @@ exports[`MaxInputModal render matches snapshot 1`] = `
                                   {
                                     "alignItems": "center",
                                     "flex": 1,
-                                    "marginHorizontal": 16,
                                   }
                                 }
                               >

--- a/app/components/UI/Earn/modals/LendingMaxWithdrawalModal/__snapshots__/LendingMaxWithdrawalModal.test.tsx.snap
+++ b/app/components/UI/Earn/modals/LendingMaxWithdrawalModal/__snapshots__/LendingMaxWithdrawalModal.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`LendingMaxWithdrawalModal should render correctly 1`] = `
         {
           "backgroundColor": "#ffffff",
           "flexDirection": "row",
+          "gap": 16,
           "padding": 16,
         },
         false,
@@ -31,7 +32,6 @@ exports[`LendingMaxWithdrawalModal should render correctly 1`] = `
         {
           "alignItems": "center",
           "flex": 1,
-          "marginHorizontal": 16,
         }
       }
     >

--- a/app/components/UI/NetworkModal/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/NetworkModal/__snapshots__/index.test.tsx.snap
@@ -150,6 +150,7 @@ exports[`NetworkDetails renders correctly 1`] = `
                     {
                       "backgroundColor": "#ffffff",
                       "flexDirection": "row",
+                      "gap": 16,
                       "padding": 16,
                     },
                     false,
@@ -160,20 +161,8 @@ exports[`NetworkDetails renders correctly 1`] = `
                 <View
                   style={
                     {
-                      "width": undefined,
-                    }
-                  }
-                >
-                  <View
-                    onLayout={[Function]}
-                  />
-                </View>
-                <View
-                  style={
-                    {
                       "alignItems": "center",
                       "flex": 1,
-                      "marginHorizontal": 16,
                     }
                   }
                 >
@@ -191,17 +180,6 @@ exports[`NetworkDetails renders correctly 1`] = `
                   >
                     Add Test Network
                   </Text>
-                </View>
-                <View
-                  style={
-                    {
-                      "width": undefined,
-                    }
-                  }
-                >
-                  <View
-                    onLayout={[Function]}
-                  />
                 </View>
               </View>
               <RCTScrollView

--- a/app/components/UI/NetworkVerificationInfo/__snapshots__/NetworkVerificationInfo.test.tsx.snap
+++ b/app/components/UI/NetworkVerificationInfo/__snapshots__/NetworkVerificationInfo.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`NetworkVerificationInfo renders correctly 1`] = `
         {
           "backgroundColor": "#ffffff",
           "flexDirection": "row",
+          "gap": 16,
           "padding": 16,
         },
         false,
@@ -20,20 +21,8 @@ exports[`NetworkVerificationInfo renders correctly 1`] = `
     <View
       style={
         {
-          "width": undefined,
-        }
-      }
-    >
-      <View
-        onLayout={[Function]}
-      />
-    </View>
-    <View
-      style={
-        {
           "alignItems": "center",
           "flex": 1,
-          "marginHorizontal": 16,
         }
       }
     >
@@ -51,17 +40,6 @@ exports[`NetworkVerificationInfo renders correctly 1`] = `
       >
         Add Test Chain
       </Text>
-    </View>
-    <View
-      style={
-        {
-          "width": undefined,
-        }
-      }
-    >
-      <View
-        onLayout={[Function]}
-      />
     </View>
   </View>
   <RCTScrollView
@@ -536,6 +514,7 @@ exports[`NetworkVerificationInfo renders updated details when isNetworkRpcUpdate
         {
           "backgroundColor": "#ffffff",
           "flexDirection": "row",
+          "gap": 16,
           "padding": 16,
         },
         false,
@@ -546,20 +525,8 @@ exports[`NetworkVerificationInfo renders updated details when isNetworkRpcUpdate
     <View
       style={
         {
-          "width": undefined,
-        }
-      }
-    >
-      <View
-        onLayout={[Function]}
-      />
-    </View>
-    <View
-      style={
-        {
           "alignItems": "center",
           "flex": 1,
-          "marginHorizontal": 16,
         }
       }
     >
@@ -577,17 +544,6 @@ exports[`NetworkVerificationInfo renders updated details when isNetworkRpcUpdate
       >
         Update Test Chain
       </Text>
-    </View>
-    <View
-      style={
-        {
-          "width": undefined,
-        }
-      }
-    >
-      <View
-        onLayout={[Function]}
-      />
     </View>
   </View>
   <RCTScrollView

--- a/app/components/UI/Perps/components/PerpsBottomSheetTooltip/__snapshots__/PerpsBottomSheetTooltip.test.tsx.snap
+++ b/app/components/UI/Perps/components/PerpsBottomSheetTooltip/__snapshots__/PerpsBottomSheetTooltip.test.tsx.snap
@@ -136,6 +136,7 @@ exports[`PerpsBottomSheetTooltip renders correctly when visible 1`] = `
               {
                 "backgroundColor": "#ffffff",
                 "flexDirection": "row",
+                "gap": 16,
                 "padding": 16,
               },
               false,
@@ -146,20 +147,8 @@ exports[`PerpsBottomSheetTooltip renders correctly when visible 1`] = `
           <View
             style={
               {
-                "width": undefined,
-              }
-            }
-          >
-            <View
-              onLayout={[Function]}
-            />
-          </View>
-          <View
-            style={
-              {
                 "alignItems": "center",
                 "flex": 1,
-                "marginHorizontal": 16,
               }
             }
           >
@@ -178,17 +167,6 @@ exports[`PerpsBottomSheetTooltip renders correctly when visible 1`] = `
             >
               Leverage
             </Text>
-          </View>
-          <View
-            style={
-              {
-                "width": undefined,
-              }
-            }
-          >
-            <View
-              onLayout={[Function]}
-            />
           </View>
         </View>
         <View

--- a/app/components/UI/Ramp/Aggregator/Views/NetworkSwitcher/__snapshots__/NetworkSwitcher.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/NetworkSwitcher/__snapshots__/NetworkSwitcher.test.tsx.snap
@@ -968,6 +968,7 @@ exports[`NetworkSwitcher View renders and dismisses network modal when pressing 
                                                     {
                                                       "backgroundColor": "#ffffff",
                                                       "flexDirection": "row",
+                                                      "gap": 16,
                                                       "padding": 16,
                                                     },
                                                     false,
@@ -978,20 +979,8 @@ exports[`NetworkSwitcher View renders and dismisses network modal when pressing 
                                                 <View
                                                   style={
                                                     {
-                                                      "width": undefined,
-                                                    }
-                                                  }
-                                                >
-                                                  <View
-                                                    onLayout={[Function]}
-                                                  />
-                                                </View>
-                                                <View
-                                                  style={
-                                                    {
                                                       "alignItems": "center",
                                                       "flex": 1,
-                                                      "marginHorizontal": 16,
                                                     }
                                                   }
                                                 >
@@ -1009,17 +998,6 @@ exports[`NetworkSwitcher View renders and dismisses network modal when pressing 
                                                   >
                                                     Add Cronos Mainnet
                                                   </Text>
-                                                </View>
-                                                <View
-                                                  style={
-                                                    {
-                                                      "width": undefined,
-                                                    }
-                                                  }
-                                                >
-                                                  <View
-                                                    onLayout={[Function]}
-                                                  />
                                                 </View>
                                               </View>
                                               <RCTScrollView

--- a/app/components/UI/Ramp/Aggregator/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
@@ -1074,6 +1074,7 @@ exports[`Quotes custom action renders correctly after animation with the recomme
                                 {
                                   "backgroundColor": "#ffffff",
                                   "flexDirection": "row",
+                                  "gap": 16,
                                   "padding": 16,
                                 },
                                 false,
@@ -1097,7 +1098,6 @@ exports[`Quotes custom action renders correctly after animation with the recomme
                                 {
                                   "alignItems": "center",
                                   "flex": 1,
-                                  "marginHorizontal": 16,
                                 }
                               }
                             >
@@ -3195,6 +3195,7 @@ exports[`Quotes renders correctly after animation with expanded quotes 2`] = `
                                 {
                                   "backgroundColor": "#ffffff",
                                   "flexDirection": "row",
+                                  "gap": 16,
                                   "padding": 16,
                                 },
                                 false,
@@ -3218,7 +3219,6 @@ exports[`Quotes renders correctly after animation with expanded quotes 2`] = `
                                 {
                                   "alignItems": "center",
                                   "flex": 1,
-                                  "marginHorizontal": 16,
                                 }
                               }
                             >
@@ -5032,6 +5032,7 @@ exports[`Quotes renders correctly after animation with the recommended quote 1`]
                                 {
                                   "backgroundColor": "#ffffff",
                                   "flexDirection": "row",
+                                  "gap": 16,
                                   "padding": 16,
                                 },
                                 false,
@@ -5055,7 +5056,6 @@ exports[`Quotes renders correctly after animation with the recommended quote 1`]
                                 {
                                   "alignItems": "center",
                                   "flex": 1,
-                                  "marginHorizontal": 16,
                                 }
                               }
                             >

--- a/app/components/UI/Ramp/Deposit/Views/Modals/IncompatibleAccountTokenModal/__snapshots__/IncompatibleAccountTokenModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/IncompatibleAccountTokenModal/__snapshots__/IncompatibleAccountTokenModal.test.tsx.snap
@@ -435,6 +435,7 @@ exports[`IncompatibleAccountTokenModal renders the modal with the correct title 
                                 {
                                   "backgroundColor": "#ffffff",
                                   "flexDirection": "row",
+                                  "gap": 16,
                                   "padding": 16,
                                 },
                                 false,
@@ -458,7 +459,6 @@ exports[`IncompatibleAccountTokenModal renders the modal with the correct title 
                                 {
                                   "alignItems": "center",
                                   "flex": 1,
-                                  "marginHorizontal": 16,
                                 }
                               }
                             >

--- a/app/components/UI/Ramp/Deposit/Views/Modals/PaymentMethodSelectorModal/__snapshots__/PaymentMethodSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/PaymentMethodSelectorModal/__snapshots__/PaymentMethodSelectorModal.test.tsx.snap
@@ -435,6 +435,7 @@ exports[`PaymentMethodSelectorModal Component renders correctly and matches snap
                                 {
                                   "backgroundColor": "#ffffff",
                                   "flexDirection": "row",
+                                  "gap": 16,
                                   "padding": 16,
                                 },
                                 false,
@@ -458,7 +459,6 @@ exports[`PaymentMethodSelectorModal Component renders correctly and matches snap
                                 {
                                   "alignItems": "center",
                                   "flex": 1,
-                                  "marginHorizontal": 16,
                                 }
                               }
                             >

--- a/app/components/UI/Ramp/Deposit/Views/Modals/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
@@ -435,6 +435,7 @@ exports[`RegionSelectorModal Component render matches snapshot 1`] = `
                                 {
                                   "backgroundColor": "#ffffff",
                                   "flexDirection": "row",
+                                  "gap": 16,
                                   "padding": 16,
                                 },
                                 false,
@@ -458,7 +459,6 @@ exports[`RegionSelectorModal Component render matches snapshot 1`] = `
                                 {
                                   "alignItems": "center",
                                   "flex": 1,
-                                  "marginHorizontal": 16,
                                 }
                               }
                             >
@@ -1567,6 +1567,7 @@ exports[`RegionSelectorModal Component render matches snapshot when search has n
                                 {
                                   "backgroundColor": "#ffffff",
                                   "flexDirection": "row",
+                                  "gap": 16,
                                   "padding": 16,
                                 },
                                 false,
@@ -1590,7 +1591,6 @@ exports[`RegionSelectorModal Component render matches snapshot when search has n
                                 {
                                   "alignItems": "center",
                                   "flex": 1,
-                                  "marginHorizontal": 16,
                                 }
                               }
                             >
@@ -2287,6 +2287,7 @@ exports[`RegionSelectorModal Component render matches snapshot when searching fo
                                 {
                                   "backgroundColor": "#ffffff",
                                   "flexDirection": "row",
+                                  "gap": 16,
                                   "padding": 16,
                                 },
                                 false,
@@ -2310,7 +2311,6 @@ exports[`RegionSelectorModal Component render matches snapshot when searching fo
                                 {
                                   "alignItems": "center",
                                   "flex": 1,
-                                  "marginHorizontal": 16,
                                 }
                               }
                             >

--- a/app/components/UI/Ramp/Deposit/Views/Modals/SsnInfoModal/__snapshots__/SsnInfoModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/SsnInfoModal/__snapshots__/SsnInfoModal.test.tsx.snap
@@ -435,6 +435,7 @@ exports[`SsnInfoModal Component renders correctly and matches snapshot 1`] = `
                                 {
                                   "backgroundColor": "#ffffff",
                                   "flexDirection": "row",
+                                  "gap": 16,
                                   "padding": 16,
                                 },
                                 false,
@@ -458,7 +459,6 @@ exports[`SsnInfoModal Component renders correctly and matches snapshot 1`] = `
                                 {
                                   "alignItems": "center",
                                   "flex": 1,
-                                  "marginHorizontal": 16,
                                 }
                               }
                             >

--- a/app/components/UI/Ramp/Deposit/Views/Modals/StateSelectorModal/__snapshots__/StateSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/StateSelectorModal/__snapshots__/StateSelectorModal.test.tsx.snap
@@ -435,6 +435,7 @@ exports[`StateSelectorModal Component Snapshot Tests renders cleared search stat
                                 {
                                   "backgroundColor": "#ffffff",
                                   "flexDirection": "row",
+                                  "gap": 16,
                                   "padding": 16,
                                 },
                                 false,
@@ -458,7 +459,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders cleared search stat
                                 {
                                   "alignItems": "center",
                                   "flex": 1,
-                                  "marginHorizontal": 16,
                                 }
                               }
                             >
@@ -1208,6 +1208,7 @@ exports[`StateSelectorModal Component Snapshot Tests renders empty state when no
                                 {
                                   "backgroundColor": "#ffffff",
                                   "flexDirection": "row",
+                                  "gap": 16,
                                   "padding": 16,
                                 },
                                 false,
@@ -1231,7 +1232,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders empty state when no
                                 {
                                   "alignItems": "center",
                                   "flex": 1,
-                                  "marginHorizontal": 16,
                                 }
                               }
                             >
@@ -1925,6 +1925,7 @@ exports[`StateSelectorModal Component Snapshot Tests renders filtered state when
                                 {
                                   "backgroundColor": "#ffffff",
                                   "flexDirection": "row",
+                                  "gap": 16,
                                   "padding": 16,
                                 },
                                 false,
@@ -1948,7 +1949,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders filtered state when
                                 {
                                   "alignItems": "center",
                                   "flex": 1,
-                                  "marginHorizontal": 16,
                                 }
                               }
                             >
@@ -2698,6 +2698,7 @@ exports[`StateSelectorModal Component Snapshot Tests renders filtered state when
                                 {
                                   "backgroundColor": "#ffffff",
                                   "flexDirection": "row",
+                                  "gap": 16,
                                   "padding": 16,
                                 },
                                 false,
@@ -2721,7 +2722,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders filtered state when
                                 {
                                   "alignItems": "center",
                                   "flex": 1,
-                                  "marginHorizontal": 16,
                                 }
                               }
                             >
@@ -3471,6 +3471,7 @@ exports[`StateSelectorModal Component Snapshot Tests renders initial state corre
                                 {
                                   "backgroundColor": "#ffffff",
                                   "flexDirection": "row",
+                                  "gap": 16,
                                   "padding": 16,
                                 },
                                 false,
@@ -3494,7 +3495,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders initial state corre
                                 {
                                   "alignItems": "center",
                                   "flex": 1,
-                                  "marginHorizontal": 16,
                                 }
                               }
                             >
@@ -4507,6 +4507,7 @@ exports[`StateSelectorModal Component Snapshot Tests renders partial search resu
                                 {
                                   "backgroundColor": "#ffffff",
                                   "flexDirection": "row",
+                                  "gap": 16,
                                   "padding": 16,
                                 },
                                 false,
@@ -4530,7 +4531,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders partial search resu
                                 {
                                   "alignItems": "center",
                                   "flex": 1,
-                                  "marginHorizontal": 16,
                                 }
                               }
                             >

--- a/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
@@ -435,6 +435,7 @@ exports[`TokenSelectorModal Component displays network filter selector when pres
                                 {
                                   "backgroundColor": "#ffffff",
                                   "flexDirection": "row",
+                                  "gap": 16,
                                   "padding": 16,
                                 },
                                 false,
@@ -458,7 +459,6 @@ exports[`TokenSelectorModal Component displays network filter selector when pres
                                 {
                                   "alignItems": "center",
                                   "flex": 1,
-                                  "marginHorizontal": 16,
                                 }
                               }
                             >
@@ -1256,6 +1256,7 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                 {
                                   "backgroundColor": "#ffffff",
                                   "flexDirection": "row",
+                                  "gap": 16,
                                   "padding": 16,
                                 },
                                 false,
@@ -1279,7 +1280,6 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                 {
                                   "alignItems": "center",
                                   "flex": 1,
-                                  "marginHorizontal": 16,
                                 }
                               }
                             >

--- a/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedRegionModal/__snapshots__/UnsupportedRegionModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedRegionModal/__snapshots__/UnsupportedRegionModal.test.tsx.snap
@@ -415,6 +415,7 @@ exports[`UnsupportedRegionModal handles missing region gracefully 1`] = `
                                 {
                                   "backgroundColor": "#ffffff",
                                   "flexDirection": "row",
+                                  "gap": 16,
                                   "padding": 16,
                                 },
                                 false,
@@ -438,7 +439,6 @@ exports[`UnsupportedRegionModal handles missing region gracefully 1`] = `
                                 {
                                   "alignItems": "center",
                                   "flex": 1,
-                                  "marginHorizontal": 16,
                                 }
                               }
                             >
@@ -1088,6 +1088,7 @@ exports[`UnsupportedRegionModal render match snapshot 1`] = `
                                 {
                                   "backgroundColor": "#ffffff",
                                   "flexDirection": "row",
+                                  "gap": 16,
                                   "padding": 16,
                                 },
                                 false,
@@ -1111,7 +1112,6 @@ exports[`UnsupportedRegionModal render match snapshot 1`] = `
                                 {
                                   "alignItems": "center",
                                   "flex": 1,
-                                  "marginHorizontal": 16,
                                 }
                               }
                             >

--- a/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedStateModal/__snapshots__/UnsupportedStateModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedStateModal/__snapshots__/UnsupportedStateModal.test.tsx.snap
@@ -415,6 +415,7 @@ exports[`UnsupportedStateModal render match snapshot 1`] = `
                                 {
                                   "backgroundColor": "#ffffff",
                                   "flexDirection": "row",
+                                  "gap": 16,
                                   "padding": 16,
                                 },
                                 false,
@@ -438,7 +439,6 @@ exports[`UnsupportedStateModal render match snapshot 1`] = `
                                 {
                                   "alignItems": "center",
                                   "flex": 1,
-                                  "marginHorizontal": 16,
                                 }
                               }
                             >

--- a/app/components/UI/Ramp/Deposit/Views/Modals/WebviewModal/__snapshots__/WebviewModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/WebviewModal/__snapshots__/WebviewModal.test.tsx.snap
@@ -436,6 +436,7 @@ exports[`WebviewModal Component renders correctly and matches snapshot 1`] = `
                                 {
                                   "backgroundColor": "#ffffff",
                                   "flexDirection": "row",
+                                  "gap": 16,
                                   "padding": 16,
                                   "paddingVertical": 0,
                                 },
@@ -460,7 +461,6 @@ exports[`WebviewModal Component renders correctly and matches snapshot 1`] = `
                                 {
                                   "alignItems": "center",
                                   "flex": 1,
-                                  "marginHorizontal": 16,
                                 }
                               }
                             />
@@ -992,6 +992,7 @@ exports[`WebviewModal Component should display error view when webview HTTP erro
                                 {
                                   "backgroundColor": "#ffffff",
                                   "flexDirection": "row",
+                                  "gap": 16,
                                   "padding": 16,
                                   "paddingVertical": 0,
                                 },
@@ -1016,7 +1017,6 @@ exports[`WebviewModal Component should display error view when webview HTTP erro
                                 {
                                   "alignItems": "center",
                                   "flex": 1,
-                                  "marginHorizontal": 16,
                                 }
                               }
                             />

--- a/app/components/UI/Stake/components/GasImpactModal/__snapshots__/GasImpactModal.test.tsx.snap
+++ b/app/components/UI/Stake/components/GasImpactModal/__snapshots__/GasImpactModal.test.tsx.snap
@@ -142,6 +142,7 @@ exports[`GasImpactModal render matches snapshot 1`] = `
                 {
                   "backgroundColor": "#ffffff",
                   "flexDirection": "row",
+                  "gap": 16,
                   "padding": 16,
                 },
                 false,
@@ -165,7 +166,6 @@ exports[`GasImpactModal render matches snapshot 1`] = `
                 {
                   "alignItems": "center",
                   "flex": 1,
-                  "marginHorizontal": 16,
                 }
               }
             >

--- a/app/components/UI/Stake/components/PoolStakingLearnMoreModal/__snapshots__/PoolStakingLearnMoreModal.test.tsx.snap
+++ b/app/components/UI/Stake/components/PoolStakingLearnMoreModal/__snapshots__/PoolStakingLearnMoreModal.test.tsx.snap
@@ -116,6 +116,7 @@ exports[`PoolStakingLearnMoreModal render matches snapshot 1`] = `
                 {
                   "backgroundColor": "#ffffff",
                   "flexDirection": "row",
+                  "gap": 16,
                   "padding": 16,
                 },
                 false,
@@ -139,7 +140,6 @@ exports[`PoolStakingLearnMoreModal render matches snapshot 1`] = `
                 {
                   "alignItems": "center",
                   "flex": 1,
-                  "marginHorizontal": 16,
                 }
               }
             >

--- a/app/components/UI/UpdateNeeded/__snapshots__/UpdateNeeded.test.tsx.snap
+++ b/app/components/UI/UpdateNeeded/__snapshots__/UpdateNeeded.test.tsx.snap
@@ -396,6 +396,7 @@ exports[`UpdateNeeded should render snapshot correctly 1`] = `
                                 "alignItems": "center",
                                 "backgroundColor": "#ffffff",
                                 "flexDirection": "row",
+                                "gap": 16,
                               },
                               {
                                 "marginTop": 0,
@@ -420,7 +421,6 @@ exports[`UpdateNeeded should render snapshot correctly 1`] = `
                               {
                                 "alignItems": "center",
                                 "flex": 1,
-                                "marginHorizontal": 16,
                               }
                             }
                           >

--- a/app/components/Views/AccountPermissions/AccountPermissionsConfirmRevokeAll/__snapshots__/AccountPermissionsConfirmRevokeAll.test.tsx.snap
+++ b/app/components/Views/AccountPermissions/AccountPermissionsConfirmRevokeAll/__snapshots__/AccountPermissionsConfirmRevokeAll.test.tsx.snap
@@ -132,6 +132,7 @@ exports[`AccountPermissionsConfirmRevokeAll renders correctly 1`] = `
               {
                 "backgroundColor": "#ffffff",
                 "flexDirection": "row",
+                "gap": 16,
                 "padding": 16,
               },
               false,
@@ -142,20 +143,8 @@ exports[`AccountPermissionsConfirmRevokeAll renders correctly 1`] = `
           <View
             style={
               {
-                "width": undefined,
-              }
-            }
-          >
-            <View
-              onLayout={[Function]}
-            />
-          </View>
-          <View
-            style={
-              {
                 "alignItems": "center",
                 "flex": 1,
-                "marginHorizontal": 16,
               }
             }
           >
@@ -173,17 +162,6 @@ exports[`AccountPermissionsConfirmRevokeAll renders correctly 1`] = `
             >
               Disconnect all
             </Text>
-          </View>
-          <View
-            style={
-              {
-                "width": undefined,
-              }
-            }
-          >
-            <View
-              onLayout={[Function]}
-            />
           </View>
         </View>
         <View

--- a/app/components/Views/AccountPermissions/ConnectionDetails/__snapshots__/ConnectionDetails.test.tsx.snap
+++ b/app/components/Views/AccountPermissions/ConnectionDetails/__snapshots__/ConnectionDetails.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`ConnectionDetails renders correctly 1`] = `
         {
           "backgroundColor": "#ffffff",
           "flexDirection": "row",
+          "gap": 16,
           "padding": 16,
         },
         false,
@@ -25,20 +26,8 @@ exports[`ConnectionDetails renders correctly 1`] = `
     <View
       style={
         {
-          "width": undefined,
-        }
-      }
-    >
-      <View
-        onLayout={[Function]}
-      />
-    </View>
-    <View
-      style={
-        {
           "alignItems": "center",
           "flex": 1,
-          "marginHorizontal": 16,
         }
       }
     >
@@ -56,17 +45,6 @@ exports[`ConnectionDetails renders correctly 1`] = `
       >
         Connection Details
       </Text>
-    </View>
-    <View
-      style={
-        {
-          "width": undefined,
-        }
-      }
-    >
-      <View
-        onLayout={[Function]}
-      />
     </View>
   </View>
   <View

--- a/app/components/Views/AccountPermissions/PermittedNetworksInfoSheet/__snapshots__/PermittedNetworksInfoSheet.test.tsx.snap
+++ b/app/components/Views/AccountPermissions/PermittedNetworksInfoSheet/__snapshots__/PermittedNetworksInfoSheet.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`PermittedNetworksInfoSheet should render correctly 1`] = `
         {
           "backgroundColor": "#ffffff",
           "flexDirection": "row",
+          "gap": 16,
           "padding": 16,
         },
         false,
@@ -26,20 +27,8 @@ exports[`PermittedNetworksInfoSheet should render correctly 1`] = `
     <View
       style={
         {
-          "width": undefined,
-        }
-      }
-    >
-      <View
-        onLayout={[Function]}
-      />
-    </View>
-    <View
-      style={
-        {
           "alignItems": "center",
           "flex": 1,
-          "marginHorizontal": 16,
         }
       }
     >
@@ -57,17 +46,6 @@ exports[`PermittedNetworksInfoSheet should render correctly 1`] = `
       >
         Permitted networks
       </Text>
-    </View>
-    <View
-      style={
-        {
-          "width": undefined,
-        }
-      }
-    >
-      <View
-        onLayout={[Function]}
-      />
     </View>
   </View>
   <View

--- a/app/components/Views/ActivityView/index.js
+++ b/app/components/Views/ActivityView/index.js
@@ -33,7 +33,6 @@ import { selectIsEvmNetworkSelected } from '../../../selectors/multichainNetwork
 import { selectNetworkName } from '../../../selectors/networkInfos';
 import { IconName } from '../../../component-library/components/Icons/Icon';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { DEFAULT_HEADERBASE_TITLE_TEXTVARIANT } from '../../../component-library/components/HeaderBase/HeaderBase.constants';
 import { typography } from '@metamask/design-tokens';
 import { useStyles } from '../../hooks/useStyles';
 import TextComponent, {
@@ -209,10 +208,7 @@ const ActivityView = () => {
   return (
     <ErrorBoundary navigation={navigation} view="ActivityView">
       <View style={[styles.header, { marginTop: insets.top }]}>
-        <Text
-          style={styles.title}
-          variant={DEFAULT_HEADERBASE_TITLE_TEXTVARIANT}
-        >
+        <Text style={styles.title} variant={TextVariant.HeadingSM}>
           {strings('transactions_view.title')}
         </Text>
       </View>

--- a/app/components/Views/Asset/__snapshots__/index.test.js.snap
+++ b/app/components/Views/Asset/__snapshots__/index.test.js.snap
@@ -281,6 +281,7 @@ exports[`Asset Multichain Functionality should exclude mixed token/SOL transacti
               {
                 "backgroundColor": "#ffffff",
                 "flexDirection": "row",
+                "gap": 16,
               },
               {
                 "marginTop": 0,
@@ -388,7 +389,6 @@ exports[`Asset Multichain Functionality should exclude mixed token/SOL transacti
               {
                 "alignItems": "center",
                 "flex": 1,
-                "marginHorizontal": 16,
               }
             }
           >
@@ -2123,6 +2123,7 @@ exports[`Asset Multichain Functionality should exclude transactions with empty a
               {
                 "backgroundColor": "#ffffff",
                 "flexDirection": "row",
+                "gap": 16,
               },
               {
                 "marginTop": 0,
@@ -2230,7 +2231,6 @@ exports[`Asset Multichain Functionality should exclude transactions with empty a
               {
                 "alignItems": "center",
                 "flex": 1,
-                "marginHorizontal": 16,
               }
             }
           >
@@ -3965,6 +3965,7 @@ exports[`Asset Multichain Functionality should filter SPL token transactions cor
               {
                 "backgroundColor": "#ffffff",
                 "flexDirection": "row",
+                "gap": 16,
               },
               {
                 "marginTop": 0,
@@ -4072,7 +4073,6 @@ exports[`Asset Multichain Functionality should filter SPL token transactions cor
               {
                 "alignItems": "center",
                 "flex": 1,
-                "marginHorizontal": 16,
               }
             }
           >
@@ -5846,6 +5846,7 @@ exports[`Asset Multichain Functionality should filter native SOL transactions co
               {
                 "backgroundColor": "#ffffff",
                 "flexDirection": "row",
+                "gap": 16,
               },
               {
                 "marginTop": 0,
@@ -5953,7 +5954,6 @@ exports[`Asset Multichain Functionality should filter native SOL transactions co
               {
                 "alignItems": "center",
                 "flex": 1,
-                "marginHorizontal": 16,
               }
             }
           >
@@ -7688,6 +7688,7 @@ exports[`Asset Multichain Functionality should handle state with no multichain t
               {
                 "backgroundColor": "#ffffff",
                 "flexDirection": "row",
+                "gap": 16,
               },
               {
                 "marginTop": 0,
@@ -7795,7 +7796,6 @@ exports[`Asset Multichain Functionality should handle state with no multichain t
               {
                 "alignItems": "center",
                 "flex": 1,
-                "marginHorizontal": 16,
               }
             }
           >
@@ -9530,6 +9530,7 @@ exports[`Asset Multichain Functionality should handle unknown SPL token filterin
               {
                 "backgroundColor": "#ffffff",
                 "flexDirection": "row",
+                "gap": 16,
               },
               {
                 "marginTop": 0,
@@ -9637,7 +9638,6 @@ exports[`Asset Multichain Functionality should handle unknown SPL token filterin
               {
                 "alignItems": "center",
                 "flex": 1,
-                "marginHorizontal": 16,
               }
             }
           >
@@ -11411,6 +11411,7 @@ exports[`Asset Multichain Functionality should render EVM assets with Transactio
               {
                 "backgroundColor": "#ffffff",
                 "flexDirection": "row",
+                "gap": 16,
               },
               {
                 "marginTop": 0,
@@ -11518,7 +11519,6 @@ exports[`Asset Multichain Functionality should render EVM assets with Transactio
               {
                 "alignItems": "center",
                 "flex": 1,
-                "marginHorizontal": 16,
               }
             }
           >
@@ -11941,6 +11941,7 @@ exports[`Asset Multichain Functionality should render non-EVM assets with Multic
               {
                 "backgroundColor": "#ffffff",
                 "flexDirection": "row",
+                "gap": 16,
               },
               {
                 "marginTop": 0,
@@ -12048,7 +12049,6 @@ exports[`Asset Multichain Functionality should render non-EVM assets with Multic
               {
                 "alignItems": "center",
                 "flex": 1,
-                "marginHorizontal": 16,
               }
             }
           >
@@ -13783,6 +13783,7 @@ exports[`Asset Multichain Functionality should sort filtered transactions by tim
               {
                 "backgroundColor": "#ffffff",
                 "flexDirection": "row",
+                "gap": 16,
               },
               {
                 "marginTop": 0,
@@ -13890,7 +13891,6 @@ exports[`Asset Multichain Functionality should sort filtered transactions by tim
               {
                 "alignItems": "center",
                 "flex": 1,
-                "marginHorizontal": 16,
               }
             }
           >
@@ -15625,6 +15625,7 @@ exports[`Asset Multichain Functionality should use EVM transactions for EVM acco
               {
                 "backgroundColor": "#ffffff",
                 "flexDirection": "row",
+                "gap": 16,
               },
               {
                 "marginTop": 0,
@@ -15732,7 +15733,6 @@ exports[`Asset Multichain Functionality should use EVM transactions for EVM acco
               {
                 "alignItems": "center",
                 "flex": 1,
-                "marginHorizontal": 16,
               }
             }
           >

--- a/app/components/Views/NetworkSelector/RpcSelectionModal/__snapshots__/RpcSelectionModal.test.tsx.snap
+++ b/app/components/Views/NetworkSelector/RpcSelectionModal/__snapshots__/RpcSelectionModal.test.tsx.snap
@@ -124,6 +124,7 @@ exports[`RpcSelectionModal should render correctly when visible 1`] = `
             {
               "backgroundColor": "#ffffff",
               "flexDirection": "row",
+              "gap": 16,
               "padding": 16,
             },
             false,
@@ -134,20 +135,8 @@ exports[`RpcSelectionModal should render correctly when visible 1`] = `
         <View
           style={
             {
-              "width": undefined,
-            }
-          }
-        >
-          <View
-            onLayout={[Function]}
-          />
-        </View>
-        <View
-          style={
-            {
               "alignItems": "center",
               "flex": 1,
-              "marginHorizontal": 16,
             }
           }
         >
@@ -274,17 +263,6 @@ exports[`RpcSelectionModal should render correctly when visible 1`] = `
               </View>
             </View>
           </TouchableOpacity>
-        </View>
-        <View
-          style={
-            {
-              "width": undefined,
-            }
-          }
-        >
-          <View
-            onLayout={[Function]}
-          />
         </View>
       </View>
       <View

--- a/app/components/Views/Wallet/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Wallet/__snapshots__/index.test.tsx.snap
@@ -58,6 +58,7 @@ exports[`Wallet Conditional Rendering should render banner when basic functional
                 "borderBottomColor": "#b7bbc866",
                 "borderBottomWidth": 1,
                 "flexDirection": "row",
+                "gap": 16,
                 "height": 72,
               },
               {
@@ -168,7 +169,6 @@ exports[`Wallet Conditional Rendering should render banner when basic functional
               {
                 "alignItems": "center",
                 "flex": 1,
-                "marginHorizontal": 16,
               }
             }
           >
@@ -1170,6 +1170,7 @@ exports[`Wallet Conditional Rendering should render loader when no selected acco
                 "borderBottomColor": "#b7bbc866",
                 "borderBottomWidth": 1,
                 "flexDirection": "row",
+                "gap": 16,
                 "height": 72,
               },
               {
@@ -1280,7 +1281,6 @@ exports[`Wallet Conditional Rendering should render loader when no selected acco
               {
                 "alignItems": "center",
                 "flex": 1,
-                "marginHorizontal": 16,
               }
             }
           >
@@ -2282,6 +2282,7 @@ exports[`Wallet should render correctly 1`] = `
                 "borderBottomColor": "#b7bbc866",
                 "borderBottomWidth": 1,
                 "flexDirection": "row",
+                "gap": 16,
                 "height": 72,
               },
               {
@@ -2392,7 +2393,6 @@ exports[`Wallet should render correctly 1`] = `
               {
                 "alignItems": "center",
                 "flex": 1,
-                "marginHorizontal": 16,
               }
             }
           >
@@ -3394,6 +3394,7 @@ exports[`Wallet should render correctly when Solana support is enabled 1`] = `
                 "borderBottomColor": "#b7bbc866",
                 "borderBottomWidth": 1,
                 "flexDirection": "row",
+                "gap": 16,
                 "height": 72,
               },
               {
@@ -3504,7 +3505,6 @@ exports[`Wallet should render correctly when Solana support is enabled 1`] = `
               {
                 "alignItems": "center",
                 "flex": 1,
-                "marginHorizontal": 16,
               }
             }
           >
@@ -4506,6 +4506,7 @@ exports[`Wallet should render correctly when there are no detected tokens 1`] = 
                 "borderBottomColor": "#b7bbc866",
                 "borderBottomWidth": 1,
                 "flexDirection": "row",
+                "gap": 16,
                 "height": 72,
               },
               {
@@ -4616,7 +4617,6 @@ exports[`Wallet should render correctly when there are no detected tokens 1`] = 
               {
                 "alignItems": "center",
                 "flex": 1,
-                "marginHorizontal": 16,
               }
             }
           >


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR refactors the HeaderBase component to align with the MetaMask Design System (MMDS) Figma specifications by replacing the `align` prop with a more comprehensive `variant` prop system.

### What is the reason for the change?
The previous implementation used an `align` prop that was based on incorrect Figma references. The actual MMDS Figma component uses a variant-based approach that provides a more elegant and holistic solution for header configurations.

### What is the improvement/solution?
1. **Replaced `align` prop with `variant` prop**: Instead of just controlling alignment, the new variant system (`Display` and `Compact`) manages both:
   - Text alignment (left for Display, center for Compact)
   - Text size variant (HeadingLG for Display, HeadingSM for Compact)
   
2. **Optimized accessory wrapper rendering**: Accessory wrappers are now conditionally rendered based on:
   - The variant being used
   - Whether accessories actually exist
   
   This improvement:
   - Fixes misalignment issues in the Display variant where empty wrappers were taking up space
   - Increases the available area for title text, reducing unnecessary truncation or wrapping
   - Improves overall layout efficiency

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: 

## **Manual testing steps**

```gherkin
Feature: HeaderBase Component Variants

  Scenario: User views a header with Display variant
    Given the app is open with a screen using HeaderBase
    
    When the HeaderBase uses variant={HeaderBaseVariant.Display}
    Then the title should be left-aligned
    And the title should use HeadingLG text size
    And only necessary accessory wrappers should be rendered

  Scenario: User views a header with Compact variant  
    Given the app is open with a screen using HeaderBase
    
    When the HeaderBase uses variant={HeaderBaseVariant.Compact}
    Then the title should be center-aligned
    And the title should use HeadingSM text size
    And accessory wrappers should be rendered for visual centering when needed

  Scenario: User views a header without accessories
    Given the app is open with a screen using HeaderBase
    
    When the HeaderBase has no startAccessory or endAccessory props
    Then no empty accessory wrappers should be rendered
    And the title should have maximum available width
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
- Headers used `align` prop with only alignment control
- Empty accessory wrappers were always rendered
- Text variant was fixed regardless of alignment



### **After**
- Headers use `variant` prop with cohesive design system alignment
- Accessory wrappers are conditionally rendered
- Text variant changes appropriately with variant selection
- Better space utilization for title text

https://github.com/user-attachments/assets/8c7eb242-b49b-4690-81ad-41348f8b4194

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.