### PR TITLE
test: add ci workflows for running performance

### DIFF
--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -400,8 +400,8 @@ jobs:
       
       - name: Set Android Test Environment
         run: |
+          echo "Setting test environment for device: ${{ matrix.device.name }}"
           {
-            echo "Setting test environment for device: ${{ matrix.device.name }}"
             echo "BROWSERSTACK_DEVICE=${{ matrix.device.name }}"
             echo "BROWSERSTACK_OS_VERSION=${{ matrix.device.os_version }}"
             echo "BROWSERSTACK_ANDROID_APP_URL=${{ needs.trigger-qa-builds-and-upload.outputs.browserstack-android-url }}"
@@ -493,8 +493,8 @@ jobs:
       
       - name: Set iOS Test Environment
         run: |
+          echo "Setting test environment for device: ${{ matrix.device.name }}"
           {
-            echo "Setting test environment for device: ${{ matrix.device.name }}"
             echo "BROWSERSTACK_DEVICE=${{ matrix.device.name }}"
             echo "BROWSERSTACK_OS_VERSION=${{ matrix.device.os_version }}"
             echo "BROWSERSTACK_IOS_APP_URL=${{ needs.trigger-qa-builds-and-upload.outputs.browserstack-ios-url }}"

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -49,12 +49,12 @@ jobs:
           echo "Reading device matrix from appwright/device-matrix.json"
           
           # Extract Android devices
-          ANDROID_MATRIX=$(cat appwright/device-matrix.json | jq -r ".android_devices | map({name: .name, os_version: .os_version, category: .category}) | tojson")
-          echo "android=$ANDROID_MATRIX" >> $GITHUB_OUTPUT
+          ANDROID_MATRIX=$(jq -r ".android_devices | map({name: .name, os_version: .os_version, category: .category}) | tojson" appwright/device-matrix.json)
+          echo "android=$ANDROID_MATRIX" >> "$GITHUB_OUTPUT"
           
           # Extract iOS devices
-          IOS_MATRIX=$(cat appwright/device-matrix.json | jq -r ".ios_devices | map({name: .name, os_version: .os_version, category: .category}) | tojson")
-          echo "ios=$IOS_MATRIX" >> $GITHUB_OUTPUT
+          IOS_MATRIX=$(jq -r ".ios_devices | map({name: .name, os_version: .os_version, category: .category}) | tojson" appwright/device-matrix.json)
+          echo "ios=$IOS_MATRIX" >> "$GITHUB_OUTPUT"
           
           echo "Android matrix: $ANDROID_MATRIX"
           echo "iOS matrix: $IOS_MATRIX"
@@ -225,7 +225,8 @@ jobs:
           ANDROID_ARTIFACTS=$(curl -s -H "Authorization: $BITRISE_API_TOKEN" \
             "https://api.bitrise.io/v0.1/apps/$BITRISE_APP_ID/builds/$ANDROID_BUILD_ID/artifacts")
           
-          if [[ $? -ne 0 ]]; then
+          if ! curl -s -H "Authorization: $BITRISE_API_TOKEN" \
+            "https://api.bitrise.io/v0.1/apps/$BITRISE_APP_ID/builds/$ANDROID_BUILD_ID/artifacts" > /dev/null; then
             echo "Error: Failed to fetch Android artifacts"
             exit 1
           fi
@@ -248,14 +249,14 @@ jobs:
               echo "Downloading Android browserstack JSON..."
               wget -O "android_browserstack_apps.json" "$ANDROID_BS_DOWNLOAD_URL"
               
-              if [[ $? -ne 0 ]]; then
+              if ! wget -O "android_browserstack_apps.json" "$ANDROID_BS_DOWNLOAD_URL"; then
                 echo "Error: Failed to download Android browserstack JSON"
                 exit 1
               fi
               
               # Extract the first Android APK app_url
-              ANDROID_BS_URL=$(cat "android_browserstack_apps.json" | jq -r '.[] | select(.app_name | endswith(".apk")) | .app_url' | head -1)
-              ANDROID_VERSION=$(cat "android_browserstack_apps.json" | jq -r '.[] | select(.app_name | endswith(".apk")) | .app_version' | head -1)
+              ANDROID_BS_URL=$(jq -r '.[] | select(.app_name | endswith(".apk")) | .app_url' "android_browserstack_apps.json" | head -1)
+              ANDROID_VERSION=$(jq -r '.[] | select(.app_name | endswith(".apk")) | .app_version' "android_browserstack_apps.json" | head -1)
               
               echo "Android BrowserStack URL: $ANDROID_BS_URL"
               echo "Android version: $ANDROID_VERSION"
@@ -275,7 +276,8 @@ jobs:
           IOS_ARTIFACTS=$(curl -s -H "Authorization: $BITRISE_API_TOKEN" \
             "https://api.bitrise.io/v0.1/apps/$BITRISE_APP_ID/builds/$IOS_BUILD_ID/artifacts")
           
-          if [[ $? -ne 0 ]]; then
+          if ! curl -s -H "Authorization: $BITRISE_API_TOKEN" \
+            "https://api.bitrise.io/v0.1/apps/$BITRISE_APP_ID/builds/$IOS_BUILD_ID/artifacts" > /dev/null; then
             echo "Error: Failed to fetch iOS artifacts"
             exit 1
           fi
@@ -299,14 +301,14 @@ jobs:
               echo "Downloading iOS browserstack JSON..."
               wget -O "ios_browserstack_apps.json" "$IOS_BS_DOWNLOAD_URL"
               
-              if [[ $? -ne 0 ]]; then
+              if ! wget -O "ios_browserstack_apps.json" "$IOS_BS_DOWNLOAD_URL"; then
                 echo "Error: Failed to download iOS browserstack JSON"
                 exit 1
               fi
               
               # Extract the first iOS IPA app_url
-              IOS_BS_URL=$(cat "ios_browserstack_apps.json" | jq -r '.[] | select(.app_name | endswith(".ipa")) | .app_url' | head -1)
-              IOS_VERSION=$(cat "ios_browserstack_apps.json" | jq -r '.[] | select(.app_name | endswith(".ipa")) | .app_version' | head -1)
+              IOS_BS_URL=$(jq -r '.[] | select(.app_name | endswith(".ipa")) | .app_url' "ios_browserstack_apps.json" | head -1)
+              IOS_VERSION=$(jq -r '.[] | select(.app_name | endswith(".ipa")) | .app_version' "ios_browserstack_apps.json" | head -1)
               
               echo "iOS BrowserStack URL: $IOS_BS_URL"
               echo "iOS version: $IOS_VERSION"
@@ -390,13 +392,15 @@ jobs:
       
       - name: Set Android Test Environment
         run: |
-          echo "Setting test environment for device: ${{ matrix.device.name }}"
-          echo "BROWSERSTACK_DEVICE=${{ matrix.device.name }}" >> $GITHUB_ENV
-          echo "BROWSERSTACK_OS_VERSION=${{ matrix.device.os_version }}" >> $GITHUB_ENV
-          echo "BROWSERSTACK_ANDROID_APP_URL=${{ needs.trigger-qa-builds-and-upload.outputs.browserstack-android-url }}" >> $GITHUB_ENV
-          echo "TEST_PLATFORM=android" >> $GITHUB_ENV
-          echo "TEST_SUITE=${{ github.event.inputs.test_suite }}" >> $GITHUB_ENV
-          echo "QA_APP_VERSION=${{ needs.trigger-qa-builds-and-upload.outputs.android-version }}" >> $GITHUB_ENV
+          {
+            echo "Setting test environment for device: ${{ matrix.device.name }}"
+            echo "BROWSERSTACK_DEVICE=${{ matrix.device.name }}"
+            echo "BROWSERSTACK_OS_VERSION=${{ matrix.device.os_version }}"
+            echo "BROWSERSTACK_ANDROID_APP_URL=${{ needs.trigger-qa-builds-and-upload.outputs.browserstack-android-url }}"
+            echo "TEST_PLATFORM=android"
+            echo "TEST_SUITE=${{ github.event.inputs.test_suite }}"
+            echo "QA_APP_VERSION=${{ needs.trigger-qa-builds-and-upload.outputs.android-version }}"
+          } >> "$GITHUB_ENV"
       
       - name: Run Android Tests on ${{ matrix.device.name }}
         env:
@@ -481,12 +485,14 @@ jobs:
       
       - name: Set iOS Test Environment
         run: |
-          echo "Setting test environment for device: ${{ matrix.device.name }}"
-          echo "BROWSERSTACK_DEVICE=${{ matrix.device.name }}" >> $GITHUB_ENV
-          echo "BROWSERSTACK_OS_VERSION=${{ matrix.device.os_version }}" >> $GITHUB_ENV
-          echo "BROWSERSTACK_IOS_APP_URL=${{ needs.trigger-qa-builds-and-upload.outputs.browserstack-ios-url }}" >> $GITHUB_ENV
-          echo "TEST_SUITE=${{ github.event.inputs.test_suite }}" >> $GITHUB_ENV
-          echo "QA_APP_VERSION=${{ needs.trigger-qa-builds-and-upload.outputs.ios-version }}" >> $GITHUB_ENV
+          {
+            echo "Setting test environment for device: ${{ matrix.device.name }}"
+            echo "BROWSERSTACK_DEVICE=${{ matrix.device.name }}"
+            echo "BROWSERSTACK_OS_VERSION=${{ matrix.device.os_version }}"
+            echo "BROWSERSTACK_IOS_APP_URL=${{ needs.trigger-qa-builds-and-upload.outputs.browserstack-ios-url }}"
+            echo "TEST_SUITE=${{ github.event.inputs.test_suite }}"
+            echo "QA_APP_VERSION=${{ needs.trigger-qa-builds-and-upload.outputs.ios-version }}"
+          } >> "$GITHUB_ENV"
       
       - name: Run iOS Tests on ${{ matrix.device.name }}
         env:

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -50,11 +50,13 @@ jobs:
           
           # Extract Android devices
           ANDROID_MATRIX=$(jq -r ".android_devices | map({name: .name, os_version: .os_version, category: .category}) | tojson" appwright/device-matrix.json)
-          echo "android=$ANDROID_MATRIX" >> "$GITHUB_OUTPUT"
-          
           # Extract iOS devices
           IOS_MATRIX=$(jq -r ".ios_devices | map({name: .name, os_version: .os_version, category: .category}) | tojson" appwright/device-matrix.json)
-          echo "ios=$IOS_MATRIX" >> "$GITHUB_OUTPUT"
+          
+          {
+            echo "android=$ANDROID_MATRIX"
+            echo "ios=$IOS_MATRIX"
+          } >> "$GITHUB_OUTPUT"
           
           echo "Android matrix: $ANDROID_MATRIX"
           echo "iOS matrix: $IOS_MATRIX"
@@ -260,8 +262,10 @@ jobs:
               
               echo "Android BrowserStack URL: $ANDROID_BS_URL"
               echo "Android version: $ANDROID_VERSION"
-              echo "android-version=$ANDROID_VERSION" >> $GITHUB_OUTPUT
-              echo "browserstack-android-url=$ANDROID_BS_URL" >> $GITHUB_OUTPUT
+              {
+                echo "android-version=$ANDROID_VERSION"
+                echo "browserstack-android-url=$ANDROID_BS_URL"
+              } >> "$GITHUB_OUTPUT"
             else
               echo "Error: No Android browserstack JSON download URL found"
               exit 1
@@ -312,8 +316,10 @@ jobs:
               
               echo "iOS BrowserStack URL: $IOS_BS_URL"
               echo "iOS version: $IOS_VERSION"
-              echo "ios-version=$IOS_VERSION" >> $GITHUB_OUTPUT
-              echo "browserstack-ios-url=$IOS_BS_URL" >> $GITHUB_OUTPUT
+              {
+                echo "ios-version=$IOS_VERSION"
+                echo "browserstack-ios-url=$IOS_BS_URL"
+              } >> "$GITHUB_OUTPUT"
             else
               echo "Error: No iOS browserstack JSON download URL found"
               exit 1

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -342,7 +342,6 @@ jobs:
       browserstack-android-url: ${{ steps.download-artifacts.outputs.browserstack-android-url }}
       browserstack-ios-url: ${{ steps.download-artifacts.outputs.browserstack-ios-url }}
 
-  # Sequential Android Tests on Multiple Devices
   android-tests:
     name: Android Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -540,6 +540,7 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
     
+      - name: Check Test Results
         run: |
           if [ "${{ needs.android-tests.result }}" == "failure" ] || [ "${{ needs.ios-tests.result }}" == "failure" ]; then
             echo "Some tests failed. Check the individual job results above."
@@ -547,7 +548,8 @@ jobs:
             exit 1
           else
             echo "All test jobs completed successfully!"
-          fi     
+          fi
+      
       - name: Display QA Build Info
         run: |
           echo "=== QA Build Information ==="

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -152,7 +152,7 @@ jobs:
           fi
           
           # Store build slug for artifact download
-          echo "BUILD_SLUG=$BUILD_SLUG" >> $GITHUB_ENV
+          echo "BUILD_SLUG=$BUILD_SLUG" >> "$GITHUB_ENV"
           
           echo "Waiting for build to complete..."
           TIMEOUT=1800  # 30 minutes
@@ -209,8 +209,10 @@ jobs:
           fi
           
           # Store build IDs for artifact download
-          echo "ANDROID_BUILD_ID=$ANDROID_BUILD_ID" >> $GITHUB_ENV
-          echo "IOS_BUILD_ID=$IOS_BUILD_ID" >> $GITHUB_ENV
+          {
+            echo "ANDROID_BUILD_ID=$ANDROID_BUILD_ID"
+            echo "IOS_BUILD_ID=$IOS_BUILD_ID"
+          } >> "$GITHUB_ENV"
       
       - name: Download Build Artifacts
         id: download-artifacts

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -1,0 +1,559 @@
+name: Build Apps and Run Performance E2E Tests
+on:
+  workflow_dispatch:
+    inputs:
+      info:
+        description: 'This workflow runs performance tests on multiple devices for both iOS and Android platforms. Device matrix is automatically read from appwright/device-matrix.json'
+        required: false
+        type: string
+      browserstack_app_url_android:
+        description: 'BrowserStack Android App URL (bs://...)'
+        required: false
+        type: string
+      browserstack_app_url_ios:
+        description: 'BrowserStack iOS App URL (bs://...)'
+        required: false
+        type: string
+      test_suite:
+        description: 'Test suite to run (e.g., **/tests/*.spec.js for all tests)'
+        required: false
+        default: '**/tests/performance/*.spec.js'
+        type: string
+permissions:
+  contents: read
+  id-token: write
+env:
+  BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+  BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+  MM_TEST_ACCOUNT_SRP: ${{ secrets.MM_TEST_ACCOUNT_SRP }}
+  TEST_SRP_1: ${{ secrets.TEST_SRP_1 }}
+  TEST_SRP_2: ${{ secrets.TEST_SRP_2 }}
+  TEST_SRP_3: ${{ secrets.TEST_SRP_3 }}
+  DISABLE_VIDEO_DOWNLOAD: true
+
+jobs:
+  read-device-matrix:
+    name: Read Device Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      android_matrix: ${{ steps.matrix.outputs.android }}
+      ios_matrix: ${{ steps.matrix.outputs.ios }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Read device matrix
+        id: matrix
+        run: |
+          # This step reads the device matrix from appwright/device-matrix.json
+          echo "Reading device matrix from appwright/device-matrix.json"
+          
+          # Extract Android devices
+          ANDROID_MATRIX=$(cat appwright/device-matrix.json | jq -r ".android_devices | map({name: .name, os_version: .os_version, category: .category}) | tojson")
+          echo "android=$ANDROID_MATRIX" >> $GITHUB_OUTPUT
+          
+          # Extract iOS devices
+          IOS_MATRIX=$(cat appwright/device-matrix.json | jq -r ".ios_devices | map({name: .name, os_version: .os_version, category: .category}) | tojson")
+          echo "ios=$IOS_MATRIX" >> $GITHUB_OUTPUT
+          
+          echo "Android matrix: $ANDROID_MATRIX"
+          echo "iOS matrix: $IOS_MATRIX"
+          
+          # Validate that we have devices
+          ANDROID_COUNT=$(echo "$ANDROID_MATRIX" | jq 'length')
+          IOS_COUNT=$(echo "$IOS_MATRIX" | jq 'length')
+          
+          echo "Found $ANDROID_COUNT Android devices and $IOS_COUNT iOS devices"
+          
+          if [ "$ANDROID_COUNT" -eq 0 ] && [ "$IOS_COUNT" -eq 0 ]; then
+            echo "Error: No devices found in device-matrix.json"
+            exit 1
+          fi
+
+  # Job to trigger QA builds and extract BrowserStack URLs
+  trigger-qa-builds-and-upload:
+    name: Trigger QA Builds and Extract BrowserStack URLs
+    runs-on: ubuntu-latest
+    needs: read-device-matrix
+    env:
+      BITRISE_APP_ID: ${{ secrets.BITRISE_APP_ID }}
+      BITRISE_BUILD_TRIGGER_TOKEN: ${{ secrets.BITRISE_BUILD_TRIGGER_TOKEN }}
+      BITRISE_API_TOKEN: ${{ secrets.BITRISE_API_TOKEN }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+      
+      - name: Install dependencies
+        run: yarn setup
+      
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            .yarn/cache
+            .yarn/install-state.gz
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      
+      - name: Trigger Bitrise QA Builds
+        env:
+          BITRISE_APP_ID: ${{ env.BITRISE_APP_ID }}
+          BITRISE_BUILD_TRIGGER_TOKEN: ${{ env.BITRISE_BUILD_TRIGGER_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Triggering Bitrise QA builds..."
+          echo "BITRISE_APP_ID: $BITRISE_APP_ID"
+          echo "Current branch: ${{ github.ref_name }}"
+          
+          # Trigger QA builds pipeline (handles both Android and iOS)
+          BUILD_RESPONSE=$(curl -s -X POST \
+            "https://app.bitrise.io/app/$BITRISE_APP_ID/build/start.json" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "build_params": {
+                "branch": "${{ github.ref_name }}",
+                "pipeline_id": "create_qa_builds_pipeline",
+                "commit_message": "Triggered by Performance E2E workflow"
+              },
+              "hook_info": {
+                "type": "bitrise",
+                "build_trigger_token": "'$BITRISE_BUILD_TRIGGER_TOKEN'"
+              },
+              "triggered_by": "GitHub Actions Performance E2E"
+            }')
+          
+          echo "Build response: $BUILD_RESPONSE"
+          BUILD_SLUG=$(echo "$BUILD_RESPONSE" | jq -r '.build_slug')
+          echo "Build slug: $BUILD_SLUG"
+          
+          if [[ -z "$BUILD_SLUG" || "$BUILD_SLUG" == "null" ]]; then
+            echo "Error: Failed to get build slug"
+            echo "Full response: $BUILD_RESPONSE"
+            echo "Trying alternative response structure..."
+            # Try different possible response structures
+            BUILD_SLUG=$(echo "$BUILD_RESPONSE" | jq -r '.data.build_slug // .build_slug // .slug')
+            echo "Alternative build slug: $BUILD_SLUG"
+            if [[ -z "$BUILD_SLUG" || "$BUILD_SLUG" == "null" ]]; then
+              echo "Still no build slug found. Response keys:"
+              echo "$BUILD_RESPONSE" | jq -r 'keys[]'
+              exit 1
+            fi
+          fi
+          
+          # Store build slug for artifact download
+          echo "BUILD_SLUG=$BUILD_SLUG" >> $GITHUB_ENV
+          
+          echo "Waiting for build to complete..."
+          TIMEOUT=1800  # 30 minutes
+          ELAPSED=0
+          
+          while [ $ELAPSED -lt $TIMEOUT ]; do
+            # Check pipeline status using the correct v0.1 API endpoint
+            echo "Checking pipeline status for slug: $BUILD_SLUG"
+            PIPELINE_RESPONSE=$(curl -s -H "Authorization: $BITRISE_API_TOKEN" \
+              "https://api.bitrise.io/v0.1/apps/$BITRISE_APP_ID/pipelines/$BUILD_SLUG")
+            echo "Pipeline response: $PIPELINE_RESPONSE"
+            
+            PIPELINE_STATUS=$(echo "$PIPELINE_RESPONSE" | jq -r '.status')
+            echo "Pipeline status: $PIPELINE_STATUS"
+            
+            if [ "$PIPELINE_STATUS" = "succeeded" ]; then
+              echo "Pipeline completed successfully!"
+              break
+            elif [ "$PIPELINE_STATUS" = "failed" ]; then
+              echo "Pipeline failed!"
+              exit 1
+            elif [ "$PIPELINE_STATUS" = "in_progress" ] || [ "$PIPELINE_STATUS" = "running" ]; then
+              echo "Pipeline is in progress..."
+            elif [ "$PIPELINE_STATUS" = "null" ]; then
+              echo "Pipeline status is null, checking if pipeline exists..."
+
+            fi
+            
+            sleep 30
+            ELAPSED=$((ELAPSED + 30))
+          done
+          
+          if [ $ELAPSED -ge $TIMEOUT ]; then
+            echo "Timeout waiting for pipeline to complete"
+            echo "Final pipeline status: $PIPELINE_STATUS"
+            echo "Pipeline slug: $BUILD_SLUG"
+            exit 1
+          fi
+          
+          # Extract build IDs from the completed pipeline
+          echo "Extracting build IDs from completed pipeline..."
+          ANDROID_BUILD_ID=$(echo "$PIPELINE_RESPONSE" | jq -r '.stages[0].workflows[] | select(.name == "build_android_qa") | .external_id')
+          IOS_BUILD_ID=$(echo "$PIPELINE_RESPONSE" | jq -r '.stages[0].workflows[] | select(.name == "build_ios_qa") | .external_id')
+          
+          
+          if [[ -z "$ANDROID_BUILD_ID" || "$ANDROID_BUILD_ID" == "null" ]]; then
+            echo "Error: Failed to get Android build ID"
+            exit 1
+          fi
+          
+          if [[ -z "$IOS_BUILD_ID" || "$IOS_BUILD_ID" == "null" ]]; then
+            echo "Error: Failed to get iOS build ID"
+            exit 1
+          fi
+          
+          # Store build IDs for artifact download
+          echo "ANDROID_BUILD_ID=$ANDROID_BUILD_ID" >> $GITHUB_ENV
+          echo "IOS_BUILD_ID=$IOS_BUILD_ID" >> $GITHUB_ENV
+      
+      - name: Download Build Artifacts
+        id: download-artifacts
+        env:
+          BITRISE_APP_ID: ${{ env.BITRISE_APP_ID }}
+          BITRISE_API_TOKEN: ${{ env.BITRISE_API_TOKEN }}
+        run: |
+          echo "Downloading browserstack_uploaded_apps.json files..."
+          echo "Android Build ID: $ANDROID_BUILD_ID"
+          echo "iOS Build ID: $IOS_BUILD_ID"
+          
+          # Download Android browserstack_uploaded_apps.json
+          echo "Fetching Android artifacts..."
+          ANDROID_ARTIFACTS=$(curl -s -H "Authorization: $BITRISE_API_TOKEN" \
+            "https://api.bitrise.io/v0.1/apps/$BITRISE_APP_ID/builds/$ANDROID_BUILD_ID/artifacts")
+          
+          if [[ $? -ne 0 ]]; then
+            echo "Error: Failed to fetch Android artifacts"
+            exit 1
+          fi
+                    
+          # Find the browserstack_uploaded_apps.json file
+          ANDROID_BS_JSON_ARTIFACT=$(echo "$ANDROID_ARTIFACTS" | jq -r '.data[] | 
+            select(.title == "browserstack_uploaded_apps.json")')
+          
+          echo "Android browserstack JSON artifact: $ANDROID_BS_JSON_ARTIFACT"
+          
+          if [[ -n "$ANDROID_BS_JSON_ARTIFACT" ]]; then
+            ANDROID_BS_ARTIFACT_SLUG=$(echo "$ANDROID_BS_JSON_ARTIFACT" | jq -r '.slug')
+
+            # Download the JSON file
+            ANDROID_BS_DOWNLOAD_URL=$(curl -s -H "Authorization: $BITRISE_API_TOKEN" \
+              "https://api.bitrise.io/v0.1/apps/$BITRISE_APP_ID/builds/$ANDROID_BUILD_ID/artifacts/$ANDROID_BS_ARTIFACT_SLUG" | \
+              jq -r '.data.expiring_download_url')
+            
+            if [[ -n "$ANDROID_BS_DOWNLOAD_URL" && "$ANDROID_BS_DOWNLOAD_URL" != "null" ]]; then
+              echo "Downloading Android browserstack JSON..."
+              wget -O "android_browserstack_apps.json" "$ANDROID_BS_DOWNLOAD_URL"
+              
+              if [[ $? -ne 0 ]]; then
+                echo "Error: Failed to download Android browserstack JSON"
+                exit 1
+              fi
+              
+              # Extract the first Android APK app_url
+              ANDROID_BS_URL=$(cat "android_browserstack_apps.json" | jq -r '.[] | select(.app_name | endswith(".apk")) | .app_url' | head -1)
+              ANDROID_VERSION=$(cat "android_browserstack_apps.json" | jq -r '.[] | select(.app_name | endswith(".apk")) | .app_version' | head -1)
+              
+              echo "Android BrowserStack URL: $ANDROID_BS_URL"
+              echo "Android version: $ANDROID_VERSION"
+              echo "android-version=$ANDROID_VERSION" >> $GITHUB_OUTPUT
+              echo "browserstack-android-url=$ANDROID_BS_URL" >> $GITHUB_OUTPUT
+            else
+              echo "Error: No Android browserstack JSON download URL found"
+              exit 1
+            fi
+          else
+            echo "Error: No Android browserstack_uploaded_apps.json artifact found"
+            exit 1
+          fi
+          
+          # Download iOS browserstack_uploaded_apps.json
+          echo "Fetching iOS artifacts..."
+          IOS_ARTIFACTS=$(curl -s -H "Authorization: $BITRISE_API_TOKEN" \
+            "https://api.bitrise.io/v0.1/apps/$BITRISE_APP_ID/builds/$IOS_BUILD_ID/artifacts")
+          
+          if [[ $? -ne 0 ]]; then
+            echo "Error: Failed to fetch iOS artifacts"
+            exit 1
+          fi
+                    
+          # Find the browserstack_uploaded_apps.json file
+          IOS_BS_JSON_ARTIFACT=$(echo "$IOS_ARTIFACTS" | jq -r '.data[] | 
+            select(.title == "browserstack_uploaded_apps.json")')
+          
+          echo "iOS browserstack JSON artifact: $IOS_BS_JSON_ARTIFACT"
+          
+          if [[ -n "$IOS_BS_JSON_ARTIFACT" ]]; then
+            IOS_BS_ARTIFACT_SLUG=$(echo "$IOS_BS_JSON_ARTIFACT" | jq -r '.slug')
+            echo "iOS browserstack artifact slug: $IOS_BS_ARTIFACT_SLUG"
+            
+            # Download the JSON file
+            IOS_BS_DOWNLOAD_URL=$(curl -s -H "Authorization: $BITRISE_API_TOKEN" \
+              "https://api.bitrise.io/v0.1/apps/$BITRISE_APP_ID/builds/$IOS_BUILD_ID/artifacts/$IOS_BS_ARTIFACT_SLUG" | \
+              jq -r '.data.expiring_download_url')
+            
+            if [[ -n "$IOS_BS_DOWNLOAD_URL" && "$IOS_BS_DOWNLOAD_URL" != "null" ]]; then
+              echo "Downloading iOS browserstack JSON..."
+              wget -O "ios_browserstack_apps.json" "$IOS_BS_DOWNLOAD_URL"
+              
+              if [[ $? -ne 0 ]]; then
+                echo "Error: Failed to download iOS browserstack JSON"
+                exit 1
+              fi
+              
+              # Extract the first iOS IPA app_url
+              IOS_BS_URL=$(cat "ios_browserstack_apps.json" | jq -r '.[] | select(.app_name | endswith(".ipa")) | .app_url' | head -1)
+              IOS_VERSION=$(cat "ios_browserstack_apps.json" | jq -r '.[] | select(.app_name | endswith(".ipa")) | .app_version' | head -1)
+              
+              echo "iOS BrowserStack URL: $IOS_BS_URL"
+              echo "iOS version: $IOS_VERSION"
+              echo "ios-version=$IOS_VERSION" >> $GITHUB_OUTPUT
+              echo "browserstack-ios-url=$IOS_BS_URL" >> $GITHUB_OUTPUT
+            else
+              echo "Error: No iOS browserstack JSON download URL found"
+              exit 1
+            fi
+          else
+            echo "Error: No iOS browserstack_uploaded_apps.json artifact found"
+            exit 1
+          fi
+          
+          echo "BrowserStack URLs extracted successfully!"
+          echo "Android: $ANDROID_BS_URL"
+          echo "iOS: $IOS_BS_URL"
+    
+    outputs:
+      android-version: ${{ steps.download-artifacts.outputs.android-version }}
+      ios-version: ${{ steps.download-artifacts.outputs.ios-version }}
+      browserstack-android-url: ${{ steps.download-artifacts.outputs.browserstack-android-url }}
+      browserstack-ios-url: ${{ steps.download-artifacts.outputs.browserstack-ios-url }}
+
+  # Sequential Android Tests on Multiple Devices
+  android-tests:
+    name: Android Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    needs: [trigger-qa-builds-and-upload, read-device-matrix]
+    strategy:
+      fail-fast: false
+      matrix:
+        device: ${{ fromJson(needs.read-device-matrix.outputs.android_matrix) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Restore node_modules cache
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            .yarn/cache
+            .yarn/install-state.gz
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+      
+      - name: Install dependencies (if cache miss)
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn setup
+      
+      - name: BrowserStack Env Setup
+        uses: browserstack/github-actions/setup-env@4478e16186f38e5be07721931642e65a028713c3
+        with:
+          username: ${{ env.BROWSERSTACK_USERNAME }}
+          access-key: ${{ env.BROWSERSTACK_ACCESS_KEY }}
+          build-name: ${{ github.repository }}-${{ github.ref_name }}-android-${{ matrix.device.name }}-${{ matrix.device.os_version }}-${{ github.run_number }}
+          project-name: ${{ github.repository }}
+      
+      - name: Setup BrowserStack Local
+        uses: browserstack/github-actions/setup-local@4478e16186f38e5be07721931642e65a028713c3
+        with:
+          local-testing: start
+          local-identifier: ${{ github.run_id }}
+          local-args: --force-local --verbose
+      
+      - name: Wait for BrowserStack Local
+        run: |
+          echo "Waiting for BrowserStack Local to be ready..."
+          sleep 30
+          echo "BrowserStack Local should be ready now"
+      
+      - name: Set Android Test Environment
+        run: |
+          echo "Setting test environment for device: ${{ matrix.device.name }}"
+          echo "BROWSERSTACK_DEVICE=${{ matrix.device.name }}" >> $GITHUB_ENV
+          echo "BROWSERSTACK_OS_VERSION=${{ matrix.device.os_version }}" >> $GITHUB_ENV
+          echo "BROWSERSTACK_ANDROID_APP_URL=${{ needs.trigger-qa-builds-and-upload.outputs.browserstack-android-url }}" >> $GITHUB_ENV
+          echo "TEST_PLATFORM=android" >> $GITHUB_ENV
+          echo "TEST_SUITE=${{ github.event.inputs.test_suite }}" >> $GITHUB_ENV
+          echo "QA_APP_VERSION=${{ needs.trigger-qa-builds-and-upload.outputs.android-version }}" >> $GITHUB_ENV
+      
+      - name: Run Android Tests on ${{ matrix.device.name }}
+        env:
+          BROWSERSTACK_LOCAL: true
+          BROWSERSTACK_LOCAL_IDENTIFIER: ${{ github.run_id }}
+        run: |
+          echo "=== Testing ${{ matrix.device.name }} (${{ matrix.device.category }} Class) ==="
+          echo "OS Version: ${{ matrix.device.os_version }}"
+          echo "Category: ${{ matrix.device.category }}"
+          echo "Branch: ${{ github.ref_name }}"
+          echo "QA App Version: ${{ needs.trigger-qa-builds-and-upload.outputs.android-version }}"
+          echo "BrowserStack Android App URL: ${{ needs.trigger-qa-builds-and-upload.outputs.browserstack-android-url }}"
+          
+          yarn run-appwright:android-bs
+      
+      - name: Upload Android Test Results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: android-test-results-${{ matrix.device.name }}-${{ matrix.device.os_version }}
+          path: |
+            appwright/test-reports/appwright-report/
+            appwright/reporters/reports
+          if-no-files-found: ignore
+          retention-days: 7
+
+  ios-tests:
+    name: iOS Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    needs: [trigger-qa-builds-and-upload, read-device-matrix]
+    strategy:
+      fail-fast: false
+      matrix:
+        device: ${{ fromJson(needs.read-device-matrix.outputs.ios_matrix) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Restore node_modules cache
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            .yarn/cache
+            .yarn/install-state.gz
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+      
+      - name: Install dependencies (if cache miss)
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn setup
+      
+      - name: BrowserStack Env Setup
+        uses: browserstack/github-actions/setup-env@4478e16186f38e5be07721931642e65a028713c3
+        with:
+          username: ${{ env.BROWSERSTACK_USERNAME }}
+          access-key: ${{ env.BROWSERSTACK_ACCESS_KEY }}
+          build-name: ${{ github.repository }}-${{ github.ref_name }}-ios-${{ matrix.device.name }}-${{ matrix.device.os_version }}-${{ github.run_number }}
+          project-name: ${{ github.repository }}
+      
+      - name: Setup BrowserStack Local
+        uses: browserstack/github-actions/setup-local@4478e16186f38e5be07721931642e65a028713c3
+        with:
+          local-testing: start
+          local-identifier: ${{ github.run_id }}
+          local-args: --force-local --verbose
+      
+      - name: Wait for BrowserStack Local
+        run: |
+          echo "Waiting for BrowserStack Local to be ready..."
+          sleep 30
+          echo "BrowserStack Local should be ready now"
+      
+      - name: Set iOS Test Environment
+        run: |
+          echo "Setting test environment for device: ${{ matrix.device.name }}"
+          echo "BROWSERSTACK_DEVICE=${{ matrix.device.name }}" >> $GITHUB_ENV
+          echo "BROWSERSTACK_OS_VERSION=${{ matrix.device.os_version }}" >> $GITHUB_ENV
+          echo "BROWSERSTACK_IOS_APP_URL=${{ needs.trigger-qa-builds-and-upload.outputs.browserstack-ios-url }}" >> $GITHUB_ENV
+          echo "TEST_SUITE=${{ github.event.inputs.test_suite }}" >> $GITHUB_ENV
+          echo "QA_APP_VERSION=${{ needs.trigger-qa-builds-and-upload.outputs.ios-version }}" >> $GITHUB_ENV
+      
+      - name: Run iOS Tests on ${{ matrix.device.name }}
+        env:
+          BROWSERSTACK_LOCAL: true
+          BROWSERSTACK_LOCAL_IDENTIFIER: ${{ github.run_id }}
+        run: |
+          echo "=== Testing ${{ matrix.device.name }} (${{ matrix.device.category }} Class) ==="
+          echo "OS Version: ${{ matrix.device.os_version }}"
+          echo "Category: ${{ matrix.device.category }}"
+          echo "Branch: ${{ github.ref_name }}"
+          echo "QA App Version: ${{ needs.trigger-qa-builds-and-upload.outputs.ios-version }}"
+          echo "BrowserStack iOS App URL: ${{ needs.trigger-qa-builds-and-upload.outputs.browserstack-ios-url }}"
+          if [ "${{ matrix.device.os_version }}" == "13" ] || [ "${{ matrix.device.os_version }}" == "11" ]; then
+            echo "Warning: iOS ${{ matrix.device.os_version }} may not be supported by MetaMask app"
+          fi
+          
+          yarn run-appwright:ios-bs
+      
+      - name: Upload iOS Test Results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: ios-test-results-${{ matrix.device.name }}-${{ matrix.device.os_version }}
+          path: |
+            appwright/test-reports/appwright-report/
+            appwright/reporters/reports
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # Results Gathering Job
+  gather-results:
+    name: Gather Test Results
+    runs-on: ubuntu-latest
+    needs: [trigger-qa-builds-and-upload, android-tests, ios-tests]
+    if: always()
+    
+    steps:
+      - name: Download All Test Results
+        uses: actions/download-artifact@v4
+        with:
+          path: appwright/test-reports/
+      
+      - name: Upload Combined Reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: combined-reports
+          path: |
+            appwright/test-reports/appwright-report/
+            appwright/reporters/reports
+          if-no-files-found: ignore
+          retention-days: 14
+    
+        run: |
+          if [ "${{ needs.android-tests.result }}" == "failure" ] || [ "${{ needs.ios-tests.result }}" == "failure" ]; then
+            echo "Some tests failed. Check the individual job results above."
+            echo "Note: iOS 13 and iOS 11 failures are expected due to MetaMask app compatibility."
+            exit 1
+          else
+            echo "All test jobs completed successfully!"
+          fi     
+      - name: Display QA Build Info
+        run: |
+          echo "=== QA Build Information ==="
+          echo "Android Version: ${{ needs.trigger-qa-builds-and-upload.outputs.android-version }}"
+          echo "iOS Version: ${{ needs.trigger-qa-builds-and-upload.outputs.ios-version }}"
+          echo ""
+          echo "=== BrowserStack App URLs ==="
+          echo "Android App URL: ${{ needs.trigger-qa-builds-and-upload.outputs.browserstack-android-url }}"
+          echo "iOS App URL: ${{ needs.trigger-qa-builds-and-upload.outputs.browserstack-ios-url }}"

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -110,6 +110,7 @@ jobs:
         env:
           BITRISE_APP_ID: ${{ env.BITRISE_APP_ID }}
           BITRISE_BUILD_TRIGGER_TOKEN: ${{ env.BITRISE_BUILD_TRIGGER_TOKEN }}
+          BITRISE_API_TOKEN: ${{ env.BITRISE_API_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Triggering Bitrise QA builds..."
@@ -128,7 +129,7 @@ jobs:
               },
               "hook_info": {
                 "type": "bitrise",
-                "build_trigger_token": "'$BITRISE_BUILD_TRIGGER_TOKEN'"
+                "build_trigger_token": "'"$BITRISE_BUILD_TRIGGER_TOKEN"'"
               },
               "triggered_by": "GitHub Actions Performance E2E"
             }')
@@ -158,7 +159,7 @@ jobs:
           TIMEOUT=1800  # 30 minutes
           ELAPSED=0
           
-          while [ $ELAPSED -lt $TIMEOUT ]; do
+          while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
             # Check pipeline status using the correct v0.1 API endpoint
             echo "Checking pipeline status for slug: $BUILD_SLUG"
             PIPELINE_RESPONSE=$(curl -s -H "Authorization: $BITRISE_API_TOKEN" \
@@ -185,7 +186,7 @@ jobs:
             ELAPSED=$((ELAPSED + 30))
           done
           
-          if [ $ELAPSED -ge $TIMEOUT ]; then
+          if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
             echo "Timeout waiting for pipeline to complete"
             echo "Final pipeline status: $PIPELINE_STATUS"
             echo "Pipeline slug: $BUILD_SLUG"

--- a/.github/workflows/trigger-performance-e2e.yml
+++ b/.github/workflows/trigger-performance-e2e.yml
@@ -77,12 +77,12 @@ jobs:
             fi
             
             # Extract Android devices with optional category filtering
-            ANDROID_MATRIX=$(cat appwright/device-matrix.json | jq -r ".android_devices $CATEGORY_FILTER | map({name: .name, os_version: .os_version, category: .category}) | tojson")
-            echo "android=$ANDROID_MATRIX" >> $GITHUB_OUTPUT
+            ANDROID_MATRIX=$(jq -r ".android_devices $CATEGORY_FILTER | map({name: .name, os_version: .os_version, category: .category}) | tojson" appwright/device-matrix.json)
+            echo "android=$ANDROID_MATRIX" >> "$GITHUB_OUTPUT"
             
             # Extract iOS devices with optional category filtering
-            IOS_MATRIX=$(cat appwright/device-matrix.json | jq -r ".ios_devices $CATEGORY_FILTER | map({name: .name, os_version: .os_version, category: .category}) | tojson")
-            echo "ios=$IOS_MATRIX" >> $GITHUB_OUTPUT
+            IOS_MATRIX=$(jq -r ".ios_devices $CATEGORY_FILTER | map({name: .name, os_version: .os_version, category: .category}) | tojson" appwright/device-matrix.json)
+            echo "ios=$IOS_MATRIX" >> "$GITHUB_OUTPUT"
             
             echo "Android matrix: $ANDROID_MATRIX"
             echo "iOS matrix: $IOS_MATRIX"
@@ -146,19 +146,19 @@ jobs:
       - name: Set Android Test Environment
         run: |
           echo "Setting test environment for device: ${{ matrix.device.name }}"
-          echo "BROWSERSTACK_DEVICE=${{ matrix.device.name }}" >> $GITHUB_ENV
-          echo "BROWSERSTACK_OS_VERSION=${{ matrix.device.os_version }}" >> $GITHUB_ENV
-          echo "BROWSERSTACK_ANDROID_APP_URL=${{ github.event.inputs.browserstack_app_url_android }}" >> $GITHUB_ENV
-          echo "BROWSERSTACK_BUILD_NAME=Android-Performance-${{ github.ref_name }}-Branch" >> $GITHUB_ENV
-          echo "TEST_PLATFORM=android" >> $GITHUB_ENV
-          echo "TEST_SUITE=${{ github.event.inputs.test_suite }}" >> $GITHUB_ENV
+          echo "BROWSERSTACK_DEVICE=${{ matrix.device.name }}" >> "$GITHUB_ENV"
+          echo "BROWSERSTACK_OS_VERSION=${{ matrix.device.os_version }}" >> "$GITHUB_ENV"
+          echo "BROWSERSTACK_ANDROID_APP_URL=${{ github.event.inputs.browserstack_app_url_android }}" >> "$GITHUB_ENV"
+          echo "BROWSERSTACK_BUILD_NAME=Android-Performance-${{ github.ref_name }}-Branch" >> "$GITHUB_ENV"
+          echo "TEST_PLATFORM=android" >> "$GITHUB_ENV"
+          echo "TEST_SUITE=${{ github.event.inputs.test_suite }}" >> "$GITHUB_ENV"
       
       - name: Run Android Tests on ${{ matrix.device.name }}
         env:
           BROWSERSTACK_LOCAL: true
           BROWSERSTACK_LOCAL_IDENTIFIER: ${{ github.run_id }}
         run: |
-          echo "=== Testing ${{ matrix.device.name }} (${{ matrix.device.category }} Class) ==="
+          echo "=== Testing ${{ matrix.device.name }} (${{ matrix.device.category }}) ==="
           echo "OS Version: ${{ matrix.device.os_version }}"
           echo "Category: ${{ matrix.device.category }}"
           echo "Branch: ${{ github.ref_name }}"
@@ -219,18 +219,18 @@ jobs:
       - name: Set iOS Test Environment
         run: |
           echo "Setting test environment for device: ${{ matrix.device.name }}"
-          echo "BROWSERSTACK_DEVICE=${{ matrix.device.name }}" >> $GITHUB_ENV
-          echo "BROWSERSTACK_OS_VERSION=${{ matrix.device.os_version }}" >> $GITHUB_ENV
-          echo "BROWSERSTACK_IOS_APP_URL=${{ github.event.inputs.browserstack_app_url_ios }}" >> $GITHUB_ENV
-          echo "BROWSERSTACK_BUILD_NAME=iOS-Performance-${{ github.ref_name }}-Branch" >> $GITHUB_ENV
-          echo "TEST_SUITE=${{ github.event.inputs.test_suite }}" >> $GITHUB_ENV
+          echo "BROWSERSTACK_DEVICE=${{ matrix.device.name }}" >> "$GITHUB_ENV"
+          echo "BROWSERSTACK_OS_VERSION=${{ matrix.device.os_version }}" >> "$GITHUB_ENV"
+          echo "BROWSERSTACK_IOS_APP_URL=${{ github.event.inputs.browserstack_app_url_ios }}" >> "$GITHUB_ENV"
+          echo "BROWSERSTACK_BUILD_NAME=iOS-Performance-${{ github.ref_name }}-Branch" >> "$GITHUB_ENV"
+          echo "TEST_SUITE=${{ github.event.inputs.test_suite }}" >> "$GITHUB_ENV"
       
       - name: Run iOS Tests on ${{ matrix.device.name }}
         env:
           BROWSERSTACK_LOCAL: true
           BROWSERSTACK_LOCAL_IDENTIFIER: ${{ github.run_id }}
         run: |
-          echo "=== Testing ${{ matrix.device.name }} (${{ matrix.device.category }} Class) ==="
+          echo "=== Testing ${{ matrix.device.name }} (${{ matrix.device.category }}) ==="
           echo "OS Version: ${{ matrix.device.os_version }}"
           echo "Category: ${{ matrix.device.category }}"
           echo "Branch: ${{ github.ref_name }}"

--- a/.github/workflows/trigger-performance-e2e.yml
+++ b/.github/workflows/trigger-performance-e2e.yml
@@ -105,7 +105,6 @@ jobs:
               exit 1
             fi
           fi
-  # Sequential Android Tests on Multiple Devices
   android-tests:
     name: Android Tests
     runs-on: ubuntu-latest
@@ -183,7 +182,6 @@ jobs:
             appwright/reporters/reports
           if-no-files-found: ignore
           retention-days: 7
-  # Sequential iOS Tests on Multiple Devices
   ios-tests:
     name: iOS Tests
     runs-on: ubuntu-latest
@@ -223,7 +221,7 @@ jobs:
       - name: Wait for BrowserStack Local
         run: |
           echo "Waiting for BrowserStack Local to be ready..."
-          sleep 30
+          sleep 15
           echo "BrowserStack Local should be ready now"
       
       - name: Set iOS Test Environment

--- a/.github/workflows/trigger-performance-e2e.yml
+++ b/.github/workflows/trigger-performance-e2e.yml
@@ -1,43 +1,116 @@
 name: Performance E2E Test Manual WorkFlow
- ## This is 1 out of 5 Prs which will enable us to trigger the performance e2e via a workflow dispatch  
- ## The infra to build the apps is not currently setup hence to trigger this workflow, you would need to
- ## grab the browserstack app_url from the build_android_qa workflow in github. 
 on:
   workflow_dispatch:
     inputs:
       info:
-        description: 'For available devices and OS versions, visit: https://www.browserstack.com/list-of-browsers-and-platforms/app_automate'
+        description: 'This workflow runs performance tests on multiple devices for both iOS and Android platforms. Device matrix is automatically read from appwright/device-matrix.json, or you can provide a custom matrix or filter by category.'
         required: false
-        default: 'Info: Visit the link above for device and OS options'
         type: string
-      device:
-        description: 'Device to run tests on (e.g., Xiaomi Redmi Note 11)'
-        required: false
-        default: 'Xiaomi Redmi Note 11'
-        type: string
-      os_version:
-        description: 'OS Version (e.g., 11.0)'
-        required: false
-        default: '11.0'
-        type: string
-      browserstack_app_url:
-        description: 'Browserstack App URL'
+      browserstack_app_url_android:
+        description: 'BrowserStack Android App URL (bs://...)'
         required: true
         type: string
-  # schedule:
-  #   # Every 3 hours on main branch
-  #   - cron: '0 */3 * * *'
+      browserstack_app_url_ios:
+        description: 'BrowserStack iOS App URL (bs://...)'
+        required: true
+        type: string
+      test_suite:
+        description: 'Test suite to run (e.g., **/tests/*.spec.js for all tests)'
+        required: false
+        default: '**/tests/performance/*.spec.js'
+        type: string
+      device_matrix:
+        description: 'Device matrix JSON string (leave empty to use default from appwright/device-matrix.json)'
+        required: false
+        type: string
+      device_category:
+        description: 'Filter devices by category (high, medium, low, or leave empty for all)'
+        required: false
+        type: string
+permissions:
+  contents: read
+  id-token: write
+env:
+  BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+  BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+  MM_TEST_ACCOUNT_SRP: ${{ secrets.MM_TEST_ACCOUNT_SRP }}
+  TEST_SRP_1: ${{ secrets.TEST_SRP_1 }}
+  TEST_SRP_2: ${{ secrets.TEST_SRP_2 }}
+  TEST_SRP_3: ${{ secrets.TEST_SRP_3 }}
+  DISABLE_VIDEO_DOWNLOAD: true
 
 jobs:
-  run-performance-test:
+  # Job to read device matrix from JSON file
+  read-device-matrix:
+    name: Read Device Matrix
     runs-on: ubuntu-latest
-    env:
-      BROWSERSTACK_DEVICE: ${{ github.event.inputs.device || 'Xiaomi Redmi Note 11' }}
-      BROWSERSTACK_OS_VERSION: ${{ github.event.inputs.os_version || '11.0' }}
-      BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
-      BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
-      BROWSERSTACK_ANDROID_APP_URL: ${{ github.event.inputs.browserstack_app_url }}
-      MM_TEST_ACCOUNT_SRP: ${{ secrets.MM_TEST_ACCOUNT_SRP }}
+    outputs:
+      android_matrix: ${{ steps.matrix.outputs.android }}
+      ios_matrix: ${{ steps.matrix.outputs.ios }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Read device matrix
+        id: matrix
+        run: |
+          # This step reads the device matrix from appwright/device-matrix.json
+          # You can override this by providing a custom device_matrix input
+          # You can also filter devices by category using the device_category input
+          
+          if [ -n "${{ github.event.inputs.device_matrix }}" ]; then
+            # Use custom device matrix from input
+            echo "Using custom device matrix from input"
+            echo "android=${{ github.event.inputs.device_matrix }}" >> $GITHUB_OUTPUT
+            echo "ios=${{ github.event.inputs.device_matrix }}" >> $GITHUB_OUTPUT
+          else
+            # Read from JSON file and filter by category
+            echo "Reading device matrix from appwright/device-matrix.json"
+            
+            # Build jq filter based on category input
+            CATEGORY_FILTER=""
+            if [ -n "${{ github.event.inputs.device_category }}" ]; then
+              CATEGORY_FILTER="| map(select(.category == \"${{ github.event.inputs.device_category }}\"))"
+              echo "Filtering devices by category: ${{ github.event.inputs.device_category }}"
+            else
+              echo "No category filter applied - using all devices"
+            fi
+            
+            # Extract Android devices with optional category filtering
+            ANDROID_MATRIX=$(cat appwright/device-matrix.json | jq -r ".android_devices $CATEGORY_FILTER | map({name: .name, os_version: .os_version, category: .category}) | tojson")
+            echo "android=$ANDROID_MATRIX" >> $GITHUB_OUTPUT
+            
+            # Extract iOS devices with optional category filtering
+            IOS_MATRIX=$(cat appwright/device-matrix.json | jq -r ".ios_devices $CATEGORY_FILTER | map({name: .name, os_version: .os_version, category: .category}) | tojson")
+            echo "ios=$IOS_MATRIX" >> $GITHUB_OUTPUT
+            
+            echo "Android matrix: $ANDROID_MATRIX"
+            echo "iOS matrix: $IOS_MATRIX"
+            
+            # Validate that we have devices
+            ANDROID_COUNT=$(echo "$ANDROID_MATRIX" | jq 'length')
+            IOS_COUNT=$(echo "$IOS_MATRIX" | jq 'length')
+            
+            echo "Found $ANDROID_COUNT Android devices and $IOS_COUNT iOS devices"
+            
+            if [ "$ANDROID_COUNT" -eq 0 ] && [ "$IOS_COUNT" -eq 0 ]; then
+              echo "Error: No devices found matching the criteria"
+              if [ -n "${{ github.event.inputs.device_category }}" ]; then
+                echo "Try removing the category filter or check if '${{ github.event.inputs.device_category }}' is a valid category"
+              fi
+              exit 1
+            fi
+          fi
+  # Sequential Android Tests on Multiple Devices
+  android-tests:
+    name: Android Tests
+    runs-on: ubuntu-latest
+    needs: read-device-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        device: ${{ fromJson(needs.read-device-matrix.outputs.android_matrix) }}
+    
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -46,18 +119,17 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
+          cache: 'yarn'
       
       - name: Install dependencies
         run: yarn setup
-
       - name: BrowserStack Env Setup
         uses: browserstack/github-actions/setup-env@4478e16186f38e5be07721931642e65a028713c3
         with:
-          username: ${{ secrets.BROWSERSTACK_USERNAME }}
-          access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
-          build-name: ${{ github.repository }}-${{ github.ref_name }}-${{ github.event.inputs.device || 'Xiaomi Redmi Note 11' }}-run-${{ github.run_number }}
+          username: ${{ env.BROWSERSTACK_USERNAME }}
+          access-key: ${{ env.BROWSERSTACK_ACCESS_KEY }}
+          build-name: ${{ github.repository }}-${{ github.ref_name }}-android-${{ matrix.device.name }}-${{ matrix.device.os_version }}-${{ github.run_number }}
           project-name: ${{ github.repository }}
-
       - name: Setup BrowserStack Local
         uses: browserstack/github-actions/setup-local@4478e16186f38e5be07721931642e65a028713c3
         with:
@@ -71,12 +143,143 @@ jobs:
           sleep 30
           echo "BrowserStack Local should be ready now"
       
-      - name: Run Android Performance Tests
+      - name: Set Android Test Environment
+        run: |
+          echo "Setting test environment for device: ${{ matrix.device.name }}"
+          echo "BROWSERSTACK_DEVICE=${{ matrix.device.name }}" >> $GITHUB_ENV
+          echo "BROWSERSTACK_OS_VERSION=${{ matrix.device.os_version }}" >> $GITHUB_ENV
+          echo "BROWSERSTACK_ANDROID_APP_URL=${{ github.event.inputs.browserstack_app_url_android }}" >> $GITHUB_ENV
+          echo "BROWSERSTACK_BUILD_NAME=Android-Performance-${{ github.ref_name }}-Branch" >> $GITHUB_ENV
+          echo "TEST_PLATFORM=android" >> $GITHUB_ENV
+          echo "TEST_SUITE=${{ github.event.inputs.test_suite }}" >> $GITHUB_ENV
+      
+      - name: Run Android Tests on ${{ matrix.device.name }}
         env:
           BROWSERSTACK_LOCAL: true
           BROWSERSTACK_LOCAL_IDENTIFIER: ${{ github.run_id }}
         run: |
-          echo "Running tests on branch: ${{ github.ref_name }}"
-          echo "Device: ${{ env.BROWSERSTACK_DEVICE }}"
-          echo "OS Version: ${{ env.BROWSERSTACK_OS_VERSION }}"
-          yarn test:wdio:android:browserstack --performance
+          echo "=== Testing ${{ matrix.device.name }} (${{ matrix.device.category }} Class) ==="
+          echo "OS Version: ${{ matrix.device.os_version }}"
+          echo "Category: ${{ matrix.device.category }}"
+          echo "Branch: ${{ github.ref_name }}"
+          
+          yarn run-appwright:android-bs
+      
+      - name: Upload Android Test Results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: android-test-results-${{ matrix.device.name }}-${{ matrix.device.os_version }}
+          path: |
+            appwright/test-reports/appwright-report/
+            appwright/reporters/reports
+          if-no-files-found: ignore
+          retention-days: 7
+  # Sequential iOS Tests on Multiple Devices
+  ios-tests:
+    name: iOS Tests
+    runs-on: ubuntu-latest
+    needs: read-device-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        device: ${{ fromJson(needs.read-device-matrix.outputs.ios_matrix) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+      
+      - name: Install dependencies
+        run: yarn setup
+      - name: BrowserStack Env Setup
+        uses: browserstack/github-actions/setup-env@4478e16186f38e5be07721931642e65a028713c3
+        with:
+          username: ${{ env.BROWSERSTACK_USERNAME }}
+          access-key: ${{ env.BROWSERSTACK_ACCESS_KEY }}
+          build-name: ${{ github.repository }}-${{ github.ref_name }}-ios-${{ matrix.device.name }}-${{ matrix.device.os_version }}-${{ github.run_number }}
+          project-name: ${{ github.repository }}
+      - name: Setup BrowserStack Local
+        uses: browserstack/github-actions/setup-local@4478e16186f38e5be07721931642e65a028713c3
+        with:
+          local-testing: start
+          local-identifier: ${{ github.run_id }}
+          local-args: --force-local --verbose
+      
+      - name: Wait for BrowserStack Local
+        run: |
+          echo "Waiting for BrowserStack Local to be ready..."
+          sleep 30
+          echo "BrowserStack Local should be ready now"
+      
+      - name: Set iOS Test Environment
+        run: |
+          echo "Setting test environment for device: ${{ matrix.device.name }}"
+          echo "BROWSERSTACK_DEVICE=${{ matrix.device.name }}" >> $GITHUB_ENV
+          echo "BROWSERSTACK_OS_VERSION=${{ matrix.device.os_version }}" >> $GITHUB_ENV
+          echo "BROWSERSTACK_IOS_APP_URL=${{ github.event.inputs.browserstack_app_url_ios }}" >> $GITHUB_ENV
+          echo "BROWSERSTACK_BUILD_NAME=iOS-Performance-${{ github.ref_name }}-Branch" >> $GITHUB_ENV
+          echo "TEST_SUITE=${{ github.event.inputs.test_suite }}" >> $GITHUB_ENV
+      
+      - name: Run iOS Tests on ${{ matrix.device.name }}
+        env:
+          BROWSERSTACK_LOCAL: true
+          BROWSERSTACK_LOCAL_IDENTIFIER: ${{ github.run_id }}
+        run: |
+          echo "=== Testing ${{ matrix.device.name }} (${{ matrix.device.category }} Class) ==="
+          echo "OS Version: ${{ matrix.device.os_version }}"
+          echo "Category: ${{ matrix.device.category }}"
+          echo "Branch: ${{ github.ref_name }}"
+          if [ "${{ matrix.device.os_version }}" == "13" ] || [ "${{ matrix.device.os_version }}" == "11" ]; then
+            echo "Warning: iOS ${{ matrix.device.os_version }} may not be supported by MetaMask app"
+          fi
+          
+          yarn run-appwright:ios-bs
+      
+      - name: Upload iOS Test Results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: ios-test-results-${{ matrix.device.name }}-${{ matrix.device.os_version }}
+          path: |
+            appwright/test-reports/appwright-report/
+            appwright/reporters/reports
+          if-no-files-found: ignore
+          retention-days: 7
+  # Results Gathering Job
+  gather-results:
+    name: Gather Test Results
+    runs-on: ubuntu-latest
+    needs: [read-device-matrix, android-tests, ios-tests]
+    if: always()
+    
+    steps:
+      - name: Download All Test Results
+        uses: actions/download-artifact@v4
+        with:
+          path: appwright/test-reports/
+      
+      - name: Upload Combined Reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: combined-reports
+          path: |
+            appwright/test-reports/appwright-report/
+            appwright/reporters/reports
+          if-no-files-found: ignore
+          retention-days: 14
+    
+      - name: Check Test Results
+        run: |
+          if [ "${{ needs.android-tests.result }}" == "failure" ] || [ "${{ needs.ios-tests.result }}" == "failure" ]; then
+            echo "Some tests failed. Check the individual job results above."
+            echo "Note: iOS 13 and iOS 11 failures are expected due to MetaMask app compatibility."
+            exit 1
+          else
+            echo "All test jobs completed successfully!"
+          fi

--- a/.github/workflows/trigger-performance-e2e.yml
+++ b/.github/workflows/trigger-performance-e2e.yml
@@ -78,11 +78,13 @@ jobs:
             
             # Extract Android devices with optional category filtering
             ANDROID_MATRIX=$(jq -r ".android_devices $CATEGORY_FILTER | map({name: .name, os_version: .os_version, category: .category}) | tojson" appwright/device-matrix.json)
-            echo "android=$ANDROID_MATRIX" >> "$GITHUB_OUTPUT"
-            
             # Extract iOS devices with optional category filtering
             IOS_MATRIX=$(jq -r ".ios_devices $CATEGORY_FILTER | map({name: .name, os_version: .os_version, category: .category}) | tojson" appwright/device-matrix.json)
-            echo "ios=$IOS_MATRIX" >> "$GITHUB_OUTPUT"
+            
+            {
+              echo "android=$ANDROID_MATRIX"
+              echo "ios=$IOS_MATRIX"
+            } >> "$GITHUB_OUTPUT"
             
             echo "Android matrix: $ANDROID_MATRIX"
             echo "iOS matrix: $IOS_MATRIX"
@@ -123,6 +125,7 @@ jobs:
       
       - name: Install dependencies
         run: yarn setup
+      
       - name: BrowserStack Env Setup
         uses: browserstack/github-actions/setup-env@4478e16186f38e5be07721931642e65a028713c3
         with:
@@ -130,6 +133,7 @@ jobs:
           access-key: ${{ env.BROWSERSTACK_ACCESS_KEY }}
           build-name: ${{ github.repository }}-${{ github.ref_name }}-android-${{ matrix.device.name }}-${{ matrix.device.os_version }}-${{ github.run_number }}
           project-name: ${{ github.repository }}
+      
       - name: Setup BrowserStack Local
         uses: browserstack/github-actions/setup-local@4478e16186f38e5be07721931642e65a028713c3
         with:
@@ -146,12 +150,14 @@ jobs:
       - name: Set Android Test Environment
         run: |
           echo "Setting test environment for device: ${{ matrix.device.name }}"
-          echo "BROWSERSTACK_DEVICE=${{ matrix.device.name }}" >> "$GITHUB_ENV"
-          echo "BROWSERSTACK_OS_VERSION=${{ matrix.device.os_version }}" >> "$GITHUB_ENV"
-          echo "BROWSERSTACK_ANDROID_APP_URL=${{ github.event.inputs.browserstack_app_url_android }}" >> "$GITHUB_ENV"
-          echo "BROWSERSTACK_BUILD_NAME=Android-Performance-${{ github.ref_name }}-Branch" >> "$GITHUB_ENV"
-          echo "TEST_PLATFORM=android" >> "$GITHUB_ENV"
-          echo "TEST_SUITE=${{ github.event.inputs.test_suite }}" >> "$GITHUB_ENV"
+          {
+            echo "BROWSERSTACK_DEVICE=${{ matrix.device.name }}"
+            echo "BROWSERSTACK_OS_VERSION=${{ matrix.device.os_version }}"
+            echo "BROWSERSTACK_ANDROID_APP_URL=${{ github.event.inputs.browserstack_app_url_android }}"
+            echo "BROWSERSTACK_BUILD_NAME=Android-Performance-${{ github.ref_name }}-Branch"
+            echo "TEST_PLATFORM=android"
+            echo "TEST_SUITE=${{ github.event.inputs.test_suite }}"
+          } >> "$GITHUB_ENV"
       
       - name: Run Android Tests on ${{ matrix.device.name }}
         env:
@@ -196,6 +202,7 @@ jobs:
       
       - name: Install dependencies
         run: yarn setup
+      
       - name: BrowserStack Env Setup
         uses: browserstack/github-actions/setup-env@4478e16186f38e5be07721931642e65a028713c3
         with:
@@ -203,6 +210,7 @@ jobs:
           access-key: ${{ env.BROWSERSTACK_ACCESS_KEY }}
           build-name: ${{ github.repository }}-${{ github.ref_name }}-ios-${{ matrix.device.name }}-${{ matrix.device.os_version }}-${{ github.run_number }}
           project-name: ${{ github.repository }}
+      
       - name: Setup BrowserStack Local
         uses: browserstack/github-actions/setup-local@4478e16186f38e5be07721931642e65a028713c3
         with:
@@ -219,11 +227,13 @@ jobs:
       - name: Set iOS Test Environment
         run: |
           echo "Setting test environment for device: ${{ matrix.device.name }}"
-          echo "BROWSERSTACK_DEVICE=${{ matrix.device.name }}" >> "$GITHUB_ENV"
-          echo "BROWSERSTACK_OS_VERSION=${{ matrix.device.os_version }}" >> "$GITHUB_ENV"
-          echo "BROWSERSTACK_IOS_APP_URL=${{ github.event.inputs.browserstack_app_url_ios }}" >> "$GITHUB_ENV"
-          echo "BROWSERSTACK_BUILD_NAME=iOS-Performance-${{ github.ref_name }}-Branch" >> "$GITHUB_ENV"
-          echo "TEST_SUITE=${{ github.event.inputs.test_suite }}" >> "$GITHUB_ENV"
+          {
+            echo "BROWSERSTACK_DEVICE=${{ matrix.device.name }}"
+            echo "BROWSERSTACK_OS_VERSION=${{ matrix.device.os_version }}"
+            echo "BROWSERSTACK_IOS_APP_URL=${{ github.event.inputs.browserstack_app_url_ios }}"
+            echo "BROWSERSTACK_BUILD_NAME=iOS-Performance-${{ github.ref_name }}-Branch"
+            echo "TEST_SUITE=${{ github.event.inputs.test_suite }}"
+          } >> "$GITHUB_ENV"
       
       - name: Run iOS Tests on ${{ matrix.device.name }}
         env:

--- a/.github/workflows/trigger-performance-e2e.yml
+++ b/.github/workflows/trigger-performance-e2e.yml
@@ -61,8 +61,10 @@ jobs:
           if [ -n "${{ github.event.inputs.device_matrix }}" ]; then
             # Use custom device matrix from input
             echo "Using custom device matrix from input"
-            echo "android=${{ github.event.inputs.device_matrix }}" >> $GITHUB_OUTPUT
-            echo "ios=${{ github.event.inputs.device_matrix }}" >> $GITHUB_OUTPUT
+            {
+              echo "android=${{ github.event.inputs.device_matrix }}"
+              echo "ios=${{ github.event.inputs.device_matrix }}"
+            } >> "$GITHUB_OUTPUT"
           else
             # Read from JSON file and filter by category
             echo "Reading device matrix from appwright/device-matrix.json"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR is part of the work to split https://github.com/MetaMask/metamask-mobile/pull/17773 into a smaller PR. The workflows added here are dependent on the code in https://github.com/MetaMask/metamask-mobile/pull/17773. 



<img width="1897" height="781" alt="image" src="https://github.com/user-attachments/assets/75659e5f-7ddc-4e44-acb8-edebc77188c3" />


In order to run the test on CI, you would need to use the workflow dispatch job called `trigger-performance-e2e.yml`


You’ll need a BrowserStack URL first. To get it:

Run create_qa_builds_pipeline on Bitrise.
Once done, open the Artifacts tab and find browserstack_uploaded_apps.json (from build_android_qa). For example this [build](https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/7060652a-7ef9-4d0f-a44f-c736ae6a3bbc?tab=artifacts).


The first entry in that JSON will include your app’s URL (look for the bs:// prefix).

<img width="647" height="343" alt="image" src="https://github.com/user-attachments/assets/d1c4618b-593c-4f4e-8142-cadca4a9ac60" />


##### Automatic App Build <> Trigger tests Workflow 

There is another job to trigger the builds and tests called `run-performance-e2e.yml` which essentially builds the apps via bitrise, then uses the generated build bs urls and launches the tests. In future iterations, this workflow will no longer depend on Bitrise but more so on GitHub Actions to build the apps. 

<img width="1889" height="646" alt="image" src="https://github.com/user-attachments/assets/637e7a7e-a00a-4407-be27-5777f1cace93" />


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
