### PR TITLE
fix: cp-7.54.0 remove network/account filters from deposit order selector

### DIFF
--- a/app/components/UI/Ramp/Deposit/Views/Root/Root.test.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/Root/Root.test.tsx
@@ -2,7 +2,7 @@ import { waitFor, screen } from '@testing-library/react-native';
 import Root from './Root';
 import Routes from '../../../../../../constants/navigation/Routes';
 import { backgroundState } from '../../../../../../util/test/initial-root-state';
-import { getOrders } from '../../../../../../reducers/fiatOrders';
+import { getAllDepositOrders } from '../../../../../../reducers/fiatOrders';
 import type { FiatOrder } from '../../../../../../reducers/fiatOrders/types';
 import {
   FIAT_ORDER_PROVIDERS,
@@ -44,7 +44,7 @@ jest.mock('../../sdk', () => {
 
 jest.mock('../../../../../../reducers/fiatOrders', () => ({
   ...jest.requireActual('../../../../../../reducers/fiatOrders'),
-  getOrders: jest.fn(),
+  getAllDepositOrders: jest.fn(),
   fiatOrdersGetStartedDeposit: jest.fn((_state: unknown) => true),
   setFiatOrdersGetStartedDeposit: jest.fn(),
   fiatOrdersRegionSelectorDeposit: jest.fn(
@@ -73,7 +73,9 @@ describe('Root Component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetStarted = true;
-    (getOrders as jest.MockedFunction<typeof getOrders>).mockReturnValue([]);
+    (
+      getAllDepositOrders as jest.MockedFunction<typeof getAllDepositOrders>
+    ).mockReturnValue([]);
   });
 
   it('render matches snapshot', () => {
@@ -123,9 +125,9 @@ describe('Root Component', () => {
       },
     ] as FiatOrder[];
 
-    (getOrders as jest.MockedFunction<typeof getOrders>).mockReturnValue(
-      mockOrders,
-    );
+    (
+      getAllDepositOrders as jest.MockedFunction<typeof getAllDepositOrders>
+    ).mockReturnValue(mockOrders);
     mockCheckExistingToken.mockResolvedValue(false);
     render(Root);
 

--- a/app/components/UI/Ramp/Deposit/Views/Root/Root.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/Root/Root.tsx
@@ -4,7 +4,7 @@ import Routes from '../../../../../../constants/navigation/Routes';
 import { useDepositSDK } from '../../sdk';
 import GetStarted from './GetStarted/GetStarted';
 import { useSelector } from 'react-redux';
-import { getOrders } from '../../../../../../reducers/fiatOrders';
+import { getAllDepositOrders } from '../../../../../../reducers/fiatOrders';
 import {
   FIAT_ORDER_STATES,
   FIAT_ORDER_PROVIDERS,
@@ -16,7 +16,7 @@ const Root = () => {
   const [initialRoute] = useState<string>(Routes.DEPOSIT.BUILD_QUOTE);
   const { checkExistingToken, getStarted } = useDepositSDK();
   const hasCheckedToken = useRef(false);
-  const orders = useSelector(getOrders);
+  const orders = useSelector(getAllDepositOrders);
 
   useEffect(() => {
     const initializeFlow = async () => {

--- a/app/reducers/fiatOrders/index.ts
+++ b/app/reducers/fiatOrders/index.ts
@@ -212,6 +212,10 @@ export const getOrders = createSelector(
     ),
 );
 
+export const getAllDepositOrders = createSelector(ordersSelector, (orders) =>
+  orders.filter((order) => order.provider === FIAT_ORDER_PROVIDERS.DEPOSIT),
+);
+
 export const getPendingOrders = createSelector(
   ordersSelector,
   selectedAddressSelector,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Fixes deposit orders disappearing when users switch networks/accounts during SEPA/Wire transfers by removing network and account filtering from the deposit order selector, ensuring orders remain detectable across a multi-chain context.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
