### PR TITLE
fix: deescalate google error cp-7.54.0

### DIFF
--- a/app/components/Views/Onboarding/index.js
+++ b/app/components/Views/Onboarding/index.js
@@ -555,7 +555,10 @@ class Onboarding extends PureComponent {
       ) {
         // QA: do not show error sheet if user cancelled
         return;
-      } else if (error.code === OAuthErrorType.GoogleLoginNoCredential) {
+      } else if (
+        error.code === OAuthErrorType.GoogleLoginNoCredential ||
+        error.code === OAuthErrorType.GoogleLoginNoMatchingCredential
+      ) {
         // de-escalate google no credential error
         const errorMessage = 'google_login_no_credential';
         this.props.navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {

--- a/app/components/Views/Onboarding/index.js
+++ b/app/components/Views/Onboarding/index.js
@@ -570,10 +570,9 @@ class Onboarding extends PureComponent {
         });
         return;
       }
-        // unexpected oauth login error
-        this.handleOAuthLoginError(error);
-        return;
-
+      // unexpected oauth login error
+      this.handleOAuthLoginError(error);
+      return;
     }
 
     const errorMessage = 'oauth_error';

--- a/app/components/Views/Onboarding/index.js
+++ b/app/components/Views/Onboarding/index.js
@@ -548,15 +548,6 @@ class Onboarding extends PureComponent {
     if (error instanceof OAuthError) {
       // For OAuth API failures (excluding user cancellation/dismissal), handle based on analytics consent
       if (
-        error.code !== OAuthErrorType.UserCancelled &&
-        error.code !== OAuthErrorType.UserDismissed &&
-        error.code !== OAuthErrorType.GoogleLoginError &&
-        error.code !== OAuthErrorType.AppleLoginError
-      ) {
-        this.handleOAuthLoginError(error);
-        return;
-      }
-      if (
         error.code === OAuthErrorType.UserCancelled ||
         error.code === OAuthErrorType.UserDismissed ||
         error.code === OAuthErrorType.GoogleLoginError ||
@@ -564,7 +555,25 @@ class Onboarding extends PureComponent {
       ) {
         // QA: do not show error sheet if user cancelled
         return;
+      } else if (error.code === OAuthErrorType.GoogleLoginNoCredential) {
+        // de-escalate google no credential error
+        const errorMessage = 'google_login_no_credential';
+        this.props.navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
+          screen: Routes.SHEET.SUCCESS_ERROR_SHEET,
+          params: {
+            title: strings(`error_sheet.${errorMessage}_title`),
+            description: strings(`error_sheet.${errorMessage}_description`),
+            descriptionAlign: 'center',
+            buttonLabel: strings(`error_sheet.${errorMessage}_button`),
+            type: 'error',
+          },
+        });
+        return;
       }
+        // unexpected oauth login error
+        this.handleOAuthLoginError(error);
+        return;
+
     }
 
     const errorMessage = 'oauth_error';

--- a/app/components/Views/Onboarding/index.test.tsx
+++ b/app/components/Views/Onboarding/index.test.tsx
@@ -547,9 +547,6 @@ describe('Onboarding', () => {
     const mockCreateLoginHandler = jest.requireMock(
       '../../../core/OAuthService/OAuthLoginHandlers',
     ).createLoginHandler;
-    // const { OAuthError, OAuthErrorType } = jest.requireMock(
-    //   '../../../core/OAuthService/error',
-    // );
 
     beforeEach(() => {
       mockSeedlessOnboardingEnabled.mockReturnValue(true);

--- a/app/components/Views/Onboarding/index.test.tsx
+++ b/app/components/Views/Onboarding/index.test.tsx
@@ -22,7 +22,7 @@ import { Authentication } from '../../../core';
 import Routes from '../../../constants/navigation/Routes';
 import { ONBOARDING, PREVIOUS_SCREEN } from '../../../constants/navigation';
 import { strings } from '../../../../locales/i18n';
-import Logger from '../../../util/Logger';
+import { OAuthError, OAuthErrorType } from '../../../core/OAuthService/error';
 
 const mockInitialState = {
   engine: {
@@ -71,28 +71,6 @@ jest.mock('../../../core/OAuthService/OAuthLoginHandlers', () => ({
 jest.mock('../../../core/OAuthService/OAuthService', () => ({
   handleOAuthLogin: jest.fn(),
   resetOauthState: jest.fn(),
-}));
-
-jest.mock('../../../core/OAuthService/error', () => ({
-  OAuthError: class OAuthError extends Error {
-    code: string;
-    constructor(code: string) {
-      super();
-      this.code = code;
-    }
-  },
-  OAuthErrorType: {
-    UnknownError: 'unknown_error',
-    UserCancelled: 'user_cancelled',
-    UserDismissed: 'user_dismissed',
-    LoginError: 'login_error',
-    InvalidProvider: 'invalid_provider',
-    UnsupportedPlatform: 'unsupported_platform',
-    LoginInProgress: 'login_in_progress',
-    AuthServerError: 'auth_server_error',
-    InvalidGetAuthTokenParams: 'invalid_get_auth_token_params',
-    InvalidOauthStateError: 'invalid_oauth_state_error',
-  },
 }));
 
 jest.mock('../../../store/storage-wrapper', () => ({
@@ -569,9 +547,9 @@ describe('Onboarding', () => {
     const mockCreateLoginHandler = jest.requireMock(
       '../../../core/OAuthService/OAuthLoginHandlers',
     ).createLoginHandler;
-    const { OAuthError, OAuthErrorType } = jest.requireMock(
-      '../../../core/OAuthService/error',
-    );
+    // const { OAuthError, OAuthErrorType } = jest.requireMock(
+    //   '../../../core/OAuthService/error',
+    // );
 
     beforeEach(() => {
       mockSeedlessOnboardingEnabled.mockReturnValue(true);
@@ -682,7 +660,7 @@ describe('Onboarding', () => {
     });
 
     it('should show error sheet for OAuth user cancellation', async () => {
-      const cancelError = new OAuthError(OAuthErrorType.UserCancelled);
+      const cancelError = new OAuthError('', OAuthErrorType.UserCancelled);
       mockCreateLoginHandler.mockReturnValue('mockGoogleHandler');
       mockOAuthService.handleOAuthLogin.mockRejectedValue(cancelError);
 
@@ -729,7 +707,7 @@ describe('Onboarding', () => {
     });
 
     it('do not show error sheet for OAuth user dismissal', async () => {
-      const dismissError = new OAuthError(OAuthErrorType.UserDismissed);
+      const dismissError = new OAuthError('', OAuthErrorType.UserDismissed);
       mockCreateLoginHandler.mockReturnValue('mockAppleHandler');
       mockOAuthService.handleOAuthLogin.mockRejectedValue(dismissError);
 
@@ -864,6 +842,118 @@ describe('Onboarding', () => {
         }),
       );
     });
+
+    it('should show error sheet for OAuth when no credential is available in Android', async () => {
+      const noCredentialError = new OAuthError(
+        '',
+        OAuthErrorType.GoogleLoginNoCredential,
+      );
+      mockCreateLoginHandler.mockReturnValue('mockGoogleHandler');
+      mockOAuthService.handleOAuthLogin.mockRejectedValue(noCredentialError);
+
+      mockNavigate.mockClear();
+      const { getByTestId } = renderScreen(
+        Onboarding,
+        { name: 'Onboarding' },
+        {
+          state: mockInitialState,
+        },
+      );
+
+      const createWalletButton = getByTestId(
+        OnboardingSelectorIDs.NEW_WALLET_BUTTON,
+      );
+      await act(async () => {
+        fireEvent.press(createWalletButton);
+      });
+
+      const navCall = mockNavigate.mock.calls.find(
+        (call) =>
+          call[0] === Routes.MODAL.ROOT_MODAL_FLOW &&
+          call[1]?.screen === Routes.SHEET.ONBOARDING_SHEET,
+      );
+
+      const googleOAuthFunction = navCall[1].params.onPressContinueWithGoogle;
+
+      mockNavigate.mockClear();
+      await act(async () => {
+        await googleOAuthFunction(true);
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        Routes.MODAL.ROOT_MODAL_FLOW,
+        expect.objectContaining({
+          screen: Routes.SHEET.SUCCESS_ERROR_SHEET,
+          params: expect.objectContaining({
+            title: strings('error_sheet.google_login_no_credential_title'),
+            description: strings(
+              'error_sheet.google_login_no_credential_description',
+            ),
+            descriptionAlign: 'center',
+            buttonLabel: strings(
+              'error_sheet.google_login_no_credential_button',
+            ),
+            type: 'error',
+          }),
+        }),
+      );
+    });
+
+    it('should show error sheet for OAuth when no matching credential in Android', async () => {
+      const noCredentialError = new OAuthError(
+        '',
+        OAuthErrorType.GoogleLoginNoMatchingCredential,
+      );
+      mockCreateLoginHandler.mockReturnValue('mockGoogleHandler');
+      mockOAuthService.handleOAuthLogin.mockRejectedValue(noCredentialError);
+
+      mockNavigate.mockClear();
+      const { getByTestId } = renderScreen(
+        Onboarding,
+        { name: 'Onboarding' },
+        {
+          state: mockInitialState,
+        },
+      );
+
+      const createWalletButton = getByTestId(
+        OnboardingSelectorIDs.NEW_WALLET_BUTTON,
+      );
+      await act(async () => {
+        fireEvent.press(createWalletButton);
+      });
+
+      const navCall = mockNavigate.mock.calls.find(
+        (call) =>
+          call[0] === Routes.MODAL.ROOT_MODAL_FLOW &&
+          call[1]?.screen === Routes.SHEET.ONBOARDING_SHEET,
+      );
+
+      const googleOAuthFunction = navCall[1].params.onPressContinueWithGoogle;
+
+      mockNavigate.mockClear();
+      await act(async () => {
+        await googleOAuthFunction(true);
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        Routes.MODAL.ROOT_MODAL_FLOW,
+        expect.objectContaining({
+          screen: Routes.SHEET.SUCCESS_ERROR_SHEET,
+          params: expect.objectContaining({
+            title: strings('error_sheet.google_login_no_credential_title'),
+            description: strings(
+              'error_sheet.google_login_no_credential_description',
+            ),
+            descriptionAlign: 'center',
+            buttonLabel: strings(
+              'error_sheet.google_login_no_credential_button',
+            ),
+            type: 'error',
+          }),
+        }),
+      );
+    });
   });
 
   describe('ErrorBoundary Tests', () => {
@@ -873,9 +963,6 @@ describe('Onboarding', () => {
     const mockCreateLoginHandler = jest.requireMock(
       '../../../core/OAuthService/OAuthLoginHandlers',
     ).createLoginHandler;
-    const { OAuthError, OAuthErrorType } = jest.requireMock(
-      '../../../core/OAuthService/error',
-    );
 
     beforeEach(() => {
       mockSeedlessOnboardingEnabled.mockReturnValue(true);
@@ -888,12 +975,12 @@ describe('Onboarding', () => {
     });
 
     it('should trigger ErrorBoundary for OAuth login failures when analytics disabled', async () => {
-      const loggerErrorSpy = jest.spyOn(Logger, 'error');
       mockMetricsIsEnabled.mockReturnValueOnce(false);
-      const dismissError = new OAuthError(OAuthErrorType.AuthServerError);
+      const serverError = new OAuthError('', OAuthErrorType.AuthServerError);
       mockCreateLoginHandler.mockReturnValue('mockAppleHandler');
-      mockOAuthService.handleOAuthLogin.mockRejectedValue(dismissError);
+      mockOAuthService.handleOAuthLogin.mockRejectedValue(serverError);
 
+      mockNavigate.mockClear();
       const { getByTestId } = renderScreen(
         Onboarding,
         { name: 'Onboarding' },
@@ -921,16 +1008,6 @@ describe('Onboarding', () => {
         await appleOAuthFunction(false);
       });
 
-      // Verify that the built-in ErrorBoundary caught the error and rendered its fallback UI
-      expect(loggerErrorSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: 'OAuth login failed: ',
-        }),
-        expect.objectContaining({
-          View: 'Onboarding',
-          ErrorBoundary: true,
-        }),
-      );
       expect(mockTrackEvent).toHaveBeenLastCalledWith(
         expect.objectContaining({
           name: 'Error Screen Viewed',
@@ -940,7 +1017,7 @@ describe('Onboarding', () => {
 
     it('should not trigger ErrorBoundary for OAuth login failures when analytics enabled', async () => {
       mockMetricsIsEnabled.mockReturnValue(true);
-      const dismissError = new OAuthError(OAuthErrorType.AuthServerError);
+      const dismissError = new OAuthError('', OAuthErrorType.AuthServerError);
       mockCreateLoginHandler.mockReturnValue('mockAppleHandler');
       mockOAuthService.handleOAuthLogin.mockRejectedValue(dismissError);
 

--- a/app/core/OAuthService/OAuthLoginHandlers/androidHandlers/google.ts
+++ b/app/core/OAuthService/OAuthLoginHandlers/androidHandlers/google.ts
@@ -76,6 +76,18 @@ export class AndroidGoogleLoginHandler extends BaseLoginHandler {
             'handleGoogleLogin: User cancelled the login process',
             OAuthErrorType.UserCancelled,
           );
+        } else if (error.message.toLowerCase().includes('no credentials')) {
+          throw new OAuthError(
+            'handleGoogleLogin: Google login no credential',
+            OAuthErrorType.GoogleLoginNoCredential,
+          );
+        } else if (
+          error.message.toLowerCase().includes('matching credential')
+        ) {
+          throw new OAuthError(
+            'handleGoogleLogin: Google login no matching credential',
+            OAuthErrorType.GoogleLoginNoMatchingCredential,
+          );
         } else {
           throw new OAuthError(error, OAuthErrorType.UnknownError);
         }

--- a/app/core/OAuthService/OAuthLoginHandlers/androidHandlers/google.ts
+++ b/app/core/OAuthService/OAuthLoginHandlers/androidHandlers/google.ts
@@ -9,6 +9,12 @@ import { BaseHandlerOptions, BaseLoginHandler } from '../baseHandler';
 import { OAuthErrorType, OAuthError } from '../../error';
 import Logger from '../../../../util/Logger';
 
+const ACM_ERRORS_REGEX = {
+  CANCEL: /cancel/i,
+  NO_CREDENTIAL: /no credential/i,
+  NO_MATCHING_CREDENTIAL: /matching credential/i,
+};
+
 /**
  * AndroidGoogleLoginHandler is the login handler for the Google login on android.
  */
@@ -71,21 +77,21 @@ export class AndroidGoogleLoginHandler extends BaseLoginHandler {
       if (error instanceof OAuthError) {
         throw error;
       } else if (error instanceof Error) {
-        if (error.message.toLowerCase().includes('cancel')) {
+        if (ACM_ERRORS_REGEX.CANCEL.test(error.message)) {
           throw new OAuthError(
             'handleGoogleLogin: User cancelled the login process',
             OAuthErrorType.UserCancelled,
           );
-        } else if (error.message.toLowerCase().includes('no credential')) {
+        } else if (ACM_ERRORS_REGEX.NO_CREDENTIAL.test(error.message)) {
           throw new OAuthError(
-            'handleGoogleLogin: Google login no credential',
+            'handleGoogleLogin: Google login has no credential',
             OAuthErrorType.GoogleLoginNoCredential,
           );
         } else if (
-          error.message.toLowerCase().includes('matching credential')
+          ACM_ERRORS_REGEX.NO_MATCHING_CREDENTIAL.test(error.message)
         ) {
           throw new OAuthError(
-            'handleGoogleLogin: Google login no matching credential',
+            'handleGoogleLogin: Google login has no matching credential',
             OAuthErrorType.GoogleLoginNoMatchingCredential,
           );
         } else {

--- a/app/core/OAuthService/OAuthLoginHandlers/androidHandlers/google.ts
+++ b/app/core/OAuthService/OAuthLoginHandlers/androidHandlers/google.ts
@@ -76,7 +76,7 @@ export class AndroidGoogleLoginHandler extends BaseLoginHandler {
             'handleGoogleLogin: User cancelled the login process',
             OAuthErrorType.UserCancelled,
           );
-        } else if (error.message.toLowerCase().includes('no credentials')) {
+        } else if (error.message.toLowerCase().includes('no credential')) {
           throw new OAuthError(
             'handleGoogleLogin: Google login no credential',
             OAuthErrorType.GoogleLoginNoCredential,

--- a/app/core/OAuthService/OAuthLoginHandlers/index.test.ts
+++ b/app/core/OAuthService/OAuthLoginHandlers/index.test.ts
@@ -476,7 +476,7 @@ describe('OAuth login handlers', () => {
             OAuthErrorType.GoogleLoginNoCredential,
           );
           expect((error as OAuthError).message).toContain(
-            `Google login no credential - handleGoogleLogin: Google login no credential`,
+            `Google login no credential - handleGoogleLogin: Google login has no credential`,
           );
         }
       });
@@ -495,7 +495,7 @@ describe('OAuth login handlers', () => {
             OAuthErrorType.GoogleLoginNoMatchingCredential,
           );
           expect((error as OAuthError).message).toContain(
-            `Google login no matching credential - handleGoogleLogin: Google login no matching credential`,
+            `Google login no matching credential - handleGoogleLogin: Google login has no matching credential`,
           );
         }
       });

--- a/app/core/OAuthService/OAuthLoginHandlers/index.test.ts
+++ b/app/core/OAuthService/OAuthLoginHandlers/index.test.ts
@@ -476,7 +476,7 @@ describe('OAuth login handlers', () => {
             OAuthErrorType.GoogleLoginNoCredential,
           );
           expect((error as OAuthError).message).toContain(
-            `Google login no credential - handleGoogleLogin: Google login has no credential`,
+            `Google login has no credential - handleGoogleLogin: Google login has no credential`,
           );
         }
       });
@@ -495,7 +495,7 @@ describe('OAuth login handlers', () => {
             OAuthErrorType.GoogleLoginNoMatchingCredential,
           );
           expect((error as OAuthError).message).toContain(
-            `Google login no matching credential - handleGoogleLogin: Google login has no matching credential`,
+            `Google login has no matching credential - handleGoogleLogin: Google login has no matching credential`,
           );
         }
       });

--- a/app/core/OAuthService/OAuthLoginHandlers/index.test.ts
+++ b/app/core/OAuthService/OAuthLoginHandlers/index.test.ts
@@ -462,6 +462,44 @@ describe('OAuth login handlers', () => {
         }
       });
 
+      // no credentials
+      it('should throw GoogleLoginNoCredential when no credentials are found', async () => {
+        const message = 'e1 error Mo.m: No credential available';
+        mockSignInWithGoogle.mockRejectedValue(new Error(message));
+
+        const handler = createLoginHandler('android', AuthConnection.Google);
+        try {
+          await handler.login();
+        } catch (error) {
+          expect(error).toBeInstanceOf(OAuthError);
+          expect((error as OAuthError).code).toBe(
+            OAuthErrorType.GoogleLoginNoCredential,
+          );
+          expect((error as OAuthError).message).toContain(
+            `Google login no credential - handleGoogleLogin: Google login no credential`,
+          );
+        }
+      });
+
+      it('should throw GoogleLoginNoMatchingCredential when no matching credential is found', async () => {
+        const message =
+          'During begin signin, failure response from one tap. 16: [28433] Cannot find matching credential error';
+        mockSignInWithGoogle.mockRejectedValue(new Error(message));
+
+        const handler = createLoginHandler('android', AuthConnection.Google);
+        try {
+          await handler.login();
+        } catch (error) {
+          expect(error).toBeInstanceOf(OAuthError);
+          expect((error as OAuthError).code).toBe(
+            OAuthErrorType.GoogleLoginNoMatchingCredential,
+          );
+          expect((error as OAuthError).message).toContain(
+            `Google login no matching credential - handleGoogleLogin: Google login no matching credential`,
+          );
+        }
+      });
+
       it('should re-throw existing OAuthError instances', async () => {
         const existingError = new OAuthError(
           'Test error',

--- a/app/core/OAuthService/error.ts
+++ b/app/core/OAuthService/error.ts
@@ -11,6 +11,8 @@ export enum OAuthErrorType {
   InvalidOauthStateError = 10010,
   GoogleLoginError = 10011,
   AppleLoginError = 10012,
+  GoogleLoginNoCredential = 10013,
+  GoogleLoginNoMatchingCredential = 10014,
 }
 
 export const OAuthErrorMessages: Record<OAuthErrorType, string> = {
@@ -26,6 +28,9 @@ export const OAuthErrorMessages: Record<OAuthErrorType, string> = {
   [OAuthErrorType.InvalidOauthStateError]: 'Invalid OAuth state',
   [OAuthErrorType.GoogleLoginError]: 'Google login error',
   [OAuthErrorType.AppleLoginError]: 'Apple login error',
+  [OAuthErrorType.GoogleLoginNoCredential]: 'Google login no credential',
+  [OAuthErrorType.GoogleLoginNoMatchingCredential]:
+    'Google login no matching credential',
 } as const;
 
 export class OAuthError extends Error {

--- a/app/core/OAuthService/error.ts
+++ b/app/core/OAuthService/error.ts
@@ -28,9 +28,9 @@ export const OAuthErrorMessages: Record<OAuthErrorType, string> = {
   [OAuthErrorType.InvalidOauthStateError]: 'Invalid OAuth state',
   [OAuthErrorType.GoogleLoginError]: 'Google login error',
   [OAuthErrorType.AppleLoginError]: 'Apple login error',
-  [OAuthErrorType.GoogleLoginNoCredential]: 'Google login no credential',
+  [OAuthErrorType.GoogleLoginNoCredential]: 'Google login has no credential',
   [OAuthErrorType.GoogleLoginNoMatchingCredential]:
-    'Google login no matching credential',
+    'Google login has no matching credential',
 } as const;
 
 export class OAuthError extends Error {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5205,6 +5205,11 @@
     "user_cancelled_title": "Login cancelled",
     "user_cancelled_description": "You cancelled the login process.\nTry again when you’re ready.",
     "user_cancelled_button": "Try again",
+  
+    "google_login_no_credential_title": "Google login failed",
+    "google_login_no_credential_description": "We couldn’t find a Google account associated with this login. Try again with a different login method.",
+    "google_login_no_credential_button": "Try again",
+
     "oauth_error_title": "Login failed",
     "oauth_error_description": "An error occurred while logging in.\nTry again and if the issue continues, contact MetaMask Support.",
     "oauth_error_button": "Try again"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
De escalate google login error - no credential

Android credential manager throw no credential when there are no account sign in on device.
Or occasionally not able to find matching account during first login and able to login afterwards.
This is not blocking error but the error is then throw as sentry capture error which would cause anxiety to user.

The pr de-escalate with bottom sheet error and allow user to try to login again with same or other method

This Pr also fixed the issue #18597 as it change the regex checking method.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:
https://github.com/MetaMask/metamask-mobile/issues/18556
https://github.com/MetaMask/metamask-mobile/issues/18597

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user try login google via android when there is no account signin in android
    Given user's android device do not have any google account

    When user try to login via google
    Then user should not be prompt with sentry error. bottom sheet error should be prompted
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/185d367f-63c8-4b11-a4c9-6942a25b276f


### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/af8cb600-d89f-48f6-8be8-f3a85f71f29d


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
