### PR TITLE
chore(component-library): extract components-temp folder into separate PR

### DIFF
--- a/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.tsx
@@ -1,6 +1,7 @@
 import { AccountGroupObject } from '@metamask/account-tree-controller';
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { TouchableOpacity, View } from 'react-native';
+import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 import { useStyles } from '../../../hooks';
 import styleSheet from './AccountCell.styles';
@@ -13,6 +14,9 @@ import {
 } from '../../../../components/UI/Box/box.types';
 import Icon, { IconName, IconSize } from '../../../components/Icons/Icon';
 import { AccountCellIds } from '../../../../../e2e/selectors/MultichainAccounts/AccountCell.selectors';
+import { selectBalanceByAccountGroup } from '../../../../selectors/assets/balances';
+import { formatWithThreshold } from '../../../../util/assets';
+import I18n from '../../../../../locales/i18n';
 import Routes from '../../../../constants/navigation/Routes';
 
 interface AccountCellProps {
@@ -29,6 +33,23 @@ const AccountCell = ({ accountGroup, isSelected }: AccountCellProps) => {
       accountGroup,
     });
   }, [navigate, accountGroup]);
+
+  const selectBalanceForGroup = useMemo(
+    () => selectBalanceByAccountGroup(accountGroup.id),
+    [accountGroup.id],
+  );
+  const groupBalance = useSelector(selectBalanceForGroup);
+  const displayBalance = useMemo(() => {
+    if (!groupBalance) {
+      return undefined;
+    }
+    const value = groupBalance.totalBalanceInUserCurrency;
+    const currency = groupBalance.userCurrency;
+    return formatWithThreshold(value, 0.01, I18n.locale, {
+      style: 'currency',
+      currency: currency.toUpperCase(),
+    });
+  }, [groupBalance]);
 
   return (
     <Box
@@ -63,10 +84,7 @@ const AccountCell = ({ accountGroup, isSelected }: AccountCellProps) => {
           color={TextColor.Default}
           testID={AccountCellIds.BALANCE}
         >
-          {
-            // TODO: REPLACE WITH ACTUAL BALANCE
-            '$1234567890.00'
-          }
+          {displayBalance}
         </Text>
         <TouchableOpacity
           testID={AccountCellIds.MENU}

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListCell/AccountListCell.test.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListCell/AccountListCell.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { fireEvent } from '@testing-library/react-native';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import AccountListCell from './AccountListCell';
 import { createMockAccountGroup } from '../../test-utils';
 
@@ -10,6 +11,22 @@ jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ navigate: mockNavigate }),
 }));
 
+// Configurable mock balance for selector, avoids deep store dependencies
+const mockBalance = { value: 0, currency: 'usd' };
+
+jest.mock('../../../../../selectors/assets/balances', () => {
+  const actual = jest.requireActual('../../../../../selectors/assets/balances');
+  return {
+    ...actual,
+    selectBalanceByAccountGroup: (groupId: string) => () => ({
+      walletId: groupId.split('/')[0],
+      groupId,
+      totalBalanceInUserCurrency: mockBalance.value,
+      userCurrency: mockBalance.currency,
+    }),
+  };
+});
+
 const mockAccountGroup = createMockAccountGroup(
   'keyring:test-group/ethereum',
   'Test Account',
@@ -19,7 +36,7 @@ const mockAccountGroup = createMockAccountGroup(
 describe('AccountListCell', () => {
   it('renders correctly with account data', () => {
     const mockOnSelectAccount = jest.fn();
-    const { getByText } = render(
+    const { getByText } = renderWithProvider(
       <AccountListCell
         accountGroup={mockAccountGroup}
         isSelected={false}
@@ -32,7 +49,7 @@ describe('AccountListCell', () => {
 
   it('calls onSelectAccount when pressed', () => {
     const mockOnSelectAccount = jest.fn();
-    const { getByText } = render(
+    const { getByText } = renderWithProvider(
       <AccountListCell
         accountGroup={mockAccountGroup}
         isSelected={false}

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAddressRow/MultichainAddressRow.constants.ts
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAddressRow/MultichainAddressRow.constants.ts
@@ -15,6 +15,13 @@ export const MULTICHAIN_ADDRESS_ROW_QR_BUTTON_TEST_ID =
 
 export const SAMPLE_ICONS = [
   {
+    name: IconName.Copy,
+    callback: () => {
+      // Do nothing
+    },
+    testId: MULTICHAIN_ADDRESS_ROW_COPY_BUTTON_TEST_ID,
+  },
+  {
     name: IconName.QrCode,
     callback: () => {
       // Do nothing

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAddressRow/MultichainAddressRow.styles.ts
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAddressRow/MultichainAddressRow.styles.ts
@@ -38,10 +38,6 @@ const styleSheet = (params: {
       alignItems: 'center',
       gap: 8,
     } as ViewStyle,
-    overlay: {
-      backgroundColor: colors.success.muted,
-      borderRadius: 16,
-    } as ViewStyle,
   });
 };
 

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAddressRow/MultichainAddressRow.test.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAddressRow/MultichainAddressRow.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { render } from '@testing-library/react-native';
 import MultichainAddressRow from './MultichainAddressRow';
 import {
   SAMPLE_MULTICHAIN_ADDRESS_ROW_PROPS,
@@ -10,7 +10,6 @@ import {
   MULTICHAIN_ADDRESS_ROW_COPY_BUTTON_TEST_ID,
   MULTICHAIN_ADDRESS_ROW_QR_BUTTON_TEST_ID,
 } from './MultichainAddressRow.constants';
-import { IconName } from '../../../components/Icons/Icon';
 
 // Mock useCopyClipboard hook
 jest.mock(
@@ -24,14 +23,14 @@ jest.mock('../../../../util/networks', () => ({
 }));
 
 describe('MultichainAddressRow', () => {
-  it('renders MultichainAddressRow correctly', () => {
+  it('should render correctly', () => {
     const wrapper = render(
       <MultichainAddressRow {...SAMPLE_MULTICHAIN_ADDRESS_ROW_PROPS} />,
     );
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('renders the network name', () => {
+  it('should render the network name', () => {
     const { getByTestId } = render(
       <MultichainAddressRow {...SAMPLE_MULTICHAIN_ADDRESS_ROW_PROPS} />,
     );
@@ -41,7 +40,7 @@ describe('MultichainAddressRow', () => {
     expect(networkName.props.children).toBe('Ethereum Mainnet');
   });
 
-  it('renders the truncated address', () => {
+  it('should render the truncated address', () => {
     const { getByTestId } = render(
       <MultichainAddressRow {...SAMPLE_MULTICHAIN_ADDRESS_ROW_PROPS} />,
     );
@@ -49,7 +48,7 @@ describe('MultichainAddressRow', () => {
     expect(address.props.children).toBe('0x12345...67890');
   });
 
-  it('renders the network icon', () => {
+  it('should render the network icon', () => {
     const { getByTestId } = render(
       <MultichainAddressRow {...SAMPLE_MULTICHAIN_ADDRESS_ROW_PROPS} />,
     );
@@ -59,35 +58,15 @@ describe('MultichainAddressRow', () => {
     expect(networkIcon).toBeTruthy();
   });
 
-  it('renders copy and QR buttons', () => {
-    const mockCallback = jest.fn();
-    const copyParams = {
-      callback: mockCallback,
-      successMessage: 'Copied to clipboard!',
-    };
-
+  it('should render copy and QR buttons', () => {
     const { getByTestId } = render(
-      <MultichainAddressRow
-        {...SAMPLE_MULTICHAIN_ADDRESS_ROW_PROPS}
-        copyParams={copyParams}
-      />,
+      <MultichainAddressRow {...SAMPLE_MULTICHAIN_ADDRESS_ROW_PROPS} />,
     );
-
     const copyButton = getByTestId(MULTICHAIN_ADDRESS_ROW_COPY_BUTTON_TEST_ID);
     const qrButton = getByTestId(MULTICHAIN_ADDRESS_ROW_QR_BUTTON_TEST_ID);
 
     expect(copyButton).toBeTruthy();
     expect(qrButton).toBeTruthy();
-  });
-
-  it('does not render copy button if copyParams are missing', () => {
-    const { queryByTestId } = render(
-      <MultichainAddressRow {...SAMPLE_MULTICHAIN_ADDRESS_ROW_PROPS} />,
-    );
-
-    expect(
-      queryByTestId(MULTICHAIN_ADDRESS_ROW_COPY_BUTTON_TEST_ID),
-    ).toBeNull();
   });
 
   it('should accept custom testID', () => {
@@ -102,7 +81,7 @@ describe('MultichainAddressRow', () => {
     expect(component).toBeTruthy();
   });
 
-  it('handles unknown chainId', () => {
+  it('should handle unknown chainId', () => {
     const propsWithUnknownChainId = {
       ...SAMPLE_MULTICHAIN_ADDRESS_ROW_PROPS,
       chainId: 'eip155:999999' as const,
@@ -118,105 +97,11 @@ describe('MultichainAddressRow', () => {
     expect(networkIcon).toBeTruthy();
   });
 
-  it('renders with default testID when not provided', () => {
+  it('should render with default testID when not provided', () => {
     const { getByTestId } = render(
       <MultichainAddressRow {...SAMPLE_MULTICHAIN_ADDRESS_ROW_PROPS} />,
     );
     const component = getByTestId(MULTICHAIN_ADDRESS_ROW_TEST_ID);
     expect(component).toBeTruthy();
-  });
-
-  it('shows success message when copy is triggered', () => {
-    const mockCallback = jest.fn();
-    const copyParams = {
-      callback: mockCallback,
-      successMessage: 'Copied to clipboard!',
-    };
-
-    const { getByTestId, queryByText } = render(
-      <MultichainAddressRow
-        {...SAMPLE_MULTICHAIN_ADDRESS_ROW_PROPS}
-        copyParams={copyParams}
-      />,
-    );
-
-    const copyButton = getByTestId(MULTICHAIN_ADDRESS_ROW_COPY_BUTTON_TEST_ID);
-
-    // Simulate pressing the copy button
-    fireEvent.press(copyButton);
-
-    // Success message should be displayed
-    expect(queryByText(copyParams.successMessage)).toBeTruthy();
-  });
-
-  it('renders custom icons with proper callbacks', () => {
-    const mockIconCallback = jest.fn();
-    const icons = [
-      {
-        name: IconName.Apple,
-        callback: mockIconCallback,
-        testId: 'custom-icon-test-id',
-      },
-    ];
-
-    const { getByTestId } = render(
-      <MultichainAddressRow
-        {...SAMPLE_MULTICHAIN_ADDRESS_ROW_PROPS}
-        icons={icons}
-      />,
-    );
-
-    const customIcon = getByTestId('custom-icon-test-id');
-
-    // Simulate pressing the custom icon
-    fireEvent.press(customIcon);
-
-    // Verify mock callback function is called
-    expect(mockIconCallback).toHaveBeenCalled();
-  });
-
-  it('does not display success message if copyParams is not provided', () => {
-    const { queryByText } = render(
-      <MultichainAddressRow
-        {...SAMPLE_MULTICHAIN_ADDRESS_ROW_PROPS}
-        copyParams={undefined}
-      />,
-    );
-
-    expect(queryByText('Copied to clipboard!')).toBeNull();
-  });
-
-  it('renders truncated address correctly when copyParams is missing', () => {
-    const { getByTestId } = render(
-      <MultichainAddressRow
-        {...SAMPLE_MULTICHAIN_ADDRESS_ROW_PROPS}
-        copyParams={undefined}
-      />,
-    );
-
-    const address = getByTestId(MULTICHAIN_ADDRESS_ROW_ADDRESS_TEST_ID);
-    expect(address.props.children).toBe('0x12345...67890');
-  });
-
-  it('does not throw errors for undefined icons', () => {
-    const { getByTestId } = render(
-      <MultichainAddressRow
-        {...SAMPLE_MULTICHAIN_ADDRESS_ROW_PROPS}
-        icons={undefined}
-      />,
-    );
-
-    const actionsContainer = getByTestId(MULTICHAIN_ADDRESS_ROW_TEST_ID);
-    expect(actionsContainer).toBeTruthy();
-  });
-
-  it('completes animation steps for green flash', () => {
-    const { getByTestId } = render(
-      <MultichainAddressRow {...SAMPLE_MULTICHAIN_ADDRESS_ROW_PROPS} />,
-    );
-
-    // Check animation overlay exists
-    const overlay = getByTestId(MULTICHAIN_ADDRESS_ROW_TEST_ID);
-    expect(overlay).toBeTruthy();
   });
 });

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAddressRow/MultichainAddressRow.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAddressRow/MultichainAddressRow.tsx
@@ -1,11 +1,6 @@
-import React, {
-  useEffect,
-  useCallback,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
-import { View, Animated, Easing, StyleSheet } from 'react-native';
+import React from 'react';
+import { View } from 'react-native';
+
 import Avatar, {
   AvatarSize,
   AvatarVariant,
@@ -14,21 +9,19 @@ import ButtonIcon, {
   ButtonIconSizes,
 } from '../../../components/Buttons/ButtonIcon';
 import Text, { TextVariant, TextColor } from '../../../components/Texts/Text';
-import { IconColor, IconName } from '../../../components/Icons/Icon';
+import { IconColor } from '../../../components/Icons/Icon';
 import { useStyles } from '../../../hooks';
 import { formatAddress } from '../../../../util/address';
 import { getNetworkImageSource } from '../../../../util/networks';
+
 import styleSheet from './MultichainAddressRow.styles';
-import { Icon, MultichainAddressRowProps } from './MultichainAddressRow.types';
+import { MultichainAddressRowProps } from './MultichainAddressRow.types';
 import {
+  MULTICHAIN_ADDRESS_ROW_TEST_ID,
   MULTICHAIN_ADDRESS_ROW_NETWORK_ICON_TEST_ID,
   MULTICHAIN_ADDRESS_ROW_NETWORK_NAME_TEST_ID,
   MULTICHAIN_ADDRESS_ROW_ADDRESS_TEST_ID,
-  MULTICHAIN_ADDRESS_ROW_TEST_ID,
-  MULTICHAIN_ADDRESS_ROW_COPY_BUTTON_TEST_ID,
 } from './MultichainAddressRow.constants';
-
-export const DEFAULT_SUCCESS_DURATION = 1200; // 1.2 seconds
 
 const MultichainAddressRow = ({
   chainId,
@@ -36,126 +29,16 @@ const MultichainAddressRow = ({
   address,
   icons,
   style,
-  copyParams,
   testID = MULTICHAIN_ADDRESS_ROW_TEST_ID,
-  ...viewProps
+  ...props
 }: MultichainAddressRowProps) => {
   const { styles } = useStyles(styleSheet, { style });
+
   const networkImageSource = getNetworkImageSource({ chainId });
-  const truncatedAddress = useMemo(
-    () => formatAddress(address, 'short'),
-    [address],
-  );
-
-  const progress = useRef(new Animated.Value(0)).current;
-  const [showSuccess, setShowSuccess] = useState(false);
-
-  const successTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const animationCleanupRef = useRef<(() => void) | null>(null);
-
-  // Cleanup timer
-  const clearSuccessTimer = useCallback(() => {
-    if (successTimer.current) {
-      clearTimeout(successTimer.current);
-      successTimer.current = null;
-    }
-  }, []);
-
-  // Animation function now returns a cleanup function, which we track and call on unmount!
-  const startBlink = useCallback(() => {
-    const steps: Animated.CompositeAnimation[] = [];
-    steps.push(
-      Animated.timing(progress, {
-        toValue: 1,
-        duration: DEFAULT_SUCCESS_DURATION / 3,
-        easing: Easing.out(Easing.quad),
-        useNativeDriver: true,
-      }),
-    );
-    steps.push(
-      Animated.timing(progress, {
-        toValue: 0,
-        duration: (2 * DEFAULT_SUCCESS_DURATION) / 3,
-        easing: Easing.in(Easing.quad),
-        useNativeDriver: true,
-      }),
-    );
-    // Start and properly manage animated sequence lifecycle
-    const animation = Animated.sequence(steps);
-    animation.start();
-    // Cancel animation on unmount to avoid memory leaks
-    return () => animation.stop();
-  }, [progress]);
-
-  const triggerSuccess = useCallback(() => {
-    if (!copyParams) {
-      return; // Prevent triggering feedback when copyParams are undefined
-    }
-    setShowSuccess(true);
-    clearSuccessTimer();
-    successTimer.current = setTimeout(() => {
-      setShowSuccess(false);
-    }, DEFAULT_SUCCESS_DURATION);
-  }, [clearSuccessTimer, copyParams]);
-
-  const handleCopy = useCallback(async () => {
-    if (!copyParams) {
-      return; // Prevent copying or triggering animations when copyParams are undefined
-    }
-    // Clean up previous animation if running
-    if (animationCleanupRef.current) {
-      animationCleanupRef.current();
-      animationCleanupRef.current = null;
-    }
-    // Start new animation and retain its cleanup
-    animationCleanupRef.current = startBlink();
-    triggerSuccess();
-    if (copyParams?.callback) {
-      await copyParams.callback();
-    }
-  }, [copyParams, startBlink, triggerSuccess]);
-
-  // Cleanup effect for timers and animation
-  useEffect(
-    () => () => {
-      clearSuccessTimer();
-      if (animationCleanupRef.current) {
-        animationCleanupRef.current();
-        animationCleanupRef.current = null;
-      }
-    },
-    [clearSuccessTimer],
-  );
-
-  // Render additional icons passed to the component
-  const renderIcons = () =>
-    icons
-      ? icons.map((icon: Icon, index: number) => (
-          <ButtonIcon
-            key={index}
-            iconName={icon.name}
-            size={ButtonIconSizes.Md}
-            onPress={icon.callback}
-            iconColor={IconColor.Default}
-            testID={icon.testId}
-          />
-        ))
-      : null;
-
-  // Green overlay style (absolute fill)
-  const overlayStyle = [
-    StyleSheet.absoluteFillObject,
-    {
-      opacity: progress,
-    },
-  ];
+  const truncatedAddress = formatAddress(address, 'short');
 
   return (
-    <View style={styles.base} testID={testID} {...viewProps}>
-      <Animated.View
-        pointerEvents="none"
-        style={[overlayStyle, styles.overlay]}
-      />
+    <View style={styles.base} testID={testID} {...props}>
       <Avatar
         variant={AvatarVariant.Network}
         size={AvatarSize.Md}
@@ -163,6 +46,7 @@ const MultichainAddressRow = ({
         imageSource={networkImageSource}
         testID={MULTICHAIN_ADDRESS_ROW_NETWORK_ICON_TEST_ID}
       />
+
       <View style={styles.content}>
         <Text
           variant={TextVariant.BodyMDMedium}
@@ -171,31 +55,26 @@ const MultichainAddressRow = ({
         >
           {networkName}
         </Text>
-        {showSuccess && copyParams ? (
-          <Text variant={TextVariant.BodySM} color={TextColor.Success}>
-            {copyParams.successMessage}
-          </Text>
-        ) : (
-          <Text
-            variant={TextVariant.BodySM}
-            color={TextColor.Alternative}
-            testID={MULTICHAIN_ADDRESS_ROW_ADDRESS_TEST_ID}
-          >
-            {truncatedAddress}
-          </Text>
-        )}
+        <Text
+          variant={TextVariant.BodySM}
+          color={TextColor.Alternative}
+          testID={MULTICHAIN_ADDRESS_ROW_ADDRESS_TEST_ID}
+        >
+          {truncatedAddress}
+        </Text>
       </View>
+
       <View style={styles.actions}>
-        {copyParams && (
+        {icons.map((icon, index) => (
           <ButtonIcon
-            iconName={IconName.Copy}
+            key={index}
+            iconName={icon.name}
             size={ButtonIconSizes.Md}
-            onPress={handleCopy}
-            iconColor={showSuccess ? IconColor.Success : IconColor.Default}
-            testID={MULTICHAIN_ADDRESS_ROW_COPY_BUTTON_TEST_ID}
+            onPress={icon.callback}
+            iconColor={IconColor.Default}
+            testID={icon.testId}
           />
-        )}
-        {renderIcons()}
+        ))}
       </View>
     </View>
   );

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAddressRow/MultichainAddressRow.types.ts
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAddressRow/MultichainAddressRow.types.ts
@@ -20,20 +20,6 @@ export interface Icon {
   testId: string;
 }
 
-/**
- * Parameters for the copy operation.
- */
-export interface CopyParams {
-  /**
-   * Success message
-   */
-  successMessage?: string;
-  /**
-   * Callback function to execute when the copy action is successful
-   */
-  callback: () => Promise<void>;
-}
-
 export interface MultichainAddressRowProps {
   /**
    * Chain ID to identify the network
@@ -48,16 +34,12 @@ export interface MultichainAddressRowProps {
    */
   address: string;
   /**
-   * Copy operation parameters
-   */
-  copyParams?: CopyParams;
-  /**
    * Object containing icons to display in the row.
    * Each icon should have a name, a callback function, and test ID.
    * The callback will be executed when the icon is pressed.
    * Icons are displayed in the order they are provided.
    */
-  icons?: Icon[];
+  icons: Icon[];
   /**
    * Optional style object for the container
    */

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAddressRow/__snapshots__/MultichainAddressRow.test.tsx.snap
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAddressRow/__snapshots__/MultichainAddressRow.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MultichainAddressRow renders MultichainAddressRow correctly 1`] = `
+exports[`MultichainAddressRow should render correctly 1`] = `
 <View
   style={
     {
@@ -14,22 +14,6 @@ exports[`MultichainAddressRow renders MultichainAddressRow correctly 1`] = `
   }
   testID="multichain-address-row"
 >
-  <View
-    collapsable={false}
-    pointerEvents="none"
-    style={
-      {
-        "backgroundColor": "#457a391a",
-        "borderRadius": 16,
-        "bottom": 0,
-        "left": 0,
-        "opacity": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      }
-    }
-  />
   <View
     style={
       {
@@ -110,6 +94,39 @@ exports[`MultichainAddressRow renders MultichainAddressRow correctly 1`] = `
       }
     }
   >
+    <TouchableOpacity
+      accessible={true}
+      activeOpacity={1}
+      disabled={false}
+      onPress={[Function]}
+      onPressIn={[Function]}
+      onPressOut={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "borderRadius": 8,
+          "height": 28,
+          "justifyContent": "center",
+          "opacity": 1,
+          "width": 28,
+        }
+      }
+      testID="multichain-address-row-copy-button"
+    >
+      <SvgMock
+        color="#121314"
+        fill="currentColor"
+        height={20}
+        name="Copy"
+        style={
+          {
+            "height": 20,
+            "width": 20,
+          }
+        }
+        width={20}
+      />
+    </TouchableOpacity>
     <TouchableOpacity
       accessible={true}
       activeOpacity={1}

--- a/app/component-library/components-temp/MultichainAccounts/test-utils.ts
+++ b/app/component-library/components-temp/MultichainAccounts/test-utils.ts
@@ -120,6 +120,32 @@ export const createMockState = (
             selectedAccount: Object.keys(internalAccounts)[0],
           },
         },
+        // Minimal controllers required by balance selectors used in AccountCell
+        TokenBalancesController: {
+          tokenBalances: {},
+        },
+        TokenRatesController: {
+          marketData: {},
+        },
+        MultichainBalancesController: {
+          balances: {},
+        },
+        MultichainAssetsRatesController: {
+          conversionRates: {},
+        },
+        TokensController: {
+          allTokens: {},
+          allIgnoredTokens: {},
+          allDetectedTokens: {},
+        },
+        // Optional but safe defaults to avoid downstream selector assumptions
+        CurrencyRateController: {
+          currentCurrency: 'usd',
+          currencyRates: {},
+        },
+        NetworkEnablementController: {
+          enabledNetworkMap: {},
+        },
         RemoteFeatureFlagController: {
           remoteFeatureFlags: {
             enableMultichainAccounts: {


### PR DESCRIPTION
This PR extracts the temporary component library folder into its own PR to decouple UI library work from the aggregated balances feature.

- Moved: `app/component-library/components-temp/**` from `feat/aggregated-balances-portfolio-change`
- No functional changes outside the extracted folder

Testing:
- CI only. No runtime behavior changes expected.

Cleanup:
- This PR contains only the folder extraction. Follow-up PR will remove these files from the feature branch to keep scope focused.
