### PR TITLE
fix: modal backdrop touch handling when backdropOpacity is 0

### DIFF
--- a/patches/react-native-modal+14.0.0-rc.1.patch
+++ b/patches/react-native-modal+14.0.0-rc.1.patch
@@ -1,8 +1,86 @@
 diff --git a/node_modules/react-native-modal/dist/modal.js b/node_modules/react-native-modal/dist/modal.js
-index 74edee4..b2558b3 100644
+index 74edee4..a4a1cd9 100644
 --- a/node_modules/react-native-modal/dist/modal.js
 +++ b/node_modules/react-native-modal/dist/modal.js
-@@ -538,9 +538,10 @@ export class ReactNativeModal extends React.Component {
+@@ -47,6 +47,10 @@ const extractAnimationFromProps = (props) => ({
+ export class ReactNativeModal extends React.Component {
+     static defaultProps = defaultProps;
+     backHandler = null;
++      
++    getEffectiveBackdropOpacity = () => this.props.backdropOpacity === 0 ? 0.1 : this.props.backdropOpacity;
++      
++    getEffectiveBackdropColor = () => this.props.backdropOpacity === 0 ? 'transparent' : this.props.backdropColor;
+     // We use an internal state for keeping track of the modal visibility: this allows us to keep
+     // the modal visible during the exit animation, even if the user has already change the
+     // isVisible prop to false.
+@@ -130,10 +134,17 @@ export class ReactNativeModal extends React.Component {
+             this.animationOut = animationOut;
+         }
+         // If backdrop opacity has been changed then make sure to update it
+-        if (this.props.backdropOpacity !== prevProps.backdropOpacity &&
+-            this.backdropRef) {
+-            this.backdropRef.transitionTo({ opacity: this.props.backdropOpacity }, this.props.backdropTransitionInTiming);
+-        }
++        if (
++            (this.props.backdropOpacity === 0 ? 0.1 : this.props.backdropOpacity) !==
++            (prevProps.backdropOpacity === 0 ? 0.1 : prevProps.backdropOpacity)
++          &&
++            this.backdropRef
++          ) {
++            this.backdropRef.transitionTo(
++              { opacity: this.getEffectiveBackdropOpacity() },
++              this.props.backdropTransitionInTiming
++            );
++          }        
+         // On modal open request, we slide the view up and fade in the backdrop
+         if (this.props.isVisible && !prevProps.isVisible) {
+             this.open();
+@@ -213,7 +224,7 @@ export class ReactNativeModal extends React.Component {
+                     const newOpacityFactor = 1 - this.calcDistancePercentage(gestureState);
+                     this.backdropRef &&
+                         this.backdropRef.transitionTo({
+-                            opacity: this.props.backdropOpacity * newOpacityFactor,
++                            opacity: this.getEffectiveBackdropOpacity() * newOpacityFactor,
+                         });
+                     animEvt(evt, gestureState);
+                     if (this.props.onSwipeMove) {
+@@ -264,7 +275,7 @@ export class ReactNativeModal extends React.Component {
+                 }
+                 if (this.backdropRef) {
+                     this.backdropRef.transitionTo({
+-                        opacity: this.props.backdropOpacity,
++                        opacity: this.getEffectiveBackdropOpacity(),
+                     });
+                 }
+                 Animated.spring(this.state.pan, {
+@@ -383,7 +394,7 @@ export class ReactNativeModal extends React.Component {
+         }
+         this.isTransitioning = true;
+         if (this.backdropRef) {
+-            this.backdropRef.transitionTo({ opacity: this.props.backdropOpacity }, this.props.backdropTransitionInTiming);
++            this.backdropRef.transitionTo({ opacity: this.getEffectiveBackdropOpacity() }, this.props.backdropTransitionInTiming);
+         }
+         // This is for resetting the pan position,otherwise the modal gets stuck
+         // at the last released position when you try to open it.
+@@ -475,14 +486,15 @@ export class ReactNativeModal extends React.Component {
+             !React.isValidElement(this.props.customBackdrop)) {
+             console.warn('Invalid customBackdrop element passed to Modal. You must provide a valid React element.');
+         }
+-        const { customBackdrop, backdropColor, useNativeDriver, useNativeDriverForBackdrop, onBackdropPress, } = this.props;
++        const { customBackdrop, useNativeDriver, useNativeDriverForBackdrop, onBackdropPress, } = this.props;
+         const hasCustomBackdrop = !!this.props.customBackdrop;
++        const effectiveBackdropColor = this.getEffectiveBackdropColor();
+         const backdropComputedStyle = [
+             {
+                 width: this.getDeviceWidth(),
+                 height: this.getDeviceHeight(),
+                 backgroundColor: this.state.showContent && !hasCustomBackdrop
+-                    ? backdropColor
++                    ? effectiveBackdropColor
+                     : 'transparent',
+             },
+         ];
+@@ -538,9 +550,10 @@ export class ReactNativeModal extends React.Component {
                  this.makeBackdrop(),
                  containerView));
          }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
**Problem:**
When backdropOpacity is set to 0, the backdrop view cannot receive touch events on **_iOS_**, preventing users from dismissing the modal by tapping outside of it.

**Solution:**
When backdropOpacity is 0, override it to 0.1 and set backdropColor to 'transparent'. This maintains the same visual appearance while ensuring the backdrop can register touch events.

**Changes:**
- Added getEffectiveBackdropOpacity() and getEffectiveBackdropColor() methods
- Applied effective values in all backdrop opacity transitions (open, update, swipe gestures)
- Updated backdrop rendering to use effective colour
## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/18287

## **Manual testing steps**

```gherkin
Feature: Modal backdrop touch handling with transparent backdrop

  Scenario: user dismisses address copy confirmation modal by tapping outside
    Given user is on the wallet main screen
    And user can see their account address
    
    When user taps the copy address button
    And the address copy confirmation modal appears with transparent backdrop
    And user taps outside the modal content area
    Then the modal should be dismissed
    And user should return to the wallet main screen
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
![iOS before](https://github.com/user-attachments/assets/59a45970-85c6-4745-a21f-0a65ba33d276)
### **After**
![iOS after](https://github.com/user-attachments/assets/6eda84d3-27c4-4d5f-98bf-2d60b8d79131)

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
