### PR TITLE
feat: broke out perps balance modal into its own view instead of rend…

### DIFF
--- a/app/components/UI/Perps/Views/PerpsBalanceModal/PerpsBalanceModal.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsBalanceModal/PerpsBalanceModal.styles.ts
@@ -1,0 +1,13 @@
+import { StyleSheet } from 'react-native';
+
+const createStyles = () =>
+  StyleSheet.create({
+    content: {
+      padding: 24,
+    },
+    actionButton: {
+      marginBottom: 12,
+    },
+  });
+
+export default createStyles;

--- a/app/components/UI/Perps/Views/PerpsBalanceModal/PerpsBalanceModal.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsBalanceModal/PerpsBalanceModal.test.tsx
@@ -1,0 +1,102 @@
+import { useNavigation } from '@react-navigation/native';
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
+import React from 'react';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import Routes from '../../../../../constants/navigation/Routes';
+import { strings } from '../../../../../../locales/i18n';
+import PerpsBalanceModal from './PerpsBalanceModal';
+
+// Mock dependencies
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: jest.fn(),
+}));
+
+// Mock hooks
+jest.mock('../../hooks', () => ({
+  usePerpsTrading: jest.fn(),
+}));
+
+describe('PerpsBalanceModal', () => {
+  const mockNavigation = {
+    navigate: jest.fn(),
+    goBack: jest.fn(),
+  };
+
+  const mockUsePerpsTrading = jest.requireMock('../../hooks').usePerpsTrading;
+
+  // Helper function to render component with required providers
+  const renderWithProviders = (component: React.ReactElement) =>
+    render(
+      <SafeAreaProvider
+        initialMetrics={{
+          insets: { top: 0, left: 0, right: 0, bottom: 0 },
+          frame: { x: 0, y: 0, width: 0, height: 0 },
+        }}
+      >
+        {component}
+      </SafeAreaProvider>,
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useNavigation as jest.Mock).mockReturnValue(mockNavigation);
+
+    mockUsePerpsTrading.mockReturnValue({
+      depositWithConfirmation: jest.fn().mockResolvedValue({
+        result: Promise.resolve(),
+      }),
+    });
+  });
+
+  describe('Component Rendering', () => {
+    it('renders correctly with all buttons and title', () => {
+      renderWithProviders(<PerpsBalanceModal />);
+
+      expect(
+        screen.getByText(strings('perps.manage_balance')),
+      ).toBeOnTheScreen();
+      expect(screen.getByText(strings('perps.add_funds'))).toBeOnTheScreen();
+      expect(screen.getByText(strings('perps.withdraw'))).toBeOnTheScreen();
+    });
+  });
+
+  describe('User Interactions', () => {
+    it('redirects to deposit view when add funds button is pressed', async () => {
+      const mockDepositWithConfirmation = jest.fn().mockResolvedValue({
+        result: Promise.resolve(),
+      });
+      mockUsePerpsTrading.mockReturnValue({
+        depositWithConfirmation: mockDepositWithConfirmation,
+      });
+
+      renderWithProviders(<PerpsBalanceModal />);
+
+      const addFundsButton = screen.getByText(strings('perps.add_funds'));
+
+      await act(async () => {
+        fireEvent.press(addFundsButton);
+      });
+
+      expect(mockNavigation.goBack).toHaveBeenCalled();
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(Routes.PERPS.ROOT, {
+        screen: Routes.FULL_SCREEN_CONFIRMATIONS.REDESIGNED_CONFIRMATIONS,
+      });
+      expect(mockDepositWithConfirmation).toHaveBeenCalled();
+    });
+
+    it('redirects to withdraw view when withdraw button is pressed', () => {
+      renderWithProviders(<PerpsBalanceModal />);
+
+      const withdrawButton = screen.getByText(strings('perps.withdraw'));
+
+      act(() => {
+        fireEvent.press(withdrawButton);
+      });
+
+      expect(mockNavigation.goBack).toHaveBeenCalled();
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(Routes.PERPS.ROOT, {
+        screen: Routes.PERPS.WITHDRAW,
+      });
+    });
+  });
+});

--- a/app/components/UI/Perps/Views/PerpsBalanceModal/PerpsBalanceModal.tsx
+++ b/app/components/UI/Perps/Views/PerpsBalanceModal/PerpsBalanceModal.tsx
@@ -1,0 +1,93 @@
+import { useNavigation, type NavigationProp } from '@react-navigation/native';
+import React, { useCallback, useRef } from 'react';
+import { View } from 'react-native';
+import { strings } from '../../../../../../locales/i18n';
+import BottomSheet, {
+  BottomSheetRef,
+} from '../../../../../component-library/components/BottomSheets/BottomSheet';
+import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
+import Button, {
+  ButtonSize,
+  ButtonVariants,
+  ButtonWidthTypes,
+} from '../../../../../component-library/components/Buttons/Button';
+import { IconName } from '../../../../../component-library/components/Icons/Icon';
+import Text, {
+  TextVariant,
+} from '../../../../../component-library/components/Texts/Text';
+import { useStyles } from '../../../../../component-library/hooks';
+import Routes from '../../../../../constants/navigation/Routes';
+import type { PerpsNavigationParamList } from '../../controllers/types';
+import { usePerpsTrading } from '../../hooks';
+import createStyles from './PerpsBalanceModal.styles';
+
+interface PerpsBalanceModalProps {}
+
+const PerpsBalanceModal: React.FC<PerpsBalanceModalProps> = () => {
+  const { styles } = useStyles(createStyles, {});
+  const navigation = useNavigation<NavigationProp<PerpsNavigationParamList>>();
+  const { depositWithConfirmation } = usePerpsTrading();
+
+  const bottomSheetRef = useRef<BottomSheetRef>(null);
+
+  const handleClose = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
+
+  const handleAddFunds = useCallback(() => {
+    navigation.goBack();
+
+    // Navigate immediately to confirmations screen for instant UI response
+    navigation.navigate(Routes.PERPS.ROOT, {
+      screen: Routes.FULL_SCREEN_CONFIRMATIONS.REDESIGNED_CONFIRMATIONS,
+    });
+
+    // Initialize deposit in the background without blocking
+    depositWithConfirmation().catch((error) => {
+      console.error('Failed to initialize deposit:', error);
+    });
+  }, [depositWithConfirmation, navigation]);
+
+  const handleWithdrawFunds = useCallback(() => {
+    navigation.goBack();
+    navigation.navigate(Routes.PERPS.ROOT, {
+      screen: Routes.PERPS.WITHDRAW,
+    });
+  }, [navigation]);
+
+  return (
+    <BottomSheet
+      ref={bottomSheetRef}
+      onClose={handleClose}
+      shouldNavigateBack={false}
+    >
+      <BottomSheetHeader onClose={handleClose}>
+        <Text variant={TextVariant.HeadingMD}>
+          {strings('perps.manage_balance')}
+        </Text>
+      </BottomSheetHeader>
+      <View style={styles.content}>
+        <Button
+          variant={ButtonVariants.Primary}
+          size={ButtonSize.Lg}
+          width={ButtonWidthTypes.Full}
+          label={strings('perps.add_funds')}
+          onPress={handleAddFunds}
+          style={styles.actionButton}
+          startIconName={IconName.Add}
+        />
+        <Button
+          variant={ButtonVariants.Secondary}
+          size={ButtonSize.Lg}
+          width={ButtonWidthTypes.Full}
+          label={strings('perps.withdraw')}
+          onPress={handleWithdrawFunds}
+          style={styles.actionButton}
+          startIconName={IconName.Minus}
+        />
+      </View>
+    </BottomSheet>
+  );
+};
+
+export default PerpsBalanceModal;

--- a/app/components/UI/Perps/Views/PerpsBalanceModal/index.ts
+++ b/app/components/UI/Perps/Views/PerpsBalanceModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PerpsBalanceModal';

--- a/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.styles.ts
@@ -43,12 +43,6 @@ const styleSheet = (params: { theme: Theme }) => {
       padding: 24,
       alignItems: 'center',
     },
-    bottomSheetContent: {
-      padding: 24,
-    },
-    actionButton: {
-      marginBottom: 12,
-    },
     firstTimeContainer: {
       flex: 1,
       padding: 24,

--- a/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.test.tsx
@@ -12,9 +12,6 @@ jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(),
 }));
 
-// Mock PerpsStreamManager
-jest.mock('../../providers/PerpsStreamManager');
-
 // Mock PerpsConnectionProvider
 jest.mock('../../providers/PerpsConnectionProvider', () => ({
   PerpsConnectionProvider: ({ children }: { children: React.ReactNode }) =>
@@ -45,10 +42,6 @@ jest.mock('../../hooks', () => ({
     measure: jest.fn(),
     measureAsync: jest.fn(),
   })),
-}));
-
-// Mock stream hooks
-jest.mock('../../hooks/stream', () => ({
   usePerpsLivePositions: jest.fn(() => ({
     positions: [],
     isInitialLoading: false,
@@ -102,7 +95,7 @@ describe('PerpsTabView', () => {
   const mockUsePerpsConnection =
     jest.requireMock('../../hooks').usePerpsConnection;
   const mockUsePerpsLivePositions =
-    jest.requireMock('../../hooks/stream').usePerpsLivePositions;
+    jest.requireMock('../../hooks').usePerpsLivePositions;
   const mockUsePerpsTrading = jest.requireMock('../../hooks').usePerpsTrading;
   const mockUsePerpsFirstTimeUser =
     jest.requireMock('../../hooks').usePerpsFirstTimeUser;
@@ -557,7 +550,7 @@ describe('PerpsTabViewWithProvider', () => {
     // Setup mocks for wrapped component tests
     const mockUsePerpsConnection = jest.requireMock('../../hooks')
       .usePerpsConnection as jest.Mock;
-    const mockUsePerpsLivePositions = jest.requireMock('../../hooks/stream')
+    const mockUsePerpsLivePositions = jest.requireMock('../../hooks')
       .usePerpsLivePositions as jest.Mock;
     const mockUsePerpsTrading = jest.requireMock('../../hooks')
       .usePerpsTrading as jest.Mock;

--- a/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.test.tsx
@@ -1,7 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
 import { act, fireEvent, render, screen } from '@testing-library/react-native';
 import React from 'react';
-import { View } from 'react-native';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
 import type { Position } from '../../controllers/types';
@@ -95,64 +94,6 @@ jest.mock('../../components/PerpsPositionCard', () => ({
   },
 }));
 
-// Mock BottomSheet components
-jest.mock(
-  '../../../../../component-library/components/BottomSheets/BottomSheet',
-  () => {
-    const MockReact = jest.requireActual('react');
-    return {
-      __esModule: true,
-      default: MockReact.forwardRef(
-        (
-          {
-            children,
-            onClose,
-          }: {
-            children: React.ReactNode;
-            onClose: () => void;
-          },
-          ref: React.Ref<View>,
-        ) => {
-          const { View: RNView } = jest.requireActual('react-native');
-          return (
-            <RNView ref={ref} testID="bottom-sheet" onTouchEnd={onClose}>
-              {children}
-            </RNView>
-          );
-        },
-      ),
-    };
-  },
-);
-
-jest.mock(
-  '../../../../../component-library/components/BottomSheets/BottomSheetHeader',
-  () => ({
-    __esModule: true,
-    default: ({
-      children,
-      onClose,
-    }: {
-      children: React.ReactNode;
-      onClose: () => void;
-    }) => {
-      const {
-        View: RNView,
-        TouchableOpacity,
-        Text,
-      } = jest.requireActual('react-native');
-      return (
-        <RNView testID="bottom-sheet-header">
-          {children}
-          <TouchableOpacity testID="close-bottom-sheet" onPress={onClose}>
-            <Text>Close</Text>
-          </TouchableOpacity>
-        </RNView>
-      );
-    },
-  }),
-);
-
 describe('PerpsTabView', () => {
   const mockNavigation = {
     navigate: jest.fn(),
@@ -205,9 +146,6 @@ describe('PerpsTabView', () => {
 
     mockUsePerpsTrading.mockReturnValue({
       getAccountState: jest.fn(),
-      depositWithConfirmation: jest.fn().mockResolvedValue({
-        result: Promise.resolve(),
-      }),
     });
 
     mockUsePerpsFirstTimeUser.mockReturnValue({
@@ -434,7 +372,7 @@ describe('PerpsTabView', () => {
       expect(mockLoadPositions).toHaveBeenCalledTimes(0); // Should not be called on render
     });
 
-    it('should open bottom sheet when manage balance is pressed', () => {
+    it('should navigate to balance modal when manage balance is pressed', () => {
       render(<PerpsTabView />);
 
       const manageBalanceButton = screen.getByTestId('manage-balance-button');
@@ -443,68 +381,12 @@ describe('PerpsTabView', () => {
         fireEvent.press(manageBalanceButton);
       });
 
-      expect(screen.getByTestId('bottom-sheet')).toBeOnTheScreen();
-      expect(screen.getByTestId('bottom-sheet-header')).toBeOnTheScreen();
-    });
-
-    it('should close bottom sheet when close button is pressed', () => {
-      render(<PerpsTabView />);
-
-      // Open bottom sheet first
-      act(() => {
-        fireEvent.press(screen.getByTestId('manage-balance-button'));
-      });
-
-      expect(screen.getByTestId('bottom-sheet')).toBeOnTheScreen();
-
-      // Close bottom sheet
-      act(() => {
-        fireEvent.press(screen.getByTestId('close-bottom-sheet'));
-      });
-
-      expect(screen.queryByTestId('bottom-sheet')).not.toBeOnTheScreen();
-    });
-
-    it('should trigger deposit when add funds is pressed', async () => {
-      render(<PerpsTabView />);
-
-      // Open bottom sheet
-      act(() => {
-        fireEvent.press(screen.getByTestId('manage-balance-button'));
-      });
-
-      // Press add funds button
-      const addFundsButton = screen.getByText(strings('perps.add_funds'));
-      await act(() => {
-        fireEvent.press(addFundsButton);
-      });
-
-      expect(mockUsePerpsTrading().depositWithConfirmation).toHaveBeenCalled();
-
-      expect(mockNavigation.navigate).toHaveBeenCalledWith(Routes.PERPS.ROOT, {
-        screen: Routes.FULL_SCREEN_CONFIRMATIONS.REDESIGNED_CONFIRMATIONS,
-      });
-
-      // Bottom sheet should be closed
-      expect(screen.queryByTestId('bottom-sheet')).not.toBeOnTheScreen();
-    });
-
-    it('should close bottom sheet when withdraw is pressed', () => {
-      render(<PerpsTabView />);
-
-      // Open bottom sheet
-      act(() => {
-        fireEvent.press(screen.getByTestId('manage-balance-button'));
-      });
-
-      // Press withdraw button
-      const withdrawButton = screen.getByText(strings('perps.withdraw'));
-      act(() => {
-        fireEvent.press(withdrawButton);
-      });
-
-      // Bottom sheet should be closed
-      expect(screen.queryByTestId('bottom-sheet')).not.toBeOnTheScreen();
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
+        Routes.PERPS.MODALS.ROOT,
+        {
+          screen: Routes.PERPS.MODALS.BALANCE_MODAL,
+        },
+      );
     });
   });
 
@@ -522,31 +404,6 @@ describe('PerpsTabView', () => {
       expect(
         screen.getByText(strings('perps.position.list.empty_title')),
       ).toBeOnTheScreen();
-    });
-
-    it('should not show bottom sheet initially', () => {
-      render(<PerpsTabView />);
-
-      expect(screen.queryByTestId('bottom-sheet')).not.toBeOnTheScreen();
-    });
-
-    it('should maintain bottom sheet state correctly', () => {
-      render(<PerpsTabView />);
-
-      // Initially closed
-      expect(screen.queryByTestId('bottom-sheet')).not.toBeOnTheScreen();
-
-      // Open
-      act(() => {
-        fireEvent.press(screen.getByTestId('manage-balance-button'));
-      });
-      expect(screen.getByTestId('bottom-sheet')).toBeOnTheScreen();
-
-      // Close
-      act(() => {
-        fireEvent.press(screen.getByTestId('close-bottom-sheet'));
-      });
-      expect(screen.queryByTestId('bottom-sheet')).not.toBeOnTheScreen();
     });
   });
 
@@ -722,9 +579,6 @@ describe('PerpsTabViewWithProvider', () => {
 
     mockUsePerpsTrading.mockReturnValue({
       getAccountState: jest.fn(),
-      depositWithConfirmation: jest.fn().mockResolvedValue({
-        result: Promise.resolve(),
-      }),
     });
 
     mockUsePerpsFirstTimeUser.mockReturnValue({

--- a/app/components/UI/Perps/routes/index.tsx
+++ b/app/components/UI/Perps/routes/index.tsx
@@ -13,6 +13,7 @@ import PerpsOrderView from '../Views/PerpsOrderView';
 import PerpsQuoteExpiredModal from '../components/PerpsQuoteExpiredModal';
 import PerpsTutorialCarousel from '../components/PerpsTutorialCarousel';
 import { Confirm } from '../../../Views/confirmations/components/confirm';
+import PerpsBalanceModal from '../Views/PerpsBalanceModal';
 
 const Stack = createStackNavigator();
 const ModalStack = createStackNavigator();
@@ -30,6 +31,10 @@ const PerpsModalStack = () => (
     <ModalStack.Screen
       name={Routes.PERPS.MODALS.QUOTE_EXPIRED_MODAL}
       component={PerpsQuoteExpiredModal}
+    />
+    <ModalStack.Screen
+      name={Routes.PERPS.MODALS.BALANCE_MODAL}
+      component={PerpsBalanceModal}
     />
   </ModalStack.Navigator>
 );

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -223,6 +223,7 @@ const Routes = {
     MODALS: {
       ROOT: 'PerpsModals',
       QUOTE_EXPIRED_MODAL: 'PerpsQuoteExpiredModal',
+      BALANCE_MODAL: 'PerpsBalanceModal',
     },
     ORDER_HISTORY: 'PerpsOrderHistory',
     ORDER_DETAILS: 'PerpsOrderDetails',


### PR DESCRIPTION
…ering within the PerpsTabView

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The Perps balance modal was not rendering correctly on Android. Originally, I wrapped the balance modal bottom sheet in a `<Modal>` to ensure it renders from the root and not within the parent `PerpsTabView`. This works on iOS but **not** Android unfortunately.

New solution - I've broken the balance modal out into its own view. This way it renders as expected across iOS and Android.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added PerpsBalanceModal view and attached it to the PerpsModalStack.

## **Related issues**

Fixes: Perps Balance not rendering on Android

## **Manual testing steps**

```gherkin
Feature: PerpsBalanceModal

  Scenario: user wants to add or withdraw funds
    Given user is on the PerpsTabView

    When user clicks the "perps account balance" button
    Then the PerpsBalanceModal appears on Android and iOS
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/15ac26e4-937e-4e81-aeea-ea15082d32c4

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
