### PR TITLE
feat: Add `SnapUIDropdown` and `SnapUIRadioGroup`

### DIFF
--- a/app/components/Snaps/SnapUICheckbox/SnapUICheckbox.tsx
+++ b/app/components/Snaps/SnapUICheckbox/SnapUICheckbox.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent, useEffect, useState } from 'react';
 import { useSnapInterfaceContext } from '../SnapInterfaceContext';
-import { BorderColor, FlexDirection } from '../../UI/Box/box.types';
+import { FlexDirection } from '../../UI/Box/box.types';
 import Checkbox from '../../../component-library/components/Checkbox/Checkbox';
 import { HelpTextSeverity } from '../../../component-library/components/Form/HelpText/HelpText.types';
 import HelpText from '../../../component-library/components/Form/HelpText';
@@ -59,9 +59,6 @@ export const SnapUICheckbox: FunctionComponent<SnapUICheckboxProps> = ({
         onPress={handleChange}
         isChecked={value}
         label={label}
-        checkboxStyle={{
-          borderColor: BorderColor.borderMuted,
-        }}
         isDisabled={disabled}
       />
       {error && (

--- a/app/components/Snaps/SnapUICheckbox/SnapUICheckbox.tsx
+++ b/app/components/Snaps/SnapUICheckbox/SnapUICheckbox.tsx
@@ -60,6 +60,7 @@ export const SnapUICheckbox: FunctionComponent<SnapUICheckboxProps> = ({
         isChecked={value}
         label={label}
         isDisabled={disabled}
+        testID="snap-ui-renderer__checkbox"
       />
       {error && (
         // eslint-disable-next-line react-native/no-inline-styles

--- a/app/components/Snaps/SnapUIDropdown/SnapUIDropdown.tsx
+++ b/app/components/Snaps/SnapUIDropdown/SnapUIDropdown.tsx
@@ -24,7 +24,7 @@ export const SnapUIDropdown: FunctionComponent<SnapUIDropdownProps> = ({
   }));
 
   const optionComponents = options.map((option, index) => (
-    <SnapUICard key={index} title={option.value} value="" />
+    <SnapUICard key={index} title={option.name} value="" />
   ));
 
   return (

--- a/app/components/Snaps/SnapUIDropdown/SnapUIDropdown.tsx
+++ b/app/components/Snaps/SnapUIDropdown/SnapUIDropdown.tsx
@@ -1,0 +1,38 @@
+import React, { FunctionComponent } from 'react';
+import { ViewStyle } from 'react-native';
+import { SnapUISelector } from '../SnapUISelector/SnapUISelector';
+import { strings } from '../../../../locales/i18n';
+import { SnapUICard } from '../SnapUICard/SnapUICard';
+
+export interface SnapUIDropdownProps {
+  name: string;
+  options: { name: string; value: string; disabled?: boolean }[];
+  label?: string;
+  error?: string;
+  form?: string;
+  disabled?: boolean;
+  style?: ViewStyle;
+}
+
+export const SnapUIDropdown: FunctionComponent<SnapUIDropdownProps> = ({
+  options,
+  ...props
+}) => {
+  const formattedOptions = options.map((option) => ({
+    value: option.value,
+    disabled: option.disabled ?? false,
+  }));
+
+  const optionComponents = options.map((option, index) => (
+    <SnapUICard key={index} title={option.value} value="" />
+  ));
+
+  return (
+    <SnapUISelector
+      title={strings('snap_ui.dropdown.title')}
+      options={formattedOptions}
+      optionComponents={optionComponents}
+      {...props}
+    />
+  );
+};

--- a/app/components/Snaps/SnapUIDropdown/SnapUIDropdown.tsx
+++ b/app/components/Snaps/SnapUIDropdown/SnapUIDropdown.tsx
@@ -32,6 +32,7 @@ export const SnapUIDropdown: FunctionComponent<SnapUIDropdownProps> = ({
       title={strings('snap_ui.dropdown.title')}
       options={formattedOptions}
       optionComponents={optionComponents}
+      testID="snap-ui-renderer__dropdown"
       {...props}
     />
   );

--- a/app/components/Snaps/SnapUIFooterButton/SnapUIFooterButton.tsx
+++ b/app/components/Snaps/SnapUIFooterButton/SnapUIFooterButton.tsx
@@ -39,6 +39,7 @@ interface SnapUIFooterButtonProps {
   isSnapAction?: boolean;
   onCancel?: () => void;
   type: ButtonType;
+  form?: string;
   snapVariant: ButtonProps['variant'];
   disabled?: boolean;
   loading?: boolean;
@@ -56,6 +57,8 @@ export const SnapUIFooterButton: FunctionComponent<SnapUIFooterButtonProps> = ({
   variant = ButtonVariants.Primary,
   snapVariant,
   testID,
+  type,
+  form,
   ...props
 }) => {
   const theme = useTheme();
@@ -84,6 +87,14 @@ export const SnapUIFooterButton: FunctionComponent<SnapUIFooterButtonProps> = ({
       event: UserInputEventType.ButtonClickEvent,
       name,
     });
+
+    // Since we don't have onSubmit on mobile, the button submits the form.
+    if (type === ButtonType.Submit) {
+      handleEvent({
+        event: UserInputEventType.FormSubmitEvent,
+        name: form,
+      });
+    }
   };
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/app/components/Snaps/SnapUIRadioGroup/SnapUIRadioGroup.tsx
+++ b/app/components/Snaps/SnapUIRadioGroup/SnapUIRadioGroup.tsx
@@ -1,0 +1,68 @@
+import React, { FunctionComponent, useEffect, useState } from 'react';
+import { ViewStyle } from 'react-native';
+import { Box } from '../../UI/Box/Box';
+import Label from '../../../component-library/components/Form/Label';
+import { TextVariant } from '../../../component-library/components/Texts/Text';
+import HelpText, {
+  HelpTextSeverity,
+} from '../../../component-library/components/Form/HelpText';
+import RadioButton from '../../../component-library/components/RadioButton';
+import { useSnapInterfaceContext } from '../SnapInterfaceContext';
+
+export interface SnapUIRadioGroupProps {
+  name: string;
+  options: { name: string; value: string; disabled?: boolean }[];
+  label?: string;
+  error?: string;
+  form?: string;
+  disabled?: boolean;
+  style?: ViewStyle;
+}
+
+export const SnapUIRadioGroup: FunctionComponent<SnapUIRadioGroupProps> = ({
+  name,
+  options,
+  label,
+  error,
+  style,
+  disabled,
+  form,
+}) => {
+  const { handleInputChange, getValue } = useSnapInterfaceContext();
+
+  const initialValue = getValue(name, form);
+
+  const [value, setValue] = useState(initialValue);
+
+  useEffect(() => {
+    if (initialValue && value !== initialValue) {
+      setValue(initialValue);
+    }
+  }, [initialValue]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleChange = (newValue: string) => {
+    setValue(newValue);
+    handleInputChange(name, newValue, form);
+  };
+
+  return (
+    <Box style={style}>
+      {label && <Label variant={TextVariant.BodyMDMedium}>{label}</Label>}
+      {options.map((option) => (
+        <RadioButton
+          key={option.value}
+          label={option.name}
+          isChecked={value === option.value}
+          isDisabled={disabled ?? option.disabled}
+          onPress={() => handleChange(option.value)}
+        />
+      ))}
+      {error && (
+        // eslint-disable-next-line react-native/no-inline-styles
+        <HelpText severity={HelpTextSeverity.Error} style={{ marginTop: 4 }}>
+          {error}
+        </HelpText>
+      )}
+    </Box>
+  );
+};

--- a/app/components/Snaps/SnapUIRadioGroup/SnapUIRadioGroup.tsx
+++ b/app/components/Snaps/SnapUIRadioGroup/SnapUIRadioGroup.tsx
@@ -46,7 +46,7 @@ export const SnapUIRadioGroup: FunctionComponent<SnapUIRadioGroupProps> = ({
   };
 
   return (
-    <Box style={style}>
+    <Box style={style} testID="snap-ui-renderer__radio">
       {label && <Label variant={TextVariant.BodyMDMedium}>{label}</Label>}
       {options.map((option) => (
         <RadioButton
@@ -55,6 +55,7 @@ export const SnapUIRadioGroup: FunctionComponent<SnapUIRadioGroupProps> = ({
           isChecked={value === option.value}
           isDisabled={disabled ?? option.disabled}
           onPress={() => handleChange(option.value)}
+          testID="snap-ui-renderer__radio-button"
         />
       ))}
       {error && (

--- a/app/components/Snaps/SnapUIRadioGroup/SnapUIRadioGroup.tsx
+++ b/app/components/Snaps/SnapUIRadioGroup/SnapUIRadioGroup.tsx
@@ -35,7 +35,11 @@ export const SnapUIRadioGroup: FunctionComponent<SnapUIRadioGroupProps> = ({
   const [value, setValue] = useState(initialValue);
 
   useEffect(() => {
-    if (initialValue && value !== initialValue) {
+    if (
+      initialValue !== null &&
+      initialValue !== undefined &&
+      value !== initialValue
+    ) {
       setValue(initialValue);
     }
   }, [initialValue]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
@@ -357,6 +357,7 @@ exports[`SnapUIForm will render with fields 1`] = `
                       "opacity": 1,
                     }
                   }
+                  testID="snap-ui-renderer__checkbox"
                 >
                   <View
                     accessibilityRole="checkbox"
@@ -385,7 +386,7 @@ exports[`SnapUIForm will render with fields 1`] = `
                           "width": 20,
                         }
                       }
-                      testID="checkbox-icon-component"
+                      testID="snap-ui-renderer__checkbox"
                       width={20}
                     />
                   </View>
@@ -420,6 +421,7 @@ exports[`SnapUIForm will render with fields 1`] = `
                     undefined,
                   ]
                 }
+                testID="snap-ui-renderer__radio"
               >
                 <Text
                   accessibilityRole="text"
@@ -447,6 +449,7 @@ exports[`SnapUIForm will render with fields 1`] = `
                       "opacity": 1,
                     }
                   }
+                  testID="snap-ui-renderer__radio-button"
                 >
                   <View
                     accessibilityRole="radio"
@@ -497,6 +500,7 @@ exports[`SnapUIForm will render with fields 1`] = `
                       "opacity": 1,
                     }
                   }
+                  testID="snap-ui-renderer__radio-button"
                 >
                   <View
                     accessibilityRole="radio"
@@ -601,7 +605,7 @@ exports[`SnapUIForm will render with fields 1`] = `
                       "paddingTop": 8,
                     }
                   }
-                  testID="snap-ui-renderer__selector"
+                  testID="snap-ui-renderer__dropdown"
                 >
                   <View
                     alignItems="center"

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
@@ -364,7 +364,7 @@ exports[`SnapUIForm will render with fields 1`] = `
                       {
                         "alignItems": "center",
                         "backgroundColor": "#4459ff",
-                        "borderColor": "border-muted",
+                        "borderColor": "#4459ff",
                         "borderRadius": 4,
                         "borderWidth": 2,
                         "height": 20,
@@ -412,6 +412,836 @@ exports[`SnapUIForm will render with fields 1`] = `
                     </Text>
                   </View>
                 </TouchableOpacity>
+              </View>
+              <View
+                style={
+                  [
+                    {},
+                    undefined,
+                  ]
+                }
+              >
+                <Text
+                  accessibilityRole="text"
+                  style={
+                    {
+                      "color": "#121314",
+                      "fontFamily": "Geist Medium",
+                      "fontSize": 16,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                    }
+                  }
+                  testID="label"
+                >
+                  My Radio Group
+                </Text>
+                <TouchableOpacity
+                  disabled={false}
+                  onPress={[Function]}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "height": 24,
+                      "opacity": 1,
+                    }
+                  }
+                >
+                  <View
+                    accessibilityRole="radio"
+                    style={
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#ffffff",
+                        "borderColor": "#b7bbc8",
+                        "borderRadius": 99,
+                        "borderWidth": 2,
+                        "height": 20,
+                        "justifyContent": "center",
+                        "width": 20,
+                      }
+                    }
+                  />
+                  <View
+                    style={
+                      {
+                        "marginLeft": 12,
+                      }
+                    }
+                  >
+                    <Text
+                      accessibilityRole="text"
+                      style={
+                        {
+                          "color": "#121314",
+                          "fontFamily": "Geist Regular",
+                          "fontSize": 16,
+                          "letterSpacing": 0,
+                          "lineHeight": 24,
+                        }
+                      }
+                    >
+                      Radio 1
+                    </Text>
+                  </View>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  disabled={false}
+                  onPress={[Function]}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "height": 24,
+                      "opacity": 1,
+                    }
+                  }
+                >
+                  <View
+                    accessibilityRole="radio"
+                    style={
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "#ffffff",
+                        "borderColor": "#4459ff",
+                        "borderRadius": 99,
+                        "borderWidth": 2,
+                        "height": 20,
+                        "justifyContent": "center",
+                        "width": 20,
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        {
+                          "backgroundColor": "#4459ff",
+                          "borderRadius": 99,
+                          "height": 12,
+                          "width": 12,
+                        }
+                      }
+                      testID="RadioButton-icon-component"
+                    />
+                  </View>
+                  <View
+                    style={
+                      {
+                        "marginLeft": 12,
+                      }
+                    }
+                  >
+                    <Text
+                      accessibilityRole="text"
+                      style={
+                        {
+                          "color": "#121314",
+                          "fontFamily": "Geist Regular",
+                          "fontSize": 16,
+                          "letterSpacing": 0,
+                          "lineHeight": 24,
+                        }
+                      }
+                    >
+                      Radio 2
+                    </Text>
+                  </View>
+                </TouchableOpacity>
+              </View>
+              <View
+                flexDirection="column"
+                style={
+                  [
+                    {
+                      "flexDirection": "column",
+                    },
+                    undefined,
+                  ]
+                }
+              >
+                <Text
+                  accessibilityRole="text"
+                  style={
+                    {
+                      "color": "#121314",
+                      "fontFamily": "Geist Medium",
+                      "fontSize": 16,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                    }
+                  }
+                  testID="label"
+                >
+                  My Dropdown
+                </Text>
+                <TouchableOpacity
+                  accessibilityRole="button"
+                  accessible={true}
+                  activeOpacity={1}
+                  onPress={[Function]}
+                  style={
+                    {
+                      "alignItems": "center",
+                      "alignSelf": "stretch",
+                      "backgroundColor": "#ffffff",
+                      "borderColor": "#b7bbc866",
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "flexDirection": "row",
+                      "height": "auto",
+                      "justifyContent": "center",
+                      "maxHeight": 58,
+                      "minHeight": 48,
+                      "overflow": "hidden",
+                      "paddingBottom": 8,
+                      "paddingHorizontal": 16,
+                      "paddingLeft": 16,
+                      "paddingRight": 16,
+                      "paddingTop": 8,
+                    }
+                  }
+                  testID="snap-ui-renderer__selector"
+                >
+                  <View
+                    alignItems="center"
+                    flexDirection="row"
+                    gap={8}
+                    justifyContent="space-between"
+                    style={
+                      [
+                        {
+                          "alignItems": "center",
+                          "flexDirection": "row",
+                          "gap": 8,
+                          "justifyContent": "space-between",
+                        },
+                        {
+                          "flex": 1,
+                        },
+                      ]
+                    }
+                    testID="snaps-ui-card"
+                  >
+                    <View
+                      alignItems="center"
+                      flexDirection="row"
+                      gap={16}
+                      style={
+                        [
+                          {
+                            "alignItems": "center",
+                            "flexDirection": "row",
+                            "gap": 16,
+                          },
+                          undefined,
+                        ]
+                      }
+                    >
+                      <View
+                        flexDirection="column"
+                        style={
+                          [
+                            {
+                              "flexDirection": "column",
+                            },
+                            undefined,
+                          ]
+                        }
+                      >
+                        <Text
+                          accessibilityRole="text"
+                          ellipsizeMode="tail"
+                          style={
+                            {
+                              "color": "#121314",
+                              "fontFamily": "Geist Medium",
+                              "fontSize": 16,
+                              "letterSpacing": 0,
+                              "lineHeight": 24,
+                            }
+                          }
+                        >
+                          Dropdown 2
+                        </Text>
+                      </View>
+                    </View>
+                    <View
+                      flexDirection="column"
+                      style={
+                        [
+                          {
+                            "flexDirection": "column",
+                          },
+                          undefined,
+                        ]
+                      }
+                    >
+                      <Text
+                        accessibilityRole="text"
+                        ellipsizeMode="tail"
+                        style={
+                          {
+                            "color": "#121314",
+                            "fontFamily": "Geist Medium",
+                            "fontSize": 16,
+                            "letterSpacing": 0,
+                            "lineHeight": 24,
+                            "textAlign": "right",
+                          }
+                        }
+                      />
+                    </View>
+                  </View>
+                  <SvgMock
+                    color="#121314"
+                    fill="currentColor"
+                    height={16}
+                    name="ArrowDown"
+                    style={
+                      {
+                        "height": 16,
+                        "marginLeft": 8,
+                        "width": 16,
+                      }
+                    }
+                    width={16}
+                  />
+                </TouchableOpacity>
+              </View>
+              <View>
+                <Modal
+                  animationType="none"
+                  deviceHeight={null}
+                  deviceWidth={null}
+                  hardwareAccelerated={false}
+                  hideModalContentWhileAnimating={false}
+                  onBackdropPress={[Function]}
+                  onModalHide={[Function]}
+                  onModalWillHide={[Function]}
+                  onModalWillShow={[Function]}
+                  onRequestClose={[Function]}
+                  onSwipeComplete={[Function]}
+                  panResponderThreshold={4}
+                  scrollHorizontal={false}
+                  scrollOffset={0}
+                  scrollOffsetMax={0}
+                  scrollTo={null}
+                  statusBarTranslucent={false}
+                  supportedOrientations={
+                    [
+                      "portrait",
+                      "landscape",
+                    ]
+                  }
+                  swipeDirection="down"
+                  swipeThreshold={100}
+                  transparent={true}
+                  visible={true}
+                >
+                  <View
+                    accessibilityState={
+                      {
+                        "busy": undefined,
+                        "checked": undefined,
+                        "disabled": undefined,
+                        "expanded": undefined,
+                        "selected": undefined,
+                      }
+                    }
+                    accessible={true}
+                    collapsable={false}
+                    focusable={true}
+                    onClick={[Function]}
+                    onResponderGrant={[Function]}
+                    onResponderMove={[Function]}
+                    onResponderRelease={[Function]}
+                    onResponderTerminate={[Function]}
+                    onResponderTerminationRequest={[Function]}
+                    onStartShouldSetResponder={[Function]}
+                    style={
+                      {
+                        "backgroundColor": "#3f434a66",
+                        "bottom": 0,
+                        "height": 1334,
+                        "left": 0,
+                        "opacity": 0,
+                        "position": "absolute",
+                        "right": 0,
+                        "top": 0,
+                        "width": 750,
+                      }
+                    }
+                  />
+                  <View
+                    onLayout={[Function]}
+                    pointerEvents="box-none"
+                    style={
+                      [
+                        [
+                          {
+                            "margin": 37.5,
+                            "transform": [
+                              {
+                                "translateY": 0,
+                              },
+                            ],
+                          },
+                          {
+                            "flex": 1,
+                            "justifyContent": "center",
+                          },
+                          {
+                            "justifyContent": "flex-end",
+                            "margin": 0,
+                          },
+                          {
+                            "margin": 0,
+                          },
+                        ],
+                        {
+                          "paddingBottom": 0,
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      collapsable={false}
+                      deviceHeight={null}
+                      deviceWidth={null}
+                      hideModalContentWhileAnimating={false}
+                      onBackdropPress={[Function]}
+                      onModalHide={[Function]}
+                      onModalWillHide={[Function]}
+                      onModalWillShow={[Function]}
+                      onMoveShouldSetResponder={[Function]}
+                      onMoveShouldSetResponderCapture={[Function]}
+                      onResponderEnd={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderReject={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderStart={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                      onStartShouldSetResponderCapture={[Function]}
+                      onSwipeComplete={[Function]}
+                      panResponderThreshold={4}
+                      pointerEvents="box-none"
+                      scrollHorizontal={false}
+                      scrollOffset={0}
+                      scrollOffsetMax={0}
+                      scrollTo={null}
+                      statusBarTranslucent={false}
+                      style={
+                        {
+                          "flex": 1,
+                          "justifyContent": "flex-end",
+                          "margin": 0,
+                          "transform": [
+                            {
+                              "translateY": 1334,
+                            },
+                          ],
+                        }
+                      }
+                      supportedOrientations={
+                        [
+                          "portrait",
+                          "landscape",
+                        ]
+                      }
+                      swipeDirection="down"
+                      swipeThreshold={100}
+                    >
+                      <View
+                        style={
+                          {
+                            "backgroundColor": "#ffffff",
+                            "borderTopLeftRadius": 24,
+                            "borderTopRightRadius": 24,
+                            "maxHeight": "80%",
+                            "minHeight": 300,
+                            "overflow": "hidden",
+                            "paddingBottom": 20,
+                          }
+                        }
+                      >
+                        <View
+                          style={
+                            [
+                              {
+                                "backgroundColor": "#ffffff",
+                                "flexDirection": "row",
+                                "gap": 16,
+                                "padding": 16,
+                              },
+                              false,
+                            ]
+                          }
+                          testID="header"
+                        >
+                          <View
+                            style={
+                              {
+                                "width": undefined,
+                              }
+                            }
+                          >
+                            <View
+                              onLayout={[Function]}
+                            >
+                              <TouchableOpacity
+                                accessible={true}
+                                activeOpacity={1}
+                                disabled={false}
+                                onPress={[Function]}
+                                onPressIn={[Function]}
+                                onPressOut={[Function]}
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                    "borderRadius": 8,
+                                    "height": 24,
+                                    "justifyContent": "center",
+                                    "opacity": 1,
+                                    "width": 24,
+                                  }
+                                }
+                              >
+                                <SvgMock
+                                  color="#121314"
+                                  fill="currentColor"
+                                  height={16}
+                                  name="ArrowLeft"
+                                  style={
+                                    {
+                                      "height": 16,
+                                      "width": 16,
+                                    }
+                                  }
+                                  width={16}
+                                />
+                              </TouchableOpacity>
+                            </View>
+                          </View>
+                          <View
+                            style={
+                              {
+                                "alignItems": "center",
+                                "flex": 1,
+                              }
+                            }
+                          >
+                            <Text
+                              accessibilityRole="text"
+                              style={
+                                {
+                                  "color": "#121314",
+                                  "fontFamily": "Geist Bold",
+                                  "fontSize": 16,
+                                  "letterSpacing": 0,
+                                  "lineHeight": 24,
+                                  "textAlign": "center",
+                                }
+                              }
+                              testID="header-title"
+                            >
+                              Select an option
+                            </Text>
+                          </View>
+                          <View
+                            style={
+                              {
+                                "width": undefined,
+                              }
+                            }
+                          >
+                            <View
+                              onLayout={[Function]}
+                            />
+                          </View>
+                        </View>
+                        <RCTScrollView>
+                          <View>
+                            <View
+                              flexDirection="column"
+                              gap={8}
+                              style={
+                                [
+                                  {
+                                    "flexDirection": "column",
+                                    "gap": 8,
+                                  },
+                                  {
+                                    "paddingLeft": 16,
+                                    "paddingRight": 16,
+                                  },
+                                ]
+                              }
+                            >
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                activeOpacity={1}
+                                disabled={false}
+                                onPress={[Function]}
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                    "alignSelf": "stretch",
+                                    "backgroundColor": "transparent",
+                                    "borderRadius": 8,
+                                    "flexDirection": "row",
+                                    "height": "auto",
+                                    "justifyContent": "center",
+                                    "maxHeight": 58,
+                                    "minHeight": 48,
+                                    "overflow": "hidden",
+                                    "paddingBottom": 8,
+                                    "paddingHorizontal": 16,
+                                    "paddingLeft": 16,
+                                    "paddingRight": 16,
+                                    "paddingTop": 8,
+                                  }
+                                }
+                                testID="snap-ui-renderer__selector-item"
+                              >
+                                <View
+                                  alignItems="center"
+                                  flexDirection="row"
+                                  gap={8}
+                                  justifyContent="space-between"
+                                  style={
+                                    [
+                                      {
+                                        "alignItems": "center",
+                                        "flexDirection": "row",
+                                        "gap": 8,
+                                        "justifyContent": "space-between",
+                                      },
+                                      {
+                                        "flex": 1,
+                                      },
+                                    ]
+                                  }
+                                  testID="snaps-ui-card"
+                                >
+                                  <View
+                                    alignItems="center"
+                                    flexDirection="row"
+                                    gap={16}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "flexDirection": "row",
+                                          "gap": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <View
+                                      flexDirection="column"
+                                      style={
+                                        [
+                                          {
+                                            "flexDirection": "column",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityRole="text"
+                                        ellipsizeMode="tail"
+                                        style={
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Medium",
+                                            "fontSize": 16,
+                                            "letterSpacing": 0,
+                                            "lineHeight": 24,
+                                          }
+                                        }
+                                      >
+                                        Dropdown 1
+                                      </Text>
+                                    </View>
+                                  </View>
+                                  <View
+                                    flexDirection="column"
+                                    style={
+                                      [
+                                        {
+                                          "flexDirection": "column",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      accessibilityRole="text"
+                                      ellipsizeMode="tail"
+                                      style={
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Medium",
+                                          "fontSize": 16,
+                                          "letterSpacing": 0,
+                                          "lineHeight": 24,
+                                          "textAlign": "right",
+                                        }
+                                      }
+                                    />
+                                  </View>
+                                </View>
+                              </TouchableOpacity>
+                              <TouchableOpacity
+                                accessibilityRole="button"
+                                accessible={true}
+                                activeOpacity={1}
+                                disabled={false}
+                                onPress={[Function]}
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                    "alignSelf": "stretch",
+                                    "backgroundColor": "#4459ff1a",
+                                    "borderRadius": 8,
+                                    "flexDirection": "row",
+                                    "height": "auto",
+                                    "justifyContent": "center",
+                                    "maxHeight": 58,
+                                    "minHeight": 48,
+                                    "overflow": "hidden",
+                                    "paddingBottom": 8,
+                                    "paddingHorizontal": 16,
+                                    "paddingLeft": 16,
+                                    "paddingRight": 16,
+                                    "paddingTop": 8,
+                                  }
+                                }
+                                testID="snap-ui-renderer__selector-item"
+                              >
+                                <View
+                                  alignItems="center"
+                                  flexDirection="row"
+                                  gap={8}
+                                  justifyContent="space-between"
+                                  style={
+                                    [
+                                      {
+                                        "alignItems": "center",
+                                        "flexDirection": "row",
+                                        "gap": 8,
+                                        "justifyContent": "space-between",
+                                      },
+                                      {
+                                        "flex": 1,
+                                      },
+                                    ]
+                                  }
+                                  testID="snaps-ui-card"
+                                >
+                                  <View
+                                    alignItems="center"
+                                    flexDirection="row"
+                                    gap={16}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "flexDirection": "row",
+                                          "gap": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <View
+                                      flexDirection="column"
+                                      style={
+                                        [
+                                          {
+                                            "flexDirection": "column",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityRole="text"
+                                        ellipsizeMode="tail"
+                                        style={
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Medium",
+                                            "fontSize": 16,
+                                            "letterSpacing": 0,
+                                            "lineHeight": 24,
+                                          }
+                                        }
+                                      >
+                                        Dropdown 2
+                                      </Text>
+                                    </View>
+                                  </View>
+                                  <View
+                                    flexDirection="column"
+                                    style={
+                                      [
+                                        {
+                                          "flexDirection": "column",
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      accessibilityRole="text"
+                                      ellipsizeMode="tail"
+                                      style={
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Medium",
+                                          "fontSize": 16,
+                                          "letterSpacing": 0,
+                                          "lineHeight": 24,
+                                          "textAlign": "right",
+                                        }
+                                      }
+                                    />
+                                  </View>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {},
+                                      {
+                                        "backgroundColor": "#4459ff",
+                                        "borderRadius": 9999,
+                                        "bottom": 4,
+                                        "height": "auto",
+                                        "left": 4,
+                                        "marginRight": 12,
+                                        "position": "absolute",
+                                        "top": 4,
+                                        "width": 4,
+                                      },
+                                    ]
+                                  }
+                                />
+                              </TouchableOpacity>
+                            </View>
+                          </View>
+                        </RCTScrollView>
+                      </View>
+                    </View>
+                  </View>
+                </Modal>
               </View>
               <View
                 flexDirection="column"

--- a/app/components/Snaps/SnapUIRenderer/components/dropdown.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/dropdown.ts
@@ -1,0 +1,28 @@
+import { DropdownElement, OptionElement } from '@metamask/snaps-sdk/jsx';
+import { getJsxChildren } from '@metamask/snaps-utils';
+
+import { UIComponentFactory } from './types';
+
+export const dropdown: UIComponentFactory<DropdownElement> = ({
+  element: e,
+  form,
+}) => {
+  const children = getJsxChildren(e) as OptionElement[];
+
+  const options = children.map((child) => ({
+    value: child.props.value,
+    name: child.props.children,
+    disabled: child.props.disabled,
+  }));
+
+  return {
+    element: 'SnapUIDropdown',
+    props: {
+      id: e.props.name,
+      name: e.props.name,
+      disabled: e.props.disabled,
+      form,
+      options,
+    },
+  };
+};

--- a/app/components/Snaps/SnapUIRenderer/components/field.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/field.ts
@@ -8,6 +8,7 @@ import {
   AssetSelectorElement,
   AccountSelectorElement,
   DropdownElement,
+  RadioGroupElement,
 } from '@metamask/snaps-sdk/jsx';
 import { getJsxChildren } from '@metamask/snaps-utils';
 import { getPrimaryChildElementIndex, mapToTemplate } from '../utils';
@@ -18,6 +19,7 @@ import { constructInputProps } from './input';
 import { assetSelector as assetSelectorFn } from './asset-selector';
 import { accountSelector as accountSelectorFn } from './account-selector';
 import { dropdown as dropdownFn } from './dropdown';
+import { radioGroup as radioGroupFn } from './radioGroup';
 
 export const field: UIComponentFactory<FieldElement> = ({
   element: e,
@@ -215,6 +217,25 @@ export const field: UIComponentFactory<FieldElement> = ({
           id: dropdown.props.name,
           label: e.props.label,
           name: dropdown.props.name,
+          form,
+          error: e.props.error,
+          disabled: child.props.disabled,
+        },
+      };
+    }
+
+    case 'RadioGroup': {
+      const radioGroup = child as RadioGroupElement;
+      const radioGroupMapped = radioGroupFn({
+        element: radioGroup,
+      } as UIComponentParams<RadioGroupElement>);
+      return {
+        element: 'SnapUIRadioGroup',
+        props: {
+          ...radioGroupMapped.props,
+          id: radioGroup.props.name,
+          label: e.props.label,
+          name: radioGroup.props.name,
           form,
           error: e.props.error,
           disabled: child.props.disabled,

--- a/app/components/Snaps/SnapUIRenderer/components/field.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/field.ts
@@ -7,6 +7,7 @@ import {
   AddressInputElement,
   AssetSelectorElement,
   AccountSelectorElement,
+  DropdownElement,
 } from '@metamask/snaps-sdk/jsx';
 import { getJsxChildren } from '@metamask/snaps-utils';
 import { getPrimaryChildElementIndex, mapToTemplate } from '../utils';
@@ -16,6 +17,7 @@ import { UIComponentFactory, UIComponentParams } from './types';
 import { constructInputProps } from './input';
 import { assetSelector as assetSelectorFn } from './asset-selector';
 import { accountSelector as accountSelectorFn } from './account-selector';
+import { dropdown as dropdownFn } from './dropdown';
 
 export const field: UIComponentFactory<FieldElement> = ({
   element: e,
@@ -197,6 +199,25 @@ export const field: UIComponentFactory<FieldElement> = ({
           label: e.props.label,
           form,
           error: e.props.error,
+        },
+      };
+    }
+
+    case 'Dropdown': {
+      const dropdown = child as DropdownElement;
+      const dropdownMapped = dropdownFn({
+        element: dropdown,
+      } as UIComponentParams<DropdownElement>);
+      return {
+        element: 'SnapUIDropdown',
+        props: {
+          ...dropdownMapped.props,
+          id: dropdown.props.name,
+          label: e.props.label,
+          name: dropdown.props.name,
+          form,
+          error: e.props.error,
+          disabled: child.props.disabled,
         },
       };
     }

--- a/app/components/Snaps/SnapUIRenderer/components/form.test.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/form.test.ts
@@ -8,6 +8,10 @@ import {
   Selector,
   SelectorOption,
   Card,
+  RadioGroup,
+  Radio,
+  Dropdown,
+  Option,
 } from '@metamask/snaps-sdk/jsx';
 import Engine from '../../../../core/Engine/Engine';
 import { fireEvent } from '@testing-library/react-native';
@@ -59,6 +63,26 @@ describe('SnapUIForm', () => {
               }),
             }),
             Field({
+              label: 'My Radio Group',
+              children: RadioGroup({
+                name: 'radio',
+                children: [
+                  Radio({ value: 'option1', children: 'Radio 1' }),
+                  Radio({ value: 'option2', children: 'Radio 2' }),
+                ],
+              }),
+            }),
+            Field({
+              label: 'My Dropdown',
+              children: Dropdown({
+                name: 'dropdown',
+                children: [
+                  Option({ value: 'option1', children: 'Dropdown 1' }),
+                  Option({ value: 'option2', children: 'Dropdown 2' }),
+                ],
+              }),
+            }),
+            Field({
               label: 'My Selector',
               children: Selector({
                 name: 'selector',
@@ -89,7 +113,11 @@ describe('SnapUIForm', () => {
           ],
         }),
       }),
-      { state: { form: { selector: 'option1' } } },
+      {
+        state: {
+          form: { radio: 'option1', dropdown: 'option1', selector: 'option1' },
+        },
+      },
     );
 
     const input = getByTestId('input-snap-ui-input');
@@ -98,7 +126,12 @@ describe('SnapUIForm', () => {
     expect(
       mockEngine.context.SnapInterfaceController.updateInterfaceState,
     ).toHaveBeenNthCalledWith(1, MOCK_INTERFACE_ID, {
-      form: { input: 'abc', selector: 'option1' },
+      form: {
+        input: 'abc',
+        radio: 'option1',
+        dropdown: 'option1',
+        selector: 'option1',
+      },
     });
 
     expect(mockEngine.controllerMessenger.call).toHaveBeenNthCalledWith(
@@ -125,7 +158,13 @@ describe('SnapUIForm', () => {
     expect(
       mockEngine.context.SnapInterfaceController.updateInterfaceState,
     ).toHaveBeenNthCalledWith(2, MOCK_INTERFACE_ID, {
-      form: { input: 'abc', checkbox: true, selector: 'option1' },
+      form: {
+        input: 'abc',
+        checkbox: true,
+        dropdown: 'option1',
+        radio: 'option1',
+        selector: 'option1',
+      },
     });
 
     expect(mockEngine.controllerMessenger.call).toHaveBeenNthCalledWith(
@@ -155,7 +194,13 @@ describe('SnapUIForm', () => {
     expect(
       mockEngine.context.SnapInterfaceController.updateInterfaceState,
     ).toHaveBeenNthCalledWith(3, MOCK_INTERFACE_ID, {
-      form: { input: 'abc', checkbox: true, selector: 'option2' },
+      form: {
+        input: 'abc',
+        checkbox: true,
+        dropdown: 'option1',
+        radio: 'option1',
+        selector: 'option2',
+      },
     });
 
     expect(mockEngine.controllerMessenger.call).toHaveBeenNthCalledWith(
@@ -180,11 +225,88 @@ describe('SnapUIForm', () => {
       },
     );
 
+    const dropdown = getByText('Dropdown 1');
+    fireEvent.press(dropdown);
+
+    const dropdownItem = getByText('Dropdown 2');
+    fireEvent.press(dropdownItem);
+
+    expect(
+      mockEngine.context.SnapInterfaceController.updateInterfaceState,
+    ).toHaveBeenNthCalledWith(4, MOCK_INTERFACE_ID, {
+      form: {
+        input: 'abc',
+        checkbox: true,
+        dropdown: 'option2',
+        radio: 'option1',
+        selector: 'option2',
+      },
+    });
+
+    expect(mockEngine.controllerMessenger.call).toHaveBeenNthCalledWith(
+      4,
+      'SnapController:handleRequest',
+      {
+        handler: 'onUserInput',
+        origin: 'metamask',
+        request: {
+          jsonrpc: '2.0',
+          method: ' ',
+          params: {
+            event: {
+              name: 'dropdown',
+              type: 'InputChangeEvent',
+              value: 'option2',
+            },
+            id: MOCK_INTERFACE_ID,
+          },
+        },
+        snapId: MOCK_SNAP_ID,
+      },
+    );
+
+    const radioButton = getByText('Radio 2');
+    fireEvent.press(radioButton);
+
+    expect(
+      mockEngine.context.SnapInterfaceController.updateInterfaceState,
+    ).toHaveBeenNthCalledWith(5, MOCK_INTERFACE_ID, {
+      form: {
+        input: 'abc',
+        checkbox: true,
+        dropdown: 'option2',
+        radio: 'option2',
+        selector: 'option2',
+      },
+    });
+
+    expect(mockEngine.controllerMessenger.call).toHaveBeenNthCalledWith(
+      5,
+      'SnapController:handleRequest',
+      {
+        handler: 'onUserInput',
+        origin: 'metamask',
+        request: {
+          jsonrpc: '2.0',
+          method: ' ',
+          params: {
+            event: {
+              name: 'radio',
+              type: 'InputChangeEvent',
+              value: 'option2',
+            },
+            id: MOCK_INTERFACE_ID,
+          },
+        },
+        snapId: MOCK_SNAP_ID,
+      },
+    );
+
     const button = getByText('Submit');
     fireEvent.press(button);
 
     expect(mockEngine.controllerMessenger.call).toHaveBeenNthCalledWith(
-      4,
+      6,
       'SnapController:handleRequest',
       {
         handler: 'onUserInput',
@@ -202,7 +324,7 @@ describe('SnapUIForm', () => {
     );
 
     expect(mockEngine.controllerMessenger.call).toHaveBeenNthCalledWith(
-      5,
+      7,
       'SnapController:handleRequest',
       {
         handler: 'onUserInput',
@@ -217,6 +339,8 @@ describe('SnapUIForm', () => {
               value: {
                 checkbox: true,
                 input: 'abc',
+                dropdown: 'option2',
+                radio: 'option2',
                 selector: 'option2',
               },
             },

--- a/app/components/Snaps/SnapUIRenderer/components/index.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/index.ts
@@ -27,6 +27,7 @@ import { assetSelector } from './asset-selector';
 import { copyable } from './copyable';
 import { accountSelector } from './account-selector';
 import { dropdown } from './dropdown';
+import { radioGroup } from './radioGroup';
 
 export const COMPONENT_MAPPING = {
   Box: box,
@@ -58,4 +59,5 @@ export const COMPONENT_MAPPING = {
   Copyable: copyable,
   AccountSelector: accountSelector,
   Dropdown: dropdown,
+  RadioGroup: radioGroup,
 };

--- a/app/components/Snaps/SnapUIRenderer/components/index.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/index.ts
@@ -26,6 +26,7 @@ import { addressInput } from './address-input';
 import { assetSelector } from './asset-selector';
 import { copyable } from './copyable';
 import { accountSelector } from './account-selector';
+import { dropdown } from './dropdown';
 
 export const COMPONENT_MAPPING = {
   Box: box,
@@ -56,4 +57,5 @@ export const COMPONENT_MAPPING = {
   AssetSelector: assetSelector,
   Copyable: copyable,
   AccountSelector: accountSelector,
+  Dropdown: dropdown,
 };

--- a/app/components/Snaps/SnapUIRenderer/components/radioGroup.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/radioGroup.ts
@@ -1,0 +1,28 @@
+import { RadioGroupElement, RadioElement } from '@metamask/snaps-sdk/jsx';
+import { getJsxChildren } from '@metamask/snaps-utils';
+
+import { UIComponentFactory } from './types';
+
+export const radioGroup: UIComponentFactory<RadioGroupElement> = ({
+  element: e,
+  form,
+}) => {
+  const children = getJsxChildren(e) as RadioElement[];
+
+  const options = children.map((child) => ({
+    value: child.props.value,
+    name: child.props.children,
+    disabled: child.props.disabled,
+  }));
+
+  return {
+    element: 'SnapUIRadioGroup',
+    props: {
+      id: e.props.name,
+      name: e.props.name,
+      disabled: e.props.disabled,
+      form,
+      options,
+    },
+  };
+};

--- a/app/components/Snaps/SnapUISelector/SnapUISelector.tsx
+++ b/app/components/Snaps/SnapUISelector/SnapUISelector.tsx
@@ -30,6 +30,7 @@ export interface SnapUISelectorProps {
   disabled?: boolean;
   style?: ViewStyle;
   compact?: boolean;
+  testID?: string;
 }
 
 interface SelectorItemProps {
@@ -84,6 +85,7 @@ export const SnapUISelector: React.FunctionComponent<SnapUISelectorProps> = ({
   onSelect,
   style,
   compact = false,
+  testID = 'snap-ui-renderer__selector',
 }) => {
   const { styles } = useStyles(stylesheet, { compact });
   const { handleInputChange, getValue } = useSnapInterfaceContext();
@@ -145,7 +147,7 @@ export const SnapUISelector: React.FunctionComponent<SnapUISelectorProps> = ({
           endIconName={IconName.ArrowDown}
           onPress={handleModalOpen}
           style={styles.button}
-          testID="snap-ui-renderer__selector"
+          testID={testID}
         />
         {error && (
           <HelpText severity={HelpTextSeverity.Error} style={styles.helpText}>

--- a/app/components/UI/TemplateRenderer/SafeComponentList.ts
+++ b/app/components/UI/TemplateRenderer/SafeComponentList.ts
@@ -37,6 +37,7 @@ import { SnapUIInfoRow } from '../../Snaps/SnapUIInfoRow/SnapUIInfoRow';
 import { SnapUIAssetSelector } from '../../Snaps/SnapUIAssetSelector/SnapUIAssetSelector';
 import { SnapUICopyable } from '../../Snaps/SnapUICopyable/SnapUICopyable';
 import { SnapUIAccountSelector } from '../../Snaps/SnapUIAccountSelector/SnapUIAccountSelector';
+import { SnapUIRadioGroup } from '../../Snaps/SnapUIRadioGroup/SnapUIRadioGroup';
 
 export const safeComponentList = {
   BottomSheetFooter,
@@ -62,6 +63,7 @@ export const safeComponentList = {
   SnapUIButton,
   SnapUICheckbox,
   SnapUIDropdown,
+  SnapUIRadioGroup,
   SnapUIAvatar,
   SnapUIAddress,
   SnapUIBanner,

--- a/app/components/UI/TemplateRenderer/SafeComponentList.ts
+++ b/app/components/UI/TemplateRenderer/SafeComponentList.ts
@@ -25,6 +25,7 @@ import { SnapUIIcon } from '../../Snaps/SnapUIIcon/SnapUIIcon';
 import { SnapUIButton } from '../../Snaps/SnapUIButton/SnapUIButton';
 import { SnapUIBanner } from '../../Snaps/SnapUIBanner/SnapUIBanner';
 import { SnapUICheckbox } from '../../Snaps/SnapUICheckbox/SnapUICheckbox';
+import { SnapUIDropdown } from '../../Snaps/SnapUIDropdown/SnapUIDropdown';
 import { SnapUIAddress } from '../../Snaps/SnapUIAddress/SnapUIAddress';
 import { SnapUIAvatar } from '../../Snaps/SnapUIAvatar/SnapUIAvatar';
 import { SnapUISelector } from '../../Snaps/SnapUISelector/SnapUISelector';
@@ -60,6 +61,7 @@ export const safeComponentList = {
   ConfirmInfoRowValueDouble,
   SnapUIButton,
   SnapUICheckbox,
+  SnapUIDropdown,
   SnapUIAvatar,
   SnapUIAddress,
   SnapUIBanner,

--- a/e2e/pages/Browser/TestSnaps.ts
+++ b/e2e/pages/Browser/TestSnaps.ts
@@ -8,6 +8,7 @@ import {
   TestSnapResultSelectorWebIDS,
   TestSnapBottomSheetSelectorWebIDS,
   EntropyDropDownSelectorWebIDS,
+  NativeDropdownSelectorWebIDS,
 } from '../../selectors/Browser/TestSnaps.selectors';
 import Gestures from '../../framework/Gestures';
 import { SNAP_INSTALL_CONNECT } from '../../../app/components/Approvals/InstallSnapApproval/components/InstallSnapConnectionRequest/InstallSnapConnectionRequest.constants';
@@ -55,6 +56,10 @@ class TestSnaps {
     return Matchers.getElementByID(
       TestSnapBottomSheetSelectorWebIDS.DEFAULT_FOOTER_BUTTON_ID,
     );
+  }
+
+  get checkboxElement(): DetoxElement {
+    return Matchers.getElementByID('snap-ui-renderer__checkbox');
   }
 
   async checkResultSpan(
@@ -198,6 +203,11 @@ class TestSnaps {
     await Gestures.waitAndTap(this.footerButton);
   }
 
+  async tapSubmitButton() {
+    const button = Matchers.getElementByText('Submit');
+    await Gestures.waitAndTap(button);
+  }
+
   async dismissAlert() {
     // Matches the native WebView alert on each platform
     const button = Matchers.getElementByText(
@@ -240,6 +250,39 @@ class TestSnaps {
       },
       [source],
     );
+  }
+
+  async fillInput(name: string, text: string) {
+    const input = Matchers.getElementByID(`${name}-snap-ui-input`);
+
+    await Gestures.typeText(input, text, { hideKeyboard: true });
+  }
+
+  async selectInNativeDropdown(
+    selector: keyof typeof NativeDropdownSelectorWebIDS,
+    text: string,
+  ): Promise<void> {
+    const dropdown = Matchers.getElementByID(
+      NativeDropdownSelectorWebIDS[selector],
+    );
+
+    await Gestures.tap(dropdown);
+
+    const selectorItem = element(
+      by.text(text).withAncestor(by.id('snap-ui-renderer__selector-item')),
+    ) as unknown as DetoxElement;
+    await Gestures.tap(selectorItem);
+  }
+
+  async selectRadioButton(text: string) {
+    const radioButton = element(
+      by.text(text).withAncestor(by.id('snap-ui-renderer__radio-button')),
+    ) as unknown as DetoxElement;
+    await Gestures.tap(radioButton);
+  }
+
+  async tapCheckbox() {
+    await Gestures.tap(this.checkboxElement);
   }
 
   async installSnap(

--- a/e2e/selectors/Browser/TestSnaps.selectors.ts
+++ b/e2e/selectors/Browser/TestSnaps.selectors.ts
@@ -18,12 +18,15 @@ export const TestSnapViewSelectorWebIDS = {
   connectJsonRpcButton: 'connectjson-rpc',
   connectLifeCycleButton: 'connectlifecycle-hooks',
   connectImageButton: 'connectimages',
+  connectInteractiveButton: 'connectinteractive-ui',
   connectManageStateButton: 'connectmanage-state',
   connectNetworkAccessButton: 'connectnetwork-access',
   connectEthereumProviderButton: 'connectethereum-provider',
   connectStateButton: 'connectstate',
   connectJsx: 'connectjsx',
   connectWasmButton: 'connectwasm',
+  createDialogButton: 'createDialogButton',
+  createDialogDisabledButton: 'createDisabledDialogButton',
   displayJsxButton: 'displayJsx',
   getBackgroundEventResultButton: 'getBackgroundEvents',
   getPreferencesButton: 'getPreferences',
@@ -99,6 +102,11 @@ export const EntropyDropDownSelectorWebIDS = {
   bip44EntropyDropDown: 'bip44-entropy-selector',
   getEntropyDropDown: 'get-entropy-entropy-selector',
   networkDropDown: 'select-chain',
+};
+
+export const NativeDropdownSelectorWebIDS = {
+  snapUISelector: 'snap-ui-renderer__selector',
+  snapUIDropdown: 'snap-ui-renderer__dropdown',
 };
 
 export const TestSnapResultSelectorWebIDS = {

--- a/e2e/specs/snaps/test-snap-interactive-ui.spec.ts
+++ b/e2e/specs/snaps/test-snap-interactive-ui.spec.ts
@@ -1,0 +1,85 @@
+import { FlaskBuildTests } from '../../tags';
+import { loginToApp } from '../../viewHelper';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper';
+import TabBarComponent from '../../pages/wallet/TabBarComponent';
+import TestSnaps from '../../pages/Browser/TestSnaps';
+import { Assertions } from '../../framework';
+import Matchers from '../../utils/Matchers';
+
+jest.setTimeout(150_000);
+
+describe(FlaskBuildTests('Interactive UI Snap Tests'), () => {
+  it('can connect to the Interactive UI Snap', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().build(),
+        restartDevice: true,
+      },
+      async () => {
+        await loginToApp();
+        await TabBarComponent.tapBrowser();
+        await TestSnaps.navigateToTestSnap();
+
+        await TestSnaps.installSnap('connectInteractiveButton');
+      },
+    );
+  });
+
+  it('renders an interactive UI', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().build(),
+      },
+      async () => {
+        await TestSnaps.tapButton('createDialogButton');
+
+        await TestSnaps.fillInput('example-input', 'foo bar');
+        await TestSnaps.selectInNativeDropdown('snapUIDropdown', 'Option 2');
+        await TestSnaps.selectRadioButton('Option 1');
+        await TestSnaps.tapCheckbox();
+        await TestSnaps.selectInNativeDropdown('snapUISelector', 'Option 3');
+        await TestSnaps.tapSubmitButton();
+
+        await Assertions.expectTextDisplayed('foo bar');
+        await Assertions.expectTextDisplayed('option2');
+        await Assertions.expectTextDisplayed('option1');
+        await Assertions.expectTextDisplayed('true');
+        await Assertions.expectTextDisplayed('option3');
+
+        await TestSnaps.tapOkButton();
+      },
+    );
+  });
+
+  it('renders a disabled UI', async () => {
+    await withFixtures(
+      {
+        fixture: new FixtureBuilder().build(),
+      },
+      async () => {
+        await TestSnaps.tapButton('createDialogDisabledButton');
+
+        const input = Matchers.getElementByID('example-input-snap-ui-input');
+        await Assertions.expectElementToBeVisible(input);
+
+        await Assertions.checkIfDisabled(input);
+        await Assertions.checkIfDisabled(
+          Matchers.getElementByID('snap-ui-renderer__dropdown'),
+        );
+        await Assertions.checkIfDisabled(
+          Matchers.getElementByID('snap-ui-renderer__radio'),
+        );
+        await Assertions.checkIfDisabled(
+          Matchers.getElementByID('snap-ui-renderer__checkbox'),
+        );
+        await Assertions.checkIfDisabled(
+          Matchers.getElementByID('snap-ui-renderer__selector'),
+        );
+        await Assertions.checkIfDisabled(Matchers.getElementByText('Submit'));
+
+        await TestSnaps.tapCancelButton();
+      },
+    );
+  });
+});

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5249,6 +5249,9 @@
     "account_selector": {
       "title": "Select account"
     },
+    "dropdown": {
+      "title": "Select an option"
+    },
     "hideSentitiveInfo": {
       "message": "Hide sensitive information"
     },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR adds the `SnapUIDropdown` and `SnapUIRadioGroup` components to make the interactive-ui example Snap run correctly, additionally it introduces unit and E2E tests that confirms the components work correctly. 

It also fixes a bug with `SnapUIFooterButton` not triggering form submit events and tweaks some colors to make the components look more alike.

Also note that a large portion of the PR here is unit test snapshots that do not need extensive review. 

## **Related issues**

Closes: https://github.com/MetaMask/snaps/issues/3585

Closes: https://github.com/MetaMask/snaps/issues/3586

Closes: https://github.com/MetaMask/snaps/issues/3487

## **Manual testing steps**

1. Go to https://metamask.github.io/snaps/test-snaps/latest/
2. Install the interactive UI Snap
3. Click "Create Dialog"
4. See that the dialog works correctly

## **Screenshots/Recordings**

<img width="301" height="655" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-19 at 15 13 00" src="https://github.com/user-attachments/assets/1a5ca9b7-d54a-4f99-a734-c7702806c3c6" />


