### PR TITLE
feat: display total network fee in perps deposit

### DIFF
--- a/app/components/Views/confirmations/components/rows/total-row/total-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/total-row/total-row.test.tsx
@@ -47,7 +47,7 @@ describe('TotalRow', () => {
     useTransactionTotalFiatMock.mockReturnValue({
       value: '123.456',
       formatted: TOTAL_FIAT_MOCK,
-    });
+    } as ReturnType<typeof useTransactionTotalFiat>);
   });
 
   it('renders the total amount', () => {

--- a/app/components/Views/confirmations/components/rows/transactions/gas-fee-fiat-row/gas-fee-fiat-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/gas-fee-fiat-row/gas-fee-fiat-row.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import renderWithProvider from '../../../../../../../util/test/renderWithProvider';
+import { GasFeeFiatRow } from './gas-fee-fiat-row';
+import { merge } from 'lodash';
+import {
+  simpleSendTransactionControllerMock,
+  transactionIdMock,
+} from '../../../../__mocks__/controllers/transaction-controller-mock';
+import { transactionApprovalControllerMock } from '../../../../__mocks__/controllers/approval-controller-mock';
+import { useTransactionTotalFiat } from '../../../../hooks/pay/useTransactionTotalFiat';
+import { View as MockView } from 'react-native';
+
+jest.mock('../../../../hooks/pay/useTransactionTotalFiat');
+
+jest.mock('../../../../../../UI/AnimatedSpinner', () => ({
+  __esModule: true,
+  ...jest.requireActual('../../../../../../UI/AnimatedSpinner'),
+  default: () => <MockView testID="gas-fee-fiat-spinner">{`Spinner`}</MockView>,
+}));
+
+const GAS_FEE_FIAT_MOCK = '$1.23';
+
+function render({ isQuotesLoading }: { isQuotesLoading?: boolean } = {}) {
+  const state = merge(
+    {},
+    simpleSendTransactionControllerMock,
+    transactionApprovalControllerMock,
+    {
+      confirmationMetrics: {
+        isTransactionBridgeQuotesLoadingById: {
+          [transactionIdMock]: isQuotesLoading ?? false,
+        },
+      },
+    },
+  );
+
+  return renderWithProvider(<GasFeeFiatRow />, { state });
+}
+
+describe('GasFeeFiatRow', () => {
+  const useTransactionTotalFiatMock = jest.mocked(useTransactionTotalFiat);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    useTransactionTotalFiatMock.mockReturnValue({
+      totalGasFormatted: GAS_FEE_FIAT_MOCK,
+    } as ReturnType<typeof useTransactionTotalFiat>);
+  });
+
+  it('renders total gas fee in fiat', () => {
+    const { getByText } = render();
+    expect(getByText(GAS_FEE_FIAT_MOCK)).toBeDefined();
+  });
+
+  it('renders spinner if quotes are loading', () => {
+    const { getByTestId } = render({ isQuotesLoading: true });
+    expect(getByTestId('gas-fee-fiat-spinner')).toBeDefined();
+  });
+});

--- a/app/components/Views/confirmations/components/rows/transactions/gas-fee-fiat-row/gas-fee-fiat-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/gas-fee-fiat-row/gas-fee-fiat-row.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import Text from '../../../../../../../component-library/components/Texts/Text';
+import InfoRow from '../../../UI/info-row';
+import { strings } from '../../../../../../../../locales/i18n';
+import { useTransactionTotalFiat } from '../../../../hooks/pay/useTransactionTotalFiat';
+import { useSelector } from 'react-redux';
+import { selectIsTransactionBridgeQuotesLoadingById } from '../../../../../../../core/redux/slices/confirmationMetrics';
+import { RootState } from '../../../../../../../reducers';
+import { useTransactionMetadataRequest } from '../../../../hooks/transactions/useTransactionMetadataRequest';
+import AnimatedSpinner, {
+  SpinnerSize,
+} from '../../../../../../UI/AnimatedSpinner';
+
+export function GasFeeFiatRow() {
+  const { id: transactionId } = useTransactionMetadataRequest() ?? {};
+  const { totalGasFormatted } = useTransactionTotalFiat();
+
+  const isQuotesLoading = useSelector((state: RootState) =>
+    selectIsTransactionBridgeQuotesLoadingById(state, transactionId ?? ''),
+  );
+
+  return (
+    <InfoRow label={strings('transactions.network_fee')}>
+      {isQuotesLoading && <AnimatedSpinner size={SpinnerSize.SM} />}
+      {!isQuotesLoading && <Text>{totalGasFormatted}</Text>}
+    </InfoRow>
+  );
+}

--- a/app/components/Views/confirmations/components/rows/transactions/gas-fee-fiat-row/index.ts
+++ b/app/components/Views/confirmations/components/rows/transactions/gas-fee-fiat-row/index.ts
@@ -1,0 +1,1 @@
+export * from './gas-fee-fiat-row';

--- a/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.tsx
+++ b/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import GasFeesDetailsRow from '../../../../components/rows/transactions/gas-fee-details-row/gas-fee-details-row';
 import { PayWithRow } from '../../../../components/rows/pay-with-row';
 import useNavbar from '../../../../hooks/ui/useNavbar';
 import { EditAmount } from '../../../../components/edit-amount';
@@ -16,6 +15,7 @@ import { Box } from '../../../../../../UI/Box/Box';
 import InfoRowDivider from '../../../../components/UI/info-row-divider';
 import { InfoRowDividerVariant } from '../../../../components/UI/info-row-divider/info-row-divider.styles';
 import { usePerpsDepositView } from '../../hooks/usePerpsDepositView';
+import { GasFeeFiatRow } from '../../../../components/rows/transactions/gas-fee-fiat-row';
 
 const AMOUNT_PREFIX = '$';
 
@@ -58,7 +58,7 @@ export function PerpsDeposit() {
         </InfoSection>
         {isFullView && (
           <InfoSection>
-            <GasFeesDetailsRow disableUpdate hideSpeed fiatOnly noSection />
+            <GasFeeFiatRow />
             <InfoRowDivider variant={InfoRowDividerVariant.Large} />
             <TotalRow />
           </InfoSection>

--- a/app/components/Views/confirmations/hooks/gas/useFeeCalculations.test.ts
+++ b/app/components/Views/confirmations/hooks/gas/useFeeCalculations.test.ts
@@ -48,6 +48,7 @@ describe('useFeeCalculations', () => {
 
     expect(result.current.estimatedFeeFiat).toBe('$0.34');
     expect(result.current.estimatedFeeNative).toBe('0.0001 ETH');
+    expect(result.current.estimatedFeeFiatPrecise).toBe('0.338');
     expect(result.current.preciseNativeFeeInHex).toBe('0x5572e9c22d00');
     expect(result.current.calculateGasEstimate).toBeDefined();
   });
@@ -98,6 +99,7 @@ describe('useFeeCalculations', () => {
 
     expect(result.current.estimatedFeeFiat).toBe('< $0.01');
     expect(result.current.estimatedFeeNative).toBe('0.0001 ETH');
+    expect(result.current.estimatedFeeFiatPrecise).toBe('0.008');
     expect(result.current.preciseNativeFeeInHex).toBe('0x5572e9c22d00');
     expect(result.current.calculateGasEstimate).toBeDefined();
   });
@@ -124,6 +126,7 @@ describe('useFeeCalculations', () => {
 
     expect(result.current.estimatedFeeFiat).toBe(null);
     expect(result.current.estimatedFeeNative).toBe(null);
+    expect(result.current.estimatedFeeFiatPrecise).toBe(null);
     expect(result.current.preciseNativeFeeInHex).toBe(null);
     expect(result.current.calculateGasEstimate).toBeDefined();
   });
@@ -152,6 +155,7 @@ describe('useFeeCalculations', () => {
     // The original estimatedFee is 0x5572e9c22d00, so the sum is 0x5572e9c23d00
     expect(result.current.estimatedFeeFiat).toBe('$0.34');
     expect(result.current.estimatedFeeNative).toBe('0.0001 ETH');
+    expect(result.current.estimatedFeeFiatPrecise).toBe('0.338');
     expect(result.current.preciseNativeFeeInHex).toBe('0x5572e9c23d00');
     expect(result.current.calculateGasEstimate).toBeDefined();
   });

--- a/app/components/Views/confirmations/hooks/gas/useFeeCalculations.ts
+++ b/app/components/Views/confirmations/hooks/gas/useFeeCalculations.ts
@@ -21,6 +21,7 @@ export const useFeeCalculations = (
   transactionMeta: TransactionMeta,
 ): {
   estimatedFeeFiat: string | null;
+  estimatedFeeFiatPrecise: string | null;
   estimatedFeeNative: string | null;
   preciseNativeFeeInHex: string | null;
   calculateGasEstimate: ({
@@ -38,6 +39,7 @@ export const useFeeCalculations = (
   }) => {
     currentCurrencyFee: string | null;
     nativeCurrencyFee: string | null;
+    preciseCurrentCurrencyFee: string | null;
     preciseNativeCurrencyFee: string | null;
     preciseNativeFeeInHex: string | null;
   };
@@ -153,6 +155,7 @@ export const useFeeCalculations = (
 
   return {
     estimatedFeeFiat: estimatedFees.currentCurrencyFee,
+    estimatedFeeFiatPrecise: estimatedFees.preciseCurrentCurrencyFee,
     estimatedFeeNative: estimatedFees.nativeCurrencyFee,
     preciseNativeFeeInHex: estimatedFees.preciseNativeFeeInHex,
     calculateGasEstimate: calculateGasEstimateCallback,

--- a/app/components/Views/confirmations/hooks/gas/useGasFeeToken.test.ts
+++ b/app/components/Views/confirmations/hooks/gas/useGasFeeToken.test.ts
@@ -91,6 +91,7 @@ describe('useGasFeeToken', () => {
       preciseNativeFeeInHex: '0x1',
       estimatedFeeFiat: null,
       estimatedFeeNative: null,
+      estimatedFeeFiatPrecise: null,
       maxFeeFiat: null,
       maxFeeNative: null,
       maxFeeNativePrecise: null,

--- a/app/components/Views/confirmations/hooks/pay/useTransactionTotalFiat.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionTotalFiat.ts
@@ -8,13 +8,16 @@ import { createProjectLogger } from '@metamask/utils';
 import { useEffect } from 'react';
 import useFiatFormatter from '../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 import { TransactionBridgeQuote } from '../../utils/bridge';
+import { useFeeCalculations } from '../gas/useFeeCalculations';
 
 const log = createProjectLogger('transaction-pay');
 
 export function useTransactionTotalFiat() {
   const fiatFormatter = useFiatFormatter();
   const { values: requiredFiat } = useTransactionRequiredFiat();
-  const { id: transactionId } = useTransactionMetadataOrThrow();
+  const transactionMeta = useTransactionMetadataOrThrow();
+  const { id: transactionId } = transactionMeta;
+  const { estimatedFeeFiatPrecise } = useFeeCalculations(transactionMeta);
 
   const quotes = useSelector((state: RootState) =>
     selectTransactionBridgeQuotesById(state, transactionId),
@@ -39,9 +42,22 @@ export function useTransactionTotalFiat() {
     new BigNumber(0),
   );
 
+  const quoteGasCost =
+    quotes?.reduce(
+      (acc, quote) =>
+        acc.plus(new BigNumber(quote.totalMaxNetworkFee.valueInCurrency ?? 0)),
+      new BigNumber(0),
+    ) ?? new BigNumber(0);
+
   const total = quotesCost.plus(balanceCost);
   const value = total.toString(10);
   const formatted = fiatFormatter(total);
+
+  const totalGas = quoteGasCost.plus(
+    new BigNumber(estimatedFeeFiatPrecise ?? 0),
+  );
+
+  const totalGasFormatted = fiatFormatter(totalGas);
 
   useEffect(() => {
     log('Total fiat', {
@@ -55,6 +71,7 @@ export function useTransactionTotalFiat() {
   return {
     value,
     formatted,
+    totalGasFormatted,
   };
 }
 

--- a/app/components/Views/confirmations/hooks/pay/useTransactionTotalFiat.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionTotalFiat.ts
@@ -76,9 +76,9 @@ export function useTransactionTotalFiat() {
 }
 
 function getQuoteCostFiat(quote: TransactionBridgeQuote): BigNumber {
-  const gasCost = new BigNumber(quote.totalMaxNetworkFee.valueInCurrency ?? 0);
-  const cost = new BigNumber(quote.cost.valueInCurrency ?? 0);
-  const amount = new BigNumber(quote.adjustedReturn.valueInCurrency ?? 0);
+  const gasCost = new BigNumber(quote.totalMaxNetworkFee?.valueInCurrency ?? 0);
+  const cost = new BigNumber(quote.cost?.valueInCurrency ?? 0);
+  const amount = new BigNumber(quote.adjustedReturn?.valueInCurrency ?? 0);
 
   return amount.plus(gasCost).plus(cost);
 }

--- a/app/components/Views/confirmations/utils/gas.ts
+++ b/app/components/Views/confirmations/utils/gas.ts
@@ -34,6 +34,7 @@ export function getFeesFromHex({
     return {
       currentCurrencyFee: null,
       nativeCurrencyFee: null,
+      preciseCurrentCurrencyFee: null,
       preciseNativeCurrencyFee: null,
       preciseNativeFeeInHex: null,
     };
@@ -82,7 +83,7 @@ export function getFeesFromHex({
 
   // This is used to check if the fee is less than $0.01 - more precise than decimalCurrentCurrencyFee
   // Because decimalCurrentCurrencyFee is rounded to 2 decimal places
-  const preciseCurrentCurrencyFee = Number(
+  const preciseCurrentCurrencyFeeNum = Number(
     getValueFromWeiHex({
       value: hexFee,
       conversionRate: nativeConversionRateInBN,
@@ -94,7 +95,7 @@ export function getFeesFromHex({
   );
 
   let currentCurrencyFee;
-  if (preciseCurrentCurrencyFee < 0.01) {
+  if (preciseCurrentCurrencyFeeNum < 0.01) {
     currentCurrencyFee = `< ${fiatFormatter(new BigNumber(0.01))}`;
   } else {
     currentCurrencyFee = fiatFormatter(
@@ -105,6 +106,10 @@ export function getFeesFromHex({
   if (shouldHideFiat) {
     currentCurrencyFee = null;
   }
+
+  const preciseCurrentCurrencyFee = currentCurrencyFee
+    ? new BigNumber(preciseCurrentCurrencyFeeNum).toString(10)
+    : null;
 
   return {
     currentCurrencyFee,

--- a/app/components/Views/confirmations/utils/gas.ts
+++ b/app/components/Views/confirmations/utils/gas.ts
@@ -109,6 +109,7 @@ export function getFeesFromHex({
   return {
     currentCurrencyFee,
     nativeCurrencyFee,
+    preciseCurrentCurrencyFee,
     preciseNativeCurrencyFee,
     preciseNativeFeeInHex: add0x(hexFee),
   };
@@ -134,6 +135,7 @@ export function calculateGasEstimate({
   getFeesFromHexFn: (hexFee: string) => {
     currentCurrencyFee: string | null;
     nativeCurrencyFee: string | null;
+    preciseCurrentCurrencyFee: string | null;
     preciseNativeCurrencyFee: string | null;
     preciseNativeFeeInHex: string | null;
   };


### PR DESCRIPTION
## **Description**

Include quote gas cost in `Network fee` in Perps deposit confirmation.

Show spinner in row while quotes are loading.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#5612](https://github.com/MetaMask/MetaMask-planning/issues/5612)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
