### PR TITLE
fix: cp-7.55.0 Show imported account and hardware wallets in new send flow

### DIFF
--- a/app/components/Views/confirmations/hooks/send/useAccounts.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useAccounts.test.ts
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import { useSelector } from 'react-redux';
 import { isEvmAccountType } from '@metamask/keyring-api';
 
-import { selectMultichainWallets } from '../../../../../selectors/multichainAccounts/wallets';
+import { selectWallets } from '../../../../../selectors/multichainAccounts/wallets';
 import { selectInternalAccountsById } from '../../../../../selectors/accountsController';
 import { isSolanaAccount } from '../../../../../core/Multichain/utils';
 import { useSendContext } from '../../context/send-context';
@@ -26,7 +26,7 @@ jest.mock('../../../../../core/Multichain/utils', () => ({
 }));
 
 jest.mock('../../../../../selectors/multichainAccounts/wallets', () => ({
-  selectMultichainWallets: jest.fn(),
+  selectWallets: jest.fn(),
 }));
 
 jest.mock('../../../../../selectors/accountsController', () => ({
@@ -105,7 +105,7 @@ describe('useAccounts', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseSelector.mockImplementation((selector) => {
-      if (selector === selectMultichainWallets) {
+      if (selector === selectWallets) {
         return [mockWallet];
       }
       if (selector === selectInternalAccountsById) {
@@ -252,7 +252,7 @@ describe('useAccounts', () => {
 
   it('handles empty wallets array', () => {
     mockUseSelector.mockImplementation((selector) => {
-      if (selector === selectMultichainWallets) {
+      if (selector === selectWallets) {
         return [];
       }
       if (selector === selectInternalAccountsById) {
@@ -268,7 +268,7 @@ describe('useAccounts', () => {
 
   it('handles missing internal accounts', () => {
     mockUseSelector.mockImplementation((selector) => {
-      if (selector === selectMultichainWallets) {
+      if (selector === selectWallets) {
         return [mockWallet];
       }
       if (selector === selectInternalAccountsById) {
@@ -304,7 +304,7 @@ describe('useAccounts', () => {
     };
 
     mockUseSelector.mockImplementation((selector) => {
-      if (selector === selectMultichainWallets) {
+      if (selector === selectWallets) {
         return [walletWithEmptyGroups];
       }
       if (selector === selectInternalAccountsById) {
@@ -333,7 +333,7 @@ describe('useAccounts', () => {
     };
 
     mockUseSelector.mockImplementation((selector) => {
-      if (selector === selectMultichainWallets) {
+      if (selector === selectWallets) {
         return [walletWithEmptyAccountGroups];
       }
       if (selector === selectInternalAccountsById) {
@@ -389,7 +389,7 @@ describe('useAccounts', () => {
       );
 
       mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectMultichainWallets) {
+        if (selector === selectWallets) {
           return [mockWallet, mockSecondWallet];
         }
         if (selector === selectInternalAccountsById) {

--- a/app/components/Views/confirmations/hooks/send/useAccounts.ts
+++ b/app/components/Views/confirmations/hooks/send/useAccounts.ts
@@ -6,7 +6,7 @@ import {
   type AccountGroupObject,
 } from '@metamask/account-tree-controller';
 
-import { selectMultichainWallets } from '../../../../../selectors/multichainAccounts/wallets';
+import { selectWallets } from '../../../../../selectors/multichainAccounts/wallets';
 import { selectInternalAccountsById } from '../../../../../selectors/accountsController';
 import { isSolanaAccount } from '../../../../../core/Multichain/utils';
 import { type RecipientType } from '../../components/UI/recipient';
@@ -14,7 +14,7 @@ import { useSendContext } from '../../context/send-context';
 import { useSendType } from './useSendType';
 
 export const useAccounts = (): RecipientType[] => {
-  const multichainWallets = useSelector(selectMultichainWallets);
+  const multichainWallets = useSelector(selectWallets);
   const internalAccountsById = useSelector(selectInternalAccountsById);
   const { from } = useSendContext();
   const { isEvmSendType, isSolanaSendType } = useSendType();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to fix tiny bug on send flow where it hides "Imported accounts" and hardware wallets in `recipient` page.

The reason was to use `selectMultichainWallets` instead of `selectWallets` selector because `selectMultichainWallets` was only selecting `AccountWalletType.Entropy`

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/19001

## **Manual testing steps**

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="723" height="1440" alt="Screenshot 2025-09-01 at 10 59 37" src="https://github.com/user-attachments/assets/4ae3d975-c241-459b-a216-5755d3682c49" />


### **After**

<img width="767" height="1484" alt="Screenshot 2025-09-01 at 10 59 28" src="https://github.com/user-attachments/assets/c97fb0bf-2406-4922-81c6-98ded8c92779" />


## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
