### PR TITLE
fix: Reveal Private Credentials cp-7.54.0

### DIFF
--- a/app/components/Views/MultichainAccounts/WalletDetails/BaseWalletDetails/index.tsx
+++ b/app/components/Views/MultichainAccounts/WalletDetails/BaseWalletDetails/index.tsx
@@ -265,12 +265,7 @@ export const BaseWalletDetails = ({
           onSwipeComplete={handleCloseAddAccountModal}
           backdropOpacity={0.5}
         >
-          <View
-            style={[
-              styles.modalContent,
-              { backgroundColor: colors.background.default },
-            ]}
-          >
+          <View style={styles.modalContent}>
             <WalletAddAccountActions
               keyringId={keyringId}
               onBack={handleCloseAddAccountModal}

--- a/app/components/Views/MultichainAccounts/WalletDetails/BaseWalletDetails/styles.ts
+++ b/app/components/Views/MultichainAccounts/WalletDetails/BaseWalletDetails/styles.ts
@@ -98,6 +98,7 @@ const styleSheet = (params: { theme: Theme }) => {
     modalContent: {
       borderTopLeftRadius: 20,
       borderTopRightRadius: 20,
+      backgroundColor: colors.background.default,
     },
   });
 };

--- a/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
+++ b/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
@@ -658,7 +658,7 @@ const RevealPrivateCredential = ({
         scrollViewTestID={
           RevealSeedViewSelectorsIDs.REVEAL_CREDENTIAL_SCROLL_ID
         }
-        contentContainerStyle={styles.stretch}
+        contentContainerStyle={styles.scrollContentContainer}
         // The cancel button here is not named correctly. When it is unlocked, the button is shown as "Done"
         showCancelButton={Boolean(showCancelButton || unlocked)}
         enableOnAndroid
@@ -666,7 +666,7 @@ const RevealPrivateCredential = ({
         extraScrollHeight={40}
         showsVerticalScrollIndicator={false}
       >
-        <ScrollView>
+        <View>
           <View style={[styles.rowWrapper, styles.normalText]}>
             {isPrivateKey && account ? (
               <>
@@ -695,7 +695,7 @@ const RevealPrivateCredential = ({
               {renderPasswordEntry()}
             </View>
           )}
-        </ScrollView>
+        </View>
       </ActionView>
       {renderModal(isPrivateKey)}
 

--- a/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
+++ b/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
@@ -423,7 +423,6 @@ const RevealPrivateCredential = ({
       >
         <CustomTabView
           tabLabel={strings(`reveal_credential.text`)}
-          style={styles.tabContent}
           testID={RevealSeedViewSelectorsIDs.TAB_SCROLL_VIEW_TEXT}
         >
           <Text style={styles.boldText}>
@@ -459,7 +458,6 @@ const RevealPrivateCredential = ({
         </CustomTabView>
         <CustomTabView
           tabLabel={strings(`reveal_credential.qr_code`)}
-          style={styles.tabContent}
           testID={RevealSeedViewSelectorsIDs.TAB_SCROLL_VIEW_QR_CODE}
         >
           <View
@@ -635,7 +633,7 @@ const RevealPrivateCredential = ({
 
   return (
     <View
-      style={[styles.wrapper]}
+      style={styles.wrapper}
       testID={RevealSeedViewSelectorsIDs.REVEAL_CREDENTIAL_CONTAINER_ID}
     >
       <ActionView
@@ -658,7 +656,6 @@ const RevealPrivateCredential = ({
         scrollViewTestID={
           RevealSeedViewSelectorsIDs.REVEAL_CREDENTIAL_SCROLL_ID
         }
-        contentContainerStyle={styles.scrollContentContainer}
         // The cancel button here is not named correctly. When it is unlocked, the button is shown as "Done"
         showCancelButton={Boolean(showCancelButton || unlocked)}
         enableOnAndroid

--- a/app/components/Views/RevealPrivateCredential/__snapshots__/RevealPrivateCredential.test.tsx.snap
+++ b/app/components/Views/RevealPrivateCredential/__snapshots__/RevealPrivateCredential.test.tsx.snap
@@ -3,12 +3,10 @@
 exports[`RevealPrivateCredential handles keyring ID parameter correctly 1`] = `
 <View
   style={
-    [
-      {
-        "backgroundColor": "#ffffff",
-        "flex": 1,
-      },
-    ]
+    {
+      "backgroundColor": "#ffffff",
+      "flex": 1,
+    }
   }
   testID="reveal-private-credential-screen"
 >
@@ -21,11 +19,6 @@ exports[`RevealPrivateCredential handles keyring ID parameter correctly 1`] = `
   >
     <RCTScrollView
       automaticallyAdjustContentInsets={false}
-      contentContainerStyle={
-        {
-          "flexGrow": 1,
-        }
-      }
       contentInset={
         {
           "bottom": 0,
@@ -392,12 +385,10 @@ exports[`RevealPrivateCredential handles keyring ID parameter correctly 1`] = `
 exports[`RevealPrivateCredential renders reveal SRP correctly when the credential is directly passed 1`] = `
 <View
   style={
-    [
-      {
-        "backgroundColor": "#ffffff",
-        "flex": 1,
-      },
-    ]
+    {
+      "backgroundColor": "#ffffff",
+      "flex": 1,
+    }
   }
   testID="reveal-private-credential-screen"
 >
@@ -410,11 +401,6 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
   >
     <RCTScrollView
       automaticallyAdjustContentInsets={false}
-      contentContainerStyle={
-        {
-          "flexGrow": 1,
-        }
-      }
       contentInset={
         {
           "bottom": 0,
@@ -781,12 +767,10 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
 exports[`RevealPrivateCredential renders reveal SRP correctly when the credential is passed via the route object 1`] = `
 <View
   style={
-    [
-      {
-        "backgroundColor": "#ffffff",
-        "flex": 1,
-      },
-    ]
+    {
+      "backgroundColor": "#ffffff",
+      "flex": 1,
+    }
   }
   testID="reveal-private-credential-screen"
 >
@@ -799,11 +783,6 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
   >
     <RCTScrollView
       automaticallyAdjustContentInsets={false}
-      contentContainerStyle={
-        {
-          "flexGrow": 1,
-        }
-      }
       contentInset={
         {
           "bottom": 0,
@@ -1170,12 +1149,10 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
 exports[`RevealPrivateCredential renders reveal private key correctly 1`] = `
 <View
   style={
-    [
-      {
-        "backgroundColor": "#ffffff",
-        "flex": 1,
-      },
-    ]
+    {
+      "backgroundColor": "#ffffff",
+      "flex": 1,
+    }
   }
   testID="reveal-private-credential-screen"
 >
@@ -1188,11 +1165,6 @@ exports[`RevealPrivateCredential renders reveal private key correctly 1`] = `
   >
     <RCTScrollView
       automaticallyAdjustContentInsets={false}
-      contentContainerStyle={
-        {
-          "flexGrow": 1,
-        }
-      }
       contentInset={
         {
           "bottom": 0,
@@ -1771,12 +1743,10 @@ exports[`RevealPrivateCredential renders reveal private key correctly 1`] = `
 exports[`RevealPrivateCredential renders with a custom selectedAddress 1`] = `
 <View
   style={
-    [
-      {
-        "backgroundColor": "#ffffff",
-        "flex": 1,
-      },
-    ]
+    {
+      "backgroundColor": "#ffffff",
+      "flex": 1,
+    }
   }
   testID="reveal-private-credential-screen"
 >
@@ -1789,11 +1759,6 @@ exports[`RevealPrivateCredential renders with a custom selectedAddress 1`] = `
   >
     <RCTScrollView
       automaticallyAdjustContentInsets={false}
-      contentContainerStyle={
-        {
-          "flexGrow": 1,
-        }
-      }
       contentInset={
         {
           "bottom": 0,

--- a/app/components/Views/RevealPrivateCredential/__snapshots__/RevealPrivateCredential.test.tsx.snap
+++ b/app/components/Views/RevealPrivateCredential/__snapshots__/RevealPrivateCredential.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`RevealPrivateCredential handles keyring ID parameter correctly 1`] = `
       automaticallyAdjustContentInsets={false}
       contentContainerStyle={
         {
-          "flex": 1,
+          "flexGrow": 1,
         }
       }
       contentInset={
@@ -70,7 +70,7 @@ exports[`RevealPrivateCredential handles keyring ID parameter correctly 1`] = `
       viewIsInsideTabBar={false}
     >
       <View>
-        <RCTScrollView
+        <View
           accessibilityState={
             {
               "busy": undefined,
@@ -90,7 +90,104 @@ exports[`RevealPrivateCredential handles keyring ID parameter correctly 1`] = `
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
         >
-          <View>
+          <View
+            style={
+              [
+                {
+                  "padding": 20,
+                },
+                {
+                  "color": "#121314",
+                  "fontFamily": "CentraNo1-Book",
+                  "fontWeight": "400",
+                },
+              ]
+            }
+          >
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#121314",
+                  "fontFamily": "CentraNo1-Book",
+                  "fontSize": 16,
+                  "fontWeight": "400",
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                }
+              }
+            >
+              Your
+               
+              <Text
+                accessibilityRole="text"
+                onPress={[Function]}
+                style={
+                  {
+                    "color": "#4459ff",
+                    "fontFamily": "Geist Regular",
+                    "fontSize": 16,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  }
+                }
+              >
+                Secret Recovery Phrase
+              </Text>
+               
+              gives
+               
+              <Text
+                accessibilityRole="text"
+                style={
+                  {
+                    "color": "#121314",
+                    "fontFamily": "Geist Regular",
+                    "fontSize": 16,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  }
+                }
+              >
+                full access to your wallet, funds and accounts.
+
+
+              </Text>
+              MetaMask is a
+               
+              <Text
+                accessibilityRole="text"
+                onPress={[Function]}
+                style={
+                  {
+                    "color": "#4459ff",
+                    "fontFamily": "Geist Regular",
+                    "fontSize": 16,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  }
+                }
+              >
+                non-custodial wallet.
+                 
+              </Text>
+              That means,
+               
+              <Text
+                accessibilityRole="text"
+                style={
+                  {
+                    "color": "#121314",
+                    "fontFamily": "Geist Regular",
+                    "fontSize": 16,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  }
+                }
+              >
+                you are the owner of your Secret Recovery Phrase.
+              </Text>
+            </Text>
             <View
               style={
                 [
@@ -98,237 +195,138 @@ exports[`RevealPrivateCredential handles keyring ID parameter correctly 1`] = `
                     "padding": 20,
                   },
                   {
-                    "color": "#121314",
-                    "fontFamily": "CentraNo1-Book",
-                    "fontWeight": "400",
+                    "backgroundColor": "#ca35421a",
+                    "borderColor": "#ca3542",
+                    "borderRadius": 8,
+                    "borderWidth": 1,
+                    "marginTop": 16,
+                    "padding": 20,
                   },
                 ]
               }
             >
-              <Text
-                accessibilityRole="text"
-                style={
-                  {
-                    "color": "#121314",
-                    "fontFamily": "CentraNo1-Book",
-                    "fontSize": 16,
-                    "fontWeight": "400",
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                  }
-                }
-              >
-                Your
-                 
-                <Text
-                  accessibilityRole="text"
-                  onPress={[Function]}
-                  style={
-                    {
-                      "color": "#4459ff",
-                      "fontFamily": "Geist Regular",
-                      "fontSize": 16,
-                      "letterSpacing": 0,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  Secret Recovery Phrase
-                </Text>
-                 
-                gives
-                 
-                <Text
-                  accessibilityRole="text"
-                  style={
-                    {
-                      "color": "#121314",
-                      "fontFamily": "Geist Regular",
-                      "fontSize": 16,
-                      "letterSpacing": 0,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  full access to your wallet, funds and accounts.
-
-
-                </Text>
-                MetaMask is a
-                 
-                <Text
-                  accessibilityRole="text"
-                  onPress={[Function]}
-                  style={
-                    {
-                      "color": "#4459ff",
-                      "fontFamily": "Geist Regular",
-                      "fontSize": 16,
-                      "letterSpacing": 0,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  non-custodial wallet.
-                   
-                </Text>
-                That means,
-                 
-                <Text
-                  accessibilityRole="text"
-                  style={
-                    {
-                      "color": "#121314",
-                      "fontFamily": "Geist Regular",
-                      "fontSize": 16,
-                      "letterSpacing": 0,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  you are the owner of your Secret Recovery Phrase.
-                </Text>
-              </Text>
               <View
                 style={
                   [
                     {
-                      "padding": 20,
-                    },
-                    {
-                      "backgroundColor": "#ca35421a",
-                      "borderColor": "#ca3542",
-                      "borderRadius": 8,
-                      "borderWidth": 1,
-                      "marginTop": 16,
-                      "padding": 20,
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "flexShrink": 1,
+                      "width": "100%",
                     },
                   ]
                 }
               >
-                <View
+                <SvgMock
+                  color="#ca3542"
+                  fill="currentColor"
+                  height={24}
+                  name="EyeSlash"
                   style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "flexDirection": "row",
-                        "flexShrink": 1,
-                        "width": "100%",
-                      },
-                    ]
+                    {
+                      "height": 24,
+                      "width": 24,
+                    }
+                  }
+                  width={24}
+                />
+                <Text
+                  accessibilityRole="text"
+                  style={
+                    {
+                      "color": "#121314",
+                      "fontFamily": "CentraNo1-Book",
+                      "fontSize": 16,
+                      "fontWeight": "400",
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                      "marginLeft": 10,
+                      "marginRight": 40,
+                    }
                   }
                 >
-                  <SvgMock
-                    color="#ca3542"
-                    fill="currentColor"
-                    height={24}
-                    name="EyeSlash"
-                    style={
-                      {
-                        "height": 24,
-                        "width": 24,
-                      }
-                    }
-                    width={24}
-                  />
+                  Make sure nobody is looking at your screen. 
                   <Text
                     accessibilityRole="text"
                     style={
                       {
                         "color": "#121314",
-                        "fontFamily": "CentraNo1-Book",
+                        "fontFamily": "CentraNo1-Bold",
                         "fontSize": 16,
-                        "fontWeight": "400",
+                        "fontWeight": "600",
                         "letterSpacing": 0,
                         "lineHeight": 24,
-                        "marginLeft": 10,
-                        "marginRight": 40,
                       }
                     }
                   >
-                    Make sure nobody is looking at your screen. 
-                    <Text
-                      accessibilityRole="text"
-                      style={
-                        {
-                          "color": "#121314",
-                          "fontFamily": "CentraNo1-Bold",
-                          "fontSize": 16,
-                          "fontWeight": "600",
-                          "letterSpacing": 0,
-                          "lineHeight": 24,
-                        }
-                      }
-                    >
-                      MetaMask Support will never request this.
-                    </Text>
+                    MetaMask Support will never request this.
                   </Text>
-                </View>
+                </Text>
               </View>
             </View>
-            <View
+          </View>
+          <View
+            style={
+              [
+                {
+                  "padding": 20,
+                },
+                {
+                  "flex": 1,
+                },
+              ]
+            }
+          >
+            <Text
+              accessibilityRole="text"
               style={
-                [
-                  {
-                    "padding": 20,
-                  },
-                  {
-                    "flex": 1,
-                  },
-                ]
+                {
+                  "color": "#121314",
+                  "fontFamily": "Geist Medium",
+                  "fontSize": 16,
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                  "marginBottom": 4,
+                }
               }
             >
-              <Text
-                accessibilityRole="text"
-                style={
-                  {
-                    "color": "#121314",
-                    "fontFamily": "Geist Medium",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                    "marginBottom": 4,
-                  }
+              Enter password to continue
+            </Text>
+            <TextInput
+              keyboardAppearance="light"
+              onChangeText={[Function]}
+              onSubmitEditing={[Function]}
+              placeholder="Password"
+              placeholderTextColor="#b7bbc8"
+              secureTextEntry={true}
+              style={
+                {
+                  "borderColor": "#b7bbc8",
+                  "borderRadius": 5,
+                  "borderWidth": 2,
+                  "color": "#121314",
+                  "padding": 10,
                 }
-              >
-                Enter password to continue
-              </Text>
-              <TextInput
-                keyboardAppearance="light"
-                onChangeText={[Function]}
-                onSubmitEditing={[Function]}
-                placeholder="Password"
-                placeholderTextColor="#b7bbc8"
-                secureTextEntry={true}
-                style={
-                  {
-                    "borderColor": "#b7bbc8",
-                    "borderRadius": 5,
-                    "borderWidth": 2,
-                    "color": "#121314",
-                    "padding": 10,
-                  }
+              }
+              testID="private-credential-password-text-input"
+            />
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#ca3542",
+                  "fontFamily": "CentraNo1-Book",
+                  "fontSize": 16,
+                  "fontWeight": "400",
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                  "marginTop": 10,
                 }
-                testID="private-credential-password-text-input"
-              />
-              <Text
-                accessibilityRole="text"
-                style={
-                  {
-                    "color": "#ca3542",
-                    "fontFamily": "CentraNo1-Book",
-                    "fontSize": 16,
-                    "fontWeight": "400",
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                    "marginTop": 10,
-                  }
-                }
-                testID="password-warning"
-              />
-            </View>
+              }
+              testID="password-warning"
+            />
           </View>
-        </RCTScrollView>
+        </View>
         <View
           style={
             [
@@ -414,7 +412,7 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
       automaticallyAdjustContentInsets={false}
       contentContainerStyle={
         {
-          "flex": 1,
+          "flexGrow": 1,
         }
       }
       contentInset={
@@ -461,7 +459,7 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
       viewIsInsideTabBar={false}
     >
       <View>
-        <RCTScrollView
+        <View
           accessibilityState={
             {
               "busy": undefined,
@@ -481,7 +479,104 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
         >
-          <View>
+          <View
+            style={
+              [
+                {
+                  "padding": 20,
+                },
+                {
+                  "color": "#121314",
+                  "fontFamily": "CentraNo1-Book",
+                  "fontWeight": "400",
+                },
+              ]
+            }
+          >
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#121314",
+                  "fontFamily": "CentraNo1-Book",
+                  "fontSize": 16,
+                  "fontWeight": "400",
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                }
+              }
+            >
+              Your
+               
+              <Text
+                accessibilityRole="text"
+                onPress={[Function]}
+                style={
+                  {
+                    "color": "#4459ff",
+                    "fontFamily": "Geist Regular",
+                    "fontSize": 16,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  }
+                }
+              >
+                Secret Recovery Phrase
+              </Text>
+               
+              gives
+               
+              <Text
+                accessibilityRole="text"
+                style={
+                  {
+                    "color": "#121314",
+                    "fontFamily": "Geist Regular",
+                    "fontSize": 16,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  }
+                }
+              >
+                full access to your wallet, funds and accounts.
+
+
+              </Text>
+              MetaMask is a
+               
+              <Text
+                accessibilityRole="text"
+                onPress={[Function]}
+                style={
+                  {
+                    "color": "#4459ff",
+                    "fontFamily": "Geist Regular",
+                    "fontSize": 16,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  }
+                }
+              >
+                non-custodial wallet.
+                 
+              </Text>
+              That means,
+               
+              <Text
+                accessibilityRole="text"
+                style={
+                  {
+                    "color": "#121314",
+                    "fontFamily": "Geist Regular",
+                    "fontSize": 16,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  }
+                }
+              >
+                you are the owner of your Secret Recovery Phrase.
+              </Text>
+            </Text>
             <View
               style={
                 [
@@ -489,237 +584,138 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
                     "padding": 20,
                   },
                   {
-                    "color": "#121314",
-                    "fontFamily": "CentraNo1-Book",
-                    "fontWeight": "400",
+                    "backgroundColor": "#ca35421a",
+                    "borderColor": "#ca3542",
+                    "borderRadius": 8,
+                    "borderWidth": 1,
+                    "marginTop": 16,
+                    "padding": 20,
                   },
                 ]
               }
             >
-              <Text
-                accessibilityRole="text"
-                style={
-                  {
-                    "color": "#121314",
-                    "fontFamily": "CentraNo1-Book",
-                    "fontSize": 16,
-                    "fontWeight": "400",
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                  }
-                }
-              >
-                Your
-                 
-                <Text
-                  accessibilityRole="text"
-                  onPress={[Function]}
-                  style={
-                    {
-                      "color": "#4459ff",
-                      "fontFamily": "Geist Regular",
-                      "fontSize": 16,
-                      "letterSpacing": 0,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  Secret Recovery Phrase
-                </Text>
-                 
-                gives
-                 
-                <Text
-                  accessibilityRole="text"
-                  style={
-                    {
-                      "color": "#121314",
-                      "fontFamily": "Geist Regular",
-                      "fontSize": 16,
-                      "letterSpacing": 0,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  full access to your wallet, funds and accounts.
-
-
-                </Text>
-                MetaMask is a
-                 
-                <Text
-                  accessibilityRole="text"
-                  onPress={[Function]}
-                  style={
-                    {
-                      "color": "#4459ff",
-                      "fontFamily": "Geist Regular",
-                      "fontSize": 16,
-                      "letterSpacing": 0,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  non-custodial wallet.
-                   
-                </Text>
-                That means,
-                 
-                <Text
-                  accessibilityRole="text"
-                  style={
-                    {
-                      "color": "#121314",
-                      "fontFamily": "Geist Regular",
-                      "fontSize": 16,
-                      "letterSpacing": 0,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  you are the owner of your Secret Recovery Phrase.
-                </Text>
-              </Text>
               <View
                 style={
                   [
                     {
-                      "padding": 20,
-                    },
-                    {
-                      "backgroundColor": "#ca35421a",
-                      "borderColor": "#ca3542",
-                      "borderRadius": 8,
-                      "borderWidth": 1,
-                      "marginTop": 16,
-                      "padding": 20,
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "flexShrink": 1,
+                      "width": "100%",
                     },
                   ]
                 }
               >
-                <View
+                <SvgMock
+                  color="#ca3542"
+                  fill="currentColor"
+                  height={24}
+                  name="EyeSlash"
                   style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "flexDirection": "row",
-                        "flexShrink": 1,
-                        "width": "100%",
-                      },
-                    ]
+                    {
+                      "height": 24,
+                      "width": 24,
+                    }
+                  }
+                  width={24}
+                />
+                <Text
+                  accessibilityRole="text"
+                  style={
+                    {
+                      "color": "#121314",
+                      "fontFamily": "CentraNo1-Book",
+                      "fontSize": 16,
+                      "fontWeight": "400",
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                      "marginLeft": 10,
+                      "marginRight": 40,
+                    }
                   }
                 >
-                  <SvgMock
-                    color="#ca3542"
-                    fill="currentColor"
-                    height={24}
-                    name="EyeSlash"
-                    style={
-                      {
-                        "height": 24,
-                        "width": 24,
-                      }
-                    }
-                    width={24}
-                  />
+                  Make sure nobody is looking at your screen. 
                   <Text
                     accessibilityRole="text"
                     style={
                       {
                         "color": "#121314",
-                        "fontFamily": "CentraNo1-Book",
+                        "fontFamily": "CentraNo1-Bold",
                         "fontSize": 16,
-                        "fontWeight": "400",
+                        "fontWeight": "600",
                         "letterSpacing": 0,
                         "lineHeight": 24,
-                        "marginLeft": 10,
-                        "marginRight": 40,
                       }
                     }
                   >
-                    Make sure nobody is looking at your screen. 
-                    <Text
-                      accessibilityRole="text"
-                      style={
-                        {
-                          "color": "#121314",
-                          "fontFamily": "CentraNo1-Bold",
-                          "fontSize": 16,
-                          "fontWeight": "600",
-                          "letterSpacing": 0,
-                          "lineHeight": 24,
-                        }
-                      }
-                    >
-                      MetaMask Support will never request this.
-                    </Text>
+                    MetaMask Support will never request this.
                   </Text>
-                </View>
+                </Text>
               </View>
             </View>
-            <View
+          </View>
+          <View
+            style={
+              [
+                {
+                  "padding": 20,
+                },
+                {
+                  "flex": 1,
+                },
+              ]
+            }
+          >
+            <Text
+              accessibilityRole="text"
               style={
-                [
-                  {
-                    "padding": 20,
-                  },
-                  {
-                    "flex": 1,
-                  },
-                ]
+                {
+                  "color": "#121314",
+                  "fontFamily": "Geist Medium",
+                  "fontSize": 16,
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                  "marginBottom": 4,
+                }
               }
             >
-              <Text
-                accessibilityRole="text"
-                style={
-                  {
-                    "color": "#121314",
-                    "fontFamily": "Geist Medium",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                    "marginBottom": 4,
-                  }
+              Enter password to continue
+            </Text>
+            <TextInput
+              keyboardAppearance="light"
+              onChangeText={[Function]}
+              onSubmitEditing={[Function]}
+              placeholder="Password"
+              placeholderTextColor="#b7bbc8"
+              secureTextEntry={true}
+              style={
+                {
+                  "borderColor": "#b7bbc8",
+                  "borderRadius": 5,
+                  "borderWidth": 2,
+                  "color": "#121314",
+                  "padding": 10,
                 }
-              >
-                Enter password to continue
-              </Text>
-              <TextInput
-                keyboardAppearance="light"
-                onChangeText={[Function]}
-                onSubmitEditing={[Function]}
-                placeholder="Password"
-                placeholderTextColor="#b7bbc8"
-                secureTextEntry={true}
-                style={
-                  {
-                    "borderColor": "#b7bbc8",
-                    "borderRadius": 5,
-                    "borderWidth": 2,
-                    "color": "#121314",
-                    "padding": 10,
-                  }
+              }
+              testID="private-credential-password-text-input"
+            />
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#ca3542",
+                  "fontFamily": "CentraNo1-Book",
+                  "fontSize": 16,
+                  "fontWeight": "400",
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                  "marginTop": 10,
                 }
-                testID="private-credential-password-text-input"
-              />
-              <Text
-                accessibilityRole="text"
-                style={
-                  {
-                    "color": "#ca3542",
-                    "fontFamily": "CentraNo1-Book",
-                    "fontSize": 16,
-                    "fontWeight": "400",
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                    "marginTop": 10,
-                  }
-                }
-                testID="password-warning"
-              />
-            </View>
+              }
+              testID="password-warning"
+            />
           </View>
-        </RCTScrollView>
+        </View>
         <View
           style={
             [
@@ -805,7 +801,7 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
       automaticallyAdjustContentInsets={false}
       contentContainerStyle={
         {
-          "flex": 1,
+          "flexGrow": 1,
         }
       }
       contentInset={
@@ -852,7 +848,7 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
       viewIsInsideTabBar={false}
     >
       <View>
-        <RCTScrollView
+        <View
           accessibilityState={
             {
               "busy": undefined,
@@ -872,7 +868,104 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
         >
-          <View>
+          <View
+            style={
+              [
+                {
+                  "padding": 20,
+                },
+                {
+                  "color": "#121314",
+                  "fontFamily": "CentraNo1-Book",
+                  "fontWeight": "400",
+                },
+              ]
+            }
+          >
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#121314",
+                  "fontFamily": "CentraNo1-Book",
+                  "fontSize": 16,
+                  "fontWeight": "400",
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                }
+              }
+            >
+              Your
+               
+              <Text
+                accessibilityRole="text"
+                onPress={[Function]}
+                style={
+                  {
+                    "color": "#4459ff",
+                    "fontFamily": "Geist Regular",
+                    "fontSize": 16,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  }
+                }
+              >
+                Secret Recovery Phrase
+              </Text>
+               
+              gives
+               
+              <Text
+                accessibilityRole="text"
+                style={
+                  {
+                    "color": "#121314",
+                    "fontFamily": "Geist Regular",
+                    "fontSize": 16,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  }
+                }
+              >
+                full access to your wallet, funds and accounts.
+
+
+              </Text>
+              MetaMask is a
+               
+              <Text
+                accessibilityRole="text"
+                onPress={[Function]}
+                style={
+                  {
+                    "color": "#4459ff",
+                    "fontFamily": "Geist Regular",
+                    "fontSize": 16,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  }
+                }
+              >
+                non-custodial wallet.
+                 
+              </Text>
+              That means,
+               
+              <Text
+                accessibilityRole="text"
+                style={
+                  {
+                    "color": "#121314",
+                    "fontFamily": "Geist Regular",
+                    "fontSize": 16,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                  }
+                }
+              >
+                you are the owner of your Secret Recovery Phrase.
+              </Text>
+            </Text>
             <View
               style={
                 [
@@ -880,237 +973,138 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
                     "padding": 20,
                   },
                   {
-                    "color": "#121314",
-                    "fontFamily": "CentraNo1-Book",
-                    "fontWeight": "400",
+                    "backgroundColor": "#ca35421a",
+                    "borderColor": "#ca3542",
+                    "borderRadius": 8,
+                    "borderWidth": 1,
+                    "marginTop": 16,
+                    "padding": 20,
                   },
                 ]
               }
             >
-              <Text
-                accessibilityRole="text"
-                style={
-                  {
-                    "color": "#121314",
-                    "fontFamily": "CentraNo1-Book",
-                    "fontSize": 16,
-                    "fontWeight": "400",
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                  }
-                }
-              >
-                Your
-                 
-                <Text
-                  accessibilityRole="text"
-                  onPress={[Function]}
-                  style={
-                    {
-                      "color": "#4459ff",
-                      "fontFamily": "Geist Regular",
-                      "fontSize": 16,
-                      "letterSpacing": 0,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  Secret Recovery Phrase
-                </Text>
-                 
-                gives
-                 
-                <Text
-                  accessibilityRole="text"
-                  style={
-                    {
-                      "color": "#121314",
-                      "fontFamily": "Geist Regular",
-                      "fontSize": 16,
-                      "letterSpacing": 0,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  full access to your wallet, funds and accounts.
-
-
-                </Text>
-                MetaMask is a
-                 
-                <Text
-                  accessibilityRole="text"
-                  onPress={[Function]}
-                  style={
-                    {
-                      "color": "#4459ff",
-                      "fontFamily": "Geist Regular",
-                      "fontSize": 16,
-                      "letterSpacing": 0,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  non-custodial wallet.
-                   
-                </Text>
-                That means,
-                 
-                <Text
-                  accessibilityRole="text"
-                  style={
-                    {
-                      "color": "#121314",
-                      "fontFamily": "Geist Regular",
-                      "fontSize": 16,
-                      "letterSpacing": 0,
-                      "lineHeight": 24,
-                    }
-                  }
-                >
-                  you are the owner of your Secret Recovery Phrase.
-                </Text>
-              </Text>
               <View
                 style={
                   [
                     {
-                      "padding": 20,
-                    },
-                    {
-                      "backgroundColor": "#ca35421a",
-                      "borderColor": "#ca3542",
-                      "borderRadius": 8,
-                      "borderWidth": 1,
-                      "marginTop": 16,
-                      "padding": 20,
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "flexShrink": 1,
+                      "width": "100%",
                     },
                   ]
                 }
               >
-                <View
+                <SvgMock
+                  color="#ca3542"
+                  fill="currentColor"
+                  height={24}
+                  name="EyeSlash"
                   style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "flexDirection": "row",
-                        "flexShrink": 1,
-                        "width": "100%",
-                      },
-                    ]
+                    {
+                      "height": 24,
+                      "width": 24,
+                    }
+                  }
+                  width={24}
+                />
+                <Text
+                  accessibilityRole="text"
+                  style={
+                    {
+                      "color": "#121314",
+                      "fontFamily": "CentraNo1-Book",
+                      "fontSize": 16,
+                      "fontWeight": "400",
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                      "marginLeft": 10,
+                      "marginRight": 40,
+                    }
                   }
                 >
-                  <SvgMock
-                    color="#ca3542"
-                    fill="currentColor"
-                    height={24}
-                    name="EyeSlash"
-                    style={
-                      {
-                        "height": 24,
-                        "width": 24,
-                      }
-                    }
-                    width={24}
-                  />
+                  Make sure nobody is looking at your screen. 
                   <Text
                     accessibilityRole="text"
                     style={
                       {
                         "color": "#121314",
-                        "fontFamily": "CentraNo1-Book",
+                        "fontFamily": "CentraNo1-Bold",
                         "fontSize": 16,
-                        "fontWeight": "400",
+                        "fontWeight": "600",
                         "letterSpacing": 0,
                         "lineHeight": 24,
-                        "marginLeft": 10,
-                        "marginRight": 40,
                       }
                     }
                   >
-                    Make sure nobody is looking at your screen. 
-                    <Text
-                      accessibilityRole="text"
-                      style={
-                        {
-                          "color": "#121314",
-                          "fontFamily": "CentraNo1-Bold",
-                          "fontSize": 16,
-                          "fontWeight": "600",
-                          "letterSpacing": 0,
-                          "lineHeight": 24,
-                        }
-                      }
-                    >
-                      MetaMask Support will never request this.
-                    </Text>
+                    MetaMask Support will never request this.
                   </Text>
-                </View>
+                </Text>
               </View>
             </View>
-            <View
+          </View>
+          <View
+            style={
+              [
+                {
+                  "padding": 20,
+                },
+                {
+                  "flex": 1,
+                },
+              ]
+            }
+          >
+            <Text
+              accessibilityRole="text"
               style={
-                [
-                  {
-                    "padding": 20,
-                  },
-                  {
-                    "flex": 1,
-                  },
-                ]
+                {
+                  "color": "#121314",
+                  "fontFamily": "Geist Medium",
+                  "fontSize": 16,
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                  "marginBottom": 4,
+                }
               }
             >
-              <Text
-                accessibilityRole="text"
-                style={
-                  {
-                    "color": "#121314",
-                    "fontFamily": "Geist Medium",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                    "marginBottom": 4,
-                  }
+              Enter password to continue
+            </Text>
+            <TextInput
+              keyboardAppearance="light"
+              onChangeText={[Function]}
+              onSubmitEditing={[Function]}
+              placeholder="Password"
+              placeholderTextColor="#b7bbc8"
+              secureTextEntry={true}
+              style={
+                {
+                  "borderColor": "#b7bbc8",
+                  "borderRadius": 5,
+                  "borderWidth": 2,
+                  "color": "#121314",
+                  "padding": 10,
                 }
-              >
-                Enter password to continue
-              </Text>
-              <TextInput
-                keyboardAppearance="light"
-                onChangeText={[Function]}
-                onSubmitEditing={[Function]}
-                placeholder="Password"
-                placeholderTextColor="#b7bbc8"
-                secureTextEntry={true}
-                style={
-                  {
-                    "borderColor": "#b7bbc8",
-                    "borderRadius": 5,
-                    "borderWidth": 2,
-                    "color": "#121314",
-                    "padding": 10,
-                  }
+              }
+              testID="private-credential-password-text-input"
+            />
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#ca3542",
+                  "fontFamily": "CentraNo1-Book",
+                  "fontSize": 16,
+                  "fontWeight": "400",
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                  "marginTop": 10,
                 }
-                testID="private-credential-password-text-input"
-              />
-              <Text
-                accessibilityRole="text"
-                style={
-                  {
-                    "color": "#ca3542",
-                    "fontFamily": "CentraNo1-Book",
-                    "fontSize": 16,
-                    "fontWeight": "400",
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                    "marginTop": 10,
-                  }
-                }
-                testID="password-warning"
-              />
-            </View>
+              }
+              testID="password-warning"
+            />
           </View>
-        </RCTScrollView>
+        </View>
         <View
           style={
             [
@@ -1196,7 +1190,7 @@ exports[`RevealPrivateCredential renders reveal private key correctly 1`] = `
       automaticallyAdjustContentInsets={false}
       contentContainerStyle={
         {
-          "flex": 1,
+          "flexGrow": 1,
         }
       }
       contentInset={
@@ -1243,7 +1237,7 @@ exports[`RevealPrivateCredential renders reveal private key correctly 1`] = `
       viewIsInsideTabBar={false}
     >
       <View>
-        <RCTScrollView
+        <View
           accessibilityState={
             {
               "busy": undefined,
@@ -1263,43 +1257,235 @@ exports[`RevealPrivateCredential renders reveal private key correctly 1`] = `
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
         >
-          <View>
+          <View
+            style={
+              [
+                {
+                  "padding": 20,
+                },
+                {
+                  "color": "#121314",
+                  "fontFamily": "CentraNo1-Book",
+                  "fontWeight": "400",
+                },
+              ]
+            }
+          >
             <View
+              alignItems="center"
+              flexDirection="column"
               style={
                 [
                   {
-                    "padding": 20,
+                    "alignItems": "center",
+                    "flexDirection": "column",
                   },
-                  {
-                    "color": "#121314",
-                    "fontFamily": "CentraNo1-Book",
-                    "fontWeight": "400",
-                  },
+                  undefined,
                 ]
               }
             >
               <View
-                alignItems="center"
-                flexDirection="column"
                 style={
-                  [
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "column",
-                    },
-                    undefined,
-                  ]
+                  {
+                    "backgroundColor": "#ffffff",
+                    "borderRadius": 8,
+                    "height": 32,
+                    "marginBottom": 8,
+                    "overflow": "hidden",
+                    "width": 32,
+                  }
                 }
               >
                 <View
                   style={
+                    [
+                      {
+                        "overflow": "hidden",
+                      },
+                      {
+                        "backgroundColor": "#F3E300",
+                        "borderRadius": 16,
+                        "height": 32,
+                        "width": 32,
+                      },
+                      {
+                        "borderRadius": 8,
+                      },
+                    ]
+                  }
+                >
+                  <RNSVGSvgView
+                    bbHeight={32}
+                    bbWidth={32}
+                    focusable={false}
+                    height={32}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "transparent",
+                          "borderWidth": 0,
+                        },
+                        {
+                          "flex": 0,
+                          "height": 32,
+                          "width": 32,
+                        },
+                      ]
+                    }
+                    width={32}
+                  >
+                    <RNSVGGroup
+                      fill={
+                        {
+                          "payload": 4278190080,
+                          "type": 0,
+                        }
+                      }
+                    >
+                      <RNSVGRect
+                        fill={
+                          {
+                            "payload": 4294033154,
+                            "type": 0,
+                          }
+                        }
+                        height={32}
+                        matrix={
+                          [
+                            0.8902128046111263,
+                            0.455544907233516,
+                            -0.455544907233516,
+                            0.8902128046111263,
+                            14.528038776231607,
+                            -10.727483724821674,
+                          ]
+                        }
+                        propList={
+                          [
+                            "fill",
+                          ]
+                        }
+                        width={32}
+                        x={0}
+                        y={0}
+                      />
+                      <RNSVGRect
+                        fill={
+                          {
+                            "payload": 4278285708,
+                            "type": 0,
+                          }
+                        }
+                        height={32}
+                        matrix={
+                          [
+                            -0.6768759696826608,
+                            -0.7360970871197343,
+                            0.7360970871197343,
+                            -0.6768759696826608,
+                            12.447006179185877,
+                            55.31217516436145,
+                          ]
+                        }
+                        propList={
+                          [
+                            "fill",
+                          ]
+                        }
+                        width={32}
+                        x={0}
+                        y={0}
+                      />
+                      <RNSVGRect
+                        fill={
+                          {
+                            "payload": 4291236915,
+                            "type": 0,
+                          }
+                        }
+                        height={32}
+                        matrix={
+                          [
+                            0.46484204572461923,
+                            0.885393625754416,
+                            -0.885393625754416,
+                            0.46484204572461923,
+                            40.698516121381054,
+                            -18.19641979556168,
+                          ]
+                        }
+                        propList={
+                          [
+                            "fill",
+                          ]
+                        }
+                        width={32}
+                        x={0}
+                        y={0}
+                      />
+                    </RNSVGGroup>
+                  </RNSVGSvgView>
+                </View>
+              </View>
+              <Text
+                accessibilityRole="text"
+                style={
+                  {
+                    "color": "#121314",
+                    "fontFamily": "Geist Medium",
+                    "fontSize": 18,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                    "marginBottom": 8,
+                  }
+                }
+              >
+                Test Account
+              </Text>
+              <View
+                alignItems="center"
+                flexDirection="row"
+                justifyContent="center"
+                style={
+                  [
                     {
-                      "backgroundColor": "#ffffff",
-                      "borderRadius": 8,
-                      "height": 32,
-                      "marginBottom": 8,
-                      "overflow": "hidden",
-                      "width": 32,
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "justifyContent": "center",
+                    },
+                    {
+                      "backgroundColor": "#4459ff1a",
+                      "borderRadius": 999,
+                      "color": "#4459ff",
+                      "gap": 4,
+                      "marginBottom": 16,
+                      "paddingBottom": 4,
+                      "paddingLeft": 12,
+                      "paddingRight": 12,
+                      "paddingTop": 4,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  accessibilityRole="text"
+                  style={
+                    {
+                      "color": "#4459ff",
+                      "fontFamily": "Geist Medium",
+                      "fontSize": 18,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                    }
+                  }
+                >
+                  0x12345...67890
+                </Text>
+                <View
+                  style={
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
                     }
                   }
                 >
@@ -1307,133 +1493,126 @@ exports[`RevealPrivateCredential renders reveal private key correctly 1`] = `
                     style={
                       [
                         {
-                          "overflow": "hidden",
+                          "transform": [
+                            {
+                              "scale": 1,
+                            },
+                          ],
                         },
                         {
-                          "backgroundColor": "#F3E300",
-                          "borderRadius": 16,
-                          "height": 32,
-                          "width": 32,
-                        },
-                        {
-                          "borderRadius": 8,
+                          "alignItems": "center",
+                          "justifyContent": "center",
                         },
                       ]
                     }
                   >
-                    <RNSVGSvgView
-                      bbHeight={32}
-                      bbWidth={32}
-                      focusable={false}
-                      height={32}
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": false,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
                       style={
                         [
                           {
+                            "alignItems": "center",
                             "backgroundColor": "transparent",
-                            "borderWidth": 0,
+                            "borderRadius": 2,
+                            "height": 40,
+                            "justifyContent": "center",
+                            "opacity": 1,
+                            "width": 40,
                           },
-                          {
-                            "flex": 0,
-                            "height": 32,
-                            "width": 32,
-                          },
+                          undefined,
                         ]
                       }
-                      width={32}
+                      testID="wallet-account-copy-button"
                     >
-                      <RNSVGGroup
-                        fill={
-                          {
-                            "payload": 4278190080,
-                            "type": 0,
-                          }
+                      <SvgMock
+                        fill="currentColor"
+                        name="Copy"
+                        style={
+                          [
+                            {
+                              "color": "#4459ff",
+                              "height": 24,
+                              "width": 24,
+                            },
+                            undefined,
+                          ]
                         }
-                      >
-                        <RNSVGRect
-                          fill={
-                            {
-                              "payload": 4294033154,
-                              "type": 0,
-                            }
-                          }
-                          height={32}
-                          matrix={
-                            [
-                              0.8902128046111263,
-                              0.455544907233516,
-                              -0.455544907233516,
-                              0.8902128046111263,
-                              14.528038776231607,
-                              -10.727483724821674,
-                            ]
-                          }
-                          propList={
-                            [
-                              "fill",
-                            ]
-                          }
-                          width={32}
-                          x={0}
-                          y={0}
-                        />
-                        <RNSVGRect
-                          fill={
-                            {
-                              "payload": 4278285708,
-                              "type": 0,
-                            }
-                          }
-                          height={32}
-                          matrix={
-                            [
-                              -0.6768759696826608,
-                              -0.7360970871197343,
-                              0.7360970871197343,
-                              -0.6768759696826608,
-                              12.447006179185877,
-                              55.31217516436145,
-                            ]
-                          }
-                          propList={
-                            [
-                              "fill",
-                            ]
-                          }
-                          width={32}
-                          x={0}
-                          y={0}
-                        />
-                        <RNSVGRect
-                          fill={
-                            {
-                              "payload": 4291236915,
-                              "type": 0,
-                            }
-                          }
-                          height={32}
-                          matrix={
-                            [
-                              0.46484204572461923,
-                              0.885393625754416,
-                              -0.885393625754416,
-                              0.46484204572461923,
-                              40.698516121381054,
-                              -18.19641979556168,
-                            ]
-                          }
-                          propList={
-                            [
-                              "fill",
-                            ]
-                          }
-                          width={32}
-                          x={0}
-                          y={0}
-                        />
-                      </RNSVGGroup>
-                    </RNSVGSvgView>
+                      />
+                    </View>
                   </View>
                 </View>
+              </View>
+            </View>
+            <View
+              style={
+                {
+                  "backgroundColor": "#ca35421a",
+                  "borderColor": "#ca3542",
+                  "borderLeftWidth": 4,
+                  "borderRadius": 4,
+                  "flexDirection": "row",
+                  "padding": 12,
+                  "paddingLeft": 8,
+                }
+              }
+              testID="banneralert"
+            >
+              <View
+                style={
+                  {
+                    "marginRight": 8,
+                  }
+                }
+              >
+                <SvgMock
+                  color="#ca3542"
+                  fill="currentColor"
+                  height={24}
+                  name="Danger"
+                  style={
+                    {
+                      "height": 24,
+                      "width": 24,
+                    }
+                  }
+                  width={24}
+                />
+              </View>
+              <View
+                style={
+                  {
+                    "flex": 1,
+                  }
+                }
+              >
                 <Text
                   accessibilityRole="text"
                   style={
@@ -1443,277 +1622,90 @@ exports[`RevealPrivateCredential renders reveal private key correctly 1`] = `
                       "fontSize": 18,
                       "letterSpacing": 0,
                       "lineHeight": 24,
-                      "marginBottom": 8,
                     }
                   }
                 >
-                  Test Account
+                  Never disclose this key.
                 </Text>
-                <View
-                  alignItems="center"
-                  flexDirection="row"
-                  justifyContent="center"
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "flexDirection": "row",
-                        "justifyContent": "center",
-                      },
-                      {
-                        "backgroundColor": "#4459ff1a",
-                        "borderRadius": 999,
-                        "color": "#4459ff",
-                        "gap": 4,
-                        "marginBottom": 16,
-                        "paddingBottom": 4,
-                        "paddingLeft": 12,
-                        "paddingRight": 12,
-                        "paddingTop": 4,
-                      },
-                    ]
-                  }
-                >
-                  <Text
-                    accessibilityRole="text"
-                    style={
-                      {
-                        "color": "#4459ff",
-                        "fontFamily": "Geist Medium",
-                        "fontSize": 18,
-                        "letterSpacing": 0,
-                        "lineHeight": 24,
-                      }
-                    }
-                  >
-                    0x12345...67890
-                  </Text>
-                  <View
-                    style={
-                      {
-                        "alignItems": "center",
-                        "flexDirection": "row",
-                      }
-                    }
-                  >
-                    <View
-                      style={
-                        [
-                          {
-                            "transform": [
-                              {
-                                "scale": 1,
-                              },
-                            ],
-                          },
-                          {
-                            "alignItems": "center",
-                            "justifyContent": "center",
-                          },
-                        ]
-                      }
-                    >
-                      <View
-                        accessibilityState={
-                          {
-                            "busy": undefined,
-                            "checked": undefined,
-                            "disabled": false,
-                            "expanded": undefined,
-                            "selected": undefined,
-                          }
-                        }
-                        accessibilityValue={
-                          {
-                            "max": undefined,
-                            "min": undefined,
-                            "now": undefined,
-                            "text": undefined,
-                          }
-                        }
-                        accessible={true}
-                        collapsable={false}
-                        focusable={true}
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onResponderGrant={[Function]}
-                        onResponderMove={[Function]}
-                        onResponderRelease={[Function]}
-                        onResponderTerminate={[Function]}
-                        onResponderTerminationRequest={[Function]}
-                        onStartShouldSetResponder={[Function]}
-                        style={
-                          [
-                            {
-                              "alignItems": "center",
-                              "backgroundColor": "transparent",
-                              "borderRadius": 2,
-                              "height": 40,
-                              "justifyContent": "center",
-                              "opacity": 1,
-                              "width": 40,
-                            },
-                            undefined,
-                          ]
-                        }
-                        testID="wallet-account-copy-button"
-                      >
-                        <SvgMock
-                          fill="currentColor"
-                          name="Copy"
-                          style={
-                            [
-                              {
-                                "color": "#4459ff",
-                                "height": 24,
-                                "width": 24,
-                              },
-                              undefined,
-                            ]
-                          }
-                        />
-                      </View>
-                    </View>
-                  </View>
-                </View>
-              </View>
-              <View
-                style={
-                  {
-                    "backgroundColor": "#ca35421a",
-                    "borderColor": "#ca3542",
-                    "borderLeftWidth": 4,
-                    "borderRadius": 4,
-                    "flexDirection": "row",
-                    "padding": 12,
-                    "paddingLeft": 8,
-                  }
-                }
-                testID="banneralert"
-              >
-                <View
+                <Text
+                  accessibilityRole="text"
                   style={
                     {
-                      "marginRight": 8,
+                      "color": "#121314",
+                      "fontFamily": "Geist Regular",
+                      "fontSize": 16,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
                     }
                   }
                 >
-                  <SvgMock
-                    color="#ca3542"
-                    fill="currentColor"
-                    height={24}
-                    name="Danger"
-                    style={
-                      {
-                        "height": 24,
-                        "width": 24,
-                      }
-                    }
-                    width={24}
-                  />
-                </View>
-                <View
-                  style={
-                    {
-                      "flex": 1,
-                    }
-                  }
-                >
-                  <Text
-                    accessibilityRole="text"
-                    style={
-                      {
-                        "color": "#121314",
-                        "fontFamily": "Geist Medium",
-                        "fontSize": 18,
-                        "letterSpacing": 0,
-                        "lineHeight": 24,
-                      }
-                    }
-                  >
-                    Never disclose this key.
-                  </Text>
-                  <Text
-                    accessibilityRole="text"
-                    style={
-                      {
-                        "color": "#121314",
-                        "fontFamily": "Geist Regular",
-                        "fontSize": 16,
-                        "letterSpacing": 0,
-                        "lineHeight": 24,
-                      }
-                    }
-                  >
-                    Anyone with your private key can steal any assets held in your account.
-                  </Text>
-                </View>
+                  Anyone with your private key can steal any assets held in your account.
+                </Text>
               </View>
-            </View>
-            <View
-              style={
-                [
-                  {
-                    "padding": 20,
-                  },
-                  {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              <Text
-                accessibilityRole="text"
-                style={
-                  {
-                    "color": "#121314",
-                    "fontFamily": "Geist Medium",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                    "marginBottom": 4,
-                  }
-                }
-              >
-                Enter password to continue
-              </Text>
-              <TextInput
-                keyboardAppearance="light"
-                onChangeText={[Function]}
-                onSubmitEditing={[Function]}
-                placeholder="Password"
-                placeholderTextColor="#b7bbc8"
-                secureTextEntry={true}
-                style={
-                  {
-                    "borderColor": "#b7bbc8",
-                    "borderRadius": 5,
-                    "borderWidth": 2,
-                    "color": "#121314",
-                    "padding": 10,
-                  }
-                }
-                testID="private-credential-password-text-input"
-              />
-              <Text
-                accessibilityRole="text"
-                style={
-                  {
-                    "color": "#ca3542",
-                    "fontFamily": "CentraNo1-Book",
-                    "fontSize": 16,
-                    "fontWeight": "400",
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                    "marginTop": 10,
-                  }
-                }
-                testID="password-warning"
-              />
             </View>
           </View>
-        </RCTScrollView>
+          <View
+            style={
+              [
+                {
+                  "padding": 20,
+                },
+                {
+                  "flex": 1,
+                },
+              ]
+            }
+          >
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#121314",
+                  "fontFamily": "Geist Medium",
+                  "fontSize": 16,
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                  "marginBottom": 4,
+                }
+              }
+            >
+              Enter password to continue
+            </Text>
+            <TextInput
+              keyboardAppearance="light"
+              onChangeText={[Function]}
+              onSubmitEditing={[Function]}
+              placeholder="Password"
+              placeholderTextColor="#b7bbc8"
+              secureTextEntry={true}
+              style={
+                {
+                  "borderColor": "#b7bbc8",
+                  "borderRadius": 5,
+                  "borderWidth": 2,
+                  "color": "#121314",
+                  "padding": 10,
+                }
+              }
+              testID="private-credential-password-text-input"
+            />
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#ca3542",
+                  "fontFamily": "CentraNo1-Book",
+                  "fontSize": 16,
+                  "fontWeight": "400",
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                  "marginTop": 10,
+                }
+              }
+              testID="password-warning"
+            />
+          </View>
+        </View>
         <View
           style={
             [
@@ -1799,7 +1791,7 @@ exports[`RevealPrivateCredential renders with a custom selectedAddress 1`] = `
       automaticallyAdjustContentInsets={false}
       contentContainerStyle={
         {
-          "flex": 1,
+          "flexGrow": 1,
         }
       }
       contentInset={
@@ -1846,7 +1838,7 @@ exports[`RevealPrivateCredential renders with a custom selectedAddress 1`] = `
       viewIsInsideTabBar={false}
     >
       <View>
-        <RCTScrollView
+        <View
           accessibilityState={
             {
               "busy": undefined,
@@ -1866,43 +1858,235 @@ exports[`RevealPrivateCredential renders with a custom selectedAddress 1`] = `
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
         >
-          <View>
+          <View
+            style={
+              [
+                {
+                  "padding": 20,
+                },
+                {
+                  "color": "#121314",
+                  "fontFamily": "CentraNo1-Book",
+                  "fontWeight": "400",
+                },
+              ]
+            }
+          >
             <View
+              alignItems="center"
+              flexDirection="column"
               style={
                 [
                   {
-                    "padding": 20,
+                    "alignItems": "center",
+                    "flexDirection": "column",
                   },
-                  {
-                    "color": "#121314",
-                    "fontFamily": "CentraNo1-Book",
-                    "fontWeight": "400",
-                  },
+                  undefined,
                 ]
               }
             >
               <View
-                alignItems="center"
-                flexDirection="column"
                 style={
-                  [
-                    {
-                      "alignItems": "center",
-                      "flexDirection": "column",
-                    },
-                    undefined,
-                  ]
+                  {
+                    "backgroundColor": "#ffffff",
+                    "borderRadius": 8,
+                    "height": 32,
+                    "marginBottom": 8,
+                    "overflow": "hidden",
+                    "width": 32,
+                  }
                 }
               >
                 <View
                   style={
+                    [
+                      {
+                        "overflow": "hidden",
+                      },
+                      {
+                        "backgroundColor": "#F3E300",
+                        "borderRadius": 16,
+                        "height": 32,
+                        "width": 32,
+                      },
+                      {
+                        "borderRadius": 8,
+                      },
+                    ]
+                  }
+                >
+                  <RNSVGSvgView
+                    bbHeight={32}
+                    bbWidth={32}
+                    focusable={false}
+                    height={32}
+                    style={
+                      [
+                        {
+                          "backgroundColor": "transparent",
+                          "borderWidth": 0,
+                        },
+                        {
+                          "flex": 0,
+                          "height": 32,
+                          "width": 32,
+                        },
+                      ]
+                    }
+                    width={32}
+                  >
+                    <RNSVGGroup
+                      fill={
+                        {
+                          "payload": 4278190080,
+                          "type": 0,
+                        }
+                      }
+                    >
+                      <RNSVGRect
+                        fill={
+                          {
+                            "payload": 4294033154,
+                            "type": 0,
+                          }
+                        }
+                        height={32}
+                        matrix={
+                          [
+                            0.8902128046111263,
+                            0.455544907233516,
+                            -0.455544907233516,
+                            0.8902128046111263,
+                            14.528038776231607,
+                            -10.727483724821674,
+                          ]
+                        }
+                        propList={
+                          [
+                            "fill",
+                          ]
+                        }
+                        width={32}
+                        x={0}
+                        y={0}
+                      />
+                      <RNSVGRect
+                        fill={
+                          {
+                            "payload": 4278285708,
+                            "type": 0,
+                          }
+                        }
+                        height={32}
+                        matrix={
+                          [
+                            -0.6768759696826608,
+                            -0.7360970871197343,
+                            0.7360970871197343,
+                            -0.6768759696826608,
+                            12.447006179185877,
+                            55.31217516436145,
+                          ]
+                        }
+                        propList={
+                          [
+                            "fill",
+                          ]
+                        }
+                        width={32}
+                        x={0}
+                        y={0}
+                      />
+                      <RNSVGRect
+                        fill={
+                          {
+                            "payload": 4291236915,
+                            "type": 0,
+                          }
+                        }
+                        height={32}
+                        matrix={
+                          [
+                            0.46484204572461923,
+                            0.885393625754416,
+                            -0.885393625754416,
+                            0.46484204572461923,
+                            40.698516121381054,
+                            -18.19641979556168,
+                          ]
+                        }
+                        propList={
+                          [
+                            "fill",
+                          ]
+                        }
+                        width={32}
+                        x={0}
+                        y={0}
+                      />
+                    </RNSVGGroup>
+                  </RNSVGSvgView>
+                </View>
+              </View>
+              <Text
+                accessibilityRole="text"
+                style={
+                  {
+                    "color": "#121314",
+                    "fontFamily": "Geist Medium",
+                    "fontSize": 18,
+                    "letterSpacing": 0,
+                    "lineHeight": 24,
+                    "marginBottom": 8,
+                  }
+                }
+              >
+                Test Account
+              </Text>
+              <View
+                alignItems="center"
+                flexDirection="row"
+                justifyContent="center"
+                style={
+                  [
                     {
-                      "backgroundColor": "#ffffff",
-                      "borderRadius": 8,
-                      "height": 32,
-                      "marginBottom": 8,
-                      "overflow": "hidden",
-                      "width": 32,
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "justifyContent": "center",
+                    },
+                    {
+                      "backgroundColor": "#4459ff1a",
+                      "borderRadius": 999,
+                      "color": "#4459ff",
+                      "gap": 4,
+                      "marginBottom": 16,
+                      "paddingBottom": 4,
+                      "paddingLeft": 12,
+                      "paddingRight": 12,
+                      "paddingTop": 4,
+                    },
+                  ]
+                }
+              >
+                <Text
+                  accessibilityRole="text"
+                  style={
+                    {
+                      "color": "#4459ff",
+                      "fontFamily": "Geist Medium",
+                      "fontSize": 18,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                    }
+                  }
+                >
+                  0x12345...67890
+                </Text>
+                <View
+                  style={
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
                     }
                   }
                 >
@@ -1910,133 +2094,126 @@ exports[`RevealPrivateCredential renders with a custom selectedAddress 1`] = `
                     style={
                       [
                         {
-                          "overflow": "hidden",
+                          "transform": [
+                            {
+                              "scale": 1,
+                            },
+                          ],
                         },
                         {
-                          "backgroundColor": "#F3E300",
-                          "borderRadius": 16,
-                          "height": 32,
-                          "width": 32,
-                        },
-                        {
-                          "borderRadius": 8,
+                          "alignItems": "center",
+                          "justifyContent": "center",
                         },
                       ]
                     }
                   >
-                    <RNSVGSvgView
-                      bbHeight={32}
-                      bbWidth={32}
-                      focusable={false}
-                      height={32}
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": false,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
                       style={
                         [
                           {
+                            "alignItems": "center",
                             "backgroundColor": "transparent",
-                            "borderWidth": 0,
+                            "borderRadius": 2,
+                            "height": 40,
+                            "justifyContent": "center",
+                            "opacity": 1,
+                            "width": 40,
                           },
-                          {
-                            "flex": 0,
-                            "height": 32,
-                            "width": 32,
-                          },
+                          undefined,
                         ]
                       }
-                      width={32}
+                      testID="wallet-account-copy-button"
                     >
-                      <RNSVGGroup
-                        fill={
-                          {
-                            "payload": 4278190080,
-                            "type": 0,
-                          }
+                      <SvgMock
+                        fill="currentColor"
+                        name="Copy"
+                        style={
+                          [
+                            {
+                              "color": "#4459ff",
+                              "height": 24,
+                              "width": 24,
+                            },
+                            undefined,
+                          ]
                         }
-                      >
-                        <RNSVGRect
-                          fill={
-                            {
-                              "payload": 4294033154,
-                              "type": 0,
-                            }
-                          }
-                          height={32}
-                          matrix={
-                            [
-                              0.8902128046111263,
-                              0.455544907233516,
-                              -0.455544907233516,
-                              0.8902128046111263,
-                              14.528038776231607,
-                              -10.727483724821674,
-                            ]
-                          }
-                          propList={
-                            [
-                              "fill",
-                            ]
-                          }
-                          width={32}
-                          x={0}
-                          y={0}
-                        />
-                        <RNSVGRect
-                          fill={
-                            {
-                              "payload": 4278285708,
-                              "type": 0,
-                            }
-                          }
-                          height={32}
-                          matrix={
-                            [
-                              -0.6768759696826608,
-                              -0.7360970871197343,
-                              0.7360970871197343,
-                              -0.6768759696826608,
-                              12.447006179185877,
-                              55.31217516436145,
-                            ]
-                          }
-                          propList={
-                            [
-                              "fill",
-                            ]
-                          }
-                          width={32}
-                          x={0}
-                          y={0}
-                        />
-                        <RNSVGRect
-                          fill={
-                            {
-                              "payload": 4291236915,
-                              "type": 0,
-                            }
-                          }
-                          height={32}
-                          matrix={
-                            [
-                              0.46484204572461923,
-                              0.885393625754416,
-                              -0.885393625754416,
-                              0.46484204572461923,
-                              40.698516121381054,
-                              -18.19641979556168,
-                            ]
-                          }
-                          propList={
-                            [
-                              "fill",
-                            ]
-                          }
-                          width={32}
-                          x={0}
-                          y={0}
-                        />
-                      </RNSVGGroup>
-                    </RNSVGSvgView>
+                      />
+                    </View>
                   </View>
                 </View>
+              </View>
+            </View>
+            <View
+              style={
+                {
+                  "backgroundColor": "#ca35421a",
+                  "borderColor": "#ca3542",
+                  "borderLeftWidth": 4,
+                  "borderRadius": 4,
+                  "flexDirection": "row",
+                  "padding": 12,
+                  "paddingLeft": 8,
+                }
+              }
+              testID="banneralert"
+            >
+              <View
+                style={
+                  {
+                    "marginRight": 8,
+                  }
+                }
+              >
+                <SvgMock
+                  color="#ca3542"
+                  fill="currentColor"
+                  height={24}
+                  name="Danger"
+                  style={
+                    {
+                      "height": 24,
+                      "width": 24,
+                    }
+                  }
+                  width={24}
+                />
+              </View>
+              <View
+                style={
+                  {
+                    "flex": 1,
+                  }
+                }
+              >
                 <Text
                   accessibilityRole="text"
                   style={
@@ -2046,277 +2223,90 @@ exports[`RevealPrivateCredential renders with a custom selectedAddress 1`] = `
                       "fontSize": 18,
                       "letterSpacing": 0,
                       "lineHeight": 24,
-                      "marginBottom": 8,
                     }
                   }
                 >
-                  Test Account
+                  Never disclose this key.
                 </Text>
-                <View
-                  alignItems="center"
-                  flexDirection="row"
-                  justifyContent="center"
-                  style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "flexDirection": "row",
-                        "justifyContent": "center",
-                      },
-                      {
-                        "backgroundColor": "#4459ff1a",
-                        "borderRadius": 999,
-                        "color": "#4459ff",
-                        "gap": 4,
-                        "marginBottom": 16,
-                        "paddingBottom": 4,
-                        "paddingLeft": 12,
-                        "paddingRight": 12,
-                        "paddingTop": 4,
-                      },
-                    ]
-                  }
-                >
-                  <Text
-                    accessibilityRole="text"
-                    style={
-                      {
-                        "color": "#4459ff",
-                        "fontFamily": "Geist Medium",
-                        "fontSize": 18,
-                        "letterSpacing": 0,
-                        "lineHeight": 24,
-                      }
-                    }
-                  >
-                    0x12345...67890
-                  </Text>
-                  <View
-                    style={
-                      {
-                        "alignItems": "center",
-                        "flexDirection": "row",
-                      }
-                    }
-                  >
-                    <View
-                      style={
-                        [
-                          {
-                            "transform": [
-                              {
-                                "scale": 1,
-                              },
-                            ],
-                          },
-                          {
-                            "alignItems": "center",
-                            "justifyContent": "center",
-                          },
-                        ]
-                      }
-                    >
-                      <View
-                        accessibilityState={
-                          {
-                            "busy": undefined,
-                            "checked": undefined,
-                            "disabled": false,
-                            "expanded": undefined,
-                            "selected": undefined,
-                          }
-                        }
-                        accessibilityValue={
-                          {
-                            "max": undefined,
-                            "min": undefined,
-                            "now": undefined,
-                            "text": undefined,
-                          }
-                        }
-                        accessible={true}
-                        collapsable={false}
-                        focusable={true}
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onResponderGrant={[Function]}
-                        onResponderMove={[Function]}
-                        onResponderRelease={[Function]}
-                        onResponderTerminate={[Function]}
-                        onResponderTerminationRequest={[Function]}
-                        onStartShouldSetResponder={[Function]}
-                        style={
-                          [
-                            {
-                              "alignItems": "center",
-                              "backgroundColor": "transparent",
-                              "borderRadius": 2,
-                              "height": 40,
-                              "justifyContent": "center",
-                              "opacity": 1,
-                              "width": 40,
-                            },
-                            undefined,
-                          ]
-                        }
-                        testID="wallet-account-copy-button"
-                      >
-                        <SvgMock
-                          fill="currentColor"
-                          name="Copy"
-                          style={
-                            [
-                              {
-                                "color": "#4459ff",
-                                "height": 24,
-                                "width": 24,
-                              },
-                              undefined,
-                            ]
-                          }
-                        />
-                      </View>
-                    </View>
-                  </View>
-                </View>
-              </View>
-              <View
-                style={
-                  {
-                    "backgroundColor": "#ca35421a",
-                    "borderColor": "#ca3542",
-                    "borderLeftWidth": 4,
-                    "borderRadius": 4,
-                    "flexDirection": "row",
-                    "padding": 12,
-                    "paddingLeft": 8,
-                  }
-                }
-                testID="banneralert"
-              >
-                <View
+                <Text
+                  accessibilityRole="text"
                   style={
                     {
-                      "marginRight": 8,
+                      "color": "#121314",
+                      "fontFamily": "Geist Regular",
+                      "fontSize": 16,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
                     }
                   }
                 >
-                  <SvgMock
-                    color="#ca3542"
-                    fill="currentColor"
-                    height={24}
-                    name="Danger"
-                    style={
-                      {
-                        "height": 24,
-                        "width": 24,
-                      }
-                    }
-                    width={24}
-                  />
-                </View>
-                <View
-                  style={
-                    {
-                      "flex": 1,
-                    }
-                  }
-                >
-                  <Text
-                    accessibilityRole="text"
-                    style={
-                      {
-                        "color": "#121314",
-                        "fontFamily": "Geist Medium",
-                        "fontSize": 18,
-                        "letterSpacing": 0,
-                        "lineHeight": 24,
-                      }
-                    }
-                  >
-                    Never disclose this key.
-                  </Text>
-                  <Text
-                    accessibilityRole="text"
-                    style={
-                      {
-                        "color": "#121314",
-                        "fontFamily": "Geist Regular",
-                        "fontSize": 16,
-                        "letterSpacing": 0,
-                        "lineHeight": 24,
-                      }
-                    }
-                  >
-                    Anyone with your private key can steal any assets held in your account.
-                  </Text>
-                </View>
+                  Anyone with your private key can steal any assets held in your account.
+                </Text>
               </View>
-            </View>
-            <View
-              style={
-                [
-                  {
-                    "padding": 20,
-                  },
-                  {
-                    "flex": 1,
-                  },
-                ]
-              }
-            >
-              <Text
-                accessibilityRole="text"
-                style={
-                  {
-                    "color": "#121314",
-                    "fontFamily": "Geist Medium",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                    "marginBottom": 4,
-                  }
-                }
-              >
-                Enter password to continue
-              </Text>
-              <TextInput
-                keyboardAppearance="light"
-                onChangeText={[Function]}
-                onSubmitEditing={[Function]}
-                placeholder="Password"
-                placeholderTextColor="#b7bbc8"
-                secureTextEntry={true}
-                style={
-                  {
-                    "borderColor": "#b7bbc8",
-                    "borderRadius": 5,
-                    "borderWidth": 2,
-                    "color": "#121314",
-                    "padding": 10,
-                  }
-                }
-                testID="private-credential-password-text-input"
-              />
-              <Text
-                accessibilityRole="text"
-                style={
-                  {
-                    "color": "#ca3542",
-                    "fontFamily": "CentraNo1-Book",
-                    "fontSize": 16,
-                    "fontWeight": "400",
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
-                    "marginTop": 10,
-                  }
-                }
-                testID="password-warning"
-              />
             </View>
           </View>
-        </RCTScrollView>
+          <View
+            style={
+              [
+                {
+                  "padding": 20,
+                },
+                {
+                  "flex": 1,
+                },
+              ]
+            }
+          >
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#121314",
+                  "fontFamily": "Geist Medium",
+                  "fontSize": 16,
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                  "marginBottom": 4,
+                }
+              }
+            >
+              Enter password to continue
+            </Text>
+            <TextInput
+              keyboardAppearance="light"
+              onChangeText={[Function]}
+              onSubmitEditing={[Function]}
+              placeholder="Password"
+              placeholderTextColor="#b7bbc8"
+              secureTextEntry={true}
+              style={
+                {
+                  "borderColor": "#b7bbc8",
+                  "borderRadius": 5,
+                  "borderWidth": 2,
+                  "color": "#121314",
+                  "padding": 10,
+                }
+              }
+              testID="private-credential-password-text-input"
+            />
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#ca3542",
+                  "fontFamily": "CentraNo1-Book",
+                  "fontSize": 16,
+                  "fontWeight": "400",
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                  "marginTop": 10,
+                }
+              }
+              testID="password-warning"
+            />
+          </View>
+        </View>
         <View
           style={
             [

--- a/app/components/Views/RevealPrivateCredential/styles.ts
+++ b/app/components/Views/RevealPrivateCredential/styles.ts
@@ -46,7 +46,7 @@ export const createStyles = (theme: Theme) =>
       padding: 20,
     },
     tabContentContainer: {
-      minHeight: 320,
+      minHeight: Platform.OS === 'android' ? 320 : 0,
       flexGrow: 1,
       flexShrink: 0,
       marginBottom: Platform.OS === 'android' ? 20 : 0,
@@ -100,9 +100,6 @@ export const createStyles = (theme: Theme) =>
       color: theme.colors.text.default,
       ...fontStyles.bold,
     },
-    tabContent: {
-      paddingVertical: 20,
-    },
     tabContainer: {
       paddingHorizontal: 16,
     },
@@ -138,8 +135,5 @@ export const createStyles = (theme: Theme) =>
     },
     stretch: {
       flex: 1,
-    },
-    scrollContentContainer: {
-      flexGrow: 1,
     },
   });

--- a/app/components/Views/RevealPrivateCredential/styles.ts
+++ b/app/components/Views/RevealPrivateCredential/styles.ts
@@ -139,4 +139,7 @@ export const createStyles = (theme: Theme) =>
     stretch: {
       flex: 1,
     },
+    scrollContentContainer: {
+      flexGrow: 1,
+    },
   });


### PR DESCRIPTION
## **Description**

1. What is the reason for the change?
- While testing the latest RC (7.54.0) we noticed that the reveal private credentials page (SRP and Private Key) were broken on Android. 
- Clicking the password input field caused the page content to be pushed to the very top which made it unreadable.
2. What is the improvement/solution?
- This issue was caused by the nested scrollview not applying the flexGrow to the children. I removed the scrollview in favour of a standard view and passed in the style flexGrow.
- I also refined the styles (removed unnecessary padding) so that the Done button could fit on one page without scrolling. 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-558

## **Manual testing steps**

```gherkin
Feature: Reveal private credential

  Scenario: user clicks on the three dot menu inside the account list and it takes them to the account details page
    Given a user click on reveal Secret recovery phrase

    Given a user completes the SRP reveal quiz
    When a user clicks on the password text field
    Then the password field should remain in view of the user at all times
    Given the user types the correct password
    Then their SRP should be revealed

repeat the above steps with reveal private key

```

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/7fe2ad7a-4695-4d08-8202-0a71a7b5338c


### **After**

https://github.com/user-attachments/assets/379f2479-324d-4a3a-8f6d-4969528f0591

<img width="350" height="700" alt="Simulator Screenshot - iPhone 15 Pro - 2025-08-21 at 15 17 26" src="https://github.com/user-attachments/assets/c1fe2644-a493-4c06-a600-2410b159a22c" />


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
