### PR TITLE
fix(reveal-srp): adjust styles for better layout and icon positioning on password input screen

### DIFF
--- a/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
+++ b/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
@@ -612,6 +612,7 @@ const RevealPrivateCredential = ({
           color={colors.error.default}
           name={IconName.EyeSlash}
           size={IconSize.Lg}
+          style={styles.icon}
         />
         {privCredentialName === PRIVATE_KEY ? (
           <Text style={styles.warningMessageText}>
@@ -688,9 +689,7 @@ const RevealPrivateCredential = ({
           {unlocked ? (
             renderTabView(credentialSlug)
           ) : (
-            <View style={[styles.rowWrapper, styles.stretch]}>
-              {renderPasswordEntry()}
-            </View>
+            <View style={styles.rowWrapper}>{renderPasswordEntry()}</View>
           )}
         </View>
       </ActionView>

--- a/app/components/Views/RevealPrivateCredential/__snapshots__/RevealPrivateCredential.test.tsx.snap
+++ b/app/components/Views/RevealPrivateCredential/__snapshots__/RevealPrivateCredential.test.tsx.snap
@@ -88,6 +88,7 @@ exports[`RevealPrivateCredential handles keyring ID parameter correctly 1`] = `
               [
                 {
                   "padding": 20,
+                  "paddingBottom": 0,
                 },
                 {
                   "color": "#121314",
@@ -186,6 +187,7 @@ exports[`RevealPrivateCredential handles keyring ID parameter correctly 1`] = `
                 [
                   {
                     "padding": 20,
+                    "paddingBottom": 0,
                   },
                   {
                     "backgroundColor": "#ca35421a",
@@ -194,6 +196,7 @@ exports[`RevealPrivateCredential handles keyring ID parameter correctly 1`] = `
                     "borderWidth": 1,
                     "marginTop": 16,
                     "padding": 20,
+                    "paddingBottom": 20,
                   },
                 ]
               }
@@ -202,7 +205,7 @@ exports[`RevealPrivateCredential handles keyring ID parameter correctly 1`] = `
                 style={
                   [
                     {
-                      "alignItems": "center",
+                      "alignItems": "flex-start",
                       "flexDirection": "row",
                       "flexShrink": 1,
                       "width": "100%",
@@ -217,7 +220,10 @@ exports[`RevealPrivateCredential handles keyring ID parameter correctly 1`] = `
                   name="EyeSlash"
                   style={
                     {
+                      "color": "#ca3542",
                       "height": 24,
+                      "marginTop": 3,
+                      "position": "relative",
                       "width": 24,
                     }
                   }
@@ -233,7 +239,7 @@ exports[`RevealPrivateCredential handles keyring ID parameter correctly 1`] = `
                       "fontWeight": "400",
                       "letterSpacing": 0,
                       "lineHeight": 24,
-                      "marginLeft": 10,
+                      "marginLeft": 20,
                       "marginRight": 40,
                     }
                   }
@@ -260,14 +266,10 @@ exports[`RevealPrivateCredential handles keyring ID parameter correctly 1`] = `
           </View>
           <View
             style={
-              [
-                {
-                  "padding": 20,
-                },
-                {
-                  "flex": 1,
-                },
-              ]
+              {
+                "padding": 20,
+                "paddingBottom": 0,
+              }
             }
           >
             <Text
@@ -470,6 +472,7 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
               [
                 {
                   "padding": 20,
+                  "paddingBottom": 0,
                 },
                 {
                   "color": "#121314",
@@ -568,6 +571,7 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
                 [
                   {
                     "padding": 20,
+                    "paddingBottom": 0,
                   },
                   {
                     "backgroundColor": "#ca35421a",
@@ -576,6 +580,7 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
                     "borderWidth": 1,
                     "marginTop": 16,
                     "padding": 20,
+                    "paddingBottom": 20,
                   },
                 ]
               }
@@ -584,7 +589,7 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
                 style={
                   [
                     {
-                      "alignItems": "center",
+                      "alignItems": "flex-start",
                       "flexDirection": "row",
                       "flexShrink": 1,
                       "width": "100%",
@@ -599,7 +604,10 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
                   name="EyeSlash"
                   style={
                     {
+                      "color": "#ca3542",
                       "height": 24,
+                      "marginTop": 3,
+                      "position": "relative",
                       "width": 24,
                     }
                   }
@@ -615,7 +623,7 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
                       "fontWeight": "400",
                       "letterSpacing": 0,
                       "lineHeight": 24,
-                      "marginLeft": 10,
+                      "marginLeft": 20,
                       "marginRight": 40,
                     }
                   }
@@ -642,14 +650,10 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
           </View>
           <View
             style={
-              [
-                {
-                  "padding": 20,
-                },
-                {
-                  "flex": 1,
-                },
-              ]
+              {
+                "padding": 20,
+                "paddingBottom": 0,
+              }
             }
           >
             <Text
@@ -852,6 +856,7 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
               [
                 {
                   "padding": 20,
+                  "paddingBottom": 0,
                 },
                 {
                   "color": "#121314",
@@ -950,6 +955,7 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
                 [
                   {
                     "padding": 20,
+                    "paddingBottom": 0,
                   },
                   {
                     "backgroundColor": "#ca35421a",
@@ -958,6 +964,7 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
                     "borderWidth": 1,
                     "marginTop": 16,
                     "padding": 20,
+                    "paddingBottom": 20,
                   },
                 ]
               }
@@ -966,7 +973,7 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
                 style={
                   [
                     {
-                      "alignItems": "center",
+                      "alignItems": "flex-start",
                       "flexDirection": "row",
                       "flexShrink": 1,
                       "width": "100%",
@@ -981,7 +988,10 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
                   name="EyeSlash"
                   style={
                     {
+                      "color": "#ca3542",
                       "height": 24,
+                      "marginTop": 3,
+                      "position": "relative",
                       "width": 24,
                     }
                   }
@@ -997,7 +1007,7 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
                       "fontWeight": "400",
                       "letterSpacing": 0,
                       "lineHeight": 24,
-                      "marginLeft": 10,
+                      "marginLeft": 20,
                       "marginRight": 40,
                     }
                   }
@@ -1024,14 +1034,10 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
           </View>
           <View
             style={
-              [
-                {
-                  "padding": 20,
-                },
-                {
-                  "flex": 1,
-                },
-              ]
+              {
+                "padding": 20,
+                "paddingBottom": 0,
+              }
             }
           >
             <Text
@@ -1234,6 +1240,7 @@ exports[`RevealPrivateCredential renders reveal private key correctly 1`] = `
               [
                 {
                   "padding": 20,
+                  "paddingBottom": 0,
                 },
                 {
                   "color": "#121314",
@@ -1618,14 +1625,10 @@ exports[`RevealPrivateCredential renders reveal private key correctly 1`] = `
           </View>
           <View
             style={
-              [
-                {
-                  "padding": 20,
-                },
-                {
-                  "flex": 1,
-                },
-              ]
+              {
+                "padding": 20,
+                "paddingBottom": 0,
+              }
             }
           >
             <Text
@@ -1828,6 +1831,7 @@ exports[`RevealPrivateCredential renders with a custom selectedAddress 1`] = `
               [
                 {
                   "padding": 20,
+                  "paddingBottom": 0,
                 },
                 {
                   "color": "#121314",
@@ -2212,14 +2216,10 @@ exports[`RevealPrivateCredential renders with a custom selectedAddress 1`] = `
           </View>
           <View
             style={
-              [
-                {
-                  "padding": 20,
-                },
-                {
-                  "flex": 1,
-                },
-              ]
+              {
+                "padding": 20,
+                "paddingBottom": 0,
+              }
             }
           >
             <Text

--- a/app/components/Views/RevealPrivateCredential/styles.ts
+++ b/app/components/Views/RevealPrivateCredential/styles.ts
@@ -44,6 +44,7 @@ export const createStyles = (theme: Theme) =>
     },
     rowWrapper: {
       padding: 20,
+      paddingBottom: 0,
     },
     tabContentContainer: {
       minHeight: Platform.OS === 'android' ? 320 : 0,
@@ -58,11 +59,12 @@ export const createStyles = (theme: Theme) =>
       borderWidth: 1,
       borderColor: theme.colors.error.default,
       marginTop: 16,
+      paddingBottom: 20,
     },
     warningRowWrapper: {
       flexDirection: 'row',
       flexShrink: 1,
-      alignItems: 'center',
+      alignItems: 'flex-start',
       width: '100%',
     },
     warningText: {
@@ -79,6 +81,8 @@ export const createStyles = (theme: Theme) =>
     },
     icon: {
       color: theme.colors.error.default,
+      position: 'relative',
+      marginTop: 3,
     },
     blueText: {
       color: theme.colors.primary.default,
@@ -87,7 +91,7 @@ export const createStyles = (theme: Theme) =>
       top: 2.5,
     },
     warningMessageText: {
-      marginLeft: 10,
+      marginLeft: 20,
       marginRight: 40,
       ...fontStyles.normal,
       color: theme.colors.text.default,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR fixes layout issues in import srp flow.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updates layout on password input view in reveal srp flow

## **Related issues**

Fixes:
Jira bug ticket: https://consensyssoftware.atlassian.net/browse/MUL-348
## **Manual testing steps**

```gherkin
Feature: SRP Password Entry UI Alignment

  Scenario: user attempts to reveal SRP
    Given the user has opened MetaMask mobile app
    When the user navigates to Account Details
    And goes through the reveal SRP process
    Then in the last screen before reveal should see the warning box with password input correctly aligned
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="391" height="826" alt="Screenshot 2025-08-27 at 14 42 10" src="https://github.com/user-attachments/assets/f13b5d9d-f48a-4f4b-b43c-0ee7b0209c7c" />

<!-- [screenshots/recordings] -->

### **After**
<img width="384" height="828" alt="Screenshot 2025-08-27 at 14 40 46" src="https://github.com/user-attachments/assets/e33f7c8e-b26a-4465-ae94-37a6bea0c3f2" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
