### PR TITLE
feat: faster isNonEvmAddress check

### DIFF
--- a/app/core/Multichain/test/utils.test.ts
+++ b/app/core/Multichain/test/utils.test.ts
@@ -18,6 +18,7 @@ import {
   isBtcTestnetAddress,
   getFormattedAddressFromInternalAccount,
   isSolanaAccount,
+  isNonEvmAddress,
   lastSelectedAccountAddressInEvmNetwork,
   lastSelectedAccountAddressByNonEvmNetworkChainId,
   shortenTransactionId,
@@ -37,6 +38,7 @@ import {
 // Mock these functions
 jest.mock('../../../util/address', () => ({
   formatAddress: jest.fn(),
+  isEthAddress: jest.requireActual('../../../util/address').isEthAddress,
 }));
 
 jest.mock('../networks', () => ({
@@ -50,9 +52,12 @@ const MOCK_BTC_MAINNET_ADDRESS = 'bc1qwl8399fz829uqvqly9tcatgrgtwp3udnhxfq4k';
 const MOCK_BTC_MAINNET_ADDRESS_2 = '1P5ZEDWTKTFGxQjZphgWPQUpe554WKDfHQ';
 // P2WPKH
 const MOCK_BTC_TESTNET_ADDRESS = 'tb1q63st8zfndjh00gf9hmhsdg7l8umuxudrj4lucp';
+const MOCK_BTC_REGTEST_ADDRESS = 'bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw';
 const MOCK_ETH_ADDRESS = '0xC4955C0d639D99699Bfd7Ec54d9FaFEe40e4D272';
+const MOCK_ETH_ADDRESS_2 = '0x742d35Cc6634C0532925a3b8D1f9C0D5c5b8c5F5';
 
 const SOL_ADDRESS = '7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV';
+const SOL_ADDRESS_2 = 'DRpbCBMxVnDK7maPM5tGv6MvB3v1sRMC86PZ8okm21hy';
 
 const mockEthEOAAccount: InternalAccount = {
   address: MOCK_ETH_ADDRESS,
@@ -222,6 +227,44 @@ describe('MultiChain utils', () => {
     it('returns false for non-Solana accounts', () => {
       expect(isSolanaAccount(mockEthEOAAccount)).toBe(false);
       expect(isSolanaAccount(mockBTCAccount)).toBe(false);
+    });
+  });
+
+  describe('isNonEvmAddress', () => {
+    describe('Solana addresses', () => {
+      it('returns true for valid Solana addresses', () => {
+        expect(isNonEvmAddress(SOL_ADDRESS)).toBe(true);
+        expect(isNonEvmAddress(SOL_ADDRESS_2)).toBe(true);
+      });
+    });
+
+    describe('Bitcoin mainnet addresses', () => {
+      it('returns true for P2WPKH Bitcoin mainnet addresses (bc1...)', () => {
+        expect(isNonEvmAddress(MOCK_BTC_MAINNET_ADDRESS)).toBe(true);
+      });
+
+      it('returns true for P2PKH Bitcoin mainnet addresses (1...)', () => {
+        expect(isNonEvmAddress(MOCK_BTC_MAINNET_ADDRESS_2)).toBe(true);
+      });
+    });
+
+    describe('Bitcoin testnet addresses', () => {
+      it('returns true for Bitcoin testnet addresses (tb1...)', () => {
+        expect(isNonEvmAddress(MOCK_BTC_TESTNET_ADDRESS)).toBe(true);
+      });
+    });
+
+    describe('Bitcoin regtest addresses', () => {
+      it('returns true for Bitcoin regtest addresses', () => {
+        expect(isNonEvmAddress(MOCK_BTC_REGTEST_ADDRESS)).toBe(true);
+      });
+    });
+
+    describe('Ethereum addresses', () => {
+      it('returns false for valid Ethereum addresses', () => {
+        expect(isNonEvmAddress(MOCK_ETH_ADDRESS)).toBe(false);
+        expect(isNonEvmAddress(MOCK_ETH_ADDRESS_2)).toBe(false);
+      });
     });
   });
 

--- a/app/core/Multichain/utils.ts
+++ b/app/core/Multichain/utils.ts
@@ -6,7 +6,7 @@ import Engine from '../Engine';
 import { CaipChainId, Hex } from '@metamask/utils';
 import { validate, Network } from 'bitcoin-address-validation';
 import { MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP } from './constants';
-import { formatAddress } from '../../util/address';
+import { formatAddress, isEthAddress } from '../../util/address';
 import {
   formatBlockExplorerAddressUrl,
   formatBlockExplorerTransactionUrl,
@@ -60,12 +60,9 @@ export function isSolanaAccount(account: InternalAccount): boolean {
  * @returns `true` if the address is a non-EVM address, `false` otherwise.
  */
 export function isNonEvmAddress(address: string): boolean {
-  return (
-    isSolanaAddress(address) ||
-    isBtcMainnetAddress(address) ||
-    isBtcTestnetAddress(address) ||
-    isBtcRegtestAddress(address)
-  );
+  // Instead of checking all other possible non-EVM addresses, we can just check if it's an EVM address
+  // This is much faster than doing multiple checks if it's a Solana, Bitcoin, etc. address
+  return !isEthAddress(address);
 }
 
 export function lastSelectedAccountAddressByNonEvmNetworkChainId(


### PR DESCRIPTION
## **Description**

While running `useAccounts` hook  that is used mostly in Account List I noticed that `isNonEvmAddress` could be very slow because it's running lot of checks for each address. I used reversed logic to only check if it's EVM address which is much faster. In some cases it could be more than 120x faster (120ms => <1ms)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open account list
2. Accounts are correctly displayed

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

127ms before

<img width="290" height="32" alt="Screenshot 2025-08-22 at 16 08 17" src="https://github.com/user-attachments/assets/d97a83c2-9057-417c-a231-7beaf0a00ad1" />


### **After**
0.2ms after

<img width="272" height="25" alt="Screenshot 2025-08-22 at 16 09 43" src="https://github.com/user-attachments/assets/47645c43-7d12-4b28-ab71-f71d6a6ca686" />


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
