### PR TITLE
chore: cp-7.54.0 buy view switches to param chainId

### DIFF
--- a/app/components/UI/Ramp/Aggregator/Views/NetworkSwitcher/NetworkSwitcher.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/NetworkSwitcher/NetworkSwitcher.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigation } from '@react-navigation/native';
+import { SolScope } from '@metamask/keyring-api';
 import {
   ImageSourcePropType,
   RefreshControl,
@@ -152,7 +153,7 @@ function NetworkSwitcher() {
   }, [navigation]);
 
   const switchToMainnet = useCallback(
-    (type: 'mainnet' | 'linea-mainnet') => {
+    (type: 'mainnet' | 'linea-mainnet' | SolScope.Mainnet) => {
       const { MultichainNetworkController } = Engine.context;
       MultichainNetworkController.setActiveNetwork(type);
       navigateToGetStarted();
@@ -213,6 +214,10 @@ function NetworkSwitcher() {
 
       if (getDecimalChainId(ChainId['linea-mainnet']) === chainId) {
         return switchToMainnet('linea-mainnet');
+      }
+
+      if (chainId === SolScope.Mainnet) {
+        return switchToMainnet(SolScope.Mainnet);
       }
 
       const supportedNetworkConfigurations = rampNetworksDetails.map(

--- a/app/core/DeeplinkManager/Handlers/handleCreateAccountUrl.ts
+++ b/app/core/DeeplinkManager/Handlers/handleCreateAccountUrl.ts
@@ -85,6 +85,9 @@ export function handleCreateAccountUrl({
 
   // if there are account in scope bu non of them have funds, navigate to ramps
   navigation.navigate(Routes.RAMP.BUY, {
-    chainId,
+    screen: Routes.RAMP.GET_STARTED,
+    params: {
+      chainId,
+    },
   });
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When we navigate to the ramps/buy page view from the deeplink, we pass a chainid (Solana) and this chainId is used to switch the active network for the buy page, and as a side effect it also selects the last used account for that chain.

https://github.com/user-attachments/assets/7a1f6896-ddc0-4671-9675-7fda7d576417


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Switch ramps selected chain to the passed param chainId

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Solana deeplink

  Scenario: user has an EVM account selected
    Given the user clicks a deeplink with the solana chainId being passed in the params

    When user opens the deeplink
    Then the buy/ramps page will automatically switch to he chainid passed in the params
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
