### PR TITLE
feat: use perps deposit confirmation (#18224)

### DIFF
--- a/.github/workflows/release-pr-approval.yml
+++ b/.github/workflows/release-pr-approval.yml
@@ -1,0 +1,17 @@
+name: Release PR Approval
+
+on:
+  pull_request:
+    branches:
+      - Version-v*
+      - release/*
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require Release Team approval
+        uses: op5dev/require-team-approval@dfd7b8b9a88bf82a955c103f7e19642b0411aecd
+        with:
+          team: release-team
+          token: ${{ secrets.METAMASK_EXTENSION_READ_TOKEN }}


### PR DESCRIPTION
## **Description**

This PR adds a new GitHub Actions workflow to enforce release team approval on pull requests targeting release branches (`Version-v*` and `release/*`). This provides an additional security layer for the release process by ensuring that PRs to release branches require explicit approval from the designated release team before they can be merged.

The workflow uses the `op5dev/require-team-approval` action (pinned to commit hash for security) and will automatically check for the required team approval whenever a PR is opened or updated against release branches.


## **Related issues**

Fixes: INFRA-2845

## **Manual testing steps**

1. Create a test PR targeting a release branch (e.g., `Version-v*` or `release/*`)
2. Verify the "Release PR Approval" workflow runs and shows as a required check
3. Confirm the check fails if the PR doesn't have approval from a `release-team` member
4. Have a `release-team` member approve the PR
5. Verify the check passes after team approval


### **Before**
No team approval requirement on release PRs

### **After**
Release team approval enforced via GitHub Actions check

