### PR TITLE
fix: cp-7.54.0 Use proper Jazzicon seed for non-EVM

### DIFF
--- a/app/component-library/components/Avatars/Avatar/variants/AvatarAccount/AvatarAccount.test.tsx
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarAccount/AvatarAccount.test.tsx
@@ -300,5 +300,19 @@ describe('AvatarAccount', () => {
       // Assert - Single snapshot for visual regression testing
       expect(toJSON()).toMatchSnapshot();
     });
+
+    it('maintains expected visual structure for non-EVM', () => {
+      // Arrange & Act - Only keeping one essential snapshot for visual regression
+      const { toJSON } = render(
+        <AvatarAccount
+          accountAddress="CYWSQQ2iiFL6EZzuqvMM9o22CZX3N8PowvvkpBXqLK4e"
+          type={AvatarAccountType.JazzIcon}
+          size={AvatarSize.Md}
+        />,
+      );
+
+      // Assert - Single snapshot for visual regression testing
+      expect(toJSON()).toMatchSnapshot();
+    });
   });
 });

--- a/app/component-library/components/Avatars/Avatar/variants/AvatarAccount/AvatarAccount.tsx
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarAccount/AvatarAccount.tsx
@@ -9,6 +9,7 @@ import JazzIcon from 'react-native-jazzicon';
 import AvatarBase from '../../foundation/AvatarBase';
 import { toDataUrl } from '../../../../../../util/blockies';
 import { Maskicon } from '@metamask/design-system-react-native';
+import { stringToBytes } from '@metamask/utils';
 import { useStyles } from '../../../../../hooks';
 
 // Internal dependencies.
@@ -18,6 +19,15 @@ import {
   DEFAULT_AVATARACCOUNT_TYPE,
   DEFAULT_AVATARACCOUNT_SIZE,
 } from './AvatarAccount.constants';
+
+function getJazziconSeed(address: string) {
+  // TODO: Consider making this more strict, but this should do for now.
+  if (!address.startsWith('0x')) {
+    return Array.from(stringToBytes(address.normalize('NFKC').toLowerCase()));
+  }
+  // Default behaviour for EIP155 namespace to match existing Jazzicons
+  return parseInt(address.slice(2, 10), 16);
+}
 
 const AvatarAccount = ({
   type: avatarType = DEFAULT_AVATARACCOUNT_TYPE,
@@ -37,7 +47,8 @@ const AvatarAccount = ({
         return (
           <JazzIcon
             size={Number(size)}
-            address={accountAddress}
+            // @ts-expect-error The underlying PRNG supports the seed being an array but the component is typed wrong.
+            seed={getJazziconSeed(accountAddress)}
             containerStyle={styles.artStyle}
           />
         );

--- a/app/component-library/components/Avatars/Avatar/variants/AvatarAccount/__snapshots__/AvatarAccount.test.tsx.snap
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarAccount/__snapshots__/AvatarAccount.test.tsx.snap
@@ -45,12 +45,12 @@ exports[`AvatarAccount Border Radius Handling applies border radius directly to 
   }
 >
   <JazzIcon
-    address="0x1234567890123456789012345678901234567890"
     containerStyle={
       {
         "borderRadius": 8,
       }
     }
+    seed={305419896}
     size={32}
   />
 </View>
@@ -93,11 +93,82 @@ exports[`AvatarAccount Integration - Component Snapshot maintains expected visua
   }
 >
   <JazzIcon
-    address="0x1234567890123456789012345678901234567890"
     containerStyle={
       {
         "borderRadius": 8,
       }
+    }
+    seed={305419896}
+    size={32}
+  />
+</View>
+`;
+
+exports[`AvatarAccount Integration - Component Snapshot maintains expected visual structure for non-EVM 1`] = `
+<View
+  style={
+    {
+      "backgroundColor": "#ffffff",
+      "borderRadius": 8,
+      "height": 32,
+      "overflow": "hidden",
+      "width": 32,
+    }
+  }
+>
+  <JazzIcon
+    containerStyle={
+      {
+        "borderRadius": 8,
+      }
+    }
+    seed={
+      [
+        99,
+        121,
+        119,
+        115,
+        113,
+        113,
+        50,
+        105,
+        105,
+        102,
+        108,
+        54,
+        101,
+        122,
+        122,
+        117,
+        113,
+        118,
+        109,
+        109,
+        57,
+        111,
+        50,
+        50,
+        99,
+        122,
+        120,
+        51,
+        110,
+        56,
+        112,
+        111,
+        119,
+        118,
+        118,
+        107,
+        112,
+        98,
+        120,
+        113,
+        108,
+        107,
+        52,
+        101,
+      ]
     }
     size={32}
   />


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Generate the Jazzicon seed and pass that directly to the Jazzicon component. This prevents issues where passing an incompatible address would effectively render a random icon each time.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/18912

## **Manual testing steps**

1. Change to jazzicons in settings
2. Open the account selector
3. Take note of the jazzicon for your Solana account
4. Repeat
5. Notice that it does match
6. Bonus: Compare to extension

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="399" height="310" alt="Screenshot 2025-08-29 at 08 49 38" src="https://github.com/user-attachments/assets/01d34056-8551-48a7-ae14-9d976c8aca21" />

### **After**

<img width="437" height="374" alt="Screenshot 2025-08-29 at 09 58 36" src="https://github.com/user-attachments/assets/4999d4c3-a641-485e-8a0b-96a678d56792" />
