### PR TITLE
feat: optimize Perps account/network monitoring with lifecycle manage…

### DIFF
--- a/app/components/UI/Perps/controllers/PerpsController.ts
+++ b/app/components/UI/Perps/controllers/PerpsController.ts
@@ -1786,6 +1786,32 @@ export class PerpsController extends BaseController<
   }
 
   /**
+   * Reconnect with new account/network context
+   * Called when user switches accounts or networks
+   */
+  async reconnectWithNewContext(): Promise<void> {
+    DevLogger.log('PerpsController: Reconnecting with new account/network', {
+      timestamp: new Date().toISOString(),
+    });
+
+    // Clear Redux state immediately to reset UI
+    this.update((state) => {
+      state.positions = [];
+      state.accountState = null;
+      state.pendingOrders = [];
+      state.lastError = null;
+    });
+
+    // Clear state and force reinitialization
+    // initializeProviders() will handle disconnection if needed
+    this.isInitialized = false;
+    this.initializationPromise = null;
+
+    // Reinitialize with new context
+    await this.initializeProviders();
+  }
+
+  /**
    * Eligibility (Geo-Blocking)
    * Users in the USA and Ontario (Canada) are not eligible for Perps
    */

--- a/app/components/UI/Perps/hooks/stream/usePerpsLiveAccount.ts
+++ b/app/components/UI/Perps/hooks/stream/usePerpsLiveAccount.ts
@@ -36,9 +36,12 @@ export function usePerpsLiveAccount(
     if (!streamManager) return;
 
     // Mark as no longer loading once we get first update
-    const handleAccountUpdate = (newAccount: AccountState) => {
+    const handleAccountUpdate = (newAccount: AccountState | null) => {
       setAccount(newAccount);
-      setIsInitialLoading(false);
+      // Only set loading to false if we have actual data
+      if (newAccount !== null) {
+        setIsInitialLoading(false);
+      }
     };
 
     const unsubscribe = streamManager.account.subscribe({

--- a/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
@@ -1,7 +1,3 @@
-import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
-import Engine from '../../../../core/Engine';
-import { PerpsConnectionManager } from './PerpsConnectionManager';
-
 // Mock dependencies
 jest.mock('../../../../core/SDKConnect/utils/DevLogger');
 jest.mock('../../../../core/Engine', () => ({
@@ -10,9 +6,56 @@ jest.mock('../../../../core/Engine', () => ({
       initializeProviders: jest.fn(),
       getAccountState: jest.fn(),
       disconnect: jest.fn(),
+      reconnectWithNewContext: jest.fn(),
     },
   },
 }));
+
+// Store the subscription callbacks
+const storeCallbacks: (() => void)[] = [];
+
+// Mock Redux store like other tests do
+jest.mock('../../../../store', () => ({
+  store: {
+    subscribe: jest.fn((callback) => {
+      storeCallbacks.push(callback);
+      return jest.fn(); // Returns unsubscribe function
+    }),
+    getState: jest.fn(),
+    dispatch: jest.fn(),
+  },
+}));
+
+// Mock selectors
+jest.mock('../../../../selectors/accountsController', () => ({
+  selectSelectedInternalAccountAddress: jest.fn(),
+}));
+
+jest.mock('../selectors/perpsController', () => ({
+  selectPerpsNetwork: jest.fn(),
+}));
+
+// Mock StreamManager - create a singleton mock instance
+const mockStreamManagerInstance = {
+  positions: { clearCache: jest.fn(), prewarm: jest.fn(() => jest.fn()) },
+  orders: { clearCache: jest.fn(), prewarm: jest.fn(() => jest.fn()) },
+  account: { clearCache: jest.fn(), prewarm: jest.fn(() => jest.fn()) },
+};
+
+jest.mock('../providers/PerpsStreamManager', () => ({
+  getStreamManagerInstance: jest.fn(() => mockStreamManagerInstance),
+}));
+
+// Import non-singleton modules first
+import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
+import Engine from '../../../../core/Engine';
+import { store } from '../../../../store';
+import { selectSelectedInternalAccountAddress } from '../../../../selectors/accountsController';
+import { selectPerpsNetwork } from '../selectors/perpsController';
+
+// Import PerpsConnectionManager after mocks are set up
+// This is imported here after mocks to ensure store.subscribe is mocked before the singleton is created
+import { PerpsConnectionManager } from './PerpsConnectionManager';
 
 // Helper to reset private properties for testing
 const resetManager = (manager: unknown) => {
@@ -22,12 +65,18 @@ const resetManager = (manager: unknown) => {
     isInitialized: boolean;
     connectionRefCount: number;
     initPromise: Promise<void> | null;
+    unsubscribeFromStore: (() => void) | null;
+    previousAddress: string | undefined;
+    previousPerpsNetwork: 'mainnet' | 'testnet' | undefined;
   };
   m.isConnected = false;
   m.isConnecting = false;
   m.isInitialized = false;
   m.connectionRefCount = 0;
   m.initPromise = null;
+  m.unsubscribeFromStore = null;
+  m.previousAddress = undefined;
+  m.previousPerpsNetwork = undefined;
 };
 
 describe('PerpsConnectionManager', () => {
@@ -38,10 +87,21 @@ describe('PerpsConnectionManager', () => {
       () => Promise<Record<string, unknown>>
     >;
     disconnect: jest.MockedFunction<() => Promise<void>>;
+    reconnectWithNewContext: jest.MockedFunction<() => Promise<void>>;
   };
+
+  // No need for beforeAll - singleton is created on first access
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    // Clear StreamManager mock calls
+    mockStreamManagerInstance.positions.clearCache.mockClear();
+    mockStreamManagerInstance.orders.clearCache.mockClear();
+    mockStreamManagerInstance.account.clearCache.mockClear();
+    mockStreamManagerInstance.positions.prewarm.mockClear();
+    mockStreamManagerInstance.orders.prewarm.mockClear();
+    mockStreamManagerInstance.account.prewarm.mockClear();
 
     // Reset the singleton instance state
     resetManager(PerpsConnectionManager);
@@ -253,6 +313,30 @@ describe('PerpsConnectionManager', () => {
       expect(disconnectedState.isInitialized).toBe(false);
       expect(disconnectedState.isConnecting).toBe(false);
     });
+
+    it('should clean up state monitoring when reference count reaches zero', async () => {
+      // Connect to set up monitoring
+      await PerpsConnectionManager.connect();
+
+      // Verify monitoring was set up
+      const subscribeCallsBefore = (store.subscribe as jest.Mock).mock.calls
+        .length;
+      expect(subscribeCallsBefore).toBeGreaterThan(0);
+
+      // Disconnect - should clean up monitoring
+      await PerpsConnectionManager.disconnect();
+
+      // Verify cleanup was logged
+      expect(mockDevLogger.log).toHaveBeenCalledWith(
+        'PerpsConnectionManager: State monitoring cleaned up',
+      );
+
+      // Verify monitoring is cleaned up internally
+      expect(
+        (PerpsConnectionManager as unknown as { unsubscribeFromStore: unknown })
+          .unsubscribeFromStore,
+      ).toBeNull();
+    });
   });
 
   describe('getConnectionState', () => {
@@ -310,6 +394,193 @@ describe('PerpsConnectionManager', () => {
 
       // Should disconnect when ref count reaches 0
       expect(mockPerpsController.disconnect).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('state monitoring', () => {
+    let storeCallback: () => void;
+
+    beforeEach(() => {
+      // Reset store callbacks
+      storeCallbacks.length = 0;
+
+      // Setup initial values for selectors
+      (selectSelectedInternalAccountAddress as jest.Mock).mockReturnValue(
+        '0xabc123',
+      );
+      (selectPerpsNetwork as jest.Mock).mockReturnValue('mainnet');
+      (store.getState as jest.Mock).mockReturnValue({});
+    });
+
+    it('should set up Redux store subscription on first connect', async () => {
+      // Connect to trigger monitoring setup
+      mockPerpsController.initializeProviders.mockResolvedValue();
+      mockPerpsController.getAccountState.mockResolvedValue({});
+
+      await PerpsConnectionManager.connect();
+
+      // Verify subscription was set up
+      expect(store.subscribe).toHaveBeenCalled();
+      expect(storeCallbacks.length).toBeGreaterThan(0);
+
+      // The callback should be a function
+      expect(typeof storeCallbacks[storeCallbacks.length - 1]).toBe('function');
+    });
+
+    it('should detect account changes and trigger reconnection', async () => {
+      // Setup connected state
+      mockPerpsController.initializeProviders.mockResolvedValue();
+      mockPerpsController.getAccountState.mockResolvedValue({});
+      mockPerpsController.reconnectWithNewContext.mockResolvedValue();
+
+      await PerpsConnectionManager.connect();
+
+      // Get the store callback that was registered
+      storeCallback = storeCallbacks[storeCallbacks.length - 1];
+
+      // Clear mock calls from connection
+      mockDevLogger.log.mockClear();
+
+      // Simulate account change
+      (selectSelectedInternalAccountAddress as jest.Mock).mockReturnValue(
+        '0xdef456',
+      );
+
+      // Trigger the store callback with the changed value
+      storeCallback();
+
+      // Wait for async operations
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(mockDevLogger.log).toHaveBeenCalledWith(
+        expect.stringContaining('Account or network change detected'),
+        expect.objectContaining({
+          accountChanged: true,
+          networkChanged: false,
+          previousAddress: '0xabc123',
+          currentAddress: '0xdef456',
+        }),
+      );
+    });
+
+    it('should detect network changes and trigger reconnection', async () => {
+      // Setup connected state
+      mockPerpsController.initializeProviders.mockResolvedValue();
+      mockPerpsController.getAccountState.mockResolvedValue({});
+      mockPerpsController.reconnectWithNewContext.mockResolvedValue();
+
+      await PerpsConnectionManager.connect();
+
+      // Get the store callback that was registered
+      storeCallback = storeCallbacks[storeCallbacks.length - 1];
+
+      // Clear mock calls from connection
+      mockDevLogger.log.mockClear();
+
+      // Simulate network change
+      (selectPerpsNetwork as jest.Mock).mockReturnValue('testnet');
+
+      // Trigger the store callback with the changed value
+      storeCallback();
+
+      // Wait for async operations
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(mockDevLogger.log).toHaveBeenCalledWith(
+        expect.stringContaining('Account or network change detected'),
+        expect.objectContaining({
+          accountChanged: false,
+          networkChanged: true,
+          previousNetwork: 'mainnet',
+          currentNetwork: 'testnet',
+        }),
+      );
+    });
+
+    it('should not trigger reconnection when not connected', async () => {
+      // Setup but don't connect
+      mockPerpsController.initializeProviders.mockResolvedValue();
+      mockPerpsController.getAccountState.mockResolvedValue({});
+
+      // Connect and immediately disconnect to set up monitoring
+      await PerpsConnectionManager.connect();
+      await PerpsConnectionManager.disconnect();
+
+      // Get the store callback that was registered (if any)
+      if (storeCallbacks.length > 0) {
+        storeCallback = storeCallbacks[storeCallbacks.length - 1];
+
+        // Clear mock calls
+        mockDevLogger.log.mockClear();
+
+        // Simulate account change
+        (selectSelectedInternalAccountAddress as jest.Mock).mockReturnValue(
+          '0xdef456',
+        );
+
+        // Trigger the store callback with changed values
+        storeCallback();
+
+        // Should not log account change detection because not connected
+        expect(mockDevLogger.log).not.toHaveBeenCalledWith(
+          expect.stringContaining('Account or network change detected'),
+          expect.any(Object),
+        );
+      }
+    });
+  });
+
+  describe('reconnectWithNewContext', () => {
+    beforeEach(() => {
+      mockPerpsController.reconnectWithNewContext.mockResolvedValue();
+      mockPerpsController.getAccountState.mockResolvedValue({});
+    });
+
+    it('should clear StreamManager caches', async () => {
+      // Setup connected state first
+      mockPerpsController.initializeProviders.mockResolvedValue();
+      mockPerpsController.getAccountState.mockResolvedValue({});
+      await PerpsConnectionManager.connect();
+
+      // Now call reconnectWithNewContext through the private method
+      await (
+        PerpsConnectionManager as unknown as {
+          reconnectWithNewContext: () => Promise<void>;
+        }
+      ).reconnectWithNewContext();
+
+      expect(mockStreamManagerInstance.positions.clearCache).toHaveBeenCalled();
+      expect(mockStreamManagerInstance.orders.clearCache).toHaveBeenCalled();
+      expect(mockStreamManagerInstance.account.clearCache).toHaveBeenCalled();
+    });
+
+    it('should reinitialize controller with new context', async () => {
+      await (
+        PerpsConnectionManager as unknown as {
+          reconnectWithNewContext: () => Promise<void>;
+        }
+      ).reconnectWithNewContext();
+
+      expect(mockPerpsController.reconnectWithNewContext).toHaveBeenCalled();
+      expect(mockPerpsController.getAccountState).toHaveBeenCalled();
+    });
+
+    it('should handle reconnection errors gracefully', async () => {
+      const error = new Error('Reconnection failed');
+      mockPerpsController.reconnectWithNewContext.mockRejectedValueOnce(error);
+
+      await expect(
+        (
+          PerpsConnectionManager as unknown as {
+            reconnectWithNewContext: () => Promise<void>;
+          }
+        ).reconnectWithNewContext(),
+      ).rejects.toThrow('Reconnection failed');
+
+      expect(mockDevLogger.log).toHaveBeenCalledWith(
+        expect.stringContaining('Reconnection with new context failed'),
+        error,
+      );
     });
   });
 });

--- a/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
@@ -405,10 +405,10 @@ describe('PerpsConnectionManager', () => {
       storeCallbacks.length = 0;
 
       // Setup initial values for selectors
-      (selectSelectedInternalAccountAddress as jest.Mock).mockReturnValue(
-        '0xabc123',
-      );
-      (selectPerpsNetwork as jest.Mock).mockReturnValue('mainnet');
+      (
+        selectSelectedInternalAccountAddress as unknown as jest.Mock
+      ).mockReturnValue('0xabc123');
+      (selectPerpsNetwork as unknown as jest.Mock).mockReturnValue('mainnet');
       (store.getState as jest.Mock).mockReturnValue({});
     });
 
@@ -442,9 +442,9 @@ describe('PerpsConnectionManager', () => {
       mockDevLogger.log.mockClear();
 
       // Simulate account change
-      (selectSelectedInternalAccountAddress as jest.Mock).mockReturnValue(
-        '0xdef456',
-      );
+      (
+        selectSelectedInternalAccountAddress as unknown as jest.Mock
+      ).mockReturnValue('0xdef456');
 
       // Trigger the store callback with the changed value
       storeCallback();
@@ -478,7 +478,7 @@ describe('PerpsConnectionManager', () => {
       mockDevLogger.log.mockClear();
 
       // Simulate network change
-      (selectPerpsNetwork as jest.Mock).mockReturnValue('testnet');
+      (selectPerpsNetwork as unknown as jest.Mock).mockReturnValue('testnet');
 
       // Trigger the store callback with the changed value
       storeCallback();
@@ -514,9 +514,9 @@ describe('PerpsConnectionManager', () => {
         mockDevLogger.log.mockClear();
 
         // Simulate account change
-        (selectSelectedInternalAccountAddress as jest.Mock).mockReturnValue(
-          '0xdef456',
-        );
+        (
+          selectSelectedInternalAccountAddress as unknown as jest.Mock
+        ).mockReturnValue('0xdef456');
 
         // Trigger the store callback with changed values
         storeCallback();

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -1,5 +1,8 @@
 import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
 import Engine from '../../../../core/Engine';
+import { store } from '../../../../store';
+import { selectSelectedInternalAccountAddress } from '../../../../selectors/accountsController';
+import { selectPerpsNetwork } from '../selectors/perpsController';
 import { getStreamManagerInstance } from '../providers/PerpsStreamManager';
 
 /**
@@ -16,9 +19,84 @@ class PerpsConnectionManagerClass {
   private initPromise: Promise<void> | null = null;
   private hasPreloaded = false;
   private prewarmCleanups: (() => void)[] = [];
+  private unsubscribeFromStore: (() => void) | null = null;
+  private previousAddress: string | undefined;
+  private previousPerpsNetwork: 'mainnet' | 'testnet' | undefined;
 
   private constructor() {
     // Private constructor to enforce singleton pattern
+    // Monitoring will be set up on first connect
+  }
+
+  /**
+   * Set up monitoring for account and network changes
+   */
+  private setupStateMonitoring(): void {
+    // Only set up if not already monitoring
+    if (this.unsubscribeFromStore) {
+      return;
+    }
+
+    // Get initial values
+    const state = store.getState();
+    this.previousAddress = selectSelectedInternalAccountAddress(state);
+    this.previousPerpsNetwork = selectPerpsNetwork(state);
+
+    // Subscribe to Redux store changes
+    this.unsubscribeFromStore = store.subscribe(() => {
+      const currentState = store.getState();
+      const currentAddress = selectSelectedInternalAccountAddress(currentState);
+      const currentPerpsNetwork = selectPerpsNetwork(currentState);
+
+      const hasAccountChanged =
+        this.previousAddress !== undefined &&
+        this.previousAddress !== currentAddress;
+      const hasPerpsNetworkChanged =
+        this.previousPerpsNetwork !== undefined &&
+        this.previousPerpsNetwork !== currentPerpsNetwork;
+
+      // If account or network changed and we're connected, trigger reconnection
+      if ((hasAccountChanged || hasPerpsNetworkChanged) && this.isConnected) {
+        DevLogger.log(
+          'PerpsConnectionManager: Account or network change detected',
+          {
+            accountChanged: hasAccountChanged,
+            networkChanged: hasPerpsNetworkChanged,
+            previousAddress: this.previousAddress,
+            currentAddress,
+            previousNetwork: this.previousPerpsNetwork,
+            currentNetwork: currentPerpsNetwork,
+          },
+        );
+
+        // Trigger reconnection asynchronously
+        this.reconnectWithNewContext().catch((error) => {
+          DevLogger.log(
+            'PerpsConnectionManager: Failed to reconnect after account/network change',
+            error,
+          );
+        });
+      }
+
+      // Update tracked values
+      this.previousAddress = currentAddress;
+      this.previousPerpsNetwork = currentPerpsNetwork;
+    });
+
+    DevLogger.log('PerpsConnectionManager: State monitoring set up');
+  }
+
+  /**
+   * Clean up state monitoring
+   */
+  private cleanupStateMonitoring(): void {
+    if (this.unsubscribeFromStore) {
+      this.unsubscribeFromStore();
+      this.unsubscribeFromStore = null;
+      this.previousAddress = undefined;
+      this.previousPerpsNetwork = undefined;
+      DevLogger.log('PerpsConnectionManager: State monitoring cleaned up');
+    }
   }
 
   static getInstance(): PerpsConnectionManagerClass {
@@ -29,6 +107,11 @@ class PerpsConnectionManagerClass {
   }
 
   async connect(): Promise<void> {
+    // Set up monitoring when first entering Perps (refCount 0 -> 1)
+    if (this.connectionRefCount === 0) {
+      this.setupStateMonitoring();
+    }
+
     this.connectionRefCount++;
     DevLogger.log(
       `PerpsConnectionManager: Connection requested (refCount: ${this.connectionRefCount})`,
@@ -89,6 +172,61 @@ class PerpsConnectionManagerClass {
     return this.initPromise;
   }
 
+  /**
+   * Force reconnection with new account/network context
+   * Used when user switches accounts or networks
+   */
+  async reconnectWithNewContext(): Promise<void> {
+    DevLogger.log(
+      'PerpsConnectionManager: Reconnecting with new account/network context',
+    );
+
+    try {
+      // Clean up existing connections
+      this.cleanupPreloadedSubscriptions();
+
+      // Clear all cached data from StreamManager to reset UI immediately
+      const streamManager = getStreamManagerInstance();
+      streamManager.positions.clearCache();
+      streamManager.orders.clearCache();
+      streamManager.account.clearCache();
+
+      // Reset state
+      this.isConnected = false;
+      this.isInitialized = false;
+      this.isConnecting = false;
+      this.hasPreloaded = false;
+
+      // Force the controller to reinitialize with new context
+      await Engine.context.PerpsController.reconnectWithNewContext();
+
+      // Re-establish connection
+      this.isConnecting = true;
+
+      // Trigger connection with new account
+      await Engine.context.PerpsController.getAccountState();
+
+      this.isConnected = true;
+      this.isInitialized = true;
+      this.isConnecting = false;
+      DevLogger.log(
+        'PerpsConnectionManager: Successfully reconnected with new context',
+      );
+
+      // Pre-load subscriptions again with new account
+      await this.preloadSubscriptions();
+    } catch (error) {
+      this.isConnecting = false;
+      this.isConnected = false;
+      this.isInitialized = false;
+      DevLogger.log(
+        'PerpsConnectionManager: Reconnection with new context failed',
+        error,
+      );
+      throw error;
+    }
+  }
+
   async disconnect(): Promise<void> {
     this.connectionRefCount--;
     DevLogger.log(
@@ -108,6 +246,9 @@ class PerpsConnectionManagerClass {
           // Clean up preloaded subscriptions
           this.cleanupPreloadedSubscriptions();
 
+          // Clean up state monitoring when leaving Perps
+          this.cleanupStateMonitoring();
+
           // Reset state before disconnecting to prevent race conditions
           this.isConnected = false;
           this.isInitialized = false;
@@ -118,6 +259,9 @@ class PerpsConnectionManagerClass {
         } catch (error) {
           DevLogger.log('PerpsConnectionManager: Disconnection error', error);
         }
+      } else {
+        // Even if not connected, clean up monitoring when leaving Perps
+        this.cleanupStateMonitoring();
       }
     }
   }
@@ -210,3 +354,4 @@ class PerpsConnectionManagerClass {
 }
 
 export const PerpsConnectionManager = PerpsConnectionManagerClass.getInstance();
+export default PerpsConnectionManager;


### PR DESCRIPTION
## **Description**

This PR adds account and network change monitoring to the Perps feature, ensuring that when users switch MetaMask accounts or toggle between mainnet/testnet, the Perps interface automatically reconnects and displays the correct data for the newly selected account/network.

**The Problem:**
1. When users switched MetaMask accounts, Perps continued showing the previous account's balance and positions
2. When users toggled between mainnet and testnet, Perps didn't update to show the correct network's data
3. WebSocket connections remained connected to the old account context, causing stale data display

**The Solution:**
1. Added Redux store monitoring to detect account and network changes
2. Implemented automatic WebSocket reconnection when changes are detected
3. Clear all cached data and refresh UI with new account/network data
4. Ensure monitoring only runs when user is in Perps scope for performance

## **Changelog**

CHANGELOG entry: Fixed Perps not updating when switching MetaMask accounts or networks

## **Related issues**

Fixes: Perps continues showing wrong account data after switching MetaMask accounts

## **Manual testing steps**

```gherkin
Feature: Perps Account and Network Change Detection

  Scenario: User switches MetaMask account while viewing Perps
    Given user is in the Perps trading interface with Account A
    And Account A has open positions and balance displayed

    When user switches to Account B in MetaMask
    Then Perps should automatically detect the account change
    And reconnect WebSocket with Account B's context
    And display Account B's balance and positions
    And clear all cached data from Account A

  Scenario: User switches from mainnet to testnet in Perps
    Given user is viewing Perps on mainnet
    And has mainnet positions and balance displayed

    When user toggles to testnet in Perps settings
    Then Perps should detect the network change
    And reconnect to testnet WebSocket endpoints
    And display testnet balance and positions
    And clear all mainnet cached data

  Scenario: Quick account switching maintains data integrity
    Given user is in Perps with Account A

    When user rapidly switches between Account A, B, and C
    Then each switch should trigger proper reconnection
    And final display should match the last selected account
    And no data mixing between accounts should occur
```

## **Screenshots/Recordings**

### **Before**
- Switching accounts: Perps continued showing previous account's data
- Network changes: Mainnet data persisted when switching to testnet
- Users had to manually refresh or re-enter Perps to see correct data

### **After**
- Switching accounts: Automatic detection and immediate update to new account's data
- Network changes: Seamless transition between mainnet and testnet data
- WebSocket connections properly reconnect with new context

https://github.com/user-attachments/assets/3ad8b891-d6c7-4507-a3a6-9c2669efc52a


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.