### PR TITLE
feat: get quotes directly in metamask pay

### DIFF
--- a/app/components/Views/confirmations/components/footer/footer.test.tsx
+++ b/app/components/Views/confirmations/components/footer/footer.test.tsx
@@ -16,6 +16,12 @@ import { useConfirmationContext } from '../../context/confirmation-context';
 import { useAlertsConfirmed } from '../../../../hooks/useAlertsConfirmed';
 import { Severity } from '../../types/alerts';
 import { useConfirmationAlertMetrics } from '../../hooks/metrics/useConfirmationAlertMetrics';
+import { merge } from 'lodash';
+import {
+  simpleSendTransactionControllerMock,
+  transactionIdMock,
+} from '../../__mocks__/controllers/transaction-controller-mock';
+import { transactionApprovalControllerMock } from '../../__mocks__/controllers/approval-controller-mock';
 
 const mockConfirmSpy = jest.fn();
 const mockRejectSpy = jest.fn();
@@ -192,6 +198,29 @@ describe('Footer', () => {
     const { getByTestId } = renderWithProvider(<Footer />, {
       state: personalSignatureConfirmationState,
     });
+    expect(
+      getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON).props.disabled,
+    ).toBe(true);
+  });
+
+  it('disables confirm button if quotes are loading', () => {
+    const state = merge(
+      {},
+      simpleSendTransactionControllerMock,
+      transactionApprovalControllerMock,
+      {
+        confirmationMetrics: {
+          isTransactionBridgeQuotesLoadingById: {
+            [transactionIdMock]: true,
+          },
+        },
+      },
+    );
+
+    const { getByTestId } = renderWithProvider(<Footer />, {
+      state,
+    });
+
     expect(
       getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON).props.disabled,
     ).toBe(true);

--- a/app/components/Views/confirmations/components/footer/footer.tsx
+++ b/app/components/Views/confirmations/components/footer/footer.tsx
@@ -30,6 +30,9 @@ import { useConfirmActions } from '../../hooks/useConfirmActions';
 import { isStakingConfirmation } from '../../utils/confirm';
 import styleSheet from './footer.styles';
 import Routes from '../../../../../constants/navigation/Routes';
+import { selectIsTransactionBridgeQuotesLoadingById } from '../../../../../core/redux/slices/confirmationMetrics';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../../../../reducers';
 
 export const Footer = () => {
   const {
@@ -39,23 +42,35 @@ export const Footer = () => {
     hasDangerAlerts,
     hasUnconfirmedDangerAlerts,
   } = useAlerts();
-  const { onConfirm, onReject } = useConfirmActions();
+
   const { isQRSigningInProgress, needsCameraPermission } =
     useQRHardwareContext();
+
+  const { onConfirm, onReject } = useConfirmActions();
   const { securityAlertResponse } = useSecurityAlertResponse();
   const confirmDisabled = needsCameraPermission;
   const transactionMetadata = useTransactionMetadataRequest();
   const { trackAlertMetrics } = useConfirmationAlertMetrics();
   const { isFullScreenConfirmation } = useFullScreenConfirmation();
+
   const isStakingConfirmationBool = isStakingConfirmation(
     transactionMetadata?.type as string,
   );
+
   const { isFooterVisible, isTransactionValueUpdating } =
     useConfirmationContext();
+
   const navigation = useNavigation();
 
   const [confirmAlertModalVisible, setConfirmAlertModalVisible] =
     useState(false);
+
+  const isQuotesLoading = useSelector((state: RootState) =>
+    selectIsTransactionBridgeQuotesLoadingById(
+      state,
+      transactionMetadata?.id ?? '',
+    ),
+  );
 
   const showConfirmAlertModal = useCallback(() => {
     setConfirmAlertModalVisible(true);
@@ -121,6 +136,12 @@ export const Footer = () => {
     }
   };
 
+  const isConfirmDisabled =
+    needsCameraPermission ||
+    hasBlockingAlerts ||
+    isTransactionValueUpdating ||
+    isQuotesLoading;
+
   const buttons = [
     {
       variant: ButtonVariants.Secondary,
@@ -134,10 +155,7 @@ export const Footer = () => {
       isDanger:
         securityAlertResponse?.result_type === ResultType.Malicious ||
         hasDangerAlerts,
-      isDisabled:
-        needsCameraPermission ||
-        hasBlockingAlerts ||
-        isTransactionValueUpdating,
+      isDisabled: isConfirmDisabled,
       label: confirmButtonLabel(),
       size: ButtonSize.Lg,
       onPress: onSignConfirm,

--- a/app/components/Views/confirmations/utils/bridge.test.ts
+++ b/app/components/Views/confirmations/utils/bridge.test.ts
@@ -1,7 +1,7 @@
 import {
   BridgeController,
   BridgeControllerEvents,
-  BridgeControllerState,
+  FeatureId,
   QuoteResponse,
 } from '@metamask/bridge-controller';
 import Engine from '../../../../core/Engine';
@@ -32,6 +32,7 @@ const QUOTE_REQUEST_2_MOCK: BridgeQuoteRequest = {
 };
 
 const QUOTE_1_MOCK = {
+  estimatedProcessingTimeInSeconds: 20,
   quote: {
     destAsset: {
       address: QUOTE_REQUEST_1_MOCK.targetTokenAddress,
@@ -40,6 +41,7 @@ const QUOTE_1_MOCK = {
 } as unknown as QuoteResponse;
 
 const QUOTE_2_MOCK = {
+  estimatedProcessingTimeInSeconds: 10,
   quote: {
     destAsset: {
       address: QUOTE_REQUEST_2_MOCK.targetTokenAddress,
@@ -63,8 +65,7 @@ describe('Confirmations Bridge Utils', () => {
     messengerMock = new ExtendedControllerMessenger();
 
     bridgeControllerMock = {
-      resetState: jest.fn(),
-      updateBridgeQuoteRequestParams: jest.fn().mockResolvedValue({}),
+      fetchQuotes: jest.fn(),
     } as unknown as jest.Mocked<BridgeController>;
 
     gasFeeControllerMock = {
@@ -78,34 +79,13 @@ describe('Confirmations Bridge Utils', () => {
     selectBridgeQuotesMock.mockImplementation(
       (state) =>
         ({
-          recommendedQuote:
-            state.engine.backgroundState.BridgeController.quotes[0],
+          sortedQuotes: state.engine.backgroundState.BridgeController.quotes,
         } as never),
     );
 
-    bridgeControllerMock.updateBridgeQuoteRequestParams
-      .mockImplementationOnce(() => {
-        messengerMock.publish(
-          'BridgeController:stateChange',
-          {
-            quotes: [QUOTE_1_MOCK],
-          } as BridgeControllerState,
-          [],
-        );
-
-        return Promise.resolve();
-      })
-      .mockImplementationOnce(() => {
-        messengerMock.publish(
-          'BridgeController:stateChange',
-          {
-            quotes: [QUOTE_2_MOCK],
-          } as BridgeControllerState,
-          [],
-        );
-
-        return Promise.resolve();
-      });
+    bridgeControllerMock.fetchQuotes
+      .mockResolvedValueOnce([QUOTE_1_MOCK])
+      .mockResolvedValueOnce([QUOTE_2_MOCK]);
 
     gasFeeControllerMock.fetchGasFeeEstimates.mockResolvedValue({
       gasFeeEstimates: {
@@ -139,70 +119,10 @@ describe('Confirmations Bridge Utils', () => {
       expect(quotes).toStrictEqual([QUOTE_1_MOCK, QUOTE_2_MOCK]);
     });
 
-    it('returns undefined if quotes not found after timeout', async () => {
-      bridgeControllerMock.updateBridgeQuoteRequestParams.mockReset();
+    it('requests quotes', async () => {
+      await getBridgeQuotes([QUOTE_REQUEST_1_MOCK, QUOTE_REQUEST_2_MOCK]);
 
-      const quotesPromise = getBridgeQuotes([
-        QUOTE_REQUEST_1_MOCK,
-        QUOTE_REQUEST_2_MOCK,
-      ]);
-
-      await jest.runAllTimersAsync();
-
-      const quotes = await quotesPromise;
-
-      expect(quotes).toBeUndefined();
-    });
-
-    it('returns undefined if quotes do not match request', async () => {
-      bridgeControllerMock.updateBridgeQuoteRequestParams.mockReset();
-      bridgeControllerMock.updateBridgeQuoteRequestParams
-        .mockImplementationOnce(() => {
-          messengerMock.publish(
-            'BridgeController:stateChange',
-            {
-              quotes: [QUOTE_2_MOCK],
-            } as BridgeControllerState,
-            [],
-          );
-
-          return Promise.resolve();
-        })
-        .mockImplementationOnce(() => {
-          messengerMock.publish(
-            'BridgeController:stateChange',
-            {
-              quotes: [QUOTE_1_MOCK],
-            } as BridgeControllerState,
-            [],
-          );
-
-          return Promise.resolve();
-        });
-
-      const quotesPromise = getBridgeQuotes([
-        QUOTE_REQUEST_1_MOCK,
-        QUOTE_REQUEST_2_MOCK,
-      ]);
-
-      await jest.runAllTimersAsync();
-
-      const quotes = await quotesPromise;
-
-      expect(quotes).toBeUndefined();
-    });
-
-    it('updates bridge request parameters', async () => {
-      const quotesPromise = getBridgeQuotes([
-        QUOTE_REQUEST_1_MOCK,
-        QUOTE_REQUEST_2_MOCK,
-      ]);
-
-      await quotesPromise;
-
-      expect(
-        bridgeControllerMock.updateBridgeQuoteRequestParams,
-      ).toHaveBeenCalledWith(
+      expect(bridgeControllerMock.fetchQuotes).toHaveBeenCalledWith(
         expect.objectContaining({
           walletAddress: QUOTE_REQUEST_1_MOCK.from,
           srcChainId: QUOTE_REQUEST_1_MOCK.sourceChainId,
@@ -212,11 +132,10 @@ describe('Confirmations Bridge Utils', () => {
           destTokenAddress: QUOTE_REQUEST_1_MOCK.targetTokenAddress,
         }),
         expect.any(Object),
+        FeatureId.PERPS,
       );
 
-      expect(
-        bridgeControllerMock.updateBridgeQuoteRequestParams,
-      ).toHaveBeenCalledWith(
+      expect(bridgeControllerMock.fetchQuotes).toHaveBeenCalledWith(
         expect.objectContaining({
           walletAddress: QUOTE_REQUEST_2_MOCK.from,
           srcChainId: QUOTE_REQUEST_2_MOCK.sourceChainId,
@@ -226,34 +145,32 @@ describe('Confirmations Bridge Utils', () => {
           destTokenAddress: QUOTE_REQUEST_2_MOCK.targetTokenAddress,
         }),
         expect.any(Object),
+        FeatureId.PERPS,
       );
     });
-  });
 
-  it('sets smart transactions enabled in request parameters', async () => {
-    selectShouldUseSmartTransactionMock.mockReset();
-    selectShouldUseSmartTransactionMock
-      .mockReturnValueOnce(true)
-      .mockReturnValueOnce(false);
+    it('returns undefined if no quotes', async () => {
+      bridgeControllerMock.fetchQuotes.mockReset();
+      bridgeControllerMock.fetchQuotes.mockResolvedValue([]);
 
-    await getBridgeQuotes([QUOTE_REQUEST_1_MOCK, QUOTE_REQUEST_2_MOCK]);
+      const quotes = await getBridgeQuotes([
+        QUOTE_REQUEST_1_MOCK,
+        QUOTE_REQUEST_2_MOCK,
+      ]);
 
-    expect(
-      bridgeControllerMock.updateBridgeQuoteRequestParams,
-    ).toHaveBeenCalledWith(
-      expect.any(Object),
-      expect.objectContaining({
-        stx_enabled: true,
-      }),
-    );
+      expect(quotes).toBeUndefined();
+    });
 
-    expect(
-      bridgeControllerMock.updateBridgeQuoteRequestParams,
-    ).toHaveBeenCalledWith(
-      expect.any(Object),
-      expect.objectContaining({
-        stx_enabled: false,
-      }),
-    );
+    it('uses quote with lowest estimated time', async () => {
+      bridgeControllerMock.fetchQuotes.mockReset();
+      bridgeControllerMock.fetchQuotes.mockResolvedValue([
+        QUOTE_1_MOCK,
+        QUOTE_2_MOCK,
+      ]);
+
+      const quotes = await getBridgeQuotes([QUOTE_REQUEST_1_MOCK]);
+
+      expect(quotes).toStrictEqual([QUOTE_2_MOCK]);
+    });
   });
 });

--- a/app/components/Views/confirmations/utils/bridge.ts
+++ b/app/components/Views/confirmations/utils/bridge.ts
@@ -130,6 +130,14 @@ function getActiveQuote(
 async function getGasFeeEstimates(chainId: Hex) {
   const { GasFeeController, NetworkController } = Engine.context;
 
+  const existingState =
+    GasFeeController.state?.gasFeeEstimatesByChainId?.[chainId]
+      ?.gasFeeEstimates;
+
+  if (existingState) {
+    return existingState as GasFeeEstimates;
+  }
+
   const networkClientId =
     NetworkController.findNetworkClientIdByChainId(chainId);
 

--- a/app/components/Views/confirmations/utils/bridge.ts
+++ b/app/components/Views/confirmations/utils/bridge.ts
@@ -1,5 +1,5 @@
 import {
-  BridgeControllerState,
+  FeatureId,
   QuoteMetadata,
   QuoteResponse,
 } from '@metamask/bridge-controller';
@@ -7,14 +7,13 @@ import { Hex, createProjectLogger } from '@metamask/utils';
 import Engine from '../../../../core/Engine';
 import { store } from '../../../../store';
 import { selectBridgeQuotes } from '../../../../core/redux/slices/bridge';
-import { selectShouldUseSmartTransaction } from '../../../../selectors/smartTransactionsController';
 import { GasFeeEstimates, GasFeeState } from '@metamask/gas-fee-controller';
+import { orderBy } from 'lodash';
 
 export type TransactionBridgeQuote = QuoteResponse & QuoteMetadata;
 
-const QUOTE_TIMEOUT = 1000 * 10; // 10 Seconds
-
 const log = createProjectLogger('confirmation-bridge-utils');
+let abort: AbortController;
 
 export interface BridgeQuoteRequest {
   from: Hex;
@@ -30,40 +29,33 @@ export async function getBridgeQuotes(
 ): Promise<TransactionBridgeQuote[] | undefined> {
   log('Fetching bridge quotes', requests);
 
+  abort?.abort();
+  abort = new AbortController();
+
   if (!requests?.length) {
     return [];
   }
 
   try {
-    const allQuotes: TransactionBridgeQuote[] = [];
-
     const gasFeeEstimates = await getGasFeeEstimates(requests[0].sourceChainId);
 
     log('Fetched gas fee estimates', gasFeeEstimates);
 
-    for (const request of requests) {
-      const quote = await getSingleBridgeQuotes(request, gasFeeEstimates);
+    const result = await Promise.all(
+      requests.map((request) => getSingleBridgeQuote(request, gasFeeEstimates)),
+    );
 
-      if (!quote) {
-        return undefined;
-      }
-
-      allQuotes.push(quote);
-    }
-
-    log('Fetched bridge quotes', allQuotes);
-
-    return allQuotes;
+    return result;
   } catch (error) {
     log('Error fetching bridge quotes', error);
     return undefined;
   }
 }
 
-async function getSingleBridgeQuotes(
+async function getSingleBridgeQuote(
   request: BridgeQuoteRequest,
   gasFeeEstimates: GasFeeEstimates,
-): Promise<TransactionBridgeQuote | undefined> {
+): Promise<TransactionBridgeQuote> {
   const {
     from,
     sourceChainId,
@@ -75,84 +67,33 @@ async function getSingleBridgeQuotes(
 
   const { BridgeController } = Engine.context;
 
-  BridgeController.resetState();
-
-  const activeQuotePromise = waitForQuoteOrTimeout(
-    targetTokenAddress,
-    gasFeeEstimates,
-  );
-
-  await BridgeController.updateBridgeQuoteRequestParams(
+  const quotes = await BridgeController.fetchQuotes(
     {
-      walletAddress: from,
+      destChainId: targetChainId,
+      destTokenAddress: targetTokenAddress,
+      destWalletAddress: from,
+      gasIncluded: false,
+      insufficientBal: true,
       srcChainId: sourceChainId,
       srcTokenAddress: sourceTokenAddress,
       srcTokenAmount: sourceTokenAmount,
-      destChainId: targetChainId,
-      destTokenAddress: targetTokenAddress,
-      insufficientBal: true,
-      destWalletAddress: from,
+      walletAddress: from,
     },
-    {
-      stx_enabled: isSmartTransactionsEnabled(sourceChainId),
-      token_symbol_source: '',
-      token_symbol_destination: '',
-      security_warnings: [],
-    },
+    abort.signal,
+    FeatureId.PERPS,
   );
 
-  log('Waiting for quote', request);
+  if (!quotes.length) {
+    throw new Error('No quotes found');
+  }
 
-  const activeQuote = await activeQuotePromise;
-
-  BridgeController.resetState();
-
-  return activeQuote;
-}
-
-function waitForQuoteOrTimeout(
-  targetTokenAddress: Hex,
-  gasFeeEstimates: GasFeeEstimates,
-): Promise<TransactionBridgeQuote | undefined> {
-  return new Promise<TransactionBridgeQuote>((resolve, reject) => {
-    const handler = Engine.controllerMessenger.subscribeOnceIf(
-      'BridgeController:stateChange',
-      (controllerState) => {
-        resolve(
-          getActiveQuote(
-            controllerState,
-            gasFeeEstimates,
-          ) as TransactionBridgeQuote,
-        );
-      },
-      (controllerState) => {
-        const activeQuote = getActiveQuote(controllerState);
-
-        const isMatch =
-          activeQuote?.quote.destAsset.address.toLowerCase() ===
-          targetTokenAddress.toLowerCase();
-
-        return isMatch;
-      },
-    );
-
-    setTimeout(() => {
-      Engine.controllerMessenger.tryUnsubscribe(
-        'BridgeController:stateChange',
-        handler,
-      );
-
-      log('Bridge quote request timed out');
-
-      reject(new Error('Bridge quote request timed out'));
-    }, QUOTE_TIMEOUT);
-  });
+  return getActiveQuote(quotes, gasFeeEstimates);
 }
 
 function getActiveQuote(
-  controllerState: BridgeControllerState,
-  gasFeeEstimates?: GasFeeEstimates,
-): TransactionBridgeQuote | undefined {
+  quotes: QuoteResponse[],
+  gasFeeEstimates: GasFeeEstimates,
+): TransactionBridgeQuote {
   const fullState = store.getState();
 
   const state = {
@@ -161,7 +102,10 @@ function getActiveQuote(
       ...fullState?.engine,
       backgroundState: {
         ...fullState?.engine?.backgroundState,
-        BridgeController: controllerState,
+        BridgeController: {
+          ...fullState?.engine?.backgroundState?.BridgeController,
+          quotes,
+        },
         ...(gasFeeEstimates
           ? {
               GasFeeController: {
@@ -174,7 +118,13 @@ function getActiveQuote(
     },
   };
 
-  return selectBridgeQuotes(state).recommendedQuote ?? undefined;
+  const allQuotes = selectBridgeQuotes(state).sortedQuotes;
+
+  return orderBy(
+    allQuotes,
+    (quote) => quote.estimatedProcessingTimeInSeconds,
+    'asc',
+  )[0];
 }
 
 async function getGasFeeEstimates(chainId: Hex) {
@@ -188,9 +138,4 @@ async function getGasFeeEstimates(chainId: Hex) {
   });
 
   return state.gasFeeEstimates as GasFeeEstimates;
-}
-
-function isSmartTransactionsEnabled(chainId: Hex): boolean {
-  const state = store.getState();
-  return selectShouldUseSmartTransaction(state, chainId);
 }


### PR DESCRIPTION
## **Description**

Retrieve bridge quotes in MetaMask Pay using the new `fetchQuotes` method of `BridgeController`.

Disable confirm button while quotes are loading.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
