### PR TITLE
feat: BIP-44 account support for Perps with seamless Solana account handling

### DIFF
--- a/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.test.tsx
@@ -1,6 +1,7 @@
 import { useNavigation } from '@react-navigation/native';
 import { act, fireEvent, render, screen } from '@testing-library/react-native';
 import React from 'react';
+import { useSelector } from 'react-redux';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
 import type { Position } from '../../controllers/types';
@@ -10,6 +11,20 @@ import PerpsTabViewWithProvider, { PerpsTabViewRaw } from './index';
 // Mock dependencies
 jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(),
+}));
+
+// Mock Redux
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+// Mock the multichain selector
+jest.mock('../../../../../selectors/multichainAccounts/accounts', () => ({
+  selectSelectedInternalAccountByScope: jest.fn(() => () => ({
+    address: '0x1234567890123456789012345678901234567890',
+    id: 'mock-account-id',
+    type: 'eip155:eoa',
+  })),
 }));
 
 // Mock PerpsConnectionProvider
@@ -126,10 +141,20 @@ describe('PerpsTabView', () => {
     jest.clearAllMocks();
     (useNavigation as jest.Mock).mockReturnValue(mockNavigation);
 
+    // Mock useSelector for the multichain selector
+    (useSelector as jest.Mock).mockImplementation(() => () => ({
+      address: '0x1234567890123456789012345678901234567890',
+      id: 'mock-account-id',
+      type: 'eip155:eoa',
+    }));
+
     // Default hook mocks
     mockUsePerpsConnection.mockReturnValue({
       isConnected: true,
       isInitialized: true,
+      error: null,
+      connect: jest.fn(),
+      resetError: jest.fn(),
     });
 
     mockUsePerpsLivePositions.mockReturnValue({

--- a/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.test.tsx
@@ -534,12 +534,12 @@ describe('PerpsTabView', () => {
 
       render(<PerpsTabView />);
 
-      // Should show network error
+      // Should show connection failed error (PerpsTabView always uses CONNECTION_FAILED)
       expect(
-        screen.getByText(strings('perps.errors.networkError.title')),
+        screen.getByText(strings('perps.errors.connectionFailed.title')),
       ).toBeOnTheScreen();
       expect(
-        screen.getByText(strings('perps.errors.networkError.description')),
+        screen.getByText(strings('perps.errors.connectionFailed.description')),
       ).toBeOnTheScreen();
     });
 

--- a/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.test.tsx
@@ -502,6 +502,69 @@ describe('PerpsTabView', () => {
 
       consoleSpy.mockRestore();
     });
+
+    it('should render connection error state when connection fails', () => {
+      mockUsePerpsConnection.mockReturnValue({
+        isConnected: false,
+        isInitialized: false,
+        error: 'CONNECTION_FAILED',
+        connect: jest.fn(),
+        resetError: jest.fn(),
+      });
+
+      render(<PerpsTabView />);
+
+      // Should show connection failed error
+      expect(
+        screen.getByText(strings('perps.errors.connectionFailed.title')),
+      ).toBeOnTheScreen();
+      expect(
+        screen.getByText(strings('perps.errors.connectionFailed.description')),
+      ).toBeOnTheScreen();
+    });
+
+    it('should render network error state when network error occurs', () => {
+      mockUsePerpsConnection.mockReturnValue({
+        isConnected: false,
+        isInitialized: false,
+        error: 'NETWORK_ERROR',
+        connect: jest.fn(),
+        resetError: jest.fn(),
+      });
+
+      render(<PerpsTabView />);
+
+      // Should show network error
+      expect(
+        screen.getByText(strings('perps.errors.networkError.title')),
+      ).toBeOnTheScreen();
+      expect(
+        screen.getByText(strings('perps.errors.networkError.description')),
+      ).toBeOnTheScreen();
+    });
+
+    it('should call connect when retry button is pressed on error', () => {
+      const mockConnect = jest.fn();
+      const mockResetError = jest.fn();
+
+      mockUsePerpsConnection.mockReturnValue({
+        isConnected: false,
+        isInitialized: false,
+        error: 'CONNECTION_FAILED',
+        connect: mockConnect,
+        resetError: mockResetError,
+      });
+
+      render(<PerpsTabView />);
+
+      const retryButton = screen.getByText(
+        strings('perps.errors.connectionFailed.retry'),
+      );
+      fireEvent.press(retryButton);
+
+      expect(mockResetError).toHaveBeenCalledTimes(1);
+      expect(mockConnect).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('Accessibility', () => {

--- a/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
@@ -1,6 +1,7 @@
 import { useNavigation, type NavigationProp } from '@react-navigation/native';
 import React, { useCallback, useEffect, useRef } from 'react';
 import { ScrollView, View } from 'react-native';
+import { useSelector } from 'react-redux';
 import { strings } from '../../../../../../locales/i18n';
 import Button, {
   ButtonSize,
@@ -21,6 +22,9 @@ import Routes from '../../../../../constants/navigation/Routes';
 import { MetaMetricsEvents } from '../../../../hooks/useMetrics';
 import PerpsPositionCard from '../../components/PerpsPositionCard';
 import { PerpsTabControlBar } from '../../components/PerpsTabControlBar';
+import PerpsErrorState, {
+  PerpsErrorType,
+} from '../../components/PerpsErrorState';
 import {
   PerpsEventProperties,
   PerpsEventValues,
@@ -36,6 +40,7 @@ import {
   usePerpsPerformance,
   usePerpsLivePositions,
 } from '../../hooks';
+import { selectSelectedInternalAccountByScope } from '../../../../../selectors/multichainAccounts/accounts';
 import styleSheet from './PerpsTabView.styles';
 
 interface PerpsTabViewProps {}
@@ -43,8 +48,12 @@ interface PerpsTabViewProps {}
 const PerpsTabView: React.FC<PerpsTabViewProps> = () => {
   const { styles } = useStyles(styleSheet, {});
   const navigation = useNavigation<NavigationProp<PerpsNavigationParamList>>();
+  const selectedEvmAccount = useSelector(selectSelectedInternalAccountByScope)(
+    'eip155:1',
+  );
   const { getAccountState } = usePerpsTrading();
-  const { isConnected, isInitialized } = usePerpsConnection();
+  const { isConnected, isInitialized, error, connect, resetError } =
+    usePerpsConnection();
   const { track } = usePerpsEventTracking();
   const cachedAccountState = usePerpsAccount();
 
@@ -64,15 +73,15 @@ const PerpsTabView: React.FC<PerpsTabViewProps> = () => {
     startMeasure(PerpsMeasurementName.POSITION_DATA_LOADED_PERP_TAB);
   }, [startMeasure]);
 
-  // Automatically load account state on mount and when network changes
+  // Automatically load account state on mount and when network or account changes
   useEffect(() => {
-    // Only load account state if we're connected and initialized
-    if (isConnected && isInitialized) {
+    // Only load account state if we're connected, initialized, and have an EVM account
+    if (isConnected && isInitialized && selectedEvmAccount) {
       // Fire and forget - errors are already handled in getAccountState
       // and stored in the controller's state
       getAccountState();
     }
-  }, [getAccountState, isConnected, isInitialized]);
+  }, [getAccountState, isConnected, isInitialized, selectedEvmAccount]);
 
   // Track homescreen tab viewed - only once when positions and account are loaded
   useEffect(() => {
@@ -122,6 +131,11 @@ const PerpsTabView: React.FC<PerpsTabViewProps> = () => {
       screen: Routes.PERPS.TUTORIAL,
     });
   }, [navigation]);
+
+  const handleRetryConnection = useCallback(() => {
+    resetError();
+    connect();
+  }, [connect, resetError]);
 
   const renderPositionsSection = () => {
     if (isInitialLoading) {
@@ -207,6 +221,27 @@ const PerpsTabView: React.FC<PerpsTabViewProps> = () => {
       </>
     );
   };
+
+  // Check for non-EVM account first
+  if (!selectedEvmAccount) {
+    return (
+      <View style={styles.wrapper}>
+        <PerpsErrorState errorType={PerpsErrorType.NON_EVM_ACCOUNT} />
+      </View>
+    );
+  }
+
+  // Check for connection errors
+  if (error && !isConnected) {
+    return (
+      <View style={styles.wrapper}>
+        <PerpsErrorState
+          errorType={PerpsErrorType.CONNECTION_FAILED}
+          onRetry={handleRetryConnection}
+        />
+      </View>
+    );
+  }
 
   return (
     <View style={styles.wrapper}>

--- a/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
@@ -222,17 +222,8 @@ const PerpsTabView: React.FC<PerpsTabViewProps> = () => {
     );
   };
 
-  // Check for non-EVM account first
-  if (!selectedEvmAccount) {
-    return (
-      <View style={styles.wrapper}>
-        <PerpsErrorState errorType={PerpsErrorType.NON_EVM_ACCOUNT} />
-      </View>
-    );
-  }
-
   // Check for connection errors
-  if (error && !isConnected) {
+  if (error && !isConnected && selectedEvmAccount) {
     return (
       <View style={styles.wrapper}>
         <PerpsErrorState

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsFundingTransactionView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsFundingTransactionView.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
 import Routes from '../../../../../constants/navigation/Routes';
 import PerpsFundingTransactionView from './PerpsFundingTransactionView';
 import { PerpsTransactionSelectorsIDs } from '../../../../../../e2e/selectors/Perps/Perps.selectors';
@@ -23,7 +24,6 @@ const mockTransaction = {
 // Mock all dependencies properly
 const mockUseNavigation = jest.fn();
 const mockUseRoute = jest.fn();
-const mockUseSelector = jest.fn();
 const mockUsePerpsNetwork = jest.fn();
 const mockUsePerpsBlockExplorerUrl = jest.fn();
 const mockGetHyperliquidExplorerUrl = jest.fn();
@@ -37,7 +37,13 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 jest.mock('react-redux', () => ({
-  useSelector: () => mockUseSelector(),
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../../../../../selectors/multichainAccounts/accounts', () => ({
+  selectSelectedInternalAccountByScope: jest.fn(() => () => ({
+    address: '0x1234567890abcdef1234567890abcdef12345678',
+  })),
 }));
 
 jest.mock('../../hooks', () => ({
@@ -69,9 +75,10 @@ describe('PerpsFundingTransactionView', () => {
         ),
       baseExplorerUrl: 'https://app.hyperliquid.xyz/explorer',
     });
-    mockUseSelector.mockReturnValue({
+    // Mock useSelector to return a function that returns the account
+    (useSelector as jest.Mock).mockImplementation(() => () => ({
       address: '0x1234567890abcdef1234567890abcdef12345678',
-    });
+    }));
     mockUseRoute.mockReturnValue({
       params: { transaction: mockTransaction },
     });
@@ -263,7 +270,8 @@ describe('PerpsFundingTransactionView', () => {
       setOptions: jest.fn(),
     });
 
-    mockUseSelector.mockReturnValue(null);
+    // Mock useSelector to return null for no account
+    (useSelector as jest.Mock).mockImplementationOnce(() => () => null);
 
     const { getByTestId } = render(<PerpsFundingTransactionView />);
 

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsFundingTransactionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsFundingTransactionView.tsx
@@ -19,7 +19,7 @@ import Text, {
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../../component-library/hooks';
-import { selectSelectedInternalAccount } from '../../../../../selectors/accountsController';
+import { selectSelectedInternalAccountByScope } from '../../../../../selectors/multichainAccounts/accounts';
 import ScreenView from '../../../../Base/ScreenView';
 import { getPerpsTransactionsDetailsNavbar } from '../../../Navbar';
 import { usePerpsBlockExplorerUrl } from '../../hooks';
@@ -40,7 +40,9 @@ const PerpsFundingTransactionView: React.FC = () => {
   const navigation = useNavigation<NavigationProp<PerpsNavigationParamList>>();
   const route = useRoute<PerpsFundingTransactionRouteProp>();
 
-  const selectedInternalAccount = useSelector(selectSelectedInternalAccount);
+  const selectedInternalAccount = useSelector(
+    selectSelectedInternalAccountByScope,
+  )('eip155:1');
   const { getExplorerUrl } = usePerpsBlockExplorerUrl();
 
   // Get transaction from route params

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView.tsx
@@ -20,7 +20,7 @@ import Button, {
   ButtonWidthTypes,
 } from '../../../../../component-library/components/Buttons/Button';
 import { useStyles } from '../../../../../component-library/hooks';
-import { selectSelectedInternalAccount } from '../../../../../selectors/accountsController';
+import { selectSelectedInternalAccountByScope } from '../../../../../selectors/multichainAccounts/accounts';
 import ScreenView from '../../../../Base/ScreenView';
 import { getPerpsTransactionsDetailsNavbar } from '../../../Navbar';
 import PerpsTransactionDetailAssetHero from '../../components/PerpsTransactionDetailAssetHero';
@@ -37,7 +37,9 @@ const PerpsOrderTransactionView: React.FC = () => {
   const { styles } = useStyles(styleSheet, {});
   const navigation = useNavigation<NavigationProp<PerpsNavigationParamList>>();
   const route = useRoute<PerpsOrderTransactionRouteProp>();
-  const selectedInternalAccount = useSelector(selectSelectedInternalAccount);
+  const selectedInternalAccount = useSelector(
+    selectSelectedInternalAccountByScope,
+  )('eip155:1');
   const { getExplorerUrl } = usePerpsBlockExplorerUrl();
   // Get transaction from route params
   const transaction = route.params?.transaction;

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsPositionTransactionView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsPositionTransactionView.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent } from '@testing-library/react-native';
 import PerpsPositionTransactionView from './PerpsPositionTransactionView';
 import { usePerpsNetwork, usePerpsBlockExplorerUrl } from '../../hooks';
 import { selectSelectedInternalAccount } from '../../../../../selectors/accountsController';
+import { selectSelectedInternalAccountByScope } from '../../../../../selectors/multichainAccounts/accounts';
 import renderWithProvider, {
   DeepPartial,
 } from '../../../../../util/test/renderWithProvider';
@@ -52,6 +53,13 @@ jest.mock('../../../../../selectors/accountsController', () => ({
   selectSelectedInternalAccountAddress: jest.fn(),
   selectSelectedInternalAccountFormattedAddress: jest.fn(),
   selectHasCreatedSolanaMainnetAccount: jest.fn(),
+  selectInternalAccounts: jest.fn(() => []),
+}));
+
+jest.mock('../../../../../selectors/multichainAccounts/accounts', () => ({
+  selectSelectedInternalAccountByScope: jest.fn(() => () => ({
+    address: '0x1234567890abcdef1234567890abcdef12345678',
+  })),
 }));
 
 const mockTransaction = {
@@ -334,9 +342,11 @@ describe('PerpsPositionTransactionView', () => {
   });
 
   it('should not navigate to block explorer when no selected account', () => {
-    (selectSelectedInternalAccount as unknown as jest.Mock).mockReturnValue(
-      null,
-    );
+    // Mock the multichain selector to return null
+    jest
+      .mocked(selectSelectedInternalAccountByScope)
+      .mockReturnValueOnce(() => null);
+
     const { getByText } = renderWithProvider(<PerpsPositionTransactionView />, {
       state: mockInitialState,
     });

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsPositionTransactionView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsPositionTransactionView.test.tsx
@@ -342,10 +342,10 @@ describe('PerpsPositionTransactionView', () => {
   });
 
   it('should not navigate to block explorer when no selected account', () => {
-    // Mock the multichain selector to return null
+    // Mock the multichain selector to return undefined
     jest
       .mocked(selectSelectedInternalAccountByScope)
-      .mockReturnValueOnce(() => null);
+      .mockReturnValueOnce(() => undefined);
 
     const { getByText } = renderWithProvider(<PerpsPositionTransactionView />, {
       state: mockInitialState,

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsPositionTransactionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsPositionTransactionView.tsx
@@ -19,7 +19,7 @@ import Button, {
   ButtonWidthTypes,
 } from '../../../../../component-library/components/Buttons/Button';
 import { useStyles } from '../../../../../component-library/hooks';
-import { selectSelectedInternalAccount } from '../../../../../selectors/accountsController';
+import { selectSelectedInternalAccountByScope } from '../../../../../selectors/multichainAccounts/accounts';
 import ScreenView from '../../../../Base/ScreenView';
 import { getPerpsTransactionsDetailsNavbar } from '../../../Navbar';
 import PerpsTransactionDetailAssetHero from '../../components/PerpsTransactionDetailAssetHero';
@@ -40,7 +40,9 @@ const PerpsPositionTransactionView: React.FC = () => {
   const { styles } = useStyles(styleSheet, {});
   const navigation = useNavigation<NavigationProp<PerpsNavigationParamList>>();
   const route = useRoute<PerpsPositionTransactionRouteProp>();
-  const selectedInternalAccount = useSelector(selectSelectedInternalAccount);
+  const selectedInternalAccount = useSelector(
+    selectSelectedInternalAccountByScope,
+  )('eip155:1');
   const { getExplorerUrl } = usePerpsBlockExplorerUrl();
 
   // Get transaction from route params

--- a/app/components/UI/Perps/components/PerpsErrorState/PerpsErrorState.styles.ts
+++ b/app/components/UI/Perps/components/PerpsErrorState/PerpsErrorState.styles.ts
@@ -1,0 +1,39 @@
+import { StyleSheet } from 'react-native';
+import { Theme } from '../../../../../util/theme/models';
+
+const styleSheet = (params: { theme: Theme }) => {
+  const { theme } = params;
+  const { colors } = theme;
+
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      backgroundColor: colors.background.default,
+      paddingHorizontal: 16,
+    },
+    content: {
+      alignItems: 'center',
+      maxWidth: 320,
+      width: '100%',
+    },
+    icon: {
+      marginBottom: 24,
+    },
+    title: {
+      marginBottom: 12,
+      textAlign: 'center',
+    },
+    description: {
+      marginBottom: 32,
+      textAlign: 'center',
+      lineHeight: 20,
+    },
+    button: {
+      marginTop: 8,
+    },
+  });
+};
+
+export default styleSheet;

--- a/app/components/UI/Perps/components/PerpsErrorState/PerpsErrorState.test.tsx
+++ b/app/components/UI/Perps/components/PerpsErrorState/PerpsErrorState.test.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import PerpsErrorState, { PerpsErrorType } from './PerpsErrorState';
+import { strings } from '../../../../../../locales/i18n';
+
+describe('PerpsErrorState', () => {
+  describe('CONNECTION_FAILED error type', () => {
+    it('should render connection failed error with retry button', () => {
+      const onRetryMock = jest.fn();
+      const { getByText } = render(
+        <PerpsErrorState
+          errorType={PerpsErrorType.CONNECTION_FAILED}
+          onRetry={onRetryMock}
+        />,
+      );
+
+      expect(
+        getByText(strings('perps.errors.connectionFailed.title')),
+      ).toBeTruthy();
+      expect(
+        getByText(strings('perps.errors.connectionFailed.description')),
+      ).toBeTruthy();
+
+      const retryButton = getByText(
+        strings('perps.errors.connectionFailed.retry'),
+      );
+      expect(retryButton).toBeTruthy();
+
+      fireEvent.press(retryButton);
+      expect(onRetryMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should render connection failed without retry when onRetry not provided', () => {
+      const { getByText, queryByText } = render(
+        <PerpsErrorState errorType={PerpsErrorType.CONNECTION_FAILED} />,
+      );
+
+      expect(
+        getByText(strings('perps.errors.connectionFailed.title')),
+      ).toBeTruthy();
+      expect(
+        queryByText(strings('perps.errors.connectionFailed.retry')),
+      ).toBeNull();
+    });
+  });
+
+  describe('NETWORK_ERROR error type', () => {
+    it('should render network error with retry button', () => {
+      const onRetryMock = jest.fn();
+      const { getByText } = render(
+        <PerpsErrorState
+          errorType={PerpsErrorType.NETWORK_ERROR}
+          onRetry={onRetryMock}
+        />,
+      );
+
+      expect(
+        getByText(strings('perps.errors.networkError.title')),
+      ).toBeTruthy();
+      expect(
+        getByText(strings('perps.errors.networkError.description')),
+      ).toBeTruthy();
+
+      const retryButton = getByText(strings('perps.errors.networkError.retry'));
+      expect(retryButton).toBeTruthy();
+
+      fireEvent.press(retryButton);
+      expect(onRetryMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('UNKNOWN error type', () => {
+    it('should render unknown error with retry button when onRetry provided', () => {
+      const onRetryMock = jest.fn();
+      const { getByText } = render(
+        <PerpsErrorState
+          errorType={PerpsErrorType.UNKNOWN}
+          onRetry={onRetryMock}
+        />,
+      );
+
+      expect(getByText(strings('perps.errors.unknown.title'))).toBeTruthy();
+      expect(
+        getByText(strings('perps.errors.unknown.description')),
+      ).toBeTruthy();
+
+      const retryButton = getByText(strings('perps.errors.unknown.retry'));
+      expect(retryButton).toBeTruthy();
+
+      fireEvent.press(retryButton);
+      expect(onRetryMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should render unknown error without retry button when onRetry not provided', () => {
+      const { getByText, queryByText } = render(
+        <PerpsErrorState errorType={PerpsErrorType.UNKNOWN} />,
+      );
+
+      expect(getByText(strings('perps.errors.unknown.title'))).toBeTruthy();
+      expect(
+        getByText(strings('perps.errors.unknown.description')),
+      ).toBeTruthy();
+      expect(queryByText(strings('perps.errors.unknown.retry'))).toBeNull();
+    });
+  });
+
+  describe('Default behavior', () => {
+    it('should default to UNKNOWN error type when no errorType provided', () => {
+      const { getByText } = render(<PerpsErrorState />);
+
+      expect(getByText(strings('perps.errors.unknown.title'))).toBeTruthy();
+      expect(
+        getByText(strings('perps.errors.unknown.description')),
+      ).toBeTruthy();
+    });
+
+    it('should use default testID when not provided', () => {
+      const { getByTestId } = render(<PerpsErrorState />);
+      expect(getByTestId('perps-error-state')).toBeTruthy();
+    });
+
+    it('should use custom testID when provided', () => {
+      const { getByTestId } = render(
+        <PerpsErrorState testID="custom-error-state" />,
+      );
+      expect(getByTestId('custom-error-state')).toBeTruthy();
+    });
+  });
+});

--- a/app/components/UI/Perps/components/PerpsErrorState/PerpsErrorState.tsx
+++ b/app/components/UI/Perps/components/PerpsErrorState/PerpsErrorState.tsx
@@ -1,6 +1,5 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import { View } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
 import { strings } from '../../../../../../locales/i18n';
 import Button, {
   ButtonSize,
@@ -17,11 +16,9 @@ import Text, {
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../../component-library/hooks';
-import Routes from '../../../../../constants/navigation/Routes';
 import styleSheet from './PerpsErrorState.styles';
 
 export enum PerpsErrorType {
-  NON_EVM_ACCOUNT = 'non_evm_account',
   CONNECTION_FAILED = 'connection_failed',
   NETWORK_ERROR = 'network_error',
   UNKNOWN = 'unknown',
@@ -43,27 +40,9 @@ const PerpsErrorState: React.FC<PerpsErrorStateProps> = ({
   testID = 'perps-error-state',
 }) => {
   const { styles } = useStyles(styleSheet, {});
-  const navigation = useNavigation();
-
-  const handleSwitchAccount = useCallback(() => {
-    // Navigate to account selector
-    navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-      screen: Routes.SHEET.ACCOUNT_SELECTOR,
-    });
-  }, [navigation]);
 
   const getErrorContent = () => {
     switch (errorType) {
-      case PerpsErrorType.NON_EVM_ACCOUNT:
-        return {
-          icon: IconName.Wallet,
-          title: strings('perps.errors.nonEvmAccount.title'),
-          description: strings('perps.errors.nonEvmAccount.description'),
-          primaryAction: {
-            label: strings('perps.errors.nonEvmAccount.switchAccount'),
-            onPress: handleSwitchAccount,
-          },
-        };
       case PerpsErrorType.CONNECTION_FAILED:
         return {
           icon: IconName.Wifi,

--- a/app/components/UI/Perps/components/PerpsErrorState/PerpsErrorState.tsx
+++ b/app/components/UI/Perps/components/PerpsErrorState/PerpsErrorState.tsx
@@ -1,0 +1,143 @@
+import React, { useCallback } from 'react';
+import { View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { strings } from '../../../../../../locales/i18n';
+import Button, {
+  ButtonSize,
+  ButtonVariants,
+  ButtonWidthTypes,
+} from '../../../../../component-library/components/Buttons/Button';
+import Icon, {
+  IconColor,
+  IconName,
+  IconSize,
+} from '../../../../../component-library/components/Icons/Icon';
+import Text, {
+  TextColor,
+  TextVariant,
+} from '../../../../../component-library/components/Texts/Text';
+import { useStyles } from '../../../../../component-library/hooks';
+import Routes from '../../../../../constants/navigation/Routes';
+import styleSheet from './PerpsErrorState.styles';
+
+export enum PerpsErrorType {
+  NON_EVM_ACCOUNT = 'non_evm_account',
+  CONNECTION_FAILED = 'connection_failed',
+  NETWORK_ERROR = 'network_error',
+  UNKNOWN = 'unknown',
+}
+
+interface PerpsErrorStateProps {
+  errorType?: PerpsErrorType;
+  onRetry?: () => void;
+  testID?: string;
+}
+
+/**
+ * PerpsErrorState - Error state component for Perps tab
+ * Displays appropriate error messages and actions based on error type
+ */
+const PerpsErrorState: React.FC<PerpsErrorStateProps> = ({
+  errorType = PerpsErrorType.UNKNOWN,
+  onRetry,
+  testID = 'perps-error-state',
+}) => {
+  const { styles } = useStyles(styleSheet, {});
+  const navigation = useNavigation();
+
+  const handleSwitchAccount = useCallback(() => {
+    // Navigate to account selector
+    navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
+      screen: Routes.SHEET.ACCOUNT_SELECTOR,
+    });
+  }, [navigation]);
+
+  const getErrorContent = () => {
+    switch (errorType) {
+      case PerpsErrorType.NON_EVM_ACCOUNT:
+        return {
+          icon: IconName.Wallet,
+          title: strings('perps.errors.nonEvmAccount.title'),
+          description: strings('perps.errors.nonEvmAccount.description'),
+          primaryAction: {
+            label: strings('perps.errors.nonEvmAccount.switchAccount'),
+            onPress: handleSwitchAccount,
+          },
+        };
+      case PerpsErrorType.CONNECTION_FAILED:
+        return {
+          icon: IconName.Wifi,
+          title: strings('perps.errors.connectionFailed.title'),
+          description: strings('perps.errors.connectionFailed.description'),
+          primaryAction: {
+            label: strings('perps.errors.connectionFailed.retry'),
+            onPress: onRetry,
+          },
+        };
+      case PerpsErrorType.NETWORK_ERROR:
+        return {
+          icon: IconName.Global,
+          title: strings('perps.errors.networkError.title'),
+          description: strings('perps.errors.networkError.description'),
+          primaryAction: {
+            label: strings('perps.errors.networkError.retry'),
+            onPress: onRetry,
+          },
+        };
+      default:
+        return {
+          icon: IconName.Warning,
+          title: strings('perps.errors.unknown.title'),
+          description: strings('perps.errors.unknown.description'),
+          primaryAction: onRetry
+            ? {
+                label: strings('perps.errors.unknown.retry'),
+                onPress: onRetry,
+              }
+            : undefined,
+        };
+    }
+  };
+
+  const errorContent = getErrorContent();
+  const iconSize = 48 as unknown as IconSize;
+
+  return (
+    <View style={styles.container} testID={testID}>
+      <View style={styles.content}>
+        <Icon
+          name={errorContent.icon}
+          color={IconColor.Muted}
+          size={iconSize}
+          style={styles.icon}
+        />
+        <Text
+          variant={TextVariant.HeadingMD}
+          color={TextColor.Default}
+          style={styles.title}
+        >
+          {errorContent.title}
+        </Text>
+        <Text
+          variant={TextVariant.BodyMD}
+          color={TextColor.Muted}
+          style={styles.description}
+        >
+          {errorContent.description}
+        </Text>
+        {errorContent.primaryAction?.onPress && (
+          <Button
+            variant={ButtonVariants.Primary}
+            size={ButtonSize.Lg}
+            label={errorContent.primaryAction.label}
+            onPress={errorContent.primaryAction.onPress}
+            style={styles.button}
+            width={ButtonWidthTypes.Full}
+          />
+        )}
+      </View>
+    </View>
+  );
+};
+
+export default PerpsErrorState;

--- a/app/components/UI/Perps/components/PerpsErrorState/index.ts
+++ b/app/components/UI/Perps/components/PerpsErrorState/index.ts
@@ -1,0 +1,1 @@
+export { default, PerpsErrorType } from './PerpsErrorState';

--- a/app/components/UI/Perps/components/PerpsTabControlBar/PerpsTabControlBar.tsx
+++ b/app/components/UI/Perps/components/PerpsTabControlBar/PerpsTabControlBar.tsx
@@ -26,7 +26,6 @@ export const PerpsTabControlBar: React.FC<PerpsTabControlBarProps> = ({
   onManageBalancePress,
 }) => {
   const { styles } = useStyles(styleSheet, {});
-
   // Use live account data with 1 second throttle for balance display
   const { account: perpsAccount } = usePerpsLiveAccount({ throttleMs: 1000 });
 

--- a/app/components/UI/Perps/controllers/PerpsController.test.ts
+++ b/app/components/UI/Perps/controllers/PerpsController.test.ts
@@ -1117,7 +1117,7 @@ describe('PerpsController', () => {
     });
 
     it('should handle deposit transaction confirmation', async () => {
-      withController(async ({ controller }) => {
+      await withController(async ({ controller }) => {
         // Arrange
         const mockTxHash = '0xtransaction123';
         const mockResultPromise = Promise.resolve(mockTxHash);
@@ -1162,45 +1162,8 @@ describe('PerpsController', () => {
       });
     });
 
-    it('should throw error when no EVM account found in depositWithConfirmation', async () => {
-      withController(async ({ controller }) => {
-        // Arrange
-        const mockDepositRoute: AssetRoute = {
-          assetId:
-            'eip155:42161/erc20:0xaf88d065e77c8cc2239327c5edb3a432268e5831' as CaipAssetId,
-          chainId: 'eip155:42161' as CaipChainId,
-          contractAddress: '0x2df1c51e09aecf9cacb7bc98cb1742757f163df7' as Hex,
-        };
-
-        mockHyperLiquidProvider.getDepositRoutes.mockReturnValue([
-          mockDepositRoute,
-        ]);
-        mockHyperLiquidProvider.initialize.mockResolvedValue({ success: true });
-
-        // Mock AccountTreeController to return no EVM accounts
-        const Engine = jest.requireMock('../../../../core/Engine');
-        Engine.context.AccountTreeController.getAccountsFromSelectedAccountGroup.mockReturnValue(
-          [
-            {
-              address: 'solana:abc123',
-              id: 'solana-account',
-              type: 'solana:data-account',
-              metadata: { name: 'Solana Account' },
-            },
-          ],
-        );
-
-        await controller.initializeProviders();
-
-        // Act & Assert
-        await expect(controller.depositWithConfirmation()).rejects.toThrow(
-          'No EVM-compatible account found in selected account group',
-        );
-      });
-    });
-
     it('should handle user cancellation of deposit transaction', async () => {
-      withController(async ({ controller }) => {
+      await withController(async ({ controller }) => {
         // Arrange
         const mockError = new Error('User denied transaction signature');
         const mockResultPromise = Promise.reject(mockError);
@@ -1243,7 +1206,7 @@ describe('PerpsController', () => {
     });
 
     it('should handle deposit transaction failure', async () => {
-      withController(async ({ controller }) => {
+      await withController(async ({ controller }) => {
         // Arrange
         const mockError = new Error('Insufficient balance');
         const mockResultPromise = Promise.reject(mockError);
@@ -1289,7 +1252,7 @@ describe('PerpsController', () => {
     });
 
     it('should handle deposit when TransactionController.addTransaction throws', async () => {
-      withController(async ({ controller }) => {
+      await withController(async ({ controller }) => {
         // Arrange
         const mockError = new Error('Network error');
 
@@ -1384,7 +1347,7 @@ describe('PerpsController', () => {
     });
 
     it('should handle empty deposit routes', async () => {
-      withController(async ({ controller }) => {
+      await withController(async ({ controller }) => {
         // Arrange
         mockHyperLiquidProvider.getDepositRoutes.mockReturnValue([]);
         mockHyperLiquidProvider.initialize.mockResolvedValue({ success: true });
@@ -1402,7 +1365,7 @@ describe('PerpsController', () => {
     });
 
     it('should use correct transaction type for perps deposit', async () => {
-      withController(async ({ controller }) => {
+      await withController(async ({ controller }) => {
         // Arrange
         const mockDepositRoute: AssetRoute = {
           assetId:

--- a/app/components/UI/Perps/controllers/PerpsController.test.ts
+++ b/app/components/UI/Perps/controllers/PerpsController.test.ts
@@ -50,6 +50,16 @@ jest.mock('../../../../core/Engine', () => ({
         metadata: { name: 'Test Account' },
       }),
     },
+    AccountTreeController: {
+      getAccountsFromSelectedAccountGroup: jest.fn().mockReturnValue([
+        {
+          address: '0x1234567890123456789012345678901234567890',
+          id: 'mock-account-id',
+          type: 'eip155:',
+          metadata: { name: 'Test Account' },
+        },
+      ]),
+    },
     NetworkController: {
       state: {
         selectedNetworkClientId: 'mainnet',

--- a/app/components/UI/Perps/hooks/usePerpsBlockExplorerUrl.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsBlockExplorerUrl.test.ts
@@ -6,7 +6,15 @@ import { PerpsController } from '../controllers';
 
 // Mock dependencies
 jest.mock('react-redux', () => ({
-  useSelector: jest.fn(),
+  useSelector: jest.fn(() => () => ({
+    address: '0x1234567890abcdef1234567890abcdef12345678',
+  })),
+}));
+
+jest.mock('../../../../selectors/multichainAccounts/accounts', () => ({
+  selectSelectedInternalAccountByScope: jest.fn(() => () => ({
+    address: '0x1234567890abcdef1234567890abcdef12345678',
+  })),
 }));
 
 jest.mock('../../../../core/Engine', () => ({
@@ -28,7 +36,9 @@ describe('usePerpsBlockExplorerUrl', () => {
     jest.clearAllMocks();
     Engine.context.PerpsController =
       mockController as unknown as PerpsController;
-    (useSelector as jest.Mock).mockReturnValue(mockSelectedAddress);
+    (useSelector as jest.Mock).mockReturnValue(() => ({
+      address: mockSelectedAddress,
+    }));
   });
 
   it('should return baseExplorerUrl from controller', () => {
@@ -94,7 +104,7 @@ describe('usePerpsBlockExplorerUrl', () => {
 
     it('should return null when no address available', () => {
       mockController.getBlockExplorerUrl.mockClear();
-      (useSelector as jest.Mock).mockReturnValue(null);
+      (useSelector as jest.Mock).mockReturnValue(() => null);
 
       const { result } = renderHook(() => usePerpsBlockExplorerUrl());
       const url = result.current.getExplorerUrl();

--- a/app/components/UI/Perps/hooks/usePerpsBlockExplorerUrl.ts
+++ b/app/components/UI/Perps/hooks/usePerpsBlockExplorerUrl.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { selectSelectedInternalAccountAddress } from '../../../../selectors/accountsController';
+import { selectSelectedInternalAccountByScope } from '../../../../selectors/multichainAccounts/accounts';
 import Engine from '../../../../core/Engine';
 
 export interface UsePerpsBlockExplorerUrlResult {
@@ -17,7 +17,9 @@ export const usePerpsBlockExplorerUrl = (
   defaultAddress?: string,
 ): UsePerpsBlockExplorerUrlResult => {
   const controller = Engine.context.PerpsController;
-  const selectedAddress = useSelector(selectSelectedInternalAccountAddress);
+  const selectedAddress = useSelector(selectSelectedInternalAccountByScope)(
+    'eip155:1',
+  )?.address;
 
   const baseExplorerUrl = useMemo(() => {
     try {

--- a/app/components/UI/Perps/providers/PerpsConnectionProvider.tsx
+++ b/app/components/UI/Perps/providers/PerpsConnectionProvider.tsx
@@ -193,7 +193,11 @@ export const PerpsConnectionProvider: React.FC<
 
   // Show skeleton loading UI while connection is initializing
   // This prevents components from trying to load data before the connection is ready
-  if (connectionState.isConnecting || !connectionState.isInitialized) {
+  // Don't show skeleton if there's an error (let the child components handle it)
+  if (
+    (connectionState.isConnecting || !connectionState.isInitialized) &&
+    !error
+  ) {
     return (
       <PerpsConnectionContext.Provider value={contextValue}>
         <PerpsLoadingSkeleton />

--- a/app/components/UI/Perps/services/HyperLiquidWalletService.test.ts
+++ b/app/components/UI/Perps/services/HyperLiquidWalletService.test.ts
@@ -69,6 +69,12 @@ jest.mock('../../../../selectors/accountsController', () => ({
   ),
 }));
 
+jest.mock('../../../../selectors/multichainAccounts/accounts', () => ({
+  selectSelectedInternalAccountByScope: jest.fn(
+    () => () => MOCK_SELECTED_ACCOUNT,
+  ),
+}));
+
 // Mock Engine with proper hoisting
 jest.mock('../../../../core/Engine', () => {
   const mockKeyringController = {
@@ -99,7 +105,7 @@ jest.mock('../../../../core/SDKConnect/utils/DevLogger', () => ({
 
 import { HyperLiquidWalletService } from './HyperLiquidWalletService';
 import type { CaipAccountId } from '@metamask/utils';
-import { selectSelectedInternalAccountAddress } from '../../../../selectors/accountsController';
+import { selectSelectedInternalAccountByScope } from '../../../../selectors/multichainAccounts/accounts';
 import { store } from '../../../../store';
 import Engine from '../../../../core/Engine';
 import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
@@ -160,8 +166,8 @@ describe('HyperLiquidWalletService', () => {
       it('should throw error when no account selected', async () => {
         // Mock selector to return null for this test
         jest
-          .mocked(selectSelectedInternalAccountAddress)
-          .mockReturnValueOnce(undefined);
+          .mocked(selectSelectedInternalAccountByScope)
+          .mockReturnValueOnce(() => undefined);
 
         await expect(
           walletAdapter.request({
@@ -267,8 +273,8 @@ describe('HyperLiquidWalletService', () => {
       it('should throw error when no account selected', async () => {
         // Mock selector to return null for this test
         jest
-          .mocked(selectSelectedInternalAccountAddress)
-          .mockReturnValueOnce(undefined);
+          .mocked(selectSelectedInternalAccountByScope)
+          .mockReturnValueOnce(() => undefined);
 
         await expect(
           walletAdapter.request({
@@ -344,8 +350,8 @@ describe('HyperLiquidWalletService', () => {
     it('should throw error when getting account ID with no selected account', async () => {
       // Mock selector to return null for this test
       jest
-        .mocked(selectSelectedInternalAccountAddress)
-        .mockReturnValueOnce(undefined);
+        .mocked(selectSelectedInternalAccountByScope)
+        .mockReturnValueOnce(() => undefined);
 
       await expect(service.getCurrentAccountId()).rejects.toThrow(
         'No account selected',

--- a/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
@@ -29,6 +29,13 @@ jest.mock('../../../../store', () => ({
 // Mock selectors
 jest.mock('../../../../selectors/accountsController', () => ({
   selectSelectedInternalAccountAddress: jest.fn(),
+  selectInternalAccounts: jest.fn(() => []),
+}));
+
+jest.mock('../../../../selectors/multichainAccounts/accounts', () => ({
+  selectSelectedInternalAccountByScope: jest.fn(() => () => ({
+    address: '0x1234567890123456789012345678901234567890',
+  })),
 }));
 
 jest.mock('../selectors/perpsController', () => ({
@@ -50,7 +57,7 @@ jest.mock('../providers/PerpsStreamManager', () => ({
 import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
 import Engine from '../../../../core/Engine';
 import { store } from '../../../../store';
-import { selectSelectedInternalAccountAddress } from '../../../../selectors/accountsController';
+import { selectSelectedInternalAccountByScope } from '../../../../selectors/multichainAccounts/accounts';
 import { selectPerpsNetwork } from '../selectors/perpsController';
 
 // Import PerpsConnectionManager after mocks are set up
@@ -406,8 +413,8 @@ describe('PerpsConnectionManager', () => {
 
       // Setup initial values for selectors
       (
-        selectSelectedInternalAccountAddress as unknown as jest.Mock
-      ).mockReturnValue('0xabc123');
+        selectSelectedInternalAccountByScope as unknown as jest.Mock
+      ).mockReturnValue(() => ({ address: '0xabc123' }));
       (selectPerpsNetwork as unknown as jest.Mock).mockReturnValue('mainnet');
       (store.getState as jest.Mock).mockReturnValue({});
     });
@@ -443,8 +450,8 @@ describe('PerpsConnectionManager', () => {
 
       // Simulate account change
       (
-        selectSelectedInternalAccountAddress as unknown as jest.Mock
-      ).mockReturnValue('0xdef456');
+        selectSelectedInternalAccountByScope as unknown as jest.Mock
+      ).mockReturnValue(() => ({ address: '0xdef456' }));
 
       // Trigger the store callback with the changed value
       storeCallback();
@@ -515,8 +522,8 @@ describe('PerpsConnectionManager', () => {
 
         // Simulate account change
         (
-          selectSelectedInternalAccountAddress as unknown as jest.Mock
-        ).mockReturnValue('0xdef456');
+          selectSelectedInternalAccountByScope as unknown as jest.Mock
+        ).mockReturnValue(() => ({ address: '0xdef456' }));
 
         // Trigger the store callback with changed values
         storeCallback();

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -1,7 +1,7 @@
 import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
 import Engine from '../../../../core/Engine';
 import { store } from '../../../../store';
-import { selectSelectedInternalAccountAddress } from '../../../../selectors/accountsController';
+import { selectSelectedInternalAccountByScope } from '../../../../selectors/multichainAccounts/accounts';
 import { selectPerpsNetwork } from '../selectors/perpsController';
 import { getStreamManagerInstance } from '../providers/PerpsStreamManager';
 
@@ -39,13 +39,17 @@ class PerpsConnectionManagerClass {
 
     // Get initial values
     const state = store.getState();
-    this.previousAddress = selectSelectedInternalAccountAddress(state);
+    const selectedEvmAccount =
+      selectSelectedInternalAccountByScope(state)('eip155:1');
+    this.previousAddress = selectedEvmAccount?.address;
     this.previousPerpsNetwork = selectPerpsNetwork(state);
 
     // Subscribe to Redux store changes
     this.unsubscribeFromStore = store.subscribe(() => {
       const currentState = store.getState();
-      const currentAddress = selectSelectedInternalAccountAddress(currentState);
+      const currentEvmAccount =
+        selectSelectedInternalAccountByScope(currentState)('eip155:1');
+      const currentAddress = currentEvmAccount?.address;
       const currentPerpsNetwork = selectPerpsNetwork(currentState);
 
       const hasAccountChanged =

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1129,11 +1129,6 @@
       "connectionRequired": "usePerpsConnection must be used within a PerpsConnectionProvider",
       "assetMappingFailed": "Failed to build asset mapping",
       "depositFailed": "Deposit failed",
-      "nonEvmAccount": {
-        "title": "Ethereum Account Required",
-        "description": "Perps trading requires an Ethereum account. Please switch to an Ethereum account to continue.",
-        "switchAccount": "Switch Account"
-      },
       "connectionFailed": {
         "title": "Connection Failed",
         "description": "Unable to connect to Perps services. Please check your connection and try again.",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1128,7 +1128,27 @@
       "withdrawFailed": "Failed to withdraw",
       "connectionRequired": "usePerpsConnection must be used within a PerpsConnectionProvider",
       "assetMappingFailed": "Failed to build asset mapping",
-      "depositFailed": "Deposit failed"
+      "depositFailed": "Deposit failed",
+      "nonEvmAccount": {
+        "title": "Ethereum Account Required",
+        "description": "Perps trading requires an Ethereum account. Please switch to an Ethereum account to continue.",
+        "switchAccount": "Switch Account"
+      },
+      "connectionFailed": {
+        "title": "Connection Failed",
+        "description": "Unable to connect to Perps services. Please check your connection and try again.",
+        "retry": "Retry"
+      },
+      "networkError": {
+        "title": "Network Error",
+        "description": "There was a problem connecting to the network. Please try again.",
+        "retry": "Try Again"
+      },
+      "unknown": {
+        "title": "Something Went Wrong",
+        "description": "An unexpected error occurred. Please try again later.",
+        "retry": "Retry"
+      }
     },
     "position": {
       "title": "Positions",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes the Perps tab infinite loading issue and migrates the Perps components to use the new multichain account architecture from PR #18407. The Perps tab now works seamlessly with the multichain account system, automatically using the appropriate EVM account even when a non-EVM account (like Solana) is selected.

### Key improvements:
1. **Multichain account support**: Migrated from `AccountsController` to `AccountTreeController` using BIP-44 account addresses with the new `selectSelectedInternalAccountByScope` selector
2. **Smart account handling**: When a Solana account is selected, Perps automatically uses the last active EVM account from the account group, ensuring continuous functionality
3. **Proper error recovery**: Connection failures now show an error state with a retry button instead of infinite loading
4. **Fixed infinite loading**: Resolved the issue where the Perps tab would show an infinite skeleton loader when switching accounts

## **Changelog**

CHANGELOG entry: Fixed Perps tab infinite loading issue and improved multichain account support

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/jira/software/c/projects/TAT/boards/1563/backlog?assignee=62440610247a4b00691c743a

## **Manual testing steps**

```gherkin
Feature: Perps Tab Multichain Account Support

  Scenario: User selects a Solana account
    Given the user has both EVM and Solana accounts in their wallet
    And the user is on the wallet main screen
    And an EVM account is currently selected

    When user switches to a Solana account
    And navigates to the Perps tab
    Then the Perps tab loads successfully
    And Perps continues to work with the last used EVM account
    And no infinite loading skeleton is displayed

  Scenario: User switches between different account types
    Given the user has multiple account types (EVM, Solana, Bitcoin)
    And the Perps tab is open

    When user switches between different account types
    Then the Perps tab maintains functionality
    And always uses the appropriate EVM account from the account group
    And no loading issues occur

  Scenario: Connection failure with retry
    Given the user has an EVM account selected
    And there is a network connection issue

    When user navigates to the Perps tab
    And the connection fails
    Then user sees a "Connection Failed" error message
    And user sees a "Retry" button
    And clicking "Retry" attempts to reconnect

  Scenario: Normal operation with EVM account
    Given the user has an EVM account selected
    And network connection is stable

    When user navigates to the Perps tab
    Then the Perps tab loads successfully
    And user can see their positions or first-time user screen
    And no error messages are displayed
```

## **Screenshots/Recordings**

### **Before**
- When switching accounts, the Perps tab would show an infinite loading skeleton
- The tab would fail to load properly when account changes occurred
- Used the deprecated `AccountsController` which didn't support multichain accounts properly

https://github.com/user-attachments/assets/99c2db16-9aa6-476c-8df2-70f3df7af44c


### **After**
- Perps tab seamlessly works with multichain accounts
- When a Solana account is selected, Perps automatically uses the appropriate EVM account from the same account group
- Proper error handling for connection failures with retry functionality
- Smooth transitions when switching between account types
- Uses the new `AccountTreeController` with BIP-44 account addresses

https://github.com/user-attachments/assets/f66e3b4e-c005-4c3f-b4b7-6d2e245bdc35


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.