### PR TITLE
feat: Add `useSnapNameResolution` hook

### DIFF
--- a/app/components/Snaps/hooks/useSnapNameResolution.test.tsx
+++ b/app/components/Snaps/hooks/useSnapNameResolution.test.tsx
@@ -1,0 +1,249 @@
+import React from 'react';
+import { renderHook, RenderHookOptions } from '@testing-library/react-hooks';
+import { backgroundState } from '../../../util/test/initial-root-state';
+import { useSnapNameResolution } from './useSnapNameResolution';
+import type { DeepPartial } from '@reduxjs/toolkit';
+import { RootState } from '../../../reducers';
+import { Provider } from 'react-redux';
+import configureStore from '../../../util/test/configureStore';
+
+jest.mock('../../../core/Snaps/utils', () => ({
+  ...jest.requireActual('../../../core/Snaps/utils'),
+  handleSnapRequest: jest
+    .fn()
+    .mockImplementation(async (_, { snapId, request }) => {
+      if (
+        snapId === 'npm:@metamask/solana-snap' &&
+        request.params.domain.includes('metamask')
+      ) {
+        return {
+          resolvedAddresses: [
+            {
+              resolvedAddress: '7XGrbd3dmdesSR5vAu7siidiZ1YHyizzuPCQAnh2g2Lo',
+              protocol: 'SNS',
+              domainName: 'metamask.sol',
+            },
+          ],
+        };
+      }
+
+      if (
+        snapId === 'npm:@metamask/ens-resolver-snap' &&
+        request.params.domain.includes('metamask')
+      ) {
+        return {
+          resolvedAddresses: [
+            {
+              resolvedAddress: '0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb',
+              protocol: 'ENS',
+              domainName: 'metamask.eth',
+            },
+          ],
+        };
+      }
+
+      if (
+        snapId === 'npm:social-names-snap' &&
+        request.params.domain.endsWith('.lens')
+      ) {
+        return {
+          resolvedAddresses: [
+            {
+              resolvedAddress: '0x0000000000000000000000000000000000000000',
+              protocol: 'Lens',
+              domainName: 'foo.lens',
+            },
+          ],
+        };
+      }
+
+      if (
+        snapId === 'npm:social-names-snap' &&
+        request.params.domain.startsWith('farcaster:')
+      ) {
+        return {
+          resolvedAddresses: [
+            {
+              resolvedAddress: '0x0000000000000000000000000000000000000000',
+              protocol: 'Farcaster',
+              domainName: 'farcaster:v',
+            },
+          ],
+        };
+      }
+
+      return null;
+    }),
+}));
+
+const mockState = {
+  engine: {
+    backgroundState: {
+      ...backgroundState,
+      SnapController: {
+        snaps: {
+          'npm:@metamask/ens-resolver-snap': {
+            id: 'npm:@metamask/ens-resolver-snap',
+            enabled: true,
+            version: '1.0.0',
+          },
+          'npm:@metamask/solana-snap': {
+            id: 'npm:@metamask/solana-snap',
+            enabled: true,
+            version: '1.0.0',
+          },
+          'npm:social-names-snap': {
+            id: 'npm:social-names-snap',
+            enabled: true,
+            version: '1.0.0',
+          },
+        },
+      },
+      PermissionController: {
+        subjects: {
+          'npm:@metamask/ens-resolver-snap': {
+            origin: 'npm:@metamask/ens-resolver-snap',
+            permissions: {
+              'endowment:name-lookup': {
+                caveats: null,
+                date: 1718117256761,
+                id: 'MhjpHKQFfGpMzI6YzkPGU',
+                invoker: 'npm:@metamask/ens-resolver-snap',
+                parentCapability: 'endowment:name-lookup',
+              },
+            },
+          },
+          'npm:@metamask/solana-snap': {
+            origin: 'npm:@metamask/solana-snap',
+            permissions: {
+              'endowment:name-lookup': {
+                caveats: [
+                  {
+                    type: 'chainIds',
+                    value: [
+                      'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+                      'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1',
+                    ],
+                  },
+                ],
+                date: 1718117256761,
+                id: 'MhjpHKQFfGpMzI6YzkPGA',
+                invoker: 'npm:@metamask/solana-snap',
+                parentCapability: 'endowment:name-lookup',
+              },
+            },
+          },
+          'npm:social-names-snap': {
+            origin: 'npm:social-names-snap',
+            permissions: {
+              'endowment:name-lookup': {
+                caveats: [
+                  {
+                    type: 'lookupMatchers',
+                    value: { tlds: ['lens'], schemes: ['farcaster', 'fc'] },
+                  },
+                ],
+                date: 1718117256761,
+                id: 'MhjpHKQFfGpMzI6YzkPGA',
+                invoker: 'npm:social-names-snap',
+                parentCapability: 'endowment:name-lookup',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} as unknown as DeepPartial<RootState>;
+
+function renderHookWithProvider<Result, Props>(
+  hook: (props: Props) => Result,
+  state?: DeepPartial<RootState>,
+) {
+  const store = configureStore(state);
+  const Providers = ({ children }: { children: React.ReactElement }) => (
+    <Provider store={store}>{children}</Provider>
+  );
+  return renderHook(hook, { wrapper: Providers } as RenderHookOptions<Props>);
+}
+
+describe('useSnapNameResolution', () => {
+  it('calls name resolution Snaps with the provided input', async () => {
+    const { result, waitForValueToChange } = renderHookWithProvider(
+      () =>
+        useSnapNameResolution({ chainId: 'eip155:1', domain: 'metamask.eth' }),
+      mockState,
+    );
+
+    await waitForValueToChange(() => result.current.results);
+
+    expect(result.current.results).toStrictEqual([
+      {
+        domainName: 'metamask.eth',
+        protocol: 'ENS',
+        resolvedAddress: '0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb',
+      },
+    ]);
+  });
+
+  it('supports chain ID filtering', async () => {
+    const { result, waitForValueToChange } = renderHookWithProvider(
+      () =>
+        useSnapNameResolution({
+          chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+          domain: 'metamask',
+        }),
+      mockState,
+    );
+
+    await waitForValueToChange(() => result.current.results);
+
+    expect(result.current.results).toStrictEqual([
+      {
+        domainName: 'metamask.eth',
+        protocol: 'ENS',
+        resolvedAddress: '0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb',
+      },
+      {
+        domainName: 'metamask.sol',
+        protocol: 'SNS',
+        resolvedAddress: '7XGrbd3dmdesSR5vAu7siidiZ1YHyizzuPCQAnh2g2Lo',
+      },
+    ]);
+  });
+
+  it('supports scheme filtering', async () => {
+    const { result, waitForValueToChange } = renderHookWithProvider(
+      () =>
+        useSnapNameResolution({ chainId: 'eip155:1', domain: 'farcaster:v' }),
+      mockState,
+    );
+
+    await waitForValueToChange(() => result.current.results);
+
+    expect(result.current.results).toStrictEqual([
+      {
+        domainName: 'farcaster:v',
+        protocol: 'Farcaster',
+        resolvedAddress: '0x0000000000000000000000000000000000000000',
+      },
+    ]);
+  });
+
+  it('supports TLD filtering', async () => {
+    const { result, waitForValueToChange } = renderHookWithProvider(
+      () => useSnapNameResolution({ chainId: 'eip155:1', domain: 'foo.lens' }),
+      mockState,
+    );
+
+    await waitForValueToChange(() => result.current.results);
+
+    expect(result.current.results).toStrictEqual([
+      {
+        domainName: 'foo.lens',
+        protocol: 'Lens',
+        resolvedAddress: '0x0000000000000000000000000000000000000000',
+      },
+    ]);
+  });
+});

--- a/app/components/Snaps/hooks/useSnapNameResolution.ts
+++ b/app/components/Snaps/hooks/useSnapNameResolution.ts
@@ -1,0 +1,108 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
+import {
+  getChainIdsCaveat,
+  getLookupMatchersCaveat,
+} from '@metamask/snaps-rpc-methods';
+import { AddressResolution, DomainLookupResult } from '@metamask/snaps-sdk';
+import { HandlerType } from '@metamask/snaps-utils';
+import { handleSnapRequest } from '../../../core/Snaps/utils';
+import Engine from '../../../core/Engine';
+import { getNameLookupSnaps } from '../../../selectors/snaps';
+
+/**
+ * A hook for using Snaps to resolve domain names for a given chain ID.
+ *
+ * @param options - An options bag.
+ * @param options.chainId - A CAIP-2 chain ID.
+ * @param options.domain - The domain to resolve.
+ * @returns The results of the name resolution and a flag to determine if the
+ * results are loading.
+ */
+export function useSnapNameResolution({
+  chainId,
+  domain,
+}: {
+  chainId: string;
+  domain: string;
+}) {
+  const [loading, setLoading] = useState<boolean>(false);
+  const [results, setResults] = useState<AddressResolution[]>([]);
+
+  const snaps = useSelector(getNameLookupSnaps);
+
+  const filteredSnaps = useMemo(
+    () =>
+      snaps
+        .filter(({ permission }) => {
+          const chainIdCaveat = getChainIdsCaveat(permission);
+
+          if (chainIdCaveat && !chainIdCaveat.includes(chainId)) {
+            return false;
+          }
+
+          const lookupMatchersCaveat = getLookupMatchersCaveat(permission);
+
+          if (lookupMatchersCaveat) {
+            const { tlds, schemes } = lookupMatchersCaveat;
+            return (
+              tlds?.some((tld) => domain.endsWith(`.${tld}`)) ||
+              schemes?.some((scheme) => domain.startsWith(`${scheme}:`))
+            );
+          }
+
+          return true;
+        })
+        .map(({ id }) => id),
+    [snaps, chainId, domain],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchResolutions() {
+      setLoading(true);
+
+      const controllerMessenger = Engine.controllerMessenger;
+      const responses = await Promise.allSettled(
+        filteredSnaps.map(
+          (id) =>
+            handleSnapRequest(controllerMessenger, {
+              snapId: id,
+              origin: 'metamask',
+              handler: HandlerType.OnNameLookup,
+              request: {
+                jsonrpc: '2.0',
+                method: ' ',
+                params: {
+                  chainId,
+                  domain,
+                },
+              },
+            }) as Promise<DomainLookupResult>,
+        ),
+      );
+
+      if (!cancelled) {
+        const resolutions = responses
+          .filter(
+            (response) => response.status === 'fulfilled' && response.value,
+          )
+          .flatMap(
+            (response) =>
+              (response as PromiseFulfilledResult<DomainLookupResult>).value
+                .resolvedAddresses,
+          );
+        setResults(resolutions);
+        setLoading(false);
+      }
+    }
+
+    fetchResolutions();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [filteredSnaps, domain, chainId]);
+
+  return { results, loading };
+}

--- a/app/selectors/snaps/permissionController.ts
+++ b/app/selectors/snaps/permissionController.ts
@@ -5,6 +5,7 @@ import {
   SubjectType,
 } from '@metamask/permission-controller';
 import { createDeepEqualSelector } from '../util';
+import { createSelector } from 'reselect';
 
 export const selectPermissionControllerState = (state: RootState) =>
   state.engine.backgroundState
@@ -40,3 +41,8 @@ export function selectTargetSubjectMetadata(state: RootState, origin: string) {
 
   return metadata;
 }
+
+export const getSubjects = createSelector(
+  selectPermissionControllerState,
+  (state) => state.subjects,
+);

--- a/app/selectors/snaps/snapController.ts
+++ b/app/selectors/snaps/snapController.ts
@@ -38,17 +38,20 @@ export const selectSnapsMetadata = createDeepEqualSelector(
     }, {}),
 );
 
-export const getEnabledSnaps = createDeepEqualSelector(selectSnaps, (snaps) => Object.values(snaps).reduce<Record<SnapId, Snap>>((acc, cur) => {
+export const getEnabledSnaps = createDeepEqualSelector(selectSnaps, (snaps) =>
+  Object.values(snaps).reduce<Record<SnapId, Snap>>((acc, cur) => {
     if (cur.enabled) {
       acc[cur.id] = cur;
     }
     return acc;
-  }, {}));
+  }, {}),
+);
 
 export const getNameLookupSnaps = createDeepEqualSelector(
   getEnabledSnaps,
   getSubjects,
-  (snaps, subjects) => Object.values(snaps)
+  (snaps, subjects) =>
+    Object.values(snaps)
       .filter(({ id }) => subjects[id]?.permissions['endowment:name-lookup'])
       .map((snap) => ({
         id: snap.id,

--- a/app/selectors/snaps/snapController.ts
+++ b/app/selectors/snaps/snapController.ts
@@ -1,7 +1,9 @@
 import { createSelector } from 'reselect';
 import { RootState } from '../../reducers';
 import { createDeepEqualSelector } from '../util';
-import { getLocalizedSnapManifest } from '@metamask/snaps-utils';
+import { getLocalizedSnapManifest, Snap } from '@metamask/snaps-utils';
+import { getSubjects } from './permissionController';
+import { SnapId } from '@metamask/snaps-sdk';
 
 // TODO: Filter out huge values
 export const selectSnapControllerState = (state: RootState) =>
@@ -34,4 +36,22 @@ export const selectSnapsMetadata = createDeepEqualSelector(
       };
       return snapsMetadata;
     }, {}),
+);
+
+export const getEnabledSnaps = createDeepEqualSelector(selectSnaps, (snaps) => Object.values(snaps).reduce<Record<SnapId, Snap>>((acc, cur) => {
+    if (cur.enabled) {
+      acc[cur.id] = cur;
+    }
+    return acc;
+  }, {}));
+
+export const getNameLookupSnaps = createDeepEqualSelector(
+  getEnabledSnaps,
+  getSubjects,
+  (snaps, subjects) => Object.values(snaps)
+      .filter(({ id }) => subjects[id]?.permissions['endowment:name-lookup'])
+      .map((snap) => ({
+        id: snap.id,
+        permission: subjects[snap.id]?.permissions['endowment:name-lookup'],
+      })),
 );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR adds a utility hook for using Snaps for name resolution. This is useful for the upcoming send flow revamp.

## **Related issues**

Closes: https://github.com/MetaMask/snaps/issues/2636
