### PR TITLE
fix: cleanup prewarm on account switch in stream classes

### DIFF
--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -224,6 +224,8 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
   public clearCache(): void {
     // Clear the price-specific cache
     this.priceCache.clear();
+    // Cleanup pre-warm subscription
+    this.cleanupPrewarm();
     // Call parent clearCache
     super.clearCache();
   }
@@ -390,6 +392,13 @@ class OrderStreamChannel extends StreamChannel<Order[]> {
       this.prewarmUnsubscribe = undefined;
     }
   }
+
+  public clearCache(): void {
+    // Cleanup pre-warm subscription
+    this.cleanupPrewarm();
+    // Call parent clearCache
+    super.clearCache();
+  }
 }
 
 // Specific channel for positions
@@ -437,6 +446,13 @@ class PositionStreamChannel extends StreamChannel<Position[]> {
     });
 
     return this.prewarmUnsubscribe;
+  }
+
+  public clearCache(): void {
+    // Cleanup pre-warm subscription
+    this.cleanupPrewarm();
+    // Call parent clearCache
+    super.clearCache();
   }
 
   /**
@@ -498,6 +514,13 @@ class AccountStreamChannel extends StreamChannel<AccountState | null> {
 
   protected getClearedData(): AccountState | null {
     return null;
+  }
+
+  public clearCache(): void {
+    // Cleanup pre-warm subscription
+    this.cleanupPrewarm();
+    // Call parent clearCache
+    super.clearCache();
   }
 
   /**

--- a/app/components/UI/Perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/components/UI/Perps/services/HyperLiquidSubscriptionService.ts
@@ -76,10 +76,10 @@ export class HyperLiquidSubscriptionService {
   private positionSubscriberCount = 0;
   private orderSubscriberCount = 0;
   private accountSubscriberCount = 0;
+
   private cachedPositions: Position[] | null = null;
   private cachedOrders: Order[] | null = null;
   private cachedAccount: AccountState | null = null;
-
   // Global price data cache
   private cachedPriceData: Map<string, PriceUpdate> | null = null;
 
@@ -349,10 +349,7 @@ export class HyperLiquidSubscriptionService {
 
           // Only notify position subscribers on first update (when cachedPositions is null) or when data changes
           // This prevents repeated notifications when positions remain empty
-          const shouldNotifyPositions =
-            positionsChanged || this.cachedPositions === null; // Only notify if we haven't sent initial data yet
-
-          if (shouldNotifyPositions) {
+          if (positionsChanged) {
             this.cachedPositions = positionsWithTPSL;
             this.positionSubscribers.forEach((callback) => {
               callback(positionsWithTPSL);
@@ -360,10 +357,7 @@ export class HyperLiquidSubscriptionService {
           }
 
           // Only notify order subscribers on first update (when cachedOrders is null) or when data changes
-          const shouldNotifyOrders =
-            ordersChanged || this.cachedOrders === null; // Only notify if we haven't sent initial data yet
-
-          if (shouldNotifyOrders) {
+          if (ordersChanged) {
             this.cachedOrders = orders;
             this.orderSubscribers.forEach((callback) => {
               callback(orders);
@@ -433,7 +427,7 @@ export class HyperLiquidSubscriptionService {
     this.positionSubscriberCount++;
 
     // Immediately provide cached data if available
-    if (this.cachedPositions && this.cachedPositions.length > 0) {
+    if (this.cachedPositions) {
       callback(this.cachedPositions);
     }
 
@@ -537,7 +531,7 @@ export class HyperLiquidSubscriptionService {
     this.orderSubscriberCount++;
 
     // Immediately provide cached data if available
-    if (this.cachedOrders && this.cachedOrders.length > 0) {
+    if (this.cachedOrders) {
       callback(this.cachedOrders);
     }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
1. What is the reason for the change?
We are not refreshing price data after switching an account on the market list view and also not refreshing prices on the asset detail view either
2. What is the improvement/solution?
Ensure that we are connecting to the websocket if a connection does not exist. Clean up prewarm connection if needed as in certain cases we check if the prewarm is closed and it should not be left open after an account switch.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1473

## **Manual testing steps**

```gherkin
Feature: fix no stream data for live prices on account switch

  Scenario: user views markets list
    Given user has switched to another evm account

    When user observes the market list
    Then prices should update every 3 seconds
    
  Scenario: user views markets list
    Given user has switched to another evm account

    When user observes the market list and then clicks into a coin on the list
    Then prices should update every 3 seconds and price should not be zero
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
https://github.com/user-attachments/assets/bd087797-8102-4ac4-8cdf-bad3adc15199

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/8d547422-e122-4b1a-b096-992b285f4e3d
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



