### PR TITLE
fix: Fix network selector double press issue

### DIFF
--- a/app/component-library/components/List/ListItemMultiSelect/ListItemMultiSelect.tsx
+++ b/app/component-library/components/List/ListItemMultiSelect/ListItemMultiSelect.tsx
@@ -102,11 +102,7 @@ const ListItemMultiSelect: React.FC<ListItemMultiSelectProps> = ({
   // For custom TouchableOpacity (Android), pass original onPress and let it handle disabled state internally
   // For standard TouchableOpacity, apply conditional logic to prevent disabled interaction
   const conditionalOnPress =
-    TouchableComponent === TouchableOpacity
-      ? onPress
-      : isDisabled
-      ? undefined
-      : onPress;
+    TouchableComponent !== TouchableOpacity && isDisabled ? undefined : onPress;
 
   return (
     <TouchableComponent
@@ -120,11 +116,7 @@ const ListItemMultiSelect: React.FC<ListItemMultiSelectProps> = ({
           style={styles.checkbox}
           isChecked={isSelected}
           onPressIn={
-            Platform.OS === 'android'
-              ? undefined
-              : isDisabled
-              ? undefined
-              : onPress
+            Platform.OS === 'android' || isDisabled ? undefined : onPress
           }
         />
         {children}

--- a/app/component-library/components/List/ListItemMultiSelect/ListItemMultiSelect.tsx
+++ b/app/component-library/components/List/ListItemMultiSelect/ListItemMultiSelect.tsx
@@ -55,9 +55,10 @@ const TouchableOpacity = ({
       }
     });
 
-  // Preserve onPress for accessibility (screen readers, keyboard navigation)
-  // but ensure it respects disabled state
-  const accessibleOnPress = isDisabled ? undefined : onPress;
+  // When using gesture detector, don't pass onPress to RNTouchableOpacity
+  // to prevent double event firing. The gesture detector handles the press events.
+  // Only preserve onPress for accessibility when the gesture detector isn't handling it.
+  const accessibleOnPress = undefined; // Gesture detector handles all press events
 
   return (
     <GestureDetector gesture={tap}>

--- a/app/component-library/components/List/ListItemMultiSelect/ListItemMultiSelect.tsx
+++ b/app/component-library/components/List/ListItemMultiSelect/ListItemMultiSelect.tsx
@@ -67,6 +67,8 @@ const TouchableOpacity = ({
         {...props}
         // Ensure disabled prop is available to tests
         {...(process.env.NODE_ENV === 'test' && { disabled: isDisabled })}
+        accessibilityRole="button"
+        accessible
       >
         {children}
       </RNTouchableOpacity>

--- a/app/component-library/components/List/ListItemSelect/ListItemSelect.tsx
+++ b/app/component-library/components/List/ListItemSelect/ListItemSelect.tsx
@@ -54,9 +54,10 @@ const TouchableOpacity = ({
       }
     });
 
-  // Preserve onPress for accessibility (screen readers, keyboard navigation)
-  // but ensure it respects disabled state
-  const accessibleOnPress = isDisabled ? undefined : onPress;
+  // When using gesture detector, don't pass onPress to RNTouchableOpacity
+  // to prevent double event firing. The gesture detector handles the press events.
+  // Only preserve onPress for accessibility when the gesture detector isn't handling it.
+  const accessibleOnPress = undefined; // Gesture detector handles all press events
 
   return (
     <GestureDetector gesture={tap}>

--- a/app/component-library/components/List/ListItemSelect/ListItemSelect.tsx
+++ b/app/component-library/components/List/ListItemSelect/ListItemSelect.tsx
@@ -103,11 +103,7 @@ const ListItemSelect: React.FC<ListItemSelectProps> = ({
   // For custom TouchableOpacity (Android), pass original onPress and let it handle disabled state internally
   // For standard TouchableOpacity, apply conditional logic to prevent disabled interaction
   const conditionalOnPress =
-    TouchableComponent === TouchableOpacity
-      ? onPress
-      : isDisabled
-      ? undefined
-      : onPress;
+    TouchableComponent !== TouchableOpacity && isDisabled ? undefined : onPress;
 
   return (
     <TouchableComponent

--- a/app/component-library/components/List/ListItemSelect/ListItemSelect.tsx
+++ b/app/component-library/components/List/ListItemSelect/ListItemSelect.tsx
@@ -66,6 +66,8 @@ const TouchableOpacity = ({
         {...props}
         // Ensure disabled prop is available to tests
         {...(process.env.NODE_ENV === 'test' && { disabled: isDisabled })}
+        accessibilityRole="button"
+        accessible
       >
         {children}
       </RNTouchableOpacity>


### PR DESCRIPTION
## **Description**

This PR is to prevent the apparent "double-press" that occurs when a user clicks on a network in the Network Selection Modal / Bottom Sheet

## **Changelog**

`CHANGELOG entry: Fix network selection double-press issue causing back navigation`

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/13193

## **Manual testing steps**

```gherkin
Feature: Network Selection Bottom Sheet

  Scenario: navigates to a screen other than the home screen
    Given they navigate to the home screen

    When user opens the network selection modal and selects an option
    Then the modal should close and NO NAVIGATION SHOULD OCCUR
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/0ebc0f7f-9aae-4e71-a7bf-28fb737c4533



### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
