### PR TITLE
fix(next semver version): revert calculation method to no longer rely on package.json

### DIFF
--- a/.github/scripts/get-next-semver-version.sh
+++ b/.github/scripts/get-next-semver-version.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-
 FORCE_NEXT_SEMVER_VERSION=$1
-
 # If FORCE_NEXT_SEMVER_VERSION is defined and not empty, use its value and skip the next operations
 if [ -n "$FORCE_NEXT_SEMVER_VERSION" ]
 then
@@ -9,7 +7,16 @@ then
   exit 0
 fi
 
-# Get the version from package.json
-VERSION_PACKAGE=$(node -p "require(process.env.GITHUB_WORKSPACE + '/package.json').version")
+# Get the highest version from release branches
+VERSION_BRANCHES=$(git branch -r | grep -o 'release/[0-9]*\.[0-9]*\.[0-9]*' | grep -o '[0-9]*\.[0-9]*\.[0-9]*' | sort --version-sort | tail -n 1)
 
-echo "NEXT_SEMVER_VERSION=${VERSION_PACKAGE}" >> "$GITHUB_ENV"
+# Get the highest version from tags
+VERSION_TAGS=$(git tag | grep -o 'v[0-9]*\.[0-9]*\.[0-9]*' | grep -o '[0-9]*\.[0-9]*\.[0-9]*' | sort --version-sort | tail -n 1)
+
+# Compare versions and keep the highest one
+HIGHEST_VERSION=$(printf "%s\n%s" "$VERSION_BRANCHES" "$VERSION_TAGS" | sort --version-sort | tail -n 1)
+
+# Increment the minor version of the highest version found and reset the patch version to 0
+NEXT_VERSION=$(echo "$HIGHEST_VERSION" | awk -F. -v OFS=. '{$2++; $3=0; print}')
+
+echo "NEXT_SEMVER_VERSION=${NEXT_VERSION}" >> "$GITHUB_ENV"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The automatic labeling of GitHub issues used to rely on branch names, which is the source of truth to know when a release was cut or not.
We recently changed it (in this [PR](https://github.com/MetaMask/metamask-mobile/pull/17822)) to rely on the version number indicated in `package.json` file, which gets bumped in a dedicated [version bump PR](https://github.com/MetaMask/metamask-mobile/pull/17787). Since that version bump PR is merged manually, there’s always a short window between the release being cut and the version bump PR being merged. During that window, PRs get labeled inaccurately, as highlighted by @bschorchit [here](https://consensys.slack.com/archives/C0996431ME1/p1755607631308339?thread_ts=1755606310.204709&cid=C0996431ME1).

As a consequence, we'd like to revert back to the old calculation method and no longer rely on `package.json`.

[Same PR for Extension](https://github.com/MetaMask/metamask-extension/pull/35248)

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
