### PR TITLE
feat: support atomic swaps if payment token on same chain

### DIFF
--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
@@ -15,7 +15,6 @@ import {
 } from '../../__mocks__/controllers/transaction-controller-mock';
 import { transactionApprovalControllerMock } from '../../__mocks__/controllers/approval-controller-mock';
 import { selectShouldUseSmartTransaction } from '../../../../../selectors/smartTransactionsController';
-import { TransactionBridgeQuote } from '../../utils/bridge';
 import { ConfirmationMetricsState } from '../../../../../core/redux/slices/confirmationMetrics';
 import Routes from '../../../../../constants/navigation/Routes';
 import { ORIGIN_METAMASK } from '@metamask/controller-utils';
@@ -53,6 +52,25 @@ const TOTAL_FIAT_MOCK = '$123.45';
 const NETWORK_FEE_MOCK = '$234.56';
 const BRIDGE_FEE_MOCK = '$345.67';
 
+const QUOTE_MOCK = {
+  quote: {
+    srcChainId: 1,
+    destChainId: 1,
+  },
+  approval: {
+    data: '0x1',
+    gasLimit: 1,
+    to: '0x2',
+    value: '0x3',
+  },
+  trade: {
+    data: '0x4',
+    gasLimit: 2,
+    to: '0x5',
+    value: '0x6',
+  },
+};
+
 function renderHook(
   { hasQuotes }: { hasQuotes: boolean } = {
     hasQuotes: false,
@@ -68,7 +86,7 @@ function renderHook(
         confirmationMetrics: {
           transactionBridgeQuotesById: hasQuotes
             ? {
-                [transactionIdMock]: [{} as TransactionBridgeQuote],
+                [transactionIdMock]: [QUOTE_MOCK],
               }
             : {},
         } as unknown as ConfirmationMetricsState,
@@ -193,7 +211,8 @@ describe('useTransactionConfirm', () => {
     );
   });
 
-  it('adds metamask pay properties to transaction metadata', async () => {
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('adds metamask pay properties to transaction metadata', async () => {
     const { result } = renderHook();
 
     await result.current.onConfirm();
@@ -251,6 +270,34 @@ describe('useTransactionConfirm', () => {
     await flushPromises();
 
     expect(tryEnableEvmNetworkMock).toHaveBeenCalledWith(CHAIN_ID_MOCK);
+  });
+
+  it('adds batch transactions if quotes on same chain', async () => {
+    const { result } = renderHook({ hasQuotes: true });
+
+    await result.current.onConfirm();
+
+    expect(onApprovalConfirm).toHaveBeenCalledWith(expect.anything(), {
+      txMeta: expect.objectContaining({
+        batchTransactions: [
+          {
+            data: QUOTE_MOCK.approval.data,
+            gas: '0x1',
+            isAfter: false,
+            to: QUOTE_MOCK.approval.to,
+            value: QUOTE_MOCK.approval.value,
+          },
+          {
+            data: QUOTE_MOCK.trade.data,
+            gas: '0x2',
+            isAfter: false,
+            to: QUOTE_MOCK.trade.to,
+            value: QUOTE_MOCK.trade.value,
+          },
+        ],
+        batchTransactionsOptions: {},
+      }),
+    });
   });
 
   describe('navigates to', () => {

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
@@ -211,8 +211,7 @@ describe('useTransactionConfirm', () => {
     );
   });
 
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('adds metamask pay properties to transaction metadata', async () => {
+  it('adds metamask pay properties to transaction metadata', async () => {
     const { result } = renderHook();
 
     await result.current.onConfirm();

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { useCallback, useMemo } from 'react';
 import { useNavigation } from '@react-navigation/native';
 import { useDispatch, useSelector } from 'react-redux';
@@ -66,12 +65,12 @@ export function useTransactionConfirm() {
     }
 
     const updatedMetadata = cloneDeep(transactionMetadata);
-    // updatedMetadata.metamaskPay = {};
-    // updatedMetadata.metamaskPay.bridgeFeeFiat = bridgeFeeFiat;
-    // updatedMetadata.metamaskPay.chainId = payToken?.chainId;
-    // updatedMetadata.metamaskPay.networkFeeFiat = networkFeeFiat;
-    // updatedMetadata.metamaskPay.tokenAddress = payToken?.address;
-    // updatedMetadata.metamaskPay.totalFiat = totalFiat;
+    updatedMetadata.metamaskPay = {};
+    updatedMetadata.metamaskPay.bridgeFeeFiat = bridgeFeeFiat;
+    updatedMetadata.metamaskPay.chainId = payToken?.chainId;
+    updatedMetadata.metamaskPay.networkFeeFiat = networkFeeFiat;
+    updatedMetadata.metamaskPay.tokenAddress = payToken?.address;
+    updatedMetadata.metamaskPay.totalFiat = totalFiat;
 
     if (batchTransactions) {
       updatedMetadata.batchTransactions = batchTransactions;
@@ -104,15 +103,15 @@ export function useTransactionConfirm() {
     }
   }, [
     batchTransactions,
-    // bridgeFeeFiat,
+    bridgeFeeFiat,
     chainId,
     dispatch,
     isFullScreenConfirmation,
     navigation,
-    // networkFeeFiat,
+    networkFeeFiat,
     onRequestConfirm,
-    // payToken,
-    // totalFiat,
+    payToken,
+    totalFiat,
     transactionMetadata,
     tryEnableEvmNetwork,
     type,

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
@@ -126,7 +126,7 @@ function getQuoteBatchTransactions(
   quotes: TransactionBridgeQuote[],
 ): BatchTransaction[] {
   return quotes.flatMap((quote) => [
-    ...(quote.approval ? [getQuoteBatchTransaction(quote.trade)] : []),
+    ...(quote.approval ? [getQuoteBatchTransaction(quote.approval)] : []),
     getQuoteBatchTransaction(quote.trade),
   ]);
 }

--- a/app/util/transactions/hooks/pay-hook.test.ts
+++ b/app/util/transactions/hooks/pay-hook.test.ts
@@ -162,6 +162,26 @@ describe('Pay Publish Hook', () => {
     expect(submitTransactionMock).not.toHaveBeenCalled();
   });
 
+  it('does nothing if first quote has same source and target chain', async () => {
+    jest.spyOn(store, 'getState').mockReturnValue({
+      confirmationMetrics: {
+        transactionBridgeQuotesById: {
+          [TRANSACTION_ID_MOCK]: [
+            {
+              ...QUOTE_MOCK,
+              quote: { ...QUOTE_MOCK.quote, destChainId: 123 },
+            },
+            QUOTE_2_MOCK,
+          ],
+        },
+      },
+    } as unknown as RootState);
+
+    await runHook();
+
+    expect(submitTransactionMock).not.toHaveBeenCalled();
+  });
+
   it('throws if bridge status is failed', async () => {
     submitTransactionMock.mockReset();
     submitTransactionMock.mockImplementation(async () => {

--- a/app/util/transactions/hooks/pay-hook.ts
+++ b/app/util/transactions/hooks/pay-hook.ts
@@ -65,6 +65,18 @@ export class PayHook {
       return EMPTY_RESULT;
     }
 
+    // Currently we only support a single source meaning we only check the first quote.
+    const isSameChain =
+      quotes[0].quote.srcChainId === quotes[0].quote.destChainId;
+
+    if (isSameChain) {
+      log(
+        'Ignoring quotes as source is same chain',
+        quotes[0].quote.srcChainId,
+      );
+      return EMPTY_RESULT;
+    }
+
     let index = 0;
 
     for (const quote of quotes) {


### PR DESCRIPTION
## **Description**

If the selected payment token is on the same chain as the required token, skip usage of the `BridgeStatusController` and instead create a transaction batch via the `TransactionController`.

This batch will be atomic if the chain supports EIP-7702 or smart transactions with `eth_sendBundle`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#5502](https://github.com/MetaMask/MetaMask-planning/issues/5502)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
