### PR TITLE
feat: support selected currency in perps deposit

### DIFF
--- a/.js.env.example
+++ b/.js.env.example
@@ -159,9 +159,6 @@ export MM_SEND_REDESIGN_ENABLED="true"
 # Preinstalled Snaps
 export FORCE_PREINSTALLED_SNAPS="false"
 
-# Enable payment token selection in transaction confirmation
-export MM_CONFIRMATION_INTENTS="true"
-
 # Enable multichain accounts (BIP-44 project)
 export MM_ENABLE_MULTICHAIN_ACCOUNTS_STATE_2="false"
 

--- a/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.test.tsx
+++ b/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.test.tsx
@@ -1,21 +1,31 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react-native';
-import { DepositKeyboard } from './deposit-keyboard';
-import { noop } from 'lodash';
+import { fireEvent } from '@testing-library/react-native';
+import { DepositKeyboard, DepositKeyboardProps } from './deposit-keyboard';
+import { merge, noop } from 'lodash';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import { otherControllersMock } from '../../__mocks__/controllers/other-controllers-mock';
+
+function render(props: Partial<DepositKeyboardProps> = {}) {
+  return renderWithProvider(
+    <DepositKeyboard
+      onChange={noop}
+      onDonePress={noop}
+      onPercentagePress={noop}
+      value="0"
+      hasInput={false}
+      {...props}
+    />,
+    {
+      state: merge({}, otherControllersMock),
+    },
+  );
+}
 
 describe('DepositKeyboard', () => {
   it('calls onChange when digit pressed', () => {
     const onChangeMock = jest.fn();
 
-    const { getByText } = render(
-      <DepositKeyboard
-        onChange={onChangeMock}
-        onDonePress={noop}
-        onPercentagePress={noop}
-        value="0"
-        hasInput={false}
-      />,
-    );
+    const { getByText } = render({ onChange: onChangeMock });
 
     fireEvent.press(getByText('1'));
 
@@ -23,29 +33,12 @@ describe('DepositKeyboard', () => {
   });
 
   it('hides done button if hasInput is false', () => {
-    const { queryByTestId } = render(
-      <DepositKeyboard
-        onChange={noop}
-        onDonePress={noop}
-        onPercentagePress={noop}
-        value="0"
-        hasInput={false}
-      />,
-    );
-
+    const { queryByTestId } = render();
     expect(queryByTestId('deposit-keyboard-done-button')).toBeNull();
   });
 
   it('shows done button if hasInput', () => {
-    const { getByTestId, getByText } = render(
-      <DepositKeyboard
-        onChange={noop}
-        onDonePress={noop}
-        onPercentagePress={noop}
-        value="0"
-        hasInput
-      />,
-    );
+    const { getByTestId, getByText } = render({ hasInput: true });
 
     fireEvent.press(getByText('1'));
 
@@ -55,15 +48,10 @@ describe('DepositKeyboard', () => {
   it('calls onDone when done button pressed', () => {
     const onDonePressMock = jest.fn();
 
-    const { getByTestId } = render(
-      <DepositKeyboard
-        onChange={noop}
-        onDonePress={onDonePressMock}
-        onPercentagePress={noop}
-        value="0"
-        hasInput
-      />,
-    );
+    const { getByTestId } = render({
+      hasInput: true,
+      onDonePress: onDonePressMock,
+    });
 
     fireEvent.press(getByTestId('deposit-keyboard-done-button'));
 
@@ -73,15 +61,7 @@ describe('DepositKeyboard', () => {
   it('calls onPercentagePress when percentage button pressed', () => {
     const onPercentagePressMock = jest.fn();
 
-    const { getByText } = render(
-      <DepositKeyboard
-        onChange={noop}
-        onDonePress={noop}
-        onPercentagePress={onPercentagePressMock}
-        value="0"
-        hasInput={false}
-      />,
-    );
+    const { getByText } = render({ onPercentagePress: onPercentagePressMock });
 
     fireEvent.press(getByText('50%'));
 

--- a/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.tsx
+++ b/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.tsx
@@ -9,6 +9,8 @@ import { Box } from '../../../../UI/Box/Box';
 import { FlexDirection, JustifyContent } from '../../../../UI/Box/box.types';
 import { strings } from '../../../../../../locales/i18n';
 import { View } from 'react-native';
+import { useSelector } from 'react-redux';
+import { selectCurrentCurrency } from '../../../../../selectors/currencyRateController';
 
 const PERCENTAGE_BUTTONS = [
   {
@@ -44,6 +46,7 @@ export function DepositKeyboard({
   onPercentagePress,
   value,
 }: DepositKeyboardProps) {
+  const currentCurrency = useSelector(selectCurrentCurrency);
   const { styles } = useStyles(styleSheet, {});
 
   const valueString = value.toString();
@@ -93,7 +96,8 @@ export function DepositKeyboard({
       <KeypadComponent
         value={valueString}
         onChange={handleChange}
-        currency="native"
+        currency={currentCurrency}
+        decimals={2}
       />
     </View>
   );

--- a/app/components/Views/confirmations/components/edit-amount/edit-amount.styles.ts
+++ b/app/components/Views/confirmations/components/edit-amount/edit-amount.styles.ts
@@ -1,7 +1,17 @@
 import { StyleSheet } from 'react-native';
 import { Theme } from '../../../../../util/theme/models';
 
-const styleSheet = (params: { theme: Theme; vars: { hasAlert: boolean } }) =>
+function getFontSize(length: number) {
+  if (length <= 8) return 64;
+  if (length <= 13) return 40;
+  if (length <= 18) return 30;
+  return 20;
+}
+
+const styleSheet = (params: {
+  theme: Theme;
+  vars: { amountLength: number; hasAlert: boolean };
+}) =>
   StyleSheet.create({
     container: {
       display: 'flex',
@@ -14,14 +24,21 @@ const styleSheet = (params: { theme: Theme; vars: { hasAlert: boolean } }) =>
       display: 'flex',
       flexDirection: 'column',
     },
+    inputContainer: {
+      display: 'flex',
+      flexDirection: 'row',
+      justifyContent: 'center',
+      alignItems: 'center',
+      paddingBottom: 16,
+      minHeight: 100,
+    },
     input: {
       textAlign: 'center',
-      fontSize: 64,
+      fontSize: getFontSize(params.vars.amountLength),
       fontWeight: '500',
       color: params.vars.hasAlert
         ? params.theme.colors.error.default
         : params.theme.colors.text.default,
-      marginBottom: 16,
     },
   });
 

--- a/app/components/Views/confirmations/constants/confirmations.ts
+++ b/app/components/Views/confirmations/constants/confirmations.ts
@@ -48,7 +48,7 @@ export const REDESIGNED_CONTRACT_INTERACTION_TYPES = [
 ];
 
 export const FULL_SCREEN_CONFIRMATIONS = [
-  'perpsDeposit',
+  TransactionType.perpsDeposit,
   TransactionType.simpleSend,
   TransactionType.stakingClaim,
   TransactionType.stakingDeposit,

--- a/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.tsx
+++ b/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.tsx
@@ -15,8 +15,6 @@ import { usePerpsDepositView } from '../../hooks/usePerpsDepositView';
 import { GasFeeFiatRow } from '../../../../components/rows/transactions/gas-fee-fiat-row';
 import useClearConfirmationOnBackSwipe from '../../../../hooks/ui/useClearConfirmationOnBackSwipe';
 
-const AMOUNT_PREFIX = '$';
-
 export function PerpsDeposit() {
   const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
   const [inputChanged, setInputChanged] = useState(false);
@@ -31,7 +29,6 @@ export function PerpsDeposit() {
   return (
     <>
       <EditAmount
-        prefix={AMOUNT_PREFIX}
         autoKeyboard
         onKeyboardShow={() => setIsKeyboardVisible(true)}
         onKeyboardHide={() => setIsKeyboardVisible(false)}

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.test.ts
@@ -6,15 +6,25 @@ import { AlertKeys } from '../../constants/alerts';
 import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
 import { Severity } from '../../types/alerts';
 import { strings } from '../../../../../../locales/i18n';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
 
 jest.mock('../pay/useTransactionPayToken');
 jest.mock('../pay/useTransactionPayTokenAmounts');
+jest.mock('../transactions/useTransactionMetadataRequest');
 
 function runHook() {
   return renderHook(() => useInsufficientPayTokenBalanceAlert());
 }
 
 describe('useInsufficientPayTokenBalance', () => {
+  const useTransactionMetadataRequestMock = jest.mocked(
+    useTransactionMetadataRequest,
+  );
+
   const useTransactionPayTokenAmountsMock = jest.mocked(
     useTransactionPayTokenAmounts,
   );
@@ -23,6 +33,10 @@ describe('useInsufficientPayTokenBalance', () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
+
+    useTransactionMetadataRequestMock.mockReturnValue({
+      type: TransactionType.perpsDeposit,
+    } as TransactionMeta);
   });
 
   it('returns alert if balance less than total', () => {
@@ -59,5 +73,23 @@ describe('useInsufficientPayTokenBalance', () => {
     const { result } = runHook();
 
     expect(result.current).toEqual([]);
+  });
+
+  it('returns no alert if type is not perps deposit', () => {
+    useTransactionMetadataRequestMock.mockReturnValue({
+      type: TransactionType.contractInteraction,
+    } as TransactionMeta);
+
+    useTransactionPayTokenAmountsMock.mockReturnValue({
+      totalHuman: '123.456',
+    } as ReturnType<typeof useTransactionPayTokenAmounts>);
+
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: { balance: '123.455' },
+    } as ReturnType<typeof useTransactionPayToken>);
+
+    const { result } = runHook();
+
+    expect(result.current).toStrictEqual([]);
   });
 });

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
@@ -6,8 +6,11 @@ import { AlertKeys } from '../../constants/alerts';
 import { BigNumber } from 'bignumber.js';
 import { useTransactionPayTokenAmounts } from '../pay/useTransactionPayTokenAmounts';
 import { strings } from '../../../../../../locales/i18n';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { TransactionType } from '@metamask/transaction-controller';
 
 export function useInsufficientPayTokenBalanceAlert(): Alert[] {
+  const { type } = useTransactionMetadataRequest() ?? {};
   const { totalHuman } = useTransactionPayTokenAmounts();
   const { payToken } = useTransactionPayToken();
   const { balance } = payToken ?? {};
@@ -15,7 +18,7 @@ export function useInsufficientPayTokenBalanceAlert(): Alert[] {
   const isInsufficient =
     new BigNumber(balance ?? '0').isLessThan(
       new BigNumber(totalHuman ?? '0'),
-    ) && process.env.MM_CONFIRMATION_INTENTS === 'true';
+    ) && type === TransactionType.perpsDeposit;
 
   return useMemo(() => {
     if (!isInsufficient) {

--- a/app/components/Views/confirmations/hooks/alerts/usePerpsDepositMinimumAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/usePerpsDepositMinimumAlert.test.ts
@@ -5,18 +5,32 @@ import { AlertKeys } from '../../constants/alerts';
 import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
 import { Severity } from '../../types/alerts';
 import { strings } from '../../../../../../locales/i18n';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
 
 jest.mock('../useTokenAmount');
+jest.mock('../transactions/useTransactionMetadataRequest');
 
 function runHook() {
   return renderHook(() => usePerpsDepositMinimumAlert());
 }
 
 describe('usePerpsDepositMinimumAlert', () => {
+  const useTransactionMetadataRequestMock = jest.mocked(
+    useTransactionMetadataRequest,
+  );
+
   const useTokenAmountMock = jest.mocked(useTokenAmount);
 
   beforeEach(() => {
     jest.resetAllMocks();
+
+    useTransactionMetadataRequestMock.mockReturnValue({
+      type: TransactionType.perpsDeposit,
+    } as TransactionMeta);
   });
 
   it('returns alert if token amount less than minimum', () => {
@@ -40,6 +54,20 @@ describe('usePerpsDepositMinimumAlert', () => {
   it('returns no alert if token amount greater than minimum', () => {
     useTokenAmountMock.mockReturnValue({
       amountUnformatted: '10.01',
+    } as ReturnType<typeof useTokenAmount>);
+
+    const { result } = runHook();
+
+    expect(result.current).toStrictEqual([]);
+  });
+
+  it('returns no alert if type not perps deposit', () => {
+    useTransactionMetadataRequestMock.mockReturnValue({
+      type: TransactionType.contractInteraction,
+    } as TransactionMeta);
+
+    useTokenAmountMock.mockReturnValue({
+      amountUnformatted: '9.99',
     } as ReturnType<typeof useTokenAmount>);
 
     const { result } = runHook();

--- a/app/components/Views/confirmations/hooks/alerts/usePerpsDepositMinimumAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/usePerpsDepositMinimumAlert.ts
@@ -5,15 +5,18 @@ import { Alert, Severity } from '../../types/alerts';
 import { BigNumber } from 'bignumber.js';
 import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
 import { strings } from '../../../../../../locales/i18n';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { TransactionType } from '@metamask/transaction-controller';
 
 export const MINIMUM_DEPOSIT_USD = 10;
 
 export function usePerpsDepositMinimumAlert(): Alert[] {
+  const { type } = useTransactionMetadataRequest() ?? {};
   const { amountUnformatted } = useTokenAmount();
 
   const underMinimum =
     new BigNumber(amountUnformatted ?? '0').isLessThan(MINIMUM_DEPOSIT_USD) &&
-    process.env.MM_CONFIRMATION_INTENTS === 'true';
+    type === TransactionType.perpsDeposit;
 
   return useMemo(() => {
     if (!underMinimum) {

--- a/app/components/Views/confirmations/hooks/alerts/useSignedOrSubmittedAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useSignedOrSubmittedAlert.ts
@@ -16,12 +16,22 @@ const blockableStatuses = [
 export const useSignedOrSubmittedAlert = () => {
   const transactions = useSelector(selectTransactions);
   const transactionMetadata = useTransactionMetadataRequest();
+  const { chainId, id: transactionId, txParams } = transactionMetadata || {};
+  const { from } = txParams ?? {};
+
+  const showAlert = useMemo(
+    () =>
+      transactions.some(
+        (transaction) =>
+          blockableStatuses.includes(transaction.status) &&
+          transaction.id !== transactionId &&
+          transaction.chainId === chainId &&
+          transaction.txParams.from.toLowerCase() === from?.toLowerCase(),
+      ),
+    [transactions, transactionId, chainId, from],
+  );
 
   return useMemo(() => {
-    const showAlert = transactions
-      .filter((transaction) => transaction.id !== transactionMetadata?.id)
-      .some((transaction) => blockableStatuses.includes(transaction.status));
-
     if (!showAlert) {
       return [];
     }
@@ -34,5 +44,5 @@ export const useSignedOrSubmittedAlert = () => {
         severity: Severity.Danger,
       },
     ];
-  }, [transactions, transactionMetadata]);
+  }, [showAlert]);
 };

--- a/app/components/Views/confirmations/hooks/tokens/useTokenFiatRates.ts
+++ b/app/components/Views/confirmations/hooks/tokens/useTokenFiatRates.ts
@@ -15,10 +15,11 @@ export function useTokenFiatRates(requests: TokenFiatRateRequest[]) {
   const tokenMarketDataByAddressByChainId = useSelector(selectTokenMarketData);
   const currencyRates = useSelector(selectCurrencyRates);
   const networkConfigurations = useSelector(selectNetworkConfigurations);
+  const safeRequests = useDeepMemo(() => requests, [requests]);
 
   const result = useMemo(
     () =>
-      requests.map(({ address, chainId }) => {
+      safeRequests.map(({ address, chainId }) => {
         const chainTokens = Object.values(
           tokenMarketDataByAddressByChainId[chainId] ?? {},
         );
@@ -39,7 +40,7 @@ export function useTokenFiatRates(requests: TokenFiatRateRequest[]) {
         return (token?.price ?? 1) * conversionRate;
       }),
     [
-      requests,
+      safeRequests,
       tokenMarketDataByAddressByChainId,
       currencyRates,
       networkConfigurations,
@@ -47,4 +48,9 @@ export function useTokenFiatRates(requests: TokenFiatRateRequest[]) {
   );
 
   return useDeepMemo(() => result, [result]);
+}
+
+export function useTokenFiatRate(tokenAddress: Hex, chainId: Hex) {
+  const rates = useTokenFiatRates([{ address: tokenAddress, chainId }]);
+  return rates[0];
 }

--- a/app/components/Views/confirmations/hooks/useTokenAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/useTokenAmount.test.ts
@@ -430,4 +430,14 @@ describe('Edge cases', () => {
       expect(result.current.amountUnformatted).toBe('0.0001');
     });
   });
+
+  it('returns unformatted fiat amount', async () => {
+    const { result } = renderHookWithProvider(() => useTokenAmount(), {
+      state: transferConfirmationState,
+    });
+
+    await waitFor(() => {
+      expect(result.current.fiatUnformatted).toBe('0.359625');
+    });
+  });
 });

--- a/app/components/Views/confirmations/hooks/useTokenAmount.ts
+++ b/app/components/Views/confirmations/hooks/useTokenAmount.ts
@@ -46,6 +46,7 @@ interface TokenAmount {
   amountPrecise: string | undefined;
   amountUnformatted: string | undefined;
   fiat: string | undefined;
+  fiatUnformatted: string | undefined;
   isNative: boolean | undefined;
   updateTokenAmount: (amount: string) => void;
   usdValue: string | null;
@@ -124,7 +125,10 @@ export const useTokenAmount = ({
 
   const updateTokenAmount = useCallback(
     (amount: string) => {
-      const amountRaw = calcTokenValue(amount, decimals);
+      const amountRaw = calcTokenValue(amount, decimals).decimalPlaces(
+        0,
+        BigNumber.ROUND_UP,
+      );
 
       const newData = generateTransferData('transfer', {
         toAddress: recipient,
@@ -146,6 +150,7 @@ export const useTokenAmount = ({
       amountPrecise: undefined,
       amountUnformatted: undefined,
       fiat: undefined,
+      fiatUnformatted: undefined,
       isNative: undefined,
       usdValue: null,
       updateTokenAmount,
@@ -208,6 +213,7 @@ export const useTokenAmount = ({
     amountPrecise: formatAmountMaxPrecision(I18n.locale, amount),
     amountUnformatted: amount.toString(),
     fiat: fiat !== undefined ? fiatFormatter(fiat) : undefined,
+    fiatUnformatted: fiat !== undefined ? fiat.toString(10) : undefined,
     isNative,
     updateTokenAmount,
     usdValue,

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,6 @@ process.env.MM_FOX_CODE = 'EXAMPLE_FOX_CODE';
 process.env.MM_SECURITY_ALERTS_API_ENABLED = 'true';
 process.env.PORTFOLIO_VIEW = 'true';
 process.env.SECURITY_ALERTS_API_URL = 'https://example.com';
-process.env.MM_CONFIRMATION_INTENTS = 'true';
 
 process.env.LAUNCH_DARKLY_URL =
   'https://client-config.dev-api.cx.metamask.io/v1';


### PR DESCRIPTION
## **Description**

Specify the deposit amount in the selected fiat currency in the Perps Deposit confirmation.

In addition:

- Limit maximum number of decimal places to `2`.
- Limit maximum length of input to `28`.
- Automatically update font size based on input length.
- Fix `useSignedOrSubmittedAlert` to only flag transactions on same chain and account.
- Remove `MM_CONFIRMATION_INTENTS` environment variable.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#5640](https://github.com/MetaMask/MetaMask-planning/issues/5640) [#5629](https://github.com/MetaMask/MetaMask-planning/issues/5629)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
