### PR TITLE
fix: bigger input focus area for inputs

### DIFF
--- a/app/component-library/components/Form/TextField/TextField.constants.tsx
+++ b/app/component-library/components/Form/TextField/TextField.constants.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable import/prefer-default-export */
 // Third party dependencies.
 import React from 'react';
+import { TouchableOpacity } from 'react-native';
 
 // External dependencies.
 import { TextVariant } from '../../Texts/Text';
@@ -25,7 +26,16 @@ export const TEXTFIELD_ENDACCESSORY_TEST_ID = 'textfield-endacccessory';
 // Sample consts
 export const SAMPLE_TEXTFIELD_PROPS: TextFieldProps = {
   startAccessory: <Icon {...SAMPLE_ICON_PROPS} />,
-  endAccessory: <HelpText>SAMPLE</HelpText>,
+  endAccessory: (
+    <TouchableOpacity
+      onPress={() => {
+        // eslint-disable-next-line no-console
+        console.log('pressed');
+      }}
+    >
+      <HelpText>SAMPLE</HelpText>
+    </TouchableOpacity>
+  ),
   size: DEFAULT_TEXTFIELD_SIZE,
   isError: false,
   isDisabled: false,

--- a/app/component-library/components/Form/TextField/TextField.styles.ts
+++ b/app/component-library/components/Form/TextField/TextField.styles.ts
@@ -7,6 +7,8 @@ import { Theme } from '../../../../util/theme/models';
 // Internal dependencies
 import { TextFieldStyleSheetVars } from './TextField.types';
 
+const BORDER_WIDTH = 1;
+
 /**
  * Style sheet function for TextField component.
  *
@@ -36,7 +38,7 @@ const styleSheet = (params: {
         alignItems: 'center',
         borderRadius: 8,
         height: Number(size),
-        borderWidth: 1,
+        borderWidth: BORDER_WIDTH,
         borderColor,
         opacity: isDisabled ? 0.5 : 1,
         backgroundColor: theme.colors.background.default,
@@ -54,7 +56,8 @@ const styleSheet = (params: {
     input: {
       backgroundColor: 'inherit',
       paddingHorizontal: 16,
-      height: Number(size),
+      // subtract border width from height so it won't overflow the container
+      height: Number(size) - BORDER_WIDTH * 2,
     },
     endAccessory: {
       marginLeft: 8,

--- a/app/component-library/components/Form/TextField/TextField.styles.ts
+++ b/app/component-library/components/Form/TextField/TextField.styles.ts
@@ -39,7 +39,6 @@ const styleSheet = (params: {
         borderWidth: 1,
         borderColor,
         opacity: isDisabled ? 0.5 : 1,
-        paddingHorizontal: 16,
         backgroundColor: theme.colors.background.default,
       },
       StyleSheet.flatten(style),
@@ -54,6 +53,8 @@ const styleSheet = (params: {
     // eslint-disable-next-line react-native/no-color-literals
     input: {
       backgroundColor: 'inherit',
+      paddingHorizontal: 16,
+      height: Number(size),
     },
     endAccessory: {
       marginLeft: 8,

--- a/app/component-library/components/Form/TextField/TextField.styles.ts
+++ b/app/component-library/components/Form/TextField/TextField.styles.ts
@@ -40,6 +40,7 @@ const styleSheet = (params: {
         height: Number(size),
         borderWidth: BORDER_WIDTH,
         borderColor,
+        paddingHorizontal: 16,
         opacity: isDisabled ? 0.5 : 1,
         backgroundColor: theme.colors.background.default,
       },
@@ -55,7 +56,6 @@ const styleSheet = (params: {
     // eslint-disable-next-line react-native/no-color-literals
     input: {
       backgroundColor: 'inherit',
-      paddingHorizontal: 16,
       // subtract border width from height so it won't overflow the container
       height: Number(size) - BORDER_WIDTH * 2,
     },

--- a/app/component-library/components/Form/TextField/TextField.tsx
+++ b/app/component-library/components/Form/TextField/TextField.tsx
@@ -1,8 +1,13 @@
 /* eslint-disable react/prop-types */
 
 // Third party dependencies.
-import React, { useCallback, useState } from 'react';
-import { TextInput, View } from 'react-native';
+import React, {
+  useCallback,
+  useState,
+  useRef,
+  useImperativeHandle,
+} from 'react';
+import { Pressable, TextInput, View } from 'react-native';
 
 // External dependencies.
 import { useStyles } from '../../../hooks';
@@ -19,7 +24,7 @@ import {
   TEXTFIELD_ENDACCESSORY_TEST_ID,
 } from './TextField.constants';
 
-const TextField = React.forwardRef<TextInput, TextFieldProps>(
+const TextField = React.forwardRef<TextInput | null, TextFieldProps>(
   (
     {
       style,
@@ -38,6 +43,14 @@ const TextField = React.forwardRef<TextInput, TextFieldProps>(
     ref,
   ) => {
     const [isFocused, setIsFocused] = useState(autoFocus);
+    const inputRef = useRef<TextInput>(null);
+
+    // Expose the input methods to parent components
+    useImperativeHandle<TextInput | null, TextInput | null>(
+      ref,
+      () => inputRef.current,
+      [],
+    );
 
     const { styles } = useStyles(styleSheet, {
       style,
@@ -71,8 +84,18 @@ const TextField = React.forwardRef<TextInput, TextFieldProps>(
       [isDisabled, setIsFocused, onFocus],
     );
 
+    const onPressHandler = useCallback(() => {
+      if (!isDisabled && inputRef.current) {
+        inputRef.current.focus();
+      }
+    }, [isDisabled]);
+
     return (
-      <View style={styles.base} testID={TEXTFIELD_TEST_ID}>
+      <Pressable
+        style={styles.base}
+        testID={TEXTFIELD_TEST_ID}
+        onPress={onPressHandler}
+      >
         {startAccessory && (
           <View
             style={styles.startAccessory}
@@ -92,7 +115,7 @@ const TextField = React.forwardRef<TextInput, TextFieldProps>(
               testID={testID}
               style={styles.input}
               {...props}
-              ref={ref}
+              ref={inputRef}
               isStateStylesDisabled
             />
           )}
@@ -105,7 +128,7 @@ const TextField = React.forwardRef<TextInput, TextFieldProps>(
             {endAccessory}
           </View>
         )}
-      </View>
+      </Pressable>
     );
   },
 );

--- a/app/component-library/components/Form/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/app/component-library/components/Form/TextField/__snapshots__/TextField.test.tsx.snap
@@ -12,7 +12,6 @@ exports[`TextField should render default settings correctly 1`] = `
       "flexDirection": "row",
       "height": 40,
       "opacity": 1,
-      "paddingHorizontal": 16,
     }
   }
   testID="textfield"
@@ -33,6 +32,8 @@ exports[`TextField should render default settings correctly 1`] = `
       style={
         {
           "backgroundColor": "inherit",
+          "height": 38,
+          "paddingHorizontal": 16,
         }
       }
       textVariant="sBodyMD"

--- a/app/component-library/components/Form/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/app/component-library/components/Form/TextField/__snapshots__/TextField.test.tsx.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TextField should render default settings correctly 1`] = `
-<View
+<Component
+  onPress={[Function]}
   style={
     {
       "alignItems": "center",
@@ -12,6 +13,7 @@ exports[`TextField should render default settings correctly 1`] = `
       "flexDirection": "row",
       "height": 40,
       "opacity": 1,
+      "paddingHorizontal": 16,
     }
   }
   testID="textfield"
@@ -33,11 +35,10 @@ exports[`TextField should render default settings correctly 1`] = `
         {
           "backgroundColor": "inherit",
           "height": 38,
-          "paddingHorizontal": 16,
         }
       }
       textVariant="sBodyMD"
     />
   </View>
-</View>
+</Component>
 `;

--- a/app/components/Snaps/SnapUIAddressInput/__snapshots__/SnapUIAddressInput.test.tsx.snap
+++ b/app/components/Snaps/SnapUIAddressInput/__snapshots__/SnapUIAddressInput.test.tsx.snap
@@ -254,6 +254,35 @@ exports[`SnapUIAddressInput renders with an invalid CAIP Account ID 1`] = `
   }
 >
   <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
     style={
       {
         "alignItems": "center",
@@ -264,6 +293,7 @@ exports[`SnapUIAddressInput renders with an invalid CAIP Account ID 1`] = `
         "flexDirection": "row",
         "height": 48,
         "opacity": 1,
+        "paddingHorizontal": 16,
       }
     }
     testID="textfield"
@@ -296,7 +326,6 @@ exports[`SnapUIAddressInput renders with an invalid CAIP Account ID 1`] = `
             "height": 46,
             "letterSpacing": 0,
             "opacity": 1,
-            "paddingHorizontal": 16,
             "paddingVertical": 0,
           }
         }

--- a/app/components/Snaps/SnapUIAddressInput/__snapshots__/SnapUIAddressInput.test.tsx.snap
+++ b/app/components/Snaps/SnapUIAddressInput/__snapshots__/SnapUIAddressInput.test.tsx.snap
@@ -264,7 +264,6 @@ exports[`SnapUIAddressInput renders with an invalid CAIP Account ID 1`] = `
         "flexDirection": "row",
         "height": 48,
         "opacity": 1,
-        "paddingHorizontal": 16,
       }
     }
     testID="textfield"
@@ -294,9 +293,10 @@ exports[`SnapUIAddressInput renders with an invalid CAIP Account ID 1`] = `
             "fontFamily": "Geist Regular",
             "fontSize": 16,
             "fontWeight": "400",
-            "height": 24,
+            "height": 46,
             "letterSpacing": 0,
             "opacity": 1,
+            "paddingHorizontal": 16,
             "paddingVertical": 0,
           }
         }

--- a/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.ts.snap
@@ -232,7 +232,6 @@ exports[`SnapUIRenderer prefills interactive inputs with existing state 1`] = `
                     "height": 48,
                     "maxHeight": 58,
                     "opacity": 1,
-                    "paddingHorizontal": 16,
                   }
                 }
                 testID="textfield"
@@ -262,9 +261,10 @@ exports[`SnapUIRenderer prefills interactive inputs with existing state 1`] = `
                         "fontFamily": "Geist Regular",
                         "fontSize": 16,
                         "fontWeight": "400",
-                        "height": 24,
+                        "height": 46,
                         "letterSpacing": 0,
                         "opacity": 1,
+                        "paddingHorizontal": 16,
                         "paddingVertical": 0,
                       }
                     }
@@ -359,7 +359,6 @@ exports[`SnapUIRenderer re-renders when the interface changes 1`] = `
                     "height": 48,
                     "maxHeight": 58,
                     "opacity": 1,
-                    "paddingHorizontal": 16,
                   }
                 }
                 testID="textfield"
@@ -390,9 +389,10 @@ exports[`SnapUIRenderer re-renders when the interface changes 1`] = `
                         "fontFamily": "Geist Regular",
                         "fontSize": 16,
                         "fontWeight": "400",
-                        "height": 24,
+                        "height": 46,
                         "letterSpacing": 0,
                         "opacity": 1,
+                        "paddingHorizontal": 16,
                         "paddingVertical": 0,
                       }
                     }
@@ -423,7 +423,6 @@ exports[`SnapUIRenderer re-renders when the interface changes 1`] = `
                     "height": 48,
                     "maxHeight": 58,
                     "opacity": 1,
-                    "paddingHorizontal": 16,
                   }
                 }
                 testID="textfield"
@@ -454,9 +453,10 @@ exports[`SnapUIRenderer re-renders when the interface changes 1`] = `
                         "fontFamily": "Geist Regular",
                         "fontSize": 16,
                         "fontWeight": "400",
-                        "height": 24,
+                        "height": 46,
                         "letterSpacing": 0,
                         "opacity": 1,
+                        "paddingHorizontal": 16,
                         "paddingVertical": 0,
                       }
                     }
@@ -551,7 +551,6 @@ exports[`SnapUIRenderer re-syncs state when the interface changes 1`] = `
                     "height": 48,
                     "maxHeight": 58,
                     "opacity": 1,
-                    "paddingHorizontal": 16,
                   }
                 }
                 testID="textfield"
@@ -581,9 +580,10 @@ exports[`SnapUIRenderer re-syncs state when the interface changes 1`] = `
                         "fontFamily": "Geist Regular",
                         "fontSize": 16,
                         "fontWeight": "400",
-                        "height": 24,
+                        "height": 46,
                         "letterSpacing": 0,
                         "opacity": 1,
+                        "paddingHorizontal": 16,
                         "paddingVertical": 0,
                       }
                     }
@@ -614,7 +614,6 @@ exports[`SnapUIRenderer re-syncs state when the interface changes 1`] = `
                     "height": 48,
                     "maxHeight": 58,
                     "opacity": 1,
-                    "paddingHorizontal": 16,
                   }
                 }
                 testID="textfield"
@@ -644,9 +643,10 @@ exports[`SnapUIRenderer re-syncs state when the interface changes 1`] = `
                         "fontFamily": "Geist Regular",
                         "fontSize": 16,
                         "fontWeight": "400",
-                        "height": 24,
+                        "height": 46,
                         "letterSpacing": 0,
                         "opacity": 1,
+                        "paddingHorizontal": 16,
                         "paddingVertical": 0,
                       }
                     }
@@ -1645,7 +1645,6 @@ exports[`SnapUIRenderer supports fields with multiple components 1`] = `
                       "height": 48,
                       "maxHeight": 58,
                       "opacity": 1,
-                      "paddingHorizontal": 16,
                     }
                   }
                   testID="textfield"
@@ -1763,9 +1762,10 @@ exports[`SnapUIRenderer supports fields with multiple components 1`] = `
                           "fontFamily": "Geist Regular",
                           "fontSize": 16,
                           "fontWeight": "400",
-                          "height": 24,
+                          "height": 46,
                           "letterSpacing": 0,
                           "opacity": 1,
+                          "paddingHorizontal": 16,
                           "paddingVertical": 0,
                         }
                       }
@@ -1898,7 +1898,6 @@ exports[`SnapUIRenderer supports interactive inputs 1`] = `
                     "height": 48,
                     "maxHeight": 58,
                     "opacity": 1,
-                    "paddingHorizontal": 16,
                   }
                 }
                 testID="textfield"
@@ -1928,9 +1927,10 @@ exports[`SnapUIRenderer supports interactive inputs 1`] = `
                         "fontFamily": "Geist Regular",
                         "fontSize": 16,
                         "fontWeight": "400",
-                        "height": 24,
+                        "height": 46,
                         "letterSpacing": 0,
                         "opacity": 1,
+                        "paddingHorizontal": 16,
                         "paddingVertical": 0,
                       }
                     }

--- a/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/__snapshots__/SnapUIRenderer.test.ts.snap
@@ -220,6 +220,35 @@ exports[`SnapUIRenderer prefills interactive inputs with existing state 1`] = `
               }
             >
               <View
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
                 style={
                   {
                     "alignItems": "center",
@@ -232,6 +261,7 @@ exports[`SnapUIRenderer prefills interactive inputs with existing state 1`] = `
                     "height": 48,
                     "maxHeight": 58,
                     "opacity": 1,
+                    "paddingHorizontal": 16,
                   }
                 }
                 testID="textfield"
@@ -264,7 +294,6 @@ exports[`SnapUIRenderer prefills interactive inputs with existing state 1`] = `
                         "height": 46,
                         "letterSpacing": 0,
                         "opacity": 1,
-                        "paddingHorizontal": 16,
                         "paddingVertical": 0,
                       }
                     }
@@ -347,6 +376,35 @@ exports[`SnapUIRenderer re-renders when the interface changes 1`] = `
               }
             >
               <View
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
                 style={
                   {
                     "alignItems": "center",
@@ -359,6 +417,7 @@ exports[`SnapUIRenderer re-renders when the interface changes 1`] = `
                     "height": 48,
                     "maxHeight": 58,
                     "opacity": 1,
+                    "paddingHorizontal": 16,
                   }
                 }
                 testID="textfield"
@@ -392,7 +451,6 @@ exports[`SnapUIRenderer re-renders when the interface changes 1`] = `
                         "height": 46,
                         "letterSpacing": 0,
                         "opacity": 1,
-                        "paddingHorizontal": 16,
                         "paddingVertical": 0,
                       }
                     }
@@ -411,6 +469,35 @@ exports[`SnapUIRenderer re-renders when the interface changes 1`] = `
               }
             >
               <View
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
                 style={
                   {
                     "alignItems": "center",
@@ -423,6 +510,7 @@ exports[`SnapUIRenderer re-renders when the interface changes 1`] = `
                     "height": 48,
                     "maxHeight": 58,
                     "opacity": 1,
+                    "paddingHorizontal": 16,
                   }
                 }
                 testID="textfield"
@@ -456,7 +544,6 @@ exports[`SnapUIRenderer re-renders when the interface changes 1`] = `
                         "height": 46,
                         "letterSpacing": 0,
                         "opacity": 1,
-                        "paddingHorizontal": 16,
                         "paddingVertical": 0,
                       }
                     }
@@ -539,6 +626,35 @@ exports[`SnapUIRenderer re-syncs state when the interface changes 1`] = `
               }
             >
               <View
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
                 style={
                   {
                     "alignItems": "center",
@@ -551,6 +667,7 @@ exports[`SnapUIRenderer re-syncs state when the interface changes 1`] = `
                     "height": 48,
                     "maxHeight": 58,
                     "opacity": 1,
+                    "paddingHorizontal": 16,
                   }
                 }
                 testID="textfield"
@@ -583,7 +700,6 @@ exports[`SnapUIRenderer re-syncs state when the interface changes 1`] = `
                         "height": 46,
                         "letterSpacing": 0,
                         "opacity": 1,
-                        "paddingHorizontal": 16,
                         "paddingVertical": 0,
                       }
                     }
@@ -602,6 +718,35 @@ exports[`SnapUIRenderer re-syncs state when the interface changes 1`] = `
               }
             >
               <View
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
                 style={
                   {
                     "alignItems": "center",
@@ -614,6 +759,7 @@ exports[`SnapUIRenderer re-syncs state when the interface changes 1`] = `
                     "height": 48,
                     "maxHeight": 58,
                     "opacity": 1,
+                    "paddingHorizontal": 16,
                   }
                 }
                 testID="textfield"
@@ -646,7 +792,6 @@ exports[`SnapUIRenderer re-syncs state when the interface changes 1`] = `
                         "height": 46,
                         "letterSpacing": 0,
                         "opacity": 1,
-                        "paddingHorizontal": 16,
                         "paddingVertical": 0,
                       }
                     }
@@ -1633,6 +1778,35 @@ exports[`SnapUIRenderer supports fields with multiple components 1`] = `
                   My Input
                 </Text>
                 <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
                   style={
                     {
                       "alignItems": "center",
@@ -1645,6 +1819,7 @@ exports[`SnapUIRenderer supports fields with multiple components 1`] = `
                       "height": 48,
                       "maxHeight": 58,
                       "opacity": 1,
+                      "paddingHorizontal": 16,
                     }
                   }
                   testID="textfield"
@@ -1765,7 +1940,6 @@ exports[`SnapUIRenderer supports fields with multiple components 1`] = `
                           "height": 46,
                           "letterSpacing": 0,
                           "opacity": 1,
-                          "paddingHorizontal": 16,
                           "paddingVertical": 0,
                         }
                       }
@@ -1886,6 +2060,35 @@ exports[`SnapUIRenderer supports interactive inputs 1`] = `
               }
             >
               <View
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
                 style={
                   {
                     "alignItems": "center",
@@ -1898,6 +2101,7 @@ exports[`SnapUIRenderer supports interactive inputs 1`] = `
                     "height": 48,
                     "maxHeight": 58,
                     "opacity": 1,
+                    "paddingHorizontal": 16,
                   }
                 }
                 testID="textfield"
@@ -1930,7 +2134,6 @@ exports[`SnapUIRenderer supports interactive inputs 1`] = `
                         "height": 46,
                         "letterSpacing": 0,
                         "opacity": 1,
-                        "paddingHorizontal": 16,
                         "paddingVertical": 0,
                       }
                     }

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
@@ -74,6 +74,35 @@ exports[`SnapUIForm will render 1`] = `
                 }
               >
                 <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
                   style={
                     {
                       "alignItems": "center",
@@ -86,6 +115,7 @@ exports[`SnapUIForm will render 1`] = `
                       "height": 48,
                       "maxHeight": 58,
                       "opacity": 1,
+                      "paddingHorizontal": 16,
                     }
                   }
                   testID="textfield"
@@ -118,7 +148,6 @@ exports[`SnapUIForm will render 1`] = `
                           "height": 46,
                           "letterSpacing": 0,
                           "opacity": 1,
-                          "paddingHorizontal": 16,
                           "paddingVertical": 0,
                         }
                       }
@@ -262,6 +291,35 @@ exports[`SnapUIForm will render with fields 1`] = `
                   My Input
                 </Text>
                 <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
                   style={
                     {
                       "alignItems": "center",
@@ -274,6 +332,7 @@ exports[`SnapUIForm will render with fields 1`] = `
                       "height": 48,
                       "maxHeight": 58,
                       "opacity": 1,
+                      "paddingHorizontal": 16,
                     }
                   }
                   testID="textfield"
@@ -306,7 +365,6 @@ exports[`SnapUIForm will render with fields 1`] = `
                           "height": 46,
                           "letterSpacing": 0,
                           "opacity": 1,
-                          "paddingHorizontal": 16,
                           "paddingVertical": 0,
                         }
                       }

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
@@ -86,7 +86,6 @@ exports[`SnapUIForm will render 1`] = `
                       "height": 48,
                       "maxHeight": 58,
                       "opacity": 1,
-                      "paddingHorizontal": 16,
                     }
                   }
                   testID="textfield"
@@ -116,9 +115,10 @@ exports[`SnapUIForm will render 1`] = `
                           "fontFamily": "Geist Regular",
                           "fontSize": 16,
                           "fontWeight": "400",
-                          "height": 24,
+                          "height": 46,
                           "letterSpacing": 0,
                           "opacity": 1,
+                          "paddingHorizontal": 16,
                           "paddingVertical": 0,
                         }
                       }
@@ -274,7 +274,6 @@ exports[`SnapUIForm will render with fields 1`] = `
                       "height": 48,
                       "maxHeight": 58,
                       "opacity": 1,
-                      "paddingHorizontal": 16,
                     }
                   }
                   testID="textfield"
@@ -304,9 +303,10 @@ exports[`SnapUIForm will render with fields 1`] = `
                           "fontFamily": "Geist Regular",
                           "fontSize": 16,
                           "fontWeight": "400",
-                          "height": 24,
+                          "height": 46,
                           "letterSpacing": 0,
                           "opacity": 1,
+                          "paddingHorizontal": 16,
                           "paddingVertical": 0,
                         }
                       }

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/input.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/input.test.ts.snap
@@ -73,7 +73,6 @@ exports[`SnapUIInput handles disabled input 1`] = `
                     "height": 48,
                     "maxHeight": 58,
                     "opacity": 0.5,
-                    "paddingHorizontal": 16,
                   }
                 }
                 testID="textfield"
@@ -103,9 +102,10 @@ exports[`SnapUIInput handles disabled input 1`] = `
                         "fontFamily": "Geist Regular",
                         "fontSize": 16,
                         "fontWeight": "400",
-                        "height": 24,
+                        "height": 46,
                         "letterSpacing": 0,
                         "opacity": 1,
+                        "paddingHorizontal": 16,
                         "paddingVertical": 0,
                       }
                     }
@@ -200,7 +200,6 @@ exports[`SnapUIInput renders with initial value 1`] = `
                     "height": 48,
                     "maxHeight": 58,
                     "opacity": 1,
-                    "paddingHorizontal": 16,
                   }
                 }
                 testID="textfield"
@@ -230,9 +229,10 @@ exports[`SnapUIInput renders with initial value 1`] = `
                         "fontFamily": "Geist Regular",
                         "fontSize": 16,
                         "fontWeight": "400",
-                        "height": 24,
+                        "height": 46,
                         "letterSpacing": 0,
                         "opacity": 1,
+                        "paddingHorizontal": 16,
                         "paddingVertical": 0,
                       }
                     }

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/input.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/input.test.ts.snap
@@ -61,6 +61,35 @@ exports[`SnapUIInput handles disabled input 1`] = `
               }
             >
               <View
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
                 style={
                   {
                     "alignItems": "center",
@@ -73,6 +102,7 @@ exports[`SnapUIInput handles disabled input 1`] = `
                     "height": 48,
                     "maxHeight": 58,
                     "opacity": 0.5,
+                    "paddingHorizontal": 16,
                   }
                 }
                 testID="textfield"
@@ -105,7 +135,6 @@ exports[`SnapUIInput handles disabled input 1`] = `
                         "height": 46,
                         "letterSpacing": 0,
                         "opacity": 1,
-                        "paddingHorizontal": 16,
                         "paddingVertical": 0,
                       }
                     }
@@ -188,6 +217,35 @@ exports[`SnapUIInput renders with initial value 1`] = `
               }
             >
               <View
+                accessibilityState={
+                  {
+                    "busy": undefined,
+                    "checked": undefined,
+                    "disabled": undefined,
+                    "expanded": undefined,
+                    "selected": undefined,
+                  }
+                }
+                accessibilityValue={
+                  {
+                    "max": undefined,
+                    "min": undefined,
+                    "now": undefined,
+                    "text": undefined,
+                  }
+                }
+                accessible={true}
+                collapsable={false}
+                focusable={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
                 style={
                   {
                     "alignItems": "center",
@@ -200,6 +258,7 @@ exports[`SnapUIInput renders with initial value 1`] = `
                     "height": 48,
                     "maxHeight": 58,
                     "opacity": 1,
+                    "paddingHorizontal": 16,
                   }
                 }
                 testID="textfield"
@@ -232,7 +291,6 @@ exports[`SnapUIInput renders with initial value 1`] = `
                         "height": 46,
                         "letterSpacing": 0,
                         "opacity": 1,
-                        "paddingHorizontal": 16,
                         "paddingVertical": 0,
                       }
                     }

--- a/app/components/UI/Bridge/components/BridgeDestTokenSelector/__snapshots__/BridgeDestTokenSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeDestTokenSelector/__snapshots__/BridgeDestTokenSelector.test.tsx.snap
@@ -684,7 +684,6 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                                   "flexDirection": "row",
                                   "height": 40,
                                   "opacity": 1,
-                                  "paddingHorizontal": 16,
                                 }
                               }
                               testID="textfield"
@@ -734,9 +733,10 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                                       "fontFamily": "Geist Regular",
                                       "fontSize": 16,
                                       "fontWeight": "400",
-                                      "height": 24,
+                                      "height": 38,
                                       "letterSpacing": 0,
                                       "opacity": 1,
+                                      "paddingHorizontal": 16,
                                       "paddingVertical": 0,
                                     }
                                   }

--- a/app/components/UI/Bridge/components/BridgeDestTokenSelector/__snapshots__/BridgeDestTokenSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeDestTokenSelector/__snapshots__/BridgeDestTokenSelector.test.tsx.snap
@@ -674,6 +674,35 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                               </View>
                             </RCTScrollView>
                             <View
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
                               style={
                                 {
                                   "alignItems": "center",
@@ -684,6 +713,7 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                                   "flexDirection": "row",
                                   "height": 40,
                                   "opacity": 1,
+                                  "paddingHorizontal": 16,
                                 }
                               }
                               testID="textfield"
@@ -736,7 +766,6 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                                       "height": 38,
                                       "letterSpacing": 0,
                                       "opacity": 1,
-                                      "paddingHorizontal": 16,
                                       "paddingVertical": 0,
                                     }
                                   }

--- a/app/components/UI/Bridge/components/BridgeSourceTokenSelector/__snapshots__/BridgeSourceTokenSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeSourceTokenSelector/__snapshots__/BridgeSourceTokenSelector.test.tsx.snap
@@ -711,6 +711,35 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                               />
                             </TouchableOpacity>
                             <View
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
                               style={
                                 {
                                   "alignItems": "center",
@@ -721,6 +750,7 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                   "flexDirection": "row",
                                   "height": 40,
                                   "opacity": 1,
+                                  "paddingHorizontal": 16,
                                 }
                               }
                               testID="textfield"
@@ -773,7 +803,6 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                       "height": 38,
                                       "letterSpacing": 0,
                                       "opacity": 1,
-                                      "paddingHorizontal": 16,
                                       "paddingVertical": 0,
                                     }
                                   }

--- a/app/components/UI/Bridge/components/BridgeSourceTokenSelector/__snapshots__/BridgeSourceTokenSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeSourceTokenSelector/__snapshots__/BridgeSourceTokenSelector.test.tsx.snap
@@ -721,7 +721,6 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                   "flexDirection": "row",
                                   "height": 40,
                                   "opacity": 1,
-                                  "paddingHorizontal": 16,
                                 }
                               }
                               testID="textfield"
@@ -771,9 +770,10 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                       "fontFamily": "Geist Regular",
                                       "fontSize": 16,
                                       "fontWeight": "400",
-                                      "height": 24,
+                                      "height": 38,
                                       "letterSpacing": 0,
                                       "opacity": 1,
+                                      "paddingHorizontal": 16,
                                       "paddingVertical": 0,
                                     }
                                   }

--- a/app/components/UI/Ramp/Aggregator/Views/Settings/__snapshots__/ActivationKeyForm.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/Settings/__snapshots__/ActivationKeyForm.test.tsx.snap
@@ -504,6 +504,35 @@ exports[`AddActivationKey renders correctly 1`] = `
                                 Label
                               </Text>
                               <View
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": undefined,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
                                 style={
                                   {
                                     "alignItems": "center",
@@ -514,6 +543,7 @@ exports[`AddActivationKey renders correctly 1`] = `
                                     "flexDirection": "row",
                                     "height": 40,
                                     "opacity": 1,
+                                    "paddingHorizontal": 16,
                                   }
                                 }
                                 testID="textfield"
@@ -548,7 +578,6 @@ exports[`AddActivationKey renders correctly 1`] = `
                                         "height": 38,
                                         "letterSpacing": 0,
                                         "opacity": 1,
-                                        "paddingHorizontal": 16,
                                         "paddingVertical": 0,
                                       }
                                     }
@@ -585,6 +614,35 @@ exports[`AddActivationKey renders correctly 1`] = `
                                 Key
                               </Text>
                               <View
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": undefined,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
                                 style={
                                   {
                                     "alignItems": "center",
@@ -595,6 +653,7 @@ exports[`AddActivationKey renders correctly 1`] = `
                                     "flexDirection": "row",
                                     "height": 40,
                                     "opacity": 1,
+                                    "paddingHorizontal": 16,
                                   }
                                 }
                                 testID="textfield"
@@ -631,7 +690,6 @@ exports[`AddActivationKey renders correctly 1`] = `
                                         "height": 38,
                                         "letterSpacing": 0,
                                         "opacity": 1,
-                                        "paddingHorizontal": 16,
                                         "paddingVertical": 0,
                                       }
                                     }

--- a/app/components/UI/Ramp/Aggregator/Views/Settings/__snapshots__/ActivationKeyForm.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/Settings/__snapshots__/ActivationKeyForm.test.tsx.snap
@@ -514,7 +514,6 @@ exports[`AddActivationKey renders correctly 1`] = `
                                     "flexDirection": "row",
                                     "height": 40,
                                     "opacity": 1,
-                                    "paddingHorizontal": 16,
                                   }
                                 }
                                 testID="textfield"
@@ -546,9 +545,10 @@ exports[`AddActivationKey renders correctly 1`] = `
                                         "fontFamily": "Geist Regular",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "height": 24,
+                                        "height": 38,
                                         "letterSpacing": 0,
                                         "opacity": 1,
+                                        "paddingHorizontal": 16,
                                         "paddingVertical": 0,
                                       }
                                     }
@@ -595,7 +595,6 @@ exports[`AddActivationKey renders correctly 1`] = `
                                     "flexDirection": "row",
                                     "height": 40,
                                     "opacity": 1,
-                                    "paddingHorizontal": 16,
                                   }
                                 }
                                 testID="textfield"
@@ -629,9 +628,10 @@ exports[`AddActivationKey renders correctly 1`] = `
                                         "fontFamily": "Geist Regular",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "height": 24,
+                                        "height": 38,
                                         "letterSpacing": 0,
                                         "opacity": 1,
+                                        "paddingHorizontal": 16,
                                         "paddingVertical": 0,
                                       }
                                     }

--- a/app/components/UI/Ramp/Deposit/Views/BasicInfo/__snapshots__/BasicInfo.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/BasicInfo/__snapshots__/BasicInfo.test.tsx.snap
@@ -748,6 +748,35 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                       First name
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -758,6 +787,7 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -794,7 +824,6 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -835,6 +864,35 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                       Last name
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -845,6 +903,7 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -881,7 +940,6 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -921,6 +979,35 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                     Phone number
                                   </Text>
                                   <View
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
                                     style={
                                       {
                                         "alignItems": "center",
@@ -931,6 +1018,7 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
+                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -1016,7 +1104,6 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                             "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
-                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -1080,6 +1167,35 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                       Date of birth
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -1090,6 +1206,7 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -1145,7 +1262,6 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -1218,6 +1334,35 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                     </View>
                                   </View>
                                   <View
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
                                     style={
                                       {
                                         "alignItems": "center",
@@ -1228,6 +1373,7 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
+                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -1266,7 +1412,6 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                             "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
-                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -2199,6 +2344,35 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                       First name
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -2209,6 +2383,7 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -2245,7 +2420,6 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -2286,6 +2460,35 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                       Last name
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -2296,6 +2499,7 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -2332,7 +2536,6 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -2372,6 +2575,35 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                     Phone number
                                   </Text>
                                   <View
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
                                     style={
                                       {
                                         "alignItems": "center",
@@ -2382,6 +2614,7 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
+                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -2467,7 +2700,6 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                             "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
-                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -2531,6 +2763,35 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                       Date of birth
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -2541,6 +2802,7 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -2596,7 +2858,6 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -2669,6 +2930,35 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                     </View>
                                   </View>
                                   <View
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
                                     style={
                                       {
                                         "alignItems": "center",
@@ -2679,6 +2969,7 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
+                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -2717,7 +3008,6 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                             "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
-                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -3650,6 +3940,35 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                       First name
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -3660,6 +3979,7 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -3696,7 +4016,6 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -3737,6 +4056,35 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                       Last name
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -3747,6 +4095,7 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -3783,7 +4132,6 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -3823,6 +4171,35 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                     Phone number
                                   </Text>
                                   <View
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
                                     style={
                                       {
                                         "alignItems": "center",
@@ -3833,6 +4210,7 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
+                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -3918,7 +4296,6 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                             "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
-                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -3982,6 +4359,35 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                       Date of birth
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -3992,6 +4398,7 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -4047,7 +4454,6 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -4120,6 +4526,35 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                     </View>
                                   </View>
                                   <View
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
                                     style={
                                       {
                                         "alignItems": "center",
@@ -4130,6 +4565,7 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
+                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -4168,7 +4604,6 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                             "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
-                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -5101,6 +5536,35 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                       First name
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -5111,6 +5575,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -5147,7 +5612,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -5203,6 +5667,35 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                       Last name
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -5213,6 +5706,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -5249,7 +5743,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -5304,6 +5797,35 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                     Phone number
                                   </Text>
                                   <View
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
                                     style={
                                       {
                                         "alignItems": "center",
@@ -5314,6 +5836,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
+                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -5399,7 +5922,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                             "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
-                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -5478,6 +6000,35 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                       Date of birth
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -5488,6 +6039,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -5543,7 +6095,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -5616,6 +6167,35 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                     </View>
                                   </View>
                                   <View
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
                                     style={
                                       {
                                         "alignItems": "center",
@@ -5626,6 +6206,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
+                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -5664,7 +6245,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                             "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
-                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -6612,6 +7192,35 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                       First name
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -6622,6 +7231,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -6658,7 +7268,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -6714,6 +7323,35 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                       Last name
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -6724,6 +7362,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -6760,7 +7399,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -6815,6 +7453,35 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                     Phone number
                                   </Text>
                                   <View
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
                                     style={
                                       {
                                         "alignItems": "center",
@@ -6825,6 +7492,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
+                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -6910,7 +7578,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                             "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
-                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -6974,6 +7641,35 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                       Date of birth
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -6984,6 +7680,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -7039,7 +7736,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -7112,6 +7808,35 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                     </View>
                                   </View>
                                   <View
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
                                     style={
                                       {
                                         "alignItems": "center",
@@ -7122,6 +7847,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
+                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -7160,7 +7886,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                             "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
-                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -8108,6 +8833,35 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                       First name
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -8118,6 +8872,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -8154,7 +8909,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -8210,6 +8964,35 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                       Last name
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -8220,6 +9003,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -8256,7 +9040,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -8311,6 +9094,35 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                     Phone number
                                   </Text>
                                   <View
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
                                     style={
                                       {
                                         "alignItems": "center",
@@ -8321,6 +9133,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
+                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -8406,7 +9219,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                             "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
-                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -8485,6 +9297,35 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                       Date of birth
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -8495,6 +9336,7 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -8550,7 +9392,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }

--- a/app/components/UI/Ramp/Deposit/Views/BasicInfo/__snapshots__/BasicInfo.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/BasicInfo/__snapshots__/BasicInfo.test.tsx.snap
@@ -758,7 +758,6 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -792,9 +791,10 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -845,7 +845,6 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -879,9 +878,10 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -931,7 +931,6 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
-                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -1014,9 +1013,10 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                             "fontFamily": "Geist Regular",
                                             "fontSize": 16,
                                             "fontWeight": "400",
-                                            "height": 24,
+                                            "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
+                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -1090,7 +1090,6 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -1143,9 +1142,10 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -1228,7 +1228,6 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
-                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -1264,9 +1263,10 @@ exports[`BasicInfo Component navigates to address page when form is valid and co
                                             "fontFamily": "Geist Regular",
                                             "fontSize": 16,
                                             "fontWeight": "400",
-                                            "height": 24,
+                                            "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
+                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -2209,7 +2209,6 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -2243,9 +2242,10 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -2296,7 +2296,6 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -2330,9 +2329,10 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -2382,7 +2382,6 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
-                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -2465,9 +2464,10 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                             "fontFamily": "Geist Regular",
                                             "fontSize": 16,
                                             "fontWeight": "400",
-                                            "height": 24,
+                                            "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
+                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -2541,7 +2541,6 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -2594,9 +2593,10 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -2679,7 +2679,6 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
-                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -2715,9 +2714,10 @@ exports[`BasicInfo Component prefills form data when previousFormData is provide
                                             "fontFamily": "Geist Regular",
                                             "fontSize": 16,
                                             "fontWeight": "400",
-                                            "height": 24,
+                                            "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
+                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -3660,7 +3660,6 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -3694,9 +3693,10 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -3747,7 +3747,6 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -3781,9 +3780,10 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -3833,7 +3833,6 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
-                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -3916,9 +3915,10 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                             "fontFamily": "Geist Regular",
                                             "fontSize": 16,
                                             "fontWeight": "400",
-                                            "height": 24,
+                                            "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
+                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -3992,7 +3992,6 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -4045,9 +4044,10 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -4130,7 +4130,6 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
-                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -4166,9 +4165,10 @@ exports[`BasicInfo Component render matches snapshot 1`] = `
                                             "fontFamily": "Geist Regular",
                                             "fontSize": 16,
                                             "fontWeight": "400",
-                                            "height": 24,
+                                            "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
+                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -5111,7 +5111,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -5145,9 +5144,10 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -5213,7 +5213,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -5247,9 +5246,10 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -5314,7 +5314,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
-                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -5397,9 +5396,10 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                             "fontFamily": "Geist Regular",
                                             "fontSize": 16,
                                             "fontWeight": "400",
-                                            "height": 24,
+                                            "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
+                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -5488,7 +5488,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -5541,9 +5540,10 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -5626,7 +5626,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
-                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -5662,9 +5661,10 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                             "fontFamily": "Geist Regular",
                                             "fontSize": 16,
                                             "fontWeight": "400",
-                                            "height": 24,
+                                            "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
+                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -6622,7 +6622,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -6656,9 +6655,10 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -6724,7 +6724,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -6758,9 +6757,10 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -6825,7 +6825,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
-                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -6908,9 +6907,10 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                             "fontFamily": "Geist Regular",
                                             "fontSize": 16,
                                             "fontWeight": "400",
-                                            "height": 24,
+                                            "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
+                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -6984,7 +6984,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -7037,9 +7036,10 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -7122,7 +7122,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
-                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -7158,9 +7157,10 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                             "fontFamily": "Geist Regular",
                                             "fontSize": 16,
                                             "fontWeight": "400",
-                                            "height": 24,
+                                            "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
+                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -8118,7 +8118,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -8152,9 +8151,10 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -8220,7 +8220,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -8254,9 +8253,10 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -8321,7 +8321,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
-                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -8404,9 +8403,10 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                             "fontFamily": "Geist Regular",
                                             "fontSize": 16,
                                             "fontWeight": "400",
-                                            "height": 24,
+                                            "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
+                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -8495,7 +8495,6 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -8548,9 +8547,10 @@ exports[`BasicInfo Component snapshot matches validation errors when continue is
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }

--- a/app/components/UI/Ramp/Deposit/Views/EnterAddress/__snapshots__/EnterAddress.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/EnterAddress/__snapshots__/EnterAddress.test.tsx.snap
@@ -746,6 +746,35 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                     Address line 1
                                   </Text>
                                   <View
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
                                     style={
                                       {
                                         "alignItems": "center",
@@ -756,6 +785,7 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
+                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -792,7 +822,6 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                             "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
-                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -846,6 +875,35 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                     Address line 2 (optional)
                                   </Text>
                                   <View
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
                                     style={
                                       {
                                         "alignItems": "center",
@@ -856,6 +914,7 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
+                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -892,7 +951,6 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                             "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
-                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -942,6 +1000,35 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                       City
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -952,6 +1039,7 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -987,7 +1075,6 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -1164,6 +1251,35 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                       Postal/Zip Code
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -1174,6 +1290,7 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -1210,7 +1327,6 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -1266,6 +1382,35 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                       Country
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -1276,6 +1421,7 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 0.5,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -1331,7 +1477,6 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -2262,6 +2407,35 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                     Address line 1
                                   </Text>
                                   <View
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
                                     style={
                                       {
                                         "alignItems": "center",
@@ -2272,6 +2446,7 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
+                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -2308,7 +2483,6 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                             "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
-                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -2347,6 +2521,35 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                     Address line 2 (optional)
                                   </Text>
                                   <View
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
                                     style={
                                       {
                                         "alignItems": "center",
@@ -2357,6 +2560,7 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
+                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -2393,7 +2597,6 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                             "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
-                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -2443,6 +2646,35 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                       City
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -2453,6 +2685,7 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -2488,7 +2721,6 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -2627,6 +2859,35 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                       Postal/Zip Code
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -2637,6 +2898,7 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -2673,7 +2935,6 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -2714,6 +2975,35 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                       Country
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -2724,6 +3014,7 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 0.5,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -2779,7 +3070,6 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -3710,6 +4000,35 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                     Address line 1
                                   </Text>
                                   <View
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
                                     style={
                                       {
                                         "alignItems": "center",
@@ -3720,6 +4039,7 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
+                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -3756,7 +4076,6 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                             "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
-                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -3795,6 +4114,35 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                     Address line 2 (optional)
                                   </Text>
                                   <View
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
                                     style={
                                       {
                                         "alignItems": "center",
@@ -3805,6 +4153,7 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
+                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -3841,7 +4190,6 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                             "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
-                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -3891,6 +4239,35 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                       City
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -3901,6 +4278,7 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -3936,7 +4314,6 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -4083,6 +4460,35 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                       Postal/Zip Code
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -4093,6 +4499,7 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -4129,7 +4536,6 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -4170,6 +4576,35 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                       Country
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -4180,6 +4615,7 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 0.5,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -4235,7 +4671,6 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -5166,6 +5601,35 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                     Address line 1
                                   </Text>
                                   <View
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
                                     style={
                                       {
                                         "alignItems": "center",
@@ -5176,6 +5640,7 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
+                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -5212,7 +5677,6 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                             "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
-                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -5251,6 +5715,35 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                     Address line 2 (optional)
                                   </Text>
                                   <View
+                                    accessibilityState={
+                                      {
+                                        "busy": undefined,
+                                        "checked": undefined,
+                                        "disabled": undefined,
+                                        "expanded": undefined,
+                                        "selected": undefined,
+                                      }
+                                    }
+                                    accessibilityValue={
+                                      {
+                                        "max": undefined,
+                                        "min": undefined,
+                                        "now": undefined,
+                                        "text": undefined,
+                                      }
+                                    }
+                                    accessible={true}
+                                    collapsable={false}
+                                    focusable={true}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
                                     style={
                                       {
                                         "alignItems": "center",
@@ -5261,6 +5754,7 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
+                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -5297,7 +5791,6 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                             "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
-                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -5347,6 +5840,35 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                       City
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -5357,6 +5879,7 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -5392,7 +5915,6 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -5433,6 +5955,35 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                       State/Region
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -5443,6 +5994,7 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -5478,7 +6030,6 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -5529,6 +6080,35 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                       Postal/Zip Code
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -5539,6 +6119,7 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -5575,7 +6156,6 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -5616,6 +6196,35 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                       Country
                                     </Text>
                                     <View
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": undefined,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
                                       style={
                                         {
                                           "alignItems": "center",
@@ -5626,6 +6235,7 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 0.5,
+                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -5681,7 +6291,6 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                               "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
-                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }

--- a/app/components/UI/Ramp/Deposit/Views/EnterAddress/__snapshots__/EnterAddress.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/EnterAddress/__snapshots__/EnterAddress.test.tsx.snap
@@ -756,7 +756,6 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
-                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -790,9 +789,10 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                             "fontFamily": "Geist Regular",
                                             "fontSize": 16,
                                             "fontWeight": "400",
-                                            "height": 24,
+                                            "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
+                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -856,7 +856,6 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
-                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -890,9 +889,10 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                             "fontFamily": "Geist Regular",
                                             "fontSize": 16,
                                             "fontWeight": "400",
-                                            "height": 24,
+                                            "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
+                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -952,7 +952,6 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -985,9 +984,10 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -1174,7 +1174,6 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -1208,9 +1207,10 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -1276,7 +1276,6 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 0.5,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -1329,9 +1328,10 @@ exports[`EnterAddress Component displays form validation errors when continue is
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -2272,7 +2272,6 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
-                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -2306,9 +2305,10 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                             "fontFamily": "Geist Regular",
                                             "fontSize": 16,
                                             "fontWeight": "400",
-                                            "height": 24,
+                                            "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
+                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -2357,7 +2357,6 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
-                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -2391,9 +2390,10 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                             "fontFamily": "Geist Regular",
                                             "fontSize": 16,
                                             "fontWeight": "400",
-                                            "height": 24,
+                                            "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
+                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -2453,7 +2453,6 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -2486,9 +2485,10 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -2637,7 +2637,6 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -2671,9 +2670,10 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -2724,7 +2724,6 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 0.5,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -2777,9 +2776,10 @@ exports[`EnterAddress Component prefills form data when previousFormData is prov
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -3720,7 +3720,6 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
-                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -3754,9 +3753,10 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                             "fontFamily": "Geist Regular",
                                             "fontSize": 16,
                                             "fontWeight": "400",
-                                            "height": 24,
+                                            "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
+                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -3805,7 +3805,6 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
-                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -3839,9 +3838,10 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                             "fontFamily": "Geist Regular",
                                             "fontSize": 16,
                                             "fontWeight": "400",
-                                            "height": 24,
+                                            "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
+                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -3901,7 +3901,6 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -3934,9 +3933,10 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -4093,7 +4093,6 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -4127,9 +4126,10 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -4180,7 +4180,6 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 0.5,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -4233,9 +4232,10 @@ exports[`EnterAddress Component render matches snapshot 1`] = `
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -5176,7 +5176,6 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
-                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -5210,9 +5209,10 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                             "fontFamily": "Geist Regular",
                                             "fontSize": 16,
                                             "fontWeight": "400",
-                                            "height": 24,
+                                            "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
+                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -5261,7 +5261,6 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                         "flexDirection": "row",
                                         "height": 48,
                                         "opacity": 1,
-                                        "paddingHorizontal": 16,
                                       }
                                     }
                                     testID="textfield"
@@ -5295,9 +5294,10 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                             "fontFamily": "Geist Regular",
                                             "fontSize": 16,
                                             "fontWeight": "400",
-                                            "height": 24,
+                                            "height": 46,
                                             "letterSpacing": 0,
                                             "opacity": 1,
+                                            "paddingHorizontal": 16,
                                             "paddingVertical": 0,
                                           }
                                         }
@@ -5357,7 +5357,6 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -5390,9 +5389,10 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -5443,7 +5443,6 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -5476,9 +5475,10 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -5539,7 +5539,6 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 1,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -5573,9 +5572,10 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }
@@ -5626,7 +5626,6 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                           "flexDirection": "row",
                                           "height": 48,
                                           "opacity": 0.5,
-                                          "paddingHorizontal": 16,
                                         }
                                       }
                                       testID="textfield"
@@ -5679,9 +5678,10 @@ exports[`EnterAddress Component shows text input for state when region is not US
                                               "fontFamily": "Geist Regular",
                                               "fontSize": 16,
                                               "fontWeight": "400",
-                                              "height": 24,
+                                              "height": 46,
                                               "letterSpacing": 0,
                                               "opacity": 1,
+                                              "paddingHorizontal": 16,
                                               "paddingVertical": 0,
                                             }
                                           }

--- a/app/components/UI/Ramp/Deposit/Views/EnterEmail/__snapshots__/EnterEmail.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/EnterEmail/__snapshots__/EnterEmail.test.tsx.snap
@@ -697,7 +697,6 @@ exports[`EnterEmail Component render matches snapshot 1`] = `
                                     "flexDirection": "row",
                                     "height": 48,
                                     "opacity": 1,
-                                    "paddingHorizontal": 16,
                                   }
                                 }
                                 testID="textfield"
@@ -732,9 +731,10 @@ exports[`EnterEmail Component render matches snapshot 1`] = `
                                         "fontFamily": "Geist Regular",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "height": 24,
+                                        "height": 46,
                                         "letterSpacing": 0,
                                         "opacity": 1,
+                                        "paddingHorizontal": 16,
                                         "paddingVertical": 0,
                                       }
                                     }
@@ -1520,7 +1520,6 @@ exports[`EnterEmail Component renders error message snapshot when API call fails
                                     "flexDirection": "row",
                                     "height": 48,
                                     "opacity": 1,
-                                    "paddingHorizontal": 16,
                                   }
                                 }
                                 testID="textfield"
@@ -1555,9 +1554,10 @@ exports[`EnterEmail Component renders error message snapshot when API call fails
                                         "fontFamily": "Geist Regular",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "height": 24,
+                                        "height": 46,
                                         "letterSpacing": 0,
                                         "opacity": 1,
+                                        "paddingHorizontal": 16,
                                         "paddingVertical": 0,
                                       }
                                     }
@@ -2357,7 +2357,6 @@ exports[`EnterEmail Component renders loading state snapshot 1`] = `
                                     "flexDirection": "row",
                                     "height": 48,
                                     "opacity": 1,
-                                    "paddingHorizontal": 16,
                                   }
                                 }
                                 testID="textfield"
@@ -2392,9 +2391,10 @@ exports[`EnterEmail Component renders loading state snapshot 1`] = `
                                         "fontFamily": "Geist Regular",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "height": 24,
+                                        "height": 46,
                                         "letterSpacing": 0,
                                         "opacity": 1,
+                                        "paddingHorizontal": 16,
                                         "paddingVertical": 0,
                                       }
                                     }
@@ -3180,7 +3180,6 @@ exports[`EnterEmail Component renders validation error snapshot invalid email 1`
                                     "flexDirection": "row",
                                     "height": 48,
                                     "opacity": 1,
-                                    "paddingHorizontal": 16,
                                   }
                                 }
                                 testID="textfield"
@@ -3215,9 +3214,10 @@ exports[`EnterEmail Component renders validation error snapshot invalid email 1`
                                         "fontFamily": "Geist Regular",
                                         "fontSize": 16,
                                         "fontWeight": "400",
-                                        "height": 24,
+                                        "height": 46,
                                         "letterSpacing": 0,
                                         "opacity": 1,
+                                        "paddingHorizontal": 16,
                                         "paddingVertical": 0,
                                       }
                                     }

--- a/app/components/UI/Ramp/Deposit/Views/EnterEmail/__snapshots__/EnterEmail.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/EnterEmail/__snapshots__/EnterEmail.test.tsx.snap
@@ -687,6 +687,35 @@ exports[`EnterEmail Component render matches snapshot 1`] = `
                                 We'll email you a six-digit verification code to securely log in or create an account with Transak.
                               </Text>
                               <View
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": undefined,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
                                 style={
                                   {
                                     "alignItems": "center",
@@ -697,6 +726,7 @@ exports[`EnterEmail Component render matches snapshot 1`] = `
                                     "flexDirection": "row",
                                     "height": 48,
                                     "opacity": 1,
+                                    "paddingHorizontal": 16,
                                   }
                                 }
                                 testID="textfield"
@@ -734,7 +764,6 @@ exports[`EnterEmail Component render matches snapshot 1`] = `
                                         "height": 46,
                                         "letterSpacing": 0,
                                         "opacity": 1,
-                                        "paddingHorizontal": 16,
                                         "paddingVertical": 0,
                                       }
                                     }
@@ -1510,6 +1539,35 @@ exports[`EnterEmail Component renders error message snapshot when API call fails
                                 We'll email you a six-digit verification code to securely log in or create an account with Transak.
                               </Text>
                               <View
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": undefined,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
                                 style={
                                   {
                                     "alignItems": "center",
@@ -1520,6 +1578,7 @@ exports[`EnterEmail Component renders error message snapshot when API call fails
                                     "flexDirection": "row",
                                     "height": 48,
                                     "opacity": 1,
+                                    "paddingHorizontal": 16,
                                   }
                                 }
                                 testID="textfield"
@@ -1557,7 +1616,6 @@ exports[`EnterEmail Component renders error message snapshot when API call fails
                                         "height": 46,
                                         "letterSpacing": 0,
                                         "opacity": 1,
-                                        "paddingHorizontal": 16,
                                         "paddingVertical": 0,
                                       }
                                     }
@@ -2347,6 +2405,35 @@ exports[`EnterEmail Component renders loading state snapshot 1`] = `
                                 We'll email you a six-digit verification code to securely log in or create an account with Transak.
                               </Text>
                               <View
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": undefined,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
                                 style={
                                   {
                                     "alignItems": "center",
@@ -2357,6 +2444,7 @@ exports[`EnterEmail Component renders loading state snapshot 1`] = `
                                     "flexDirection": "row",
                                     "height": 48,
                                     "opacity": 1,
+                                    "paddingHorizontal": 16,
                                   }
                                 }
                                 testID="textfield"
@@ -2394,7 +2482,6 @@ exports[`EnterEmail Component renders loading state snapshot 1`] = `
                                         "height": 46,
                                         "letterSpacing": 0,
                                         "opacity": 1,
-                                        "paddingHorizontal": 16,
                                         "paddingVertical": 0,
                                       }
                                     }
@@ -3170,6 +3257,35 @@ exports[`EnterEmail Component renders validation error snapshot invalid email 1`
                                 We'll email you a six-digit verification code to securely log in or create an account with Transak.
                               </Text>
                               <View
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": undefined,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
                                 style={
                                   {
                                     "alignItems": "center",
@@ -3180,6 +3296,7 @@ exports[`EnterEmail Component renders validation error snapshot invalid email 1`
                                     "flexDirection": "row",
                                     "height": 48,
                                     "opacity": 1,
+                                    "paddingHorizontal": 16,
                                   }
                                 }
                                 testID="textfield"
@@ -3217,7 +3334,6 @@ exports[`EnterEmail Component renders validation error snapshot invalid email 1`
                                         "height": 46,
                                         "letterSpacing": 0,
                                         "opacity": 1,
-                                        "paddingHorizontal": 16,
                                         "paddingVertical": 0,
                                       }
                                     }

--- a/app/components/UI/Ramp/Deposit/Views/Modals/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
@@ -541,7 +541,6 @@ exports[`RegionSelectorModal Component render matches snapshot 1`] = `
                                   "flexDirection": "row",
                                   "height": 40,
                                   "opacity": 1,
-                                  "paddingHorizontal": 16,
                                 }
                               }
                               testID="textfield"
@@ -591,9 +590,10 @@ exports[`RegionSelectorModal Component render matches snapshot 1`] = `
                                       "fontFamily": "Geist Regular",
                                       "fontSize": 16,
                                       "fontWeight": "400",
-                                      "height": 24,
+                                      "height": 38,
                                       "letterSpacing": 0,
                                       "opacity": 1,
+                                      "paddingHorizontal": 16,
                                       "paddingVertical": 0,
                                     }
                                   }
@@ -1673,7 +1673,6 @@ exports[`RegionSelectorModal Component render matches snapshot when search has n
                                   "flexDirection": "row",
                                   "height": 40,
                                   "opacity": 1,
-                                  "paddingHorizontal": 16,
                                 }
                               }
                               testID="textfield"
@@ -1723,9 +1722,10 @@ exports[`RegionSelectorModal Component render matches snapshot when search has n
                                       "fontFamily": "Geist Regular",
                                       "fontSize": 16,
                                       "fontWeight": "400",
-                                      "height": 24,
+                                      "height": 38,
                                       "letterSpacing": 0,
                                       "opacity": 1,
+                                      "paddingHorizontal": 16,
                                       "paddingVertical": 0,
                                     }
                                   }
@@ -2393,7 +2393,6 @@ exports[`RegionSelectorModal Component render matches snapshot when searching fo
                                   "flexDirection": "row",
                                   "height": 40,
                                   "opacity": 1,
-                                  "paddingHorizontal": 16,
                                 }
                               }
                               testID="textfield"
@@ -2443,9 +2442,10 @@ exports[`RegionSelectorModal Component render matches snapshot when searching fo
                                       "fontFamily": "Geist Regular",
                                       "fontSize": 16,
                                       "fontWeight": "400",
-                                      "height": 24,
+                                      "height": 38,
                                       "letterSpacing": 0,
                                       "opacity": 1,
+                                      "paddingHorizontal": 16,
                                       "paddingVertical": 0,
                                     }
                                   }

--- a/app/components/UI/Ramp/Deposit/Views/Modals/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
@@ -531,6 +531,35 @@ exports[`RegionSelectorModal Component render matches snapshot 1`] = `
                             }
                           >
                             <View
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
                               style={
                                 {
                                   "alignItems": "center",
@@ -541,6 +570,7 @@ exports[`RegionSelectorModal Component render matches snapshot 1`] = `
                                   "flexDirection": "row",
                                   "height": 40,
                                   "opacity": 1,
+                                  "paddingHorizontal": 16,
                                 }
                               }
                               testID="textfield"
@@ -593,7 +623,6 @@ exports[`RegionSelectorModal Component render matches snapshot 1`] = `
                                       "height": 38,
                                       "letterSpacing": 0,
                                       "opacity": 1,
-                                      "paddingHorizontal": 16,
                                       "paddingVertical": 0,
                                     }
                                   }
@@ -1663,6 +1692,35 @@ exports[`RegionSelectorModal Component render matches snapshot when search has n
                             }
                           >
                             <View
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
                               style={
                                 {
                                   "alignItems": "center",
@@ -1673,6 +1731,7 @@ exports[`RegionSelectorModal Component render matches snapshot when search has n
                                   "flexDirection": "row",
                                   "height": 40,
                                   "opacity": 1,
+                                  "paddingHorizontal": 16,
                                 }
                               }
                               testID="textfield"
@@ -1725,7 +1784,6 @@ exports[`RegionSelectorModal Component render matches snapshot when search has n
                                       "height": 38,
                                       "letterSpacing": 0,
                                       "opacity": 1,
-                                      "paddingHorizontal": 16,
                                       "paddingVertical": 0,
                                     }
                                   }
@@ -2383,6 +2441,35 @@ exports[`RegionSelectorModal Component render matches snapshot when searching fo
                             }
                           >
                             <View
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
                               style={
                                 {
                                   "alignItems": "center",
@@ -2393,6 +2480,7 @@ exports[`RegionSelectorModal Component render matches snapshot when searching fo
                                   "flexDirection": "row",
                                   "height": 40,
                                   "opacity": 1,
+                                  "paddingHorizontal": 16,
                                 }
                               }
                               testID="textfield"
@@ -2445,7 +2533,6 @@ exports[`RegionSelectorModal Component render matches snapshot when searching fo
                                       "height": 38,
                                       "letterSpacing": 0,
                                       "opacity": 1,
-                                      "paddingHorizontal": 16,
                                       "paddingVertical": 0,
                                     }
                                   }

--- a/app/components/UI/Ramp/Deposit/Views/Modals/StateSelectorModal/__snapshots__/StateSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/StateSelectorModal/__snapshots__/StateSelectorModal.test.tsx.snap
@@ -531,6 +531,35 @@ exports[`StateSelectorModal Component Snapshot Tests renders cleared search stat
                             }
                           >
                             <View
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
                               style={
                                 {
                                   "alignItems": "center",
@@ -541,6 +570,7 @@ exports[`StateSelectorModal Component Snapshot Tests renders cleared search stat
                                   "flexDirection": "row",
                                   "height": 40,
                                   "opacity": 1,
+                                  "paddingHorizontal": 16,
                                 }
                               }
                               testID="textfield"
@@ -593,7 +623,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders cleared search stat
                                       "height": 38,
                                       "letterSpacing": 0,
                                       "opacity": 1,
-                                      "paddingHorizontal": 16,
                                       "paddingVertical": 0,
                                     }
                                   }
@@ -1304,6 +1333,35 @@ exports[`StateSelectorModal Component Snapshot Tests renders empty state when no
                             }
                           >
                             <View
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
                               style={
                                 {
                                   "alignItems": "center",
@@ -1314,6 +1372,7 @@ exports[`StateSelectorModal Component Snapshot Tests renders empty state when no
                                   "flexDirection": "row",
                                   "height": 40,
                                   "opacity": 1,
+                                  "paddingHorizontal": 16,
                                 }
                               }
                               testID="textfield"
@@ -1366,7 +1425,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders empty state when no
                                       "height": 38,
                                       "letterSpacing": 0,
                                       "opacity": 1,
-                                      "paddingHorizontal": 16,
                                       "paddingVertical": 0,
                                     }
                                   }
@@ -2021,6 +2079,35 @@ exports[`StateSelectorModal Component Snapshot Tests renders filtered state when
                             }
                           >
                             <View
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
                               style={
                                 {
                                   "alignItems": "center",
@@ -2031,6 +2118,7 @@ exports[`StateSelectorModal Component Snapshot Tests renders filtered state when
                                   "flexDirection": "row",
                                   "height": 40,
                                   "opacity": 1,
+                                  "paddingHorizontal": 16,
                                 }
                               }
                               testID="textfield"
@@ -2083,7 +2171,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders filtered state when
                                       "height": 38,
                                       "letterSpacing": 0,
                                       "opacity": 1,
-                                      "paddingHorizontal": 16,
                                       "paddingVertical": 0,
                                     }
                                   }
@@ -2794,6 +2881,35 @@ exports[`StateSelectorModal Component Snapshot Tests renders filtered state when
                             }
                           >
                             <View
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
                               style={
                                 {
                                   "alignItems": "center",
@@ -2804,6 +2920,7 @@ exports[`StateSelectorModal Component Snapshot Tests renders filtered state when
                                   "flexDirection": "row",
                                   "height": 40,
                                   "opacity": 1,
+                                  "paddingHorizontal": 16,
                                 }
                               }
                               testID="textfield"
@@ -2856,7 +2973,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders filtered state when
                                       "height": 38,
                                       "letterSpacing": 0,
                                       "opacity": 1,
-                                      "paddingHorizontal": 16,
                                       "paddingVertical": 0,
                                     }
                                   }
@@ -3567,6 +3683,35 @@ exports[`StateSelectorModal Component Snapshot Tests renders initial state corre
                             }
                           >
                             <View
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
                               style={
                                 {
                                   "alignItems": "center",
@@ -3577,6 +3722,7 @@ exports[`StateSelectorModal Component Snapshot Tests renders initial state corre
                                   "flexDirection": "row",
                                   "height": 40,
                                   "opacity": 1,
+                                  "paddingHorizontal": 16,
                                 }
                               }
                               testID="textfield"
@@ -3629,7 +3775,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders initial state corre
                                       "height": 38,
                                       "letterSpacing": 0,
                                       "opacity": 1,
-                                      "paddingHorizontal": 16,
                                       "paddingVertical": 0,
                                     }
                                   }
@@ -4603,6 +4748,35 @@ exports[`StateSelectorModal Component Snapshot Tests renders partial search resu
                             }
                           >
                             <View
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
                               style={
                                 {
                                   "alignItems": "center",
@@ -4613,6 +4787,7 @@ exports[`StateSelectorModal Component Snapshot Tests renders partial search resu
                                   "flexDirection": "row",
                                   "height": 40,
                                   "opacity": 1,
+                                  "paddingHorizontal": 16,
                                 }
                               }
                               testID="textfield"
@@ -4665,7 +4840,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders partial search resu
                                       "height": 38,
                                       "letterSpacing": 0,
                                       "opacity": 1,
-                                      "paddingHorizontal": 16,
                                       "paddingVertical": 0,
                                     }
                                   }

--- a/app/components/UI/Ramp/Deposit/Views/Modals/StateSelectorModal/__snapshots__/StateSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/StateSelectorModal/__snapshots__/StateSelectorModal.test.tsx.snap
@@ -541,7 +541,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders cleared search stat
                                   "flexDirection": "row",
                                   "height": 40,
                                   "opacity": 1,
-                                  "paddingHorizontal": 16,
                                 }
                               }
                               testID="textfield"
@@ -591,9 +590,10 @@ exports[`StateSelectorModal Component Snapshot Tests renders cleared search stat
                                       "fontFamily": "Geist Regular",
                                       "fontSize": 16,
                                       "fontWeight": "400",
-                                      "height": 24,
+                                      "height": 38,
                                       "letterSpacing": 0,
                                       "opacity": 1,
+                                      "paddingHorizontal": 16,
                                       "paddingVertical": 0,
                                     }
                                   }
@@ -1314,7 +1314,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders empty state when no
                                   "flexDirection": "row",
                                   "height": 40,
                                   "opacity": 1,
-                                  "paddingHorizontal": 16,
                                 }
                               }
                               testID="textfield"
@@ -1364,9 +1363,10 @@ exports[`StateSelectorModal Component Snapshot Tests renders empty state when no
                                       "fontFamily": "Geist Regular",
                                       "fontSize": 16,
                                       "fontWeight": "400",
-                                      "height": 24,
+                                      "height": 38,
                                       "letterSpacing": 0,
                                       "opacity": 1,
+                                      "paddingHorizontal": 16,
                                       "paddingVertical": 0,
                                     }
                                   }
@@ -2031,7 +2031,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders filtered state when
                                   "flexDirection": "row",
                                   "height": 40,
                                   "opacity": 1,
-                                  "paddingHorizontal": 16,
                                 }
                               }
                               testID="textfield"
@@ -2081,9 +2080,10 @@ exports[`StateSelectorModal Component Snapshot Tests renders filtered state when
                                       "fontFamily": "Geist Regular",
                                       "fontSize": 16,
                                       "fontWeight": "400",
-                                      "height": 24,
+                                      "height": 38,
                                       "letterSpacing": 0,
                                       "opacity": 1,
+                                      "paddingHorizontal": 16,
                                       "paddingVertical": 0,
                                     }
                                   }
@@ -2804,7 +2804,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders filtered state when
                                   "flexDirection": "row",
                                   "height": 40,
                                   "opacity": 1,
-                                  "paddingHorizontal": 16,
                                 }
                               }
                               testID="textfield"
@@ -2854,9 +2853,10 @@ exports[`StateSelectorModal Component Snapshot Tests renders filtered state when
                                       "fontFamily": "Geist Regular",
                                       "fontSize": 16,
                                       "fontWeight": "400",
-                                      "height": 24,
+                                      "height": 38,
                                       "letterSpacing": 0,
                                       "opacity": 1,
+                                      "paddingHorizontal": 16,
                                       "paddingVertical": 0,
                                     }
                                   }
@@ -3577,7 +3577,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders initial state corre
                                   "flexDirection": "row",
                                   "height": 40,
                                   "opacity": 1,
-                                  "paddingHorizontal": 16,
                                 }
                               }
                               testID="textfield"
@@ -3627,9 +3626,10 @@ exports[`StateSelectorModal Component Snapshot Tests renders initial state corre
                                       "fontFamily": "Geist Regular",
                                       "fontSize": 16,
                                       "fontWeight": "400",
-                                      "height": 24,
+                                      "height": 38,
                                       "letterSpacing": 0,
                                       "opacity": 1,
+                                      "paddingHorizontal": 16,
                                       "paddingVertical": 0,
                                     }
                                   }
@@ -4613,7 +4613,6 @@ exports[`StateSelectorModal Component Snapshot Tests renders partial search resu
                                   "flexDirection": "row",
                                   "height": 40,
                                   "opacity": 1,
-                                  "paddingHorizontal": 16,
                                 }
                               }
                               testID="textfield"
@@ -4663,9 +4662,10 @@ exports[`StateSelectorModal Component Snapshot Tests renders partial search resu
                                       "fontFamily": "Geist Regular",
                                       "fontSize": 16,
                                       "fontWeight": "400",
-                                      "height": 24,
+                                      "height": 38,
                                       "letterSpacing": 0,
                                       "opacity": 1,
+                                      "paddingHorizontal": 16,
                                       "paddingVertical": 0,
                                     }
                                   }

--- a/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
@@ -1480,6 +1480,35 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                             }
                           >
                             <View
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
                               style={
                                 {
                                   "alignItems": "center",
@@ -1490,6 +1519,7 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                   "flexDirection": "row",
                                   "height": 40,
                                   "opacity": 1,
+                                  "paddingHorizontal": 16,
                                 }
                               }
                               testID="textfield"
@@ -1542,7 +1572,6 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                       "height": 38,
                                       "letterSpacing": 0,
                                       "opacity": 1,
-                                      "paddingHorizontal": 16,
                                       "paddingVertical": 0,
                                     }
                                   }

--- a/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
@@ -1490,7 +1490,6 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                   "flexDirection": "row",
                                   "height": 40,
                                   "opacity": 1,
-                                  "paddingHorizontal": 16,
                                 }
                               }
                               testID="textfield"
@@ -1540,9 +1539,10 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                       "fontFamily": "Geist Regular",
                                       "fontSize": 16,
                                       "fontWeight": "400",
-                                      "height": 24,
+                                      "height": 38,
                                       "letterSpacing": 0,
                                       "opacity": 1,
+                                      "paddingHorizontal": 16,
                                       "paddingVertical": 0,
                                     }
                                   }

--- a/app/components/UI/Ramp/Deposit/components/DepositDateField/__snapshots__/DepositDateField.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/components/DepositDateField/__snapshots__/DepositDateField.test.tsx.snap
@@ -65,7 +65,6 @@ exports[`DepositDateField Platform specific rendering date picker matches snapsh
             "flexDirection": "row",
             "height": 48,
             "opacity": 1,
-            "paddingHorizontal": 16,
           }
         }
         testID="textfield"
@@ -118,9 +117,10 @@ exports[`DepositDateField Platform specific rendering date picker matches snapsh
                 "fontFamily": "Geist Regular",
                 "fontSize": 16,
                 "fontWeight": "400",
-                "height": 24,
+                "height": 46,
                 "letterSpacing": 0,
                 "opacity": 1,
+                "paddingHorizontal": 16,
                 "paddingVertical": 0,
               }
             }
@@ -210,7 +210,6 @@ exports[`DepositDateField Platform specific rendering date picker matches snapsh
             "flexDirection": "row",
             "height": 48,
             "opacity": 1,
-            "paddingHorizontal": 16,
           }
         }
         testID="textfield"
@@ -263,9 +262,10 @@ exports[`DepositDateField Platform specific rendering date picker matches snapsh
                 "fontFamily": "Geist Regular",
                 "fontSize": 16,
                 "fontWeight": "400",
-                "height": 24,
+                "height": 46,
                 "letterSpacing": 0,
                 "opacity": 1,
+                "paddingHorizontal": 16,
                 "paddingVertical": 0,
               }
             }
@@ -512,7 +512,6 @@ exports[`DepositDateField render matches snapshot 1`] = `
           "flexDirection": "row",
           "height": 48,
           "opacity": 1,
-          "paddingHorizontal": 16,
         }
       }
       testID="textfield"
@@ -565,9 +564,10 @@ exports[`DepositDateField render matches snapshot 1`] = `
               "fontFamily": "Geist Regular",
               "fontSize": 16,
               "fontWeight": "400",
-              "height": 24,
+              "height": 46,
               "letterSpacing": 0,
               "opacity": 1,
+              "paddingHorizontal": 16,
               "paddingVertical": 0,
             }
           }
@@ -643,7 +643,6 @@ exports[`DepositDateField render matches snapshot with a value 1`] = `
           "flexDirection": "row",
           "height": 48,
           "opacity": 1,
-          "paddingHorizontal": 16,
         }
       }
       testID="textfield"
@@ -696,9 +695,10 @@ exports[`DepositDateField render matches snapshot with a value 1`] = `
               "fontFamily": "Geist Regular",
               "fontSize": 16,
               "fontWeight": "400",
-              "height": 24,
+              "height": 46,
               "letterSpacing": 0,
               "opacity": 1,
+              "paddingHorizontal": 16,
               "paddingVertical": 0,
             }
           }
@@ -774,7 +774,6 @@ exports[`DepositDateField render matches snapshot with an error 1`] = `
           "flexDirection": "row",
           "height": 48,
           "opacity": 1,
-          "paddingHorizontal": 16,
         }
       }
       testID="textfield"
@@ -827,9 +826,10 @@ exports[`DepositDateField render matches snapshot with an error 1`] = `
               "fontFamily": "Geist Regular",
               "fontSize": 16,
               "fontWeight": "400",
-              "height": 24,
+              "height": 46,
               "letterSpacing": 0,
               "opacity": 1,
+              "paddingHorizontal": 16,
               "paddingVertical": 0,
             }
           }
@@ -920,7 +920,6 @@ exports[`DepositDateField render matches snapshot with empty value 1`] = `
           "flexDirection": "row",
           "height": 48,
           "opacity": 1,
-          "paddingHorizontal": 16,
         }
       }
       testID="textfield"
@@ -973,9 +972,10 @@ exports[`DepositDateField render matches snapshot with empty value 1`] = `
               "fontFamily": "Geist Regular",
               "fontSize": 16,
               "fontWeight": "400",
-              "height": 24,
+              "height": 46,
               "letterSpacing": 0,
               "opacity": 1,
+              "paddingHorizontal": 16,
               "paddingVertical": 0,
             }
           }

--- a/app/components/UI/Ramp/Deposit/components/DepositDateField/__snapshots__/DepositDateField.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/components/DepositDateField/__snapshots__/DepositDateField.test.tsx.snap
@@ -1,287 +1,58 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DepositDateField Platform specific rendering date picker matches snapshot on Android 1`] = `
-[
+<View
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessible={true}
+  focusable={true}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    {
+      "width": "100%",
+    }
+  }
+>
   <View
-    accessibilityState={
-      {
-        "busy": undefined,
-        "checked": undefined,
-        "disabled": undefined,
-        "expanded": undefined,
-        "selected": undefined,
-      }
-    }
-    accessible={true}
-    focusable={true}
-    onClick={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
     style={
-      {
-        "width": "100%",
-      }
+      [
+        {
+          "flexDirection": "column",
+          "marginBottom": 16,
+        },
+        undefined,
+      ]
     }
   >
-    <View
+    <Text
+      accessibilityRole="text"
       style={
-        [
-          {
-            "flexDirection": "column",
-            "marginBottom": 16,
-          },
-          undefined,
-        ]
+        {
+          "color": "#121314",
+          "fontFamily": "Geist Regular",
+          "fontSize": 16,
+          "letterSpacing": 0,
+          "lineHeight": 24,
+          "marginBottom": 6,
+        }
       }
+      testID="label"
     >
-      <Text
-        accessibilityRole="text"
-        style={
-          {
-            "color": "#121314",
-            "fontFamily": "Geist Regular",
-            "fontSize": 16,
-            "letterSpacing": 0,
-            "lineHeight": 24,
-            "marginBottom": 6,
-          }
-        }
-        testID="label"
-      >
-        Date of Birth
-      </Text>
-      <View
-        style={
-          {
-            "alignItems": "center",
-            "backgroundColor": "#ffffff",
-            "borderColor": "#b7bbc8",
-            "borderRadius": 8,
-            "borderWidth": 1,
-            "flexDirection": "row",
-            "height": 48,
-            "opacity": 1,
-          }
-        }
-        testID="textfield"
-      >
-        <View
-          style={
-            {
-              "marginRight": 8,
-            }
-          }
-          testID="textfield-startacccessory"
-        >
-          <SvgMock
-            color="#121314"
-            fill="currentColor"
-            height={20}
-            name="Calendar"
-            style={
-              {
-                "height": 20,
-                "width": 20,
-              }
-            }
-            width={20}
-          />
-        </View>
-        <View
-          style={
-            {
-              "flex": 1,
-            }
-          }
-        >
-          <TextInput
-            autoFocus={false}
-            editable={true}
-            keyboardAppearance="light"
-            onBlur={[Function]}
-            onFocus={[Function]}
-            placeholder="01/01/2000"
-            placeholderTextColor="#b7bbc8"
-            pointerEvents="none"
-            readOnly={true}
-            style={
-              {
-                "backgroundColor": "inherit",
-                "borderColor": "transparent",
-                "borderWidth": 1,
-                "color": "#121314",
-                "fontFamily": "Geist Regular",
-                "fontSize": 16,
-                "fontWeight": "400",
-                "height": 46,
-                "letterSpacing": 0,
-                "opacity": 1,
-                "paddingHorizontal": 16,
-                "paddingVertical": 0,
-              }
-            }
-            value="01/01/2024"
-          />
-        </View>
-      </View>
-    </View>
-  </View>,
-  <RNDateTimePicker
-    date={1704085200000}
-    displayIOS="default"
-    enabled={true}
-    maximumDate={123}
-    minimumDate={-2208970800000}
-    mode="date"
-    onChange={[Function]}
-    onPickerDismiss={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
-  />,
-]
-`;
-
-exports[`DepositDateField Platform specific rendering date picker matches snapshot on iOS 1`] = `
-[
-  <View
-    accessibilityState={
-      {
-        "busy": undefined,
-        "checked": undefined,
-        "disabled": undefined,
-        "expanded": undefined,
-        "selected": undefined,
-      }
-    }
-    accessible={true}
-    focusable={true}
-    onClick={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
-    style={
-      {
-        "width": "100%",
-      }
-    }
-  >
-    <View
-      style={
-        [
-          {
-            "flexDirection": "column",
-            "marginBottom": 16,
-          },
-          undefined,
-        ]
-      }
-    >
-      <Text
-        accessibilityRole="text"
-        style={
-          {
-            "color": "#121314",
-            "fontFamily": "Geist Regular",
-            "fontSize": 16,
-            "letterSpacing": 0,
-            "lineHeight": 24,
-            "marginBottom": 6,
-          }
-        }
-        testID="label"
-      >
-        Date of Birth
-      </Text>
-      <View
-        style={
-          {
-            "alignItems": "center",
-            "backgroundColor": "#ffffff",
-            "borderColor": "#b7bbc8",
-            "borderRadius": 8,
-            "borderWidth": 1,
-            "flexDirection": "row",
-            "height": 48,
-            "opacity": 1,
-          }
-        }
-        testID="textfield"
-      >
-        <View
-          style={
-            {
-              "marginRight": 8,
-            }
-          }
-          testID="textfield-startacccessory"
-        >
-          <SvgMock
-            color="#121314"
-            fill="currentColor"
-            height={20}
-            name="Calendar"
-            style={
-              {
-                "height": 20,
-                "width": 20,
-              }
-            }
-            width={20}
-          />
-        </View>
-        <View
-          style={
-            {
-              "flex": 1,
-            }
-          }
-        >
-          <TextInput
-            autoFocus={false}
-            editable={true}
-            keyboardAppearance="light"
-            onBlur={[Function]}
-            onFocus={[Function]}
-            placeholder="01/01/2000"
-            placeholderTextColor="#b7bbc8"
-            pointerEvents="none"
-            readOnly={true}
-            style={
-              {
-                "backgroundColor": "inherit",
-                "borderColor": "transparent",
-                "borderWidth": 1,
-                "color": "#121314",
-                "fontFamily": "Geist Regular",
-                "fontSize": 16,
-                "fontWeight": "400",
-                "height": 46,
-                "letterSpacing": 0,
-                "opacity": 1,
-                "paddingHorizontal": 16,
-                "paddingVertical": 0,
-              }
-            }
-            value="01/01/2024"
-          />
-        </View>
-      </View>
-    </View>
-  </View>,
-  <Modal
-    animationType="fade"
-    hardwareAccelerated={false}
-    onRequestClose={[Function]}
-    transparent={true}
-    visible={true}
-  >
+      Date of Birth
+    </Text>
     <View
       accessibilityState={
         {
@@ -292,9 +63,20 @@ exports[`DepositDateField Platform specific rendering date picker matches snapsh
           "selected": undefined,
         }
       }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
       accessible={true}
+      collapsable={false}
       focusable={true}
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
       onResponderRelease={[Function]}
@@ -303,149 +85,239 @@ exports[`DepositDateField Platform specific rendering date picker matches snapsh
       onStartShouldSetResponder={[Function]}
       style={
         {
-          "backgroundColor": "#3f434a66",
-          "flex": 1,
-          "justifyContent": "flex-end",
+          "alignItems": "center",
+          "backgroundColor": "#ffffff",
+          "borderColor": "#b7bbc8",
+          "borderRadius": 8,
+          "borderWidth": 1,
+          "flexDirection": "row",
+          "height": 48,
+          "opacity": 1,
+          "paddingHorizontal": 16,
         }
       }
+      testID="textfield"
     >
       <View
-        accessibilityState={
-          {
-            "busy": undefined,
-            "checked": undefined,
-            "disabled": undefined,
-            "expanded": undefined,
-            "selected": undefined,
-          }
-        }
-        accessible={true}
-        focusable={true}
-        onClick={[Function]}
-        onResponderGrant={[Function]}
-        onResponderMove={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={[Function]}
-        onResponderTerminationRequest={[Function]}
-        onStartShouldSetResponder={[Function]}
         style={
           {
-            "backgroundColor": "#ffffff",
-            "borderTopLeftRadius": 20,
-            "borderTopRightRadius": 20,
-            "padding": 16,
+            "marginRight": 8,
+          }
+        }
+        testID="textfield-startacccessory"
+      >
+        <SvgMock
+          color="#121314"
+          fill="currentColor"
+          height={20}
+          name="Calendar"
+          style={
+            {
+              "height": 20,
+              "width": 20,
+            }
+          }
+          width={20}
+        />
+      </View>
+      <View
+        style={
+          {
+            "flex": 1,
           }
         }
       >
-        <View
+        <TextInput
+          autoFocus={false}
+          editable={true}
+          keyboardAppearance="light"
+          onBlur={[Function]}
+          onFocus={[Function]}
+          placeholder="01/01/2000"
+          placeholderTextColor="#b7bbc8"
+          pointerEvents="none"
+          readOnly={true}
           style={
             {
-              "flexDirection": "row",
-              "justifyContent": "flex-end",
-              "marginBottom": 8,
+              "backgroundColor": "inherit",
+              "borderColor": "transparent",
+              "borderWidth": 1,
+              "color": "#121314",
+              "fontFamily": "Geist Regular",
+              "fontSize": 16,
+              "fontWeight": "400",
+              "height": 46,
+              "letterSpacing": 0,
+              "opacity": 1,
+              "paddingVertical": 0,
             }
           }
-        >
-          <TouchableOpacity
-            accessibilityRole="button"
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": undefined,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            onPress={[Function]}
-          >
-            <View
-              style={
-                [
-                  {},
-                ]
-              }
-            >
-              <Text
-                style={
-                  [
-                    {
-                      "color": "#007AFF",
-                      "fontSize": 18,
-                      "margin": 8,
-                      "textAlign": "center",
-                    },
-                    {
-                      "color": "#b7bbc8",
-                    },
-                  ]
-                }
-              >
-                Cancel
-              </Text>
-            </View>
-          </TouchableOpacity>
-          <TouchableOpacity
-            accessibilityRole="button"
-            accessibilityState={
-              {
-                "busy": undefined,
-                "checked": undefined,
-                "disabled": undefined,
-                "expanded": undefined,
-                "selected": undefined,
-              }
-            }
-            onPress={[Function]}
-          >
-            <View
-              style={
-                [
-                  {},
-                ]
-              }
-            >
-              <Text
-                style={
-                  [
-                    {
-                      "color": "#007AFF",
-                      "fontSize": 18,
-                      "margin": 8,
-                      "textAlign": "center",
-                    },
-                    {
-                      "color": "#4459ff",
-                    },
-                  ]
-                }
-              >
-                Done
-              </Text>
-            </View>
-          </TouchableOpacity>
-        </View>
-        <RNDateTimePicker
-          date={1704085200000}
-          displayIOS="spinner"
-          enabled={true}
-          maximumDate={123}
-          minimumDate={-2208970800000}
-          mode="date"
-          onChange={[Function]}
-          onPickerDismiss={[Function]}
-          onResponderTerminationRequest={[Function]}
-          onStartShouldSetResponder={[Function]}
-          style={
-            {
-              "backgroundColor": "#ffffff",
-            }
-          }
+          value="01/01/2024"
         />
       </View>
     </View>
-  </Modal>,
-]
+  </View>
+</View>
+`;
+
+exports[`DepositDateField Platform specific rendering date picker matches snapshot on iOS 1`] = `
+<View
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessible={true}
+  focusable={true}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    {
+      "width": "100%",
+    }
+  }
+>
+  <View
+    style={
+      [
+        {
+          "flexDirection": "column",
+          "marginBottom": 16,
+        },
+        undefined,
+      ]
+    }
+  >
+    <Text
+      accessibilityRole="text"
+      style={
+        {
+          "color": "#121314",
+          "fontFamily": "Geist Regular",
+          "fontSize": 16,
+          "letterSpacing": 0,
+          "lineHeight": 24,
+          "marginBottom": 6,
+        }
+      }
+      testID="label"
+    >
+      Date of Birth
+    </Text>
+    <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        {
+          "alignItems": "center",
+          "backgroundColor": "#ffffff",
+          "borderColor": "#b7bbc8",
+          "borderRadius": 8,
+          "borderWidth": 1,
+          "flexDirection": "row",
+          "height": 48,
+          "opacity": 1,
+          "paddingHorizontal": 16,
+        }
+      }
+      testID="textfield"
+    >
+      <View
+        style={
+          {
+            "marginRight": 8,
+          }
+        }
+        testID="textfield-startacccessory"
+      >
+        <SvgMock
+          color="#121314"
+          fill="currentColor"
+          height={20}
+          name="Calendar"
+          style={
+            {
+              "height": 20,
+              "width": 20,
+            }
+          }
+          width={20}
+        />
+      </View>
+      <View
+        style={
+          {
+            "flex": 1,
+          }
+        }
+      >
+        <TextInput
+          autoFocus={false}
+          editable={true}
+          keyboardAppearance="light"
+          onBlur={[Function]}
+          onFocus={[Function]}
+          placeholder="01/01/2000"
+          placeholderTextColor="#b7bbc8"
+          pointerEvents="none"
+          readOnly={true}
+          style={
+            {
+              "backgroundColor": "inherit",
+              "borderColor": "transparent",
+              "borderWidth": 1,
+              "color": "#121314",
+              "fontFamily": "Geist Regular",
+              "fontSize": 16,
+              "fontWeight": "400",
+              "height": 46,
+              "letterSpacing": 0,
+              "opacity": 1,
+              "paddingVertical": 0,
+            }
+          }
+          value="01/01/2024"
+        />
+      </View>
+    </View>
+  </View>
+</View>
 `;
 
 exports[`DepositDateField render matches snapshot 1`] = `
@@ -502,6 +374,35 @@ exports[`DepositDateField render matches snapshot 1`] = `
       Date of Birth
     </Text>
     <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
       style={
         {
           "alignItems": "center",
@@ -512,6 +413,7 @@ exports[`DepositDateField render matches snapshot 1`] = `
           "flexDirection": "row",
           "height": 48,
           "opacity": 1,
+          "paddingHorizontal": 16,
         }
       }
       testID="textfield"
@@ -567,7 +469,6 @@ exports[`DepositDateField render matches snapshot 1`] = `
               "height": 46,
               "letterSpacing": 0,
               "opacity": 1,
-              "paddingHorizontal": 16,
               "paddingVertical": 0,
             }
           }
@@ -633,6 +534,35 @@ exports[`DepositDateField render matches snapshot with a value 1`] = `
       Date of Birth
     </Text>
     <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
       style={
         {
           "alignItems": "center",
@@ -643,6 +573,7 @@ exports[`DepositDateField render matches snapshot with a value 1`] = `
           "flexDirection": "row",
           "height": 48,
           "opacity": 1,
+          "paddingHorizontal": 16,
         }
       }
       testID="textfield"
@@ -698,7 +629,6 @@ exports[`DepositDateField render matches snapshot with a value 1`] = `
               "height": 46,
               "letterSpacing": 0,
               "opacity": 1,
-              "paddingHorizontal": 16,
               "paddingVertical": 0,
             }
           }
@@ -764,6 +694,35 @@ exports[`DepositDateField render matches snapshot with an error 1`] = `
       Date of Birth
     </Text>
     <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
       style={
         {
           "alignItems": "center",
@@ -774,6 +733,7 @@ exports[`DepositDateField render matches snapshot with an error 1`] = `
           "flexDirection": "row",
           "height": 48,
           "opacity": 1,
+          "paddingHorizontal": 16,
         }
       }
       testID="textfield"
@@ -829,7 +789,6 @@ exports[`DepositDateField render matches snapshot with an error 1`] = `
               "height": 46,
               "letterSpacing": 0,
               "opacity": 1,
-              "paddingHorizontal": 16,
               "paddingVertical": 0,
             }
           }
@@ -910,6 +869,35 @@ exports[`DepositDateField render matches snapshot with empty value 1`] = `
       Date of Birth
     </Text>
     <View
+      accessibilityState={
+        {
+          "busy": undefined,
+          "checked": undefined,
+          "disabled": undefined,
+          "expanded": undefined,
+          "selected": undefined,
+        }
+      }
+      accessibilityValue={
+        {
+          "max": undefined,
+          "min": undefined,
+          "now": undefined,
+          "text": undefined,
+        }
+      }
+      accessible={true}
+      collapsable={false}
+      focusable={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
       style={
         {
           "alignItems": "center",
@@ -920,6 +908,7 @@ exports[`DepositDateField render matches snapshot with empty value 1`] = `
           "flexDirection": "row",
           "height": 48,
           "opacity": 1,
+          "paddingHorizontal": 16,
         }
       }
       testID="textfield"
@@ -975,7 +964,6 @@ exports[`DepositDateField render matches snapshot with empty value 1`] = `
               "height": 46,
               "letterSpacing": 0,
               "opacity": 1,
-              "paddingHorizontal": 16,
               "paddingVertical": 0,
             }
           }

--- a/app/components/UI/Ramp/Deposit/components/DepositPhoneField/__snapshots__/DepositPhoneField.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/components/DepositPhoneField/__snapshots__/DepositPhoneField.test.tsx.snap
@@ -39,7 +39,6 @@ exports[`DepositPhoneField renders correctly after flag button press 1`] = `
         "flexDirection": "row",
         "height": 48,
         "opacity": 1,
-        "paddingHorizontal": 16,
       }
     }
     testID="textfield"
@@ -121,9 +120,10 @@ exports[`DepositPhoneField renders correctly after flag button press 1`] = `
             "fontFamily": "Geist Regular",
             "fontSize": 16,
             "fontWeight": "400",
-            "height": 24,
+            "height": 46,
             "letterSpacing": 0,
             "opacity": 1,
+            "paddingHorizontal": 16,
             "paddingVertical": 0,
           }
         }
@@ -175,7 +175,6 @@ exports[`DepositPhoneField renders correctly after input change 1`] = `
         "flexDirection": "row",
         "height": 48,
         "opacity": 1,
-        "paddingHorizontal": 16,
       }
     }
     testID="textfield"
@@ -257,9 +256,10 @@ exports[`DepositPhoneField renders correctly after input change 1`] = `
             "fontFamily": "Geist Regular",
             "fontSize": 16,
             "fontWeight": "400",
-            "height": 24,
+            "height": 46,
             "letterSpacing": 0,
             "opacity": 1,
+            "paddingHorizontal": 16,
             "paddingVertical": 0,
           }
         }
@@ -311,7 +311,6 @@ exports[`DepositPhoneField renders correctly with default props 1`] = `
         "flexDirection": "row",
         "height": 48,
         "opacity": 1,
-        "paddingHorizontal": 16,
       }
     }
     testID="textfield"
@@ -393,9 +392,10 @@ exports[`DepositPhoneField renders correctly with default props 1`] = `
             "fontFamily": "Geist Regular",
             "fontSize": 16,
             "fontWeight": "400",
-            "height": 24,
+            "height": 46,
             "letterSpacing": 0,
             "opacity": 1,
+            "paddingHorizontal": 16,
             "paddingVertical": 0,
           }
         }
@@ -447,7 +447,6 @@ exports[`DepositPhoneField renders correctly with different region 1`] = `
         "flexDirection": "row",
         "height": 48,
         "opacity": 1,
-        "paddingHorizontal": 16,
       }
     }
     testID="textfield"
@@ -529,9 +528,10 @@ exports[`DepositPhoneField renders correctly with different region 1`] = `
             "fontFamily": "Geist Regular",
             "fontSize": 16,
             "fontWeight": "400",
-            "height": 24,
+            "height": 46,
             "letterSpacing": 0,
             "opacity": 1,
+            "paddingHorizontal": 16,
             "paddingVertical": 0,
           }
         }
@@ -583,7 +583,6 @@ exports[`DepositPhoneField renders correctly with error message 1`] = `
         "flexDirection": "row",
         "height": 48,
         "opacity": 1,
-        "paddingHorizontal": 16,
       }
     }
     testID="textfield"
@@ -665,9 +664,10 @@ exports[`DepositPhoneField renders correctly with error message 1`] = `
             "fontFamily": "Geist Regular",
             "fontSize": 16,
             "fontWeight": "400",
-            "height": 24,
+            "height": 46,
             "letterSpacing": 0,
             "opacity": 1,
+            "paddingHorizontal": 16,
             "paddingVertical": 0,
           }
         }
@@ -734,7 +734,6 @@ exports[`DepositPhoneField renders correctly with long phone number 1`] = `
         "flexDirection": "row",
         "height": 48,
         "opacity": 1,
-        "paddingHorizontal": 16,
       }
     }
     testID="textfield"
@@ -816,9 +815,10 @@ exports[`DepositPhoneField renders correctly with long phone number 1`] = `
             "fontFamily": "Geist Regular",
             "fontSize": 16,
             "fontWeight": "400",
-            "height": 24,
+            "height": 46,
             "letterSpacing": 0,
             "opacity": 1,
+            "paddingHorizontal": 16,
             "paddingVertical": 0,
           }
         }
@@ -870,7 +870,6 @@ exports[`DepositPhoneField renders correctly with onSubmitEditing callback 1`] =
         "flexDirection": "row",
         "height": 48,
         "opacity": 1,
-        "paddingHorizontal": 16,
       }
     }
     testID="textfield"
@@ -953,9 +952,10 @@ exports[`DepositPhoneField renders correctly with onSubmitEditing callback 1`] =
             "fontFamily": "Geist Regular",
             "fontSize": 16,
             "fontWeight": "400",
-            "height": 24,
+            "height": 46,
             "letterSpacing": 0,
             "opacity": 1,
+            "paddingHorizontal": 16,
             "paddingVertical": 0,
           }
         }
@@ -1007,7 +1007,6 @@ exports[`DepositPhoneField renders correctly with special characters in phone nu
         "flexDirection": "row",
         "height": 48,
         "opacity": 1,
-        "paddingHorizontal": 16,
       }
     }
     testID="textfield"
@@ -1089,9 +1088,10 @@ exports[`DepositPhoneField renders correctly with special characters in phone nu
             "fontFamily": "Geist Regular",
             "fontSize": 16,
             "fontWeight": "400",
-            "height": 24,
+            "height": 46,
             "letterSpacing": 0,
             "opacity": 1,
+            "paddingHorizontal": 16,
             "paddingVertical": 0,
           }
         }
@@ -1143,7 +1143,6 @@ exports[`DepositPhoneField renders correctly with unsupported region 1`] = `
         "flexDirection": "row",
         "height": 48,
         "opacity": 1,
-        "paddingHorizontal": 16,
       }
     }
     testID="textfield"
@@ -1225,9 +1224,10 @@ exports[`DepositPhoneField renders correctly with unsupported region 1`] = `
             "fontFamily": "Geist Regular",
             "fontSize": 16,
             "fontWeight": "400",
-            "height": 24,
+            "height": 46,
             "letterSpacing": 0,
             "opacity": 1,
+            "paddingHorizontal": 16,
             "paddingVertical": 0,
           }
         }
@@ -1279,7 +1279,6 @@ exports[`DepositPhoneField renders correctly with value 1`] = `
         "flexDirection": "row",
         "height": 48,
         "opacity": 1,
-        "paddingHorizontal": 16,
       }
     }
     testID="textfield"
@@ -1361,9 +1360,10 @@ exports[`DepositPhoneField renders correctly with value 1`] = `
             "fontFamily": "Geist Regular",
             "fontSize": 16,
             "fontWeight": "400",
-            "height": 24,
+            "height": 46,
             "letterSpacing": 0,
             "opacity": 1,
+            "paddingHorizontal": 16,
             "paddingVertical": 0,
           }
         }

--- a/app/components/UI/Ramp/Deposit/components/DepositPhoneField/__snapshots__/DepositPhoneField.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/components/DepositPhoneField/__snapshots__/DepositPhoneField.test.tsx.snap
@@ -29,6 +29,35 @@ exports[`DepositPhoneField renders correctly after flag button press 1`] = `
     Phone Number
   </Text>
   <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
     style={
       {
         "alignItems": "center",
@@ -39,6 +68,7 @@ exports[`DepositPhoneField renders correctly after flag button press 1`] = `
         "flexDirection": "row",
         "height": 48,
         "opacity": 1,
+        "paddingHorizontal": 16,
       }
     }
     testID="textfield"
@@ -123,7 +153,6 @@ exports[`DepositPhoneField renders correctly after flag button press 1`] = `
             "height": 46,
             "letterSpacing": 0,
             "opacity": 1,
-            "paddingHorizontal": 16,
             "paddingVertical": 0,
           }
         }
@@ -165,6 +194,35 @@ exports[`DepositPhoneField renders correctly after input change 1`] = `
     Phone Number
   </Text>
   <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
     style={
       {
         "alignItems": "center",
@@ -175,6 +233,7 @@ exports[`DepositPhoneField renders correctly after input change 1`] = `
         "flexDirection": "row",
         "height": 48,
         "opacity": 1,
+        "paddingHorizontal": 16,
       }
     }
     testID="textfield"
@@ -259,7 +318,6 @@ exports[`DepositPhoneField renders correctly after input change 1`] = `
             "height": 46,
             "letterSpacing": 0,
             "opacity": 1,
-            "paddingHorizontal": 16,
             "paddingVertical": 0,
           }
         }
@@ -301,6 +359,35 @@ exports[`DepositPhoneField renders correctly with default props 1`] = `
     Phone Number
   </Text>
   <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
     style={
       {
         "alignItems": "center",
@@ -311,6 +398,7 @@ exports[`DepositPhoneField renders correctly with default props 1`] = `
         "flexDirection": "row",
         "height": 48,
         "opacity": 1,
+        "paddingHorizontal": 16,
       }
     }
     testID="textfield"
@@ -395,7 +483,6 @@ exports[`DepositPhoneField renders correctly with default props 1`] = `
             "height": 46,
             "letterSpacing": 0,
             "opacity": 1,
-            "paddingHorizontal": 16,
             "paddingVertical": 0,
           }
         }
@@ -437,6 +524,35 @@ exports[`DepositPhoneField renders correctly with different region 1`] = `
     Phone Number
   </Text>
   <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
     style={
       {
         "alignItems": "center",
@@ -447,6 +563,7 @@ exports[`DepositPhoneField renders correctly with different region 1`] = `
         "flexDirection": "row",
         "height": 48,
         "opacity": 1,
+        "paddingHorizontal": 16,
       }
     }
     testID="textfield"
@@ -531,7 +648,6 @@ exports[`DepositPhoneField renders correctly with different region 1`] = `
             "height": 46,
             "letterSpacing": 0,
             "opacity": 1,
-            "paddingHorizontal": 16,
             "paddingVertical": 0,
           }
         }
@@ -573,6 +689,35 @@ exports[`DepositPhoneField renders correctly with error message 1`] = `
     Phone Number
   </Text>
   <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
     style={
       {
         "alignItems": "center",
@@ -583,6 +728,7 @@ exports[`DepositPhoneField renders correctly with error message 1`] = `
         "flexDirection": "row",
         "height": 48,
         "opacity": 1,
+        "paddingHorizontal": 16,
       }
     }
     testID="textfield"
@@ -667,7 +813,6 @@ exports[`DepositPhoneField renders correctly with error message 1`] = `
             "height": 46,
             "letterSpacing": 0,
             "opacity": 1,
-            "paddingHorizontal": 16,
             "paddingVertical": 0,
           }
         }
@@ -724,6 +869,35 @@ exports[`DepositPhoneField renders correctly with long phone number 1`] = `
     Phone Number
   </Text>
   <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
     style={
       {
         "alignItems": "center",
@@ -734,6 +908,7 @@ exports[`DepositPhoneField renders correctly with long phone number 1`] = `
         "flexDirection": "row",
         "height": 48,
         "opacity": 1,
+        "paddingHorizontal": 16,
       }
     }
     testID="textfield"
@@ -818,7 +993,6 @@ exports[`DepositPhoneField renders correctly with long phone number 1`] = `
             "height": 46,
             "letterSpacing": 0,
             "opacity": 1,
-            "paddingHorizontal": 16,
             "paddingVertical": 0,
           }
         }
@@ -860,6 +1034,35 @@ exports[`DepositPhoneField renders correctly with onSubmitEditing callback 1`] =
     Phone Number
   </Text>
   <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
     style={
       {
         "alignItems": "center",
@@ -870,6 +1073,7 @@ exports[`DepositPhoneField renders correctly with onSubmitEditing callback 1`] =
         "flexDirection": "row",
         "height": 48,
         "opacity": 1,
+        "paddingHorizontal": 16,
       }
     }
     testID="textfield"
@@ -955,7 +1159,6 @@ exports[`DepositPhoneField renders correctly with onSubmitEditing callback 1`] =
             "height": 46,
             "letterSpacing": 0,
             "opacity": 1,
-            "paddingHorizontal": 16,
             "paddingVertical": 0,
           }
         }
@@ -997,6 +1200,35 @@ exports[`DepositPhoneField renders correctly with special characters in phone nu
     Phone Number
   </Text>
   <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
     style={
       {
         "alignItems": "center",
@@ -1007,6 +1239,7 @@ exports[`DepositPhoneField renders correctly with special characters in phone nu
         "flexDirection": "row",
         "height": 48,
         "opacity": 1,
+        "paddingHorizontal": 16,
       }
     }
     testID="textfield"
@@ -1091,7 +1324,6 @@ exports[`DepositPhoneField renders correctly with special characters in phone nu
             "height": 46,
             "letterSpacing": 0,
             "opacity": 1,
-            "paddingHorizontal": 16,
             "paddingVertical": 0,
           }
         }
@@ -1133,6 +1365,35 @@ exports[`DepositPhoneField renders correctly with unsupported region 1`] = `
     Phone Number
   </Text>
   <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
     style={
       {
         "alignItems": "center",
@@ -1143,6 +1404,7 @@ exports[`DepositPhoneField renders correctly with unsupported region 1`] = `
         "flexDirection": "row",
         "height": 48,
         "opacity": 1,
+        "paddingHorizontal": 16,
       }
     }
     testID="textfield"
@@ -1227,7 +1489,6 @@ exports[`DepositPhoneField renders correctly with unsupported region 1`] = `
             "height": 46,
             "letterSpacing": 0,
             "opacity": 1,
-            "paddingHorizontal": 16,
             "paddingVertical": 0,
           }
         }
@@ -1269,6 +1530,35 @@ exports[`DepositPhoneField renders correctly with value 1`] = `
     Phone Number
   </Text>
   <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
     style={
       {
         "alignItems": "center",
@@ -1279,6 +1569,7 @@ exports[`DepositPhoneField renders correctly with value 1`] = `
         "flexDirection": "row",
         "height": 48,
         "opacity": 1,
+        "paddingHorizontal": 16,
       }
     }
     testID="textfield"
@@ -1363,7 +1654,6 @@ exports[`DepositPhoneField renders correctly with value 1`] = `
             "height": 46,
             "letterSpacing": 0,
             "opacity": 1,
-            "paddingHorizontal": 16,
             "paddingVertical": 0,
           }
         }

--- a/app/components/Views/ChoosePassword/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ChoosePassword/__snapshots__/index.test.tsx.snap
@@ -146,6 +146,35 @@ exports[`ChoosePassword render matches snapshot 1`] = `
               Create new password
             </Text>
             <View
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
               style={
                 {
                   "alignItems": "center",
@@ -156,6 +185,7 @@ exports[`ChoosePassword render matches snapshot 1`] = `
                   "flexDirection": "row",
                   "height": 48,
                   "opacity": 1,
+                  "paddingHorizontal": 16,
                 }
               }
               testID="textfield"
@@ -193,7 +223,6 @@ exports[`ChoosePassword render matches snapshot 1`] = `
                       "height": 46,
                       "letterSpacing": 0,
                       "opacity": 1,
-                      "paddingHorizontal": 16,
                       "paddingVertical": 0,
                     }
                   }
@@ -253,6 +282,35 @@ exports[`ChoosePassword render matches snapshot 1`] = `
               Confirm password
             </Text>
             <View
+              accessibilityState={
+                {
+                  "busy": undefined,
+                  "checked": undefined,
+                  "disabled": undefined,
+                  "expanded": undefined,
+                  "selected": undefined,
+                }
+              }
+              accessibilityValue={
+                {
+                  "max": undefined,
+                  "min": undefined,
+                  "now": undefined,
+                  "text": undefined,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
               style={
                 {
                   "alignItems": "center",
@@ -263,6 +321,7 @@ exports[`ChoosePassword render matches snapshot 1`] = `
                   "flexDirection": "row",
                   "height": 48,
                   "opacity": 0.5,
+                  "paddingHorizontal": 16,
                 }
               }
               testID="textfield"
@@ -301,7 +360,6 @@ exports[`ChoosePassword render matches snapshot 1`] = `
                       "height": 46,
                       "letterSpacing": 0,
                       "opacity": 1,
-                      "paddingHorizontal": 16,
                       "paddingVertical": 0,
                     }
                   }

--- a/app/components/Views/ChoosePassword/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ChoosePassword/__snapshots__/index.test.tsx.snap
@@ -156,7 +156,6 @@ exports[`ChoosePassword render matches snapshot 1`] = `
                   "flexDirection": "row",
                   "height": 48,
                   "opacity": 1,
-                  "paddingHorizontal": 16,
                 }
               }
               testID="textfield"
@@ -191,9 +190,10 @@ exports[`ChoosePassword render matches snapshot 1`] = `
                       "fontFamily": "Geist Regular",
                       "fontSize": 16,
                       "fontWeight": "400",
-                      "height": 24,
+                      "height": 46,
                       "letterSpacing": 0,
                       "opacity": 1,
+                      "paddingHorizontal": 16,
                       "paddingVertical": 0,
                     }
                   }
@@ -263,7 +263,6 @@ exports[`ChoosePassword render matches snapshot 1`] = `
                   "flexDirection": "row",
                   "height": 48,
                   "opacity": 0.5,
-                  "paddingHorizontal": 16,
                 }
               }
               testID="textfield"
@@ -299,9 +298,10 @@ exports[`ChoosePassword render matches snapshot 1`] = `
                       "fontFamily": "Geist Regular",
                       "fontSize": 16,
                       "fontWeight": "400",
-                      "height": 24,
+                      "height": 46,
                       "letterSpacing": 0,
                       "opacity": 1,
+                      "paddingHorizontal": 16,
                       "paddingVertical": 0,
                     }
                   }

--- a/app/components/Views/EditAccountName/__snapshots__/EditAccountName.test.tsx.snap
+++ b/app/components/Views/EditAccountName/__snapshots__/EditAccountName.test.tsx.snap
@@ -52,7 +52,6 @@ exports[`EditAccountName should render correctly 1`] = `
             "flexDirection": "row",
             "height": 40,
             "opacity": 1,
-            "paddingHorizontal": 16,
           }
         }
         testID="textfield"
@@ -79,9 +78,10 @@ exports[`EditAccountName should render correctly 1`] = `
                 "fontFamily": "Geist Regular",
                 "fontSize": 16,
                 "fontWeight": "400",
-                "height": 24,
+                "height": 38,
                 "letterSpacing": 0,
                 "opacity": 1,
+                "paddingHorizontal": 16,
                 "paddingVertical": 0,
               }
             }
@@ -124,7 +124,6 @@ exports[`EditAccountName should render correctly 1`] = `
             "flexDirection": "row",
             "height": 40,
             "opacity": 0.5,
-            "paddingHorizontal": 16,
           }
         }
         testID="textfield"
@@ -151,9 +150,10 @@ exports[`EditAccountName should render correctly 1`] = `
                 "fontFamily": "Geist Regular",
                 "fontSize": 16,
                 "fontWeight": "400",
-                "height": 24,
+                "height": 38,
                 "letterSpacing": 0,
                 "opacity": 1,
+                "paddingHorizontal": 16,
                 "paddingVertical": 0,
               }
             }

--- a/app/components/Views/EditAccountName/__snapshots__/EditAccountName.test.tsx.snap
+++ b/app/components/Views/EditAccountName/__snapshots__/EditAccountName.test.tsx.snap
@@ -42,6 +42,35 @@ exports[`EditAccountName should render correctly 1`] = `
         Name
       </Text>
       <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           {
             "alignItems": "center",
@@ -52,6 +81,7 @@ exports[`EditAccountName should render correctly 1`] = `
             "flexDirection": "row",
             "height": 40,
             "opacity": 1,
+            "paddingHorizontal": 16,
           }
         }
         testID="textfield"
@@ -81,7 +111,6 @@ exports[`EditAccountName should render correctly 1`] = `
                 "height": 38,
                 "letterSpacing": 0,
                 "opacity": 1,
-                "paddingHorizontal": 16,
                 "paddingVertical": 0,
               }
             }
@@ -114,6 +143,35 @@ exports[`EditAccountName should render correctly 1`] = `
         Address
       </Text>
       <View
+        accessibilityState={
+          {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessibilityValue={
+          {
+            "max": undefined,
+            "min": undefined,
+            "now": undefined,
+            "text": undefined,
+          }
+        }
+        accessible={true}
+        collapsable={false}
+        focusable={true}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
         style={
           {
             "alignItems": "center",
@@ -124,6 +182,7 @@ exports[`EditAccountName should render correctly 1`] = `
             "flexDirection": "row",
             "height": 40,
             "opacity": 0.5,
+            "paddingHorizontal": 16,
           }
         }
         testID="textfield"
@@ -153,7 +212,6 @@ exports[`EditAccountName should render correctly 1`] = `
                 "height": 38,
                 "letterSpacing": 0,
                 "opacity": 1,
-                "paddingHorizontal": 16,
                 "paddingVertical": 0,
               }
             }

--- a/app/components/Views/ImportFromSecretRecoveryPhrase/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ImportFromSecretRecoveryPhrase/__snapshots__/index.test.tsx.snap
@@ -585,6 +585,8 @@ exports[`ImportFromSecretRecoveryPhrase Import a wallet UI render matches snapsh
                                           [
                                             {
                                               "backgroundColor": "inherit",
+                                              "height": 38,
+                                              "paddingHorizontal": 16,
                                             },
                                             {
                                               "flex": 1,

--- a/app/components/Views/ImportFromSecretRecoveryPhrase/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ImportFromSecretRecoveryPhrase/__snapshots__/index.test.tsx.snap
@@ -586,7 +586,6 @@ exports[`ImportFromSecretRecoveryPhrase Import a wallet UI render matches snapsh
                                             {
                                               "backgroundColor": "inherit",
                                               "height": 38,
-                                              "paddingHorizontal": 16,
                                             },
                                             {
                                               "flex": 1,

--- a/app/components/Views/Login/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Login/__snapshots__/index.test.tsx.snap
@@ -171,7 +171,6 @@ exports[`Login renders matching snapshot 1`] = `
                 "flexDirection": "row",
                 "height": 48,
                 "opacity": 1,
-                "paddingHorizontal": 16,
               }
             }
             testID="textfield"
@@ -205,9 +204,10 @@ exports[`Login renders matching snapshot 1`] = `
                     "fontFamily": "Geist Regular",
                     "fontSize": 16,
                     "fontWeight": "400",
-                    "height": 24,
+                    "height": 46,
                     "letterSpacing": 0,
                     "opacity": 1,
+                    "paddingHorizontal": 16,
                     "paddingVertical": 0,
                   }
                 }
@@ -517,7 +517,6 @@ exports[`Login renders matching snapshot when password input is focused 1`] = `
                 "flexDirection": "row",
                 "height": 48,
                 "opacity": 1,
-                "paddingHorizontal": 16,
               }
             }
             testID="textfield"
@@ -551,9 +550,10 @@ exports[`Login renders matching snapshot when password input is focused 1`] = `
                     "fontFamily": "Geist Regular",
                     "fontSize": 16,
                     "fontWeight": "400",
-                    "height": 24,
+                    "height": 46,
                     "letterSpacing": 0,
                     "opacity": 1,
+                    "paddingHorizontal": 16,
                     "paddingVertical": 0,
                   }
                 }

--- a/app/components/Views/Login/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Login/__snapshots__/index.test.tsx.snap
@@ -161,6 +161,35 @@ exports[`Login renders matching snapshot 1`] = `
             Password
           </Text>
           <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               {
                 "alignItems": "center",
@@ -171,6 +200,7 @@ exports[`Login renders matching snapshot 1`] = `
                 "flexDirection": "row",
                 "height": 48,
                 "opacity": 1,
+                "paddingHorizontal": 16,
               }
             }
             testID="textfield"
@@ -207,7 +237,6 @@ exports[`Login renders matching snapshot 1`] = `
                     "height": 46,
                     "letterSpacing": 0,
                     "opacity": 1,
-                    "paddingHorizontal": 16,
                     "paddingVertical": 0,
                   }
                 }
@@ -507,6 +536,35 @@ exports[`Login renders matching snapshot when password input is focused 1`] = `
             Password
           </Text>
           <View
+            accessibilityState={
+              {
+                "busy": undefined,
+                "checked": undefined,
+                "disabled": undefined,
+                "expanded": undefined,
+                "selected": undefined,
+              }
+            }
+            accessibilityValue={
+              {
+                "max": undefined,
+                "min": undefined,
+                "now": undefined,
+                "text": undefined,
+              }
+            }
+            accessible={true}
+            collapsable={false}
+            focusable={true}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
             style={
               {
                 "alignItems": "center",
@@ -517,6 +575,7 @@ exports[`Login renders matching snapshot when password input is focused 1`] = `
                 "flexDirection": "row",
                 "height": 48,
                 "opacity": 1,
+                "paddingHorizontal": 16,
               }
             }
             testID="textfield"
@@ -553,7 +612,6 @@ exports[`Login renders matching snapshot when password input is focused 1`] = `
                     "height": 46,
                     "letterSpacing": 0,
                     "opacity": 1,
-                    "paddingHorizontal": 16,
                     "paddingVertical": 0,
                   }
                 }

--- a/app/components/Views/ResetPassword/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ResetPassword/__snapshots__/index.test.tsx.snap
@@ -123,6 +123,35 @@ exports[`ResetPassword render matches snapshot 1`] = `
                   Enter your current password
                 </Text>
                 <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": undefined,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
                   style={
                     {
                       "alignItems": "center",
@@ -133,6 +162,7 @@ exports[`ResetPassword render matches snapshot 1`] = `
                       "flexDirection": "row",
                       "height": 48,
                       "opacity": 1,
+                      "paddingHorizontal": 16,
                     }
                   }
                   testID="textfield"
@@ -168,7 +198,6 @@ exports[`ResetPassword render matches snapshot 1`] = `
                           "height": 46,
                           "letterSpacing": 0,
                           "opacity": 1,
-                          "paddingHorizontal": 16,
                           "paddingVertical": 0,
                         }
                       }

--- a/app/components/Views/ResetPassword/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ResetPassword/__snapshots__/index.test.tsx.snap
@@ -133,7 +133,6 @@ exports[`ResetPassword render matches snapshot 1`] = `
                       "flexDirection": "row",
                       "height": 48,
                       "opacity": 1,
-                      "paddingHorizontal": 16,
                     }
                   }
                   testID="textfield"
@@ -166,9 +165,10 @@ exports[`ResetPassword render matches snapshot 1`] = `
                           "fontFamily": "Geist Regular",
                           "fontSize": 16,
                           "fontWeight": "400",
-                          "height": 24,
+                          "height": 46,
                           "letterSpacing": 0,
                           "opacity": 1,
+                          "paddingHorizontal": 16,
                           "paddingVertical": 0,
                         }
                       }

--- a/app/components/Views/SrpInput/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/SrpInput/__snapshots__/index.test.tsx.snap
@@ -13,7 +13,6 @@ exports[`SrpInput should render default settings correctly 1`] = `
         "flexDirection": "row",
         "height": 40,
         "opacity": 1,
-        "paddingHorizontal": 16,
       }
     }
     testID="textfield"
@@ -23,6 +22,8 @@ exports[`SrpInput should render default settings correctly 1`] = `
         [
           {
             "backgroundColor": "inherit",
+            "height": 38,
+            "paddingHorizontal": 16,
           },
           {
             "flex": 1,

--- a/app/components/Views/SrpInput/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/SrpInput/__snapshots__/index.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`SrpInput should render default settings correctly 1`] = `
         "flexDirection": "row",
         "height": 40,
         "opacity": 1,
+        "paddingHorizontal": 16,
       }
     }
     testID="textfield"
@@ -23,7 +24,6 @@ exports[`SrpInput should render default settings correctly 1`] = `
           {
             "backgroundColor": "inherit",
             "height": 38,
-            "paddingHorizontal": 16,
           },
           {
             "flex": 1,


### PR DESCRIPTION
## **Description**

Previously there was padding and height specified only in `View` wrapping `TextInput`. That caused `TextInput` to take only very small space inside that View so only very small spaces was clickable. Now input takes same space as actual UI that is visible.

This should improve user experience with every input in the app.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixes hit area of TextField components

## **Related issues**

Fixes:

## **Manual testing steps**

- Click on input anywhere near border and it should still focus and open keyboard

## **Screenshots/Recordings**

### **Before**

<img width="540" height="1200" alt="Screenshot_1756223973" src="https://github.com/user-attachments/assets/f3ff777c-53e4-450a-855b-3107193de755" />


### **After**

<img width="540" height="1200" alt="Screenshot_1756223955" src="https://github.com/user-attachments/assets/1f8952b3-56c1-43dd-b0e1-313f4e2cc4cc" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
