### PR TITLE
fix: user data being wiped after upgrading to new version from 7.51.4

### DIFF
--- a/app/store/migrations/093.test.ts
+++ b/app/store/migrations/093.test.ts
@@ -60,7 +60,6 @@ describe('Migration 093', () => {
     });
 
     expect(mockedStorageWrapper.getItem).toHaveBeenCalledWith(EXISTING_USER);
-    expect(mockedStorageWrapper.removeItem).toHaveBeenCalledWith(EXISTING_USER);
     expect(mockedCaptureException).not.toHaveBeenCalled();
   });
 
@@ -84,7 +83,6 @@ describe('Migration 093', () => {
     });
 
     expect(mockedStorageWrapper.getItem).toHaveBeenCalledWith(EXISTING_USER);
-    expect(mockedStorageWrapper.removeItem).toHaveBeenCalledWith(EXISTING_USER);
     expect(mockedCaptureException).not.toHaveBeenCalled();
   });
 
@@ -128,7 +126,6 @@ describe('Migration 093', () => {
     });
 
     expect(mockedStorageWrapper.getItem).toHaveBeenCalledWith(EXISTING_USER);
-    expect(mockedStorageWrapper.removeItem).toHaveBeenCalledWith(EXISTING_USER);
     expect(mockedCaptureException).toHaveBeenCalledWith(
       expect.objectContaining({
         message:
@@ -155,7 +152,6 @@ describe('Migration 093', () => {
     });
 
     expect(mockedStorageWrapper.getItem).toHaveBeenCalledWith(EXISTING_USER);
-    expect(mockedStorageWrapper.removeItem).toHaveBeenCalledWith(EXISTING_USER);
     expect(mockedCaptureException).toHaveBeenCalledWith(
       expect.objectContaining({
         message:
@@ -182,7 +178,6 @@ describe('Migration 093', () => {
     });
 
     expect(mockedStorageWrapper.getItem).toHaveBeenCalledWith(EXISTING_USER);
-    expect(mockedStorageWrapper.removeItem).toHaveBeenCalledWith(EXISTING_USER);
     expect(mockedCaptureException).toHaveBeenCalledWith(
       expect.objectContaining({
         message:
@@ -216,17 +211,15 @@ describe('Migration 093', () => {
     expect(mockedCaptureException).toHaveBeenCalledWith(error);
   });
 
-  it('handles StorageWrapper.removeItem throwing an error', async () => {
+  it('migrates data successfully without attempting to remove from MMKV', async () => {
     const state = {
       user: {
         someOtherField: 'value',
       },
     };
 
-    const error = new Error('Remove error');
     mockedEnsureValidState.mockReturnValue(true);
     mockedStorageWrapper.getItem.mockResolvedValue('true');
-    mockedStorageWrapper.removeItem.mockRejectedValue(error);
 
     const migratedState = await migrate(state);
 
@@ -238,8 +231,6 @@ describe('Migration 093', () => {
     });
 
     expect(mockedStorageWrapper.getItem).toHaveBeenCalledWith(EXISTING_USER);
-    expect(mockedStorageWrapper.removeItem).toHaveBeenCalledWith(EXISTING_USER);
-    expect(mockedCaptureException).toHaveBeenCalledWith(error);
   });
 
   it('initializes with full userInitialState when user state is missing and error occurs', async () => {
@@ -284,7 +275,6 @@ describe('Migration 093', () => {
     });
 
     expect(mockedStorageWrapper.getItem).toHaveBeenCalledWith(EXISTING_USER);
-    expect(mockedStorageWrapper.removeItem).toHaveBeenCalledWith(EXISTING_USER);
     expect(mockedCaptureException).not.toHaveBeenCalled();
   });
 
@@ -332,7 +322,6 @@ describe('Migration 093', () => {
     });
 
     expect(mockedStorageWrapper.getItem).toHaveBeenCalledWith(EXISTING_USER);
-    expect(mockedStorageWrapper.removeItem).toHaveBeenCalledWith(EXISTING_USER);
     expect(mockedCaptureException).not.toHaveBeenCalled();
   });
 });

--- a/app/store/migrations/093.ts
+++ b/app/store/migrations/093.ts
@@ -47,16 +47,6 @@ const migration = async (state: unknown): Promise<unknown> => {
     } else {
       newState.user.existingUser = existingUserValue;
     }
-
-    if (existingUser !== null) {
-      try {
-        await StorageWrapper.removeItem(EXISTING_USER);
-      } catch (removeError) {
-        // If removeItem fails, capture the error but don't change the existingUser value
-        // since we successfully retrieved it from MMKV
-        captureException(removeError as Error);
-      }
-    }
   } catch (error) {
     captureException(error as Error);
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
When migration 93 completes (migrating user data from MMKV to Redux Persist), there is a delay before the data persists to disk (via setItem in persistConfig.ts). If the user closes the app before this persistence completes, the MMKV data is deleted but the migration version number does not get updated to disk. The next time they open the app, two things happen:

- Migration 93 runs again
- There is no data in MMKV anymore, so existingUser is set to false

Hence, the app treats the user as a new user and takes them back to the onboarding screen.

In this PR, we don't delete user data from MMKV during the migration. This ensures that if the migration runs again due to the race condition, the data is still available in MMKV and the user won't be logged out.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Migration 93 Race Condition - Close and Reopen Fix
  As a MetaMask user upgrading from 7.51.4 to 7.53/7.54
  I want to remain logged in even if I close and reopen the app quickly
  So that I don't get sent back to onboarding

Background:
  Given I have a MetaMask app with 7.51.4
  And I have an existing user account with wallet data

Scenario: Close app immediately after upgrade and reopen
  Given I upgrade to v7.55.99 (build 2274 in TestFlight) or Android release build ([link](https://app.bitrise.io/build/292c6f65-a046-40eb-90d3-6632677f8372?tab=artifacts))
  When I open the app
  And I immediately force-close the app within 2-3 seconds
  And I reopen the app
  Then I should remain logged in
  And I should see my wallet screen (not onboarding)

Scenario: Normal flow - don't close app
  Given I upgrade to v7.55.99 (build 2274 in TestFlight) or Android release build ([link](https://app.bitrise.io/build/292c6f65-a046-40eb-90d3-6632677f8372?tab=artifacts))
  When I open the app
  And I wait for 10+ seconds without closing
  Then I should remain logged in
  And I should see my wallet screen
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
iOS
![iOS Before](https://github.com/user-attachments/assets/ef5546ab-2f0b-437f-8b45-5bbece69902f)
Android
![Android Before](https://github.com/user-attachments/assets/76e168ad-3ae0-447b-ad46-daa33d5f77bc)

<!-- [screenshots/recordings] -->

### **After**
iOS
![iOS After](https://github.com/user-attachments/assets/633b593f-f1f9-49f8-ad2d-6c8ccbdc9260)
Android
![Android After](https://github.com/user-attachments/assets/36d717a3-f1e1-47bd-b589-7536038c6f78)

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
