### PR TITLE
fix: Updated Wallet Header's alignment

### DIFF
--- a/app/component-library/components/HeaderBase/index.ts
+++ b/app/component-library/components/HeaderBase/index.ts
@@ -1,1 +1,2 @@
 export { default } from './HeaderBase';
+export { HeaderBaseVariant } from './HeaderBase.types';

--- a/app/component-library/components/Pickers/PickerAccount/PickerAccount.tsx
+++ b/app/component-library/components/Pickers/PickerAccount/PickerAccount.tsx
@@ -60,6 +60,7 @@ const PickerAccount: React.ForwardRefRenderFunction<
       <DSText
         variant={TextVariant.BodyMDMedium}
         testID={WalletViewSelectorsIDs.ACCOUNT_NAME_LABEL_TEXT}
+        numberOfLines={1}
       >
         {accountName}
       </DSText>

--- a/app/component-library/components/Pickers/PickerAccount/__snapshots__/PickerAccount.test.tsx.snap
+++ b/app/component-library/components/Pickers/PickerAccount/__snapshots__/PickerAccount.test.tsx.snap
@@ -28,6 +28,7 @@ exports[`PickerAccount Props Forwarding forwards hitSlop prop to PickerBase 1`] 
 >
   <Text
     accessibilityRole="text"
+    numberOfLines={1}
     style={
       {
         "color": "#121314",
@@ -79,6 +80,7 @@ exports[`PickerAccount Props Forwarding forwards style prop 1`] = `
 >
   <Text
     accessibilityRole="text"
+    numberOfLines={1}
     style={
       {
         "color": "#121314",
@@ -129,6 +131,7 @@ exports[`PickerAccount Rendering should render correctly with snapshot 1`] = `
 >
   <Text
     accessibilityRole="text"
+    numberOfLines={1}
     style={
       {
         "color": "#121314",

--- a/app/components/UI/Navbar/index.js
+++ b/app/components/UI/Navbar/index.js
@@ -1038,7 +1038,7 @@ export function getWalletNavbarOptions(
     }
   }
 
-  const isFeatureFlagEnabled = true;
+  const isFeatureFlagEnabled = isRemoveGlobalNetworkSelectorEnabled();
 
   const handleCardPress = () => {
     trackEvent(

--- a/app/components/UI/Navbar/index.js
+++ b/app/components/UI/Navbar/index.js
@@ -43,7 +43,9 @@ import Icon, {
   IconColor,
 } from '../../../component-library/components/Icons/Icon';
 import { AddContactViewSelectorsIDs } from '../../../../e2e/selectors/Settings/Contacts/AddContactView.selectors';
-import HeaderBase from '../../../component-library/components/HeaderBase';
+import HeaderBase, {
+  HeaderBaseVariant,
+} from '../../../component-library/components/HeaderBase';
 import AddressCopy from '../AddressCopy';
 import PickerAccount from '../../../component-library/components/Pickers/PickerAccount';
 import { createAccountSelectorNavDetails } from '../../../components/Views/AccountSelector';
@@ -1036,7 +1038,7 @@ export function getWalletNavbarOptions(
     }
   }
 
-  const isFeatureFlagEnabled = isRemoveGlobalNetworkSelectorEnabled();
+  const isFeatureFlagEnabled = true;
 
   const handleCardPress = () => {
     trackEvent(
@@ -1085,24 +1087,6 @@ export function getWalletNavbarOptions(
     </View>
   );
 
-  // Account picker component
-  const accountPicker = (
-    <PickerAccount
-      ref={accountActionsRef}
-      accountName={accountName}
-      onPress={() => {
-        trace({
-          name: TraceName.AccountList,
-          tags: getTraceTags(store.getState()),
-          op: TraceOperation.AccountList,
-        });
-        navigation.navigate(...createAccountSelectorNavDetails({}));
-      }}
-      testID={WalletViewSelectorsIDs.ACCOUNT_ICON}
-      hitSlop={innerStyles.touchAreaSlop}
-    />
-  );
-
   // Network picker component
   const networkPicker = (
     <PickerNetwork
@@ -1120,17 +1104,45 @@ export function getWalletNavbarOptions(
     header: () => (
       <HeaderBase
         includesTopInset
+        variant={
+          isFeatureFlagEnabled
+            ? HeaderBaseVariant.Display
+            : HeaderBaseVariant.Compact
+        }
         style={innerStyles.headerContainer}
         startAccessory={
-          <View style={innerStyles.startAccessoryContainer}>
-            {!isFeatureFlagEnabled ? networkPicker : accountPicker}
-          </View>
+          !isFeatureFlagEnabled && (
+            <View style={innerStyles.startAccessoryContainer}>
+              <PickerNetwork
+                onPress={onPressTitle}
+                label={networkName}
+                imageSource={networkImageSource}
+                testID={WalletViewSelectorsIDs.NAVBAR_NETWORK_BUTTON}
+                hideNetworkName
+                hitSlop={innerStyles.touchAreaSlop}
+                style={innerStyles.networkPickerStyle}
+              />
+            </View>
+          )
         }
         endAccessory={
           <View style={innerStyles.endAccessoryContainer}>{actionButtons}</View>
         }
       >
-        {!isFeatureFlagEnabled ? accountPicker : null}
+        <PickerAccount
+          ref={accountActionsRef}
+          accountName={accountName}
+          onPress={() => {
+            trace({
+              name: TraceName.AccountList,
+              tags: getTraceTags(store.getState()),
+              op: TraceOperation.AccountList,
+            });
+            navigation.navigate(...createAccountSelectorNavDetails({}));
+          }}
+          testID={WalletViewSelectorsIDs.ACCOUNT_ICON}
+          hitSlop={innerStyles.touchAreaSlop}
+        />
       </HeaderBase>
     ),
   };

--- a/app/components/UI/Navbar/index.js
+++ b/app/components/UI/Navbar/index.js
@@ -1049,57 +1049,6 @@ export function getWalletNavbarOptions(
     navigation.navigate(Routes.CARD.ROOT);
   };
 
-  // Action buttons for right side
-  const actionButtons = (
-    <View style={innerStyles.actionButtonsContainer}>
-      <View testID={WalletViewSelectorsIDs.NAVBAR_ADDRESS_COPY_BUTTON}>
-        <AddressCopy
-          account={selectedInternalAccount}
-          hitSlop={innerStyles.touchAreaSlop}
-        />
-      </View>
-      {isCardholder ? (
-        <CardButton
-          onPress={handleCardPress}
-          touchAreaSlop={innerStyles.touchAreaSlop}
-        />
-      ) : null}
-      {isNotificationsFeatureEnabled() && (
-        <BadgeWrapper
-          position={BadgeWrapperPosition.TopRight}
-          positionAnchorShape={BadgeWrapperPositionAnchorShape.Circular}
-          badge={
-            isNotificationEnabled && unreadNotificationCount > 0 ? (
-              <BadgeStatus status={BadgeStatusStatus.Active} />
-            ) : null
-          }
-        >
-          <ButtonIcon
-            iconProps={{ color: MMDSIconColor.Default }}
-            onPress={handleNotificationOnPress}
-            iconName={IconName.Notification}
-            size={ButtonIconSize.Lg}
-            testID={WalletViewSelectorsIDs.WALLET_NOTIFICATIONS_BUTTON}
-            hitSlop={innerStyles.touchAreaSlop}
-          />
-        </BadgeWrapper>
-      )}
-    </View>
-  );
-
-  // Network picker component
-  const networkPicker = (
-    <PickerNetwork
-      onPress={onPressTitle}
-      label={networkName}
-      imageSource={networkImageSource}
-      testID={WalletViewSelectorsIDs.NAVBAR_NETWORK_BUTTON}
-      hideNetworkName
-      hitSlop={innerStyles.touchAreaSlop}
-      style={innerStyles.networkPickerStyle}
-    />
-  );
-
   return {
     header: () => (
       <HeaderBase
@@ -1126,7 +1075,50 @@ export function getWalletNavbarOptions(
           )
         }
         endAccessory={
-          <View style={innerStyles.endAccessoryContainer}>{actionButtons}</View>
+          <View style={innerStyles.endAccessoryContainer}>
+            {
+              <View style={innerStyles.actionButtonsContainer}>
+                <View
+                  testID={WalletViewSelectorsIDs.NAVBAR_ADDRESS_COPY_BUTTON}
+                >
+                  <AddressCopy
+                    account={selectedInternalAccount}
+                    hitSlop={innerStyles.touchAreaSlop}
+                  />
+                </View>
+                {isCardholder ? (
+                  <CardButton
+                    onPress={handleCardPress}
+                    touchAreaSlop={innerStyles.touchAreaSlop}
+                  />
+                ) : null}
+                {isNotificationsFeatureEnabled() && (
+                  <BadgeWrapper
+                    position={BadgeWrapperPosition.TopRight}
+                    positionAnchorShape={
+                      BadgeWrapperPositionAnchorShape.Circular
+                    }
+                    badge={
+                      isNotificationEnabled && unreadNotificationCount > 0 ? (
+                        <BadgeStatus status={BadgeStatusStatus.Active} />
+                      ) : null
+                    }
+                  >
+                    <ButtonIcon
+                      iconProps={{ color: MMDSIconColor.Default }}
+                      onPress={handleNotificationOnPress}
+                      iconName={IconName.Notification}
+                      size={ButtonIconSize.Lg}
+                      testID={
+                        WalletViewSelectorsIDs.WALLET_NOTIFICATIONS_BUTTON
+                      }
+                      hitSlop={innerStyles.touchAreaSlop}
+                    />
+                  </BadgeWrapper>
+                )}
+              </View>
+            }
+          </View>
         }
       >
         <PickerAccount

--- a/app/components/Views/Wallet/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Wallet/__snapshots__/index.test.tsx.snap
@@ -200,6 +200,7 @@ exports[`Wallet Conditional Rendering should render banner when basic functional
             >
               <Text
                 accessibilityRole="text"
+                numberOfLines={1}
                 style={
                   {
                     "color": "#121314",
@@ -1312,6 +1313,7 @@ exports[`Wallet Conditional Rendering should render loader when no selected acco
             >
               <Text
                 accessibilityRole="text"
+                numberOfLines={1}
                 style={
                   {
                     "color": "#121314",
@@ -2424,6 +2426,7 @@ exports[`Wallet should render correctly 1`] = `
             >
               <Text
                 accessibilityRole="text"
+                numberOfLines={1}
                 style={
                   {
                     "color": "#121314",
@@ -3536,6 +3539,7 @@ exports[`Wallet should render correctly when Solana support is enabled 1`] = `
             >
               <Text
                 accessibilityRole="text"
+                numberOfLines={1}
                 style={
                   {
                     "color": "#121314",
@@ -4648,6 +4652,7 @@ exports[`Wallet should render correctly when there are no detected tokens 1`] = 
             >
               <Text
                 accessibilityRole="text"
+                numberOfLines={1}
                 style={
                   {
                     "color": "#121314",


### PR DESCRIPTION
This PR ensures that for accounts with long names, it should ellipsify the names in app header

CHANGELOG entry:

## **Related issues**

Fixes:
[18191](https://github.com/MetaMask/metamask-mobile/issues/18191)
[18198](https://github.com/MetaMask/metamask-mobile/issues/18198)

## **Manual testing steps**

1. select an account with a longer name
2. Lock and unlock the wallet a couple of times
3. Notice the Copy address and Notifications buttons should appear

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
Without Remove GNS
https://github.com/user-attachments/assets/90ffaca1-282f-429e-b725-1f1ef06249aa

With Remove GNS
https://github.com/user-attachments/assets/f0450c7b-40a4-4d0e-997b-dce62cd11bf0




## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
