### PR TITLE
test: Add APIs used in Snaps tests to allowlist

### DIFF
--- a/app/components/Views/AccountConnect/AccountConnect.tsx
+++ b/app/components/Views/AccountConnect/AccountConnect.tsx
@@ -105,6 +105,7 @@ import { WalletClientType } from '../../../core/SnapKeyring/MultichainWalletSnap
 import AddNewAccount from '../AddNewAccount';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { getApiAnalyticsProperties } from '../../../util/metrics/MultichainAPI/getApiAnalyticsProperties';
+import { isSnapId } from '@metamask/snaps-utils';
 
 const AccountConnect = (props: AccountConnectProps) => {
   const { colors } = useTheme();
@@ -327,7 +328,7 @@ const AccountConnect = (props: AccountConnectProps) => {
     let url = dappUrl || channelIdOrHostname || '';
 
     const checkOrigin = async () => {
-      if (isProductSafetyDappScanningEnabled()) {
+      if (isProductSafetyDappScanningEnabled() && !isSnapId(url)) {
         url = prefixUrlWithProtocol(url);
       }
       const scanResult = await getPhishingTestResultAsync(url);

--- a/e2e/api-mocking/mock-e2e-allowlist.ts
+++ b/e2e/api-mocking/mock-e2e-allowlist.ts
@@ -50,5 +50,5 @@ export const ALLOWLISTED_URLS = [
   'https://client-config.api.cx.metamask.io/v1/flags?client=mobile&distribution=flask&environment=dev',
   'https://acl.execution.metamask.io/latest/registry.json',
   'https://acl.execution.metamask.io/latest/signature.json',
-  'https://signature-insights.api.cx.metamask.io/v1/signature?chainId=0x539',
+  'https://signature-insights.api.cx.metamask.io/v1/signature?chainId=0x1',
 ];

--- a/e2e/api-mocking/mock-e2e-allowlist.ts
+++ b/e2e/api-mocking/mock-e2e-allowlist.ts
@@ -47,4 +47,8 @@ export const ALLOWLISTED_URLS = [
   'https://nft.api.cx.metamask.io/collections?contract=0xb66a603f4cfe17e3d27b87a8bfcad319856518b8&chainId=1',
   'https://nft.api.cx.metamask.io/users/0x76cf1cdd1fcc252442b50d6e97207228aa4aefc3/tokens?chainIds=1&limit=50&includeTopBid=true&continuation=',
   'https://bridge.dev-api.cx.metamask.io/getTokens?chainId=1',
+  'https://dapp-scanning.api.cx.metamask.io/v2/scan?url=metamask.github.io',
+  'https://client-config.api.cx.metamask.io/v1/flags?client=mobile&distribution=flask&environment=dev',
+  'https://acl.execution.metamask.io/latest/registry.json',
+  'https://acl.execution.metamask.io/latest/signature.json',
 ];

--- a/e2e/api-mocking/mock-e2e-allowlist.ts
+++ b/e2e/api-mocking/mock-e2e-allowlist.ts
@@ -50,4 +50,5 @@ export const ALLOWLISTED_URLS = [
   'https://client-config.api.cx.metamask.io/v1/flags?client=mobile&distribution=flask&environment=dev',
   'https://acl.execution.metamask.io/latest/registry.json',
   'https://acl.execution.metamask.io/latest/signature.json',
+  'https://signature-insights.api.cx.metamask.io/v1/signature?chainId=0x539',
 ];

--- a/e2e/api-mocking/mock-e2e-allowlist.ts
+++ b/e2e/api-mocking/mock-e2e-allowlist.ts
@@ -47,7 +47,6 @@ export const ALLOWLISTED_URLS = [
   'https://nft.api.cx.metamask.io/collections?contract=0xb66a603f4cfe17e3d27b87a8bfcad319856518b8&chainId=1',
   'https://nft.api.cx.metamask.io/users/0x76cf1cdd1fcc252442b50d6e97207228aa4aefc3/tokens?chainIds=1&limit=50&includeTopBid=true&continuation=',
   'https://bridge.dev-api.cx.metamask.io/getTokens?chainId=1',
-  'https://dapp-scanning.api.cx.metamask.io/v2/scan?url=metamask.github.io',
   'https://client-config.api.cx.metamask.io/v1/flags?client=mobile&distribution=flask&environment=dev',
   'https://acl.execution.metamask.io/latest/registry.json',
   'https://acl.execution.metamask.io/latest/signature.json',

--- a/e2e/api-mocking/mock-responses/defaults/dapp-scanning.ts
+++ b/e2e/api-mocking/mock-responses/defaults/dapp-scanning.ts
@@ -69,5 +69,13 @@ export const DAPP_SCANNING_MOCKS: MockEventsObject = {
         recommendedAction: 'NONE',
       },
     },
+    {
+      urlEndpoint: createDappScanningUrl('metamask.github.io'),
+      responseCode: 200,
+      response: {
+        domainName: 'metamask.github.io',
+        recommendedAction: 'NONE',
+      },
+    },
   ],
 };

--- a/e2e/api-mocking/mock-server.ts
+++ b/e2e/api-mocking/mock-server.ts
@@ -82,6 +82,11 @@ const isUrlAllowed = (url: string): boolean => {
     const parsedUrl = new URL(url);
     const hostname = parsedUrl.hostname;
 
+    // Allow data URLs, e.g. for decoding base64
+    if (parsedUrl.protocol === 'data:') {
+      return true;
+    }
+
     return ALLOWLISTED_HOSTS.some((allowedHost) => {
       // Support exact match or wildcard subdomains (e.g., "*.example.com")
       if (allowedHost.startsWith('*.')) {

--- a/e2e/specs/snaps/test-snap-ethereum-provider.spec.ts
+++ b/e2e/specs/snaps/test-snap-ethereum-provider.spec.ts
@@ -23,6 +23,7 @@ describe(FlaskBuildTests('Ethereum Provider Snap Tests'), () => {
           await setupRemoteFeatureFlagsMock(
             mockServer,
             Object.assign({}, ...confirmationsRedesignedFeatureFlags),
+            'flask',
           );
         },
       },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes Snaps E2Es by adding missing mocks where applicable and adding some URLs to the allowlist that were not added when this was refactored. This makes all Snaps E2E tests pass again.

Also fixes a bug where Snap IDs would be converted to HTTPS URLs for phishing checks.