### PR TITLE
fix: Prevent clearing Snap permissions when clearing dapp approvals

### DIFF
--- a/app/components/Views/Settings/SecuritySettings/Sections/ClearPrivacy/ClearPrivacy.tsx
+++ b/app/components/Views/Settings/SecuritySettings/Sections/ClearPrivacy/ClearPrivacy.tsx
@@ -18,6 +18,7 @@ import Button, {
 import SDKConnect from '../../../../../../../app/core/SDKConnect/SDKConnect';
 import { SecurityPrivacyViewSelectorsIDs } from '../../../../../../../e2e/selectors/Settings/SecurityAndPrivacy/SecurityPrivacyView.selectors';
 import { ClearPrivacyModalSelectorsIDs } from '../../../../../../../e2e/selectors/Settings/SecurityAndPrivacy/ClearPrivacyModal.selectors';
+import { isSnapId } from '@metamask/snaps-utils';
 
 const ClearPrivacy = () => {
   const { styles } = useStyles(styleSheet, {});
@@ -25,10 +26,10 @@ const ClearPrivacy = () => {
   const [modalVisible, setModalVisible] = useState<boolean>(false);
 
   const clearApprovals = () => {
-    // TODO: Replace "any" with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { PermissionController } = Engine.context as any;
-    PermissionController?.clearState?.();
+    const { PermissionController } = Engine.context;
+    PermissionController.getSubjectNames()
+      .filter((subject) => !isSnapId(subject))
+      .forEach((subject) => PermissionController.revokeAllPermissions(subject));
     SDKConnect.getInstance().removeAll();
     setModalVisible(false);
   };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Prevent clearing Snap permissions when clearing dapp approvals using the privacy menu. This would break functionality that relies on those permissions such as the Solana Snap. Instead, we clear every permission that is not assigned to a Snap.

## **Related issues**

Fixes: #16969

## **Manual testing steps**

1. Go to the privacy menu
2. Click "clear privacy data"
3. Click "clear"
4. Go to the home screen
5. Create a Solana account
6. See that this still works
