### PR TITLE
feat: add insufficient payment token native alert

### DIFF
--- a/app/components/Views/confirmations/components/alert-banner/alert-banner.test.tsx
+++ b/app/components/Views/confirmations/components/alert-banner/alert-banner.test.tsx
@@ -35,6 +35,7 @@ describe('AlertBanner', () => {
       content: <Text>Details for alert 3</Text>,
       alertDetails: ['Detail 5', 'Detail 6'],
       field: RowAlertKey.Amount,
+      isBlocking: true,
     },
     {
       key: '4',
@@ -42,7 +43,16 @@ describe('AlertBanner', () => {
       severity: Severity.Info,
       content: <Text>Details for alert 4</Text>,
       alertDetails: ['Detail 7', 'Detail 8'],
-      field: RowAlertKey.Amount,
+      field: RowAlertKey.PayWith,
+      isBlocking: true,
+    },
+    {
+      key: '5',
+      title: 'Alert 5',
+      severity: Severity.Info,
+      content: <Text>Details for alert 5</Text>,
+      alertDetails: ['Detail 9', 'Detail 10'],
+      field: RowAlertKey.PendingTransaction,
     },
   ];
 
@@ -84,25 +94,13 @@ describe('AlertBanner', () => {
     );
   });
 
-  it('renders field alerts if field specified', () => {
-    const { getByText } = render(<AlertBanner field={RowAlertKey.Amount} />);
+  it('renders blocking field alerts if blockingFields set', () => {
+    const { getByText } = render(<AlertBanner blockingFields />);
 
     expect(getByText('Alert 3')).toBeDefined();
     expect(getByText('Details for alert 3')).toBeDefined();
 
     expect(getByText('Alert 4')).toBeDefined();
     expect(getByText('Details for alert 4')).toBeDefined();
-  });
-
-  it('renders nothing if no field alerts mathcing specified field', () => {
-    const { queryByText } = render(
-      <AlertBanner field={RowAlertKey.Blockaid} />,
-    );
-
-    expect(queryByText('Alert 3')).toBeNull();
-    expect(queryByText('Details for alert 3')).toBeNull();
-
-    expect(queryByText('Alert 4')).toBeNull();
-    expect(queryByText('Details for alert 4')).toBeNull();
   });
 });

--- a/app/components/Views/confirmations/components/alert-banner/alert-banner.test.tsx
+++ b/app/components/Views/confirmations/components/alert-banner/alert-banner.test.tsx
@@ -95,10 +95,25 @@ describe('AlertBanner', () => {
   });
 
   it('renders blocking field alerts if blockingFields set', () => {
-    const { getByText } = render(<AlertBanner blockingFields />);
+    const { getByText, queryByText } = render(<AlertBanner blockingFields />);
 
     expect(getByText('Alert 3')).toBeDefined();
     expect(getByText('Details for alert 3')).toBeDefined();
+
+    expect(getByText('Alert 4')).toBeDefined();
+    expect(getByText('Details for alert 4')).toBeDefined();
+
+    expect(queryByText('Alert 5')).toBeNull();
+    expect(queryByText('Details for alert 5')).toBeNull();
+  });
+
+  it('excludes fields if specified and blockingFields set', () => {
+    const { getByText, queryByText } = render(
+      <AlertBanner blockingFields excludeFields={[RowAlertKey.Amount]} />,
+    );
+
+    expect(queryByText('Alert 3')).toBeNull();
+    expect(queryByText('Details for alert 3')).toBeNull();
 
     expect(getByText('Alert 4')).toBeDefined();
     expect(getByText('Details for alert 4')).toBeDefined();

--- a/app/components/Views/confirmations/components/alert-banner/alert-banner.tsx
+++ b/app/components/Views/confirmations/components/alert-banner/alert-banner.tsx
@@ -4,18 +4,26 @@ import BannerAlert from '../../../../../component-library/components/Banners/Ban
 import styleSheet from './alert-banner.styles';
 import { useStyles } from '../../../../hooks/useStyles';
 import { getBannerAlertSeverity } from '../../utils/alert-system';
+import { RowAlertKey } from '../UI/info-row/alert-row/constants';
 
 export interface AlertBannerProps {
   blockingFields?: boolean;
+  excludeFields?: RowAlertKey[];
   inline?: boolean;
 }
 
-const AlertBanner = ({ blockingFields, inline }: AlertBannerProps = {}) => {
+const AlertBanner = ({
+  blockingFields,
+  excludeFields,
+  inline,
+}: AlertBannerProps = {}) => {
   const { generalAlerts, fieldAlerts } = useAlerts();
   const { styles } = useStyles(styleSheet, { inline });
 
   const alerts = blockingFields
-    ? fieldAlerts.filter((a) => a.isBlocking)
+    ? fieldAlerts.filter(
+        (a) => a.isBlocking && !excludeFields?.includes(a.field as RowAlertKey),
+      )
     : generalAlerts;
 
   if (alerts.length === 0) {

--- a/app/components/Views/confirmations/components/alert-banner/alert-banner.tsx
+++ b/app/components/Views/confirmations/components/alert-banner/alert-banner.tsx
@@ -4,19 +4,18 @@ import BannerAlert from '../../../../../component-library/components/Banners/Ban
 import styleSheet from './alert-banner.styles';
 import { useStyles } from '../../../../hooks/useStyles';
 import { getBannerAlertSeverity } from '../../utils/alert-system';
-import { RowAlertKey } from '../UI/info-row/alert-row/constants';
 
 export interface AlertBannerProps {
-  field?: RowAlertKey;
+  blockingFields?: boolean;
   inline?: boolean;
 }
 
-const AlertBanner = ({ field, inline }: AlertBannerProps = {}) => {
+const AlertBanner = ({ blockingFields, inline }: AlertBannerProps = {}) => {
   const { generalAlerts, fieldAlerts } = useAlerts();
   const { styles } = useStyles(styleSheet, { inline });
 
-  const alerts = field
-    ? fieldAlerts.filter((a) => a.field === field)
+  const alerts = blockingFields
+    ? fieldAlerts.filter((a) => a.isBlocking)
     : generalAlerts;
 
   if (alerts.length === 0) {

--- a/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
@@ -148,6 +148,10 @@ jest.mock('../../../../../core/redux/slices/bridge', () => ({
   selectEnabledSourceChains: jest.fn().mockReturnValue([]),
 }));
 
+jest.mock('../../hooks/alerts/useInsufficientPayTokenNativeAlert', () => ({
+  useInsufficientPayTokenNativeAlert: jest.fn().mockReturnValue([]),
+}));
+
 describe('Confirm', () => {
   afterEach(() => {
     jest.restoreAllMocks();

--- a/app/components/Views/confirmations/components/edit-amount/edit-amount.test.tsx
+++ b/app/components/Views/confirmations/components/edit-amount/edit-amount.test.tsx
@@ -103,6 +103,24 @@ describe('EditAmount', () => {
     expect(getByTestId('edit-amount-input')).toHaveProp('defaultValue', '5');
   });
 
+  it('sets amount to zero when input cleared', async () => {
+    const { getByTestId, getByText } = render();
+
+    await act(async () => {
+      fireEvent.press(getByTestId('edit-amount-input'));
+    });
+
+    await act(async () => {
+      fireEvent.press(getByText('5'));
+    });
+
+    await act(async () => {
+      fireEvent.press(getByTestId('keypad-delete-button'));
+    });
+
+    expect(getByTestId('edit-amount-input')).toHaveProp('defaultValue', '0');
+  });
+
   it('displays keyboard automatically when autoKeyboard is true', () => {
     const { getByTestId } = render({ autoKeyboard: true });
 

--- a/app/components/Views/confirmations/components/edit-amount/edit-amount.test.tsx
+++ b/app/components/Views/confirmations/components/edit-amount/edit-amount.test.tsx
@@ -121,6 +121,24 @@ describe('EditAmount', () => {
     expect(getByTestId('edit-amount-input')).toHaveProp('defaultValue', '0');
   });
 
+  it('does not append to zero', async () => {
+    const { getByTestId, getByText } = render();
+
+    await act(async () => {
+      fireEvent.press(getByTestId('edit-amount-input'));
+    });
+
+    await act(async () => {
+      fireEvent.press(getByText('0'));
+    });
+
+    await act(async () => {
+      fireEvent.press(getByText('5'));
+    });
+
+    expect(getByTestId('edit-amount-input')).toHaveProp('defaultValue', '5');
+  });
+
   it('displays keyboard automatically when autoKeyboard is true', () => {
     const { getByTestId } = render({ autoKeyboard: true });
 

--- a/app/components/Views/confirmations/components/edit-amount/edit-amount.tsx
+++ b/app/components/Views/confirmations/components/edit-amount/edit-amount.tsx
@@ -80,7 +80,7 @@ export function EditAmount({
   }, [autoKeyboard, inputChanged, handleInputPress]);
 
   const handleChange = useCallback((amount: string) => {
-    const newAmount = amount.replace(/^(0+).+/, '') || '0';
+    const newAmount = amount.replace(/^0+/, '') || '0';
 
     if (newAmount.length >= MAX_LENGTH) {
       return;

--- a/app/components/Views/confirmations/components/edit-amount/edit-amount.tsx
+++ b/app/components/Views/confirmations/components/edit-amount/edit-amount.tsx
@@ -62,7 +62,7 @@ export function EditAmount({
   const { tokenFiatAmount } = payToken ?? {};
   const hasAmount = amountFiat !== '0';
 
-  const amountHuman = new BigNumber(amountFiat)
+  const amountHuman = new BigNumber(amountFiat.replace(/,/g, ''))
     .dividedBy(fiatRate ?? 1)
     .toString(10);
 
@@ -80,11 +80,13 @@ export function EditAmount({
   }, [autoKeyboard, inputChanged, handleInputPress]);
 
   const handleChange = useCallback((amount: string) => {
-    if (amount.length >= MAX_LENGTH) {
+    const newAmount = amount.replace(/^(0+).+/, '') || '0';
+
+    if (newAmount.length >= MAX_LENGTH) {
       return;
     }
 
-    setAmountFiat(amount);
+    setAmountFiat(newAmount);
     setInputChanged(true);
   }, []);
 

--- a/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
@@ -6,6 +6,8 @@ import Routes from '../../../../../../constants/navigation/Routes';
 import { useTokens } from '../../../../../UI/Bridge/hooks/useTokens';
 import { Hex } from '@metamask/utils';
 import { BridgeToken } from '../../../../../UI/Bridge/types';
+import { NATIVE_TOKEN_ADDRESS } from '../../../constants/tokens';
+import { cloneDeep } from 'lodash';
 
 jest.useFakeTimers();
 
@@ -70,6 +72,26 @@ const TOKENS_MOCK: BridgeToken[] = [
     balanceFiat: '$7.89',
     balance: '789',
     tokenFiatAmount: 7.89,
+  },
+  {
+    address: NATIVE_TOKEN_ADDRESS,
+    symbol: 'TST4',
+    name: 'Native Token 1',
+    decimals: 18,
+    chainId: CHAIN_ID_1_MOCK,
+    balanceFiat: '$1.00',
+    balance: '1',
+    tokenFiatAmount: 1,
+  },
+  {
+    address: NATIVE_TOKEN_ADDRESS,
+    symbol: 'TST5',
+    name: 'Native Token 2',
+    decimals: 18,
+    chainId: CHAIN_ID_2_MOCK,
+    balanceFiat: '$1.00',
+    balance: '1',
+    tokenFiatAmount: 1,
   },
 ];
 
@@ -137,6 +159,37 @@ describe('PayWithModal', () => {
 
     await waitFor(() => {
       expect(queryByText('Test Token 2')).toBeNull();
+    });
+  });
+
+  it('does not render tokens if no native balance on chain', async () => {
+    const tokens = cloneDeep(TOKENS_MOCK);
+
+    tokens[4].tokenFiatAmount = 0;
+
+    useTokensMock.mockReturnValue({
+      tokens,
+      pending: false,
+    });
+
+    const { getByText, queryByText } = render();
+
+    await waitFor(() => {
+      expect(getByText('Test Token 1')).toBeDefined();
+      expect(getByText('123 TST1')).toBeDefined();
+      expect(getByText('$1.23')).toBeDefined();
+    });
+
+    await waitFor(() => {
+      expect(queryByText('Test Token 2')).toBeNull();
+      expect(queryByText('456 TST2')).toBeNull();
+      expect(queryByText('$4.56')).toBeNull();
+    });
+
+    await waitFor(() => {
+      expect(getByText('Test Token 3')).toBeDefined();
+      expect(getByText('789 TST3')).toBeDefined();
+      expect(getByText('$7.89')).toBeDefined();
     });
   });
 

--- a/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
@@ -21,6 +21,7 @@ import { useNavigation } from '@react-navigation/native';
 import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
 import { useParams } from '../../../../../../util/navigation/navUtils';
 import { strings } from '../../../../../../../locales/i18n';
+import { NATIVE_TOKEN_ADDRESS } from '../../../constants/tokens';
 
 export function PayWithModal() {
   const allNetworkConfigurations = useSelector(selectNetworkConfigurations);
@@ -38,8 +39,8 @@ export function PayWithModal() {
 
   const filteredTokensList = useMemo(
     () =>
-      tokensList.filter(
-        (token) => (token.tokenFiatAmount ?? 0) >= (minimumFiatBalance ?? 0),
+      tokensList.filter((token) =>
+        isTokenSupported(token, tokensList, minimumFiatBalance ?? 0),
       ),
     [tokensList, minimumFiatBalance],
   );
@@ -115,4 +116,21 @@ export function PayWithModal() {
       title={strings('pay_with_modal.title')}
     />
   );
+}
+
+function isTokenSupported(
+  token: BridgeToken,
+  tokens: BridgeToken[],
+  requiredBalance: number,
+): boolean {
+  const nativeToken = tokens.find(
+    (t) => t.address === NATIVE_TOKEN_ADDRESS && t.chainId === token.chainId,
+  );
+
+  const isTokenBalanceSufficient =
+    (token?.tokenFiatAmount ?? 0) >= requiredBalance;
+
+  const hasNativeBalance = (nativeToken?.tokenFiatAmount ?? 0) > 0;
+
+  return isTokenBalanceSufficient && hasNativeBalance;
 }

--- a/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
@@ -48,6 +48,14 @@ export function PayWithModal() {
 
   const isTokenSupported = useCallback(
     (token: BridgeToken) => {
+      const isSelected =
+        payToken?.address.toLowerCase() === token.address.toLowerCase() &&
+        payToken?.chainId === token.chainId;
+
+      if (isSelected) {
+        return true;
+      }
+
       const isRequiredToken = targetTokens.some(
         (t) =>
           t.address.toLowerCase() === token.address.toLowerCase() &&
@@ -74,7 +82,13 @@ export function PayWithModal() {
 
       return hasNativeBalance;
     },
-    [minimumFiatBalance, targetTokens, tokensList, transactionChainId],
+    [
+      minimumFiatBalance,
+      payToken,
+      targetTokens,
+      tokensList,
+      transactionChainId,
+    ],
   );
 
   const filteredTokensList = useMemo(

--- a/app/components/Views/confirmations/constants/alerts.ts
+++ b/app/components/Views/confirmations/constants/alerts.ts
@@ -4,6 +4,7 @@ export enum AlertKeys {
   DomainMismatch = 'domain_mismatch',
   InsufficientBalance = 'insufficient_balance',
   InsufficientPayTokenBalance = 'insufficient_pay_token_balance',
+  InsufficientPayTokenNative = 'insufficient_pay_token_native',
   NoPayTokenQuotes = 'no_pay_token_quotes',
   PendingTransaction = 'pending_transaction',
   PerpsDepositMinimum = 'perps_deposit_minimum',

--- a/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.test.tsx
+++ b/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.test.tsx
@@ -69,6 +69,7 @@ describe('PerpsDeposit', () => {
 
     usePerpsDepositViewMock.mockReturnValue({
       isFullView: false,
+      isPayTokenSelected: false,
     });
 
     useTokenAssetMock.mockReturnValue({

--- a/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.tsx
+++ b/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.tsx
@@ -49,7 +49,13 @@ export function PerpsDeposit() {
               {inputChanged && <AlertMessage alerts={alerts} />}
               <PayTokenAmount amountHuman={amountHuman} />
             </Box>
-            {!isKeyboardVisible && <AlertBanner blockingFields inline />}
+            {!isKeyboardVisible && (
+              <AlertBanner
+                blockingFields
+                excludeFields={[RowAlertKey.Amount]}
+                inline
+              />
+            )}
             <InfoSection>
               <PayWithRow />
             </InfoSection>

--- a/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.tsx
+++ b/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.tsx
@@ -49,9 +49,7 @@ export function PerpsDeposit() {
               {inputChanged && <AlertMessage alerts={alerts} />}
               <PayTokenAmount amountHuman={amountHuman} />
             </Box>
-            {!isKeyboardVisible && (
-              <AlertBanner field={RowAlertKey.PayWith} inline />
-            )}
+            {!isKeyboardVisible && <AlertBanner blockingFields inline />}
             <InfoSection>
               <PayWithRow />
             </InfoSection>

--- a/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.tsx
+++ b/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.tsx
@@ -25,7 +25,7 @@ export function PerpsDeposit() {
   const [inputChanged, setInputChanged] = useState(false);
   const alerts = usePerpsDepositAlerts({ pendingTokenAmount });
 
-  const { isFullView } = usePerpsDepositView({
+  const { isFullView, isPayTokenSelected } = usePerpsDepositView({
     isKeyboardVisible,
   });
 
@@ -49,7 +49,7 @@ export function PerpsDeposit() {
               {inputChanged && <AlertMessage alerts={alerts} />}
               <PayTokenAmount amountHuman={amountHuman} />
             </Box>
-            {!isKeyboardVisible && (
+            {!isKeyboardVisible && isPayTokenSelected && (
               <AlertBanner
                 blockingFields
                 excludeFields={[RowAlertKey.Amount]}

--- a/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositView.test.ts
+++ b/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositView.test.ts
@@ -8,10 +8,12 @@ import {
 import { useTokenAmount } from '../../../hooks/useTokenAmount';
 import { usePerpsDepositView } from './usePerpsDepositView';
 import { TransactionBridgeQuote } from '../../../utils/bridge';
+import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
 
 jest.mock('./usePerpsDepositInit');
 jest.mock('../../../hooks/useTokenAmount');
 jest.mock('../../../hooks/pay/useAutomaticTransactionPayToken');
+jest.mock('../../../hooks/pay/useTransactionPayToken');
 
 function runHook(
   props: Parameters<typeof usePerpsDepositView>[0],
@@ -46,6 +48,7 @@ function runHook(
 
 describe('usePerpsDepositView', () => {
   const useTokenAmountMock = jest.mocked(useTokenAmount);
+  const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -53,6 +56,10 @@ describe('usePerpsDepositView', () => {
     useTokenAmountMock.mockReturnValue({
       amountUnformatted: '1',
     } as ReturnType<typeof useTokenAmount>);
+
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: undefined,
+    } as ReturnType<typeof useTransactionPayToken>);
   });
 
   it('returns isFullView as true if keyboard hidden and amount is non-zero with quotes loading', () => {
@@ -133,5 +140,20 @@ describe('usePerpsDepositView', () => {
     );
 
     expect(result.current.isFullView).toBe(true);
+  });
+
+  it('returns isPayTokenSelected as false if payment token not selected', () => {
+    const { result } = runHook({ isKeyboardVisible: false });
+    expect(result.current.isPayTokenSelected).toBe(false);
+  });
+
+  it('returns isPayTokenSelected as true if payment token selected', () => {
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: {},
+    } as ReturnType<typeof useTransactionPayToken>);
+
+    const { result } = runHook({ isKeyboardVisible: false });
+
+    expect(result.current.isPayTokenSelected).toBe(true);
   });
 });

--- a/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositView.test.ts
+++ b/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositView.test.ts
@@ -9,11 +9,13 @@ import { useTokenAmount } from '../../../hooks/useTokenAmount';
 import { usePerpsDepositView } from './usePerpsDepositView';
 import { TransactionBridgeQuote } from '../../../utils/bridge';
 import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
+import { useTransactionPayTokenAmounts } from '../../../hooks/pay/useTransactionPayTokenAmounts';
 
 jest.mock('./usePerpsDepositInit');
 jest.mock('../../../hooks/useTokenAmount');
 jest.mock('../../../hooks/pay/useAutomaticTransactionPayToken');
 jest.mock('../../../hooks/pay/useTransactionPayToken');
+jest.mock('../../../hooks/pay/useTransactionPayTokenAmounts');
 
 function runHook(
   props: Parameters<typeof usePerpsDepositView>[0],
@@ -49,6 +51,9 @@ function runHook(
 describe('usePerpsDepositView', () => {
   const useTokenAmountMock = jest.mocked(useTokenAmount);
   const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
+  const useTransactionPayTokenAmountsMock = jest.mocked(
+    useTransactionPayTokenAmounts,
+  );
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -60,6 +65,10 @@ describe('usePerpsDepositView', () => {
     useTransactionPayTokenMock.mockReturnValue({
       payToken: undefined,
     } as ReturnType<typeof useTransactionPayToken>);
+
+    useTransactionPayTokenAmountsMock.mockReturnValue({
+      amounts: [{}],
+    } as ReturnType<typeof useTransactionPayTokenAmounts>);
   });
 
   it('returns isFullView as true if keyboard hidden and amount is non-zero with quotes loading', () => {
@@ -136,6 +145,23 @@ describe('usePerpsDepositView', () => {
       },
       {
         quotes: [],
+      },
+    );
+
+    expect(result.current.isFullView).toBe(false);
+  });
+
+  it('returns isFullView as true if no pay token amounts', () => {
+    useTransactionPayTokenAmountsMock.mockReturnValue({
+      amounts: [],
+    } as unknown as ReturnType<typeof useTransactionPayTokenAmounts>);
+
+    const { result } = runHook(
+      {
+        isKeyboardVisible: false,
+      },
+      {
+        quotes: undefined,
       },
     );
 

--- a/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositView.ts
+++ b/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositView.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../../../../core/redux/slices/confirmationMetrics';
 import { BigNumber } from 'bignumber.js';
 import { usePerpsDepositInit } from './usePerpsDepositInit';
+import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
 
 export function usePerpsDepositView({
   isKeyboardVisible,
@@ -20,6 +21,8 @@ export function usePerpsDepositView({
 
   const { id: transactionId } = useTransactionMetadataOrThrow();
   const { amountUnformatted } = useTokenAmount();
+  const { payToken } = useTransactionPayToken();
+
   const amountValue = new BigNumber(amountUnformatted ?? '0');
 
   const quotes = useSelector((state: RootState) =>
@@ -47,5 +50,6 @@ export function usePerpsDepositView({
 
   return {
     isFullView,
+    isPayTokenSelected: Boolean(payToken),
   };
 }

--- a/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositView.ts
+++ b/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositView.ts
@@ -38,7 +38,7 @@ export function usePerpsDepositView({
   const isFullView =
     !isKeyboardVisible &&
     !amountValue.isZero() &&
-    (isQuotesLoading || quotes?.length || sourceAmounts?.length === 0);
+    (isQuotesLoading || Boolean(quotes?.length) || sourceAmounts?.length === 0);
 
   useAutomaticTransactionPayToken({
     balanceOverrides: [

--- a/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositView.ts
+++ b/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositView.ts
@@ -11,6 +11,7 @@ import {
 import { BigNumber } from 'bignumber.js';
 import { usePerpsDepositInit } from './usePerpsDepositInit';
 import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
+import { useTransactionPayTokenAmounts } from '../../../hooks/pay/useTransactionPayTokenAmounts';
 
 export function usePerpsDepositView({
   isKeyboardVisible,
@@ -22,6 +23,7 @@ export function usePerpsDepositView({
   const { id: transactionId } = useTransactionMetadataOrThrow();
   const { amountUnformatted } = useTokenAmount();
   const { payToken } = useTransactionPayToken();
+  const { amounts: sourceAmounts } = useTransactionPayTokenAmounts();
 
   const amountValue = new BigNumber(amountUnformatted ?? '0');
 
@@ -36,7 +38,7 @@ export function usePerpsDepositView({
   const isFullView =
     !isKeyboardVisible &&
     !amountValue.isZero() &&
-    (isQuotesLoading || quotes !== undefined);
+    (isQuotesLoading || quotes?.length || sourceAmounts?.length === 0);
 
   useAutomaticTransactionPayToken({
     balanceOverrides: [

--- a/app/components/Views/confirmations/hooks/alerts/useConfirmationAlerts.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useConfirmationAlerts.test.ts
@@ -16,6 +16,7 @@ import { usePendingTransactionAlert } from './usePendingTransactionAlert';
 import { usePerpsDepositMinimumAlert } from './usePerpsDepositMinimumAlert';
 import { useInsufficientPayTokenBalanceAlert } from './useInsufficientPayTokenBalanceAlert';
 import { useNoPayTokenQuotesAlert } from './useNoPayTokenQuotesAlert';
+import { useInsufficientPayTokenNativeAlert } from './useInsufficientPayTokenNativeAlert';
 
 jest.mock('./useBlockaidAlerts');
 jest.mock('./useDomainMismatchAlerts');
@@ -27,6 +28,7 @@ jest.mock('./useBatchedUnusedApprovalsAlert');
 jest.mock('./usePerpsDepositMinimumAlert');
 jest.mock('./useInsufficientPayTokenBalanceAlert');
 jest.mock('./useNoPayTokenQuotesAlert');
+jest.mock('./useInsufficientPayTokenNativeAlert');
 
 describe('useConfirmationAlerts', () => {
   const ALERT_MESSAGE_MOCK = 'This is a test alert message.';
@@ -123,6 +125,15 @@ describe('useConfirmationAlerts', () => {
     },
   ];
 
+  const mockInsufficientPayTokenNativeAlert: Alert[] = [
+    {
+      key: 'InsufficientPayTokenNativeAlert',
+      title: 'Test Insufficient Pay Token Native Alert',
+      message: ALERT_MESSAGE_MOCK,
+      severity: Severity.Danger,
+    },
+  ];
+
   beforeEach(() => {
     jest.clearAllMocks();
     (useBlockaidAlerts as jest.Mock).mockReturnValue([]);
@@ -135,6 +146,7 @@ describe('useConfirmationAlerts', () => {
     (usePerpsDepositMinimumAlert as jest.Mock).mockReturnValue([]);
     (useInsufficientPayTokenBalanceAlert as jest.Mock).mockReturnValue([]);
     (useNoPayTokenQuotesAlert as jest.Mock).mockReturnValue([]);
+    (useInsufficientPayTokenNativeAlert as jest.Mock).mockReturnValue([]);
   });
 
   it('returns empty array if no alerts', () => {
@@ -199,6 +211,9 @@ describe('useConfirmationAlerts', () => {
     (useNoPayTokenQuotesAlert as jest.Mock).mockReturnValue(
       mockNoPayTokenQuotesAlert,
     );
+    (useInsufficientPayTokenNativeAlert as jest.Mock).mockReturnValue(
+      mockInsufficientPayTokenNativeAlert,
+    );
     const { result } = renderHookWithProvider(() => useConfirmationAlerts(), {
       state: siweSignatureConfirmationState,
     });
@@ -212,6 +227,7 @@ describe('useConfirmationAlerts', () => {
       ...mockPerpsDepositMinimumAlert,
       ...mockInsufficientPayTokenBalanceAlert,
       ...mockNoPayTokenQuotesAlert,
+      ...mockInsufficientPayTokenNativeAlert,
       ...mockUpgradeAccountAlert,
     ]);
   });

--- a/app/components/Views/confirmations/hooks/alerts/useConfirmationAlerts.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useConfirmationAlerts.ts
@@ -10,6 +10,7 @@ import { useBatchedUnusedApprovalsAlert } from './useBatchedUnusedApprovalsAlert
 import { usePerpsDepositMinimumAlert } from './usePerpsDepositMinimumAlert';
 import { useInsufficientPayTokenBalanceAlert } from './useInsufficientPayTokenBalanceAlert';
 import { useNoPayTokenQuotesAlert } from './useNoPayTokenQuotesAlert';
+import { useInsufficientPayTokenNativeAlert } from './useInsufficientPayTokenNativeAlert';
 
 function useSignatureAlerts(): Alert[] {
   const domainMismatchAlerts = useDomainMismatchAlerts();
@@ -26,6 +27,7 @@ function useTransactionAlerts(): Alert[] {
   const insufficientPayTokenBalanceAlert =
     useInsufficientPayTokenBalanceAlert();
   const noPayTokenQuotesAlert = useNoPayTokenQuotesAlert();
+  const insufficientPayTokenNativeAlert = useInsufficientPayTokenNativeAlert();
 
   return useMemo(
     () => [
@@ -36,6 +38,7 @@ function useTransactionAlerts(): Alert[] {
       ...perpsDepositMinimumAlert,
       ...insufficientPayTokenBalanceAlert,
       ...noPayTokenQuotesAlert,
+      ...insufficientPayTokenNativeAlert,
     ],
     [
       insufficientBalanceAlert,
@@ -45,6 +48,7 @@ function useTransactionAlerts(): Alert[] {
       perpsDepositMinimumAlert,
       insufficientPayTokenBalanceAlert,
       noPayTokenQuotesAlert,
+      insufficientPayTokenNativeAlert,
     ],
   );
 }

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.test.ts
@@ -73,7 +73,10 @@ describe('useInsufficientBalanceAlert', () => {
         nativeCurrency: mockNativeCurrency,
       },
     } as unknown as ReturnType<typeof selectNetworkConfigurations>);
-    mockUseTransactionPayToken.mockReturnValue({ setPayToken: noop });
+    mockUseTransactionPayToken.mockReturnValue({
+      payToken: undefined,
+      setPayToken: noop,
+    });
 
     (strings as jest.Mock).mockImplementation((key, params) => {
       if (key === 'alert_system.insufficient_balance.buy_action') {

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
@@ -18,6 +18,7 @@ import { Alert, Severity } from '../../types/alerts';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { useAccountNativeBalance } from '../useAccountNativeBalance';
 import { useConfirmActions } from '../useConfirmActions';
+import { useTransactionPayToken } from '../pay/useTransactionPayToken';
 
 const HEX_ZERO = '0x0';
 
@@ -35,6 +36,7 @@ export const useInsufficientBalanceAlert = ({
   );
   const { maxValueMode } = useSelector(selectTransactionState);
   const { onReject } = useConfirmActions();
+  const { payToken } = useTransactionPayToken();
 
   return useMemo(() => {
     if (!transactionMetadata || maxValueMode) {
@@ -63,7 +65,9 @@ export const useInsufficientBalanceAlert = ({
     );
 
     const showAlert =
-      hasInsufficientBalance && (ignoreGasFeeToken || !selectedGasFeeToken);
+      hasInsufficientBalance &&
+      (ignoreGasFeeToken || !selectedGasFeeToken) &&
+      !payToken;
 
     if (!showAlert) {
       return [];
@@ -98,6 +102,7 @@ export const useInsufficientBalanceAlert = ({
     navigation,
     networkConfigurations,
     onReject,
+    payToken,
     transactionMetadata,
   ]);
 };

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.test.ts
@@ -20,7 +20,7 @@ function runHook() {
   return renderHook(() => useInsufficientPayTokenBalanceAlert());
 }
 
-describe('useInsufficientPayTokenBalance', () => {
+describe('useInsufficientPayTokenBalanceAlert', () => {
   const useTransactionMetadataRequestMock = jest.mocked(
     useTransactionMetadataRequest,
   );

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenNativeAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenNativeAlert.test.ts
@@ -1,0 +1,105 @@
+import { renderHook } from '@testing-library/react-native';
+import { useTransactionPayToken } from '../pay/useTransactionPayToken';
+import { AlertKeys } from '../../constants/alerts';
+import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
+import { Severity } from '../../types/alerts';
+import { strings } from '../../../../../../locales/i18n';
+import { useInsufficientPayTokenNativeAlert } from './useInsufficientPayTokenNativeAlert';
+import { useTransactionTotalFiat } from '../pay/useTransactionTotalFiat';
+import { useTokensWithBalance } from '../../../../UI/Bridge/hooks/useTokensWithBalance';
+import { NATIVE_TOKEN_ADDRESS } from '../../constants/tokens';
+
+jest.mock('../pay/useTransactionPayToken');
+jest.mock('../pay/useTransactionTotalFiat');
+jest.mock('../../../../UI/Bridge/hooks/useTokensWithBalance');
+
+const CHAIN_ID_MOCK = '0x123';
+const BALANCE_FIAT = 123.45;
+
+function runHook() {
+  return renderHook(() => useInsufficientPayTokenNativeAlert());
+}
+
+describe('useInsufficientPayTokenNativeAlert', () => {
+  const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
+  const useTransactionTotalFiatMock = jest.mocked(useTransactionTotalFiat);
+  const useTokensWithBalanceMock = jest.mocked(useTokensWithBalance);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns alert if native balance less than quote network fees', () => {
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: { chainId: CHAIN_ID_MOCK },
+    } as unknown as ReturnType<typeof useTransactionPayToken>);
+
+    useTokensWithBalanceMock.mockReturnValue([
+      {
+        address: NATIVE_TOKEN_ADDRESS,
+        chainId: CHAIN_ID_MOCK,
+        tokenFiatAmount: BALANCE_FIAT,
+      },
+    ] as unknown as ReturnType<typeof useTokensWithBalance>);
+
+    useTransactionTotalFiatMock.mockReturnValue({
+      quoteNetworkFee: `${BALANCE_FIAT + 0.01}`,
+    } as unknown as ReturnType<typeof useTransactionTotalFiat>);
+
+    const { result } = runHook();
+
+    expect(result.current).toEqual([
+      {
+        key: AlertKeys.InsufficientPayTokenNative,
+        field: RowAlertKey.PayWith,
+        message: strings('alert_system.insufficient_pay_token_native.message'),
+        severity: Severity.Danger,
+        isBlocking: true,
+      },
+    ]);
+  });
+
+  it('returns no alerts if native balance sufficient', () => {
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: { chainId: CHAIN_ID_MOCK },
+    } as unknown as ReturnType<typeof useTransactionPayToken>);
+
+    useTokensWithBalanceMock.mockReturnValue([
+      {
+        address: NATIVE_TOKEN_ADDRESS,
+        chainId: CHAIN_ID_MOCK,
+        tokenFiatAmount: BALANCE_FIAT,
+      },
+    ] as unknown as ReturnType<typeof useTokensWithBalance>);
+
+    useTransactionTotalFiatMock.mockReturnValue({
+      quoteNetworkFee: `${BALANCE_FIAT}`,
+    } as unknown as ReturnType<typeof useTransactionTotalFiat>);
+
+    const { result } = runHook();
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  it('returns no alerts if no payment token selected', () => {
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: undefined,
+    } as unknown as ReturnType<typeof useTransactionPayToken>);
+
+    useTokensWithBalanceMock.mockReturnValue([
+      {
+        address: NATIVE_TOKEN_ADDRESS,
+        chainId: CHAIN_ID_MOCK,
+        tokenFiatAmount: BALANCE_FIAT,
+      },
+    ] as unknown as ReturnType<typeof useTokensWithBalance>);
+
+    useTransactionTotalFiatMock.mockReturnValue({
+      quoteNetworkFee: `${BALANCE_FIAT + 0.01}`,
+    } as unknown as ReturnType<typeof useTransactionTotalFiat>);
+
+    const { result } = runHook();
+
+    expect(result.current).toStrictEqual([]);
+  });
+});

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenNativeAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenNativeAlert.ts
@@ -1,0 +1,40 @@
+import { useMemo } from 'react';
+import { Alert, Severity } from '../../types/alerts';
+import { useTransactionPayToken } from '../pay/useTransactionPayToken';
+import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
+import { AlertKeys } from '../../constants/alerts';
+import { BigNumber } from 'bignumber.js';
+import { strings } from '../../../../../../locales/i18n';
+import { useTransactionTotalFiat } from '../pay/useTransactionTotalFiat';
+import { useTokensWithBalance } from '../../../../UI/Bridge/hooks/useTokensWithBalance';
+import { NATIVE_TOKEN_ADDRESS } from '../../constants/tokens';
+
+export function useInsufficientPayTokenNativeAlert(): Alert[] {
+  const { quoteNetworkFee } = useTransactionTotalFiat();
+  const { payToken } = useTransactionPayToken();
+  const { chainId } = payToken ?? {};
+  const chainIds = useMemo(() => (chainId ? [chainId] : []), [chainId]);
+  const tokens = useTokensWithBalance({ chainIds });
+  const nativeToken = tokens.find((t) => t.address === NATIVE_TOKEN_ADDRESS);
+  const { tokenFiatAmount } = nativeToken ?? {};
+
+  const isInsufficient = new BigNumber(tokenFiatAmount ?? '0').isLessThan(
+    new BigNumber(quoteNetworkFee ?? '0'),
+  );
+
+  return useMemo(() => {
+    if (!isInsufficient) {
+      return [];
+    }
+
+    return [
+      {
+        key: AlertKeys.InsufficientPayTokenNative,
+        field: RowAlertKey.PayWith,
+        message: strings('alert_system.insufficient_pay_token_native.message'),
+        severity: Severity.Danger,
+        isBlocking: true,
+      },
+    ];
+  }, [isInsufficient]);
+}

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenNativeAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenNativeAlert.ts
@@ -18,9 +18,11 @@ export function useInsufficientPayTokenNativeAlert(): Alert[] {
   const nativeToken = tokens.find((t) => t.address === NATIVE_TOKEN_ADDRESS);
   const { tokenFiatAmount } = nativeToken ?? {};
 
-  const isInsufficient = new BigNumber(tokenFiatAmount ?? '0').isLessThan(
-    new BigNumber(quoteNetworkFee ?? '0'),
-  );
+  const isInsufficient =
+    payToken &&
+    new BigNumber(tokenFiatAmount ?? '0').isLessThan(
+      new BigNumber(quoteNetworkFee ?? '0'),
+    );
 
   return useMemo(() => {
     if (!isInsufficient) {

--- a/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.test.ts
@@ -73,7 +73,6 @@ describe('useNoPayTokenQuotesAlert', () => {
         key: AlertKeys.NoPayTokenQuotes,
         field: RowAlertKey.PayWith,
         message: strings('alert_system.no_pay_token_quotes.message'),
-        title: strings('alert_system.no_pay_token_quotes.title'),
         severity: Severity.Danger,
         isBlocking: true,
       },

--- a/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.ts
@@ -37,7 +37,6 @@ export function useNoPayTokenQuotesAlert() {
         key: AlertKeys.NoPayTokenQuotes,
         field: RowAlertKey.PayWith,
         message: strings('alert_system.no_pay_token_quotes.message'),
-        title: strings('alert_system.no_pay_token_quotes.title'),
         severity: Severity.Danger,
         isBlocking: true,
       },

--- a/app/components/Views/confirmations/hooks/metrics/useConfirmationAlertMetrics.ts
+++ b/app/components/Views/confirmations/hooks/metrics/useConfirmationAlertMetrics.ts
@@ -111,6 +111,7 @@ const ALERTS_NAME_METRICS: AlertNameMetrics = {
   [AlertKeys.DomainMismatch]: 'domain_mismatch',
   [AlertKeys.InsufficientBalance]: 'insufficient_balance',
   [AlertKeys.InsufficientPayTokenBalance]: 'insufficient_pay_token_balance',
+  [AlertKeys.InsufficientPayTokenNative]: 'insufficient_pay_token_native',
   [AlertKeys.NoPayTokenQuotes]: 'no_pay_token_quotes',
   [AlertKeys.PendingTransaction]: 'pending_transaction',
   [AlertKeys.PerpsDepositMinimum]: 'perps_deposit_minimum',

--- a/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.ts
@@ -11,6 +11,7 @@ import { useTransactionRequiredTokens } from './useTransactionRequiredTokens';
 import { simpleSendTransactionControllerMock } from '../../__mocks__/controllers/transaction-controller-mock';
 import { transactionApprovalControllerMock } from '../../__mocks__/controllers/approval-controller-mock';
 import { selectEnabledSourceChains } from '../../../../../core/redux/slices/bridge';
+import { NATIVE_TOKEN_ADDRESS } from '../../constants/tokens';
 
 jest.mock('./useTransactionPayToken');
 jest.mock('../../../../UI/Bridge/hooks/useTokensWithBalance');
@@ -133,6 +134,11 @@ describe('useAutomaticTransactionPayToken', () => {
         chainId: CHAIN_ID_2_MOCK,
         tokenFiatAmount: TOTAL_FIAT_MOCK + 20,
       },
+      {
+        address: NATIVE_TOKEN_ADDRESS,
+        chainId: CHAIN_ID_1_MOCK,
+        tokenFiatAmount: 1,
+      },
     ] as unknown as ReturnType<typeof useTokensWithBalance>);
 
     runHook();
@@ -165,6 +171,16 @@ describe('useAutomaticTransactionPayToken', () => {
         chainId: CHAIN_ID_2_MOCK,
         tokenFiatAmount: TOTAL_FIAT_MOCK + 20,
       },
+      {
+        address: NATIVE_TOKEN_ADDRESS,
+        chainId: CHAIN_ID_1_MOCK,
+        tokenFiatAmount: 1,
+      },
+      {
+        address: NATIVE_TOKEN_ADDRESS,
+        chainId: CHAIN_ID_2_MOCK,
+        tokenFiatAmount: 1,
+      },
     ] as unknown as ReturnType<typeof useTokensWithBalance>);
 
     runHook();
@@ -186,6 +202,16 @@ describe('useAutomaticTransactionPayToken', () => {
         address: TOKEN_ADDRESS_2_MOCK,
         chainId: CHAIN_ID_2_MOCK,
         tokenFiatAmount: TOTAL_FIAT_MOCK - 1,
+      },
+      {
+        address: NATIVE_TOKEN_ADDRESS,
+        chainId: CHAIN_ID_1_MOCK,
+        tokenFiatAmount: 1,
+      },
+      {
+        address: NATIVE_TOKEN_ADDRESS,
+        chainId: CHAIN_ID_2_MOCK,
+        tokenFiatAmount: 1,
       },
     ] as unknown as ReturnType<typeof useTokensWithBalance>);
 
@@ -230,6 +256,16 @@ describe('useAutomaticTransactionPayToken', () => {
         chainId: CHAIN_ID_2_MOCK,
         tokenFiatAmount: TOTAL_FIAT_MOCK + 10,
       },
+      {
+        address: NATIVE_TOKEN_ADDRESS,
+        chainId: CHAIN_ID_1_MOCK,
+        tokenFiatAmount: 1,
+      },
+      {
+        address: NATIVE_TOKEN_ADDRESS,
+        chainId: CHAIN_ID_2_MOCK,
+        tokenFiatAmount: 1,
+      },
     ] as unknown as ReturnType<typeof useTokensWithBalance>);
 
     runHook({
@@ -244,6 +280,48 @@ describe('useAutomaticTransactionPayToken', () => {
 
     expect(setPayTokenMock).toHaveBeenCalledWith({
       address: TOKEN_ADDRESS_2_MOCK,
+      chainId: CHAIN_ID_2_MOCK,
+    });
+  });
+
+  it('does not select token if no native balance on chain', () => {
+    useTokensWithBalanceMock.mockReturnValue([
+      {
+        address: TOKEN_ADDRESS_1_MOCK,
+        chainId: CHAIN_ID_1_MOCK,
+        tokenFiatAmount: TOTAL_FIAT_MOCK - 1,
+      },
+      {
+        address: TOKEN_ADDRESS_2_MOCK,
+        chainId: CHAIN_ID_1_MOCK,
+        tokenFiatAmount: TOTAL_FIAT_MOCK + 5,
+      },
+      {
+        address: TOKEN_ADDRESS_3_MOCK,
+        chainId: CHAIN_ID_1_MOCK,
+        tokenFiatAmount: TOTAL_FIAT_MOCK + 10,
+      },
+      {
+        address: TOKEN_ADDRESS_3_MOCK,
+        chainId: CHAIN_ID_2_MOCK,
+        tokenFiatAmount: TOTAL_FIAT_MOCK + 20,
+      },
+      {
+        address: NATIVE_TOKEN_ADDRESS,
+        chainId: CHAIN_ID_1_MOCK,
+        tokenFiatAmount: 0,
+      },
+      {
+        address: NATIVE_TOKEN_ADDRESS,
+        chainId: CHAIN_ID_2_MOCK,
+        tokenFiatAmount: 1,
+      },
+    ] as unknown as ReturnType<typeof useTokensWithBalance>);
+
+    runHook();
+
+    expect(setPayTokenMock).toHaveBeenCalledWith({
+      address: TOKEN_ADDRESS_3_MOCK,
       chainId: CHAIN_ID_2_MOCK,
     });
   });

--- a/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
@@ -10,6 +10,7 @@ import { useEffect, useMemo, useRef } from 'react';
 import { Hex } from 'viem';
 import { createProjectLogger } from '@metamask/utils';
 import { useTransactionPayToken } from './useTransactionPayToken';
+import { BridgeToken } from '../../../../UI/Bridge/types';
 
 const log = createProjectLogger('transaction-pay');
 
@@ -52,11 +53,11 @@ export function useAutomaticTransactionPayToken({
 
     const requiredBalance = balanceOverride?.balance ?? totalFiat;
 
-    const sufficientBalanceTokens = orderBy(
-      tokens.filter((token) => (token.tokenFiatAmount ?? 0) >= requiredBalance),
-      (token) => token?.tokenFiatAmount ?? 0,
-      'desc',
-    );
+  const sufficientBalanceTokens = orderBy(
+    tokens.filter((token) => isTokenSupported(token, tokens, requiredBalance)),
+    (token) => token?.tokenFiatAmount ?? 0,
+    'desc',
+  );
 
     const requiredToken = sufficientBalanceTokens.find(
       (token) =>
@@ -99,4 +100,21 @@ export function useAutomaticTransactionPayToken({
 
     log('Automatically selected pay token', automaticToken);
   }, [automaticToken, isUpdated, requiredTokens, setPayToken]);
+}
+
+function isTokenSupported(
+  token: BridgeToken,
+  tokens: BridgeToken[],
+  requiredBalance: number,
+): boolean {
+  const nativeToken = tokens.find(
+    (t) => t.address === NATIVE_TOKEN_ADDRESS && t.chainId === token.chainId,
+  );
+
+  const isTokenBalanceSufficient =
+    (token?.tokenFiatAmount ?? 0) >= requiredBalance;
+
+  const hasNativeBalance = (nativeToken?.tokenFiatAmount ?? 0) > 0;
+
+  return isTokenBalanceSufficient && hasNativeBalance;
 }

--- a/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
@@ -53,11 +53,13 @@ export function useAutomaticTransactionPayToken({
 
     const requiredBalance = balanceOverride?.balance ?? totalFiat;
 
-  const sufficientBalanceTokens = orderBy(
-    tokens.filter((token) => isTokenSupported(token, tokens, requiredBalance)),
-    (token) => token?.tokenFiatAmount ?? 0,
-    'desc',
-  );
+    const sufficientBalanceTokens = orderBy(
+      tokens.filter((token) =>
+        isTokenSupported(token, tokens, requiredBalance),
+      ),
+      (token) => token?.tokenFiatAmount ?? 0,
+      'desc',
+    );
 
     const requiredToken = sufficientBalanceTokens.find(
       (token) =>

--- a/app/components/Views/confirmations/hooks/pay/useTransactionBridgeQuotes.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionBridgeQuotes.test.ts
@@ -178,22 +178,25 @@ describe('useTransactionBridgeQuotes', () => {
     expect(result.current.quotes).toStrictEqual([]);
   });
 
-  it('returns empty list if blocking alert unless no quotes alert', async () => {
-    useAlertsMock.mockReturnValue({
-      alerts: [
-        {
-          key: AlertKeys.NoPayTokenQuotes,
-          isBlocking: true,
-        },
-      ],
-    } as unknown as ReturnType<typeof useAlerts>);
+  it.each([AlertKeys.NoPayTokenQuotes, AlertKeys.InsufficientPayTokenNative])(
+    'returns empty list if blocking alert unless %s alert',
+    async (alertKey) => {
+      useAlertsMock.mockReturnValue({
+        alerts: [
+          {
+            key: alertKey,
+            isBlocking: true,
+          },
+        ],
+      } as unknown as ReturnType<typeof useAlerts>);
 
-    const result = runHook();
+      const result = runHook();
 
-    await act(async () => {
-      // Intentionally empty
-    });
+      await act(async () => {
+        // Intentionally empty
+      });
 
-    expect(result.current.quotes).toStrictEqual([QUOTE_MOCK, QUOTE_MOCK]);
-  });
+      expect(result.current.quotes).toStrictEqual([QUOTE_MOCK, QUOTE_MOCK]);
+    },
+  );
 });

--- a/app/components/Views/confirmations/hooks/pay/useTransactionBridgeQuotes.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionBridgeQuotes.ts
@@ -14,6 +14,11 @@ import { useDeepMemo } from '../useDeepMemo';
 import { useAlerts } from '../../context/alert-system-context';
 import { AlertKeys } from '../../constants/alerts';
 
+const EXCLUDED_ALERTS = [
+  AlertKeys.NoPayTokenQuotes,
+  AlertKeys.InsufficientPayTokenNative,
+];
+
 const log = createProjectLogger('transaction-pay');
 
 export function useTransactionBridgeQuotes() {
@@ -22,7 +27,7 @@ export function useTransactionBridgeQuotes() {
   const { alerts } = useAlerts();
 
   const hasBlockingAlert = alerts.some(
-    (a) => a.isBlocking && a.key !== AlertKeys.NoPayTokenQuotes,
+    (a) => a.isBlocking && !EXCLUDED_ALERTS.includes(a.key as AlertKeys),
   );
 
   const {
@@ -75,7 +80,7 @@ export function useTransactionBridgeQuotes() {
       return [];
     }
 
-    return getBridgeQuotes(requests as BridgeQuoteRequest[]);
+    return getBridgeQuotes(requests);
   }, [requests]);
 
   useEffect(() => {

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayTokenAmounts.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayTokenAmounts.ts
@@ -32,8 +32,16 @@ export function useTransactionPayTokenAmounts({
     ];
   }, [address, chainId]);
 
+  const safeAmountOverrides = useDeepMemo(
+    () => amountOverrides,
+    [amountOverrides],
+  );
+
   const tokenFiatRate = useTokenFiatRates(fiatRequests)[0];
-  const { values } = useTransactionRequiredFiat({ amountOverrides });
+
+  const { values } = useTransactionRequiredFiat({
+    amountOverrides: safeAmountOverrides,
+  });
 
   const amounts = useDeepMemo(() => {
     if (!address || !chainId || !tokenFiatRate || !decimals) {

--- a/app/components/Views/confirmations/hooks/pay/useTransactionRequiredTokens.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionRequiredTokens.test.ts
@@ -14,6 +14,7 @@ import { Interface } from '@ethersproject/abi';
 import { toHex } from '@metamask/controller-utils';
 import { NATIVE_TOKEN_ADDRESS } from '../../constants/tokens';
 import { useTokenWithBalance } from '../tokens/useTokenWithBalance';
+import { otherControllersMock } from '../../__mocks__/controllers/other-controllers-mock';
 
 jest.mock('../tokens/useTokenWithBalance');
 
@@ -28,6 +29,7 @@ const STATE_MOCK = merge(
   },
   simpleSendTransactionControllerMock,
   transactionApprovalControllerMock,
+  otherControllersMock,
 );
 
 function runHook({
@@ -78,6 +80,29 @@ describe('useTransactionRequiredTokens', () => {
     const tokens = runHook({
       transaction: {
         txParams: {
+          maxFeePerGas: toHex(50000000000000),
+          gas: '0x3',
+        } as TransactionParams,
+      },
+    }).result.current;
+
+    expect(tokens).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          address: EMPTY_ADDRESS,
+          amountHuman: '0.00015',
+          amountRaw: '150000000000000',
+          decimals: 18,
+          skipIfBalance: true,
+        }),
+      ]),
+    );
+  });
+
+  it('returns gas token as one dollar minimum', () => {
+    const tokens = runHook({
+      transaction: {
+        txParams: {
           maxFeePerGas: '0x3',
           gas: '0x5',
         } as TransactionParams,
@@ -88,8 +113,8 @@ describe('useTransactionRequiredTokens', () => {
       expect.arrayContaining([
         expect.objectContaining({
           address: EMPTY_ADDRESS,
-          amountHuman: '0.000000000000000015',
-          amountRaw: '15',
+          amountHuman: '0.0001',
+          amountRaw: '100000000000000',
           decimals: 18,
           skipIfBalance: true,
         }),

--- a/app/components/Views/confirmations/hooks/pay/useTransactionTotalFiat.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionTotalFiat.test.ts
@@ -173,4 +173,35 @@ describe('useTransactionTotalFiat', () => {
 
     expect(result.current.totalGasFormatted).toBe('$13.68');
   });
+
+  it('returns quote network fee', () => {
+    const { result } = runHook({
+      quotes: [
+        {
+          sentAmount: {
+            valueInCurrency: '100',
+          },
+          toTokenAmount: {
+            valueInCurrency: '90',
+          },
+          totalMaxNetworkFee: {
+            valueInCurrency: '1.23',
+          },
+        },
+        {
+          sentAmount: {
+            valueInCurrency: '80',
+          },
+          toTokenAmount: {
+            valueInCurrency: '60',
+          },
+          totalMaxNetworkFee: {
+            valueInCurrency: '2.34',
+          },
+        },
+      ] as TransactionBridgeQuote[],
+    });
+
+    expect(result.current.quoteNetworkFee).toBe('3.57');
+  });
 });

--- a/app/components/Views/confirmations/hooks/pay/useTransactionTotalFiat.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionTotalFiat.ts
@@ -68,9 +68,10 @@ export function useTransactionTotalFiat() {
   }, [balanceCost, formatted, quoteTotal, totalNetworkFeeFormatted, value]);
 
   return {
-    value,
     formatted,
+    quoteNetworkFee: quoteNetworkFeeTotal.toString(10),
     totalGasFormatted: totalNetworkFeeFormatted,
+    value,
   };
 }
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -54,7 +54,10 @@
       "message": "Min order value is $10"
     },
     "insufficient_pay_token_balance": {
-      "message": "Insufficient funds. Select different token."
+      "message": "Insufficient token funds. Select different token."
+    },
+    "insufficient_pay_token_native": {
+      "message": "Insufficient native funds on payment token chain. Select different token."
     },
     "no_pay_token_quotes": {
       "title": "We couldn't find any quotes.",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -60,8 +60,7 @@
       "message": "Insufficient native funds on payment token chain. Select different token."
     },
     "no_pay_token_quotes": {
-      "title": "We couldn't find any quotes.",
-      "message": "Change the amount or select a different token for payment."
+      "message": "This payment route isn't available right now. Try changing the amount, network, or token and we'll find the best option."
     }
   },
   "blockaid_banner": {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -54,7 +54,7 @@
       "message": "Min order value is $10"
     },
     "insufficient_pay_token_balance": {
-      "message": "Insufficient token funds. Select different token."
+      "message": "Insufficient funds. Select different token."
     },
     "insufficient_pay_token_native": {
       "message": "Insufficient native funds on payment token chain. Select different token."


### PR DESCRIPTION
## **Description**

Show an alert if the selected payment token is on a chain with insufficient native balance for the gas and relay fee of the current quotes.

Also:

- Hide tokens from the picker if their chain has no native balance.
- Always show target tokens and selected payment token in token picker modal.
- Display all blocking field alerts in the alert banner in the Perps deposit confirmation.
- Disable insufficient balance alert if pay token selected.
- Update quote alert message.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#5644](https://github.com/MetaMask/MetaMask-planning/issues/5644) [#5658](https://github.com/MetaMask/MetaMask-planning/issues/5658) [#5636](https://github.com/MetaMask/MetaMask-planning/issues/5636) #19033 [#5713](https://github.com/MetaMask/MetaMask-planning/issues/5713)

## **Manual testing steps**

## **Screenshots/Recordings**

<img width="350" alt="Native Alert" src="https://github.com/user-attachments/assets/067c8e67-8cbc-4922-a0b3-b79886eb634a" />

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
