### PR TITLE
fix: Update Perps order keypad buttons to match latest design

### DIFF
--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.styles.ts
@@ -85,5 +85,5 @@ const createStyles = (colors: Colors) =>
       backgroundColor: colors.background.default,
     },
   });
-
+// test
 export default createStyles;

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.styles.ts
@@ -82,6 +82,7 @@ const createStyles = (colors: Colors) =>
       flex: 1,
     },
     keypad: {
+      paddingHorizontal: 16,
       backgroundColor: colors.background.default,
     },
   });

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.styles.ts
@@ -74,17 +74,17 @@ const createStyles = (colors: Colors) =>
     percentageButtonsContainer: {
       flexDirection: 'row',
       justifyContent: 'space-between',
-      paddingHorizontal: 24,
-      marginBottom: 16,
-      gap: 12,
+      paddingHorizontal: 16,
+      paddingBottom: 8,
+      gap: 8,
     },
     percentageButton: {
       flex: 1,
+      minWidth: 0, // Ensures buttons can shrink properly
     },
     keypad: {
       paddingHorizontal: 16,
       backgroundColor: colors.background.default,
     },
   });
-// test
 export default createStyles;

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -144,7 +144,6 @@ const PerpsOrderViewContentBase: React.FC = () => {
     setOrderType,
     handlePercentageAmount,
     handleMaxAmount,
-    handleMinAmount,
     calculations,
   } = usePerpsOrderContext();
 
@@ -525,10 +524,6 @@ const PerpsOrderViewContentBase: React.FC = () => {
     handleMaxAmount();
   };
 
-  const handleMinPress = () => {
-    handleMinAmount();
-  };
-
   const handleDonePress = () => {
     setIsInputFocused(false);
   };
@@ -867,23 +862,6 @@ const PerpsOrderViewContentBase: React.FC = () => {
             <Button
               variant={ButtonVariants.Secondary}
               size={ButtonSize.Md}
-              label="75%"
-              onPress={() => handlePercentagePress(0.75)}
-              style={styles.percentageButton}
-            />
-          </View>
-
-          <View style={styles.percentageButtonsContainer}>
-            <Button
-              variant={ButtonVariants.Secondary}
-              size={ButtonSize.Md}
-              label="Min"
-              onPress={handleMinPress}
-              style={styles.percentageButton}
-            />
-            <Button
-              variant={ButtonVariants.Secondary}
-              size={ButtonSize.Md}
               label={strings('perps.deposit.max_button')}
               onPress={handleMaxPress}
               style={styles.percentageButton}
@@ -902,6 +880,7 @@ const PerpsOrderViewContentBase: React.FC = () => {
             onChange={handleKeypadChange}
             currency="USD"
             decimals={0}
+            style={styles.keypad}
           />
         </View>
       )}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Simplified the Perps order entry keypad action buttons to improve UX and reduce visual clutter. Removed less commonly used percentage options and consolidated the layout into a single row.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Improved Perps order entry interface with streamlined quick action buttons

## **Related issues**

Fixes: Perps order entry keypad button layout

## **Manual testing steps**

```gherkin
Feature: Perps Order Entry Keypad Actions

  Scenario: User enters order amount with quick actions
    Given the user is on the Perps order view
    And the user taps on the amount input field

    When the keypad appears
    Then the user should see four action buttons: 25%, 50%, Max, Done
    And the buttons should be properly aligned with the numeric keypad below

  Scenario: User uses percentage buttons
    Given the keypad is open with action buttons visible

    When the user taps 25%
    Then the amount should be set to 25% of available balance
    
    When the user taps 50%
    Then the amount should be set to 50% of available balance
    
    When the user taps Max
    Then the amount should be set to the maximum available balance
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-18 at 22 32 44" src="https://github.com/user-attachments/assets/be575ade-017e-4dbb-95c1-5fecb3678232" />

### **After**
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-18 at 22 41 27" src="https://github.com/user-attachments/assets/1a5b98b0-6033-422b-8a71-f1216bdfbdd1" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.