### PR TITLE
feat: add useAccountGroupName hook and integrate into Wallet view

### DIFF
--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -99,6 +99,7 @@ import {
 import { selectIsBackupAndSyncEnabled } from '../../../selectors/identity';
 import { ButtonVariants } from '../../../component-library/components/Buttons/Button';
 import { useAccountName } from '../../hooks/useAccountName';
+import { useAccountGroupName } from '../../hooks/multichainAccounts/useAccountGroupName';
 
 import { PortfolioBalance } from '../../UI/Tokens/TokenList/PortfolioBalance';
 import useCheckNftAutoDetectionModal from '../../hooks/useCheckNftAutoDetectionModal';
@@ -465,6 +466,9 @@ const Wallet = ({
   const hdKeyrings = useSelector(selectHDKeyrings);
 
   const accountName = useAccountName();
+  const accountGroupName = useAccountGroupName();
+
+  const displayName = accountGroupName || accountName;
   useAccountsWithNetworkActivitySync();
 
   const { networks } = useNetworksByNamespace({
@@ -733,7 +737,7 @@ const Wallet = ({
       getWalletNavbarOptions(
         walletRef,
         selectedInternalAccount,
-        accountName,
+        displayName,
         networkName,
         networkImageSource,
         onTitlePress,
@@ -748,7 +752,7 @@ const Wallet = ({
     );
   }, [
     selectedInternalAccount,
-    accountName,
+    displayName,
     networkName,
     networkImageSource,
     onTitlePress,

--- a/app/components/hooks/multichainAccounts/useAccountGroupName.test.ts
+++ b/app/components/hooks/multichainAccounts/useAccountGroupName.test.ts
@@ -1,0 +1,51 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useSelector } from 'react-redux';
+import { useAccountGroupName } from './useAccountGroupName';
+import { selectMultichainAccountsState2Enabled } from '../../../selectors/featureFlagController/multichainAccounts/enabledMultichainAccounts';
+import { selectSelectedAccountGroup } from '../../../selectors/multichainAccounts/accountTreeController';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+describe('useAccountGroupName', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the account group name when multichain accounts state 2 is enabled', () => {
+    const mockUseSelector = useSelector as jest.Mock;
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === selectMultichainAccountsState2Enabled) {
+        return true;
+      }
+      if (selector === selectSelectedAccountGroup) {
+        return {
+          metadata: { name: 'My Account Group' },
+        };
+      }
+      return undefined;
+    });
+
+    const { result } = renderHook(() => useAccountGroupName());
+    expect(result.current).toBe('My Account Group');
+  });
+
+  it('returns null when multichain accounts state 2 is disabled', () => {
+    const mockUseSelector = useSelector as jest.Mock;
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === selectMultichainAccountsState2Enabled) {
+        return false;
+      }
+      if (selector === selectSelectedAccountGroup) {
+        return {
+          metadata: { name: 'My Account Group' },
+        };
+      }
+      return undefined;
+    });
+
+    const { result } = renderHook(() => useAccountGroupName());
+    expect(result.current).toBeNull();
+  });
+});

--- a/app/components/hooks/multichainAccounts/useAccountGroupName.ts
+++ b/app/components/hooks/multichainAccounts/useAccountGroupName.ts
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { selectMultichainAccountsState2Enabled } from '../../../selectors/featureFlagController/multichainAccounts/enabledMultichainAccounts';
+import { selectSelectedAccountGroup } from '../../../selectors/multichainAccounts/accountTreeController';
+
+/**
+ * Hook that returns the account group name when multichain accounts state 2 is enabled.
+ * Returns null when the feature is disabled or no account group is selected.
+ */
+export const useAccountGroupName = () => {
+  const isMultichainAccountsState2Enabled = useSelector(
+    selectMultichainAccountsState2Enabled,
+  );
+  const selectedAccountGroup = useSelector(selectSelectedAccountGroup);
+
+  return useMemo(() => {
+    if (isMultichainAccountsState2Enabled && selectedAccountGroup) {
+      return selectedAccountGroup.metadata.name;
+    }
+    return null;
+  }, [isMultichainAccountsState2Enabled, selectedAccountGroup]);
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR adds `useAccountGroupName` to be used as display name in Wallet component when multichain accounts are enabled
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:
Jira ticket: https://consensyssoftware.atlassian.net/browse/MUL-399

## **Manual testing steps**

```gherkin
Feature: Account Group Name Display in Wallet View
  As a MetaMask Mobile user
  I want to see the account group name in the wallet header when multichain accounts are enabled
  So that I can easily identify which account group I'm currently viewing

  Background:
    Given the MetaMask Mobile app is installed and running
    And I have completed the onboarding process
    And I have at least one account group with a custom name

  @multichain-accounts @wallet-header
  Scenario: Display account group name when multichain accounts state 2 is enabled
    Given multichain accounts state 2 feature flag is enabled
    And I have an account group named "Personal Wallet"
    And the account group contains at least one account
    And I am on the main wallet view
    When the wallet view loads
    Then I should see "Personal Wallet" displayed in the wallet header
    And the account group name should be clearly visible to the user

  @multichain-accounts @wallet-header
  Scenario: Fall back to account name when multichain accounts state 2 is disabled
    Given multichain accounts state 2 feature flag is disabled
    And I have an account named "Account 1"
    And I am on the main wallet view
    When the wallet view loads
    Then I should see "Account 1" displayed in the wallet header
    And the account group name should not be displayed

  @multichain-accounts @wallet-header @edge-case
  Scenario: Handle missing account group metadata gracefully
    Given multichain accounts state 2 feature flag is enabled
    And I have a selected account group
    But the account group metadata is null or undefined
    And I am on the main wallet view
    When the wallet view loads
    Then the app should not crash
    And the header should display a fallback name or remain empty
    And no error should be logged to the console

  @multichain-accounts @wallet-header
  Scenario: Update header when switching between account groups
    Given multichain accounts state 2 feature flag is enabled
    And I have multiple account groups:
      | Group Name      | Accounts |
      | Personal Wallet | 2        |
      | Business Wallet | 1        |
    And I am currently viewing "Personal Wallet"
    And I am on the main wallet view
    When I switch to "Business Wallet" account group
    Then the wallet header should update to display "Business Wallet"
    And the change should be immediate without requiring a page refresh

  @multichain-accounts @wallet-header @long-names
  Scenario: Display long account group names appropriately
    Given multichain accounts state 2 feature flag is enabled
    And I have an account group named "My Very Long Account Group Name That Might Overflow"
    And I am on the main wallet view
    When the wallet view loads
    Then the account group name should be displayed in the header
    And the name should be truncated or wrapped appropriately if too long
    And the header layout should remain intact

  @multichain-accounts @wallet-header @special-characters
  Scenario: Display account group names with special characters
    Given multichain accounts state 2 feature flag is enabled
    And I have an account group named "🚀 Crypto Portfolio & Trading 💰"
    And I am on the main wallet view
    When the wallet view loads
    Then the account group name "🚀 Crypto Portfolio & Trading 💰" should be displayed correctly
    And all special characters and emojis should render properly

  @multichain-accounts @wallet-header @performance
  Scenario: Account group name updates efficiently
    Given multichain accounts state 2 feature flag is enabled
    And I have multiple account groups
    And I am on the main wallet view
    When I rapidly switch between different account groups
    Then each account group name should update in the header
    And there should be no performance degradation
    And no memory leaks should occur from the useAccountGroupName hook

  @multichain-accounts @wallet-header @network-switching
  Scenario: Account group name persists when switching networks
    Given multichain accounts state 2 feature flag is enabled
    And I have an account group named "Multi-Chain Wallet"
    And I am on the Ethereum mainnet
    And I am on the main wallet view
    When I switch to Polygon network
    Then the account group name "Multi-Chain Wallet" should still be displayed
    And the header should not revert to showing individual account names

  @multichain-accounts @wallet-header @state-management
  Scenario: Account group name reflects current Redux state
    Given multichain accounts state 2 feature flag is enabled
    And I have an account group named "Trading Account"
    And I am on the main wallet view
    When the selected account group changes in the Redux store
    Then the useAccountGroupName hook should return the updated name
    And the wallet header should reflect the new account group name
    And the update should happen reactively without manual refresh
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
