### PR TITLE
INFRA-2867: Added chore prefix to PR, await for create release, remove commits.csv from changelog pr, add workflow artifact

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -23,7 +23,7 @@ jobs:
 
   create-release-pr:
     needs: generate-build-version
-    uses: MetaMask/github-tools/.github/workflows/create-release-pr.yml@d15d78647c5493e12cc55717504fbf10aabd05a9
+    uses: MetaMask/github-tools/.github/workflows/create-release-pr.yml@03eade10be5004a31416f47faa5e5d7102c53ffe
     with:
       platform: mobile
       checkout-base-branch: ${{ inputs.checkout-base-branch }}
@@ -31,7 +31,7 @@ jobs:
       semver-version: ${{ inputs.semver-version }}
       previous-version-ref: ${{ inputs.previous-version-ref }}
       mobile-build-version: ${{ needs.generate-build-version.outputs.build-version }}
-      github-tools-version: d15d78647c5493e12cc55717504fbf10aabd05a9
+      github-tools-version: 03eade10be5004a31416f47faa5e5d7102c53ffe
 
     secrets:
       # This token needs read permissions to metamask-planning & write permissions to metamask-mobile


### PR DESCRIPTION


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Ticket: https://consensyssoftware.atlassian.net/browse/INFRA-2867
Added chore prefix to PR, await for create release, remove commits.csv from changelog pr, add commits.csv to workflow artifacts

The Github Action doesn’t inform us when [createReleaseSheet](https://github.com/MetaMask/github-tools/blob/dde6d530bebae07d1e50180894ab2cac64170a2c/.github/scripts/update-release-sheet.mjs#L313) succeeds or fails, we should add an ‘await’ in front of it.

The changelog PR shall not include ‘commits.csv’ as we have here: [MetaMask/metamask-extension@](https://github.com/MetaMask/metamask-extension/commit/e6be418e07eb04d47ce7dd07432a2136382f1180#r2254840331)https://github.com/MetaMask/metamask-extension/commit/e6be418e07eb04d47ce7dd07432a2136382f1180[#r2254840331](https://github.com/MetaMask/metamask-extension/commit/e6be418e07eb04d47ce7dd07432a2136382f1180#r2254840331)

The title of the version bump PR created by the Github Action doesn’t respect conventional commits format, which makes the CI fail. It should be prefixed with release: .
Tested here: https://github.com/consensys-test/metamask-extension-test-workflow2/actions/runs/17270524861/job/49013733053, https://github.com/consensys-test/metamask-extension-test-workflow2/actions/runs/17272422001
https://github.com/consensys-test/metamask-extension-test-workflow2/pull/28 (No commits.csv)
https://github.com/consensys-test/metamask-extension-test-workflow2/pull/32 (Added release prefix)
https://github.com/consensys-test/metamask-extension-test-workflow2/actions/runs/17272422001 (commits.csv workflow artifact)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
