### PR TITLE
fix(card): cache prevent loading different address

### DIFF
--- a/app/components/UI/Card/hooks/useGetPriorityCardToken.test.ts
+++ b/app/components/UI/Card/hooks/useGetPriorityCardToken.test.ts
@@ -199,10 +199,13 @@ describe('useGetPriorityCardToken', () => {
       expect.objectContaining({
         type: expect.stringContaining('setCardPriorityToken'),
         payload: expect.objectContaining({
-          address: '0xToken1',
-          symbol: 'TKN1',
-          name: 'Token 1',
-          allowanceState: AllowanceState.Enabled,
+          address: '0x1234567890123456789012345678901234567890',
+          token: expect.objectContaining({
+            address: '0xToken1',
+            symbol: 'TKN1',
+            name: 'Token 1',
+            allowanceState: AllowanceState.Enabled,
+          }),
         }),
       }),
     );
@@ -210,7 +213,10 @@ describe('useGetPriorityCardToken', () => {
     expect(mockDispatch).toHaveBeenCalledWith(
       expect.objectContaining({
         type: expect.stringContaining('setCardPriorityTokenLastFetched'),
-        payload: expect.any(Date),
+        payload: expect.objectContaining({
+          address: '0x1234567890123456789012345678901234567890',
+          lastFetched: expect.any(Date),
+        }),
       }),
     );
 
@@ -244,10 +250,13 @@ describe('useGetPriorityCardToken', () => {
       expect.objectContaining({
         type: expect.stringContaining('setCardPriorityToken'),
         payload: expect.objectContaining({
-          address: '0xToken1',
-          symbol: 'TKN1',
-          name: 'Token 1',
-          allowanceState: AllowanceState.Enabled,
+          address: '0x1234567890123456789012345678901234567890',
+          token: expect.objectContaining({
+            address: '0xToken1',
+            symbol: 'TKN1',
+            name: 'Token 1',
+            allowanceState: AllowanceState.Enabled,
+          }),
         }),
       }),
     );
@@ -335,14 +344,18 @@ describe('useGetPriorityCardToken', () => {
     const useReduxMocks = jest.requireMock('react-redux');
     useReduxMocks.useDispatch.mockReturnValue(testMockDispatch);
 
-    // Track selector calls for debugging
-    const selectorCalls: string[] = [];
-
     // Mock useSelector to consistently return cached values
+    // We need to track which selector is being called and return appropriate values
+    let selectorCallCount = 0;
+    const expectedSelectorCalls = [
+      'selectAllTokenBalances', // First call for token balances
+      'selectCardPriorityToken', // Second call for cached priority token
+      'selectCardPriorityTokenLastFetched', // Third call for last fetched timestamp
+    ];
+
     useReduxMocks.useSelector.mockImplementation(
       (selector: (state: unknown) => unknown) => {
         const selectorString = selector.toString();
-        selectorCalls.push(selectorString.substring(0, 50) + '...');
 
         if (selectorString.includes('selectAllTokenBalances')) {
           return {
@@ -353,23 +366,34 @@ describe('useGetPriorityCardToken', () => {
             },
           };
         }
-        if (
-          selectorString.includes('selectCardPriorityToken') &&
-          !selectorString.includes('LastFetched')
-        ) {
+
+        // For the address-based selectors, they will contain references to the state structure
+        // Let's be more explicit about what we return
+        if (selectorString.includes('priorityTokensByAddress')) {
           return cachedToken;
         }
-        if (
-          selectorString.includes('selectCardPriorityTokenLastFetched') ||
-          selectorString.includes('LastFetched')
-        ) {
+
+        if (selectorString.includes('lastFetchedByAddress')) {
           return recentTimestamp;
         }
-        return null;
-      },
-    );
 
-    // Mock the SDK with test-specific functions
+        // Fallback: if we can't identify the selector, assume it's asking for cached data
+        const currentCall =
+          expectedSelectorCalls[
+            selectorCallCount % expectedSelectorCalls.length
+          ];
+        selectorCallCount++;
+
+        switch (currentCall) {
+          case 'selectCardPriorityToken':
+            return cachedToken;
+          case 'selectCardPriorityTokenLastFetched':
+            return recentTimestamp;
+          default:
+            return null;
+        }
+      },
+    ); // Mock the SDK with test-specific functions
     const sdkMocks = jest.requireMock('../sdk');
     sdkMocks.useCardSDK.mockReturnValue({
       sdk: {
@@ -480,9 +504,12 @@ describe('useGetPriorityCardToken', () => {
       expect.objectContaining({
         type: 'card/setCardPriorityToken',
         payload: expect.objectContaining({
-          address: '0xToken1',
-          symbol: 'TKN1',
-          name: 'Token 1',
+          address: expect.any(String),
+          token: expect.objectContaining({
+            address: '0xToken1',
+            symbol: 'TKN1',
+            name: 'Token 1',
+          }),
         }),
       }),
     );
@@ -533,10 +560,13 @@ describe('useGetPriorityCardToken', () => {
       expect.objectContaining({
         type: 'card/setCardPriorityToken',
         payload: expect.objectContaining({
-          address: '0xToken1',
-          symbol: 'TKN1',
-          name: 'Token 1',
-          allowanceState: AllowanceState.Enabled,
+          address: expect.any(String),
+          token: expect.objectContaining({
+            address: '0xToken1',
+            symbol: 'TKN1',
+            name: 'Token 1',
+            allowanceState: AllowanceState.Enabled,
+          }),
         }),
       }),
     );
@@ -627,10 +657,13 @@ describe('useGetPriorityCardToken', () => {
       expect.objectContaining({
         type: 'card/setCardPriorityToken',
         payload: expect.objectContaining({
-          address: '0xToken2',
-          symbol: 'TKN2',
-          name: 'Token 2',
-          allowanceState: AllowanceState.Enabled,
+          address: expect.any(String),
+          token: expect.objectContaining({
+            address: '0xToken2',
+            symbol: 'TKN2',
+            name: 'Token 2',
+            allowanceState: AllowanceState.Enabled,
+          }),
         }),
       }),
     );
@@ -698,10 +731,13 @@ describe('useGetPriorityCardToken', () => {
       expect.objectContaining({
         type: 'card/setCardPriorityToken',
         payload: expect.objectContaining({
-          address: '0xToken1',
-          symbol: 'TKN1',
-          name: 'Token 1',
-          allowanceState: AllowanceState.Enabled,
+          address: expect.any(String),
+          token: expect.objectContaining({
+            address: '0xToken1',
+            symbol: 'TKN1',
+            name: 'Token 1',
+            allowanceState: AllowanceState.Enabled,
+          }),
         }),
       }),
     );
@@ -777,10 +813,13 @@ describe('useGetPriorityCardToken', () => {
       expect.objectContaining({
         type: 'card/setCardPriorityToken',
         payload: expect.objectContaining({
-          address: '0xToken1',
-          symbol: 'TKN1',
-          name: 'Token 1',
-          allowanceState: AllowanceState.Enabled,
+          address: expect.any(String),
+          token: expect.objectContaining({
+            address: '0xToken1',
+            symbol: 'TKN1',
+            name: 'Token 1',
+            allowanceState: AllowanceState.Enabled,
+          }),
         }),
       }),
     );
@@ -858,10 +897,13 @@ describe('useGetPriorityCardToken', () => {
       expect.objectContaining({
         type: 'card/setCardPriorityToken',
         payload: expect.objectContaining({
-          address: '0xToken1',
-          symbol: 'TKN1',
-          name: 'Token 1',
-          allowanceState: AllowanceState.Enabled,
+          address: expect.any(String),
+          token: expect.objectContaining({
+            address: '0xToken1',
+            symbol: 'TKN1',
+            name: 'Token 1',
+            allowanceState: AllowanceState.Enabled,
+          }),
         }),
       }),
     );
@@ -883,10 +925,13 @@ describe('useGetPriorityCardToken', () => {
       expect.objectContaining({
         type: 'card/setCardPriorityToken',
         payload: expect.objectContaining({
-          address: '0xToken2',
-          symbol: 'TKN2',
-          name: 'Token 2',
-          allowanceState: AllowanceState.Enabled,
+          address: expect.any(String),
+          token: expect.objectContaining({
+            address: '0xToken2',
+            symbol: 'TKN2',
+            name: 'Token 2',
+            allowanceState: AllowanceState.Enabled,
+          }),
         }),
       }),
     );
@@ -911,10 +956,13 @@ describe('useGetPriorityCardToken', () => {
       expect.objectContaining({
         type: 'card/setCardPriorityToken',
         payload: expect.objectContaining({
-          address: '0xToken1',
-          symbol: 'TKN1',
-          name: 'Token 1',
-          allowanceState: AllowanceState.Enabled,
+          address: expect.any(String),
+          token: expect.objectContaining({
+            address: '0xToken1',
+            symbol: 'TKN1',
+            name: 'Token 1',
+            allowanceState: AllowanceState.Enabled,
+          }),
         }),
       }),
     );
@@ -1026,12 +1074,15 @@ describe('useGetPriorityCardToken', () => {
       expect.objectContaining({
         type: 'card/setCardPriorityToken',
         payload: expect.objectContaining({
-          address: '0xToken1',
-          symbol: 'TKN1',
-          name: 'Token 1',
-          allowanceState: AllowanceState.NotEnabled,
-          isStaked: false,
-          chainId: LINEA_CHAIN_ID,
+          address: expect.any(String),
+          token: expect.objectContaining({
+            address: '0xToken1',
+            symbol: 'TKN1',
+            name: 'Token 1',
+            allowanceState: AllowanceState.NotEnabled,
+            isStaked: false,
+            chainId: LINEA_CHAIN_ID,
+          }),
         }),
       }),
     );
@@ -1039,7 +1090,10 @@ describe('useGetPriorityCardToken', () => {
     expect(mockDispatch).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'card/setCardPriorityTokenLastFetched',
-        payload: expect.any(Date),
+        payload: expect.objectContaining({
+          address: '0x1234567890123456789012345678901234567890',
+          lastFetched: expect.any(Date),
+        }),
       }),
     );
 
@@ -1071,14 +1125,20 @@ describe('useGetPriorityCardToken', () => {
     expect(mockDispatch).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'card/setCardPriorityToken',
-        payload: null,
+        payload: expect.objectContaining({
+          address: '0x1234567890123456789012345678901234567890',
+          token: null,
+        }),
       }),
     );
 
     expect(mockDispatch).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'card/setCardPriorityTokenLastFetched',
-        payload: expect.any(Date),
+        payload: expect.objectContaining({
+          address: '0x1234567890123456789012345678901234567890',
+          lastFetched: expect.any(Date),
+        }),
       }),
     );
 
@@ -1131,10 +1191,13 @@ describe('useGetPriorityCardToken', () => {
       expect.objectContaining({
         type: 'card/setCardPriorityToken',
         payload: expect.objectContaining({
-          address: '0xToken1',
-          symbol: 'TKN1',
-          name: 'Token 1',
-          allowanceState: AllowanceState.NotEnabled, // Zero allowance = NotEnabled
+          address: expect.any(String),
+          token: expect.objectContaining({
+            address: '0xToken1',
+            symbol: 'TKN1',
+            name: 'Token 1',
+            allowanceState: AllowanceState.NotEnabled, // Zero allowance = NotEnabled
+          }),
         }),
       }),
     );
@@ -1142,7 +1205,10 @@ describe('useGetPriorityCardToken', () => {
     expect(mockDispatch).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'card/setCardPriorityTokenLastFetched',
-        payload: expect.any(Date),
+        payload: expect.objectContaining({
+          address: '0x1234567890123456789012345678901234567890',
+          lastFetched: expect.any(Date),
+        }),
       }),
     );
 
@@ -1172,8 +1238,11 @@ describe('useGetPriorityCardToken', () => {
       expect.objectContaining({
         type: 'card/setCardPriorityToken',
         payload: expect.objectContaining({
-          address: '0xToken1', // First supported token as fallback
-          allowanceState: AllowanceState.NotEnabled,
+          address: expect.any(String),
+          token: expect.objectContaining({
+            address: '0xToken1', // First supported token as fallback
+            allowanceState: AllowanceState.NotEnabled,
+          }),
         }),
       }),
     );

--- a/app/components/UI/Card/hooks/useGetPriorityCardToken.tsx
+++ b/app/components/UI/Card/hooks/useGetPriorityCardToken.tsx
@@ -129,8 +129,10 @@ export const useGetPriorityCardToken = (
 
   // Extract controller state
   const allTokenBalances = useSelector(selectAllTokenBalances);
-  const priorityToken = useSelector(selectCardPriorityToken);
-  const lastFetched = useSelector(selectCardPriorityTokenLastFetched);
+  const priorityToken = useSelector(selectCardPriorityToken(selectedAddress));
+  const lastFetched = useSelector(
+    selectCardPriorityTokenLastFetched(selectedAddress),
+  );
 
   // Helper to check if cache is still valid (less than 5 minutes old)
   const isCacheValid = useCallback(() => {
@@ -208,22 +210,52 @@ export const useGetPriorityCardToken = (
             } as CardTokenAllowance;
 
             // Update cache with fallback token
-            dispatch(setCardPriorityToken(fallbackToken));
-            dispatch(setCardPriorityTokenLastFetched(new Date()));
+            dispatch(
+              setCardPriorityToken({
+                address: selectedAddress,
+                token: fallbackToken,
+              }),
+            );
+            dispatch(
+              setCardPriorityTokenLastFetched({
+                address: selectedAddress,
+                lastFetched: new Date(),
+              }),
+            );
 
             return fallbackToken;
           }
 
-          dispatch(setCardPriorityToken(null));
-          dispatch(setCardPriorityTokenLastFetched(new Date()));
+          dispatch(
+            setCardPriorityToken({
+              address: selectedAddress,
+              token: null,
+            }),
+          );
+          dispatch(
+            setCardPriorityTokenLastFetched({
+              address: selectedAddress,
+              lastFetched: new Date(),
+            }),
+          );
           return null;
         }
 
         const validAllowances = filterNonZeroAllowances(cardTokenAllowances);
         if (validAllowances.length === 0) {
           const defaultToken = cardTokenAllowances[0] || null;
-          dispatch(setCardPriorityToken(defaultToken));
-          dispatch(setCardPriorityTokenLastFetched(new Date()));
+          dispatch(
+            setCardPriorityToken({
+              address: selectedAddress,
+              token: defaultToken,
+            }),
+          );
+          dispatch(
+            setCardPriorityTokenLastFetched({
+              address: selectedAddress,
+              lastFetched: new Date(),
+            }),
+          );
           return defaultToken;
         }
 
@@ -278,8 +310,18 @@ export const useGetPriorityCardToken = (
         }
 
         // Update cache with the final token and current timestamp
-        dispatch(setCardPriorityToken(finalToken));
-        dispatch(setCardPriorityTokenLastFetched(new Date()));
+        dispatch(
+          setCardPriorityToken({
+            address: selectedAddress,
+            token: finalToken,
+          }),
+        );
+        dispatch(
+          setCardPriorityTokenLastFetched({
+            address: selectedAddress,
+            lastFetched: new Date(),
+          }),
+        );
 
         return finalToken;
       } catch (err) {

--- a/app/core/redux/slices/card/index.test.ts
+++ b/app/core/redux/slices/card/index.test.ts
@@ -45,17 +45,23 @@ const MOCK_PRIORITY_TOKEN: CardTokenAllowance = {
   allowance: ethers.BigNumber.from('500000000000000000'),
 };
 
+const testAddress = '0x1234567890123456789012345678901234567890';
+
 const CARD_STATE_MOCK: CardSliceState = {
   cardholderAccounts: CARDHOLDER_ACCOUNTS_MOCK,
-  priorityToken: MOCK_PRIORITY_TOKEN,
-  lastFetched: new Date('2025-08-21T10:00:00Z'),
+  priorityTokensByAddress: {
+    [testAddress.toLowerCase()]: MOCK_PRIORITY_TOKEN,
+  },
+  lastFetchedByAddress: {
+    [testAddress.toLowerCase()]: new Date('2025-08-21T10:00:00Z'),
+  },
   isLoaded: true,
 };
 
 const EMPTY_CARD_STATE_MOCK: CardSliceState = {
   cardholderAccounts: [],
-  priorityToken: null,
-  lastFetched: null,
+  priorityTokensByAddress: {},
+  lastFetchedByAddress: {},
   isLoaded: false,
 };
 
@@ -184,8 +190,12 @@ describe('Card Reducer', () => {
     it('should reset card state', () => {
       const currentState: CardSliceState = {
         cardholderAccounts: ['0x123'],
-        priorityToken: MOCK_PRIORITY_TOKEN,
-        lastFetched: new Date(),
+        priorityTokensByAddress: {
+          '0x123': MOCK_PRIORITY_TOKEN,
+        },
+        lastFetchedByAddress: {
+          '0x123': new Date(),
+        },
         isLoaded: true,
       };
 
@@ -198,42 +208,98 @@ describe('Card Reducer', () => {
 
 describe('Card Caching Functionality', () => {
   describe('selectCardPriorityToken', () => {
-    it('should return the priority token when it exists', () => {
+    it('should return the priority token when it exists for the given address', () => {
       const mockRootState = {
         card: CARD_STATE_MOCK,
       } as unknown as RootState;
 
-      expect(selectCardPriorityToken(mockRootState)).toEqual(
-        MOCK_PRIORITY_TOKEN,
-      );
+      const selector = selectCardPriorityToken(testAddress);
+      expect(selector(mockRootState)).toEqual(MOCK_PRIORITY_TOKEN);
     });
 
-    it('should return null when no priority token exists', () => {
+    it('should return null when no priority token exists for the given address', () => {
       const mockRootState = {
         card: EMPTY_CARD_STATE_MOCK,
       } as unknown as RootState;
 
-      expect(selectCardPriorityToken(mockRootState)).toBeNull();
+      const selector = selectCardPriorityToken(testAddress);
+      expect(selector(mockRootState)).toBeNull();
+    });
+
+    it('should return null when address is not provided', () => {
+      const mockRootState = {
+        card: CARD_STATE_MOCK,
+      } as unknown as RootState;
+
+      const selector = selectCardPriorityToken();
+      expect(selector(mockRootState)).toBeNull();
+    });
+
+    it('should handle different address cases', () => {
+      const mockRootState = {
+        card: CARD_STATE_MOCK,
+      } as unknown as RootState;
+
+      // Test with uppercase address
+      const upperCaseSelector = selectCardPriorityToken(
+        testAddress.toUpperCase(),
+      );
+      expect(upperCaseSelector(mockRootState)).toEqual(MOCK_PRIORITY_TOKEN);
+
+      // Test with different address that doesn't exist
+      const differentAddressSelector = selectCardPriorityToken(
+        '0x9999999999999999999999999999999999999999',
+      );
+      expect(differentAddressSelector(mockRootState)).toBeNull();
     });
   });
 
   describe('selectCardPriorityTokenLastFetched', () => {
-    it('should return the last fetched timestamp when it exists', () => {
+    it('should return the last fetched timestamp when it exists for the given address', () => {
       const mockRootState = {
         card: CARD_STATE_MOCK,
       } as unknown as RootState;
 
-      expect(selectCardPriorityTokenLastFetched(mockRootState)).toEqual(
-        new Date('2025-08-21T10:00:00Z'),
-      );
+      const selector = selectCardPriorityTokenLastFetched(testAddress);
+      expect(selector(mockRootState)).toEqual(new Date('2025-08-21T10:00:00Z'));
     });
 
-    it('should return null when no last fetched timestamp exists', () => {
+    it('should return null when no last fetched timestamp exists for the given address', () => {
       const mockRootState = {
         card: EMPTY_CARD_STATE_MOCK,
       } as unknown as RootState;
 
-      expect(selectCardPriorityTokenLastFetched(mockRootState)).toBeNull();
+      const selector = selectCardPriorityTokenLastFetched(testAddress);
+      expect(selector(mockRootState)).toBeNull();
+    });
+
+    it('should return null when address is not provided', () => {
+      const mockRootState = {
+        card: CARD_STATE_MOCK,
+      } as unknown as RootState;
+
+      const selector = selectCardPriorityTokenLastFetched();
+      expect(selector(mockRootState)).toBeNull();
+    });
+
+    it('should handle different address cases', () => {
+      const mockRootState = {
+        card: CARD_STATE_MOCK,
+      } as unknown as RootState;
+
+      // Test with uppercase address
+      const upperCaseSelector = selectCardPriorityTokenLastFetched(
+        testAddress.toUpperCase(),
+      );
+      expect(upperCaseSelector(mockRootState)).toEqual(
+        new Date('2025-08-21T10:00:00Z'),
+      );
+
+      // Test with different address that doesn't exist
+      const differentAddressSelector = selectCardPriorityTokenLastFetched(
+        '0x9999999999999999999999999999999999999999',
+      );
+      expect(differentAddressSelector(mockRootState)).toBeNull();
     });
   });
 
@@ -248,7 +314,7 @@ describe('Card Caching Functionality', () => {
       dateNowSpy.mockRestore();
     });
 
-    it('should return true when cache is within 5-minute window', () => {
+    it('should return true when cache is within 5-minute window for the given address', () => {
       // Mock Date.now to return 4 minutes after fetch time
       dateNowSpy.mockReturnValue(new Date('2025-08-21T10:04:00Z').getTime());
 
@@ -256,27 +322,30 @@ describe('Card Caching Functionality', () => {
         card: CARD_STATE_MOCK,
       } as unknown as RootState;
 
-      expect(selectIsCardCacheValid(mockRootState)).toBe(true);
+      const selector = selectIsCardCacheValid(testAddress);
+      expect(selector(mockRootState)).toBe(true);
     });
 
-    it('should return false when cache is older than 5 minutes', () => {
+    it('should return false when cache is older than 5 minutes for the given address', () => {
       // Mock Date.now to return 6 minutes after fetch time
       dateNowSpy.mockReturnValue(new Date('2025-08-21T10:06:00Z').getTime());
 
-      // Use a different state object to avoid selector memoization
       const stateWithOldCache: CardSliceState = {
         ...CARD_STATE_MOCK,
-        lastFetched: new Date('2025-08-21T10:00:00Z'), // Same time but different object
+        lastFetchedByAddress: {
+          [testAddress.toLowerCase()]: new Date('2025-08-21T10:00:00Z'),
+        },
       };
 
       const mockRootState = {
         card: stateWithOldCache,
       } as unknown as RootState;
 
-      expect(selectIsCardCacheValid(mockRootState)).toBe(false);
+      const selector = selectIsCardCacheValid(testAddress);
+      expect(selector(mockRootState)).toBe(false);
     });
 
-    it('should return false when no last fetched timestamp exists', () => {
+    it('should return false when no last fetched timestamp exists for the given address', () => {
       // Mock Date.now to any time
       dateNowSpy.mockReturnValue(new Date('2025-08-21T10:04:00Z').getTime());
 
@@ -284,7 +353,8 @@ describe('Card Caching Functionality', () => {
         card: EMPTY_CARD_STATE_MOCK,
       } as unknown as RootState;
 
-      expect(selectIsCardCacheValid(mockRootState)).toBe(false);
+      const selector = selectIsCardCacheValid(testAddress);
+      expect(selector(mockRootState)).toBe(false);
     });
 
     it('should handle ISO date strings from redux-persist', () => {
@@ -293,31 +363,48 @@ describe('Card Caching Functionality', () => {
 
       const stateWithStringDate: CardSliceState = {
         ...CARD_STATE_MOCK,
-        lastFetched: '2025-08-21T10:00:00Z', // String instead of Date object
+        lastFetchedByAddress: {
+          [testAddress.toLowerCase()]: '2025-08-21T10:00:00Z', // String instead of Date object
+        },
       };
 
       const mockRootState = {
         card: stateWithStringDate,
       } as unknown as RootState;
 
-      expect(selectIsCardCacheValid(mockRootState)).toBe(true);
+      const selector = selectIsCardCacheValid(testAddress);
+      expect(selector(mockRootState)).toBe(true);
+    });
+
+    it('should return false when address is not provided', () => {
+      // Mock Date.now to return 4 minutes after fetch time
+      dateNowSpy.mockReturnValue(new Date('2025-08-21T10:04:00Z').getTime());
+
+      const mockRootState = {
+        card: CARD_STATE_MOCK,
+      } as unknown as RootState;
+
+      const selector = selectIsCardCacheValid();
+      expect(selector(mockRootState)).toBe(false);
     });
 
     it('should return false for cache exactly 5 minutes old', () => {
       // Mock Date.now to return exactly 5 minutes after fetch time
       dateNowSpy.mockReturnValue(new Date('2025-08-21T10:05:00Z').getTime());
 
-      // Use a different state object to avoid selector memoization
       const stateWithExactlyOldCache: CardSliceState = {
         ...CARD_STATE_MOCK,
-        lastFetched: new Date('2025-08-21T10:00:00Z'), // Same time but different object
+        lastFetchedByAddress: {
+          [testAddress.toLowerCase()]: new Date('2025-08-21T10:00:00Z'),
+        },
       };
 
       const mockRootState = {
         card: stateWithExactlyOldCache,
       } as unknown as RootState;
 
-      expect(selectIsCardCacheValid(mockRootState)).toBe(false);
+      const selector = selectIsCardCacheValid(testAddress);
+      expect(selector(mockRootState)).toBe(false);
     });
 
     it('should return true for cache 4 minutes and 59 seconds old', () => {
@@ -328,104 +415,247 @@ describe('Card Caching Functionality', () => {
         card: CARD_STATE_MOCK,
       } as unknown as RootState;
 
-      expect(selectIsCardCacheValid(mockRootState)).toBe(true);
+      const selector = selectIsCardCacheValid(testAddress);
+      expect(selector(mockRootState)).toBe(true);
     });
   });
-  describe('setCardPriorityToken action', () => {
-    it('should set the priority token', () => {
+
+  describe('setCardPriorityToken', () => {
+    it('should set the priority token for the given address', () => {
       const state = cardReducer(
         initialState,
-        setCardPriorityToken(MOCK_PRIORITY_TOKEN),
+        setCardPriorityToken({
+          address: testAddress,
+          token: MOCK_PRIORITY_TOKEN,
+        }),
       );
 
-      expect(state.priorityToken).toEqual(MOCK_PRIORITY_TOKEN);
-      expect(state.cardholderAccounts).toEqual(initialState.cardholderAccounts);
-      expect(state.lastFetched).toEqual(initialState.lastFetched);
-      expect(state.isLoaded).toEqual(initialState.isLoaded);
+      expect(state.priorityTokensByAddress[testAddress.toLowerCase()]).toEqual(
+        MOCK_PRIORITY_TOKEN,
+      );
+      expect(state.lastFetchedByAddress).toEqual(
+        initialState.lastFetchedByAddress,
+      );
     });
 
-    it('should clear the priority token when set to null', () => {
+    it('should set priority token to null for the given address', () => {
       const stateWithToken = {
         ...initialState,
-        priorityToken: MOCK_PRIORITY_TOKEN,
+        priorityTokensByAddress: {
+          [testAddress.toLowerCase()]: MOCK_PRIORITY_TOKEN,
+        },
       };
 
-      const state = cardReducer(stateWithToken, setCardPriorityToken(null));
+      const state = cardReducer(
+        stateWithToken,
+        setCardPriorityToken({
+          address: testAddress,
+          token: null,
+        }),
+      );
 
-      expect(state.priorityToken).toBeNull();
+      expect(
+        state.priorityTokensByAddress[testAddress.toLowerCase()],
+      ).toBeNull();
     });
 
-    it('should overwrite existing priority token', () => {
+    it('should update existing priority token for the given address', () => {
       const newToken: CardTokenAllowance = {
         ...MOCK_PRIORITY_TOKEN,
-        symbol: 'USDT',
-        name: 'Tether',
+        symbol: 'UPDATED',
       };
 
       const stateWithToken = {
         ...initialState,
-        priorityToken: MOCK_PRIORITY_TOKEN,
+        priorityTokensByAddress: {
+          [testAddress.toLowerCase()]: MOCK_PRIORITY_TOKEN,
+        },
       };
 
-      const state = cardReducer(stateWithToken, setCardPriorityToken(newToken));
+      const state = cardReducer(
+        stateWithToken,
+        setCardPriorityToken({
+          address: testAddress,
+          token: newToken,
+        }),
+      );
 
-      expect(state.priorityToken).toEqual(newToken);
+      expect(state.priorityTokensByAddress[testAddress.toLowerCase()]).toEqual(
+        newToken,
+      );
+    });
+
+    it('should store tokens for different addresses separately', () => {
+      const address1 = testAddress;
+      const address2 = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+      const token2: CardTokenAllowance = {
+        ...MOCK_PRIORITY_TOKEN,
+        symbol: 'TOKEN2',
+      };
+
+      let state = cardReducer(
+        initialState,
+        setCardPriorityToken({
+          address: address1,
+          token: MOCK_PRIORITY_TOKEN,
+        }),
+      );
+
+      state = cardReducer(
+        state,
+        setCardPriorityToken({
+          address: address2,
+          token: token2,
+        }),
+      );
+
+      expect(state.priorityTokensByAddress[address1.toLowerCase()]).toEqual(
+        MOCK_PRIORITY_TOKEN,
+      );
+      expect(state.priorityTokensByAddress[address2.toLowerCase()]).toEqual(
+        token2,
+      );
+    });
+
+    it('should normalize address to lowercase', () => {
+      const upperCaseAddress = testAddress.toUpperCase();
+
+      const state = cardReducer(
+        initialState,
+        setCardPriorityToken({
+          address: upperCaseAddress,
+          token: MOCK_PRIORITY_TOKEN,
+        }),
+      );
+
+      expect(state.priorityTokensByAddress[testAddress.toLowerCase()]).toEqual(
+        MOCK_PRIORITY_TOKEN,
+      );
+      expect(state.priorityTokensByAddress[upperCaseAddress]).toBeUndefined();
     });
   });
 
-  describe('setCardPriorityTokenLastFetched action', () => {
-    it('should set the last fetched timestamp with Date object', () => {
-      const timestamp = new Date('2025-08-21T12:00:00Z');
+  describe('setCardPriorityTokenLastFetched', () => {
+    it('should set the last fetched timestamp for the given address', () => {
+      const testDate = new Date('2025-08-21T10:00:00Z');
+
       const state = cardReducer(
         initialState,
-        setCardPriorityTokenLastFetched(timestamp),
+        setCardPriorityTokenLastFetched({
+          address: testAddress,
+          lastFetched: testDate,
+        }),
       );
 
-      expect(state.lastFetched).toEqual(timestamp);
-      expect(state.cardholderAccounts).toEqual(initialState.cardholderAccounts);
-      expect(state.priorityToken).toEqual(initialState.priorityToken);
-      expect(state.isLoaded).toEqual(initialState.isLoaded);
+      expect(state.lastFetchedByAddress[testAddress.toLowerCase()]).toEqual(
+        testDate,
+      );
+      expect(state.priorityTokensByAddress).toEqual(
+        initialState.priorityTokensByAddress,
+      );
     });
 
-    it('should set the last fetched timestamp with ISO string', () => {
-      const timestamp = '2025-08-21T12:00:00Z';
+    it('should handle ISO date strings', () => {
+      const testDateString = '2025-08-21T10:00:00Z';
+
       const state = cardReducer(
         initialState,
-        setCardPriorityTokenLastFetched(timestamp),
+        setCardPriorityTokenLastFetched({
+          address: testAddress,
+          lastFetched: testDateString,
+        }),
       );
 
-      expect(state.lastFetched).toEqual(timestamp);
+      expect(state.lastFetchedByAddress[testAddress.toLowerCase()]).toEqual(
+        testDateString,
+      );
     });
 
-    it('should clear the last fetched timestamp when set to null', () => {
+    it('should store last fetched timestamps for different addresses separately', () => {
+      const address1 = testAddress;
+      const address2 = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+      const date1 = new Date('2025-08-21T10:00:00Z');
+      const date2 = new Date('2025-08-21T11:00:00Z');
+
+      let state = cardReducer(
+        initialState,
+        setCardPriorityTokenLastFetched({
+          address: address1,
+          lastFetched: date1,
+        }),
+      );
+
+      state = cardReducer(
+        state,
+        setCardPriorityTokenLastFetched({
+          address: address2,
+          lastFetched: date2,
+        }),
+      );
+
+      expect(state.lastFetchedByAddress[address1.toLowerCase()]).toEqual(date1);
+      expect(state.lastFetchedByAddress[address2.toLowerCase()]).toEqual(date2);
+    });
+
+    it('should normalize address to lowercase', () => {
+      const upperCaseAddress = testAddress.toUpperCase();
+      const testDate = new Date('2025-08-21T10:00:00Z');
+
+      const state = cardReducer(
+        initialState,
+        setCardPriorityTokenLastFetched({
+          address: upperCaseAddress,
+          lastFetched: testDate,
+        }),
+      );
+
+      expect(state.lastFetchedByAddress[testAddress.toLowerCase()]).toEqual(
+        testDate,
+      );
+      expect(state.lastFetchedByAddress[upperCaseAddress]).toBeUndefined();
+    });
+
+    it('should set lastFetched to null for the given address', () => {
       const stateWithTimestamp = {
         ...initialState,
-        lastFetched: new Date(),
+        lastFetchedByAddress: {
+          [testAddress.toLowerCase()]: new Date(),
+        },
       };
 
       const state = cardReducer(
         stateWithTimestamp,
-        setCardPriorityTokenLastFetched(null),
+        setCardPriorityTokenLastFetched({
+          address: testAddress,
+          lastFetched: null,
+        }),
       );
 
-      expect(state.lastFetched).toBeNull();
+      expect(state.lastFetchedByAddress[testAddress.toLowerCase()]).toBeNull();
     });
 
-    it('should overwrite existing timestamp', () => {
+    it('should overwrite existing timestamp for the given address', () => {
       const oldTimestamp = new Date('2025-08-21T10:00:00Z');
       const newTimestamp = new Date('2025-08-21T11:00:00Z');
 
       const stateWithTimestamp = {
         ...initialState,
-        lastFetched: oldTimestamp,
+        lastFetchedByAddress: {
+          [testAddress.toLowerCase()]: oldTimestamp,
+        },
       };
 
       const state = cardReducer(
         stateWithTimestamp,
-        setCardPriorityTokenLastFetched(newTimestamp),
+        setCardPriorityTokenLastFetched({
+          address: testAddress,
+          lastFetched: newTimestamp,
+        }),
       );
 
-      expect(state.lastFetched).toEqual(newTimestamp);
+      expect(state.lastFetchedByAddress[testAddress.toLowerCase()]).toEqual(
+        newTimestamp,
+      );
     });
   });
 });

--- a/app/core/redux/slices/card/index.ts
+++ b/app/core/redux/slices/card/index.ts
@@ -8,15 +8,15 @@ import { CardTokenAllowance } from '../../../../components/UI/Card/types';
 
 export interface CardSliceState {
   cardholderAccounts: string[];
-  priorityToken: CardTokenAllowance | null;
-  lastFetched: Date | string | null;
+  priorityTokensByAddress: Record<string, CardTokenAllowance | null>;
+  lastFetchedByAddress: Record<string, Date | string | null>;
   isLoaded: boolean;
 }
 
 export const initialState: CardSliceState = {
   cardholderAccounts: [],
-  priorityToken: null,
-  lastFetched: null,
+  priorityTokensByAddress: {},
+  lastFetchedByAddress: {},
   isLoaded: false,
 };
 
@@ -35,15 +35,23 @@ const slice = createSlice({
     resetCardState: () => initialState,
     setCardPriorityToken: (
       state,
-      action: PayloadAction<CardTokenAllowance | null>,
+      action: PayloadAction<{
+        address: string;
+        token: CardTokenAllowance | null;
+      }>,
     ) => {
-      state.priorityToken = action.payload;
+      state.priorityTokensByAddress[action.payload.address.toLowerCase()] =
+        action.payload.token;
     },
     setCardPriorityTokenLastFetched: (
       state,
-      action: PayloadAction<Date | string | null>,
+      action: PayloadAction<{
+        address: string;
+        lastFetched: Date | string | null;
+      }>,
     ) => {
-      state.lastFetched = action.payload;
+      state.lastFetchedByAddress[action.payload.address.toLowerCase()] =
+        action.payload.lastFetched;
     },
   },
   extraReducers: (builder) => {
@@ -75,23 +83,27 @@ export const selectCardholderAccounts = createSelector(
   (card) => card.cardholderAccounts,
 );
 
-export const selectCardPriorityToken = (state: RootState) =>
-  selectCardState(state).priorityToken;
+export const selectCardPriorityToken = (address?: string) =>
+  createSelector(selectCardState, (card) =>
+    address
+      ? card.priorityTokensByAddress[address.toLowerCase()] || null
+      : null,
+  );
 
-export const selectCardPriorityTokenLastFetched = (state: RootState) =>
-  selectCardState(state).lastFetched;
+export const selectCardPriorityTokenLastFetched = (address?: string) =>
+  createSelector(selectCardState, (card) =>
+    address ? card.lastFetchedByAddress[address.toLowerCase()] || null : null,
+  );
 
-export const selectIsCardCacheValid = createSelector(
-  selectCardPriorityTokenLastFetched,
-  (lastFetched) => {
+export const selectIsCardCacheValid = (address?: string) =>
+  createSelector(selectCardPriorityTokenLastFetched(address), (lastFetched) => {
     if (!lastFetched) return false;
     const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000);
     // Handle both Date objects and ISO date strings (from redux-persist)
     const lastFetchedDate =
       lastFetched instanceof Date ? lastFetched : new Date(lastFetched);
     return lastFetchedDate > fiveMinutesAgo;
-  },
-);
+  });
 
 const selectSelectedInternalAccount = (state: RootState) =>
   selectSelectedInternalAccountFormattedAddress(state);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes a caching bug in the Card feature where priority token cache was being shared between different cardholder addresses. Previously, when a user opened the card home page with one address and then switched to another cardholder address, the cached priority token data from the first address would be incorrectly displayed for the second address.

**Problem:** The Redux state stored priority tokens and cache timestamps globally rather than per-address, causing cache pollution between different accounts.

**Solution:** Refactored the card Redux slice to use address-keyed maps for both priority tokens and cache timestamps, ensuring each address maintains its own isolated cache. Updated selectors to accept address parameters and modified the hook to dispatch address-specific actions.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug where switching between cardholder addresses would display cached priority token data from the previously viewed address

## **Related issues**

Fixes: #18999

## **Manual testing steps**

```gherkin
Feature: Card priority token caching per address

  Scenario: user switches between different cardholder addresses
    Given user has multiple addresses that are cardholders
    And user opens the card home page with address A
    And priority token data is loaded and cached for address A

    When user switches to address B (also a cardholder)
    And opens the card home page
    Then the card should fetch fresh priority token data for address B
    And should not display cached data from address A
    And subsequent visits to address B should use address B's cached data

  Scenario: user returns to previously viewed cardholder address
    Given user has viewed card home page for address A
    And priority token data is cached for address A
    And user has switched to and viewed address B

    When user switches back to address A
    And opens the card home page
    Then the card should display cached priority token data for address A
    And should not make unnecessary API calls if cache is still valid
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/e733c614-11fc-47f2-af3e-05e15b7435a2

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/05b7b5a6-3ad2-45f1-84db-f8051ad542e5

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
