### PR TITLE
chore: reduce actions drift, add more concurrency

### DIFF
--- a/.github/workflows/add-release-label.yml
+++ b/.github/workflows/add-release-label.yml
@@ -13,12 +13,12 @@ jobs:
     if: github.event.pull_request.merged == true
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
             fetch-depth: 0 # This is needed to checkout all branches
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/add-release-label.yml
+++ b/.github/workflows/add-release-label.yml
@@ -18,7 +18,7 @@ jobs:
             fetch-depth: 0 # This is needed to checkout all branches
 
       - name: Set up Node.js
-        uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/bitrise-e2e-gate.yml
+++ b/.github/workflows/bitrise-e2e-gate.yml
@@ -21,10 +21,10 @@ jobs:
       checks: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/bitrise-e2e-gate.yml
+++ b/.github/workflows/bitrise-e2e-gate.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up Node.js
-        uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -28,10 +28,10 @@ jobs:
       apk-uploaded: ${{ steps.upload-apk.outcome == 'success' }}
       aab-uploaded: ${{ steps.upload-aab.outcome == 'success' }}
       sourcemap-uploaded: ${{ steps.upload-sourcemap.outcome == 'success' }}
-    
+
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Setup Android Build Environment
         uses: MetaMask/github-tools/.github/actions/setup-e2e-env@self-hosted-runners-config
@@ -42,7 +42,7 @@ jobs:
           target: qa
 
       - name: Cache Gradle dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: |
             ~/.gradle/caches
@@ -56,7 +56,7 @@ jobs:
         run: |
           echo "🚀 Setting up project..."
           yarn setup:github-ci --no-build-ios
-          
+
           echo "🏗 Building Android E2E APKs..."
           export NODE_OPTIONS="--max-old-space-size=8192"
           cp android/gradle.properties.github android/gradle.properties
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload Android APK
         id: upload-apk
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: app-prod-release.apk
           path: android/app/build/outputs/apk/prod/release/app-prod-release.apk
@@ -107,7 +107,7 @@ jobs:
 
       - name: Upload Android Test APK
         id: upload-test-apk
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: app-prod-release-androidTest.apk
           path: android/app/build/outputs/apk/androidTest/prod/release/app-prod-release-androidTest.apk
@@ -116,7 +116,7 @@ jobs:
 
       - name: Upload Android AAB
         id: upload-aab
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: app-prod-release.aab
           path: android/app/build/outputs/bundle/prodRelease/app-prod-release.aab
@@ -126,7 +126,7 @@ jobs:
 
       - name: Upload Android Source Map
         id: upload-sourcemap
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: index.android.bundle.map
           path: sourcemaps/android/index.android.bundle.map

--- a/.github/workflows/check-attributions.yml
+++ b/.github/workflows/check-attributions.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'

--- a/.github/workflows/check-pr-labels.yml
+++ b/.github/workflows/check-pr-labels.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
             fetch-depth: 1 # This retrieves only the latest commit.
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/check-pr-labels.yml
+++ b/.github/workflows/check-pr-labels.yml
@@ -23,7 +23,7 @@ jobs:
             fetch-depth: 1 # This retrieves only the latest commit.
 
       - name: Set up Node.js
-        uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/check-template-and-add-labels.yml
+++ b/.github/workflows/check-template-and-add-labels.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 1 # This retrieves only the latest commit.
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/check-template-and-add-labels.yml
+++ b/.github/workflows/check-template-and-add-labels.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 1 # This retrieves only the latest commit.
 
       - name: Set up Node.js
-        uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,16 +6,20 @@ on:
   merge_group:
     types: [checks_requested]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !(contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/heads/stable')) }}
+
 jobs:
   check-diff:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: yarn
-      - uses: ruby/setup-ruby@a6e6f86333f0a2523ece813039b8b4be04560854 #v1
+      - uses: ruby/setup-ruby@efbf473cab83af4468e8606cc33eca9281bb213f # v1.256.0
         with:
           ruby-version: '3.1.6'
         env:
@@ -33,8 +37,8 @@ jobs:
   dedupe:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: yarn
@@ -51,8 +55,8 @@ jobs:
   git-safe-dependencies:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: yarn
@@ -71,10 +75,10 @@ jobs:
           - test:depcheck
           - test:tgz-check
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: yarn
@@ -95,8 +99,8 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: yarn
@@ -110,7 +114,7 @@ jobs:
         shell: bash
         run: |
           mv ./tests/coverage/coverage-final.json ./tests/coverage/coverage-${{ matrix.shard }}.json
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-${{ matrix.shard }}
           path: ./tests/coverage/coverage-${{ matrix.shard }}.json
@@ -134,13 +138,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: unit-tests
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: yarn
       - run: yarn setup --node
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           path: tests/coverage/
       - name: Gather partial coverage reports into one directory
@@ -149,7 +153,7 @@ jobs:
           mv ./tests/coverage/coverage-*/* ./tests/coverage
       - run: yarn test:merge-coverage
       - run: yarn test:validate-coverage
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage
           path: ./tests/merged-coverage/lcov.info
@@ -167,8 +171,8 @@ jobs:
   js-bundle-size-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: yarn
@@ -182,7 +186,7 @@ jobs:
         run: ./scripts/js-bundle-stats.sh ios/main.jsbundle 45
 
       - name: Upload iOS bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ios-bundle
           path: ios/main.jsbundle
@@ -192,10 +196,10 @@ jobs:
     needs: [js-bundle-size-check]
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Download iOS bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: ios-bundle
           path: ios/main.jsbundle
@@ -210,13 +214,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: merge-unit-tests
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0 # SonarCloud needs a full checkout to perform necessary analysis
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: coverage
           path: coverage/
@@ -227,8 +231,7 @@ jobs:
       - name: SonarCloud Scan
         if: ${{ env.HAVE_SONAR_TOKEN == 'true' && github.event_name == 'pull_request' }}
         continue-on-error: true
-        # This is SonarSource/sonarcloud-github-action@v2.0.0
-        uses: SonarSource/sonarcloud-github-action@4b4d7634dab97dcee0b75763a54a6dc92a9e6bc1
+        uses: SonarSource/sonarcloud-github-action@4b4d7634dab97dcee0b75763a54a6dc92a9e6bc1 # v2.0.0
         env:
           HAVE_SONAR_TOKEN: ${{ secrets.SONAR_TOKEN != '' }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -253,7 +256,7 @@ jobs:
     needs: sonar-cloud
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: SonarCloud Quality Gate Status
         id: sonar-status
         env:
@@ -306,7 +309,7 @@ jobs:
     name: Check workflows
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Download actionlint
         id: download-actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/62dc61a45fc95efe8c800af7a557ab0b9165d63b/scripts/download-actionlint.bash) 1.7.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: yarn
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: yarn
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: yarn
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 2
-      - uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: yarn
@@ -100,7 +100,7 @@ jobs:
         shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: yarn
@@ -139,7 +139,7 @@ jobs:
     needs: unit-tests
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: yarn
@@ -172,7 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: yarn
@@ -217,7 +217,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0 # SonarCloud needs a full checkout to perform necessary analysis
-      - uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
       - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0

--- a/.github/workflows/close-bug-report.yml
+++ b/.github/workflows/close-bug-report.yml
@@ -18,7 +18,7 @@ jobs:
             fetch-depth: 1 # This retrieves only the latest commit.
 
       - name: Set up Node.js
-        uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/close-bug-report.yml
+++ b/.github/workflows/close-bug-report.yml
@@ -6,19 +6,19 @@ on:
       - stable
     types:
       - closed
-    
+
 jobs:
   close-bug-report:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
             fetch-depth: 1 # This retrieves only the latest commit.
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/create-bug-report.yml
+++ b/.github/workflows/create-bug-report.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Set up Node.js
         if: steps.extract_version.outputs.version
-        uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/create-bug-report.yml
+++ b/.github/workflows/create-bug-report.yml
@@ -19,11 +19,11 @@ jobs:
 
       - name: Checkout repository
         if: steps.extract_version.outputs.version
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up Node.js
         if: steps.extract_version.outputs.version
-        uses: actions/setup-node@v3
+        uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/create-cherry-pick-pr.yml
+++ b/.github/workflows/create-cherry-pick-pr.yml
@@ -19,7 +19,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           ref: ${{ vars.branch_name }}
@@ -27,7 +27,7 @@ jobs:
       - name: Get Node.js version
         id: nvm
         run: echo "NODE_VERSION=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
       - name: Create Cherry Pick PR

--- a/.github/workflows/create-cherry-pick-pr.yml
+++ b/.github/workflows/create-cherry-pick-pr.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Get Node.js version
         id: nvm
         run: echo "NODE_VERSION=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ steps.nvm.outputs.NODE_VERSION }}
       - name: Create Cherry Pick PR

--- a/.github/workflows/create-release-draft.yml
+++ b/.github/workflows/create-release-draft.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: ${{ github.ref }}  # Explicitly specifies the tag ref
 

--- a/.github/workflows/crowdin_action.yml
+++ b/.github/workflows/crowdin_action.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           # Use PAT to ensure that the commit later can trigger status check workflows
           token: ${{ secrets.METAMASKBOT_CROWDIN_TOKEN }}

--- a/.github/workflows/detect-mobile-build-changes.yml
+++ b/.github/workflows/detect-mobile-build-changes.yml
@@ -30,7 +30,7 @@ jobs:
       any: ${{ steps.set-outputs.outputs.any_changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
@@ -51,8 +51,8 @@ jobs:
               - 'app/components/**/android/**'     # Android UI components
               - 'app/util/**/android/**'           # Android utilities
               - 'package.json'                     # If native deps change
-              
- 
+
+
             ios:
               - 'ios/**'                           # All iOS project files
               - 'Podfile'                          # CocoaPods dependencies
@@ -66,8 +66,8 @@ jobs:
               - 'app/components/**/ios/**'         # iOS UI components
               - 'app/util/**/ios/**'               # iOS utilities
               - 'package.json'                     # If native deps change
-              
-              
+
+
             shared:
               - 'metro.config.js'                  # Metro bundler
               - 'tsconfig.json'                    # TypeScript config
@@ -89,7 +89,7 @@ jobs:
           android_direct="${{ steps.filter.outputs.android }}"
           ios_direct="${{ steps.filter.outputs.ios }}"
           shared_changed="${{ steps.filter.outputs.shared }}"
-          
+
           # Apply shared logic: if shared files changed, both platforms should build
           if [[ "$shared_changed" == 'true' ]]; then
             android_final="true"
@@ -98,11 +98,11 @@ jobs:
             android_final="$android_direct"
             ios_final="$ios_direct"
           fi
-          
+
           # Set outputs
           echo "android_final=$android_final" >> "${GITHUB_OUTPUT}"
           echo "ios_final=$ios_final" >> "${GITHUB_OUTPUT}"
-          
+
           # Set any_changed
           if [[ "$android_final" == 'true' || "$ios_final" == 'true' ]]; then
             echo "any_changed=true" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Build and load
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5

--- a/.github/workflows/fitness-functions.yml
+++ b/.github/workflows/fitness-functions.yml
@@ -10,12 +10,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/run-bitrise-e2e-check.yml
+++ b/.github/workflows/run-bitrise-e2e-check.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up Node.js
-        uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/run-bitrise-e2e-check.yml
+++ b/.github/workflows/run-bitrise-e2e-check.yml
@@ -23,10 +23,10 @@ jobs:
       checks: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/run-bitrise-flask-e2e-check.yml
+++ b/.github/workflows/run-bitrise-flask-e2e-check.yml
@@ -21,10 +21,10 @@ jobs:
       checks: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
 
@@ -41,4 +41,4 @@ jobs:
         # The status check created under this workflow may be bucketed under another check suite in Github actions. This is a result of workflows with the same triggers.
         # For example, the status check may show as `CLA Signature Bot / Bitrise Flask E2E Status`. This is a bug on Github's UI. https://github.com/orgs/community/discussions/24616
         run: yarn run run-bitrise-e2e-check
-        working-directory: '.github/scripts' 
+        working-directory: '.github/scripts'

--- a/.github/workflows/run-bitrise-flask-e2e-check.yml
+++ b/.github/workflows/run-bitrise-flask-e2e-check.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up Node.js
-        uses: actions/checkout@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/run-e2e-api-specs.yml
+++ b/.github/workflows/run-e2e-api-specs.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.platform }}-${{ inputs.test-suite-name }}
+  cancel-in-progress: ${{ !(contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/heads/stable')) }}
+
 jobs:
   api-specs-ios:
     name: "api-specs-ios"
@@ -31,18 +35,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: ${{ github.head_ref || github.ref }}
           clean: true
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20.18.0'
           cache: 'yarn'
-          
+
       - name: Enable Corepack and setup Yarn
         run: |
           corepack enable
@@ -68,13 +72,13 @@ jobs:
       - name: Build Detox framework cache for API specs
         run: |
           echo "🔧 Building Detox framework cache specifically for API specs..."
-          
+
           # Clean any existing cache first
           yarn detox clean-framework-cache
-          
+
           # Build fresh framework cache
           yarn detox build-framework-cache
-          
+
           # Verify the framework was built successfully
           if [[ -d ~/Library/Detox/ios/framework ]]; then
             echo "✅ Detox framework cache built successfully"
@@ -88,7 +92,7 @@ jobs:
         run: |
           echo "🚀 Setting up pre-built QA app for API specs..."
 
-          # Base URL for artifacts  
+          # Base URL for artifacts
           base_url="https://github.com/MetaMask/tmp-bitrise-migration-artifacts/releases/download/test5"
 
           # Create required directory
@@ -129,40 +133,40 @@ jobs:
       - name: Clean environment before API specs
         run: |
           echo "🧹 Cleaning environment before API specs tests..."
-          
+
           # Clean up any lock files
           find . -name "*.lock" -type f -delete 2>/dev/null || true
-          
+
           # Reset Detox lock file
           yarn detox reset-lock-file
-          
+
           # Clean any hanging processes
           pkill -f "Metro\|node\|npm" 2>/dev/null || true
-          
+
           echo "✅ Environment cleaned and ready for API specs"
 
       - name: Run API Specs tests
         run: |
           echo "🚀 Running API specs tests..."
           echo "Using Detox configuration: ios.sim.apiSpecs"
-          
+
           # Run API specs with retries
           yarn test:api-specs --retries 1
-          
+
           echo "✅ API specs tests completed"
 
       - name: Upload API specs test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: api-specs-test-results
           path: e2e/reports/
           retention-days: 7
-      
+
       - name: Upload API specs screenshots
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: api-specs-screenshots
           path: artifacts/
-          retention-days: 7 
+          retention-days: 7

--- a/.github/workflows/run-e2e-api-specs.yml
+++ b/.github/workflows/run-e2e-api-specs.yml
@@ -10,7 +10,7 @@ on:
     types: [opened, synchronize]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.platform }}-${{ inputs.test-suite-name }}
+  group: ${{ github.workflow }}-${{ github.ref }}-run-e2e-api-specs
   cancel-in-progress: ${{ !(contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/heads/stable')) }}
 
 jobs:

--- a/.github/workflows/run-e2e-workflow.yml
+++ b/.github/workflows/run-e2e-workflow.yml
@@ -64,14 +64,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: ${{ github.event_name == 'merge_group' && github.event.merge_group.head_sha || github.event.pull_request.head.sha || github.sha }}
           clean: true
           fetch-depth: 0
 
       - name: Set up E2E environment
-        uses: MetaMask/github-tools/.github/actions/setup-e2e-env@self-hosted-runners-config 
+        uses: MetaMask/github-tools/.github/actions/setup-e2e-env@self-hosted-runners-config
         with:
           platform: ${{ inputs.platform }}
           setup-simulator: ${{ inputs.platform == 'ios' }}
@@ -90,13 +90,13 @@ jobs:
         if: ${{ inputs.platform == 'android' }}
         run: |
           echo "🏗 Setting up Android artifacts from build job..."
-          
+
           # Create required directories
           mkdir -p android/app/build/outputs/apk/prod/release/
 
       - name: Download Android build artifacts
         if: ${{ inputs.platform == 'android' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           path: artifacts/
 
@@ -165,19 +165,19 @@ jobs:
           else
             export BITRISE_TRIGGERED_WORKFLOW_ID="android_workflow"
           fi
-          
+
           ./scripts/run-e2e-tags.sh
-          
+
           echo "✅ Test execution completed"
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ inputs.test-suite-name }}-test-results
           path: e2e/reports/
           retention-days: 7
-      
+
       - name: Prepare screenshots
         if: failure()
         run: |
@@ -206,7 +206,7 @@ jobs:
 
       - name: Upload screenshots
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ inputs.test-suite-name }}-screenshots
           path: artifacts/

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -11,6 +11,10 @@ permissions:
   contents: read
   id-token: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !(contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/heads/stable')) }}
+
 jobs:
   # Build Android APKs once for all Android tests
   build-android-apks:
@@ -251,16 +255,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-        
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
       - name: Download all test results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           path: all-test-results/
           pattern: "*-test-results"
 
       - name: Post Test Report
-        uses: dorny/test-reporter@dc3a92680fcc15842eef52e8c4606ea7ce6bd3f3
+        uses: dorny/test-reporter@dc3a92680fcc15842eef52e8c4606ea7ce6bd3f3 # v2.1.1
         with:
           name: "E2E Smoke Test Results"
           path: "all-test-results/**/*.xml"
@@ -270,7 +274,7 @@ jobs:
           list-tests: "all"
 
       - name: Upload merged report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: merged-test-report
           path: all-test-results/**/*.xml

--- a/.github/workflows/stable-branch-sync.yml
+++ b/.github/workflows/stable-branch-sync.yml
@@ -18,7 +18,7 @@ jobs:
       next-version: ${{ env.NEXT_SEMVER_VERSION }}
     steps:
         - name: Checkout
-          uses: actions/checkout@v4
+          uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
           with:
             fetch-depth: 0
 

--- a/.github/workflows/test-android-build-app.yml
+++ b/.github/workflows/test-android-build-app.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       # Get the source code from the repository
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       # Install Android SDK, Node.js, and other Android development dependencies
       - name: Installing Android Environment Setup
@@ -130,7 +130,7 @@ jobs:
       # Upload the Android APK file for device installation and testing
       - name: Upload Android APK Artifact
         id: upload-apk
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: app-qa-release.apk
           path: android/app/build/outputs/apk/qa/release/app-qa-release.apk
@@ -141,7 +141,7 @@ jobs:
       # Upload the Android App Bundle (AAB) for Play Store distribution
       - name: Upload Android AAB Artifact
         id: upload-aab
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: app-qa-release.aab
           path: android/app/build/outputs/bundle/qaRelease/app-qa-release.aab
@@ -152,7 +152,7 @@ jobs:
       # Upload source map file for crash debugging and error tracking
       - name: Upload Android Source Map
         id: upload-sourcemap
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: index.android.bundle.map
           path: sourcemaps/android/index.android.bundle.map

--- a/.github/workflows/test-ios-build-app.yml
+++ b/.github/workflows/test-ios-build-app.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       # Get the source code from the repository
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       # Display system information for debugging purposes
       - name: Detect CPU architecture
@@ -109,7 +109,7 @@ jobs:
       # Upload the iOS .app file that works in simulators (no certificates needed)
       - name: Upload iOS APP Artifact (Simulator)
         id: upload-app
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: MetaMask-QA.app
           path: ios/build/Build/Products/Release-iphonesimulator/MetaMask-QA.app
@@ -120,7 +120,7 @@ jobs:
       # Upload iOS .ipa file for device installation (requires certificates - may not exist)
       - name: Upload iOS IPA Artifact (Device)
         id: upload-ipa
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: MetaMask-QA.ipa
           path: ios/build/output/MetaMask-QA.ipa
@@ -131,7 +131,7 @@ jobs:
       # Upload iOS .xcarchive file for debugging and re-signing (requires certificates - may not exist)
       - name: Upload iOS Archive Artifact
         id: upload-archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: MetaMask-QA.xcarchive
           path: ios/build/MetaMask-QA.xcarchive
@@ -142,7 +142,7 @@ jobs:
       # Upload source map file for crash debugging and error tracking if exists
       - name: Upload iOS Source Map
         id: upload-sourcemap
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: index.js.map
           path: sourcemaps/ios/index.js.map

--- a/.github/workflows/trigger-performance-e2e.yml
+++ b/.github/workflows/trigger-performance-e2e.yml
@@ -1,7 +1,7 @@
 name: Performance E2E Test Manual WorkFlow
- ## This is 1 out of 5 Prs which will enable us to trigger the performance e2e via a workflow dispatch  
+ ## This is 1 out of 5 Prs which will enable us to trigger the performance e2e via a workflow dispatch
  ## The infra to build the apps is not currently setup hence to trigger this workflow, you would need to
- ## grab the browserstack app_url from the build_android_qa workflow in github. 
+ ## grab the browserstack app_url from the build_android_qa workflow in github.
 on:
   workflow_dispatch:
     inputs:
@@ -28,6 +28,10 @@ on:
   #   # Every 3 hours on main branch
   #   - cron: '0 */3 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.platform }}-${{ inputs.test-suite-name }}
+  cancel-in-progress: ${{ !(contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/heads/stable')) }}
+
 jobs:
   run-performance-test:
     runs-on: ubuntu-latest
@@ -40,13 +44,13 @@ jobs:
       MM_TEST_ACCOUNT_SRP: ${{ secrets.MM_TEST_ACCOUNT_SRP }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-      
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
-      
+
       - name: Install dependencies
         run: yarn setup
 
@@ -64,13 +68,13 @@ jobs:
           local-testing: start
           local-identifier: ${{ github.run_id }}
           local-args: --force-local --verbose
-      
+
       - name: Wait for BrowserStack Local
         run: |
           echo "Waiting for BrowserStack Local to be ready..."
           sleep 30
           echo "BrowserStack Local should be ready now"
-      
+
       - name: Run Android Performance Tests
         env:
           BROWSERSTACK_LOCAL: true

--- a/.github/workflows/trigger-performance-e2e.yml
+++ b/.github/workflows/trigger-performance-e2e.yml
@@ -29,7 +29,7 @@ on:
   #   - cron: '0 */3 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.platform }}-${{ inputs.test-suite-name }}
+  group: ${{ github.workflow }}-${{ github.ref }}-trigger-performance-e2e
   cancel-in-progress: ${{ !(contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/heads/stable')) }}
 
 jobs:

--- a/.github/workflows/update-attributions.yml
+++ b/.github/workflows/update-attributions.yml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       IS_FORK: ${{ steps.is-fork.outputs.IS_FORK }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Determine whether this PR is from a fork
         id: is-fork
         run: echo "IS_FORK=$(gh pr view --json isCrossRepository --jq '.isCrossRepository' "${PR_NUMBER}" )" >> "$GITHUB_OUTPUT"
@@ -28,7 +28,7 @@ jobs:
     if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: React to the comment
         run: |
           gh api \
@@ -52,14 +52,14 @@ jobs:
       COMMIT_SHA: ${{ steps.commit-sha.outputs.COMMIT_SHA }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
@@ -79,14 +79,14 @@ jobs:
     if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
@@ -110,7 +110,7 @@ jobs:
     if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           # Use PAT to ensure that the commit later can trigger status check workflows
           token: ${{ secrets.ACTIONS_WRITE_TOKEN }}
@@ -180,7 +180,7 @@ jobs:
       - is-fork-pull-request
       - check-status
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Post comment if the update failed

--- a/.github/workflows/update-latest-build-version.yml
+++ b/.github/workflows/update-latest-build-version.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: generate-build-version
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           ref: ${{ inputs.base-branch }}


### PR DESCRIPTION
## **Description**

This PR enhances our CI/CD workflow security and efficiency by implementing two key improvements:

**What is the reason for the change?**
- **Security**: Using major version tags (e.g., `v3`) for GitHub Actions creates potential security vulnerabilities, as malicious code could be injected into future releases within that major version
- **Resource optimization**: Multiple workflow runs for the same PR/branch waste CI resources and can cause confusion when viewing build status

**What is the improvement/solution?**
- **Pin actions to specific SHA commits** instead of major version tags to ensure immutable, verified action versions
- **Add workflow concurrency controls** to automatically cancel stale/outdated workflow runs when new commits are pushed, reducing resource consumption and providing clearer build status

## **Changelog**

CHANGELOG entry: null

## **Manual testing steps**

```gherkin
Feature: Improved CI/CD workflow security and efficiency
  Scenario: Developer pushes multiple commits to PR branch
    Given a PR branch with existing workflow runs
    When developer pushes a new commit to the same branch
    Then previous workflow runs should be automatically cancelled
    And only the latest workflow run should continue
    And all GitHub Actions should use pinned SHA versions instead of version tags