### PR TITLE
chore: Update PerpsPositionCard to include Funding cost

### DIFF
--- a/app/components/UI/Perps/components/PerpsOpenOrderCard/PerpsOpenOrderCard.test.tsx
+++ b/app/components/UI/Perps/components/PerpsOpenOrderCard/PerpsOpenOrderCard.test.tsx
@@ -242,7 +242,7 @@ describe('PerpsOpenOrderCard', () => {
       render(<PerpsOpenOrderCard order={orderWithoutTP} expanded />);
 
       // Should find "not set" text in the component
-      expect(screen.getByText('Not Set')).toBeOnTheScreen();
+      expect(screen.getByText('Not set')).toBeOnTheScreen();
     });
 
     it('handles missing stop loss price', () => {
@@ -254,7 +254,7 @@ describe('PerpsOpenOrderCard', () => {
       render(<PerpsOpenOrderCard order={orderWithoutSL} expanded />);
 
       // Should find "not set" text in the component
-      expect(screen.getByText('Not Set')).toBeOnTheScreen();
+      expect(screen.getByText('Not set')).toBeOnTheScreen();
     });
 
     it('handles zero original size for fill percentage calculation', () => {

--- a/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.test.tsx
+++ b/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.test.tsx
@@ -200,7 +200,7 @@ describe('PerpsPositionCard', () => {
       ).toBeOnTheScreen();
       expect(screen.getByText('$2,000.00')).toBeOnTheScreen();
       expect(
-        screen.getByText('perps.position.card.market_price'),
+        screen.getByText('perps.position.card.funding_cost'),
       ).toBeOnTheScreen();
       expect(
         screen.getByText('perps.position.card.liquidation_price'),
@@ -491,7 +491,7 @@ describe('PerpsPositionCard', () => {
       // Assert - Check that all 6 body items are present
       const bodyLabels = [
         'perps.position.card.entry_price',
-        'perps.position.card.market_price',
+        'perps.position.card.funding_cost',
         'perps.position.card.liquidation_price',
         'perps.position.card.take_profit',
         'perps.position.card.stop_loss',

--- a/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
+++ b/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
@@ -52,8 +52,6 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
   const { styles } = useStyles(styleSheet, {});
   const navigation = useNavigation<NavigationProp<PerpsNavigationParamList>>();
 
-  // Note: Live price subscriptions removed as we're now showing funding cost instead of market price
-
   const [isTPSLVisible, setIsTPSLVisible] = useState(false);
   const [isClosePositionVisible, setIsClosePositionVisible] = useState(false);
   const [selectedPosition, setSelectedPosition] = useState<Position | null>(

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1154,15 +1154,15 @@
     "position": {
       "title": "Positions",
       "card": {
-        "entry_price": "Entry Price",
-        "market_price": "Market Price",
-        "liquidation_price": "Liquidation Price",
-        "take_profit": "Take Profit",
-        "stop_loss": "Stop Loss",
+        "entry_price": "Entry price",
+        "funding_cost": "Funding cost",
+        "liquidation_price": "Liq. Price",
+        "take_profit": "Take profit",
+        "stop_loss": "Stop loss",
         "margin": "Margin",
-        "not_set": "Not Set",
+        "not_set": "Not set",
         "edit_tpsl": "Edit TP/SL",
-        "close_position": "Close Position"
+        "close_position": "Close position"
       },
       "list": {
         "loading": "Loading positions...",


### PR DESCRIPTION
## **Description**

Market price should get replaced by funding cost in the PerpsPositionDetailCard component:

## **Changelog**

CHANGELOG entry: Remove market price, and replace with funding cost in PerpsPositionDetail card

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1352

## **Manual testing steps**

```gherkin
Feature: Funding cost

  Scenario: As a user I want to see the funding cost of my Perps position
    Given I have a position with a funding cost

    When user opens the perps position details page
    Then I should see the Funding cost in the position details card
```

## **Screenshots/Recordings**

<img width="423" height="410" alt="Screenshot 2025-08-27 at 4 18 31 PM" src="https://github.com/user-attachments/assets/99fdb34f-be64-4072-ab43-bd4b6679e0f2" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
