### PR TITLE
feat: replace BN with native BigInt

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -167,6 +167,7 @@ module.exports = {
     driver: true,
     $: true,
     $$: true,
+    BigInt: true,
   },
 
   settings: {

--- a/app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.tsx
+++ b/app/component-library/components-temp/CustomSpendCap/CustomInput/CustomInput.tsx
@@ -4,7 +4,7 @@ import { TextInput, View } from 'react-native';
 
 import { strings } from '../../../../../locales/i18n';
 import formatNumber from '../../../../util/formatNumber';
-import { dotAndCommaDecimalFormatter } from '../../../../util/number';
+import { dotAndCommaDecimalFormatter } from '../../../../util/number/legacy';
 import Text, { TextVariant } from '../../../components/Texts/Text';
 // External dependencies.
 import { useStyles } from '../../../hooks';

--- a/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.tsx
+++ b/app/component-library/components-temp/CustomSpendCap/CustomSpendCap.tsx
@@ -6,7 +6,7 @@ import { strings } from '../../../../locales/i18n';
 import InfoModal from '../../../components/UI/Swaps/components/InfoModal';
 import { TOKEN_APPROVAL_SPENDING_CAP } from '../../../constants/urls';
 import formatNumber from '../../../util/formatNumber';
-import { isNumber } from '../../../util/number';
+import { isNumber } from '../../../util/number/legacy';
 import Button, { ButtonVariants } from '../../components/Buttons/Button';
 import Icon, { IconName, IconSize } from '../../components/Icons/Icon';
 import Text, { TextVariant } from '../../components/Texts/Text';

--- a/app/component-library/components-temp/Price/AggregatedPercentage/AggregatedPercentage.tsx
+++ b/app/component-library/components-temp/Price/AggregatedPercentage/AggregatedPercentage.tsx
@@ -5,7 +5,7 @@ import {
 } from '../../../../component-library/components/Texts/Text';
 import SensitiveText from '../../../../component-library/components/Texts/SensitiveText';
 import { View } from 'react-native';
-import { renderFiat } from '../../../../util/number';
+import { renderFiat } from '../../../../util/number/legacy';
 import { useSelector } from 'react-redux';
 import { selectCurrentCurrency } from '../../../../selectors/currencyRateController';
 import styleSheet from './AggregatedPercentage.styles';

--- a/app/component-library/components-temp/Price/AggregatedPercentage/utils.ts
+++ b/app/component-library/components-temp/Price/AggregatedPercentage/utils.ts
@@ -1,7 +1,7 @@
 import i18n from '../../../../../locales/i18n';
 import { DECIMALS_TO_SHOW } from '../../../../components/UI/Tokens/constants';
 import { formatWithThreshold } from '../../../../util/assets';
-import { renderFiat } from '../../../../util/number';
+import { renderFiat } from '../../../../util/number/legacy';
 import { TextColor } from '../../../components/Texts/Text';
 
 export const getFormattedAmountChange = (

--- a/app/components/Nav/Main/RootRPCMethodsUI.js
+++ b/app/components/Nav/Main/RootRPCMethodsUI.js
@@ -9,7 +9,7 @@ import abi from 'human-standard-token-abi';
 import NotificationManager from '../../../core/NotificationManager';
 import Engine from '../../../core/Engine';
 import { strings } from '../../../../locales/i18n';
-import { hexToBN, fromWei, isZeroValue } from '../../../util/number';
+import { hexToBN, fromWei, isZeroValue } from '../../../util/number/legacy';
 import {
   setEtherTransaction,
   setTransactionObject,

--- a/app/components/UI/AccountInfoCard/index.js
+++ b/app/components/UI/AccountInfoCard/index.js
@@ -22,7 +22,7 @@ import {
   safeToChecksumAddress,
 } from '../../../util/address';
 import Device from '../../../util/device';
-import { hexToBN, renderFromWei, weiToFiat } from '../../../util/number';
+import { hexToBN, renderFromWei, weiToFiat } from '../../../util/number/legacy';
 import { ThemeContext, mockTheme } from '../../../util/theme';
 import {
   getActiveTabUrl,

--- a/app/components/UI/AssetOverview/AssetOverview.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.tsx
@@ -36,7 +36,7 @@ import {
   renderFromTokenMinimalUnit,
   renderFromWei,
   toHexadecimal,
-} from '../../../util/number';
+} from '../../../util/number/legacy';
 import { getEther } from '../../../util/transactions';
 import Text from '../../Base/Text';
 import { createWebviewNavDetails } from '../../Views/SimpleWebview';

--- a/app/components/UI/AssetOverview/Price/Price.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.tsx
@@ -9,7 +9,7 @@ import Icon from 'react-native-vector-icons/Feather';
 import { strings } from '../../../../../locales/i18n';
 import { useStyles } from '../../../../component-library/hooks';
 import { toDateFormat } from '../../../../util/date';
-import { addCurrencySymbol } from '../../../../util/number';
+import { addCurrencySymbol } from '../../../../util/number/legacy';
 import Text, {
   TextColor,
   TextVariant,

--- a/app/components/UI/Bridge/components/BridgeDestTokenSelector/BridgeDestTokenSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeDestTokenSelector/BridgeDestTokenSelector.test.tsx
@@ -302,18 +302,26 @@ describe('BridgeDestTokenSelector', () => {
       { state: initialState },
     );
 
-    // Act - wait for token to appear and press it
+    // Wait for tokens to be rendered
     await waitFor(() => {
-      const token1Element = getByText('HELLO');
-      fireEvent.press(token1Element);
+      expect(getByText('HELLO')).toBeTruthy();
     });
 
-    // Advance timers to trigger debounced function (wrapped in act to handle state updates)
-    await act(async () => {
+    // Act - press the token
+    const token1Element = getByText('HELLO');
+    fireEvent.press(token1Element);
+
+    // Advance timers to trigger debounced function
+    act(() => {
       jest.advanceTimersByTime(500);
     });
 
-    // Assert - check that actions were called
+    // Wait for the debounced action to complete
+    await waitFor(() => {
+      expect(setDestToken).toHaveBeenCalled();
+    });
+
+    // Assert - check that actions were called with correct parameters
     expect(setDestToken).toHaveBeenCalledWith(
       expect.objectContaining({
         address: ethToken2Address,

--- a/app/components/UI/Bridge/components/BridgeDestTokenSelector/index.tsx
+++ b/app/components/UI/Bridge/components/BridgeDestTokenSelector/index.tsx
@@ -129,7 +129,7 @@ export const BridgeDestTokenSelector: React.FC = () => {
           onPress={debouncedTokenPress}
           networkName={networkName}
           networkImageSource={getNetworkImageSource({
-            chainId: item.chainId as Hex,
+            chainId: item.chainId,
           })}
           isSelected={
             selectedDestToken?.address === item.address &&

--- a/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/index.tsx
+++ b/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/index.tsx
@@ -12,7 +12,10 @@ import {
 } from '../../../../../core/redux/slices/bridge';
 import { strings } from '../../../../../../locales/i18n';
 import { selectCurrentCurrency } from '../../../../../selectors/currencyRateController';
-import { addCurrencySymbol, renderNumber } from '../../../../../util/number';
+import {
+  addCurrencySymbol,
+  renderNumber,
+} from '../../../../../util/number/legacy';
 import Button, {
   ButtonVariants,
   ButtonWidthTypes,

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/index.ts
@@ -16,7 +16,7 @@ import { useCallback, useMemo, useEffect, useState, useRef } from 'react';
 import {
   fromTokenMinimalUnit,
   isNumberValue,
-} from '../../../../../util/number';
+} from '../../../../../util/number/legacy';
 import { selectPrimaryCurrency } from '../../../../../selectors/settings';
 import {
   isQuoteExpired,

--- a/app/components/UI/Bridge/hooks/useHasSufficientGas/index.ts
+++ b/app/components/UI/Bridge/hooks/useHasSufficientGas/index.ts
@@ -9,7 +9,7 @@ import { CaipChainId, Hex } from '@metamask/utils';
 import { useBridgeQuoteData } from '../useBridgeQuoteData';
 import { getNativeSourceToken } from '../useInitialSourceToken';
 import { BigNumber } from 'bignumber.js';
-import { isNumberValue } from '../../../../../util/number';
+import { isNumberValue } from '../../../../../util/number/legacy';
 
 interface Props {
   quote: ReturnType<typeof useBridgeQuoteData>['activeQuote'];

--- a/app/components/UI/Bridge/hooks/useTokensWithBalance/index.ts
+++ b/app/components/UI/Bridge/hooks/useTokensWithBalance/index.ts
@@ -20,7 +20,7 @@ import { selectMultichainTokenListForAccountId } from '../../../../../selectors/
 import { selectAccountTokensAcrossChainsForAddress } from '../../../../../selectors/multichain/evm';
 import { BridgeToken } from '../../types';
 import { RootState } from '../../../../../reducers';
-import { renderNumber, renderFiat } from '../../../../../util/number';
+import { renderNumber, renderFiat } from '../../../../../util/number/legacy';
 import { formatUnits } from 'ethers/lib/utils';
 import { BigNumber } from 'ethers';
 import { selectAccountsByChainId } from '../../../../../selectors/accountTrackerController';

--- a/app/components/UI/Bridge/utils/exchange-rates.ts
+++ b/app/components/UI/Bridge/utils/exchange-rates.ts
@@ -10,7 +10,7 @@ import {
   isStrictHexString,
 } from '@metamask/utils';
 import { selectMultichainAssetsRates } from '../../../../selectors/multichain';
-import { balanceToFiatNumber } from '../../../../util/number';
+import { balanceToFiatNumber } from '../../../../util/number/legacy';
 import { BridgeToken } from '../types';
 import { handleFetch, toChecksumHexAddress } from '@metamask/controller-utils';
 import {

--- a/app/components/UI/Bridge/utils/transaction-history.ts
+++ b/app/components/UI/Bridge/utils/transaction-history.ts
@@ -21,7 +21,7 @@ import {
   balanceToFiatNumber,
   weiToFiatNumber,
   weiToFiat,
-} from '../../../../util/number';
+} from '../../../../util/number/legacy';
 import { Hex } from '@metamask/utils';
 import { ethers } from 'ethers';
 import { toFormattedAddress } from '../../../../util/address';

--- a/app/components/UI/CollectibleOverview/index.js
+++ b/app/components/UI/CollectibleOverview/index.js
@@ -25,7 +25,7 @@ import AntIcons from 'react-native-vector-icons/AntDesign';
 import Device from '../../../util/device';
 import { isIPFSUri, renderShortText } from '../../../util/general';
 import { toLocaleDate } from '../../../util/date';
-import { renderFromWei } from '../../../util/number';
+import { renderFromWei } from '../../../util/number/legacy';
 import { renderShortAddress } from '../../../util/address';
 import { isMainNet } from '../../../util/networks';
 import etherscanLink from '@metamask/etherscan-link';

--- a/app/components/UI/ConfirmAddAsset/ConfirmAddAsset.test.tsx
+++ b/app/components/UI/ConfirmAddAsset/ConfirmAddAsset.test.tsx
@@ -5,7 +5,7 @@ import renderWithProvider, {
   DeepPartial,
 } from '../../../util/test/renderWithProvider';
 import useBalance from '../Ramp/Aggregator/hooks/useBalance';
-import { toTokenMinimalUnit } from '../../../util/number';
+import { toTokenMinimalUnit } from '../../../util/number/legacy';
 import { userEvent } from '@testing-library/react-native';
 import BN4 from 'bnjs4';
 import { RootState } from '../../../reducers';

--- a/app/components/UI/Earn/Views/EarnInputView/EarnInputView.test.tsx
+++ b/app/components/UI/Earn/Views/EarnInputView/EarnInputView.test.tsx
@@ -19,7 +19,7 @@ import {
   ConfirmationRedesignRemoteFlags,
   selectConfirmationRedesignFlags,
 } from '../../../../../selectors/featureFlagController/confirmations';
-import { toWei, weiToFiatNumber } from '../../../../../util/number';
+import { toWei, weiToFiatNumber } from '../../../../../util/number/legacy';
 import {
   MOCK_ACCOUNTS_CONTROLLER_STATE,
   MOCK_ADDRESS_2,

--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/Erc20TokenHero/index.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/Erc20TokenHero/index.tsx
@@ -12,7 +12,7 @@ import Badge, {
 import NetworkAssetLogo from '../../../../../NetworkAssetLogo';
 import AvatarToken from '../../../../../../../component-library/components/Avatars/Avatar/variants/AvatarToken';
 import { AvatarSize } from '../../../../../../../component-library/components/Avatars/Avatar';
-import { renderFromTokenMinimalUnit } from '../../../../../../../util/number';
+import { renderFromTokenMinimalUnit } from '../../../../../../../util/number/legacy';
 import Text, {
   TextVariant,
 } from '../../../../../../../component-library/components/Texts/Text';

--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/index.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/index.tsx
@@ -18,7 +18,7 @@ import { capitalize } from '../../../../../util/general';
 import {
   addCurrencySymbol,
   renderFromTokenMinimalUnit,
-} from '../../../../../util/number';
+} from '../../../../../util/number/legacy';
 import { useStyles } from '../../../../hooks/useStyles';
 import { getStakingNavbar } from '../../../Navbar';
 import { MetaMetricsEvents, useMetrics } from '../../../../hooks/useMetrics';

--- a/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/index.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/index.tsx
@@ -26,7 +26,7 @@ import { IMetaMetricsEvent } from '../../../../../core/Analytics';
 import Engine from '../../../../../core/Engine';
 import { selectSelectedInternalAccountByScope } from '../../../../../selectors/multichainAccounts/accounts';
 import { getNetworkImageSource } from '../../../../../util/networks';
-import { renderFromTokenMinimalUnit } from '../../../../../util/number';
+import { renderFromTokenMinimalUnit } from '../../../../../util/number/legacy';
 import { MetaMetricsEvents, useMetrics } from '../../../../hooks/useMetrics';
 import { useStyles } from '../../../../hooks/useStyles';
 import InfoRowDivider from '../../../../Views/confirmations/components/UI/info-row-divider';

--- a/app/components/UI/Earn/Views/EarnWithdrawInputView/EarnWithdrawInputView.tsx
+++ b/app/components/UI/Earn/Views/EarnWithdrawInputView/EarnWithdrawInputView.tsx
@@ -50,7 +50,7 @@ import { EARN_INPUT_VIEW_ACTIONS } from '../EarnInputView/EarnInputView.types';
 import styleSheet from './EarnWithdrawInputView.styles';
 import { EarnWithdrawInputViewProps } from './EarnWithdrawInputView.types';
 import BN from 'bnjs4';
-import { renderFromTokenMinimalUnit } from '../../../../../util/number';
+import { renderFromTokenMinimalUnit } from '../../../../../util/number/legacy';
 import { TokenI } from '../../../Tokens/types';
 import useEarnTokens from '../../hooks/useEarnTokens';
 import { EarnTokenDetails } from '../../types/lending.types';

--- a/app/components/UI/Earn/components/Earnings/EarningsHistory/EarningsHistory.utils.ts
+++ b/app/components/UI/Earn/components/Earnings/EarningsHistory/EarningsHistory.utils.ts
@@ -6,7 +6,7 @@ import {
   weiToFiatNumber,
   renderFromWei,
   fromWei,
-} from '../../../../../../util/number';
+} from '../../../../../../util/number/legacy';
 import { BN } from 'ethereumjs-util';
 import type { TimePeriodGroupInfo } from './EarningsHistory.types';
 import { DateRange } from './EarningsTimePeriod/EarningsTimePeriod.types';

--- a/app/components/UI/Earn/components/InputDisplay/InputDisplay.test.tsx
+++ b/app/components/UI/Earn/components/InputDisplay/InputDisplay.test.tsx
@@ -4,7 +4,7 @@ import InputDisplay, { INPUT_DISPLAY_TEST_IDS, InputDisplayProps } from '.';
 import { MOCK_ACCOUNTS_CONTROLLER_STATE } from '../../../../../util/test/accountsControllerTestUtils';
 import initialRootState from '../../../../../util/test/initial-root-state';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
-import { renderFromTokenMinimalUnit } from '../../../../../util/number';
+import { renderFromTokenMinimalUnit } from '../../../../../util/number/legacy';
 import Routes from '../../../../../constants/navigation/Routes';
 
 const mockNavigate = jest.fn();

--- a/app/components/UI/Earn/hooks/useEarnGasFee.ts
+++ b/app/components/UI/Earn/hooks/useEarnGasFee.ts
@@ -7,7 +7,7 @@ import Engine from '../../../../core/Engine';
 import { selectSelectedInternalAccountByScope } from '../../../../selectors/multichainAccounts/accounts';
 import { getFormattedAddressFromInternalAccount } from '../../../../core/Multichain/utils';
 import { decGWEIToHexWEI } from '../../../../util/conversions';
-import { hexToBN } from '../../../../util/number';
+import { hexToBN } from '../../../../util/number/legacy';
 import { useStakeContext } from '../../Stake/hooks/useStakeContext';
 import { EARN_EXPERIENCES } from '../constants/experiences';
 import { EarnTokenDetails } from '../types/lending.types';

--- a/app/components/UI/Earn/hooks/useEarnInput.ts
+++ b/app/components/UI/Earn/hooks/useEarnInput.ts
@@ -6,7 +6,7 @@ import {
   limitToMaximumDecimalPlaces,
   renderFiat,
   weiToFiatNumber,
-} from '../../../../util/number';
+} from '../../../../util/number/legacy';
 import useBalance from '../../Stake/hooks/useBalance';
 import { EarnTokenDetails } from '../types/lending.types';
 import useEarnDepositGasFee from './useEarnGasFee';

--- a/app/components/UI/Earn/hooks/useEarnings.ts
+++ b/app/components/UI/Earn/hooks/useEarnings.ts
@@ -11,7 +11,7 @@ import {
   renderFromTokenMinimalUnit,
   renderFromWei,
   weiToFiatNumber,
-} from '../../../../util/number';
+} from '../../../../util/number/legacy';
 import useBalance from '../../Stake/hooks/useBalance';
 import usePooledStakes from '../../Stake/hooks/usePooledStakes';
 import { TokenI } from '../../Tokens/types';

--- a/app/components/UI/Earn/hooks/useInput.ts
+++ b/app/components/UI/Earn/hooks/useInput.ts
@@ -9,7 +9,7 @@ import {
   fromTokenMinimalUnit,
   renderFromTokenMinimalUnit,
   toTokenMinimalUnit,
-} from '../../../../util/number';
+} from '../../../../util/number/legacy';
 import { selectChainId } from '../../../../selectors/networkController';
 import { selectStablecoinLendingEnabledFlag } from '../selectors/featureFlags';
 import { Keys } from '../../../Base/Keypad/constants';

--- a/app/components/UI/Earn/utils/number.ts
+++ b/app/components/UI/Earn/utils/number.ts
@@ -1,4 +1,4 @@
-import { isNumber } from '../../../../util/number';
+import { isNumber } from '../../../../util/number/legacy';
 
 const findFirstDigitIndex = (str: string) => {
   for (let i = 0; i < str.length; i++) {

--- a/app/components/UI/Earn/utils/token/index.ts
+++ b/app/components/UI/Earn/utils/token/index.ts
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js';
 import {
   addCurrencySymbol,
   renderFromTokenMinimalUnit,
-} from '../../../../../util/number';
+} from '../../../../../util/number/legacy';
 import { EarnTokenDetails } from '../../types/lending.types';
 import { TOKENS_REQUIRING_ALLOWANCE_RESET } from '../../constants/token';
 

--- a/app/components/UI/HardwareWallet/AccountDetails/index.tsx
+++ b/app/components/UI/HardwareWallet/AccountDetails/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text } from 'react-native';
 import Icon from 'react-native-vector-icons/EvilIcons';
-import { renderFromWei } from '../../../../util/number';
+import { renderFromWei } from '../../../../util/number/legacy';
 import { useTheme } from '../../../../util/theme';
 import EthereumAddress from '../../../UI/EthereumAddress';
 import { createStyle } from './styles';

--- a/app/components/UI/Notification/TransactionNotification/index.js
+++ b/app/components/UI/Notification/TransactionNotification/index.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import Animated, { useSharedValue } from 'react-native-reanimated';
 import { strings } from '../../../../../locales/i18n';
 import Engine from '../../../../core/Engine';
-import { renderFromWei, fastSplit } from '../../../../util/number';
+import { renderFromWei, fastSplit } from '../../../../util/number/legacy';
 import { validateTransactionActionBalance } from '../../../../util/transactions';
 import {
   fontStyles,

--- a/app/components/UI/PaymentRequest/index.js
+++ b/app/components/UI/PaymentRequest/index.js
@@ -29,7 +29,7 @@ import {
   renderFromTokenMinimalUnit,
   fromTokenMinimalUnit,
   toTokenMinimalUnit,
-} from '../../../util/number';
+} from '../../../util/number/legacy';
 import { strings } from '../../../../locales/i18n';
 import FontAwesome from 'react-native-vector-icons/FontAwesome';
 import StyledButton from '../StyledButton';

--- a/app/components/UI/PaymentRequestSuccess/index.js
+++ b/app/components/UI/PaymentRequestSuccess/index.js
@@ -23,7 +23,7 @@ import Logger from '../../../util/Logger';
 import Share from 'react-native-share'; // eslint-disable-line  import/default
 import Modal from 'react-native-modal';
 import QRCode from 'react-native-qrcode-svg';
-import { renderNumber } from '../../../util/number';
+import { renderNumber } from '../../../util/number/legacy';
 import Device from '../../../util/device';
 import { strings } from '../../../../locales/i18n';
 import { protectWalletModalVisible } from '../../../actions/user';

--- a/app/components/UI/Perps/services/HyperLiquidWalletService.ts
+++ b/app/components/UI/Perps/services/HyperLiquidWalletService.ts
@@ -11,7 +11,7 @@ import { SignTypedDataVersion } from '@metamask/keyring-controller';
 import { getChainId } from '../constants/hyperLiquidConfig';
 import { strings } from '../../../../../locales/i18n';
 import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
-import { toHexadecimal } from '../../../../util/number';
+import { toHexadecimal } from '../../../../util/number/legacy';
 
 /**
  * Service for MetaMask wallet integration with HyperLiquid SDK

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
@@ -21,7 +21,7 @@ import {
 import useLimits from '../../hooks/useLimits';
 import useAddressBalance from '../../../../../hooks/useAddressBalance/useAddressBalance';
 import useBalance from '../../hooks/useBalance';
-import { toTokenMinimalUnit } from '../../../../../../util/number';
+import { toTokenMinimalUnit } from '../../../../../../util/number/legacy';
 import { RampType } from '../../../../../../reducers/fiatOrders/types';
 import { NATIVE_ADDRESS } from '../../../../../../constants/on-ramp';
 import { MOCK_ACCOUNTS_CONTROLLER_STATE } from '../../../../../../util/test/accountsControllerTestUtils';

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
@@ -83,7 +83,7 @@ import styleSheet from './BuildQuote.styles';
 import {
   toTokenMinimalUnit,
   fromTokenMinimalUnitString,
-} from '../../../../../../util/number';
+} from '../../../../../../util/number/legacy';
 import useGasPriceEstimation from '../../hooks/useGasPriceEstimation';
 import useIntentAmount from '../../hooks/useIntentAmount';
 import useERC20GasLimitEstimation from '../../hooks/useERC20GasLimitEstimation';

--- a/app/components/UI/Ramp/Aggregator/Views/SendTransaction/SendTransaction.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/SendTransaction/SendTransaction.tsx
@@ -50,7 +50,7 @@ import {
   addHexPrefix,
   fromTokenMinimalUnitString,
   toTokenMinimalUnit,
-} from '../../../../../../util/number';
+} from '../../../../../../util/number/legacy';
 import { strings } from '../../../../../../../locales/i18n';
 import { useStyles } from '../../../../../../component-library/hooks';
 import { addTransaction } from '../../../../../../util/transaction-controller';

--- a/app/components/UI/Ramp/Aggregator/components/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/OrderDetails.tsx
@@ -18,7 +18,7 @@ import {
   renderFiat,
   renderFromTokenMinimalUnit,
   toTokenMinimalUnit,
-} from '../../../../../util/number';
+} from '../../../../../util/number/legacy';
 import { FiatOrder, getProviderName } from '../../../../../reducers/fiatOrders';
 import useBlockExplorer from '../../../Swaps/utils/useBlockExplorer';
 import Spinner from '../../../AnimatedSpinner';

--- a/app/components/UI/Ramp/Aggregator/components/OrderListItem/OrderListItem.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/OrderListItem/OrderListItem.tsx
@@ -10,7 +10,10 @@ import {
 } from '../../../../../../reducers/fiatOrders';
 import { strings } from '../../../../../../../locales/i18n';
 import { toDateFormat } from '../../../../../../util/date';
-import { addCurrencySymbol, renderFiat } from '../../../../../../util/number';
+import {
+  addCurrencySymbol,
+  renderFiat,
+} from '../../../../../../util/number/legacy';
 import { getOrderAmount } from '../../utils';
 import Text, {
   TextColor,

--- a/app/components/UI/Ramp/Aggregator/components/Quote/Quote.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/Quote/Quote.tsx
@@ -23,7 +23,7 @@ import {
   renderFiat,
   renderFromTokenMinimalUnit,
   toTokenMinimalUnit,
-} from '../../../../../../util/number';
+} from '../../../../../../util/number/legacy';
 import { strings } from '../../../../../../../locales/i18n';
 import ApplePayButton from '../../containers/ApplePayButton';
 import RemoteImage from '../../../../../Base/RemoteImage';

--- a/app/components/UI/Ramp/Aggregator/hooks/useBalance.test.ts
+++ b/app/components/UI/Ramp/Aggregator/hooks/useBalance.test.ts
@@ -8,7 +8,7 @@ import { renderHookWithProvider } from '../../../../../util/test/renderWithProvi
 import { backgroundState } from '../../../../../util/test/initial-root-state';
 import useBalance from './useBalance';
 import { NATIVE_ADDRESS } from '../../../../../constants/on-ramp';
-import { hexToBN } from '../../../../../util/number';
+import { hexToBN } from '../../../../../util/number/legacy';
 import { TokenBalancesControllerState } from '@metamask/assets-controllers';
 import { selectSelectedInternalAccountByScope } from '../../../../../selectors/multichainAccounts/accounts';
 import { selectMultichainBalances } from '../../../../../selectors/multichain';

--- a/app/components/UI/Ramp/Aggregator/hooks/useBalance.ts
+++ b/app/components/UI/Ramp/Aggregator/hooks/useBalance.ts
@@ -15,7 +15,7 @@ import {
   renderFromTokenMinimalUnit,
   renderFromWei,
   weiToFiat,
-} from '../../../../../util/number';
+} from '../../../../../util/number/legacy';
 import { CaipChainId, Hex } from '@metamask/utils';
 import { toHex } from '@metamask/controller-utils';
 ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)

--- a/app/components/UI/Ramp/Aggregator/hooks/useERC20GasLimitEstimation.ts
+++ b/app/components/UI/Ramp/Aggregator/hooks/useERC20GasLimitEstimation.ts
@@ -6,7 +6,7 @@ import { getGasLimit } from '../../../../../util/custom-gas';
 import { safeToChecksumAddress } from '../../../../../util/address';
 import { generateTransferData } from '../../../../../util/transactions';
 import { addHexPrefix, BN } from 'ethereumjs-util';
-import { toTokenMinimalUnit } from '../../../../../util/number';
+import { toTokenMinimalUnit } from '../../../../../util/number/legacy';
 
 const TRANSFER_GAS_LIMIT = 21000;
 const POLLING_INTERVAL = 15000; // 15s

--- a/app/components/UI/Ramp/Aggregator/hooks/useHandleSuccessfulOrder.ts
+++ b/app/components/UI/Ramp/Aggregator/hooks/useHandleSuccessfulOrder.ts
@@ -8,7 +8,7 @@ import { protectWalletModalVisible } from '../../../../../actions/user';
 import NotificationManager from '../../../../../core/NotificationManager';
 import { addFiatOrder, FiatOrder } from '../../../../../reducers/fiatOrders';
 import { selectAccountsByChainId } from '../../../../../selectors/accountTrackerController';
-import { hexToBN, toHexadecimal } from '../../../../../util/number';
+import { hexToBN, toHexadecimal } from '../../../../../util/number/legacy';
 
 import useThunkDispatch from '../../../../hooks/useThunkDispatch';
 import { getNotificationDetails } from '../utils';

--- a/app/components/UI/Ramp/Aggregator/hooks/useIntentAmount.ts
+++ b/app/components/UI/Ramp/Aggregator/hooks/useIntentAmount.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import type BN4 from 'bnjs4';
 import { useRampSDK } from '../sdk';
 import parseAmount from '../utils/parseAmount';
-import { toTokenMinimalUnit } from '../../../../../util/number';
+import { toTokenMinimalUnit } from '../../../../../util/number/legacy';
 import { FiatCurrency } from '@consensys/on-ramp-sdk';
 
 /**

--- a/app/components/UI/Ramp/Aggregator/utils/index.ts
+++ b/app/components/UI/Ramp/Aggregator/utils/index.ts
@@ -15,7 +15,7 @@ import {
   renderFromTokenMinimalUnit,
   renderNumber,
   toTokenMinimalUnit,
-} from '../../../../../util/number';
+} from '../../../../../util/number/legacy';
 import { RampType } from '../types';
 import { FiatOrder } from '../../../../../reducers/fiatOrders';
 import { FIAT_ORDER_STATES } from '../../../../../constants/on-ramp';

--- a/app/components/UI/Ramp/Deposit/utils/index.ts
+++ b/app/components/UI/Ramp/Deposit/utils/index.ts
@@ -1,7 +1,7 @@
 import { DepositOrder } from '@consensys/native-ramps-sdk';
 import { FiatOrder } from '../../../../../reducers/fiatOrders';
 import { FIAT_ORDER_STATES } from '../../../../../constants/on-ramp';
-import { renderNumber } from '../../../../../util/number';
+import { renderNumber } from '../../../../../util/number/legacy';
 import { getIntlNumberFormatter } from '../../../../../util/intl';
 import I18n, { strings } from '../../../../../../locales/i18n';
 import { AppThemeKey, Colors } from '../../../../../util/theme/models';

--- a/app/components/UI/Stake/components/StakingBalance/StakingBanners/ClaimBanner/ClaimBanner.tsx
+++ b/app/components/UI/Stake/components/StakingBalance/StakingBanners/ClaimBanner/ClaimBanner.tsx
@@ -29,7 +29,7 @@ import usePoolStakedClaim from '../../../../hooks/usePoolStakedClaim';
 import { useStakeContext } from '../../../../hooks/useStakeContext';
 import useStakingChain from '../../../../hooks/useStakingChain';
 import styleSheet from './ClaimBanner.styles';
-import { renderFromWei } from '../../../../../../../util/number';
+import { renderFromWei } from '../../../../../../../util/number/legacy';
 import { TokenI } from '../../../../../Tokens/types';
 import { getDecimalChainId } from '../../../../../../../util/networks';
 import { trace, TraceName } from '../../../../../../../util/trace';

--- a/app/components/UI/Stake/components/StakingConfirmation/TokenValueStack/TokenValueStack.test.tsx
+++ b/app/components/UI/Stake/components/StakingConfirmation/TokenValueStack/TokenValueStack.test.tsx
@@ -3,7 +3,7 @@ import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import TokenValueStack from './TokenValueStack';
 import { Image } from 'react-native';
 import { TokenValueStackProps } from './TokenValueStack.types';
-import { renderFromWei } from '../../../../../../util/number';
+import { renderFromWei } from '../../../../../../util/number/legacy';
 import { backgroundState } from '../../../../../../util/test/initial-root-state';
 
 jest.mock('../../../../../hooks/useIpfsGateway', () => jest.fn());

--- a/app/components/UI/Stake/components/StakingConfirmation/TokenValueStack/TokenValueStack.tsx
+++ b/app/components/UI/Stake/components/StakingConfirmation/TokenValueStack/TokenValueStack.tsx
@@ -17,7 +17,7 @@ import NetworkMainAssetLogo from '../../../../NetworkMainAssetLogo';
 import styleSheet from './TokenValueStack.styles';
 import images from '../../../../../../images/image-icons';
 import { TokenValueStackProps } from './TokenValueStack.types';
-import { renderFromWei } from '../../../../../../util/number';
+import { renderFromWei } from '../../../../../../util/number/legacy';
 
 const TokenValueStack = ({
   amountWei,

--- a/app/components/UI/Stake/components/StakingConfirmation/YouReceiveCard/YouReceiveCard.test.tsx
+++ b/app/components/UI/Stake/components/StakingConfirmation/YouReceiveCard/YouReceiveCard.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import YouReceiveCard from './YouReceiveCard';
 import { YouReceiveCardProps } from './YouReceiveCard.types';
-import { renderFromWei } from '../../../../../../util/number';
+import { renderFromWei } from '../../../../../../util/number/legacy';
 import { strings } from '../../../../../../../locales/i18n';
 
 const mockNavigate = jest.fn();

--- a/app/components/UI/Stake/components/StakingConfirmation/YouReceiveCard/YouReceiveCard.tsx
+++ b/app/components/UI/Stake/components/StakingConfirmation/YouReceiveCard/YouReceiveCard.tsx
@@ -13,7 +13,7 @@ import Text, {
   TextColor,
 } from '../../../../../../component-library/components/Texts/Text';
 import Card from '../../../../../../component-library/components/Cards/Card';
-import { renderFromWei } from '../../../../../../util/number';
+import { renderFromWei } from '../../../../../../util/number/legacy';
 import { useStyles } from '../../../../../hooks/useStyles';
 import styleSheet from './YouReceiveCard.styles';
 import ethLogo from '../../../../../../images/ethereum.png';

--- a/app/components/UI/Stake/hooks/useBalance.ts
+++ b/app/components/UI/Stake/hooks/useBalance.ts
@@ -13,7 +13,7 @@ import {
   renderFromWei,
   weiToFiat,
   weiToFiatNumber,
-} from '../../../../util/number';
+} from '../../../../util/number/legacy';
 import { getFormattedAddressFromInternalAccount } from '../../../../core/Multichain/utils';
 import { EVM_SCOPE } from '../../Earn/constants/networks';
 

--- a/app/components/UI/Swaps/QuotesView.js
+++ b/app/components/UI/Swaps/QuotesView.js
@@ -34,7 +34,7 @@ import {
   toWei,
   weiToFiat,
   calculateEthFeeForMultiLayer,
-} from '../../../util/number';
+} from '../../../util/number/legacy';
 import {
   isMainnetByChainId,
   isMultiLayerFeeNetwork,

--- a/app/components/UI/Swaps/components/ApprovalTransactionEditionModal.js
+++ b/app/components/UI/Swaps/components/ApprovalTransactionEditionModal.js
@@ -7,7 +7,10 @@ import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view
 import { swapsUtils } from '@metamask/swaps-controller';
 
 import EditPermission from '../../../Views/confirmations/legacy/components/ApproveTransactionReview/EditPermission';
-import { fromTokenMinimalUnitString, hexToBN } from '../../../../util/number';
+import {
+  fromTokenMinimalUnitString,
+  hexToBN,
+} from '../../../../util/number/legacy';
 import {
   decodeApproveData,
   generateTxWithNewTokenAllowance,

--- a/app/components/UI/Swaps/components/QuotesModal.js
+++ b/app/components/UI/Swaps/components/QuotesModal.js
@@ -22,7 +22,7 @@ import {
   toWei,
   weiToFiat,
   calculateEthFeeForMultiLayer,
-} from '../../../../util/number';
+} from '../../../../util/number/legacy';
 import { getQuotesSourceMessage } from '../utils';
 import Text from '../../../Base/Text';
 import Title from '../../../Base/Title';

--- a/app/components/UI/Swaps/components/TokenSelectModal.js
+++ b/app/components/UI/Swaps/components/TokenSelectModal.js
@@ -19,7 +19,7 @@ import { connect } from 'react-redux';
 import { isValidAddress } from 'ethereumjs-util';
 
 import Device from '../../../../util/device';
-import { addCurrencySymbol } from '../../../../util/number';
+import { addCurrencySymbol } from '../../../../util/number/legacy';
 import { strings } from '../../../../../locales/i18n';
 import { fontStyles } from '../../../../styles/common';
 

--- a/app/components/UI/Swaps/index.js
+++ b/app/components/UI/Swaps/index.js
@@ -25,7 +25,7 @@ import {
   toTokenMinimalUnit,
   weiToFiat,
   safeNumberToBN,
-} from '../../../util/number';
+} from '../../../util/number/legacy';
 import { areAddressesEqual, toFormattedAddress } from '../../../util/address';
 import { swapsUtils } from '@metamask/swaps-controller';
 import { MetaMetricsEvents } from '../../../core/Analytics';

--- a/app/components/UI/Swaps/utils/gas.ts
+++ b/app/components/UI/Swaps/utils/gas.ts
@@ -4,7 +4,7 @@ import type {
 } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 import { estimateGasFee } from '../../../../util/transaction-controller';
-import { addHexPrefix } from '../../../../util/number';
+import { addHexPrefix } from '../../../../util/number/legacy';
 import { decGWEIToHexWEI } from '../../../../util/conversions';
 import AppConstants from '../../../../core/AppConstants';
 

--- a/app/components/UI/Swaps/utils/token-list-utils.ts
+++ b/app/components/UI/Swaps/utils/token-list-utils.ts
@@ -7,7 +7,7 @@ import {
   renderFromTokenMinimalUnit,
   renderFromWei,
   weiToFiatNumber,
-} from '../../../../util/number';
+} from '../../../../util/number/legacy';
 
 export interface Token {
   address: string;

--- a/app/components/UI/Swaps/utils/useBalance.js
+++ b/app/components/UI/Swaps/utils/useBalance.js
@@ -4,7 +4,7 @@ import {
   renderFromTokenMinimalUnit,
   renderFromWei,
   safeNumberToBN,
-} from '../../../../util/number';
+} from '../../../../util/number/legacy';
 import { safeToChecksumAddress } from '../../../../util/address';
 
 function useBalance(

--- a/app/components/UI/Swaps/utils/useGasTokenFiatAmount.test.ts
+++ b/app/components/UI/Swaps/utils/useGasTokenFiatAmount.test.ts
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { useGasTokenFiatAmount } from './useGasTokenFiatAmount';
 import { swapsUtils } from '@metamask/swaps-controller';
-import { toWei, weiToFiat } from '../../../../util/number';
+import { toWei, weiToFiat } from '../../../../util/number/legacy';
 import { hexToDecimal } from '../../../../util/conversions';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
 import { Quote } from '@metamask/swaps-controller/dist/types';
@@ -15,7 +15,7 @@ jest.mock('@metamask/swaps-controller', () => ({
   },
 }));
 
-jest.mock('../../../../util/number', () => ({
+jest.mock('../../../../util/number/legacy', () => ({
   toWei: jest.fn(),
   weiToFiat: jest.fn(),
 }));

--- a/app/components/UI/Swaps/utils/useGasTokenFiatAmount.ts
+++ b/app/components/UI/Swaps/utils/useGasTokenFiatAmount.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { swapsUtils } from '@metamask/swaps-controller';
 import { ContractExchangeRates } from '@metamask/assets-controllers';
-import { toWei, weiToFiat } from '../../../../util/number';
+import { toWei, weiToFiat } from '../../../../util/number/legacy';
 import { hexToDecimal } from '../../../../util/conversions';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
 import { Quote } from '@metamask/swaps-controller/dist/types';

--- a/app/components/UI/Tokens/util/deriveBalanceFromAssetMarketDetails.test.ts
+++ b/app/components/UI/Tokens/util/deriveBalanceFromAssetMarketDetails.test.ts
@@ -2,14 +2,14 @@ import {
   renderFromTokenMinimalUnit,
   addCurrencySymbol,
   balanceToFiatNumber,
-} from '../../../../util/number';
+} from '../../../../util/number/legacy';
 import { safeToChecksumAddress } from '../../../../util/address';
 import { TOKEN_BALANCE_LOADING, TOKEN_RATE_UNDEFINED } from '../constants';
 import { TokenI } from '../types';
 import { deriveBalanceFromAssetMarketDetails } from './deriveBalanceFromAssetMarketDetails';
 
 // Mock utility functions
-jest.mock('../../../../util/number', () => ({
+jest.mock('../../../../util/number/legacy', () => ({
   renderFromTokenMinimalUnit: jest.fn(),
   addCurrencySymbol: jest.fn(),
   balanceToFiatNumber: jest.fn(),

--- a/app/components/UI/Tokens/util/deriveBalanceFromAssetMarketDetails.ts
+++ b/app/components/UI/Tokens/util/deriveBalanceFromAssetMarketDetails.ts
@@ -3,7 +3,7 @@ import {
   renderFromTokenMinimalUnit,
   addCurrencySymbol,
   balanceToFiatNumber,
-} from '../../../../util/number';
+} from '../../../../util/number/legacy';
 import { safeToChecksumAddress } from '../../../../util/address';
 import { TOKEN_BALANCE_LOADING, TOKEN_RATE_UNDEFINED } from '../constants';
 import { TokenI } from '../types';

--- a/app/components/UI/TransactionElement/utils-gas.js
+++ b/app/components/UI/TransactionElement/utils-gas.js
@@ -1,6 +1,11 @@
 import { isEIP1559Transaction } from '@metamask/transaction-controller';
 import { sumHexWEIs } from '../../../util/conversions';
-import { hexToBN, isBN, BNToHex, renderToGwei } from '../../../util/number';
+import {
+  hexToBN,
+  isBN,
+  BNToHex,
+  renderToGwei,
+} from '../../../util/number/legacy';
 import { calculateEIP1559GasFeeHexes } from '../../../util/transactions';
 
 export function calculateTotalGas(transaction) {

--- a/app/components/UI/TransactionElement/utils.js
+++ b/app/components/UI/TransactionElement/utils.js
@@ -10,7 +10,7 @@ import {
   weiToFiatNumber,
   addCurrencySymbol,
   limitToMaximumDecimalPlaces,
-} from '../../../util/number';
+} from '../../../util/number/legacy';
 import { strings } from '../../../../locales/i18n';
 import {
   renderFullAddress,

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -53,7 +53,11 @@ import {
   getBlockExplorerAddressUrl,
   getBlockExplorerName,
 } from '../../../util/networks';
-import { addHexPrefix, hexToBN, renderFromWei } from '../../../util/number';
+import {
+  addHexPrefix,
+  hexToBN,
+  renderFromWei,
+} from '../../../util/number/legacy';
 import { mockTheme, ThemeContext } from '../../../util/theme';
 import {
   speedUpTransaction,

--- a/app/components/UI/Transactions/index.test.tsx
+++ b/app/components/UI/Transactions/index.test.tsx
@@ -153,7 +153,7 @@ jest.mock('../../../util/transactions', () => ({
   validateTransactionActionBalance: jest.fn(() => false),
 }));
 
-jest.mock('../../../util/number', () => ({
+jest.mock('../../../util/number/legacy', () => ({
   addHexPrefix: jest.fn((val) => `0x${val}`),
   hexToBN: jest.fn(() => ({ toString: () => '100' })),
   renderFromWei: jest.fn(() => '0.001'),

--- a/app/components/UI/UrlAutocomplete/Result.tsx
+++ b/app/components/UI/UrlAutocomplete/Result.tsx
@@ -22,7 +22,7 @@ import { NetworkBadgeSource } from '../AssetOverview/Balance/Balance';
 import AvatarToken from '../../../component-library/components/Avatars/Avatar/variants/AvatarToken';
 import AppConstants from '../../../core/AppConstants';
 import { selectCurrentCurrency } from '../../../selectors/currencyRateController';
-import { addCurrencySymbol } from '../../../util/number';
+import { addCurrencySymbol } from '../../../util/number/legacy';
 import PercentageChange from '../../../component-library/components-temp/Price/PercentageChange';
 
 interface ResultProps {

--- a/app/components/Views/AssetDetails/index.tsx
+++ b/app/components/Views/AssetDetails/index.tsx
@@ -29,7 +29,7 @@ import { Token as TokenType } from '@metamask/assets-controllers';
 import {
   balanceToFiat,
   renderFromTokenMinimalUnit,
-} from '../../../util/number';
+} from '../../../util/number/legacy';
 import WarningMessage from '../confirmations/legacy/SendFlow/WarningMessage';
 import { useTheme } from '../../../util/theme';
 import { MetaMetricsEvents } from '../../../core/Analytics';

--- a/app/components/Views/DetectedTokens/components/Token.tsx
+++ b/app/components/Views/DetectedTokens/components/Token.tsx
@@ -17,7 +17,7 @@ import { selectEvmChainId } from '../../../../selectors/networkController';
 import {
   balanceToFiat,
   renderFromTokenMinimalUnit,
-} from '../../../../util/number';
+} from '../../../../util/number/legacy';
 import { useTheme } from '../../../../util/theme';
 import {
   selectCurrencyRates,

--- a/app/components/Views/GasEducationCarousel/index.js
+++ b/app/components/Views/GasEducationCarousel/index.js
@@ -22,7 +22,7 @@ import { useTheme } from '../../../util/theme';
 import { GAS_ESTIMATE_TYPES } from '@metamask/gas-fee-controller';
 import AppConstants from '../../../core/AppConstants';
 import { decGWEIToHexWEI } from '../../../util/conversions';
-import { BNToHex, hexToBN } from '../../../util/number';
+import { BNToHex, hexToBN } from '../../../util/number/legacy';
 import {
   calculateEIP1559GasFeeHexes,
   getTicker,

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
@@ -33,7 +33,7 @@ import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view
 import BigNumber from 'bignumber.js';
 import { jsonRpcRequest } from '../../../../../util/jsonRpcRequest';
 import Logger from '../../../../../util/Logger';
-import { isPrefixedFormattedHexString } from '../../../../../util/number';
+import { isPrefixedFormattedHexString } from '../../../../../util/number/legacy';
 import AppConstants from '../../../../../core/AppConstants';
 import ScrollableTabView from '@tommasini/react-native-scrollable-tab-view';
 import TabBar from '../../../../../component-library/components-temp/TabBar/TabBar';

--- a/app/components/Views/confirmations/components/edit-amount/edit-amount.tsx
+++ b/app/components/Views/confirmations/components/edit-amount/edit-amount.tsx
@@ -7,7 +7,7 @@ import { DepositKeyboard, DepositKeyboardSkeleton } from '../deposit-keyboard';
 import { useConfirmationContext } from '../../context/confirmation-context';
 import { useTransactionPayToken } from '../../hooks/pay/useTransactionPayToken';
 import { BigNumber } from 'bignumber.js';
-import { getCurrencySymbol } from '../../../../../util/number';
+import { getCurrencySymbol } from '../../../../../util/number/legacy';
 import { useTokenFiatRate } from '../../hooks/tokens/useTokenFiatRates';
 import { useTransactionMetadataRequest } from '../../hooks/transactions/useTransactionMetadataRequest';
 import { Hex } from '@metamask/utils';

--- a/app/components/Views/confirmations/components/gas/max-base-fee-input/max-base-fee-input.tsx
+++ b/app/components/Views/confirmations/components/gas/max-base-fee-input/max-base-fee-input.tsx
@@ -9,7 +9,7 @@ import Text, {
 } from '../../../../../../component-library/components/Texts/Text';
 import { strings } from '../../../../../../../locales/i18n';
 import { hexWEIToDecGWEI } from '../../../../../../util/conversions';
-import { limitToMaximumDecimalPlaces } from '../../../../../../util/number';
+import { limitToMaximumDecimalPlaces } from '../../../../../../util/number/legacy';
 import { useGasFeeEstimates } from '../../../hooks/gas/useGasFeeEstimates';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
 import { convertGasInputToHexWEI } from '../../../utils/gas';

--- a/app/components/Views/confirmations/components/gas/priority-fee-input/priority-fee-input.tsx
+++ b/app/components/Views/confirmations/components/gas/priority-fee-input/priority-fee-input.tsx
@@ -9,7 +9,7 @@ import Text, {
 } from '../../../../../../component-library/components/Texts/Text';
 import { strings } from '../../../../../../../locales/i18n';
 import { hexWEIToDecGWEI } from '../../../../../../util/conversions';
-import { limitToMaximumDecimalPlaces } from '../../../../../../util/number';
+import { limitToMaximumDecimalPlaces } from '../../../../../../util/number/legacy';
 import { useGasFeeEstimates } from '../../../hooks/gas/useGasFeeEstimates';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
 import { convertGasInputToHexWEI } from '../../../utils/gas';

--- a/app/components/Views/confirmations/components/info/typed-sign-v3v4/simulation/components/native-value-display/native-value-display.tsx
+++ b/app/components/Views/confirmations/components/info/typed-sign-v3v4/simulation/components/native-value-display/native-value-display.tsx
@@ -24,7 +24,7 @@ import {
 } from '../../../../../../../../UI/SimulationDetails/formatAmount';
 import { AssetType } from '../../../../../../../../UI/SimulationDetails/types';
 import { shortenString } from '../../../../../../../../../util/notifications/methods/common';
-import { isNumberValue } from '../../../../../../../../../util/number';
+import { isNumberValue } from '../../../../../../../../../util/number/legacy';
 import { calcTokenAmount } from '../../../../../../../../../util/transactions';
 import BottomModal from '../../../../../UI/bottom-modal';
 

--- a/app/components/Views/confirmations/components/info/typed-sign-v3v4/simulation/components/value-display/value-display.tsx
+++ b/app/components/Views/confirmations/components/info/typed-sign-v3v4/simulation/components/value-display/value-display.tsx
@@ -23,7 +23,7 @@ import Address from '../../../../../UI/info-row/info-value/address';
 
 import Logger from '../../../../../../../../../util/Logger';
 import { shortenString } from '../../../../../../../../../util/notifications/methods/common';
-import { isNumberValue } from '../../../../../../../../../util/number';
+import { isNumberValue } from '../../../../../../../../../util/number/legacy';
 import { useTheme } from '../../../../../../../../../util/theme';
 import { calcTokenAmount } from '../../../../../../../../../util/transactions';
 

--- a/app/components/Views/confirmations/context/send-context/utils.ts
+++ b/app/components/Views/confirmations/context/send-context/utils.ts
@@ -3,7 +3,7 @@ import { BNToHex, toHex } from '@metamask/controller-utils';
 import { TransactionParams } from '@metamask/transaction-controller';
 
 import { generateTransferData } from '../../../../../util/transactions';
-import { toTokenMinimalUnit, toWei } from '../../../../../util/number';
+import { toTokenMinimalUnit, toWei } from '../../../../../util/number/legacy';
 import { AssetType } from '../../types/token';
 import { isNativeToken } from '../../utils/generic';
 

--- a/app/components/Views/confirmations/external/staking/hooks/useStakingDetails.ts
+++ b/app/components/Views/confirmations/external/staking/hooks/useStakingDetails.ts
@@ -5,7 +5,7 @@ import I18n from '../../../../../../../locales/i18n';
 import { RootState } from '../../../../../../reducers';
 import { selectConversionRateByChainId } from '../../../../../../selectors/currencyRateController';
 import { getDecimalChainId } from '../../../../../../util/networks';
-import { fromWei, hexToBN } from '../../../../../../util/number';
+import { fromWei, hexToBN } from '../../../../../../util/number/legacy';
 import useFiatFormatter from '../../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 import { formatAmount } from '../../../../../UI/SimulationDetails/formatAmount';
 import useVaultMetadata from '../../../../../UI/Stake/hooks/useVaultMetadata';

--- a/app/components/Views/confirmations/hooks/send/useBalance.ts
+++ b/app/components/Views/confirmations/hooks/send/useBalance.ts
@@ -1,7 +1,7 @@
 import BN from 'bnjs4';
 import { useMemo } from 'react';
 
-import { hexToBN } from '../../../../../util/number';
+import { hexToBN } from '../../../../../util/number/legacy';
 import { AssetType, TokenStandard } from '../../types/token';
 import { formatToFixedDecimals, fromHexWithDecimals } from '../../utils/send';
 import { useSendContext } from '../../context/send-context';

--- a/app/components/Views/confirmations/hooks/send/useCurrencyConversions.ts
+++ b/app/components/Views/confirmations/hooks/send/useCurrencyConversions.ts
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { RootState } from '../../../../../reducers';
-import { getCurrencySymbol } from '../../../../../util/number';
+import { getCurrencySymbol } from '../../../../../util/number/legacy';
 import { selectContractExchangeRatesByChainId } from '../../../../../selectors/tokenRatesController';
 import { selectCurrentCurrency } from '../../../../../selectors/currencyRateController';
 import { AssetType } from '../../types/token';

--- a/app/components/Views/confirmations/hooks/send/usePercentageAmount.ts
+++ b/app/components/Views/confirmations/hooks/send/usePercentageAmount.ts
@@ -3,7 +3,7 @@ import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 import { useCallback } from 'react';
 
-import { hexToBN } from '../../../../../util/number';
+import { hexToBN } from '../../../../../util/number/legacy';
 import { useAsyncResult } from '../../../../hooks/useAsyncResult';
 import { AssetType } from '../../types/token';
 import { fromBNWithDecimals, getLayer1GasFeeForSend } from '../../utils/send';

--- a/app/components/Views/confirmations/hooks/useTokenAmount.ts
+++ b/app/components/Views/confirmations/hooks/useTokenAmount.ts
@@ -16,7 +16,7 @@ import {
 } from '../../../../selectors/currencyRateController';
 import { selectContractExchangeRatesByChainId } from '../../../../selectors/tokenRatesController';
 import { safeToChecksumAddress } from '../../../../util/address';
-import { toBigNumber } from '../../../../util/number';
+import { toBigNumber } from '../../../../util/number/legacy';
 import {
   calcTokenAmount,
   calcTokenValue,

--- a/app/components/Views/confirmations/legacy/Approval/components/TransactionEditor/index.js
+++ b/app/components/Views/confirmations/legacy/Approval/components/TransactionEditor/index.js
@@ -8,7 +8,7 @@ import {
   fromWei,
   renderFromWei,
   toHexadecimal,
-} from '../../../../../../../util/number';
+} from '../../../../../../../util/number/legacy';
 import { isValidAddress, addHexPrefix } from 'ethereumjs-util';
 import BN from 'bnjs4';
 import { strings } from '../../../../../../../../locales/i18n';

--- a/app/components/Views/confirmations/legacy/Approval/index.js
+++ b/app/components/Views/confirmations/legacy/Approval/index.js
@@ -5,7 +5,7 @@ import Engine from '../../../../../core/Engine';
 import PropTypes from 'prop-types';
 import TransactionEditor from './components/TransactionEditor';
 import Modal from 'react-native-modal';
-import { safeBNToHex } from '../../../../../util/number';
+import { safeBNToHex } from '../../../../../util/number/legacy';
 import { getTransactionOptionsTitle } from '../../../../UI/Navbar';
 import { resetTransaction } from '../../../../../actions/transaction';
 import { connect } from 'react-redux';

--- a/app/components/Views/confirmations/legacy/Approve/index.js
+++ b/app/components/Views/confirmations/legacy/Approve/index.js
@@ -20,7 +20,11 @@ import {
   setProposedNonce,
 } from '../../../../../actions/transaction';
 import { GAS_ESTIMATE_TYPES } from '@metamask/gas-fee-controller';
-import { fromWei, renderFromWei, hexToBN } from '../../../../../util/number';
+import {
+  fromWei,
+  renderFromWei,
+  hexToBN,
+} from '../../../../../util/number/legacy';
 import {
   getNormalizedTxState,
   getTicker,

--- a/app/components/Views/confirmations/legacy/ApproveView/Approve/index.js
+++ b/app/components/Views/confirmations/legacy/ApproveView/Approve/index.js
@@ -20,7 +20,11 @@ import {
   setProposedNonce,
 } from '../../../../../../actions/transaction';
 import { GAS_ESTIMATE_TYPES } from '@metamask/gas-fee-controller';
-import { fromWei, renderFromWei, hexToBN } from '../../../../../../util/number';
+import {
+  fromWei,
+  renderFromWei,
+  hexToBN,
+} from '../../../../../../util/number/legacy';
 import {
   getNormalizedTxState,
   getTicker,

--- a/app/components/Views/confirmations/legacy/Send/index.js
+++ b/app/components/Views/confirmations/legacy/Send/index.js
@@ -16,7 +16,7 @@ import {
   hexToBN,
   fromWei,
   fromTokenMinimalUnit,
-} from '../../../../../util/number';
+} from '../../../../../util/number/legacy';
 import { strings } from '../../../../../../locales/i18n';
 import { getTransactionOptionsTitle } from '../../../../UI/Navbar';
 import { connect } from 'react-redux';

--- a/app/components/Views/confirmations/legacy/SendFlow/AddressFrom/AddressFrom.tsx
+++ b/app/components/Views/confirmations/legacy/SendFlow/AddressFrom/AddressFrom.tsx
@@ -9,7 +9,7 @@ import Routes from '../../../../../../constants/navigation/Routes';
 import { selectAccountsByChainId } from '../../../../../../selectors/accountTrackerController';
 import { selectSelectedInternalAccount } from '../../../../../../selectors/accountsController';
 import { doENSReverseLookup } from '../../../../../../util/ENSUtils';
-import { renderFromWei, hexToBN } from '../../../../../../util/number';
+import { renderFromWei, hexToBN } from '../../../../../../util/number/legacy';
 import { getEther, getTicker } from '../../../../../../util/transactions';
 import { AddressFrom } from '../../../../../UI/AddressInputs';
 import { SFAddressFromProps } from './AddressFrom.types';

--- a/app/components/Views/confirmations/legacy/SendFlow/Amount/index.js
+++ b/app/components/Views/confirmations/legacy/SendFlow/Amount/index.js
@@ -44,7 +44,7 @@ import {
   toHexadecimal,
   hexToBN,
   formatValueToMatchTokenDecimals,
-} from '../../../../../../util/number';
+} from '../../../../../../util/number/legacy';
 import {
   getTicker,
   generateTransferData,

--- a/app/components/Views/confirmations/legacy/SendFlow/Confirm/index.js
+++ b/app/components/Views/confirmations/legacy/SendFlow/Confirm/index.js
@@ -20,7 +20,7 @@ import {
   balanceToFiat,
   isDecimal,
   hexToBN,
-} from '../../../../../../util/number';
+} from '../../../../../../util/number/legacy';
 import {
   getTicker,
   decodeTransferData,

--- a/app/components/Views/confirmations/legacy/SendFlow/Confirm/validation.test.ts
+++ b/app/components/Views/confirmations/legacy/SendFlow/Confirm/validation.test.ts
@@ -3,14 +3,14 @@ import {
   validateSufficientBalance,
   validateSufficientTokenBalance,
 } from './validation';
-import { renderFromWei, hexToBN } from '../../../../../../util/number';
+import { renderFromWei, hexToBN } from '../../../../../../util/number/legacy';
 import {
   getTicker,
   decodeTransferData,
 } from '../../../../../../util/transactions';
 import { strings } from '../../../../../../../locales/i18n';
 
-jest.mock('../../../../../../util/number', () => ({
+jest.mock('../../../../../../util/number/legacy', () => ({
   renderFromWei: jest.fn(),
   hexToBN: jest.fn(),
 }));

--- a/app/components/Views/confirmations/legacy/SendFlow/Confirm/validation.ts
+++ b/app/components/Views/confirmations/legacy/SendFlow/Confirm/validation.ts
@@ -1,4 +1,4 @@
-import { renderFromWei, hexToBN } from '../../../../../../util/number';
+import { renderFromWei, hexToBN } from '../../../../../../util/number/legacy';
 import {
   getTicker,
   decodeTransferData,

--- a/app/components/Views/confirmations/legacy/SendFlow/components/CustomNonceModal/index.js
+++ b/app/components/Views/confirmations/legacy/SendFlow/components/CustomNonceModal/index.js
@@ -17,7 +17,7 @@ import PropTypes from 'prop-types';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import EvilIcons from 'react-native-vector-icons/EvilIcons';
 import { useTheme } from '../../../../../../../util/theme';
-import { isNumber } from '../../../../../../../util/number';
+import { isNumber } from '../../../../../../../util/number/legacy';
 
 const createStyles = (colors) =>
   StyleSheet.create({

--- a/app/components/Views/confirmations/legacy/components/ApproveTransactionReview/EditPermission/index.tsx
+++ b/app/components/Views/confirmations/legacy/components/ApproveTransactionReview/EditPermission/index.tsx
@@ -9,7 +9,7 @@ import {
 import { fontStyles } from '../../../../../../../styles/common';
 import StyledButton from '../../../../../../UI/StyledButton';
 import { strings } from '../../../../../../../../locales/i18n';
-import { isNumber } from '../../../../../../../util/number';
+import { isNumber } from '../../../../../../../util/number/legacy';
 import ConnectHeader from '../../../../../../UI/ConnectHeader';
 import Device from '../../../../../../../util/device';
 import ErrorMessage from '../../../SendFlow/ErrorMessage';

--- a/app/components/Views/confirmations/legacy/components/ApproveTransactionReview/index.js
+++ b/app/components/Views/confirmations/legacy/components/ApproveTransactionReview/index.js
@@ -26,7 +26,7 @@ import {
   hexToBN,
   isNumber,
   renderFromTokenMinimalUnit,
-} from '../../../../../../util/number';
+} from '../../../../../../util/number/legacy';
 import {
   getTicker,
   getNormalizedTxState,

--- a/app/components/Views/confirmations/legacy/components/TransactionReview/TransactionReviewInformation/index.js
+++ b/app/components/Views/confirmations/legacy/components/TransactionReview/TransactionReviewInformation/index.js
@@ -19,7 +19,7 @@ import {
   renderFromWei,
   BNToHex,
   hexToBN,
-} from '../../../../../../../util/number';
+} from '../../../../../../../util/number/legacy';
 import { strings } from '../../../../../../../../locales/i18n';
 import {
   getTicker,

--- a/app/components/Views/confirmations/legacy/components/TransactionReview/index.js
+++ b/app/components/Views/confirmations/legacy/components/TransactionReview/index.js
@@ -38,7 +38,7 @@ import {
   renderFromTokenMinimalUnit,
   renderFromWei,
   weiToFiat,
-} from '../../../../../../util/number';
+} from '../../../../../../util/number/legacy';
 import { ThemeContext, mockTheme } from '../../../../../../util/theme';
 import {
   decodeTransferData,

--- a/app/components/Views/confirmations/legacy/components/UpdateEIP1559Tx/index.jsx
+++ b/app/components/Views/confirmations/legacy/components/UpdateEIP1559Tx/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import { GAS_ESTIMATE_TYPES } from '@metamask/gas-fee-controller';
 import { CANCEL_RATE, SPEED_UP_RATE } from '@metamask/transaction-controller';
 import { isHexString } from '@metamask/utils';
@@ -21,7 +22,7 @@ import {
   fromWei,
   hexToBN,
   renderFromWei,
-} from '../../../../../../util/number';
+} from '../../../../../../util/number/legacy';
 import { getTicker } from '../../../../../../util/transactions';
 import EditGasFee1559Update from '../EditGasFee1559Update';
 

--- a/app/components/Views/confirmations/legacy/components/WatchAssetRequest/index.js
+++ b/app/components/Views/confirmations/legacy/components/WatchAssetRequest/index.js
@@ -6,7 +6,7 @@ import { useSelector } from 'react-redux';
 import { fontStyles } from '../../../../../../styles/common';
 import { strings } from '../../../../../../../locales/i18n';
 import ActionView from '../../../../../UI/ActionView';
-import { renderFromTokenMinimalUnit } from '../../../../../../util/number';
+import { renderFromTokenMinimalUnit } from '../../../../../../util/number/legacy';
 import TokenImage from '../../../../../UI/TokenImage';
 import Device from '../../../../../../util/device';
 import { MetaMetricsEvents } from '../../../../../../core/Analytics';

--- a/app/components/Views/confirmations/utils/send.ts
+++ b/app/components/Views/confirmations/utils/send.ts
@@ -21,7 +21,7 @@ import {
   TRANSFER_FROM_FUNCTION_SIGNATURE,
   TRANSFER_FUNCTION_SIGNATURE,
 } from '../../../../util/transactions';
-import { BNToHex, hexToBN, toWei } from '../../../../util/number';
+import { BNToHex, hexToBN, toWei } from '../../../../util/number/legacy';
 import { AssetType, TokenStandard } from '../types/token';
 import { MMM_ORIGIN } from '../constants/confirmations';
 import { isNativeToken } from '../utils/generic';

--- a/app/components/hooks/useAddressBalance/useAddressBalance.ts
+++ b/app/components/hooks/useAddressBalance/useAddressBalance.ts
@@ -9,7 +9,7 @@ import { getTicker } from '../../../util/transactions';
 import {
   renderFromTokenMinimalUnit,
   renderFromWei,
-} from '../../../util/number';
+} from '../../../util/number/legacy';
 import {
   selectEvmTicker,
   selectNetworkConfigurationByChainId,

--- a/app/components/hooks/useGetFormattedTokensPerChain.tsx
+++ b/app/components/hooks/useGetFormattedTokensPerChain.tsx
@@ -2,14 +2,12 @@ import { useSelector } from 'react-redux';
 import { useEffect, useMemo, useState } from 'react';
 import { MarketDataDetails, Token } from '@metamask/assets-controllers';
 import { InternalAccount } from '@metamask/keyring-internal-api';
-import { add0x } from '@metamask/utils';
 import { isEqual } from 'lodash';
 import { selectAllTokens } from '../../selectors/tokensController';
 import { selectAllTokenBalances } from '../../selectors/tokenBalancesController';
 import {
   renderFromTokenMinimalUnit,
   balanceToFiatNumber,
-  toHexadecimal,
 } from '../../util/number';
 import {
   selectEvmChainId,
@@ -23,6 +21,7 @@ import {
 import { isTestNet } from '../../util/networks';
 import { selectShowFiatInTestnets } from '../../selectors/settings';
 import { selectSelectedNonEvmNetworkChainId } from '../../selectors/multichainNetworkController';
+import { Hex } from '@metamask/utils';
 interface AllTokens {
   [chainId: string]: {
     [tokenAddress: string]: Token[];
@@ -194,8 +193,7 @@ export const useGetFormattedTokensPerChain = (
         const matchedChainSymbol = allNetworks[singleChain].nativeCurrency;
         const conversionRate =
           currencyRates?.[matchedChainSymbol]?.conversionRate ?? 0;
-        const tokenExchangeRates =
-          marketData?.[add0x(toHexadecimal(singleChain))];
+        const tokenExchangeRates = marketData?.[singleChain as Hex];
         const decimalsToShow = (currentCurrency === 'usd' && 2) || undefined;
         const tokensWithBalances = getTokenFiatBalances({
           tokens,

--- a/app/components/hooks/useGetFormattedTokensPerChain.tsx
+++ b/app/components/hooks/useGetFormattedTokensPerChain.tsx
@@ -2,12 +2,13 @@ import { useSelector } from 'react-redux';
 import { useEffect, useMemo, useState } from 'react';
 import { MarketDataDetails, Token } from '@metamask/assets-controllers';
 import { InternalAccount } from '@metamask/keyring-internal-api';
+import { add0x } from '@metamask/utils';
 import { isEqual } from 'lodash';
 import { selectAllTokens } from '../../selectors/tokensController';
 import { selectAllTokenBalances } from '../../selectors/tokenBalancesController';
 import {
-  balanceToFiatNumber,
   renderFromTokenMinimalUnit,
+  balanceToFiatNumber,
   toHexadecimal,
 } from '../../util/number';
 import {
@@ -193,7 +194,8 @@ export const useGetFormattedTokensPerChain = (
         const matchedChainSymbol = allNetworks[singleChain].nativeCurrency;
         const conversionRate =
           currencyRates?.[matchedChainSymbol]?.conversionRate ?? 0;
-        const tokenExchangeRates = marketData?.[toHexadecimal(singleChain)];
+        const tokenExchangeRates =
+          marketData?.[add0x(toHexadecimal(singleChain))];
         const decimalsToShow = (currentCurrency === 'usd' && 2) || undefined;
         const tokensWithBalances = getTokenFiatBalances({
           tokens,

--- a/app/components/hooks/useGetTotalFiatBalanceCrossChains.tsx
+++ b/app/components/hooks/useGetTotalFiatBalanceCrossChains.tsx
@@ -12,11 +12,7 @@ import { selectShowFiatInTestnets } from '../../selectors/settings';
 import { isTestNet } from '../../util/networks';
 import { useMemo } from 'react';
 import { selectEVMEnabledNetworks } from '../../selectors/networkEnablementController';
-import {
-  hexToBigInt,
-  toHexadecimal,
-  weiToFiatNumber,
-} from '../../util/number/bigInt';
+import { hexToBigInt, toHexadecimal, weiToFiatNumber } from '../../util/number';
 
 interface TokenFiatBalancesCrossChains {
   chainId: string;

--- a/app/components/hooks/useGetTotalFiatBalanceCrossChains.tsx
+++ b/app/components/hooks/useGetTotalFiatBalanceCrossChains.tsx
@@ -13,6 +13,7 @@ import { isTestNet } from '../../util/networks';
 import { useMemo } from 'react';
 import { selectEVMEnabledNetworks } from '../../selectors/networkEnablementController';
 import { hexToBigInt, toHexadecimal, weiToFiatNumber } from '../../util/number';
+import { add0x } from '@metamask/utils';
 
 interface TokenFiatBalancesCrossChains {
   chainId: string;
@@ -124,8 +125,8 @@ export const useGetTotalFiatBalanceCrossChains = (
             accountsByChainId[hexChainId][toChecksumHexAddress(account.address)]
               .stakedBalance || '0x00',
           );
-          const totalAccountBalance = (balanceBN + stakedBalanceBN).toString(
-            16,
+          const totalAccountBalance = add0x(
+            (balanceBN + stakedBalanceBN).toString(16),
           );
           ethFiat = weiToFiatNumber(
             totalAccountBalance,

--- a/app/core/Engine/Engine.test.ts
+++ b/app/core/Engine/Engine.test.ts
@@ -9,7 +9,7 @@ import {
   MOCK_ADDRESS_1,
 } from '../../util/test/accountsControllerTestUtils';
 import { mockNetworkState } from '../../util/test/network';
-import { Hex, KnownCaipNamespace } from '@metamask/utils';
+import { add0x, Hex, KnownCaipNamespace } from '@metamask/utils';
 import { KeyringControllerState } from '@metamask/keyring-controller';
 import { backupVault } from '../BackupVault';
 import { getVersion } from 'react-native-device-info';
@@ -399,7 +399,9 @@ describe('Engine', () => {
       AccountTrackerController: {
         accountsByChainId: {
           [chainId]: {
-            [selectedAddress]: { balance: (ethBalance * 1e18).toString() },
+            [selectedAddress]: {
+              balance: add0x((ethBalance * 1e18).toString(16)),
+            },
           },
         },
       },
@@ -428,8 +430,8 @@ describe('Engine', () => {
           accountsByChainId: {
             [chainId]: {
               [selectedAddress]: {
-                balance: '0',
-                stakedBalance: '0',
+                balance: '0x0',
+                stakedBalance: '0x0',
               },
             },
           },
@@ -602,8 +604,8 @@ describe('Engine', () => {
           accountsByChainId: {
             [chainId]: {
               [selectedAddress]: {
-                balance: (ethBalance * 1e18).toString(),
-                stakedBalance: (stakedEthBalance * 1e18).toString(),
+                balance: add0x((ethBalance * 1e18).toString(16)),
+                stakedBalance: add0x((stakedEthBalance * 1e18).toString(16)),
               },
             },
           },

--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -73,14 +73,15 @@ import {
 } from '../../util/networks/engineNetworkUtils';
 import AppConstants from '../AppConstants';
 import { store } from '../../store';
+
 import {
-  renderFromTokenMinimalUnit,
-  balanceToFiatNumber,
-  weiToFiatNumber,
-  toHexadecimal,
-  hexToBN,
+  hexToBigInt,
   renderFromWei,
+  weiToFiatNumber,
+  balanceToFiatNumber,
+  renderFromTokenMinimalUnit,
 } from '../../util/number';
+
 import NotificationManager from '../NotificationManager';
 import Logger from '../../util/Logger';
 import { isZero } from '../../util/lodash';
@@ -1535,7 +1536,6 @@ export class Engine {
 
     networkConfigurations.forEach((networkConfig) => {
       const { chainId } = networkConfig;
-      const chainIdHex = toHexadecimal(chainId);
 
       if (isTestNet(chainId) && !showFiatOnTestnets) {
         return;
@@ -1567,17 +1567,18 @@ export class Engine {
       }
 
       const accountData =
-        accountsByChainId?.[chainIdHex]?.[
-          selectedInternalAccountFormattedAddress
-        ];
+        accountsByChainId?.[chainId]?.[selectedInternalAccountFormattedAddress];
       if (accountData) {
         const balanceHex = accountData.balance;
-        const balanceBN = hexToBN(balanceHex);
+        const balanceBigInt = hexToBigInt(balanceHex);
 
-        const stakedBalanceBN = hexToBN(accountData.stakedBalance || '0x00');
-        const totalAccountBalance = balanceBN
-          .add(stakedBalanceBN)
-          .toString('hex');
+        const stakedBalanceBigInt = hexToBigInt(
+          accountData.stakedBalance || '0x00',
+        );
+
+        const totalAccountBalance = (
+          balanceBigInt + stakedBalanceBigInt
+        ).toString(16);
 
         const chainEthFiat = weiToFiatNumber(
           totalAccountBalance,
@@ -1590,7 +1591,7 @@ export class Engine {
           totalEthFiat += chainEthFiat;
         }
 
-        const tokenExchangeRates = marketData?.[chainIdHex];
+        const tokenExchangeRates = marketData?.[chainId];
         const ethPricePercentChange1d =
           tokenExchangeRates?.[zeroAddress() as Hex]?.pricePercentChange1d;
 
@@ -1620,10 +1621,10 @@ export class Engine {
       }
 
       const tokens =
-        TokensController.state.allTokens?.[chainIdHex]?.[
+        TokensController.state.allTokens?.[chainId]?.[
           selectedInternalAccount.address
         ] || [];
-      const tokenExchangeRates = marketData?.[chainIdHex];
+      const tokenExchangeRates = marketData?.[chainId];
 
       if (tokens.length > 0) {
         const { tokenBalances: allTokenBalances } =

--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -98,7 +98,7 @@ import { getUserStorageControllerMessenger } from './messengers/identity/user-st
 import { createUserStorageController } from './controllers/identity/create-user-storage-controller';
 ///: END:ONLY_INCLUDE_IF
 import { backupVault } from '../BackupVault';
-import { Hex, Json, KnownCaipNamespace } from '@metamask/utils';
+import { add0x, Hex, Json, KnownCaipNamespace } from '@metamask/utils';
 import { providerErrors } from '@metamask/rpc-errors';
 
 import { PPOM, ppomInit } from '../../lib/ppom/PPOMView';
@@ -1576,9 +1576,9 @@ export class Engine {
           accountData.stakedBalance || '0x00',
         );
 
-        const totalAccountBalance = (
-          balanceBigInt + stakedBalanceBigInt
-        ).toString(16);
+        const totalAccountBalance = add0x(
+          (balanceBigInt + stakedBalanceBigInt).toString(16),
+        );
 
         const chainEthFiat = weiToFiatNumber(
           totalAccountBalance,

--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -98,7 +98,7 @@ import { getUserStorageControllerMessenger } from './messengers/identity/user-st
 import { createUserStorageController } from './controllers/identity/create-user-storage-controller';
 ///: END:ONLY_INCLUDE_IF
 import { backupVault } from '../BackupVault';
-import { add0x, Hex, Json, KnownCaipNamespace } from '@metamask/utils';
+import { Hex, Json, KnownCaipNamespace } from '@metamask/utils';
 import { providerErrors } from '@metamask/rpc-errors';
 
 import { PPOM, ppomInit } from '../../lib/ppom/PPOMView';
@@ -1576,9 +1576,7 @@ export class Engine {
           accountData.stakedBalance || '0x00',
         );
 
-        const totalAccountBalance = add0x(
-          (balanceBigInt + stakedBalanceBigInt).toString(16),
-        );
+        const totalAccountBalance = balanceBigInt + stakedBalanceBigInt;
 
         const chainEthFiat = weiToFiatNumber(
           totalAccountBalance,

--- a/app/core/Engine/controllers/gas-fee-controller/gas-fee-controller-init.test.ts
+++ b/app/core/Engine/controllers/gas-fee-controller/gas-fee-controller-init.test.ts
@@ -2,7 +2,7 @@ import { GasFeeController } from '@metamask/gas-fee-controller';
 import { swapsUtils } from '@metamask/swaps-controller';
 import { NetworkController } from '@metamask/network-controller';
 
-import { addHexPrefix } from '../../../../util/number';
+import { addHexPrefix } from '../../../../util/number/legacy';
 import { isMainnetByChainId } from '../../../../util/networks';
 import { ExtendedControllerMessenger } from '../../../ExtendedControllerMessenger';
 import AppConstants from '../../../AppConstants';
@@ -13,7 +13,7 @@ import { GasFeeControllerInit } from './gas-fee-controller-init';
 
 jest.mock('@metamask/gas-fee-controller');
 jest.mock('../../../../util/networks');
-jest.mock('../../../../util/number');
+jest.mock('../../../../util/number/legacy');
 
 /**
  * Build a mock NetworkController.

--- a/app/core/Engine/controllers/gas-fee-controller/gas-fee-controller-init.ts
+++ b/app/core/Engine/controllers/gas-fee-controller/gas-fee-controller-init.ts
@@ -7,7 +7,7 @@ import type {
 } from '../../types';
 import AppConstants from '../../../AppConstants';
 import Logger from '../../../../util/Logger';
-import { addHexPrefix } from '../../../../util/number';
+import { addHexPrefix } from '../../../../util/number/legacy';
 import { isMainnetByChainId } from '../../../../util/networks';
 import { type GasFeeControllerMessenger } from '../../messengers/gas-fee-controller-messenger/gas-fee-controller-messenger';
 

--- a/app/core/GasPolling/GasPolling.ts
+++ b/app/core/GasPolling/GasPolling.ts
@@ -11,7 +11,7 @@ import {
 import { selectEvmTicker } from '../../selectors/networkController';
 import { selectContractBalances } from '../../selectors/tokenBalancesController';
 import { selectContractExchangeRates } from '../../selectors/tokenRatesController';
-import { fromWei, isBN, toGwei } from '../../util/number';
+import { fromWei, isBN, toGwei } from '../../util/number/legacy';
 import {
   parseTransactionEIP1559,
   parseTransactionLegacy,

--- a/app/core/NotificationManager.js
+++ b/app/core/NotificationManager.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import Engine from './Engine';
-import { hexToBN, renderFromWei } from '../util/number';
+import { hexToBN, renderFromWei } from '../util/number/legacy';
 import Device from '../util/device';
 import { strings } from '../../locales/i18n';
 import { AppState } from 'react-native';

--- a/app/selectors/assets/assets-list.ts
+++ b/app/selectors/assets/assets-list.ts
@@ -17,7 +17,7 @@ import { selectEvmNetworkConfigurationsByChainId } from '../networkController';
 import { selectEnabledNetworksByNamespace } from '../networkEnablementController';
 import { selectTokenSortConfig } from '../preferencesController';
 import { createDeepEqualSelector } from '../util';
-import { fromWei, hexToBN, weiToFiatNumber } from '../../util/number';
+import { fromWei, hexToBN, weiToFiatNumber } from '../../util/number/legacy';
 import {
   selectCurrencyRates,
   selectCurrentCurrency,

--- a/app/selectors/earnController/earn/index.ts
+++ b/app/selectors/earnController/earn/index.ts
@@ -16,8 +16,12 @@ import {
   getDecimalChainId,
   isPortfolioViewEnabled,
 } from '../../../util/networks';
-import { hexToBN, renderFiat, weiToFiatNumber } from '../../../util/number';
 import { selectSelectedInternalAccountByScope } from '../../multichainAccounts/accounts';
+import {
+  hexToBN,
+  renderFiat,
+  weiToFiatNumber,
+} from '../../../util/number/legacy';
 import { selectAccountsByChainId } from '../../accountTrackerController';
 import {
   selectCurrencyRates,

--- a/app/selectors/multichain/evm.ts
+++ b/app/selectors/multichain/evm.ts
@@ -20,7 +20,7 @@ import {
   selectNetworkConfigurations,
 } from '../networkController';
 import { TokenI } from '../../components/UI/Tokens/types';
-import { renderFromWei, weiToFiat } from '../../util/number';
+import { renderFromWei, weiToFiat } from '../../util/number/legacy';
 import {
   hexToBN,
   toChecksumHexAddress,

--- a/app/util/confirmation/transactions.ts
+++ b/app/util/confirmation/transactions.ts
@@ -7,7 +7,7 @@ import {
   TransactionEnvelopeType,
   TransactionParams,
 } from '@metamask/transaction-controller';
-import { addHexPrefix, safeBNToHex } from '../number';
+import { addHexPrefix, safeBNToHex } from '../number/legacy';
 import { safeToChecksumAddress } from '../address';
 
 export function buildTransactionParams({

--- a/app/util/custom-gas/index.js
+++ b/app/util/custom-gas/index.js
@@ -1,5 +1,10 @@
 import BN from 'bnjs4';
-import { renderFromWei, weiToFiat, toWei, conversionUtil } from '../number';
+import {
+  renderFromWei,
+  weiToFiat,
+  toWei,
+  conversionUtil,
+} from '../number/legacy';
 import { strings } from '../../../locales/i18n';
 import TransactionTypes from '../../core/TransactionTypes';
 import { estimateGas } from '../transaction-controller';

--- a/app/util/dappTransactions/index.ts
+++ b/app/util/dappTransactions/index.ts
@@ -1,5 +1,5 @@
 import { remove0x } from '@metamask/utils';
-import { isBN, hexToBN } from '../number';
+import { isBN, hexToBN } from '../number/legacy';
 import { areAddressesEqual, toFormattedAddress } from '../address';
 import Engine from '../../core/Engine';
 import TransactionTypes from '../../core/TransactionTypes';

--- a/app/util/importAdditionalAccounts.ts
+++ b/app/util/importAdditionalAccounts.ts
@@ -1,5 +1,5 @@
 import Engine from '../core/Engine';
-import { BNToHex } from '../util/number';
+import { BNToHex } from '../util/number/legacy';
 import Logger from '../util/Logger';
 import ExtendedKeyringTypes from '../../app/constants/keyringTypes';
 import type EthQuery from '@metamask/eth-query';

--- a/app/util/networks/index.js
+++ b/app/util/networks/index.js
@@ -20,7 +20,7 @@ import {
   toHex,
 } from '@metamask/controller-utils';
 import { toLowerCaseEquals } from '../general';
-import { fastSplit } from '../number';
+import { fastSplit } from '../number/legacy';
 import { regex } from '../../../app/util/regex';
 import { MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP } from '../../../app/core/Multichain/constants';
 import {

--- a/app/util/number/index.ts
+++ b/app/util/number/index.ts
@@ -1,17 +1,25 @@
 /**
  * Collection of utility functions for consistent formatting and conversion
  */
-import { stripHexPrefix } from 'ethereumjs-util';
-import BN4 from 'bnjs4';
+
 import { utils as ethersUtils } from 'ethers';
-import convert from '@metamask/ethjs-unit';
-import { add0x, remove0x } from '@metamask/utils';
-import numberToBN from 'number-to-bn';
+import {
+  add0x,
+  unitMap,
+  fromWei as fromWeiUtil,
+  numberToString,
+  toWei as toWeiUtil,
+} from '@metamask/utils';
 import BigNumber from 'bignumber.js';
 
 import currencySymbols from '../currency-symbols.json';
 import { isZero } from '../lodash';
 import { regex } from '../regex';
+import { stripHexPrefix } from '../address';
+
+type EthereumUnit = keyof typeof unitMap;
+type CurrencyCode = keyof typeof currencySymbols;
+type SignedHex = `0x${string}` | `-0x${string}`;
 
 const MAX_DECIMALS_FOR_TOKENS = 36;
 BigNumber.config({ DECIMAL_PLACES: MAX_DECIMALS_FOR_TOKENS });
@@ -21,78 +29,79 @@ const BIG_NUMBER_WEI_MULTIPLIER = new BigNumber('1000000000000000000');
 const BIG_NUMBER_GWEI_MULTIPLIER = new BigNumber('1000000000');
 const BIG_NUMBER_ETH_MULTIPLIER = new BigNumber('1');
 
-/**
- * Converts a hex string to a BN object.
- * Adapt function with non string argument handler
- *
- * @param inputHex - Number represented as a hex string.
- * @returns A BN instance.
- */
-export const hexToBN = (inputHex) =>
-  typeof inputHex !== 'string'
-    ? new BN4(inputHex, 16)
-    : inputHex
-    ? new BN4(remove0x(inputHex), 16)
-    : new BN4(0);
+export const hexToBigInt = (inputHex: string | number | bigint): bigint => {
+  if (typeof inputHex !== 'string') {
+    return BigInt(inputHex);
+  }
+  // not an empty string
+  if (inputHex) {
+    return BigInt(addHexPrefix(inputHex));
+  }
+  return BigInt(0);
+};
 
-/**
- * Converts a BN object to a hex string with a '0x' prefix.
- *
- * @param inputBn - BN instance to convert to a hex string.
- * @returns A '0x'-prefixed hex string.
- */
-// TODO: Either fix this lint violation or explain why it's necessary to ignore.
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export function BNToHex(inputBn) {
-  return add0x(inputBn.toString(16));
-}
+export const bigIntToHex = (value: bigint): string => add0x(value.toString(16));
 
 // Setter Maps
+export const toBigInt = {
+  hex: (n: string): bigint => BigInt(add0x(n)),
+  dec: (n: string | number): bigint => BigInt(String(n)),
+};
 export const toBigNumber = {
-  hex: (n) => new BigNumber(stripHexPrefix(n), 16),
-  dec: (n) => new BigNumber(String(n), 10),
-  BN: (n) => new BigNumber(n.toString(16), 16),
+  hex: (n: string): BigNumber => new BigNumber(stripHexPrefix(n), 16),
+  dec: (n: string | number): BigNumber => new BigNumber(String(n), 10),
+  BN: (n: bigint | BigNumber | string | number): BigNumber =>
+    new BigNumber(n.toString(16), 16),
 };
+type NumericBase = keyof typeof toBigNumber;
+
 const toNormalizedDenomination = {
-  WEI: (bigNumber) => bigNumber.div(BIG_NUMBER_WEI_MULTIPLIER),
-  GWEI: (bigNumber) => bigNumber.div(BIG_NUMBER_GWEI_MULTIPLIER),
-  ETH: (bigNumber) => bigNumber.div(BIG_NUMBER_ETH_MULTIPLIER),
+  WEI: (bigNumber: BigNumber): BigNumber =>
+    bigNumber.div(BIG_NUMBER_WEI_MULTIPLIER),
+  GWEI: (bigNumber: BigNumber): BigNumber =>
+    bigNumber.div(BIG_NUMBER_GWEI_MULTIPLIER),
+  ETH: (bigNumber: BigNumber): BigNumber =>
+    bigNumber.div(BIG_NUMBER_ETH_MULTIPLIER),
 };
+type NormalizedDenomination = keyof typeof toNormalizedDenomination;
+
 const toSpecifiedDenomination = {
-  WEI: (bigNumber) =>
+  WEI: (bigNumber: BigNumber): BigNumber =>
     bigNumber.times(BIG_NUMBER_WEI_MULTIPLIER).decimalPlaces(0),
-  GWEI: (bigNumber) =>
+  GWEI: (bigNumber: BigNumber): BigNumber =>
     bigNumber.times(BIG_NUMBER_GWEI_MULTIPLIER).decimalPlaces(9),
-  ETH: (bigNumber) =>
+  ETH: (bigNumber: BigNumber): BigNumber =>
     bigNumber.times(BIG_NUMBER_ETH_MULTIPLIER).decimalPlaces(9),
 };
+type SpecifiedDenomination = keyof typeof toSpecifiedDenomination;
+
 const baseChange = {
-  hex: (n) => n.toString(16),
-  dec: (n) => new BigNumber(n).toString(10),
-  BN: (n) => new BN4(n.toString(16)),
+  hex: (n: bigint | BigNumber): string => n.toString(16),
+  dec: (n: bigint | BigNumber): string => n.toString(10),
+  BN: (n: bigint | BigNumber): string => n.toString(16), // Returns hex string that can be used to create BigInt
 };
 
 /**
  * Prefixes a hex string with '0x' or '-0x' and returns it. Idempotent.
  *
- * @param {string} str - The string to prefix.
- * @returns {string} The prefixed string.
+ * @param str - The string to prefix.
+ * @returns The prefixed string.
  */
-export const addHexPrefix = (str) => {
+export function addHexPrefix(str: string): SignedHex {
   if (typeof str !== 'string' || str.match(regex.hexPrefix)) {
-    return str;
+    return str as SignedHex;
   }
 
   if (str.match(regex.hexPrefix)) {
-    return str.replace('0X', '0x');
+    return str.replace('0X', '0x') as SignedHex;
   }
 
   if (str.startsWith('-')) {
-    return str.replace('-', '-0x');
+    return str.replace('-', '-0x') as SignedHex;
   }
 
   return `0x${str}`;
-};
+}
 
 /**
  * Converts wei to a different unit
@@ -101,8 +110,11 @@ export const addHexPrefix = (str) => {
  * @param {string} unit - Unit to convert to, ether by default
  * @returns {string} - String containing the new number
  */
-export function fromWei(value = 0, unit = 'ether') {
-  return convert.fromWei(value, unit);
+export function fromWei(
+  value: number | string | bigint = 0,
+  unit: EthereumUnit = 'ether',
+): string {
+  return fromWeiUtil(value, unit);
 }
 
 /**
@@ -113,26 +125,27 @@ export function fromWei(value = 0, unit = 'ether') {
  * @param {boolean} [isRounding=true] - If true, minimalInput is converted to number and rounded for large numbers.
  * @returns {string} - String containing the new number
  */
+
 export function fromTokenMinimalUnit(
-  minimalInput,
-  decimals,
+  minimalInput: number | string | bigint,
+  decimals: number,
   isRounding = true,
-) {
+): string {
   minimalInput = isRounding ? Number(minimalInput) : minimalInput;
   const prefixedInput = addHexPrefix(minimalInput.toString(16));
-  let minimal = safeNumberToBN(prefixedInput);
-  const negative = minimal.lt(new BN4(0));
-  const base = toBN(Math.pow(10, decimals).toString());
+  let minimal = safeNumberToBigInt(prefixedInput);
+  const negative = minimal < 0n;
+  const base = BigInt(Math.pow(10, decimals).toString());
 
   if (negative) {
-    minimal = minimal.mul(negative);
+    minimal = bigIntAbs(minimal); // Use absolute value
   }
-  let fraction = minimal.mod(base).toString(10);
+  let fraction = (minimal % base).toString(10);
   while (fraction.length < decimals) {
     fraction = '0' + fraction;
   }
-  fraction = fraction.match(regex.fractions)[1];
-  const whole = minimal.div(base).toString(10);
+  fraction = fraction.match(regex.fractions)?.[1] || '0';
+  const whole = (minimal / base).toString(10);
   let value = '' + whole + (fraction === '0' ? '' : '.' + fraction);
   if (negative) {
     value = '-' + value;
@@ -147,7 +160,10 @@ export function fromTokenMinimalUnit(
  * @param {number} decimals - Token decimals to convert
  * @returns {string} - String containing the new number
  */
-export function fromTokenMinimalUnitString(minimalInput, decimals) {
+export function fromTokenMinimalUnitString(
+  minimalInput: string,
+  decimals: number,
+) {
   if (typeof minimalInput !== 'string') {
     throw new TypeError('minimalInput must be a string');
   }
@@ -165,13 +181,16 @@ export function fromTokenMinimalUnitString(minimalInput, decimals) {
 /**
  * Converts some unit to token minimal unit
  *
- * @param {number|string|BN4} tokenValue - Value to convert
- * @param {number} decimals - Unit to convert from, ether by default
- * @returns {BN} - BN instance containing the new number
+ * @param tokenValue - Value to convert
+ * @param decimals - Unit to convert from, ether by default
+ * @returns - BigInt instance containing the new number
  */
-export function toTokenMinimalUnit(tokenValue, decimals) {
-  const base = toBN(Math.pow(10, decimals).toString());
-  let value = convert.numberToString(tokenValue);
+export function toTokenMinimalUnit(
+  tokenValue: number | string | bigint,
+  decimals: number,
+): bigint {
+  const base = BigInt(Math.pow(10, decimals).toString());
+  let value = numberToString(tokenValue);
   const negative = value.substring(0, 1) === '-';
   if (negative) {
     value = value.substring(1);
@@ -210,29 +229,29 @@ export function toTokenMinimalUnit(tokenValue, decimals) {
   while (fraction.length < decimals) {
     fraction += '0';
   }
-  whole = new BN4(whole);
-  fraction = new BN4(fraction);
-  let tokenMinimal = whole.mul(base).add(fraction);
+  const wholeBigInt = BigInt(whole);
+  const fractionBigInt = BigInt(fraction);
+  let tokenMinimal = wholeBigInt * base + fractionBigInt;
   if (negative) {
-    tokenMinimal = tokenMinimal.mul(negative);
+    tokenMinimal *= -1n;
   }
-  return new BN4(tokenMinimal.toString(10), 10);
+  return tokenMinimal;
 }
 
 /**
  * Converts some token minimal unit to render format string, showing 5 decimals
  *
- * @param {Number|String|BN4} tokenValue - Token value to convert
+ * @param {Number|String|bigint} tokenValue - Token value to convert
  * @param {Number} decimals - Token decimals to convert
  * @param {Number} decimalsToShow - Decimals to 5
  * @returns {String} - Number of token minimal unit, in render format
  * If value is less than 5 precision decimals will show '< 0.00001'
  */
 export function renderFromTokenMinimalUnit(
-  tokenValue,
-  decimals,
+  tokenValue: number | string | bigint,
+  decimals: number,
   decimalsToShow = 5,
-) {
+): string {
   const minimalUnit = fromTokenMinimalUnit(tokenValue || 0, decimals);
   const minimalUnitNumber = parseFloat(minimalUnit);
   let renderMinimalUnit;
@@ -258,11 +277,11 @@ export function renderFromTokenMinimalUnit(
  * If value is less than 5 precision decimals will show '< 0.00001'
  */
 export function renderFiatAddition(
-  transferFiat,
-  feeFiat,
-  currentCurrency,
+  transferFiat: number,
+  feeFiat: number,
+  currentCurrency: CurrencyCode,
   decimalsToShow = 5,
-) {
+): string {
   const addition = transferFiat + feeFiat;
   let renderMinimalUnit;
   if (addition < 0.00001 && addition > 0) {
@@ -283,7 +302,7 @@ export function renderFiatAddition(
  * @param {number} maxDecimalPlaces
  * @returns {string}
  */
-export function limitToMaximumDecimalPlaces(num, maxDecimalPlaces = 5) {
+export function limitToMaximumDecimalPlaces(num: number, maxDecimalPlaces = 5) {
   if (isNaN(num) || isNaN(maxDecimalPlaces)) {
     return num;
   }
@@ -298,66 +317,61 @@ export function limitToMaximumDecimalPlaces(num, maxDecimalPlaces = 5) {
  * @param {number} conversionRate - ETH to current currency conversion rate
  * @param {number} exchangeRate - Asset to ETH conversion rate
  * @param {number} decimals - Asset decimals
- * @returns {Object} - The converted balance as BN instance
+ * @returns {bigint} - The converted balance as bigint instance
  */
 export function fiatNumberToTokenMinimalUnit(
-  fiat,
-  conversionRate,
-  exchangeRate,
-  decimals,
-) {
-  const floatFiatConverted = parseFloat(fiat) / (conversionRate * exchangeRate);
+  fiat: number | string,
+  conversionRate: number,
+  exchangeRate: number,
+  decimals: number,
+): bigint {
+  const fiatNumber = typeof fiat === 'string' ? parseFloat(fiat) : fiat;
+  const floatFiatConverted = fiatNumber / (conversionRate * exchangeRate);
   const base = Math.pow(10, decimals);
-  let weiNumber = floatFiatConverted * base;
+  const weiNumber = floatFiatConverted * base;
   // avoid decimals
-  weiNumber = weiNumber.toLocaleString('fullwide', { useGrouping: false });
-  const weiBN = safeNumberToBN(weiNumber);
+  const weiNumberLocale = weiNumber.toLocaleString('fullwide', {
+    useGrouping: false,
+  });
+  const weiBN = safeNumberToBigInt(weiNumberLocale);
   return weiBN;
 }
 
 /**
  * Converts wei to render format string, showing 5 decimals
  *
- * @param {Number|String|BN4} value - Wei to convert
- * @param {Number} decimalsToShow - Decimals to 5
- * @returns {String} - Number of token minimal unit, in render format
+ * @param value - Wei to convert
+ * @param decimalsToShow - Decimals to 5
+ * @returns Number of token minimal unit, in render format
  * If value is less than 5 precision decimals will show '< 0.00001'
  */
-export function renderFromWei(value, decimalsToShow = 5) {
-  let renderWei = '0';
+export function renderFromWei(
+  value: number | string | bigint,
+  decimalsToShow = 5,
+): string {
+  let weiDisplay = '0';
   // avoid undefined
   if (value) {
     const wei = fromWei(value);
     const weiNumber = parseFloat(wei);
     if (weiNumber < 0.00001 && weiNumber > 0) {
-      renderWei = '< 0.00001';
+      weiDisplay = '< 0.00001';
     } else {
       const base = Math.pow(10, decimalsToShow);
-      renderWei = (Math.round(weiNumber * base) / base).toString();
+      weiDisplay = (Math.round(weiNumber * base) / base).toString();
     }
   }
-  return renderWei;
+  return weiDisplay;
 }
 
 /**
- * Converts token BN value to hex string number to be sent
- *
- * @param {Object} value - BN instance to convert
- * @param {number} decimals - Decimals to be considered on the conversion
- * @returns {string} - String of the hex token value
- */
-export function calcTokenValueToSend(value, decimals) {
-  return value ? (value * Math.pow(10, decimals)).toString(16) : 0;
-}
-
-/**
- * Checks if a value is a BN instance
+ * Checks if a value is a BigInt instance
  *
  * @param {object|string} value - Value to check
- * @returns {boolean} - True if the value is a BN instance
+ * @returns {boolean} - True if the value is a BigInt instance
  */
-export function isBN(value) {
-  return BN4.isBN(value);
+export function isBigInt(value: number | string | bigint): boolean {
+  return typeof value === 'bigint';
 }
 
 /**
@@ -366,7 +380,9 @@ export function isBN(value) {
  * @param {number | string} value - String to check
  * @returns {boolean} - True if the string is a valid decimal
  */
-export function isDecimal(value) {
+export function isDecimal(valueInput: number | string): boolean {
+  const value =
+    typeof valueInput === 'string' ? valueInput : valueInput.toString();
   return (
     Number.isFinite(parseFloat(value)) &&
     !Number.isNaN(parseFloat(value)) &&
@@ -375,22 +391,15 @@ export function isDecimal(value) {
 }
 
 /**
- * Creates a BN object from a string
- *
- * @param {string} value - Some numeric value represented as a string
- * @returns {Object} - BN instance
- */
-export function toBN(value) {
-  return new BN4(value);
-}
-
-/**
  * Determines if a string is a valid number
  *
  * @param {*} str - Number string
  * @returns {boolean} - True if the string  is a valid number
  */
-export function isNumber(str) {
+export function isNumber(str?: string | null): boolean {
+  if (str === null || str === undefined) {
+    return false;
+  }
   return regex.number.test(str);
 }
 
@@ -400,7 +409,9 @@ export function isNumber(str) {
  * @param {number | string | null | undefined} value - Value to check
  * @returns {boolean} - True if the value is a valid number
  */
-export function isNumberValue(value) {
+export function isNumberValue(
+  value: number | string | null | undefined,
+): boolean {
   if (value === null || value === undefined) {
     return false;
   }
@@ -412,7 +423,7 @@ export function isNumberValue(value) {
   return isDecimal(value);
 }
 
-export const dotAndCommaDecimalFormatter = (value) => {
+export const dotAndCommaDecimalFormatter = (value: number | string): string => {
   const valueStr = String(value);
 
   const formattedValue = valueStr.replace(',', '.');
@@ -429,7 +440,9 @@ export const dotAndCommaDecimalFormatter = (value) => {
  * @see https://262.ecma-international.org/5.1/#sec-9.8.1
  */
 
-export const isNumberScientificNotationWhenString = (value) => {
+export const isNumberScientificNotationWhenString = (
+  value: number | string | bigint,
+): value is number => {
   if (typeof value !== 'number') {
     return false;
   }
@@ -440,64 +453,72 @@ export const isNumberScientificNotationWhenString = (value) => {
 /**
  * Converts some unit to wei
  *
- * @param {number|string|BN4} value - Value to convert
+ * @param {number|string|bigint} value - Value to convert
  * @param {string} unit - Unit to convert from, ether by default
- * @returns {BN4} - BN instance containing the new number
+ * @returns {bigint} - BigInt instance containing the new number
  */
-export function toWei(value, unit = 'ether') {
-  // check the posibilty to convert to BN
+export function toWei(
+  value: number | string | bigint,
+  unit: EthereumUnit = 'ether',
+): bigint {
+  // check the posibilty to convert to BigInt
   // directly on the swaps screen
   if (isNumberScientificNotationWhenString(value)) {
     value = value.toFixed(18);
   }
-  return convert.toWei(value, unit);
+  return toWeiUtil(value, unit);
 }
 
 /**
  * Converts some unit to Gwei
  *
- * @param {number|string|BN4} value - Value to convert
+ * @param {number|string|bigint} value - Value to convert
  * @param {string} unit - Unit to convert from, ether by default
- * @returns {Object} - BN instance containing the new number
+ * @returns {bigint} - BigInt instance containing the new number
  */
-export function toGwei(value, unit = 'ether') {
-  return fromWei(value, unit) * 1000000000;
+export function toGwei(
+  value: number | string | bigint,
+  unit: EthereumUnit = 'ether',
+): bigint {
+  return BigInt(fromWei(value, unit)) * 1000000000n;
 }
 
 /**
  * Converts some unit to Gwei and return it in render format
  *
- * @param {number|string|BN4} value - Value to convert
+ * @param {number|string|bigint} value - Value to convert
  * @param {string} unit - Unit to convert from, ether by default
  * @returns {string} - String instance containing the renderable number
  */
-export function renderToGwei(value, unit = 'ether') {
-  const gwei = fromWei(value, unit) * 1000000000;
-  let gweiFixed = parseFloat(Math.round(gwei));
+export function renderToGwei(
+  value: number | string | bigint,
+  unit: EthereumUnit = 'ether',
+): number {
+  const gwei = parseFloat(fromWei(value, unit)) * 1000000000;
+  let gweiFixed = Math.round(gwei);
   gweiFixed = isNaN(gweiFixed) ? 0 : gweiFixed;
   return gweiFixed;
 }
 
 /**
- * Converts wei expressed as a BN instance into a human-readable fiat string
- * TODO: wei should be a BN instance, but we're not sure if it's always the case
+ * Converts wei expressed as a BigInt instance into a human-readable fiat string
+ * TODO: wei should be a BigInt instance, but we're not sure if it's always the case
 //
- * @param {number | BN4} wei - BN corresponding to an amount of wei
+ * @param {number | bigint} wei - BigInt corresponding to an amount of wei
  * @param {number | null} conversionRate - ETH to current currency conversion rate
  * @param {string} currencyCode - Current currency code to display
  * @returns {string} - Currency-formatted string
  */
 export function weiToFiat(
-  wei,
-  conversionRate = null,
-  currencyCode,
-  decimalsToShow = 5,
+  wei: number | bigint,
+  conversionRate: number | null,
+  currencyCode: CurrencyCode,
 ) {
   if (!conversionRate) return undefined;
-  if (!wei || !isBN(wei) || !conversionRate) {
+  if (!wei || !isBigInt(wei) || !conversionRate) {
     return addCurrencySymbol(0, currencyCode);
   }
-  decimalsToShow = (currencyCode === 'usd' && 2) || undefined;
+  const decimalsToShow = (currencyCode === 'usd' && 2) || undefined;
   const value = weiToFiatNumber(wei, conversionRate, decimalsToShow);
   return addCurrencySymbol(value, currencyCode);
 }
@@ -510,27 +531,34 @@ export function weiToFiat(
  * @returns {string} - Currency-formatted string
  */
 export function addCurrencySymbol(
-  amount,
-  currencyCode,
+  amountInput: number | string,
+  currencyCode: CurrencyCode,
   extendDecimals = false,
 ) {
-  const prefix = parseFloat(amount) < 0 ? '-' : '';
+  let amount: number | string =
+    typeof amountInput === 'string' ? parseFloat(amountInput) : amountInput;
+  const prefix = amount < 0 ? '-' : '';
+
   if (extendDecimals) {
     if (isNumberScientificNotationWhenString(amount)) {
       amount = amount.toFixed(18);
     }
 
     // if bigger than 0.01, show 2 decimals
-    if (amount >= 0.01 || amount <= -0.01) {
+    if (Number(amount) >= 0.01 || Number(amount) <= -0.01) {
       amount = parseFloat(amount).toFixed(2);
     }
 
     // if less than 0.01, show all the decimals that are zero except the trailing zeros, and 3 decimals for the rest that are not zero
-    if ((amount < 0.01 && amount > 0) || (amount > -0.01 && amount < 0)) {
+    if (
+      (Number(amount) < 0.01 && Number(amount) > 0) ||
+      (Number(amount) > -0.01 && Number(amount) < 0)
+    ) {
       const decimalString = amount.toString().split('.')[1];
       if (decimalString && decimalString.length > 1) {
         const firstNonZeroDecimal = decimalString.indexOf(
-          decimalString.match(regex.decimalString)[0],
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          decimalString.match(regex.decimalString)![0],
         );
         if (firstNonZeroDecimal > 0) {
           amount = parseFloat(amount).toFixed(firstNonZeroDecimal + 3);
@@ -542,7 +570,7 @@ export function addCurrencySymbol(
   }
 
   if (currencyCode === 'usd' && !extendDecimals) {
-    amount = parseFloat(amount).toFixed(2);
+    amount = Number(amount).toFixed(2);
   }
 
   const amountString = amount.toString();
@@ -554,7 +582,7 @@ export function addCurrencySymbol(
     return `${prefix}${currencySymbols[currencyCode]}${absAmountStr}`;
   }
 
-  const lowercaseCurrencyCode = currencyCode?.toLowerCase();
+  const lowercaseCurrencyCode = currencyCode?.toLowerCase() as CurrencyCode;
 
   if (currencySymbols[lowercaseCurrencyCode]) {
     return `${prefix}${currencySymbols[lowercaseCurrencyCode]}${absAmountStr}`;
@@ -564,17 +592,21 @@ export function addCurrencySymbol(
 }
 
 /**
- * Converts wei expressed as a BN instance into a human-readable fiat string
+ * Converts wei expressed as a BigInt instance into a human-readable fiat string
  *
- * @param {number|string|BN4} wei - BN corresponding to an amount of wei
- * @param {number} conversionRate - ETH to current currency conversion rate
- * @param {Number} decimalsToShow - Decimals to 5
- * @returns {Number} - The converted balance
+ * @param wei - BigInt corresponding to an amount of wei
+ * @param conversionRate - ETH to current currency conversion rate
+ * @param decimalsToShow - Decimals to 5
+ * @returns The converted balance
  */
-export function weiToFiatNumber(wei, conversionRate, decimalsToShow = 5) {
+export function weiToFiatNumber(
+  wei: number | string | bigint,
+  conversionRate: number,
+  decimalsToShow = 5,
+) {
   const base = Math.pow(10, decimalsToShow);
-  const eth = fromWei(wei).toString();
-  let value = parseFloat(Math.floor(eth * conversionRate * base) / base);
+  const eth = fromWei(wei, 'ether');
+  let value = Math.floor(parseFloat(eth) * conversionRate * base) / base;
   value = isNaN(value) ? 0.0 : value;
   return value;
 }
@@ -585,7 +617,7 @@ export function weiToFiatNumber(wei, conversionRate, decimalsToShow = 5) {
  * @param {string} wei - Amount in decimal notation
  * @returns {string} - Number string with less or equal 18 decimals
  */
-export function handleWeiNumber(wei) {
+export function handleWeiNumber(wei: string): string {
   const comps = wei.split('.');
   let fraction = comps[1];
   if (fraction && fraction.length > 18) fraction = fraction.substring(0, 18);
@@ -598,10 +630,15 @@ export function handleWeiNumber(wei) {
  *
  * @param {number|string} fiat - Fiat number
  * @param {number} conversionRate - ETH to current currency conversion rate
- * @returns {Object} - The converted balance as BN instance
+ * @returns {bigint} - The converted balance as BigInt instance
  */
-export function fiatNumberToWei(fiat, conversionRate) {
-  const floatFiatConverted = parseFloat(fiat) / conversionRate;
+export function fiatNumberToWei(
+  fiatInput: number | string,
+  conversionRate: number,
+) {
+  const fiat =
+    typeof fiatInput === 'string' ? parseFloat(fiatInput) : fiatInput;
+  const floatFiatConverted = fiat / conversionRate;
   if (
     !floatFiatConverted ||
     isNaN(floatFiatConverted) ||
@@ -610,25 +647,40 @@ export function fiatNumberToWei(fiat, conversionRate) {
     return '0x0';
   }
   const base = Math.pow(10, 18);
-  let weiNumber = Math.trunc(base * floatFiatConverted);
+  let weiNumber: number | string = Math.trunc(base * floatFiatConverted);
   // avoid decimals
   weiNumber = weiNumber.toLocaleString('fullwide', { useGrouping: false });
-  const weiBN = safeNumberToBN(weiNumber);
-  return weiBN;
+  return safeNumberToBigInt(weiNumber);
 }
 
 /**
- * Wraps 'numberToBN' method to avoid potential undefined and decimal values
+ * Wraps 'numberToBigInt' method to avoid potential undefined and decimal values
  *
- * @param {number|string} value -  number
- * @returns {Object} - The converted value as BN instance
+ * @param value -  number
+ * @returns - The converted value as BigInt instance
  */
-export function safeNumberToBN(value) {
+export function safeNumberToBigInt(value: number | string | bigint): bigint {
+  if (typeof value === 'bigint') {
+    return value;
+  }
+  const safeValue = fastSplit(value?.toString()) || '0';
+  // Nested try/catch because of perforamnce reasons
   try {
-    const safeValue = fastSplit(value?.toString()) || '0';
-    return numberToBN(safeValue);
+    // Try quickly convert number/string which should work in most cases
+    return BigInt(safeValue);
   } catch {
-    return numberToBN('0');
+    try {
+      // In case of missing hex prefix it will fail so we try to add it
+      let signedHex: number | string = addHexPrefix(safeValue);
+      if (signedHex.startsWith('-0x')) {
+        // For some reason BigInt cannot handle negative -0x string in constructor so we need to convert it to number first
+        signedHex = parseInt(signedHex, 16);
+      }
+      return BigInt(signedHex);
+    } catch {
+      // In case everything fails return zero
+      return BigInt(0);
+    }
   }
 }
 
@@ -640,7 +692,9 @@ export function safeNumberToBN(value) {
  * @returns {string} - the selected splitted element
  */
 
-export function fastSplit(value, divider = '.') {
+export function fastSplit(valueInput: string | number, divider = '.') {
+  const value =
+    typeof valueInput === 'string' ? valueInput : valueInput.toString();
   const [from, to] = [value.indexOf(divider), 0];
   return value.substring(from, to) || value;
 }
@@ -655,16 +709,16 @@ export function fastSplit(value, divider = '.') {
  * @returns {string} - Currency-formatted string
  */
 export function balanceToFiat(
-  balance,
-  conversionRate,
-  exchangeRate,
-  currencyCode,
-) {
+  balance: number | string | bigint,
+  conversionRate: number | null | undefined,
+  exchangeRate: number,
+  currencyCode: CurrencyCode,
+): string | undefined {
   if (
     balance === undefined ||
     balance === null ||
     exchangeRate === undefined ||
-    conversionRate === undefined ||
+    !conversionRate ||
     exchangeRate === 0
   ) {
     return undefined;
@@ -683,20 +737,19 @@ export function balanceToFiat(
  * @returns {Number} - The converted balance
  */
 export function balanceToFiatNumber(
-  balance,
-  conversionRate,
-  exchangeRate,
+  balance: number | string | bigint,
+  conversionRate: number,
+  exchangeRate: number,
   decimalsToShow = 5,
 ) {
   const base = Math.pow(10, decimalsToShow);
-  let fiatFixed = parseFloat(
-    Math.floor(balance * conversionRate * exchangeRate * base) / base,
-  );
+  let fiatFixed =
+    Math.floor(Number(balance) * conversionRate * exchangeRate * base) / base;
   fiatFixed = isNaN(fiatFixed) ? 0.0 : fiatFixed;
   return fiatFixed;
 }
 
-export function getCurrencySymbol(currencyCode) {
+export function getCurrencySymbol(currencyCode: CurrencyCode) {
   if (currencySymbols[currencyCode]) {
     return `${currencySymbols[currencyCode]}`;
   }
@@ -711,15 +764,16 @@ export function getCurrencySymbol(currencyCode) {
  * @param {number} decimalsToShow - Decimals to 5
  * @returns {string} - The converted balance
  */
-export function renderFiat(value, currencyCode, decimalsToShow = 5) {
+export function renderFiat(
+  value: number | string,
+  currencyCode: CurrencyCode,
+  decimalsToShow: number = 5,
+) {
   const base = Math.pow(10, decimalsToShow);
-  let fiatFixed = parseFloat(Math.round(value * base) / base);
+  let fiatFixed = Math.round(Number(value) * base) / base;
   fiatFixed = isNaN(fiatFixed) ? 0.0 : fiatFixed;
   if (currencySymbols[currencyCode]) {
-    const isNegative = fiatFixed < 0;
-    const absValue = Math.abs(fiatFixed);
-    const sign = isNegative ? '-' : '';
-    return `${sign}${currencySymbols[currencyCode]}${absValue}`;
+    return `${currencySymbols[currencyCode]}${fiatFixed}`;
   }
   return `${fiatFixed} ${currencyCode.toUpperCase()}`;
 }
@@ -730,11 +784,11 @@ export function renderFiat(value, currencyCode, decimalsToShow = 5) {
  * @param {object} value - Object containing wei value in BN format
  * @returns {string} - Corresponding wei value
  */
-export function renderWei(value) {
+export function renderWei(value?: bigint | null): string {
   if (!value) return '0';
   const wei = fromWei(value);
-  const renderWei = wei * Math.pow(10, 18);
-  return renderWei.toString();
+  const weiDisplay = Number(wei) * Math.pow(10, 18);
+  return weiDisplay.toString();
 }
 /**
  * Format a string number in an string number with at most 5 decimal places
@@ -742,7 +796,7 @@ export function renderWei(value) {
  * @param {string} number - String containing a number
  * @returns {string} - String number with none or at most 5 decimal places
  */
-export function renderNumber(number) {
+export function renderNumber(number: string): string {
   const index = number.indexOf('.');
   if (index === 0) return number;
   return number.substring(0, index + 6);
@@ -752,11 +806,13 @@ export function renderNumber(number) {
  * Checks whether the given value is a 0x-prefixed, non-zero, non-zero-padded,
  * hexadecimal string.
  *
- * @param {any} value - The value to check.
+ * @param value - The value to check.
  * @returns {boolean} True if the value is a correctly formatted hex string,
  * false otherwise.
  */
-export function isPrefixedFormattedHexString(value) {
+export function isPrefixedFormattedHexString(
+  value: string | number | bigint,
+): boolean {
   if (typeof value !== 'string') {
     return false;
   }
@@ -775,10 +831,22 @@ const converter = ({
   conversionRate,
   invertConversionRate,
   roundDown,
+}: {
+  value: number | string | bigint | BigNumber;
+  fromNumericBase: NumericBase;
+  fromDenomination: NormalizedDenomination;
+  fromCurrency?: CurrencyCode | null;
+  toNumericBase: NumericBase;
+  toDenomination: SpecifiedDenomination;
+  toCurrency?: CurrencyCode | null;
+  numberOfDecimals?: number;
+  conversionRate?: number;
+  invertConversionRate?: boolean;
+  roundDown?: number;
 }) => {
-  let convertedValue = fromNumericBase
-    ? toBigNumber[fromNumericBase](value)
-    : value;
+  let convertedValue: BigNumber | string = fromNumericBase
+    ? toBigNumber[fromNumericBase](value as unknown as string)
+    : BigNumber(value);
 
   if (fromDenomination) {
     convertedValue = toNormalizedDenomination[fromDenomination](convertedValue);
@@ -822,7 +890,7 @@ const converter = ({
 };
 
 export const conversionUtil = (
-  value,
+  value: number | string | bigint | BigNumber,
   {
     fromCurrency = null,
     toCurrency = fromCurrency,
@@ -833,6 +901,16 @@ export const conversionUtil = (
     numberOfDecimals,
     conversionRate,
     invertConversionRate,
+  }: {
+    fromCurrency?: CurrencyCode | null;
+    toCurrency?: CurrencyCode | null;
+    fromNumericBase: NumericBase;
+    toNumericBase: NumericBase;
+    fromDenomination: NormalizedDenomination;
+    toDenomination: SpecifiedDenomination;
+    numberOfDecimals?: number;
+    conversionRate?: number;
+    invertConversionRate?: boolean;
   },
 ) =>
   converter({
@@ -848,18 +926,25 @@ export const conversionUtil = (
     value: value || '0',
   });
 
-export const toHexadecimal = (decimal) => {
-  if (!decimal) return decimal;
+export const toHexadecimal = (
+  decimal?: number | string | bigint | null,
+): string => {
+  if (typeof decimal === 'bigint') {
+    return decimal.toString(16);
+  }
   if (decimal !== typeof 'string') {
     decimal = String(decimal);
   }
   if (decimal.startsWith('0x')) return decimal;
-  return toBigNumber.dec(decimal).toString(16);
+  return toBigInt.dec(decimal).toString(16);
 };
 
 export const calculateEthFeeForMultiLayer = ({
   multiLayerL1FeeTotal,
   ethFee = 0,
+}: {
+  multiLayerL1FeeTotal?: number | string | bigint | null;
+  ethFee: number | string | bigint;
 }) => {
   if (!multiLayerL1FeeTotal) {
     return ethFee;
@@ -877,20 +962,30 @@ export const calculateEthFeeForMultiLayer = ({
 
 /**
  *
- * @param {number|string|object} value - Value to check
+ * @param {number|string|bigint} value - Value to check
  * @returns {boolean} - true if value is zero
  */
-export const isZeroValue = (value) => {
+export const isZeroValue = (value: number | string | bigint): boolean => {
   if (value === null || value === undefined) {
     return false;
   }
-  return value === '0x0' || (isBN(value) && value.isZero()) || isZero(value);
+  return value === '0x0' || (isBigInt(value) && value === 0n) || isZero(value);
 };
 
-export const formatValueToMatchTokenDecimals = (value, decimal) => {
-  if (value === null || value === undefined) {
-    return value;
+export const formatValueToMatchTokenDecimals = (
+  valueInput: number | string | bigint | null | undefined,
+  decimal?: number | string | null,
+) => {
+  if (
+    valueInput === null ||
+    valueInput === undefined ||
+    decimal === null ||
+    decimal === undefined ||
+    typeof decimal === 'string'
+  ) {
+    return valueInput;
   }
+  let value = valueInput.toString();
   const decimalIndex = value.indexOf('.');
   if (decimalIndex !== -1) {
     const fractionalLength = value.substring(decimalIndex + 1).length;
@@ -901,12 +996,13 @@ export const formatValueToMatchTokenDecimals = (value, decimal) => {
   return value;
 };
 
-export const safeBNToHex = (value) => {
+export const safeBigIntToHex = (
+  value: bigint | null | undefined,
+): string | null | undefined => {
   if (value === null || value === undefined) {
     return value;
   }
-
-  return BNToHex(value);
+  return bigIntToHex(value);
 };
 
 /**
@@ -917,7 +1013,10 @@ export const safeBNToHex = (value) => {
  * @param number - The number to format.
  * @returns A localized string of the formatted number + unit.
  */
-export const localizeLargeNumber = (i18n, number) => {
+export const localizeLargeNumber = (
+  i18n: { t: (k: string) => string },
+  number: number,
+): string => {
   const oneTrillion = 1000000000000;
   const oneBillion = 1000000000;
   const oneMillion = 1000000;
@@ -938,9 +1037,18 @@ export const localizeLargeNumber = (i18n, number) => {
   return number.toFixed(2);
 };
 
-export const convertDecimalToPercentage = (decimal) => {
+export const convertDecimalToPercentage = (decimal: number): string => {
   if (typeof decimal !== 'number' || isNaN(decimal)) {
     throw new Error('Input must be a valid number');
   }
   return (decimal * 100).toFixed(2) + '%';
 };
+
+/**
+ * Gets the absolute value of a BigInt
+ * @param value - The BigInt value
+ * @returns The absolute value as BigInt
+ */
+export function bigIntAbs(value: bigint): bigint {
+  return value < 0n ? -value : value;
+}

--- a/app/util/number/legacy.js
+++ b/app/util/number/legacy.js
@@ -1,0 +1,948 @@
+/**
+ * Collection of utility functions for consistent formatting and conversion
+ */
+import { stripHexPrefix } from 'ethereumjs-util';
+import BN4 from 'bnjs4';
+import { utils as ethersUtils } from 'ethers';
+import convert from '@metamask/ethjs-unit';
+import { add0x, remove0x } from '@metamask/utils';
+import numberToBN from 'number-to-bn';
+import BigNumber from 'bignumber.js';
+
+import currencySymbols from '../currency-symbols.json';
+import { isZero } from '../lodash';
+import { regex } from '../regex';
+
+const MAX_DECIMALS_FOR_TOKENS = 36;
+BigNumber.config({ DECIMAL_PLACES: MAX_DECIMALS_FOR_TOKENS });
+
+// Big Number Constants
+const BIG_NUMBER_WEI_MULTIPLIER = new BigNumber('1000000000000000000');
+const BIG_NUMBER_GWEI_MULTIPLIER = new BigNumber('1000000000');
+const BIG_NUMBER_ETH_MULTIPLIER = new BigNumber('1');
+
+/**
+ * @deprecated Use hexToBigInt instead.
+ * Converts a hex string to a BN object.
+ * Adapt function with non string argument handler
+ *
+ * @param inputHex - Number represented as a hex string.
+ * @returns A BN instance.
+ */
+export const hexToBN = (inputHex) =>
+  typeof inputHex !== 'string'
+    ? new BN4(inputHex, 16)
+    : inputHex
+    ? new BN4(remove0x(inputHex), 16)
+    : new BN4(0);
+
+/**
+ * @deprecated Use bigIntToHex instead.
+ * Converts a BN object to a hex string with a '0x' prefix.
+ *
+ * @param inputBn - BN instance to convert to a hex string.
+ * @returns A '0x'-prefixed hex string.
+ */
+// TODO: Either fix this lint violation or explain why it's necessary to ignore.
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export function BNToHex(inputBn) {
+  return add0x(inputBn.toString(16));
+}
+
+// Setter Maps
+export const toBigNumber = {
+  hex: (n) => new BigNumber(stripHexPrefix(n), 16),
+  dec: (n) => new BigNumber(String(n), 10),
+  BN: (n) => new BigNumber(n.toString(16), 16),
+};
+const toNormalizedDenomination = {
+  WEI: (bigNumber) => bigNumber.div(BIG_NUMBER_WEI_MULTIPLIER),
+  GWEI: (bigNumber) => bigNumber.div(BIG_NUMBER_GWEI_MULTIPLIER),
+  ETH: (bigNumber) => bigNumber.div(BIG_NUMBER_ETH_MULTIPLIER),
+};
+const toSpecifiedDenomination = {
+  WEI: (bigNumber) =>
+    bigNumber.times(BIG_NUMBER_WEI_MULTIPLIER).decimalPlaces(0),
+  GWEI: (bigNumber) =>
+    bigNumber.times(BIG_NUMBER_GWEI_MULTIPLIER).decimalPlaces(9),
+  ETH: (bigNumber) =>
+    bigNumber.times(BIG_NUMBER_ETH_MULTIPLIER).decimalPlaces(9),
+};
+const baseChange = {
+  hex: (n) => n.toString(16),
+  dec: (n) => new BigNumber(n).toString(10),
+  BN: (n) => new BN4(n.toString(16)),
+};
+
+/**
+ * Prefixes a hex string with '0x' or '-0x' and returns it. Idempotent.
+ *
+ * @param {string} str - The string to prefix.
+ * @returns {string} The prefixed string.
+ */
+export const addHexPrefix = (str) => {
+  if (typeof str !== 'string' || str.match(regex.hexPrefix)) {
+    return str;
+  }
+
+  if (str.match(regex.hexPrefix)) {
+    return str.replace('0X', '0x');
+  }
+
+  if (str.startsWith('-')) {
+    return str.replace('-', '-0x');
+  }
+
+  return `0x${str}`;
+};
+
+/**
+ * Converts wei to a different unit
+ *
+ * @param {number|string|Object} value - Wei to convert
+ * @param {string} unit - Unit to convert to, ether by default
+ * @returns {string} - String containing the new number
+ */
+export function fromWei(value = 0, unit = 'ether') {
+  return convert.fromWei(value, unit);
+}
+
+/**
+ * Converts token minimal unit to readable string value
+ *
+ * @param {number|string|Object} minimalInput - Token minimal unit to convert
+ * @param {number|string} decimals - Token decimals to convert
+ * @param {boolean} [isRounding=true] - If true, minimalInput is converted to number and rounded for large numbers.
+ * @returns {string} - String containing the new number
+ */
+export function fromTokenMinimalUnit(
+  minimalInput,
+  decimals,
+  isRounding = true,
+) {
+  minimalInput = isRounding ? Number(minimalInput) : minimalInput;
+  const prefixedInput = addHexPrefix(minimalInput.toString(16));
+  let minimal = safeNumberToBN(prefixedInput);
+  const negative = minimal.lt(new BN4(0));
+  const base = toBN(Math.pow(10, decimals).toString());
+
+  if (negative) {
+    minimal = minimal.mul(negative);
+  }
+  let fraction = minimal.mod(base).toString(10);
+  while (fraction.length < decimals) {
+    fraction = '0' + fraction;
+  }
+  fraction = fraction.match(regex.fractions)[1];
+  const whole = minimal.div(base).toString(10);
+  let value = '' + whole + (fraction === '0' ? '' : '.' + fraction);
+  if (negative) {
+    value = '-' + value;
+  }
+  return value;
+}
+
+/**
+ * Converts token minimal unit to readable string value
+ *
+ * @param {string} minimalInput - Token minimal unit to convert
+ * @param {number} decimals - Token decimals to convert
+ * @returns {string} - String containing the new number
+ */
+export function fromTokenMinimalUnitString(minimalInput, decimals) {
+  if (typeof minimalInput !== 'string') {
+    throw new TypeError('minimalInput must be a string');
+  }
+
+  const tokenFormat = ethersUtils.formatUnits(minimalInput, decimals);
+  const isInteger = Boolean(regex.integer.exec(tokenFormat));
+
+  const [integerPart, decimalPart] = tokenFormat.split('.');
+  if (isInteger) {
+    return integerPart;
+  }
+  return `${integerPart}.${decimalPart}`;
+}
+
+/**
+ * Converts some unit to token minimal unit
+ *
+ * @param {number|string|BN4} tokenValue - Value to convert
+ * @param {number} decimals - Unit to convert from, ether by default
+ * @returns {BN} - BN instance containing the new number
+ */
+export function toTokenMinimalUnit(tokenValue, decimals) {
+  const base = toBN(Math.pow(10, decimals).toString());
+  let value = convert.numberToString(tokenValue);
+  const negative = value.substring(0, 1) === '-';
+  if (negative) {
+    value = value.substring(1);
+  }
+  if (value === '.') {
+    throw new Error(
+      '[number] while converting number ' +
+        tokenValue +
+        ' to token minimal util, invalid value',
+    );
+  }
+  // Split it into a whole and fractional part
+  const comps = value.split('.');
+  if (comps.length > 2) {
+    throw new Error(
+      '[number] while converting number ' +
+        tokenValue +
+        ' to token minimal util,  too many decimal points',
+    );
+  }
+  let whole = comps[0],
+    fraction = comps[1];
+  if (!whole) {
+    whole = '0';
+  }
+  if (!fraction) {
+    fraction = '';
+  }
+  if (fraction.length > decimals) {
+    throw new Error(
+      '[number] while converting number ' +
+        tokenValue +
+        ' to token minimal util, too many decimal places',
+    );
+  }
+  while (fraction.length < decimals) {
+    fraction += '0';
+  }
+  whole = new BN4(whole);
+  fraction = new BN4(fraction);
+  let tokenMinimal = whole.mul(base).add(fraction);
+  if (negative) {
+    tokenMinimal = tokenMinimal.mul(negative);
+  }
+  return new BN4(tokenMinimal.toString(10), 10);
+}
+
+/**
+ * Converts some token minimal unit to render format string, showing 5 decimals
+ *
+ * @param {Number|String|BN4} tokenValue - Token value to convert
+ * @param {Number} decimals - Token decimals to convert
+ * @param {Number} decimalsToShow - Decimals to 5
+ * @returns {String} - Number of token minimal unit, in render format
+ * If value is less than 5 precision decimals will show '< 0.00001'
+ */
+export function renderFromTokenMinimalUnit(
+  tokenValue,
+  decimals,
+  decimalsToShow = 5,
+) {
+  const minimalUnit = fromTokenMinimalUnit(tokenValue || 0, decimals);
+  const minimalUnitNumber = parseFloat(minimalUnit);
+  let renderMinimalUnit;
+  if (minimalUnitNumber < 0.00001 && minimalUnitNumber > 0) {
+    renderMinimalUnit = '< 0.00001';
+  } else {
+    const base = Math.pow(10, decimalsToShow);
+    renderMinimalUnit = (
+      Math.round(minimalUnitNumber * base) / base
+    ).toString();
+  }
+  return renderMinimalUnit;
+}
+
+/**
+ * Converts two fiat amounts into one with their respective currency, showing up to 5 decimals
+ *
+ * @param {number} transferFiat - Number representing fiat value of a transfer
+ * @param {number} feeFiat - Number representing fiat value of transaction fee
+ * @param {string} currentCurrency - Currency
+ * @param {number} decimalsToShow - Defaults to 5
+ * @returns {String} - Formatted fiat value of the addition, in render format
+ * If value is less than 5 precision decimals will show '< 0.00001'
+ */
+export function renderFiatAddition(
+  transferFiat,
+  feeFiat,
+  currentCurrency,
+  decimalsToShow = 5,
+) {
+  const addition = transferFiat + feeFiat;
+  let renderMinimalUnit;
+  if (addition < 0.00001 && addition > 0) {
+    renderMinimalUnit = '< 0.00001';
+  } else {
+    const base = Math.pow(10, decimalsToShow);
+    renderMinimalUnit = (Math.round(addition * base) / base).toString();
+  }
+  if (currencySymbols[currentCurrency]) {
+    return `${currencySymbols[currentCurrency]}${renderMinimalUnit}`;
+  }
+  return `${renderMinimalUnit} ${currentCurrency}`;
+}
+
+/**
+ * Limits a number to a max decimal places.
+ * @param {number} num
+ * @param {number} maxDecimalPlaces
+ * @returns {string}
+ */
+export function limitToMaximumDecimalPlaces(num, maxDecimalPlaces = 5) {
+  if (isNaN(num) || isNaN(maxDecimalPlaces)) {
+    return num;
+  }
+  const base = Math.pow(10, maxDecimalPlaces);
+  return (Math.round(num * base) / base).toString();
+}
+
+/**
+ * Converts fiat number as human-readable fiat string to token miniml unit expressed as a BN
+ *
+ * @param {number|string} fiat - Fiat number
+ * @param {number} conversionRate - ETH to current currency conversion rate
+ * @param {number} exchangeRate - Asset to ETH conversion rate
+ * @param {number} decimals - Asset decimals
+ * @returns {Object} - The converted balance as BN instance
+ */
+export function fiatNumberToTokenMinimalUnit(
+  fiat,
+  conversionRate,
+  exchangeRate,
+  decimals,
+) {
+  const floatFiatConverted = parseFloat(fiat) / (conversionRate * exchangeRate);
+  const base = Math.pow(10, decimals);
+  let weiNumber = floatFiatConverted * base;
+  // avoid decimals
+  weiNumber = weiNumber.toLocaleString('fullwide', { useGrouping: false });
+  const weiBN = safeNumberToBN(weiNumber);
+  return weiBN;
+}
+
+/**
+ * Converts wei to render format string, showing 5 decimals
+ *
+ * @param {Number|String|BN4} value - Wei to convert
+ * @param {Number} decimalsToShow - Decimals to 5
+ * @returns {String} - Number of token minimal unit, in render format
+ * If value is less than 5 precision decimals will show '< 0.00001'
+ */
+export function renderFromWei(value, decimalsToShow = 5) {
+  let renderWei = '0';
+  // avoid undefined
+  if (value) {
+    const wei = fromWei(value);
+    const weiNumber = parseFloat(wei);
+    if (weiNumber < 0.00001 && weiNumber > 0) {
+      renderWei = '< 0.00001';
+    } else {
+      const base = Math.pow(10, decimalsToShow);
+      renderWei = (Math.round(weiNumber * base) / base).toString();
+    }
+  }
+  return renderWei;
+}
+
+/**
+ * Converts token BN value to hex string number to be sent
+ *
+ * @param {Object} value - BN instance to convert
+ * @param {number} decimals - Decimals to be considered on the conversion
+ * @returns {string} - String of the hex token value
+ */
+export function calcTokenValueToSend(value, decimals) {
+  return value ? (value * Math.pow(10, decimals)).toString(16) : 0;
+}
+
+/**
+ * Checks if a value is a BN instance
+ *
+ * @param {object|string} value - Value to check
+ * @returns {boolean} - True if the value is a BN instance
+ */
+export function isBN(value) {
+  return BN4.isBN(value);
+}
+
+/**
+ * Determines if a string is a valid decimal
+ *
+ * @param {number | string} value - String to check
+ * @returns {boolean} - True if the string is a valid decimal
+ */
+export function isDecimal(value) {
+  return (
+    Number.isFinite(parseFloat(value)) &&
+    !Number.isNaN(parseFloat(value)) &&
+    !isNaN(+value)
+  );
+}
+
+/**
+ * Creates a BN object from a string
+ *
+ * @param {string} value - Some numeric value represented as a string
+ * @returns {Object} - BN instance
+ */
+export function toBN(value) {
+  return new BN4(value);
+}
+
+/**
+ * Determines if a string is a valid number
+ *
+ * @param {*} str - Number string
+ * @returns {boolean} - True if the string  is a valid number
+ */
+export function isNumber(str) {
+  return regex.number.test(str);
+}
+
+/**
+ * Determines if a value is a number
+ *
+ * @param {number | string | null | undefined} value - Value to check
+ * @returns {boolean} - True if the value is a valid number
+ */
+export function isNumberValue(value) {
+  if (value === null || value === undefined) {
+    return false;
+  }
+
+  if (typeof value === 'number') {
+    return !Number.isNaN(value) && Number.isFinite(value);
+  }
+
+  return isDecimal(value);
+}
+
+export const dotAndCommaDecimalFormatter = (value) => {
+  const valueStr = String(value);
+
+  const formattedValue = valueStr.replace(',', '.');
+
+  return formattedValue;
+};
+
+/**
+ * Determines whether the given number is going to be
+ * displalyed in scientific notation after being converted to a string.
+ *
+ * @param {number} value - The value to check.
+ * @returns {boolean} True if the value is a number in scientific notation, false otherwise.
+ * @see https://262.ecma-international.org/5.1/#sec-9.8.1
+ */
+
+export const isNumberScientificNotationWhenString = (value) => {
+  if (typeof value !== 'number') {
+    return false;
+  }
+  // toLowerCase is needed since E is also valid
+  return value.toString().toLowerCase().includes('e');
+};
+
+/**
+ * Converts some unit to wei
+ *
+ * @param {number|string|BN4} value - Value to convert
+ * @param {string} unit - Unit to convert from, ether by default
+ * @returns {BN4} - BN instance containing the new number
+ */
+export function toWei(value, unit = 'ether') {
+  // check the posibilty to convert to BN
+  // directly on the swaps screen
+  if (isNumberScientificNotationWhenString(value)) {
+    value = value.toFixed(18);
+  }
+  return convert.toWei(value, unit);
+}
+
+/**
+ * Converts some unit to Gwei
+ *
+ * @param {number|string|BN4} value - Value to convert
+ * @param {string} unit - Unit to convert from, ether by default
+ * @returns {Object} - BN instance containing the new number
+ */
+export function toGwei(value, unit = 'ether') {
+  return fromWei(value, unit) * 1000000000;
+}
+
+/**
+ * Converts some unit to Gwei and return it in render format
+ *
+ * @param {number|string|BN4} value - Value to convert
+ * @param {string} unit - Unit to convert from, ether by default
+ * @returns {string} - String instance containing the renderable number
+ */
+export function renderToGwei(value, unit = 'ether') {
+  const gwei = fromWei(value, unit) * 1000000000;
+  let gweiFixed = parseFloat(Math.round(gwei));
+  gweiFixed = isNaN(gweiFixed) ? 0 : gweiFixed;
+  return gweiFixed;
+}
+
+/**
+ * Converts wei expressed as a BN instance into a human-readable fiat string
+ * TODO: wei should be a BN instance, but we're not sure if it's always the case
+//
+ * @param {number | BN4} wei - BN corresponding to an amount of wei
+ * @param {number | null} conversionRate - ETH to current currency conversion rate
+ * @param {string} currencyCode - Current currency code to display
+ * @returns {string} - Currency-formatted string
+ */
+export function weiToFiat(
+  wei,
+  conversionRate = null,
+  currencyCode,
+  decimalsToShow = 5,
+) {
+  if (!conversionRate) return undefined;
+  if (!wei || !isBN(wei) || !conversionRate) {
+    return addCurrencySymbol(0, currencyCode);
+  }
+  decimalsToShow = (currencyCode === 'usd' && 2) || undefined;
+  const value = weiToFiatNumber(wei, conversionRate, decimalsToShow);
+  return addCurrencySymbol(value, currencyCode);
+}
+
+/**
+ * Renders fiat amount with currency symbol if exists
+ *
+ * @param {number|string} amount  Number corresponding to a currency amount
+ * @param {string} currencyCode Current currency code to display
+ * @returns {string} - Currency-formatted string
+ */
+export function addCurrencySymbol(
+  amount,
+  currencyCode,
+  extendDecimals = false,
+) {
+  const prefix = parseFloat(amount) < 0 ? '-' : '';
+  if (extendDecimals) {
+    if (isNumberScientificNotationWhenString(amount)) {
+      amount = amount.toFixed(18);
+    }
+
+    // if bigger than 0.01, show 2 decimals
+    if (amount >= 0.01 || amount <= -0.01) {
+      amount = parseFloat(amount).toFixed(2);
+    }
+
+    // if less than 0.01, show all the decimals that are zero except the trailing zeros, and 3 decimals for the rest that are not zero
+    if ((amount < 0.01 && amount > 0) || (amount > -0.01 && amount < 0)) {
+      const decimalString = amount.toString().split('.')[1];
+      if (decimalString && decimalString.length > 1) {
+        const firstNonZeroDecimal = decimalString.indexOf(
+          decimalString.match(regex.decimalString)[0],
+        );
+        if (firstNonZeroDecimal > 0) {
+          amount = parseFloat(amount).toFixed(firstNonZeroDecimal + 3);
+          // remove trailing zeros
+          amount = amount.replace(regex.trailingZero, '');
+        }
+      }
+    }
+  }
+
+  if (currencyCode === 'usd' && !extendDecimals) {
+    amount = parseFloat(amount).toFixed(2);
+  }
+
+  const amountString = amount.toString();
+  const absAmountStr = amountString.startsWith('-')
+    ? amountString.slice(1) // Remove the first character if it's a '-'
+    : amountString;
+
+  if (currencySymbols[currencyCode]) {
+    return `${prefix}${currencySymbols[currencyCode]}${absAmountStr}`;
+  }
+
+  const lowercaseCurrencyCode = currencyCode?.toLowerCase();
+
+  if (currencySymbols[lowercaseCurrencyCode]) {
+    return `${prefix}${currencySymbols[lowercaseCurrencyCode]}${absAmountStr}`;
+  }
+
+  return `${prefix}${absAmountStr} ${currencyCode}`;
+}
+
+/**
+ * Converts wei expressed as a BN instance into a human-readable fiat string
+ *
+ * @param {number|string|BN4} wei - BN corresponding to an amount of wei
+ * @param {number} conversionRate - ETH to current currency conversion rate
+ * @param {Number} decimalsToShow - Decimals to 5
+ * @returns {Number} - The converted balance
+ */
+export function weiToFiatNumber(wei, conversionRate, decimalsToShow = 5) {
+  const base = Math.pow(10, decimalsToShow);
+  const eth = fromWei(wei).toString();
+  let value = parseFloat(Math.floor(eth * conversionRate * base) / base);
+  value = isNaN(value) ? 0.0 : value;
+  return value;
+}
+
+/**
+ * Handles wie input to have less or equal to 18 decimals
+ *
+ * @param {string} wei - Amount in decimal notation
+ * @returns {string} - Number string with less or equal 18 decimals
+ */
+export function handleWeiNumber(wei) {
+  const comps = wei.split('.');
+  let fraction = comps[1];
+  if (fraction && fraction.length > 18) fraction = fraction.substring(0, 18);
+  const finalWei = fraction ? [comps[0], fraction].join('.') : comps[0];
+  return finalWei;
+}
+
+/**
+ * Converts fiat number as human-readable fiat string to wei expressed as a BN
+ *
+ * @param {number|string} fiat - Fiat number
+ * @param {number} conversionRate - ETH to current currency conversion rate
+ * @returns {Object} - The converted balance as BN instance
+ */
+export function fiatNumberToWei(fiat, conversionRate) {
+  const floatFiatConverted = parseFloat(fiat) / conversionRate;
+  if (
+    !floatFiatConverted ||
+    isNaN(floatFiatConverted) ||
+    floatFiatConverted === Infinity
+  ) {
+    return '0x0';
+  }
+  const base = Math.pow(10, 18);
+  let weiNumber = Math.trunc(base * floatFiatConverted);
+  // avoid decimals
+  weiNumber = weiNumber.toLocaleString('fullwide', { useGrouping: false });
+  const weiBN = safeNumberToBN(weiNumber);
+  return weiBN;
+}
+
+/**
+ * Wraps 'numberToBN' method to avoid potential undefined and decimal values
+ *
+ * @param {number|string} value -  number
+ * @returns {Object} - The converted value as BN instance
+ */
+export function safeNumberToBN(value) {
+  try {
+    const safeValue = fastSplit(value?.toString()) || '0';
+    return numberToBN(safeValue);
+  } catch {
+    return numberToBN('0');
+  }
+}
+
+/**
+ * Performs a fast string split and returns the first item of the string based on the divider provided
+ *
+ * @param {number|string} value -  number/string to be splitted
+ * @param {string} divider -  string value to use to split the string (default '.')
+ * @returns {string} - the selected splitted element
+ */
+
+export function fastSplit(value, divider = '.') {
+  const [from, to] = [value.indexOf(divider), 0];
+  return value.substring(from, to) || value;
+}
+
+/**
+ * Calculates fiat balance of an asset
+ *
+ * @param {number|string} balance - Number corresponding to a balance of an asset
+ * @param {number|null|undefined} conversionRate - ETH to current currency conversion rate
+ * @param {number|undefined} exchangeRate - Asset to ETH conversion rate
+ * @param {string} currencyCode - Current currency code to display
+ * @returns {string} - Currency-formatted string
+ */
+export function balanceToFiat(
+  balance,
+  conversionRate,
+  exchangeRate,
+  currencyCode,
+) {
+  if (
+    balance === undefined ||
+    balance === null ||
+    exchangeRate === undefined ||
+    conversionRate === undefined ||
+    exchangeRate === 0
+  ) {
+    return undefined;
+  }
+  const fiatFixed = balanceToFiatNumber(balance, conversionRate, exchangeRate);
+  return addCurrencySymbol(fiatFixed, currencyCode);
+}
+
+/**
+ * Calculates fiat balance of an asset and returns a number
+ *
+ * @param {number|string} balance - Number or string corresponding to a balance of an asset
+ * @param {number} conversionRate - ETH to current currency conversion rate
+ * @param {number} exchangeRate - Asset to ETH conversion rate
+ * @param {number} decimalsToShow - Decimals to 5
+ * @returns {Number} - The converted balance
+ */
+export function balanceToFiatNumber(
+  balance,
+  conversionRate,
+  exchangeRate,
+  decimalsToShow = 5,
+) {
+  const base = Math.pow(10, decimalsToShow);
+  let fiatFixed = parseFloat(
+    Math.floor(balance * conversionRate * exchangeRate * base) / base,
+  );
+  fiatFixed = isNaN(fiatFixed) ? 0.0 : fiatFixed;
+  return fiatFixed;
+}
+
+export function getCurrencySymbol(currencyCode) {
+  if (currencySymbols[currencyCode]) {
+    return `${currencySymbols[currencyCode]}`;
+  }
+  return currencyCode;
+}
+
+/**
+ * Formats a fiat value into a string ready to be rendered
+ *
+ * @param {number} value - number corresponding to a balance of an asset
+ * @param {string} currencyCode - Current currency code to display
+ * @param {number} decimalsToShow - Decimals to 5
+ * @returns {string} - The converted balance
+ */
+export function renderFiat(value, currencyCode, decimalsToShow = 5) {
+  const base = Math.pow(10, decimalsToShow);
+  let fiatFixed = parseFloat(Math.round(value * base) / base);
+  fiatFixed = isNaN(fiatFixed) ? 0.0 : fiatFixed;
+  if (currencySymbols[currencyCode]) {
+    const isNegative = fiatFixed < 0;
+    const absValue = Math.abs(fiatFixed);
+    const sign = isNegative ? '-' : '';
+    return `${sign}${currencySymbols[currencyCode]}${absValue}`;
+  }
+  return `${fiatFixed} ${currencyCode.toUpperCase()}`;
+}
+
+/**
+ * Converts BN wei value to wei units in string format
+ *
+ * @param {object} value - Object containing wei value in BN format
+ * @returns {string} - Corresponding wei value
+ */
+export function renderWei(value) {
+  if (!value) return '0';
+  const wei = fromWei(value);
+  const renderWei = wei * Math.pow(10, 18);
+  return renderWei.toString();
+}
+/**
+ * Format a string number in an string number with at most 5 decimal places
+ *
+ * @param {string} number - String containing a number
+ * @returns {string} - String number with none or at most 5 decimal places
+ */
+export function renderNumber(number) {
+  const index = number.indexOf('.');
+  if (index === 0) return number;
+  return number.substring(0, index + 6);
+}
+
+/**
+ * Checks whether the given value is a 0x-prefixed, non-zero, non-zero-padded,
+ * hexadecimal string.
+ *
+ * @param {any} value - The value to check.
+ * @returns {boolean} True if the value is a correctly formatted hex string,
+ * false otherwise.
+ */
+export function isPrefixedFormattedHexString(value) {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  return regex.prefixedFormattedHexString.test(value);
+}
+
+const converter = ({
+  value,
+  fromNumericBase,
+  fromDenomination,
+  fromCurrency,
+  toNumericBase,
+  toDenomination,
+  toCurrency,
+  numberOfDecimals,
+  conversionRate,
+  invertConversionRate,
+  roundDown,
+}) => {
+  let convertedValue = fromNumericBase
+    ? toBigNumber[fromNumericBase](value)
+    : value;
+
+  if (fromDenomination) {
+    convertedValue = toNormalizedDenomination[fromDenomination](convertedValue);
+  }
+
+  if (fromCurrency !== toCurrency) {
+    if (conversionRate === null || conversionRate === undefined) {
+      throw new Error(
+        `Converting from ${fromCurrency} to ${toCurrency} requires a conversionRate, but one was not provided`,
+      );
+    }
+    let rate = toBigNumber.dec(conversionRate);
+    if (invertConversionRate) {
+      rate = new BigNumber(1.0).div(conversionRate);
+    }
+    convertedValue = convertedValue.times(rate);
+  }
+
+  if (toDenomination) {
+    convertedValue = toSpecifiedDenomination[toDenomination](convertedValue);
+  }
+
+  if (numberOfDecimals) {
+    convertedValue = convertedValue.decimalPlaces(
+      numberOfDecimals,
+      BigNumber.ROUND_HALF_DOWN,
+    );
+  }
+
+  if (roundDown) {
+    convertedValue = convertedValue.decimalPlaces(
+      roundDown,
+      BigNumber.ROUND_DOWN,
+    );
+  }
+
+  if (toNumericBase) {
+    convertedValue = baseChange[toNumericBase](convertedValue);
+  }
+  return convertedValue;
+};
+
+export const conversionUtil = (
+  value,
+  {
+    fromCurrency = null,
+    toCurrency = fromCurrency,
+    fromNumericBase,
+    toNumericBase,
+    fromDenomination,
+    toDenomination,
+    numberOfDecimals,
+    conversionRate,
+    invertConversionRate,
+  },
+) =>
+  converter({
+    fromCurrency,
+    toCurrency,
+    fromNumericBase,
+    toNumericBase,
+    fromDenomination,
+    toDenomination,
+    numberOfDecimals,
+    conversionRate,
+    invertConversionRate,
+    value: value || '0',
+  });
+
+export const toHexadecimal = (decimal) => {
+  if (!decimal) return decimal;
+  if (decimal !== typeof 'string') {
+    decimal = String(decimal);
+  }
+  if (decimal.startsWith('0x')) return decimal;
+  return toBigNumber.dec(decimal).toString(16);
+};
+
+export const calculateEthFeeForMultiLayer = ({
+  multiLayerL1FeeTotal,
+  ethFee = 0,
+}) => {
+  if (!multiLayerL1FeeTotal) {
+    return ethFee;
+  }
+  const multiLayerL1FeeTotalDecEth = conversionUtil(multiLayerL1FeeTotal, {
+    fromNumericBase: 'hex',
+    toNumericBase: 'dec',
+    fromDenomination: 'WEI',
+    toDenomination: 'ETH',
+  });
+  return new BigNumber(multiLayerL1FeeTotalDecEth)
+    .plus(new BigNumber(ethFee ?? 0))
+    .toString(10);
+};
+
+/**
+ *
+ * @param {number|string|object} value - Value to check
+ * @returns {boolean} - true if value is zero
+ */
+export const isZeroValue = (value) => {
+  if (value === null || value === undefined) {
+    return false;
+  }
+  return value === '0x0' || (isBN(value) && value.isZero()) || isZero(value);
+};
+
+export const formatValueToMatchTokenDecimals = (value, decimal) => {
+  if (value === null || value === undefined) {
+    return value;
+  }
+  const decimalIndex = value.indexOf('.');
+  if (decimalIndex !== -1) {
+    const fractionalLength = value.substring(decimalIndex + 1).length;
+    if (fractionalLength > decimal) {
+      value = parseFloat(value).toFixed(decimal);
+    }
+  }
+  return value;
+};
+
+export const safeBNToHex = (value) => {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  return BNToHex(value);
+};
+
+/**
+ * Formats a potentially large number to the nearest unit.
+ * e.g. 1T for trillions, 2.3B for billions, 4.56M for millions, 7,890 for thousands, etc.
+ *
+ * @param t - An I18nContext translator.
+ * @param number - The number to format.
+ * @returns A localized string of the formatted number + unit.
+ */
+export const localizeLargeNumber = (i18n, number) => {
+  const oneTrillion = 1000000000000;
+  const oneBillion = 1000000000;
+  const oneMillion = 1000000;
+
+  if (number >= oneTrillion) {
+    return `${(number / oneTrillion).toFixed(2)}${i18n.t(
+      'token.trillion_abbreviation',
+    )}`;
+  } else if (number >= oneBillion) {
+    return `${(number / oneBillion).toFixed(2)}${i18n.t(
+      'token.billion_abbreviation',
+    )}`;
+  } else if (number >= oneMillion) {
+    return `${(number / oneMillion).toFixed(2)}${i18n.t(
+      'token.million_abbreviation',
+    )}`;
+  }
+  return number.toFixed(2);
+};
+
+export const convertDecimalToPercentage = (decimal) => {
+  if (typeof decimal !== 'number' || isNaN(decimal)) {
+    throw new Error('Input must be a valid number');
+  }
+  return (decimal * 100).toFixed(2) + '%';
+};

--- a/app/util/number/legacy.js
+++ b/app/util/number/legacy.js
@@ -22,7 +22,7 @@ const BIG_NUMBER_GWEI_MULTIPLIER = new BigNumber('1000000000');
 const BIG_NUMBER_ETH_MULTIPLIER = new BigNumber('1');
 
 /**
- * @deprecated Use hexToBigInt instead.
+ * @deprecated Use hexToBigInt instead from utils/number
  * Converts a hex string to a BN object.
  * Adapt function with non string argument handler
  *
@@ -37,7 +37,7 @@ export const hexToBN = (inputHex) =>
     : new BN4(0);
 
 /**
- * @deprecated Use bigIntToHex instead.
+ * @deprecated Use bigIntToHex instead from utils/number
  * Converts a BN object to a hex string with a '0x' prefix.
  *
  * @param inputBn - BN instance to convert to a hex string.
@@ -50,6 +50,9 @@ export function BNToHex(inputBn) {
 }
 
 // Setter Maps
+/**
+ * @deprecated This object should be replaced with one from utils/number.
+ */
 export const toBigNumber = {
   hex: (n) => new BigNumber(stripHexPrefix(n), 16),
   dec: (n) => new BigNumber(String(n), 10),
@@ -79,6 +82,7 @@ const baseChange = {
  *
  * @param {string} str - The string to prefix.
  * @returns {string} The prefixed string.
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export const addHexPrefix = (str) => {
   if (typeof str !== 'string' || str.match(regex.hexPrefix)) {
@@ -102,6 +106,7 @@ export const addHexPrefix = (str) => {
  * @param {number|string|Object} value - Wei to convert
  * @param {string} unit - Unit to convert to, ether by default
  * @returns {string} - String containing the new number
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function fromWei(value = 0, unit = 'ether') {
   return convert.fromWei(value, unit);
@@ -114,6 +119,7 @@ export function fromWei(value = 0, unit = 'ether') {
  * @param {number|string} decimals - Token decimals to convert
  * @param {boolean} [isRounding=true] - If true, minimalInput is converted to number and rounded for large numbers.
  * @returns {string} - String containing the new number
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function fromTokenMinimalUnit(
   minimalInput,
@@ -148,6 +154,7 @@ export function fromTokenMinimalUnit(
  * @param {string} minimalInput - Token minimal unit to convert
  * @param {number} decimals - Token decimals to convert
  * @returns {string} - String containing the new number
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function fromTokenMinimalUnitString(minimalInput, decimals) {
   if (typeof minimalInput !== 'string') {
@@ -170,6 +177,7 @@ export function fromTokenMinimalUnitString(minimalInput, decimals) {
  * @param {number|string|BN4} tokenValue - Value to convert
  * @param {number} decimals - Unit to convert from, ether by default
  * @returns {BN} - BN instance containing the new number
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function toTokenMinimalUnit(tokenValue, decimals) {
   const base = toBN(Math.pow(10, decimals).toString());
@@ -229,6 +237,7 @@ export function toTokenMinimalUnit(tokenValue, decimals) {
  * @param {Number} decimalsToShow - Decimals to 5
  * @returns {String} - Number of token minimal unit, in render format
  * If value is less than 5 precision decimals will show '< 0.00001'
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function renderFromTokenMinimalUnit(
   tokenValue,
@@ -258,6 +267,7 @@ export function renderFromTokenMinimalUnit(
  * @param {number} decimalsToShow - Defaults to 5
  * @returns {String} - Formatted fiat value of the addition, in render format
  * If value is less than 5 precision decimals will show '< 0.00001'
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function renderFiatAddition(
   transferFiat,
@@ -284,6 +294,7 @@ export function renderFiatAddition(
  * @param {number} num
  * @param {number} maxDecimalPlaces
  * @returns {string}
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function limitToMaximumDecimalPlaces(num, maxDecimalPlaces = 5) {
   if (isNaN(num) || isNaN(maxDecimalPlaces)) {
@@ -301,6 +312,7 @@ export function limitToMaximumDecimalPlaces(num, maxDecimalPlaces = 5) {
  * @param {number} exchangeRate - Asset to ETH conversion rate
  * @param {number} decimals - Asset decimals
  * @returns {Object} - The converted balance as BN instance
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function fiatNumberToTokenMinimalUnit(
   fiat,
@@ -324,6 +336,7 @@ export function fiatNumberToTokenMinimalUnit(
  * @param {Number} decimalsToShow - Decimals to 5
  * @returns {String} - Number of token minimal unit, in render format
  * If value is less than 5 precision decimals will show '< 0.00001'
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function renderFromWei(value, decimalsToShow = 5) {
   let renderWei = '0';
@@ -347,6 +360,7 @@ export function renderFromWei(value, decimalsToShow = 5) {
  * @param {Object} value - BN instance to convert
  * @param {number} decimals - Decimals to be considered on the conversion
  * @returns {string} - String of the hex token value
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function calcTokenValueToSend(value, decimals) {
   return value ? (value * Math.pow(10, decimals)).toString(16) : 0;
@@ -357,6 +371,7 @@ export function calcTokenValueToSend(value, decimals) {
  *
  * @param {object|string} value - Value to check
  * @returns {boolean} - True if the value is a BN instance
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function isBN(value) {
   return BN4.isBN(value);
@@ -367,6 +382,7 @@ export function isBN(value) {
  *
  * @param {number | string} value - String to check
  * @returns {boolean} - True if the string is a valid decimal
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function isDecimal(value) {
   return (
@@ -381,6 +397,7 @@ export function isDecimal(value) {
  *
  * @param {string} value - Some numeric value represented as a string
  * @returns {Object} - BN instance
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function toBN(value) {
   return new BN4(value);
@@ -391,6 +408,7 @@ export function toBN(value) {
  *
  * @param {*} str - Number string
  * @returns {boolean} - True if the string  is a valid number
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function isNumber(str) {
   return regex.number.test(str);
@@ -401,6 +419,7 @@ export function isNumber(str) {
  *
  * @param {number | string | null | undefined} value - Value to check
  * @returns {boolean} - True if the value is a valid number
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function isNumberValue(value) {
   if (value === null || value === undefined) {
@@ -414,6 +433,9 @@ export function isNumberValue(value) {
   return isDecimal(value);
 }
 
+/**
+ * @deprecated This function should be replaced with one from utils/number.
+ */
 export const dotAndCommaDecimalFormatter = (value) => {
   const valueStr = String(value);
 
@@ -429,6 +451,7 @@ export const dotAndCommaDecimalFormatter = (value) => {
  * @param {number} value - The value to check.
  * @returns {boolean} True if the value is a number in scientific notation, false otherwise.
  * @see https://262.ecma-international.org/5.1/#sec-9.8.1
+ * @deprecated This function should be replaced with one from utils/number.
  */
 
 export const isNumberScientificNotationWhenString = (value) => {
@@ -445,6 +468,7 @@ export const isNumberScientificNotationWhenString = (value) => {
  * @param {number|string|BN4} value - Value to convert
  * @param {string} unit - Unit to convert from, ether by default
  * @returns {BN4} - BN instance containing the new number
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function toWei(value, unit = 'ether') {
   // check the posibilty to convert to BN
@@ -461,6 +485,7 @@ export function toWei(value, unit = 'ether') {
  * @param {number|string|BN4} value - Value to convert
  * @param {string} unit - Unit to convert from, ether by default
  * @returns {Object} - BN instance containing the new number
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function toGwei(value, unit = 'ether') {
   return fromWei(value, unit) * 1000000000;
@@ -472,6 +497,7 @@ export function toGwei(value, unit = 'ether') {
  * @param {number|string|BN4} value - Value to convert
  * @param {string} unit - Unit to convert from, ether by default
  * @returns {string} - String instance containing the renderable number
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function renderToGwei(value, unit = 'ether') {
   const gwei = fromWei(value, unit) * 1000000000;
@@ -488,6 +514,7 @@ export function renderToGwei(value, unit = 'ether') {
  * @param {number | null} conversionRate - ETH to current currency conversion rate
  * @param {string} currencyCode - Current currency code to display
  * @returns {string} - Currency-formatted string
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function weiToFiat(
   wei,
@@ -510,6 +537,7 @@ export function weiToFiat(
  * @param {number|string} amount  Number corresponding to a currency amount
  * @param {string} currencyCode Current currency code to display
  * @returns {string} - Currency-formatted string
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function addCurrencySymbol(
   amount,
@@ -572,6 +600,7 @@ export function addCurrencySymbol(
  * @param {number} conversionRate - ETH to current currency conversion rate
  * @param {Number} decimalsToShow - Decimals to 5
  * @returns {Number} - The converted balance
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function weiToFiatNumber(wei, conversionRate, decimalsToShow = 5) {
   const base = Math.pow(10, decimalsToShow);
@@ -586,6 +615,7 @@ export function weiToFiatNumber(wei, conversionRate, decimalsToShow = 5) {
  *
  * @param {string} wei - Amount in decimal notation
  * @returns {string} - Number string with less or equal 18 decimals
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function handleWeiNumber(wei) {
   const comps = wei.split('.');
@@ -601,6 +631,7 @@ export function handleWeiNumber(wei) {
  * @param {number|string} fiat - Fiat number
  * @param {number} conversionRate - ETH to current currency conversion rate
  * @returns {Object} - The converted balance as BN instance
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function fiatNumberToWei(fiat, conversionRate) {
   const floatFiatConverted = parseFloat(fiat) / conversionRate;
@@ -624,6 +655,7 @@ export function fiatNumberToWei(fiat, conversionRate) {
  *
  * @param {number|string} value -  number
  * @returns {Object} - The converted value as BN instance
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function safeNumberToBN(value) {
   try {
@@ -640,6 +672,7 @@ export function safeNumberToBN(value) {
  * @param {number|string} value -  number/string to be splitted
  * @param {string} divider -  string value to use to split the string (default '.')
  * @returns {string} - the selected splitted element
+ * @deprecated This function should be replaced with one from utils/number.
  */
 
 export function fastSplit(value, divider = '.') {
@@ -655,6 +688,7 @@ export function fastSplit(value, divider = '.') {
  * @param {number|undefined} exchangeRate - Asset to ETH conversion rate
  * @param {string} currencyCode - Current currency code to display
  * @returns {string} - Currency-formatted string
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function balanceToFiat(
   balance,
@@ -683,6 +717,7 @@ export function balanceToFiat(
  * @param {number} exchangeRate - Asset to ETH conversion rate
  * @param {number} decimalsToShow - Decimals to 5
  * @returns {Number} - The converted balance
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function balanceToFiatNumber(
   balance,
@@ -698,6 +733,9 @@ export function balanceToFiatNumber(
   return fiatFixed;
 }
 
+/**
+ * @deprecated This function should be replaced with one from utils/number.
+ */
 export function getCurrencySymbol(currencyCode) {
   if (currencySymbols[currencyCode]) {
     return `${currencySymbols[currencyCode]}`;
@@ -712,6 +750,7 @@ export function getCurrencySymbol(currencyCode) {
  * @param {string} currencyCode - Current currency code to display
  * @param {number} decimalsToShow - Decimals to 5
  * @returns {string} - The converted balance
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function renderFiat(value, currencyCode, decimalsToShow = 5) {
   const base = Math.pow(10, decimalsToShow);
@@ -731,6 +770,7 @@ export function renderFiat(value, currencyCode, decimalsToShow = 5) {
  *
  * @param {object} value - Object containing wei value in BN format
  * @returns {string} - Corresponding wei value
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function renderWei(value) {
   if (!value) return '0';
@@ -743,6 +783,7 @@ export function renderWei(value) {
  *
  * @param {string} number - String containing a number
  * @returns {string} - String number with none or at most 5 decimal places
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function renderNumber(number) {
   const index = number.indexOf('.');
@@ -757,6 +798,7 @@ export function renderNumber(number) {
  * @param {any} value - The value to check.
  * @returns {boolean} True if the value is a correctly formatted hex string,
  * false otherwise.
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export function isPrefixedFormattedHexString(value) {
   if (typeof value !== 'string') {
@@ -823,6 +865,9 @@ const converter = ({
   return convertedValue;
 };
 
+/**
+ * @deprecated This function should be replaced with one from utils/number.
+ */
 export const conversionUtil = (
   value,
   {
@@ -850,6 +895,9 @@ export const conversionUtil = (
     value: value || '0',
   });
 
+/**
+ * @deprecated This function should be replaced with one from utils/number.
+ */
 export const toHexadecimal = (decimal) => {
   if (!decimal) return decimal;
   if (decimal !== typeof 'string') {
@@ -859,6 +907,9 @@ export const toHexadecimal = (decimal) => {
   return toBigNumber.dec(decimal).toString(16);
 };
 
+/**
+ * @deprecated This function should be replaced with one from utils/number.
+ */
 export const calculateEthFeeForMultiLayer = ({
   multiLayerL1FeeTotal,
   ethFee = 0,
@@ -881,6 +932,7 @@ export const calculateEthFeeForMultiLayer = ({
  *
  * @param {number|string|object} value - Value to check
  * @returns {boolean} - true if value is zero
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export const isZeroValue = (value) => {
   if (value === null || value === undefined) {
@@ -889,6 +941,9 @@ export const isZeroValue = (value) => {
   return value === '0x0' || (isBN(value) && value.isZero()) || isZero(value);
 };
 
+/**
+ * @deprecated This function should be replaced with one from utils/number.
+ */
 export const formatValueToMatchTokenDecimals = (value, decimal) => {
   if (value === null || value === undefined) {
     return value;
@@ -903,6 +958,9 @@ export const formatValueToMatchTokenDecimals = (value, decimal) => {
   return value;
 };
 
+/**
+ * @deprecated This function should be replaced with one from utils/number.
+ */
 export const safeBNToHex = (value) => {
   if (value === null || value === undefined) {
     return value;
@@ -918,6 +976,7 @@ export const safeBNToHex = (value) => {
  * @param t - An I18nContext translator.
  * @param number - The number to format.
  * @returns A localized string of the formatted number + unit.
+ * @deprecated This function should be replaced with one from utils/number.
  */
 export const localizeLargeNumber = (i18n, number) => {
   const oneTrillion = 1000000000000;
@@ -940,6 +999,9 @@ export const localizeLargeNumber = (i18n, number) => {
   return number.toFixed(2);
 };
 
+/**
+ * @deprecated This function should be replaced with one from utils/number.
+ */
 export const convertDecimalToPercentage = (decimal) => {
   if (typeof decimal !== 'number' || isNaN(decimal)) {
     throw new Error('Input must be a valid number');

--- a/app/util/transactions/index.js
+++ b/app/util/transactions/index.js
@@ -29,7 +29,7 @@ import {
   weiToFiat,
   weiToFiatNumber,
   toTokenMinimalUnit,
-} from '../number';
+} from '../number/legacy';
 import AppConstants from '../../core/AppConstants';
 import { isMainnetByChainId } from '../networks';
 import { UINT256_BN_MAX_VALUE } from '../../constants/transaction';

--- a/app/util/transactions/index.test.ts
+++ b/app/util/transactions/index.test.ts
@@ -7,7 +7,7 @@ import { ERC721, ERC1155 } from '@metamask/controller-utils';
 
 import { handleMethodData } from '../../util/transaction-controller';
 
-import { BNToHex } from '../number';
+import { BNToHex } from '../number/legacy';
 import { UINT256_BN_MAX_VALUE } from '../../constants/transaction';
 import { NEGATIVE_TOKEN_DECIMALS } from '../../constants/error';
 import {


### PR DESCRIPTION
## **Description**

This draft of migration from BN.js to native `BigInt`. It needs https://github.com/MetaMask/utils/pull/255 to be merged and released first.

Native BigInt is much much faster than JS only BN implementation. This could improve app performance in many places like account list, login, dashboard etc. I already measured `useAccounts` hook and it made it 7x faster `220ms => 30ms`.

#### Proposal for handling migration:

I moved cloned previous file `index.js` to `legacy.js` and updated imports everywhere to use this old implementation. Then I migrated whole old `index.js` to TS and to use `BigInt`. I also marked all legacy functions as deprecated so they could be spotted more easily during future refactoring and replaced with new implementation.

I think this approach is best in current situation because:
1. Even that I tried my best I could have introduced some bugs it's better to introduce new functions slowly
2. We are on tight schedule with performance improvements and updating these functions across whole codebase could take quite a long time and I am not even talking about testing and PR review
3. I also added TS types which is causing type errors in some places where new functions are used because previous versions were typed as `any`.

TODOs:
- [x] merge https://github.com/MetaMask/utils/pull/255
- [x] merge https://github.com/MetaMask/metamask-mobile/pull/18949 and then rebase
- [x] in Engine.ts, around line ~1916 there is function` toHexadecimal` and while migrating it to new implementation with bigint I noticed that i receives params like `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` . In old implementation it causes `toHexadecima`l return `NaN` and in my new implementation it throws error. I guess this might be causing bug even in current implementation like total balance not being correct if there is more than one Solana account or something like that.
- [x] How to gracefully migrate from old BN? I would suggest keeping old BN implementation and only that functions deprecated.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
4. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check that total balance across the app is correct for different SRPs (combinations of coins/tokens/networks etc.)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce BigInt-backed number utilities while re-pointing existing code to legacy implementations, updating balance/fee logic and tests accordingly.
> 
> - **Core number utils (BigInt)**:
>   - Add new `util/number/index.ts` with BigInt-based conversions/formatting (`hexToBigInt`, `bigIntToHex`, `toWei`, `fromWei`, fiat/token helpers, etc.).
>   - Preserve previous BN.js utils in `util/number/legacy.js` (marked deprecated) and add comprehensive `legacy.test.ts`.
>   - Update ESLint globals to include `BigInt`.
> - **Codebase migration (temporary legacy shim)**:
>   - Replace imports of `util/number` with `util/number/legacy` across app (Swaps, Ramp, Earn, Stake, Bridge, Transactions, selectors, hooks, components, tests).
>   - Adjust typings/usages (e.g., remove unnecessary `Hex` cast, tweak chainId handling for images/selectors).
> - **Engine and calculations**:
>   - Update balance/fiat computations to use BigInt paths (`hexToBigInt`, `bigInt` math) and avoid string BN math; fix chainId map lookups (use raw `chainId`).
>   - Modify tests and data to store balances as hex strings with `0x` prefix.
> - **Tests and minor fixes**:
>   - Add new tests for BigInt utils and adapt existing tests/mocks to legacy paths.
>   - Small test logic refinements (e.g., async wait/press order, debounced assertions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ea5e81bb1eef462987fee7e91d67982349468f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->