### PR TITLE
fix: alert flicker in perps deposit

### DIFF
--- a/app/components/Views/confirmations/__mocks__/controllers/other-controllers-mock.ts
+++ b/app/components/Views/confirmations/__mocks__/controllers/other-controllers-mock.ts
@@ -1,5 +1,6 @@
 import { merge } from 'lodash';
 import { toChecksumAddress } from '../../../../../util/address';
+import { toHex } from '@metamask/controller-utils';
 
 export const accountMock = '0xdc47789de4ceff0e8fe9d15d728af7f17550c164';
 export const tokenAddress1Mock = '0x1234567890abcdef1234567890abcdef12345678';
@@ -46,7 +47,13 @@ export const accountTrackerControllerMock = {
   engine: {
     backgroundState: {
       AccountTrackerController: {
-        accountsByChainId: {},
+        accountsByChainId: {
+          '0x1': {
+            [accountMock]: {
+              balance: toHex(2 * 10 ** 18),
+            },
+          },
+        },
       },
     },
   },

--- a/app/components/Views/confirmations/__mocks__/controllers/other-controllers-mock.ts
+++ b/app/components/Views/confirmations/__mocks__/controllers/other-controllers-mock.ts
@@ -1,4 +1,5 @@
 import { merge } from 'lodash';
+import { toChecksumAddress } from '../../../../../util/address';
 
 export const accountMock = '0xdc47789de4ceff0e8fe9d15d728af7f17550c164';
 export const tokenAddress1Mock = '0x1234567890abcdef1234567890abcdef12345678';
@@ -68,7 +69,14 @@ export const tokenBalancesControllerMock = {
   engine: {
     backgroundState: {
       TokenBalancesController: {
-        tokenBalances: {},
+        tokenBalances: {
+          [accountMock]: {
+            '0x1': {
+              [tokenAddress1Mock]: '0x64', // 100
+              [toChecksumAddress(tokenAddress1Mock)]: '0x64',
+            },
+          },
+        },
       },
     },
   },

--- a/app/components/Views/confirmations/__mocks__/controllers/other-controllers-mock.ts
+++ b/app/components/Views/confirmations/__mocks__/controllers/other-controllers-mock.ts
@@ -1,5 +1,4 @@
 import { merge } from 'lodash';
-import { toChecksumAddress } from '../../../../../util/address';
 import { toHex } from '@metamask/controller-utils';
 
 export const accountMock = '0xdc47789de4ceff0e8fe9d15d728af7f17550c164';
@@ -80,7 +79,7 @@ export const tokenBalancesControllerMock = {
           [accountMock]: {
             '0x1': {
               [tokenAddress1Mock]: '0x64', // 100
-              [toChecksumAddress(tokenAddress1Mock)]: '0x64',
+              '0x1234567890AbcdEF1234567890aBcdef12345678': '0x64',
             },
           },
         },

--- a/app/components/Views/confirmations/components/alert-message/alert-message.test.tsx
+++ b/app/components/Views/confirmations/components/alert-message/alert-message.test.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { AlertMessage, AlertMessageProps } from './alert-message';
-import { useAlerts } from '../../context/alert-system-context';
 import { RowAlertKey } from '../UI/info-row/alert-row/constants';
+import { Alert } from '../../types/alerts';
 
-jest.mock('../../context/alert-system-context');
-
-function render(props: Partial<AlertMessageProps> = {}) {
+function render(props: AlertMessageProps) {
   return renderWithProvider(<AlertMessage {...props} />, {
     state: {},
   });
@@ -16,14 +14,12 @@ const MESSAGE_MOCK = 'Test Message';
 const FIELD_MOCK = 'testField' as RowAlertKey;
 
 describe('AlertMessage', () => {
-  const useAlertsMock = jest.mocked(useAlerts);
-
   beforeEach(() => {
     jest.resetAllMocks();
   });
 
   it('renders message from first alert', () => {
-    useAlertsMock.mockReturnValue({
+    const { getByText } = render({
       alerts: [
         {
           message: MESSAGE_MOCK,
@@ -31,16 +27,14 @@ describe('AlertMessage', () => {
         {
           message: 'other',
         },
-      ],
-    } as unknown as ReturnType<typeof useAlerts>);
-
-    const { getByText } = render();
+      ] as Alert[],
+    });
 
     expect(getByText(MESSAGE_MOCK)).toBeDefined();
   });
 
   it('renders message from first field alert', () => {
-    useAlertsMock.mockReturnValue({
+    const { getByText } = render({
       alerts: [
         {
           message: MESSAGE_MOCK,
@@ -53,21 +47,14 @@ describe('AlertMessage', () => {
         {
           message: 'other2',
         },
-      ],
-    } as unknown as ReturnType<typeof useAlerts>);
-
-    const { getByText } = render({ field: FIELD_MOCK });
+      ] as Alert[],
+    });
 
     expect(getByText(MESSAGE_MOCK)).toBeDefined();
   });
 
   it('renders nothing if no alerts', () => {
-    useAlertsMock.mockReturnValue({
-      alerts: [],
-    } as unknown as ReturnType<typeof useAlerts>);
-
-    const { queryByText } = render();
-
+    const { queryByText } = render({ alerts: [] });
     expect(queryByText(MESSAGE_MOCK)).toBeNull();
   });
 });

--- a/app/components/Views/confirmations/components/alert-message/alert-message.tsx
+++ b/app/components/Views/confirmations/components/alert-message/alert-message.tsx
@@ -1,24 +1,21 @@
 import React from 'react';
 import Text from '../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../hooks/useStyles';
-import { useAlerts } from '../../context/alert-system-context';
-import { RowAlertKey } from '../UI/info-row/alert-row/constants';
 import styleSheet from './alert-message.styles';
+import { Alert } from '../../types/alerts';
 
 export interface AlertMessageProps {
-  field?: RowAlertKey;
+  alerts: Alert[];
 }
 
-export function AlertMessage({ field }: AlertMessageProps = {}) {
+export function AlertMessage({ alerts }: AlertMessageProps) {
   const { styles } = useStyles(styleSheet, {});
-  const { alerts } = useAlerts();
-  const filteredAlerts = alerts.filter((a) => !field || a.field === field);
 
-  if (!filteredAlerts.length) {
+  if (!alerts.length) {
     return null;
   }
 
-  const message = filteredAlerts[0].message;
+  const message = alerts[0].message;
 
   return <Text style={styles.message}>{message}</Text>;
 }

--- a/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.tsx
+++ b/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { memo, useCallback } from 'react';
 import KeypadComponent, { KeypadChangeData } from '../../../../Base/Keypad';
 import { useStyles } from '../../../../hooks/useStyles';
 import styleSheet from './deposit-keyboard.styles';
@@ -39,66 +39,68 @@ export interface DepositKeyboardProps {
   value: string;
 }
 
-export function DepositKeyboard({
-  hasInput,
-  onChange,
-  onDonePress,
-  onPercentagePress,
-  value,
-}: DepositKeyboardProps) {
-  const currentCurrency = useSelector(selectCurrentCurrency);
-  const { styles } = useStyles(styleSheet, {});
+export const DepositKeyboard = memo(
+  ({
+    hasInput,
+    onChange,
+    onDonePress,
+    onPercentagePress,
+    value,
+  }: DepositKeyboardProps) => {
+    const currentCurrency = useSelector(selectCurrentCurrency);
+    const { styles } = useStyles(styleSheet, {});
 
-  const valueString = value.toString();
+    const valueString = value.toString();
 
-  const handleChange = useCallback(
-    (data: KeypadChangeData) => {
-      onChange(data.value);
-    },
-    [onChange],
-  );
+    const handleChange = useCallback(
+      (data: KeypadChangeData) => {
+        onChange(data.value);
+      },
+      [onChange],
+    );
 
-  const handlePercentagePress = useCallback(
-    (percentage: number) => {
-      onPercentagePress(percentage);
-    },
-    [onPercentagePress],
-  );
+    const handlePercentagePress = useCallback(
+      (percentage: number) => {
+        onPercentagePress(percentage);
+      },
+      [onPercentagePress],
+    );
 
-  return (
-    <View>
-      <Box
-        testID="deposit-keyboard"
-        flexDirection={FlexDirection.Row}
-        justifyContent={JustifyContent.spaceBetween}
-        gap={10}
-      >
-        {!hasInput &&
-          PERCENTAGE_BUTTONS.map(({ label, value: buttonValue }) => (
+    return (
+      <View>
+        <Box
+          testID="deposit-keyboard"
+          flexDirection={FlexDirection.Row}
+          justifyContent={JustifyContent.spaceBetween}
+          gap={10}
+        >
+          {!hasInput &&
+            PERCENTAGE_BUTTONS.map(({ label, value: buttonValue }) => (
+              <Button
+                key={buttonValue}
+                label={label}
+                style={styles.percentageButton}
+                onPress={() => handlePercentagePress(buttonValue)}
+                variant={ButtonVariants.Secondary}
+              />
+            ))}
+          {hasInput && (
             <Button
-              key={buttonValue}
-              label={label}
+              testID="deposit-keyboard-done-button"
+              label={strings('confirm.deposit_edit_amount_done')}
               style={styles.percentageButton}
-              onPress={() => handlePercentagePress(buttonValue)}
-              variant={ButtonVariants.Secondary}
+              onPress={onDonePress}
+              variant={ButtonVariants.Primary}
             />
-          ))}
-        {hasInput && (
-          <Button
-            testID="deposit-keyboard-done-button"
-            label={strings('confirm.deposit_edit_amount_done')}
-            style={styles.percentageButton}
-            onPress={onDonePress}
-            variant={ButtonVariants.Primary}
-          />
-        )}
-      </Box>
-      <KeypadComponent
-        value={valueString}
-        onChange={handleChange}
-        currency={currentCurrency}
-        decimals={2}
-      />
-    </View>
-  );
-}
+          )}
+        </Box>
+        <KeypadComponent
+          value={valueString}
+          onChange={handleChange}
+          currency={currentCurrency}
+          decimals={2}
+        />
+      </View>
+    );
+  },
+);

--- a/app/components/Views/confirmations/components/edit-amount/edit-amount.styles.ts
+++ b/app/components/Views/confirmations/components/edit-amount/edit-amount.styles.ts
@@ -39,6 +39,7 @@ const styleSheet = (params: {
       color: params.vars.hasAlert
         ? params.theme.colors.error.default
         : params.theme.colors.text.default,
+      lineHeight: getFontSize(params.vars.amountLength) * 1.3,
     },
   });
 

--- a/app/components/Views/confirmations/components/edit-amount/edit-amount.styles.ts
+++ b/app/components/Views/confirmations/components/edit-amount/edit-amount.styles.ts
@@ -31,6 +31,7 @@ const styleSheet = (params: {
       alignItems: 'center',
       paddingBottom: 16,
       minHeight: 100,
+      gap: 5,
     },
     input: {
       textAlign: 'center',
@@ -39,7 +40,6 @@ const styleSheet = (params: {
       color: params.vars.hasAlert
         ? params.theme.colors.error.default
         : params.theme.colors.text.default,
-      lineHeight: getFontSize(params.vars.amountLength) * 1.3,
     },
   });
 

--- a/app/components/Views/confirmations/components/edit-amount/edit-amount.test.tsx
+++ b/app/components/Views/confirmations/components/edit-amount/edit-amount.test.tsx
@@ -70,8 +70,8 @@ describe('EditAmount', () => {
     const { getByTestId } = render();
 
     expect(getByTestId('edit-amount-input')).toHaveProp(
-      'value',
-      `$${VALUE_MOCK}`,
+      'defaultValue',
+      `${VALUE_MOCK}`,
     );
   });
 
@@ -110,7 +110,7 @@ describe('EditAmount', () => {
       fireEvent.press(getByText('5'));
     });
 
-    expect(getByTestId('edit-amount-input')).toHaveProp('value', '$5');
+    expect(getByTestId('edit-amount-input')).toHaveProp('defaultValue', '5');
   });
 
   it('displays keyboard automatically when autoKeyboard is true', () => {
@@ -159,7 +159,7 @@ describe('EditAmount', () => {
 
     await jest.runAllTimersAsync();
 
-    expect(input).toHaveProp('value', '$600.27');
+    expect(input).toHaveProp('defaultValue', '600.27');
   });
 
   it('does nothing if percentage button pressed with no pay token selected', async () => {
@@ -200,7 +200,7 @@ describe('EditAmount', () => {
       });
     }
 
-    expect(getByTestId('edit-amount-input')).toHaveProp('value', '$5.12');
+    expect(getByTestId('edit-amount-input')).toHaveProp('defaultValue', '5.12');
   });
 
   it('limits length to 28', async () => {
@@ -217,8 +217,8 @@ describe('EditAmount', () => {
     }
 
     expect(getByTestId('edit-amount-input')).toHaveProp(
-      'value',
-      '$123456789012345678901234567',
+      'defaultValue',
+      '123456789012345678901234567',
     );
   });
 });

--- a/app/components/Views/confirmations/components/edit-amount/edit-amount.test.tsx
+++ b/app/components/Views/confirmations/components/edit-amount/edit-amount.test.tsx
@@ -6,16 +6,11 @@ import { EditAmount, EditAmountProps } from './edit-amount';
 import { transactionApprovalControllerMock } from '../../__mocks__/controllers/approval-controller-mock';
 import { useTokenAmount } from '../../hooks/useTokenAmount';
 import { act, fireEvent } from '@testing-library/react-native';
-import {
-  AlertsContextParams,
-  useAlerts,
-} from '../../context/alert-system-context';
 import { useTransactionPayToken } from '../../hooks/pay/useTransactionPayToken';
 import { useTokenFiatRate } from '../../hooks/tokens/useTokenFiatRates';
 import { otherControllersMock } from '../../__mocks__/controllers/other-controllers-mock';
 
 jest.mock('../../hooks/useTokenAmount');
-jest.mock('../../context/alert-system-context');
 jest.mock('../../hooks/pay/useTransactionPayToken');
 jest.mock('../../hooks/tokens/useTokenFiatRates');
 
@@ -37,7 +32,6 @@ function render(props: EditAmountProps = {}) {
 
 describe('EditAmount', () => {
   const useTokenAmountMock = jest.mocked(useTokenAmount);
-  const useAlertsMock = jest.mocked(useAlerts);
   const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
   const useTokenFiatRateMock = jest.mocked(useTokenFiatRate);
   const updateTokenAmountMock = jest.fn();
@@ -49,10 +43,6 @@ describe('EditAmount', () => {
       fiatUnformatted: '0',
       updateTokenAmount: updateTokenAmountMock,
     } as unknown as ReturnType<typeof useTokenAmount>);
-
-    useAlertsMock.mockReturnValue({
-      fieldAlerts: [],
-    } as unknown as AlertsContextParams);
 
     useTransactionPayTokenMock.mockReturnValue({
       payToken: { balanceFiat: '0' },

--- a/app/components/Views/confirmations/components/edit-amount/edit-amount.tsx
+++ b/app/components/Views/confirmations/components/edit-amount/edit-amount.tsx
@@ -15,6 +15,7 @@ import { getCurrencySymbol } from '../../../../../util/number';
 import { useTokenFiatRate } from '../../hooks/tokens/useTokenFiatRates';
 import { useTransactionMetadataRequest } from '../../hooks/transactions/useTransactionMetadataRequest';
 import { Hex } from '@metamask/utils';
+import Text from '../../../../../component-library/components/Texts/Text';
 
 const MAX_LENGTH = 28;
 
@@ -124,27 +125,27 @@ export function EditAmount({
     [handleChange, tokenFiatAmount],
   );
 
-  const displayValue = `${fiatSymbol}${amountFiat}`;
-
   return (
     <View style={styles.container}>
       <View style={styles.primaryContainer}>
         <View style={styles.inputContainer}>
+          <Text style={styles.input}>{fiatSymbol}</Text>
           <TextInput
             testID="edit-amount-input"
-            value={displayValue}
             style={styles.input}
             ref={inputRef}
+            defaultValue={amountFiat}
             showSoftInputOnFocus={false}
             onPress={handleInputPress}
             onChangeText={handleChange}
+            keyboardType="number-pad"
           />
         </View>
         {children?.(amountHuman)}
       </View>
       {showKeyboard && (
         <DepositKeyboard
-          value={amountFiat.toString()}
+          value={amountFiat}
           hasInput={hasAmount}
           onChange={handleChange}
           onDonePress={handleKeyboardDone}

--- a/app/components/Views/confirmations/components/edit-amount/edit-amount.tsx
+++ b/app/components/Views/confirmations/components/edit-amount/edit-amount.tsx
@@ -15,7 +15,6 @@ import { getCurrencySymbol } from '../../../../../util/number';
 import { useTokenFiatRate } from '../../hooks/tokens/useTokenFiatRates';
 import { useTransactionMetadataRequest } from '../../hooks/transactions/useTransactionMetadataRequest';
 import { Hex } from '@metamask/utils';
-import Text from '../../../../../component-library/components/Texts/Text';
 
 const MAX_LENGTH = 28;
 
@@ -79,18 +78,13 @@ export function EditAmount({
     }
   }, [autoKeyboard, inputChanged, handleInputPress]);
 
-  const handleChange = useCallback(
-    (amount: string) => {
-      const normalizedAmount = amount.replace(new RegExp(fiatSymbol, 'g'), '');
+  const handleChange = useCallback((amount: string) => {
+    if (amount.length >= MAX_LENGTH) {
+      return;
+    }
 
-      if (normalizedAmount.length >= MAX_LENGTH) {
-        return;
-      }
-
-      setAmountFiat(normalizedAmount);
-    },
-    [fiatSymbol],
-  );
+    setAmountFiat(amount);
+  }, []);
 
   const handleKeyboardDone = useCallback(() => {
     updateTokenAmount(amountHuman);
@@ -129,7 +123,11 @@ export function EditAmount({
     <View style={styles.container}>
       <View style={styles.primaryContainer}>
         <View style={styles.inputContainer}>
-          <Text style={styles.input}>{fiatSymbol}</Text>
+          <TextInput
+            style={styles.input}
+            defaultValue={fiatSymbol}
+            editable={false}
+          />
           <TextInput
             testID="edit-amount-input"
             style={styles.input}
@@ -139,6 +137,7 @@ export function EditAmount({
             onPress={handleInputPress}
             onChangeText={handleChange}
             keyboardType="number-pad"
+            maxLength={MAX_LENGTH}
           />
         </View>
         {children?.(amountHuman)}

--- a/app/components/Views/confirmations/components/info/approve/approve.test.tsx
+++ b/app/components/Views/confirmations/components/info/approve/approve.test.tsx
@@ -8,50 +8,36 @@ import { flushPromises } from '../../../../../../util/test/utils';
 import { useConfirmationMetricEvents } from '../../../hooks/metrics/useConfirmationMetricEvents';
 import Approve from './approve';
 
-jest.mock('../../../../../../core/Engine', () => ({
-  getTotalEvmFiatAccountBalance: () => ({ tokenFiat: 10 }),
-  context: {
-    NetworkController: {
-      getNetworkConfigurationByNetworkClientId: jest.fn(),
-    },
-    GasFeeController: {
-      startPolling: jest.fn(),
-      stopPollingByPollingToken: jest.fn(),
-    },
-    TransactionController: {
-      updateTransaction: jest.fn(),
-      getTransactions: jest.fn().mockReturnValue([]),
-      getNonceLock: jest
-        .fn()
-        .mockResolvedValue({ nextNonce: 2, releaseLock: jest.fn() }),
-    },
-    AccountsController: {
-      state: {
-        internalAccounts: {
-          accounts: {
-            '0x0000000000000000000000000000000000000000': {
-              address: '0x0000000000000000000000000000000000000000',
-            },
-          },
-        },
+jest.mock('../../../../../../core/Engine', () => {
+  const { otherControllersMock } = jest.requireActual(
+    '../../../__mocks__/controllers/other-controllers-mock',
+  );
+  return {
+    getTotalEvmFiatAccountBalance: () => ({ tokenFiat: 10 }),
+    context: {
+      NetworkController: {
+        getNetworkConfigurationByNetworkClientId: jest.fn(),
+      },
+      GasFeeController: {
+        startPolling: jest.fn(),
+        stopPollingByPollingToken: jest.fn(),
+      },
+      TransactionController: {
+        updateTransaction: jest.fn(),
+        getTransactions: jest.fn().mockReturnValue([]),
+        getNonceLock: jest
+          .fn()
+          .mockResolvedValue({ nextNonce: 2, releaseLock: jest.fn() }),
+      },
+      KeyringController: {
+        state: otherControllersMock.engine.backgroundState.KeyringController,
+      },
+      AccountsController: {
+        state: otherControllersMock.engine.backgroundState.AccountsController,
       },
     },
-    KeyringController: {
-      state: {
-        keyrings: [
-          {
-            type: 'HD Key Tree',
-            accounts: ['0x0000000000000000000000000000000000000000'],
-            metadata: {
-              id: '01JNG71B7GTWH0J1TSJY9891S0',
-              name: '',
-            },
-          },
-        ],
-      },
-    },
-  },
-}));
+  };
+});
 
 jest.mock('../../../hooks/useConfirmActions', () => ({
   useConfirmActions: jest.fn(),

--- a/app/components/Views/confirmations/components/info/approve/approve.test.tsx
+++ b/app/components/Views/confirmations/components/info/approve/approve.test.tsx
@@ -8,36 +8,50 @@ import { flushPromises } from '../../../../../../util/test/utils';
 import { useConfirmationMetricEvents } from '../../../hooks/metrics/useConfirmationMetricEvents';
 import Approve from './approve';
 
-jest.mock('../../../../../../core/Engine', () => {
-  const { otherControllersMock } = jest.requireActual(
-    '../../../__mocks__/controllers/other-controllers-mock',
-  );
-  return {
-    getTotalEvmFiatAccountBalance: () => ({ tokenFiat: 10 }),
-    context: {
-      NetworkController: {
-        getNetworkConfigurationByNetworkClientId: jest.fn(),
-      },
-      GasFeeController: {
-        startPolling: jest.fn(),
-        stopPollingByPollingToken: jest.fn(),
-      },
-      TransactionController: {
-        updateTransaction: jest.fn(),
-        getTransactions: jest.fn().mockReturnValue([]),
-        getNonceLock: jest
-          .fn()
-          .mockResolvedValue({ nextNonce: 2, releaseLock: jest.fn() }),
-      },
-      KeyringController: {
-        state: otherControllersMock.engine.backgroundState.KeyringController,
-      },
-      AccountsController: {
-        state: otherControllersMock.engine.backgroundState.AccountsController,
+jest.mock('../../../../../../core/Engine', () => ({
+  getTotalEvmFiatAccountBalance: () => ({ tokenFiat: 10 }),
+  context: {
+    NetworkController: {
+      getNetworkConfigurationByNetworkClientId: jest.fn(),
+    },
+    GasFeeController: {
+      startPolling: jest.fn(),
+      stopPollingByPollingToken: jest.fn(),
+    },
+    TransactionController: {
+      updateTransaction: jest.fn(),
+      getTransactions: jest.fn().mockReturnValue([]),
+      getNonceLock: jest
+        .fn()
+        .mockResolvedValue({ nextNonce: 2, releaseLock: jest.fn() }),
+    },
+    AccountsController: {
+      state: {
+        internalAccounts: {
+          accounts: {
+            '0x0000000000000000000000000000000000000000': {
+              address: '0x0000000000000000000000000000000000000000',
+            },
+          },
+        },
       },
     },
-  };
-});
+    KeyringController: {
+      state: {
+        keyrings: [
+          {
+            type: 'HD Key Tree',
+            accounts: ['0x0000000000000000000000000000000000000000'],
+            metadata: {
+              id: '01JNG71B7GTWH0J1TSJY9891S0',
+              name: '',
+            },
+          },
+        ],
+      },
+    },
+  },
+}));
 
 jest.mock('../../../hooks/useConfirmActions', () => ({
   useConfirmActions: jest.fn(),

--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
@@ -58,9 +58,12 @@ describe('PayWithRow', () => {
     jest.mocked(useTransactionPayToken).mockReturnValue({
       payToken: {
         address: ADDRESS_MOCK,
+        balance: '0',
+        balanceFiat: '$0',
         chainId: CHAIN_ID_MOCK,
         decimals: 4,
         symbol: 'test',
+        tokenFiatAmount: 0,
       },
       setPayToken: jest.fn(),
     });

--- a/app/components/Views/confirmations/components/token-icon/token-icon.test.tsx
+++ b/app/components/Views/confirmations/components/token-icon/token-icon.test.tsx
@@ -1,21 +1,20 @@
 import React from 'react';
 import { TokenIcon, TokenIconProps } from './token-icon';
-import { Hex } from '@metamask/utils';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
-import { backgroundState } from '../../../../../util/test/initial-root-state';
 import { useTokensWithBalance } from '../../../../UI/Bridge/hooks/useTokensWithBalance';
+import { merge } from 'lodash';
+import {
+  otherControllersMock,
+  tokenAddress1Mock,
+} from '../../__mocks__/controllers/other-controllers-mock';
 
 jest.mock('../../../../UI/Bridge/hooks/useTokensWithBalance');
 
-const ADDRESS_MOCK = '0x1234567890abcdef1234567890abcdef12345678' as Hex;
-const CHAIN_ID_MOCK = '0x123';
+const ADDRESS_MOCK = tokenAddress1Mock;
+const CHAIN_ID_MOCK = '0x1';
 const SYMBOL_MOCK = 'TST';
 
-const STATE_MOCK = {
-  engine: {
-    backgroundState,
-  },
-};
+const STATE_MOCK = merge({}, otherControllersMock);
 
 function render(props: TokenIconProps) {
   return renderWithProvider(<TokenIcon {...props} />, {

--- a/app/components/Views/confirmations/components/token-icon/token-icon.test.tsx
+++ b/app/components/Views/confirmations/components/token-icon/token-icon.test.tsx
@@ -1,18 +1,14 @@
 import React from 'react';
 import { TokenIcon, TokenIconProps } from './token-icon';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
-import { useTokensWithBalance } from '../../../../UI/Bridge/hooks/useTokensWithBalance';
 import { merge } from 'lodash';
 import {
   otherControllersMock,
   tokenAddress1Mock,
 } from '../../__mocks__/controllers/other-controllers-mock';
 
-jest.mock('../../../../UI/Bridge/hooks/useTokensWithBalance');
-
 const ADDRESS_MOCK = tokenAddress1Mock;
 const CHAIN_ID_MOCK = '0x1';
-const SYMBOL_MOCK = 'TST';
 
 const STATE_MOCK = merge({}, otherControllersMock);
 
@@ -23,19 +19,8 @@ function render(props: TokenIconProps) {
 }
 
 describe('TokenIcon', () => {
-  const useTokensWithBalanceMock = jest.mocked(useTokensWithBalance);
-
   beforeEach(() => {
     jest.resetAllMocks();
-
-    useTokensWithBalanceMock.mockReturnValue([
-      {
-        address: ADDRESS_MOCK,
-        chainId: CHAIN_ID_MOCK,
-        symbol: SYMBOL_MOCK,
-        decimals: 18,
-      },
-    ]);
   });
 
   it('renders token icon', () => {

--- a/app/components/Views/confirmations/components/token-icon/token-icon.tsx
+++ b/app/components/Views/confirmations/components/token-icon/token-icon.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Hex } from '@metamask/utils';
-import { useTokensWithBalance } from '../../../../UI/Bridge/hooks/useTokensWithBalance';
 import SwapsTokenIcon from '../../../../UI/Swaps/components/TokenIcon';
 import styleSheet from './token-icon.styles';
 import { useStyles } from '../../../../hooks/useStyles';
@@ -11,6 +10,9 @@ import Badge, {
   BadgeVariant,
 } from '../../../../../component-library/components/Badges/Badge';
 import { getNetworkImageSource } from '../../../../../util/networks';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../../../../reducers';
+import { selectSingleTokenByAddressAndChainId } from '../../../../../selectors/tokensController';
 
 export interface TokenIconProps {
   address: Hex;
@@ -19,12 +21,9 @@ export interface TokenIconProps {
 
 export const TokenIcon: React.FC<TokenIconProps> = ({ address, chainId }) => {
   const { styles } = useStyles(styleSheet, {});
-  const tokens = useTokensWithBalance({ chainIds: [chainId] });
 
-  const token = tokens.find(
-    (t) =>
-      t.address.toLowerCase() === address.toLowerCase() &&
-      t.chainId === chainId,
+  const token = useSelector((state: RootState) =>
+    selectSingleTokenByAddressAndChainId(state, address, chainId),
   );
 
   if (!token) {

--- a/app/components/Views/confirmations/components/token-icon/token-icon.tsx
+++ b/app/components/Views/confirmations/components/token-icon/token-icon.tsx
@@ -10,9 +10,7 @@ import Badge, {
   BadgeVariant,
 } from '../../../../../component-library/components/Badges/Badge';
 import { getNetworkImageSource } from '../../../../../util/networks';
-import { useSelector } from 'react-redux';
-import { RootState } from '../../../../../reducers';
-import { selectSingleTokenByAddressAndChainId } from '../../../../../selectors/tokensController';
+import { useTokenWithBalance } from '../../hooks/tokens/useTokenWithBalance';
 
 export interface TokenIconProps {
   address: Hex;
@@ -22,9 +20,7 @@ export interface TokenIconProps {
 export const TokenIcon: React.FC<TokenIconProps> = ({ address, chainId }) => {
   const { styles } = useStyles(styleSheet, {});
 
-  const token = useSelector((state: RootState) =>
-    selectSingleTokenByAddressAndChainId(state, address, chainId),
-  );
+  const token = useTokenWithBalance(address, chainId);
 
   if (!token) {
     return null;

--- a/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.test.tsx
+++ b/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.test.tsx
@@ -57,11 +57,12 @@ describe('PerpsDeposit', () => {
     useTransactionPayTokenMock.mockReturnValue({
       payToken: {
         address: '0x123',
-        chainId: '0x1',
         balance: '0',
         balanceFiat: '0',
+        chainId: '0x1',
         decimals: 18,
         symbol: 'TST',
+        tokenFiatAmount: 0,
       },
       setPayToken: noop,
     });

--- a/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.tsx
+++ b/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { PayWithRow } from '../../../../components/rows/pay-with-row';
 import useNavbar from '../../../../hooks/ui/useNavbar';
 import { EditAmount } from '../../../../components/edit-amount';
@@ -14,30 +14,39 @@ import { Box } from '../../../../../../UI/Box/Box';
 import { usePerpsDepositView } from '../../hooks/usePerpsDepositView';
 import { GasFeeFiatRow } from '../../../../components/rows/transactions/gas-fee-fiat-row';
 import useClearConfirmationOnBackSwipe from '../../../../hooks/ui/useClearConfirmationOnBackSwipe';
+import { usePerpsDepositAlerts } from '../../hooks/usePerpsDepositAlerts';
 
 export function PerpsDeposit() {
+  useNavbar(strings('confirm.title.perps_deposit'));
+  useClearConfirmationOnBackSwipe();
+
   const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
+  const [pendingTokenAmount, setPendingTokenAmount] = useState<string>();
   const [inputChanged, setInputChanged] = useState(false);
+  const alerts = usePerpsDepositAlerts({ pendingTokenAmount });
 
   const { isFullView } = usePerpsDepositView({
     isKeyboardVisible,
   });
 
-  useNavbar(strings('confirm.title.perps_deposit'));
-  useClearConfirmationOnBackSwipe();
+  const handleChange = useCallback((amount: string) => {
+    setPendingTokenAmount(amount);
+    setInputChanged(true);
+  }, []);
 
   return (
     <>
       <EditAmount
+        alerts={alerts}
         autoKeyboard
+        onChange={handleChange}
         onKeyboardShow={() => setIsKeyboardVisible(true)}
         onKeyboardHide={() => setIsKeyboardVisible(false)}
-        onKeyboardDone={() => setInputChanged(true)}
       >
         {(amountHuman) => (
           <>
             <Box gap={16}>
-              {inputChanged && <AlertMessage field={RowAlertKey.Amount} />}
+              {inputChanged && <AlertMessage alerts={alerts} />}
               <PayTokenAmount amountHuman={amountHuman} />
             </Box>
             {!isKeyboardVisible && (

--- a/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositAlerts.test.ts
+++ b/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositAlerts.test.ts
@@ -1,0 +1,35 @@
+import { renderHook } from '@testing-library/react-native';
+import { usePerpsDepositAlerts } from './usePerpsDepositAlerts';
+
+jest.mock('../../../hooks/alerts/usePerpsDepositMinimumAlert', () => ({
+  usePerpsDepositMinimumAlert: () => [
+    {
+      id: 'alert-1',
+    },
+  ],
+}));
+
+jest.mock('../../../hooks/alerts/useInsufficientPayTokenBalanceAlert', () => ({
+  useInsufficientPayTokenBalanceAlert: () => [
+    {
+      id: 'alert-2',
+    },
+  ],
+}));
+
+describe('usePerpsDepositAlerts', () => {
+  it('returns alerts', () => {
+    const { result } = renderHook(() =>
+      usePerpsDepositAlerts({ pendingTokenAmount: '0.01' }),
+    );
+
+    expect(result.current).toStrictEqual([
+      {
+        id: 'alert-1',
+      },
+      {
+        id: 'alert-2',
+      },
+    ]);
+  });
+});

--- a/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositAlerts.ts
+++ b/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositAlerts.ts
@@ -1,0 +1,26 @@
+import { useMemo } from 'react';
+import { usePerpsDepositMinimumAlert } from '../../../hooks/alerts/usePerpsDepositMinimumAlert';
+import { Alert } from '../../../types/alerts';
+import { useInsufficientPayTokenBalanceAlert } from '../../../hooks/alerts/useInsufficientPayTokenBalanceAlert';
+import { ARBITRUM_USDC_ADDRESS } from './usePerpsDepositInit';
+
+export function usePerpsDepositAlerts({
+  pendingTokenAmount,
+}: {
+  pendingTokenAmount: string | undefined;
+}): Alert[] {
+  const perpsDepositMinimumAlert = usePerpsDepositMinimumAlert({
+    pendingTokenAmount: pendingTokenAmount ?? '0',
+  });
+
+  const insufficientTokenFundsAlert = useInsufficientPayTokenBalanceAlert({
+    amountOverrides: {
+      [ARBITRUM_USDC_ADDRESS]: pendingTokenAmount ?? '0',
+    },
+  });
+
+  return useMemo(
+    () => [...perpsDepositMinimumAlert, ...insufficientTokenFundsAlert],
+    [perpsDepositMinimumAlert, insufficientTokenFundsAlert],
+  );
+}

--- a/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositView.test.ts
+++ b/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositView.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../../../__mocks__/controllers/transaction-controller-mock';
 import { useTokenAmount } from '../../../hooks/useTokenAmount';
 import { usePerpsDepositView } from './usePerpsDepositView';
+import { TransactionBridgeQuote } from '../../../utils/bridge';
 
 jest.mock('./usePerpsDepositInit');
 jest.mock('../../../hooks/useTokenAmount');
@@ -16,10 +17,10 @@ function runHook(
   props: Parameters<typeof usePerpsDepositView>[0],
   {
     isLoading,
-    hasQuotes,
+    quotes,
   }: {
     isLoading?: boolean;
-    hasQuotes?: boolean;
+    quotes?: Partial<TransactionBridgeQuote>[];
   } = {},
 ) {
   const state = merge(
@@ -29,7 +30,7 @@ function runHook(
     {
       confirmationMetrics: {
         transactionBridgeQuotesById: {
-          [transactionIdMock]: hasQuotes ? [{}] : undefined,
+          [transactionIdMock]: quotes,
         },
         isTransactionBridgeQuotesLoadingById: {
           [transactionIdMock]: isLoading,
@@ -73,7 +74,7 @@ describe('usePerpsDepositView', () => {
         isKeyboardVisible: false,
       },
       {
-        hasQuotes: true,
+        quotes: [{}],
       },
     );
 
@@ -86,7 +87,7 @@ describe('usePerpsDepositView', () => {
         isKeyboardVisible: true,
       },
       {
-        hasQuotes: true,
+        quotes: [{}],
       },
     );
 
@@ -103,10 +104,34 @@ describe('usePerpsDepositView', () => {
         isKeyboardVisible: false,
       },
       {
-        hasQuotes: true,
+        quotes: [{}],
       },
     );
 
     expect(result.current.isFullView).toBe(false);
+  });
+
+  it('returns isFullView as false if quotes are undefined', () => {
+    const { result } = runHook(
+      {
+        isKeyboardVisible: false,
+      },
+      {},
+    );
+
+    expect(result.current.isFullView).toBe(false);
+  });
+
+  it('returns isFullView as true if quotes are empty', () => {
+    const { result } = runHook(
+      {
+        isKeyboardVisible: false,
+      },
+      {
+        quotes: [],
+      },
+    );
+
+    expect(result.current.isFullView).toBe(true);
   });
 });

--- a/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositView.ts
+++ b/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositView.ts
@@ -33,7 +33,7 @@ export function usePerpsDepositView({
   const isFullView =
     !isKeyboardVisible &&
     !amountValue.isZero() &&
-    (isQuotesLoading || Boolean(quotes?.length));
+    (isQuotesLoading || quotes !== undefined);
 
   useAutomaticTransactionPayToken({
     balanceOverrides: [

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
@@ -8,10 +8,15 @@ import { useTransactionPayTokenAmounts } from '../pay/useTransactionPayTokenAmou
 import { strings } from '../../../../../../locales/i18n';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { TransactionType } from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
 
-export function useInsufficientPayTokenBalanceAlert(): Alert[] {
+export function useInsufficientPayTokenBalanceAlert({
+  amountOverrides,
+}: {
+  amountOverrides?: Record<Hex, string>;
+} = {}): Alert[] {
   const { type } = useTransactionMetadataRequest() ?? {};
-  const { totalHuman } = useTransactionPayTokenAmounts();
+  const { totalHuman } = useTransactionPayTokenAmounts({ amountOverrides });
   const { payToken } = useTransactionPayToken();
   const { balance } = payToken ?? {};
 

--- a/app/components/Views/confirmations/hooks/alerts/usePerpsDepositMinimumAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/usePerpsDepositMinimumAlert.test.ts
@@ -14,8 +14,10 @@ import {
 jest.mock('../useTokenAmount');
 jest.mock('../transactions/useTransactionMetadataRequest');
 
-function runHook() {
-  return renderHook(() => usePerpsDepositMinimumAlert());
+function runHook(
+  props: Parameters<typeof usePerpsDepositMinimumAlert>[0] = {},
+) {
+  return renderHook(() => usePerpsDepositMinimumAlert(props));
 }
 
 describe('usePerpsDepositMinimumAlert', () => {
@@ -39,6 +41,22 @@ describe('usePerpsDepositMinimumAlert', () => {
     } as ReturnType<typeof useTokenAmount>);
 
     const { result } = runHook();
+
+    expect(result.current).toStrictEqual([
+      {
+        key: AlertKeys.PerpsDepositMinimum,
+        field: RowAlertKey.Amount,
+        message: strings('alert_system.perps_deposit_minimum.message'),
+        severity: Severity.Danger,
+        isBlocking: true,
+      },
+    ]);
+  });
+
+  it('returns alert if pending token amount less than minimum', () => {
+    useTokenAmountMock.mockReturnValue({} as ReturnType<typeof useTokenAmount>);
+
+    const { result } = runHook({ pendingTokenAmount: '9.99' });
 
     expect(result.current).toStrictEqual([
       {

--- a/app/components/Views/confirmations/hooks/alerts/usePerpsDepositMinimumAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/usePerpsDepositMinimumAlert.ts
@@ -10,13 +10,18 @@ import { TransactionType } from '@metamask/transaction-controller';
 
 export const MINIMUM_DEPOSIT_USD = 10;
 
-export function usePerpsDepositMinimumAlert(): Alert[] {
+export function usePerpsDepositMinimumAlert({
+  pendingTokenAmount,
+}: {
+  pendingTokenAmount?: string;
+} = {}): Alert[] {
   const { type } = useTransactionMetadataRequest() ?? {};
   const { amountUnformatted } = useTokenAmount();
 
   const underMinimum =
-    new BigNumber(amountUnformatted ?? '0').isLessThan(MINIMUM_DEPOSIT_USD) &&
-    type === TransactionType.perpsDeposit;
+    new BigNumber(pendingTokenAmount ?? amountUnformatted ?? '0').isLessThan(
+      MINIMUM_DEPOSIT_USD,
+    ) && type === TransactionType.perpsDeposit;
 
   return useMemo(() => {
     if (!underMinimum) {

--- a/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.ts
@@ -69,6 +69,7 @@ describe('useAutomaticTransactionPayToken', () => {
     selectEnabledSourceChainsMock.mockReturnValue([]);
 
     useTransactionPayTokenMock.mockReturnValue({
+      payToken: undefined,
       setPayToken: setPayTokenMock,
     });
 

--- a/app/components/Views/confirmations/hooks/pay/useTransactionBridgeQuotes.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionBridgeQuotes.test.ts
@@ -69,6 +69,7 @@ describe('useTransactionBridgeQuotes', () => {
         chainId: CHAIN_ID_SOURCE_MOCK,
         decimals: 4,
         symbol: 'TST',
+        tokenFiatAmount: 123.456,
       },
       setPayToken: jest.fn(),
     });

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.test.ts
@@ -11,10 +11,10 @@ import {
   otherControllersMock,
   tokenAddress1Mock,
 } from '../../__mocks__/controllers/other-controllers-mock';
-import { useTokensWithBalance } from '../../../../UI/Bridge/hooks/useTokensWithBalance';
 import { BridgeToken } from '../../../../UI/Bridge/types';
+import { useTokenWithBalance } from '../tokens/useTokenWithBalance';
 
-jest.mock('../../../../UI/Bridge/hooks/useTokensWithBalance');
+jest.mock('../tokens/useTokenWithBalance');
 
 const STATE_MOCK = merge(
   simpleSendTransactionControllerMock,
@@ -58,14 +58,15 @@ function runHook({
 }
 
 describe('useTransactionPayToken', () => {
-  const useTokensWithBalanceMock = jest.mocked(useTokensWithBalance);
+  const useTokenWithBalanceMock = jest.mocked(useTokenWithBalance);
 
   beforeEach(() => {
     jest.resetAllMocks();
-    useTokensWithBalanceMock.mockReturnValue([BRIDGE_TOKEN_MOCK]);
+    useTokenWithBalanceMock.mockReturnValue(BRIDGE_TOKEN_MOCK as never);
   });
 
   it('returns undefined if no state', () => {
+    useTokenWithBalanceMock.mockReset();
     const { result } = runHook();
     expect(result.current.payToken).toBeUndefined();
   });

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
@@ -5,56 +5,34 @@ import {
   setTransactionPayToken,
 } from '../../../../../core/redux/slices/confirmationMetrics';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
-import { EMPTY_ADDRESS } from '../../../../../constants/transaction';
 import { useCallback } from 'react';
 import { RootState } from '../../../../../reducers';
-import { useTokensWithBalance } from '../../../../UI/Bridge/hooks/useTokensWithBalance';
-import { Hex } from '@metamask/utils';
+import { useTokenWithBalance } from '../tokens/useTokenWithBalance';
 
 export function useTransactionPayToken() {
   const dispatch = useDispatch();
-
-  const { chainId: transactionChainId, id: transactionId } =
-    useTransactionMetadataRequest() || {};
+  const { id: transactionId } = useTransactionMetadataRequest() || {};
 
   const selectedPayToken = useSelector((state: RootState) =>
     selectTransactionPayToken(state, transactionId as string),
   );
 
-  const chainId = selectedPayToken?.chainId || transactionChainId;
-  const tokens = useTokensWithBalance({ chainIds: [chainId] });
+  const payToken = useTokenWithBalance(
+    selectedPayToken?.address ?? '0x0',
+    selectedPayToken?.chainId ?? '0x0',
+  );
 
   const setPayToken = useCallback(
-    (payToken: TransactionPayToken) => {
+    (newPayToken: TransactionPayToken) => {
       dispatch(
         setTransactionPayToken({
           transactionId: transactionId as string,
-          payToken,
+          payToken: newPayToken,
         }),
       );
     },
     [dispatch, transactionId],
   );
-
-  const token = tokens.find(
-    (t) =>
-      t.chainId === chainId &&
-      t.address.toLowerCase() ===
-        (selectedPayToken?.address.toLowerCase() ??
-          EMPTY_ADDRESS.toLowerCase()),
-  );
-
-  if (!selectedPayToken || !token) {
-    return {
-      setPayToken,
-    };
-  }
-
-  const payToken = {
-    ...token,
-    address: token.address as Hex,
-    chainId: token.chainId as Hex,
-  };
 
   return {
     payToken,

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayTokenAmounts.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayTokenAmounts.test.ts
@@ -56,6 +56,7 @@ describe('useTransactionPayTokenAmounts', () => {
         chainId: CHAIN_ID_MOCK,
         decimals: 4,
         symbol: 'TST',
+        tokenFiatAmount: 123.456,
       },
       setPayToken: jest.fn(),
     });
@@ -207,7 +208,10 @@ describe('useTransactionPayTokenAmounts', () => {
   });
 
   it('returns undefined if no pay token selected', () => {
-    useTransactionPayTokenMock.mockReturnValue({ setPayToken: jest.fn() });
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: undefined,
+      setPayToken: jest.fn(),
+    });
 
     const sourceAmounts = runHook();
     expect(sourceAmounts.amounts).toBeUndefined();

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayTokenAmounts.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayTokenAmounts.ts
@@ -3,7 +3,7 @@ import { useEffect, useMemo } from 'react';
 import { useTransactionPayToken } from './useTransactionPayToken';
 import { useTokenFiatRates } from '../tokens/useTokenFiatRates';
 import { useTransactionRequiredFiat } from './useTransactionRequiredFiat';
-import { createProjectLogger } from '@metamask/utils';
+import { Hex, createProjectLogger } from '@metamask/utils';
 import { useDeepMemo } from '../useDeepMemo';
 
 const log = createProjectLogger('transaction-pay');
@@ -11,7 +11,11 @@ const log = createProjectLogger('transaction-pay');
 /**
  * Calculate the amount of the selected pay token, that is needed for each token required by the transaction.
  */
-export function useTransactionPayTokenAmounts() {
+export function useTransactionPayTokenAmounts({
+  amountOverrides,
+}: {
+  amountOverrides?: Record<Hex, string>;
+} = {}) {
   const { payToken } = useTransactionPayToken();
   const { address, chainId, decimals } = payToken ?? {};
 
@@ -29,7 +33,7 @@ export function useTransactionPayTokenAmounts() {
   }, [address, chainId]);
 
   const tokenFiatRate = useTokenFiatRates(fiatRequests)[0];
-  const { values } = useTransactionRequiredFiat();
+  const { values } = useTransactionRequiredFiat({ amountOverrides });
 
   const amounts = useDeepMemo(() => {
     if (!address || !chainId || !tokenFiatRate || !decimals) {

--- a/app/components/Views/confirmations/hooks/pay/useTransactionRequiredFiat.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionRequiredFiat.test.ts
@@ -20,7 +20,7 @@ jest.mock('../tokens/useTokenFiatRates');
 jest.mock('./useTransactionRequiredTokens');
 jest.mock('../../../../UI/Bridge/hooks/useTokensWithBalance');
 
-function runHook() {
+function runHook(props: Parameters<typeof useTransactionRequiredFiat>[0] = {}) {
   const state = merge(
     {
       engine: {
@@ -33,8 +33,9 @@ function runHook() {
     accountsControllerMock,
   );
 
-  return renderHookWithProvider(useTransactionRequiredFiat, { state }).result
-    .current;
+  return renderHookWithProvider(() => useTransactionRequiredFiat(props), {
+    state,
+  }).result.current;
 }
 
 describe('useTransactionRequiredFiat', () => {
@@ -90,5 +91,32 @@ describe('useTransactionRequiredFiat', () => {
   it('returns total fiat value', () => {
     const { totalFiat } = runHook();
     expect(totalFiat).toBe(23.575);
+  });
+
+  it('supports amount overrides', () => {
+    const { values } = runHook({
+      amountOverrides: {
+        [tokenAddress1Mock]: '4',
+      },
+    });
+
+    expect(values).toStrictEqual([
+      {
+        address: tokenAddress1Mock,
+        amountFiat: 16,
+        balanceFiat: 40,
+        feeFiat: 0.4,
+        skipIfBalance: false,
+        totalFiat: 16.4,
+      },
+      {
+        address: tokenAddress2Mock,
+        amountFiat: 15,
+        balanceFiat: 100,
+        feeFiat: 0.375,
+        skipIfBalance: true,
+        totalFiat: 15.375,
+      },
+    ]);
   });
 });

--- a/app/components/Views/confirmations/hooks/pay/useTransactionRequiredTokens.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionRequiredTokens.test.ts
@@ -11,11 +11,11 @@ import {
 import { EMPTY_ADDRESS } from '../../../../../constants/transaction';
 import { abiERC20 } from '@metamask/metamask-eth-abis';
 import { Interface } from '@ethersproject/abi';
-import { useTokensWithBalance } from '../../../../UI/Bridge/hooks/useTokensWithBalance';
 import { toHex } from '@metamask/controller-utils';
 import { NATIVE_TOKEN_ADDRESS } from '../../constants/tokens';
+import { useTokenWithBalance } from '../tokens/useTokenWithBalance';
 
-jest.mock('../../../../UI/Bridge/hooks/useTokensWithBalance');
+jest.mock('../tokens/useTokenWithBalance');
 
 const TOKEN_ADDRESS_MOCK = '0x1234567890123456789012345678901234567890';
 const TO_MOCK = '0x0987654321098765432109876543210987654321';
@@ -48,27 +48,30 @@ function runHook({
 }
 
 describe('useTransactionRequiredTokens', () => {
-  const useTokensWithBalanceMock = jest.mocked(useTokensWithBalance);
+  const useTokenWithBalanceMock = jest.mocked(useTokenWithBalance);
 
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
 
-    useTokensWithBalanceMock.mockReturnValue([
-      {
-        address: TOKEN_ADDRESS_MOCK,
-        balance: '0',
-        symbol: 'TST',
-        decimals: 4,
-        chainId: '0x1',
-      },
-      {
+    useTokenWithBalanceMock
+      .mockReturnValueOnce({
         address: NATIVE_TOKEN_ADDRESS,
         balance: '0',
+        balanceFiat: '0',
+        tokenFiatAmount: 0,
         symbol: 'ETH',
         decimals: 18,
         chainId: '0x1',
-      },
-    ]);
+      })
+      .mockReturnValueOnce({
+        address: TOKEN_ADDRESS_MOCK,
+        balance: '0',
+        balanceFiat: '0',
+        tokenFiatAmount: 0,
+        symbol: 'TST',
+        decimals: 4,
+        chainId: '0x1',
+      });
   });
 
   it('returns gas token', () => {
@@ -121,22 +124,26 @@ describe('useTransactionRequiredTokens', () => {
   });
 
   it('returns token balances', () => {
-    useTokensWithBalanceMock.mockReturnValue([
-      {
+    useTokenWithBalanceMock.mockReset();
+    useTokenWithBalanceMock
+      .mockReturnValueOnce({
         address: NATIVE_TOKEN_ADDRESS,
         balance: '0',
+        balanceFiat: '0',
+        tokenFiatAmount: 0,
         symbol: 'ETH',
         decimals: 18,
         chainId: '0x1',
-      },
-      {
+      })
+      .mockReturnValueOnce({
         address: TOKEN_ADDRESS_MOCK,
         balance: '3',
+        balanceFiat: '3',
+        tokenFiatAmount: 3,
         symbol: 'TST',
         decimals: 4,
         chainId: '0x1',
-      },
-    ]);
+      });
 
     const tokens = runHook({
       transaction: {

--- a/app/components/Views/confirmations/hooks/tokens/useTokenFiatRates.test.ts
+++ b/app/components/Views/confirmations/hooks/tokens/useTokenFiatRates.test.ts
@@ -2,6 +2,10 @@ import { backgroundState } from '../../../../../util/test/initial-root-state';
 import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
 import { TokenFiatRateRequest, useTokenFiatRates } from './useTokenFiatRates';
 
+jest.mock('../../../../../util/address', () => ({
+  toChecksumAddress: jest.fn((address) => address),
+}));
+
 const CHAIN_ID_1_MOCK = '0x123';
 const CHAIN_ID_2_MOCK = '0x456';
 const ADDRESS_1_MOCK = '0x789';

--- a/app/components/Views/confirmations/hooks/tokens/useTokenFiatRates.ts
+++ b/app/components/Views/confirmations/hooks/tokens/useTokenFiatRates.ts
@@ -5,6 +5,7 @@ import { selectCurrencyRates } from '../../../../../selectors/currencyRateContro
 import { selectNetworkConfigurations } from '../../../../../selectors/networkController';
 import { useMemo } from 'react';
 import { useDeepMemo } from '../useDeepMemo';
+import { toChecksumAddress } from '../../../../../util/address';
 
 export interface TokenFiatRateRequest {
   address: Hex;
@@ -20,14 +21,8 @@ export function useTokenFiatRates(requests: TokenFiatRateRequest[]) {
   const result = useMemo(
     () =>
       safeRequests.map(({ address, chainId }) => {
-        const chainTokens = Object.values(
-          tokenMarketDataByAddressByChainId[chainId] ?? {},
-        );
-
-        const token = chainTokens.find(
-          (t) => t.tokenAddress.toLowerCase() === address.toLowerCase(),
-        );
-
+        const chainTokens = tokenMarketDataByAddressByChainId[chainId] ?? {};
+        const token = chainTokens[toChecksumAddress(address)];
         const networkConfiguration = networkConfigurations[chainId];
 
         const conversionRate =

--- a/app/components/Views/confirmations/hooks/tokens/useTokenWithBalance.test.ts
+++ b/app/components/Views/confirmations/hooks/tokens/useTokenWithBalance.test.ts
@@ -1,0 +1,38 @@
+import { Hex } from '@metamask/utils';
+import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
+import { useTokenWithBalance } from './useTokenWithBalance';
+import { merge } from 'lodash';
+import {
+  otherControllersMock,
+  tokenAddress1Mock,
+} from '../../__mocks__/controllers/other-controllers-mock';
+
+function runHook(tokenAddress: Hex, chainId: Hex) {
+  return renderHookWithProvider(
+    () => useTokenWithBalance(tokenAddress, chainId),
+    {
+      state: merge({}, otherControllersMock),
+    },
+  );
+}
+
+describe('useTokenWithBalance', () => {
+  it('returns token and balance properties', () => {
+    const { result } = runHook(tokenAddress1Mock, '0x1');
+
+    expect(result.current).toStrictEqual({
+      address: tokenAddress1Mock,
+      balance: '0.01',
+      balanceFiat: '$100',
+      chainId: '0x1',
+      decimals: 4,
+      symbol: 'T1',
+      tokenFiatAmount: 100,
+    });
+  });
+
+  it('returns undefined if no token exists for the given address and chain ID', () => {
+    const { result } = runHook('0x123', '0x1');
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/app/components/Views/confirmations/hooks/tokens/useTokenWithBalance.test.ts
+++ b/app/components/Views/confirmations/hooks/tokens/useTokenWithBalance.test.ts
@@ -6,6 +6,7 @@ import {
   otherControllersMock,
   tokenAddress1Mock,
 } from '../../__mocks__/controllers/other-controllers-mock';
+import { NATIVE_TOKEN_ADDRESS } from '../../constants/tokens';
 
 function runHook(tokenAddress: Hex, chainId: Hex) {
   return renderHookWithProvider(
@@ -28,6 +29,20 @@ describe('useTokenWithBalance', () => {
       decimals: 4,
       symbol: 'T1',
       tokenFiatAmount: 100,
+    });
+  });
+
+  it('returns native token properties', () => {
+    const { result } = runHook(NATIVE_TOKEN_ADDRESS, '0x1');
+
+    expect(result.current).toStrictEqual({
+      address: NATIVE_TOKEN_ADDRESS,
+      balance: '2',
+      balanceFiat: '$20,000',
+      chainId: '0x1',
+      decimals: 18,
+      symbol: 'ETH',
+      tokenFiatAmount: 20000,
     });
   });
 

--- a/app/components/Views/confirmations/hooks/tokens/useTokenWithBalance.ts
+++ b/app/components/Views/confirmations/hooks/tokens/useTokenWithBalance.ts
@@ -1,0 +1,65 @@
+import { Hex } from '@metamask/utils';
+import { useSelector } from 'react-redux';
+import { selectSingleTokenByAddressAndChainId } from '../../../../../selectors/tokensController';
+import { RootState } from '../../../../../reducers';
+import { selectSingleTokenBalance } from '../../../../../selectors/tokenBalancesController';
+import { selectSelectedInternalAccountAddress } from '../../../../../selectors/accountsController';
+import { toChecksumAddress } from '../../../../../util/address';
+import { useTokenFiatRate } from './useTokenFiatRates';
+import { BigNumber } from 'bignumber.js';
+import { useMemo } from 'react';
+import useFiatFormatter from '../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
+
+export function useTokenWithBalance(tokenAddress: Hex, chainId: Hex) {
+  const selectedAddress = useSelector(selectSelectedInternalAccountAddress);
+  const fiatFormatter = useFiatFormatter();
+
+  const token = useSelector((state: RootState) =>
+    selectSingleTokenByAddressAndChainId(state, tokenAddress, chainId),
+  );
+
+  const tokenBalanceResult = useSelector((state: RootState) =>
+    selectSingleTokenBalance(
+      state,
+      selectedAddress as Hex,
+      toChecksumAddress(tokenAddress),
+      chainId,
+    ),
+  );
+
+  const tokenBalanceHex = useMemo(
+    () =>
+      tokenBalanceResult
+        ? Object.values(tokenBalanceResult)[0] ?? '0x0'
+        : '0x0',
+    [tokenBalanceResult],
+  );
+
+  const tokenFiatRate = useTokenFiatRate(tokenAddress, chainId);
+
+  return useMemo(() => {
+    if (!token) {
+      return undefined;
+    }
+
+    const balanceRawValue = new BigNumber(tokenBalanceHex);
+    const balanceValue = balanceRawValue.shiftedBy(-token.decimals);
+
+    const balanceFiatValue = tokenFiatRate
+      ? balanceValue.multipliedBy(tokenFiatRate)
+      : new BigNumber(0);
+
+    const balance = balanceValue.toString(10);
+    const balanceFiat = fiatFormatter(balanceFiatValue);
+    const tokenFiatAmount = balanceFiatValue.toNumber();
+
+    return {
+      ...token,
+      address: token.address as Hex,
+      balance,
+      balanceFiat,
+      chainId,
+      tokenFiatAmount,
+    };
+  }, [chainId, fiatFormatter, token, tokenBalanceHex, tokenFiatRate]);
+}

--- a/app/components/Views/confirmations/hooks/tokens/useTokenWithBalance.ts
+++ b/app/components/Views/confirmations/hooks/tokens/useTokenWithBalance.ts
@@ -22,8 +22,8 @@ export function useTokenWithBalance(tokenAddress: Hex, chainId: Hex) {
     selectSingleTokenBalance(
       state,
       selectedAddress as Hex,
-      toChecksumAddress(tokenAddress),
       chainId,
+      toChecksumAddress(tokenAddress),
     ),
   );
 

--- a/app/selectors/accountTrackerController.ts
+++ b/app/selectors/accountTrackerController.ts
@@ -4,6 +4,7 @@ import { RootState } from '../reducers';
 import { createDeepEqualSelector } from './util';
 import { selectEvmChainId } from './networkController';
 import { selectSelectedInternalAccountFormattedAddress } from './accountsController';
+import { Hex } from '@metamask/utils';
 
 const selectAccountTrackerControllerState = (state: RootState) =>
   state.engine.backgroundState.AccountTrackerController;
@@ -30,9 +31,15 @@ export const selectAccountBalanceByChainId = createDeepEqualSelector(
   selectAccountsByChainId,
   selectEvmChainId,
   selectSelectedInternalAccountFormattedAddress,
-  (accountsByChainId, chainId, selectedInternalAccountChecksummedAddress) => {
+  (_state: RootState, chainId?: Hex) => chainId,
+  (
+    accountsByChainId,
+    globalChainId,
+    selectedInternalAccountChecksummedAddress,
+    chainId,
+  ) => {
     const accountsBalance = selectedInternalAccountChecksummedAddress
-      ? accountsByChainId?.[chainId]?.[
+      ? accountsByChainId?.[chainId ?? globalChainId]?.[
           selectedInternalAccountChecksummedAddress
         ]
       : undefined;

--- a/app/selectors/tokensController.test.ts
+++ b/app/selectors/tokensController.test.ts
@@ -11,6 +11,7 @@ import {
   selectAllDetectedTokensFlat,
   selectTokensByChainIdAndAddress,
   getChainIdsToPoll,
+  selectSingleTokenByAddressAndChainId,
 } from './tokensController';
 // eslint-disable-next-line import/no-namespace
 import * as networks from '../util/networks';
@@ -357,6 +358,26 @@ describe('TokensController Selectors', () => {
         '0x1',
       );
       expect(chainIds).toStrictEqual(['0x1']);
+    });
+  });
+
+  describe('selectSingleTokenByAddressAndChainId', () => {
+    it('returns the token for the given address and chain ID', () => {
+      const token = selectSingleTokenByAddressAndChainId(
+        mockRootState,
+        '0xToken1',
+        '0x1',
+      );
+      expect(token).toStrictEqual(mockToken);
+    });
+
+    it('returns undefined if no token exists for the given address and chain ID', () => {
+      const token = selectSingleTokenByAddressAndChainId(
+        mockRootState,
+        '0xAddress1',
+        '0x2',
+      );
+      expect(token).toBeUndefined();
     });
   });
 });

--- a/app/selectors/tokensController.ts
+++ b/app/selectors/tokensController.ts
@@ -218,3 +218,20 @@ export const selectTransformedTokens = createSelector(
     return flatList;
   },
 );
+
+export const selectSingleTokenByAddressAndChainId = createSelector(
+  selectAllTokens,
+  selectSelectedInternalAccountAddress,
+  (_state: RootState, tokenAddress: Hex) => tokenAddress,
+  (_state: RootState, _tokenAddress: Hex, chainId: Hex) => chainId,
+  (allTokens, selectedAddress, tokenAddress, chainId) => {
+    if (!selectedAddress) return undefined;
+
+    const tokensForAddressAndChain =
+      allTokens[chainId]?.[selectedAddress] ?? [];
+
+    return tokensForAddressAndChain.find(
+      (token) => token.address.toLowerCase() === tokenAddress.toLowerCase(),
+    );
+  },
+);


### PR DESCRIPTION
## **Description**

Prevent brief display of alerts when changing token amount.

Specifically:

- Validate pending token amount using new `usePerpsDepositAlerts` hook.
- Show network and total rows if payment token is target.
- Add `useTokenWithBalance` hook to retrieve token details and balance for single token.
- Optimise performance of `useAutomaticTransactionPayToken`.
- Move fiat symbol out of input.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #18842

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
