### PR TITLE
fix: ignore quote in metamask pay if target not met

### DIFF
--- a/app/components/UI/AnimatedSpinner/index.js
+++ b/app/components/UI/AnimatedSpinner/index.js
@@ -8,9 +8,26 @@ import { ThemeContext, mockTheme } from '../../../util/theme';
 export const SpinnerSize = {
   MD: 'MD',
   SM: 'SM',
+  XS: 'XS',
 };
 
 const measures = {
+  [SpinnerSize.XS]: {
+    Android: {
+      height: 24.5,
+      width: 24.5,
+    },
+    iOS: {
+      height: 22,
+      width: 22,
+    },
+    static: {
+      borderRadius: 36,
+      width: 18,
+      height: 18,
+      iconSize: 18,
+    },
+  },
   [SpinnerSize.SM]: {
     Android: {
       height: 30.5,

--- a/app/components/Views/confirmations/components/UI/Tooltip/Tooltip.tsx
+++ b/app/components/Views/confirmations/components/UI/Tooltip/Tooltip.tsx
@@ -15,6 +15,7 @@ import styleSheet from './Tooltip.styles';
 interface TooltipProps {
   content: string | ReactNode;
   iconColor?: IconColor;
+  iconName?: IconName;
   onPress?: () => void;
   title?: string;
   tooltipTestId?: string;
@@ -68,6 +69,7 @@ const Tooltip = ({
   title,
   tooltipTestId = 'info-row-tooltip',
   onPress,
+  iconName = IconName.Info,
   iconColor = IconColor.Muted,
 }: TooltipProps) => {
   const [open, setOpen] = useState(false);
@@ -81,7 +83,7 @@ const Tooltip = ({
     <View>
       <ButtonIcon
         iconColor={iconColor}
-        iconName={IconName.Info}
+        iconName={iconName}
         onPress={handlePress}
         size={ButtonIconSizes.Sm}
         testID={`${tooltipTestId}-open-btn`}

--- a/app/components/Views/confirmations/components/activity/transaction-details-status-icon/index.ts
+++ b/app/components/Views/confirmations/components/activity/transaction-details-status-icon/index.ts
@@ -1,0 +1,1 @@
+export * from './transaction-details-status-icon';

--- a/app/components/Views/confirmations/components/activity/transaction-details-status-icon/transaction-details-status-icon.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-status-icon/transaction-details-status-icon.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import renderWithProvider from '../../../../../../util/test/renderWithProvider';
+import {
+  TransactionMeta,
+  TransactionStatus,
+} from '@metamask/transaction-controller';
+import { TransactionDetailsStatusIcon } from './transaction-details-status-icon';
+import { fireEvent } from '@testing-library/react-native';
+
+jest.mock('../../../hooks/activity/useTransactionDetails');
+
+const ERROR_MESSAGE_MOCK = 'Test Error';
+
+function render(transactionMeta: Partial<TransactionMeta>) {
+  return renderWithProvider(
+    <TransactionDetailsStatusIcon
+      transactionMeta={transactionMeta as TransactionMeta}
+    />,
+    {},
+  );
+}
+
+describe('TransactionDetailsStatusIcon', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('renders success icon if confirmed', () => {
+    const { getByTestId } = render({
+      status: TransactionStatus.confirmed,
+    });
+
+    expect(getByTestId('status-icon-confirmed')).toBeDefined();
+  });
+
+  it.each([
+    TransactionStatus.approved,
+    TransactionStatus.signed,
+    TransactionStatus.unapproved,
+  ])('renders spinner if status is %s', (status) => {
+    const { getByTestId } = render({
+      status,
+    });
+
+    expect(getByTestId('status-spinner')).toBeDefined();
+  });
+
+  it('renders error message if status is failed', () => {
+    const { getByText, getByTestId } = render({
+      error: {
+        name: 'test',
+        message: ERROR_MESSAGE_MOCK,
+      },
+      status: TransactionStatus.failed,
+    });
+
+    fireEvent.press(getByTestId('status-tooltip-open-btn'));
+
+    expect(getByText(ERROR_MESSAGE_MOCK)).toBeDefined();
+  });
+
+  it('renders error message from stack if status is failed', () => {
+    const { getByText, getByTestId } = render({
+      error: {
+        name: 'test',
+        message: 'test',
+        stack:
+          'test' +
+          JSON.stringify({
+            data: {
+              message: ERROR_MESSAGE_MOCK,
+            },
+          }) +
+          'test',
+      },
+      status: TransactionStatus.failed,
+    });
+
+    fireEvent.press(getByTestId('status-tooltip-open-btn'));
+
+    expect(getByText(ERROR_MESSAGE_MOCK)).toBeDefined();
+  });
+});

--- a/app/components/Views/confirmations/components/activity/transaction-details-status-icon/transaction-details-status-icon.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-status-icon/transaction-details-status-icon.test.tsx
@@ -6,6 +6,8 @@ import {
 } from '@metamask/transaction-controller';
 import { TransactionDetailsStatusIcon } from './transaction-details-status-icon';
 import { fireEvent } from '@testing-library/react-native';
+import { merge } from 'lodash';
+import { otherControllersMock } from '../../../__mocks__/controllers/other-controllers-mock';
 
 jest.mock('../../../hooks/activity/useTransactionDetails');
 
@@ -16,7 +18,9 @@ function render(transactionMeta: Partial<TransactionMeta>) {
     <TransactionDetailsStatusIcon
       transactionMeta={transactionMeta as TransactionMeta}
     />,
-    {},
+    {
+      state: merge({}, otherControllersMock),
+    },
   );
 }
 

--- a/app/components/Views/confirmations/components/activity/transaction-details-status-icon/transaction-details-status-icon.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-status-icon/transaction-details-status-icon.tsx
@@ -1,0 +1,99 @@
+import {
+  TransactionMeta,
+  TransactionStatus,
+} from '@metamask/transaction-controller';
+import React from 'react';
+import Icon, {
+  IconColor,
+  IconName,
+} from '../../../../../../component-library/components/Icons/Icon';
+import Tooltip from '../../UI/Tooltip';
+import AnimatedSpinner, {
+  SpinnerSize,
+} from '../../../../../UI/AnimatedSpinner';
+import { View } from 'react-native';
+
+export function TransactionDetailsStatusIcon({
+  transactionMeta,
+}: {
+  transactionMeta: TransactionMeta;
+}) {
+  const { status } = transactionMeta;
+
+  const iconName = getStatusIcon(status);
+  const iconColour = getStatusColour(status);
+  const errorMessage = getErrorMessage(transactionMeta);
+
+  if (status === TransactionStatus.failed && errorMessage) {
+    return (
+      <Tooltip
+        iconColor={IconColor.Error}
+        tooltipTestId="status-tooltip"
+        content={errorMessage}
+      />
+    );
+  }
+
+  if (iconName) {
+    return (
+      <Icon
+        testID={`status-icon-${status}`}
+        name={iconName}
+        color={iconColour}
+      />
+    );
+  }
+
+  return (
+    <View testID="status-spinner">
+      <AnimatedSpinner size={SpinnerSize.XS} />
+    </View>
+  );
+}
+
+function getStatusIcon(status: TransactionStatus): IconName | undefined {
+  switch (status) {
+    case TransactionStatus.confirmed:
+      return IconName.Check;
+    case TransactionStatus.failed:
+    case TransactionStatus.dropped:
+      return IconName.Warning;
+    default:
+      return undefined;
+  }
+}
+
+function getStatusColour(status: TransactionStatus): IconColor {
+  switch (status) {
+    case TransactionStatus.confirmed:
+      return IconColor.Success;
+    case TransactionStatus.failed:
+    case TransactionStatus.dropped:
+      return IconColor.Error;
+    default:
+      return IconColor.Warning;
+  }
+}
+
+function getErrorMessage(transactionMeta: TransactionMeta): string | undefined {
+  const { error } = transactionMeta;
+
+  if (!error) return undefined;
+
+  if (error.stack) {
+    try {
+      const start = error.stack.indexOf('{');
+      const end = error.stack.lastIndexOf('}');
+      const stackObject = JSON.parse(error.stack.substring(start, end + 1));
+      const stackMessage = stackObject?.data?.message;
+
+      if (stackMessage) {
+        return stackMessage;
+      }
+    } catch {
+      // Intentionally empty
+    }
+  }
+
+  return error.message;
+}

--- a/app/components/Views/confirmations/components/activity/transaction-details-status-icon/transaction-details-status-icon.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-status-icon/transaction-details-status-icon.tsx
@@ -12,13 +12,21 @@ import AnimatedSpinner, {
   SpinnerSize,
 } from '../../../../../UI/AnimatedSpinner';
 import { View } from 'react-native';
+import { useBridgeTxHistoryData } from '../../../../../../util/bridge/hooks/useBridgeTxHistoryData';
 
 export function TransactionDetailsStatusIcon({
   transactionMeta,
 }: {
   transactionMeta: TransactionMeta;
 }) {
-  const { status } = transactionMeta;
+  const { status: statusRaw } = transactionMeta;
+
+  const { isBridgeComplete } = useBridgeTxHistoryData({
+    evmTxMeta: transactionMeta,
+  });
+
+  const status =
+    isBridgeComplete === false ? TransactionStatus.submitted : statusRaw;
 
   const iconName = getStatusIcon(status);
   const iconColour = getStatusColour(status);
@@ -27,7 +35,8 @@ export function TransactionDetailsStatusIcon({
   if (status === TransactionStatus.failed && errorMessage) {
     return (
       <Tooltip
-        iconColor={IconColor.Error}
+        iconColor={iconColour}
+        iconName={iconName}
         tooltipTestId="status-tooltip"
         content={errorMessage}
       />
@@ -57,7 +66,7 @@ function getStatusIcon(status: TransactionStatus): IconName | undefined {
       return IconName.Check;
     case TransactionStatus.failed:
     case TransactionStatus.dropped:
-      return IconName.Warning;
+      return IconName.Close;
     default:
       return undefined;
   }

--- a/app/components/Views/confirmations/components/activity/transaction-details-status-row/transaction-details-status-row.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-status-row/transaction-details-status-row.test.tsx
@@ -7,11 +7,8 @@ import {
 } from '@metamask/transaction-controller';
 import { TransactionDetailsStatusRow } from './transaction-details-status-row';
 import { strings } from '../../../../../../../locales/i18n';
-import { fireEvent } from '@testing-library/react-native';
 
 jest.mock('../../../hooks/activity/useTransactionDetails');
-
-const ERROR_MESSAGE_MOCK = 'Test Error';
 
 function render() {
   return renderWithProvider(<TransactionDetailsStatusRow />, {});
@@ -43,46 +40,5 @@ describe('TransactionDetailsStatusRow', () => {
     const { getByText } = render();
 
     expect(getByText(expectedText)).toBeDefined();
-  });
-
-  it('renders error message if status is failed', () => {
-    useTransactionDetailsMock.mockReturnValue({
-      transactionMeta: {
-        error: {
-          message: ERROR_MESSAGE_MOCK,
-        },
-        status: TransactionStatus.failed,
-      } as unknown as TransactionMeta,
-    });
-
-    const { getByText, getByTestId } = render();
-
-    fireEvent.press(getByTestId('status-tooltip-open-btn'));
-
-    expect(getByText(ERROR_MESSAGE_MOCK)).toBeDefined();
-  });
-
-  it('renders error message from stack if status is failed', () => {
-    useTransactionDetailsMock.mockReturnValue({
-      transactionMeta: {
-        error: {
-          stack:
-            'test' +
-            JSON.stringify({
-              data: {
-                message: ERROR_MESSAGE_MOCK,
-              },
-            }) +
-            'test',
-        },
-        status: TransactionStatus.failed,
-      } as unknown as TransactionMeta,
-    });
-
-    const { getByText, getByTestId } = render();
-
-    fireEvent.press(getByTestId('status-tooltip-open-btn'));
-
-    expect(getByText(ERROR_MESSAGE_MOCK)).toBeDefined();
   });
 });

--- a/app/components/Views/confirmations/components/activity/transaction-details-status-row/transaction-details-status-row.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-status-row/transaction-details-status-row.test.tsx
@@ -7,8 +7,11 @@ import {
 } from '@metamask/transaction-controller';
 import { TransactionDetailsStatusRow } from './transaction-details-status-row';
 import { strings } from '../../../../../../../locales/i18n';
+import { fireEvent } from '@testing-library/react-native';
 
 jest.mock('../../../hooks/activity/useTransactionDetails');
+
+const ERROR_MESSAGE_MOCK = 'Test Error';
 
 function render() {
   return renderWithProvider(<TransactionDetailsStatusRow />, {});
@@ -40,5 +43,46 @@ describe('TransactionDetailsStatusRow', () => {
     const { getByText } = render();
 
     expect(getByText(expectedText)).toBeDefined();
+  });
+
+  it('renders error message if status is failed', () => {
+    useTransactionDetailsMock.mockReturnValue({
+      transactionMeta: {
+        error: {
+          message: ERROR_MESSAGE_MOCK,
+        },
+        status: TransactionStatus.failed,
+      } as unknown as TransactionMeta,
+    });
+
+    const { getByText, getByTestId } = render();
+
+    fireEvent.press(getByTestId('status-tooltip-open-btn'));
+
+    expect(getByText(ERROR_MESSAGE_MOCK)).toBeDefined();
+  });
+
+  it('renders error message from stack if status is failed', () => {
+    useTransactionDetailsMock.mockReturnValue({
+      transactionMeta: {
+        error: {
+          stack:
+            'test' +
+            JSON.stringify({
+              data: {
+                message: ERROR_MESSAGE_MOCK,
+              },
+            }) +
+            'test',
+        },
+        status: TransactionStatus.failed,
+      } as unknown as TransactionMeta,
+    });
+
+    const { getByText, getByTestId } = render();
+
+    fireEvent.press(getByTestId('status-tooltip-open-btn'));
+
+    expect(getByText(ERROR_MESSAGE_MOCK)).toBeDefined();
   });
 });

--- a/app/components/Views/confirmations/components/activity/transaction-details-status-row/transaction-details-status-row.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-status-row/transaction-details-status-row.test.tsx
@@ -7,11 +7,15 @@ import {
 } from '@metamask/transaction-controller';
 import { TransactionDetailsStatusRow } from './transaction-details-status-row';
 import { strings } from '../../../../../../../locales/i18n';
+import { merge } from 'lodash';
+import { otherControllersMock } from '../../../__mocks__/controllers/other-controllers-mock';
 
 jest.mock('../../../hooks/activity/useTransactionDetails');
 
 function render() {
-  return renderWithProvider(<TransactionDetailsStatusRow />, {});
+  return renderWithProvider(<TransactionDetailsStatusRow />, {
+    state: merge({}, otherControllersMock),
+  });
 }
 
 describe('TransactionDetailsStatusRow', () => {

--- a/app/components/Views/confirmations/components/activity/transaction-details-status-row/transaction-details-status-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-status-row/transaction-details-status-row.tsx
@@ -10,6 +10,7 @@ import {
   TransactionStatus,
 } from '@metamask/transaction-controller';
 import Icon, {
+  IconColor,
   IconName,
 } from '../../../../../../component-library/components/Icons/Icon';
 import { Box } from '../../../../../UI/Box/Box';
@@ -36,11 +37,15 @@ export function TransactionDetailsStatusRow() {
         gap={6}
         alignItems={AlignItems.center}
       >
-        <Icon name={statusIcon} color={statusColor} />
-        <Text color={statusColor}>{statusText}</Text>
+        {!tooltip && <Icon name={statusIcon} color={statusColor} />}
         {tooltip && (
-          <Tooltip tooltipTestId="status-tooltip" content={tooltip} />
+          <Tooltip
+            iconColor={IconColor.Error}
+            tooltipTestId="status-tooltip"
+            content={tooltip}
+          />
         )}
+        <Text color={statusColor}>{statusText}</Text>
       </Box>
     </TransactionDetailsRow>
   );
@@ -76,7 +81,7 @@ function getStatusIcon(status: TransactionStatus): IconName {
       return IconName.Check;
     case TransactionStatus.failed:
     case TransactionStatus.dropped:
-      return IconName.Error;
+      return IconName.Warning;
     default:
       return IconName.Pending;
   }

--- a/app/components/Views/confirmations/components/activity/transaction-details-status-row/transaction-details-status-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-status-row/transaction-details-status-row.tsx
@@ -5,12 +5,16 @@ import Text, {
   TextColor,
 } from '../../../../../../component-library/components/Texts/Text';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
-import { TransactionStatus } from '@metamask/transaction-controller';
+import {
+  TransactionMeta,
+  TransactionStatus,
+} from '@metamask/transaction-controller';
 import Icon, {
   IconName,
 } from '../../../../../../component-library/components/Icons/Icon';
 import { Box } from '../../../../../UI/Box/Box';
 import { AlignItems, FlexDirection } from '../../../../../UI/Box/box.types';
+import Tooltip from '../../UI/Tooltip';
 
 export function TransactionDetailsStatusRow() {
   const { transactionMeta } = useTransactionDetails();
@@ -18,6 +22,12 @@ export function TransactionDetailsStatusRow() {
   const statusText = getStatusText(transactionMeta.status);
   const statusColor = getStatusColour(transactionMeta.status);
   const statusIcon = getStatusIcon(transactionMeta.status);
+  const errorMessage = getErrorMessage(transactionMeta);
+
+  const tooltip =
+    transactionMeta.status === TransactionStatus.failed
+      ? errorMessage
+      : undefined;
 
   return (
     <TransactionDetailsRow label={strings('transactions.status')}>
@@ -28,6 +38,9 @@ export function TransactionDetailsStatusRow() {
       >
         <Icon name={statusIcon} color={statusColor} />
         <Text color={statusColor}>{statusText}</Text>
+        {tooltip && (
+          <Tooltip tooltipTestId="status-tooltip" content={tooltip} />
+        )}
       </Box>
     </TransactionDetailsRow>
   );
@@ -67,4 +80,27 @@ function getStatusIcon(status: TransactionStatus): IconName {
     default:
       return IconName.Pending;
   }
+}
+
+function getErrorMessage(transactionMeta: TransactionMeta): string | undefined {
+  const { error } = transactionMeta;
+
+  if (!error) return undefined;
+
+  if (error.stack) {
+    try {
+      const start = error.stack.indexOf('{');
+      const end = error.stack.lastIndexOf('}');
+      const stackObject = JSON.parse(error.stack.substring(start, end + 1));
+      const stackMessage = stackObject?.data?.message;
+
+      if (stackMessage) {
+        return stackMessage;
+      }
+    } catch {
+      // Intentionally empty
+    }
+  }
+
+  return error.message;
 }

--- a/app/components/Views/confirmations/components/activity/transaction-details-status-row/transaction-details-status-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-status-row/transaction-details-status-row.tsx
@@ -5,30 +5,16 @@ import Text, {
   TextColor,
 } from '../../../../../../component-library/components/Texts/Text';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
-import {
-  TransactionMeta,
-  TransactionStatus,
-} from '@metamask/transaction-controller';
-import Icon, {
-  IconColor,
-  IconName,
-} from '../../../../../../component-library/components/Icons/Icon';
+import { TransactionStatus } from '@metamask/transaction-controller';
 import { Box } from '../../../../../UI/Box/Box';
 import { AlignItems, FlexDirection } from '../../../../../UI/Box/box.types';
-import Tooltip from '../../UI/Tooltip';
+import { TransactionDetailsStatusIcon } from '../transaction-details-status-icon';
 
 export function TransactionDetailsStatusRow() {
   const { transactionMeta } = useTransactionDetails();
 
   const statusText = getStatusText(transactionMeta.status);
   const statusColor = getStatusColour(transactionMeta.status);
-  const statusIcon = getStatusIcon(transactionMeta.status);
-  const errorMessage = getErrorMessage(transactionMeta);
-
-  const tooltip =
-    transactionMeta.status === TransactionStatus.failed
-      ? errorMessage
-      : undefined;
 
   return (
     <TransactionDetailsRow label={strings('transactions.status')}>
@@ -37,14 +23,7 @@ export function TransactionDetailsStatusRow() {
         gap={6}
         alignItems={AlignItems.center}
       >
-        {!tooltip && <Icon name={statusIcon} color={statusColor} />}
-        {tooltip && (
-          <Tooltip
-            iconColor={IconColor.Error}
-            tooltipTestId="status-tooltip"
-            content={tooltip}
-          />
-        )}
+        <TransactionDetailsStatusIcon transactionMeta={transactionMeta} />
         <Text color={statusColor}>{statusText}</Text>
       </Box>
     </TransactionDetailsRow>
@@ -73,39 +52,4 @@ function getStatusColour(status: TransactionStatus): TextColor {
     default:
       return TextColor.Warning;
   }
-}
-
-function getStatusIcon(status: TransactionStatus): IconName {
-  switch (status) {
-    case TransactionStatus.confirmed:
-      return IconName.Check;
-    case TransactionStatus.failed:
-    case TransactionStatus.dropped:
-      return IconName.Warning;
-    default:
-      return IconName.Pending;
-  }
-}
-
-function getErrorMessage(transactionMeta: TransactionMeta): string | undefined {
-  const { error } = transactionMeta;
-
-  if (!error) return undefined;
-
-  if (error.stack) {
-    try {
-      const start = error.stack.indexOf('{');
-      const end = error.stack.lastIndexOf('}');
-      const stackObject = JSON.parse(error.stack.substring(start, end + 1));
-      const stackMessage = stackObject?.data?.message;
-
-      if (stackMessage) {
-        return stackMessage;
-      }
-    } catch {
-      // Intentionally empty
-    }
-  }
-
-  return error.message;
 }

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.styles.ts
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.styles.ts
@@ -14,6 +14,7 @@ const styleSheet = (params: { theme: Theme; vars: { isLast?: boolean } }) => {
       marginLeft: 9,
       marginRight: 22,
       width: isLast ? 0 : 2,
+      marginVertical: 3,
     },
     secondary: {
       paddingBottom: 12,

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.tsx
@@ -4,9 +4,6 @@ import Text, {
   TextVariant,
 } from '../../../../../../component-library/components/Texts/Text';
 import { Box } from '../../../../../UI/Box/Box';
-import Icon, {
-  IconName,
-} from '../../../../../../component-library/components/Icons/Icon';
 import {
   AlignItems,
   FlexDirection,
@@ -22,11 +19,11 @@ import { useTransactionDetails } from '../../../hooks/activity/useTransactionDet
 import { RootState } from '../../../../../../reducers';
 import {
   TransactionMeta,
-  TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
 import { useBridgeTxHistoryData } from '../../../../../../util/bridge/hooks/useBridgeTxHistoryData';
 import { BridgeHistoryItem } from '@metamask/bridge-status-controller';
+import { TransactionDetailsStatusIcon } from '../transaction-details-status-icon';
 
 export function TransactionDetailsSummary() {
   const { styles } = useStyles(styleSheet, {});
@@ -78,8 +75,6 @@ function SummaryLine({
     return null;
   }
 
-  const statusIcon = getStatusIcon(transaction.status);
-
   return (
     <Box>
       <Box
@@ -92,7 +87,7 @@ function SummaryLine({
           alignItems={AlignItems.center}
           gap={12}
         >
-          <Icon name={statusIcon} />
+          <TransactionDetailsStatusIcon transactionMeta={transaction} />
           <Text variant={TextVariant.BodyMD}>{title}</Text>
         </Box>
       </Box>
@@ -146,17 +141,5 @@ function getLineTitle(
       return strings('transaction_details.summary_title.perps_deposit');
     default:
       return undefined;
-  }
-}
-
-function getStatusIcon(status: TransactionStatus): IconName {
-  switch (status) {
-    case TransactionStatus.confirmed:
-      return IconName.Check;
-    case TransactionStatus.failed:
-    case TransactionStatus.dropped:
-      return IconName.Warning;
-    default:
-      return IconName.Pending;
   }
 }

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.tsx
@@ -22,6 +22,7 @@ import { useTransactionDetails } from '../../../hooks/activity/useTransactionDet
 import { RootState } from '../../../../../../reducers';
 import {
   TransactionMeta,
+  TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
 import { useBridgeTxHistoryData } from '../../../../../../util/bridge/hooks/useBridgeTxHistoryData';
@@ -77,6 +78,8 @@ function SummaryLine({
     return null;
   }
 
+  const statusIcon = getStatusIcon(transaction.status);
+
   return (
     <Box>
       <Box
@@ -89,7 +92,7 @@ function SummaryLine({
           alignItems={AlignItems.center}
           gap={12}
         >
-          <Icon name={IconName.Check} />
+          <Icon name={statusIcon} />
           <Text variant={TextVariant.BodyMD}>{title}</Text>
         </Box>
       </Box>
@@ -143,5 +146,17 @@ function getLineTitle(
       return strings('transaction_details.summary_title.perps_deposit');
     default:
       return undefined;
+  }
+}
+
+function getStatusIcon(status: TransactionStatus): IconName {
+  switch (status) {
+    case TransactionStatus.confirmed:
+      return IconName.Check;
+    case TransactionStatus.failed:
+    case TransactionStatus.dropped:
+      return IconName.Warning;
+    default:
+      return IconName.Pending;
   }
 }

--- a/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.tsx
+++ b/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.tsx
@@ -26,8 +26,8 @@ const PERCENTAGE_BUTTONS = [
     value: 50,
   },
   {
-    label: 'Max',
-    value: 100,
+    label: '90%',
+    value: 90,
   },
 ];
 

--- a/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { View as MockView } from 'react-native';
+import renderWithProvider from '../../../../../../util/test/renderWithProvider';
+import { merge } from 'lodash';
+import {
+  simpleSendTransactionControllerMock,
+  transactionIdMock,
+} from '../../../__mocks__/controllers/transaction-controller-mock';
+import { transactionApprovalControllerMock } from '../../../__mocks__/controllers/approval-controller-mock';
+import { TransactionBridgeQuote } from '../../../utils/bridge';
+import { ConfirmationMetricsState } from '../../../../../../core/redux/slices/confirmationMetrics';
+import { BridgeFeeRow } from './bridge-fee-row';
+import { useTransactionTotalFiat } from '../../../hooks/pay/useTransactionTotalFiat';
+
+jest.mock('../../../hooks/pay/useTransactionTotalFiat');
+
+jest.mock('../../../../../UI/AnimatedSpinner', () => ({
+  __esModule: true,
+  ...jest.requireActual('../../../../../UI/AnimatedSpinner'),
+  default: () => <MockView testID="bridge-fee-spinner">{`Spinner`}</MockView>,
+}));
+
+const BRIDGE_FEE_MOCK = '$1.23';
+
+function render({
+  quotes = [],
+  isLoading = false,
+}: {
+  quotes?: Partial<TransactionBridgeQuote>[];
+  isLoading?: boolean;
+} = {}) {
+  const state = merge(
+    {},
+    simpleSendTransactionControllerMock,
+    transactionApprovalControllerMock,
+    {
+      confirmationMetrics: {
+        isTransactionBridgeQuotesLoadingById: {
+          [transactionIdMock]: isLoading,
+        },
+        transactionBridgeQuotesById: {
+          [transactionIdMock]: quotes,
+        },
+      } as unknown as ConfirmationMetricsState,
+    },
+  );
+
+  return renderWithProvider(<BridgeFeeRow />, { state });
+}
+
+describe('BridgeFeeRow', () => {
+  const useTransactionTotalFiatMock = jest.mocked(useTransactionTotalFiat);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    useTransactionTotalFiatMock.mockReturnValue({
+      bridgeFeeFormatted: BRIDGE_FEE_MOCK,
+    } as ReturnType<typeof useTransactionTotalFiat>);
+  });
+
+  it('renders bridge fee', async () => {
+    const { getByText } = render({
+      quotes: [{}],
+    });
+
+    expect(getByText(BRIDGE_FEE_MOCK)).toBeDefined();
+  });
+
+  it('renders spinner if quotes loading', async () => {
+    const { getByTestId } = render({ isLoading: true });
+    expect(getByTestId(`bridge-fee-spinner`)).toBeDefined();
+  });
+});

--- a/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
+++ b/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import AnimatedSpinner, {
+  SpinnerSize,
+} from '../../../../../UI/AnimatedSpinner';
+import InfoRow from '../../UI/info-row';
+import { useTransactionMetadataOrThrow } from '../../../hooks/transactions/useTransactionMetadataRequest';
+import {
+  selectIsTransactionBridgeQuotesLoadingById,
+  selectTransactionBridgeQuotesById,
+} from '../../../../../../core/redux/slices/confirmationMetrics';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../../../../../reducers';
+import Text from '../../../../../../component-library/components/Texts/Text';
+import { useTransactionTotalFiat } from '../../../hooks/pay/useTransactionTotalFiat';
+import { strings } from '../../../../../../../locales/i18n';
+
+export function BridgeFeeRow() {
+  const { id: transactionId } = useTransactionMetadataOrThrow();
+  const { bridgeFeeFormatted } = useTransactionTotalFiat();
+
+  const isQuotesLoading = useSelector((state: RootState) =>
+    selectIsTransactionBridgeQuotesLoadingById(state, transactionId),
+  );
+
+  const quotes = useSelector((state: RootState) =>
+    selectTransactionBridgeQuotesById(state, transactionId),
+  );
+
+  const show = isQuotesLoading || Boolean(quotes?.length);
+
+  if (!show) {
+    return null;
+  }
+
+  return (
+    <InfoRow label={strings('confirm.label.bridge_fee')}>
+      {isQuotesLoading ? (
+        <AnimatedSpinner size={SpinnerSize.SM} />
+      ) : (
+        <Text>{bridgeFeeFormatted}</Text>
+      )}
+    </InfoRow>
+  );
+}

--- a/app/components/Views/confirmations/components/rows/bridge-fee-row/index.ts
+++ b/app/components/Views/confirmations/components/rows/bridge-fee-row/index.ts
@@ -1,0 +1,1 @@
+export * from './bridge-fee-row';

--- a/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.tsx
+++ b/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.tsx
@@ -15,6 +15,7 @@ import { usePerpsDepositView } from '../../hooks/usePerpsDepositView';
 import { GasFeeFiatRow } from '../../../../components/rows/transactions/gas-fee-fiat-row';
 import useClearConfirmationOnBackSwipe from '../../../../hooks/ui/useClearConfirmationOnBackSwipe';
 import { usePerpsDepositAlerts } from '../../hooks/usePerpsDepositAlerts';
+import { BridgeFeeRow } from '../../../../components/rows/bridge-fee-row';
 
 export function PerpsDeposit() {
   useNavbar(strings('confirm.title.perps_deposit'));
@@ -62,6 +63,7 @@ export function PerpsDeposit() {
             {isFullView && (
               <InfoSection>
                 <GasFeeFiatRow />
+                <BridgeFeeRow />
                 <BridgeTimeRow />
                 <TotalRow />
               </InfoSection>

--- a/app/components/Views/confirmations/hooks/pay/useTransactionBridgeQuotes.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionBridgeQuotes.test.ts
@@ -27,6 +27,8 @@ const TOKEN_ADDRESS_TARGET_2_MOCK = '0x789' as Hex;
 const ACCOUNT_ADDRESS_MOCK = '0xabc';
 const SOURCE_AMOUNT_1_MOCK = '1234';
 const SOURCE_AMOUNT_2_MOCK = '5678';
+const MINIMUM_TOKEN_AMOUNT_1_MOCK = '1.23';
+const MINIMUM_TOKEN_AMOUNT_2_MOCK = '2.34';
 
 const QUOTE_MOCK = {
   quote: {},
@@ -79,10 +81,12 @@ describe('useTransactionBridgeQuotes', () => {
         {
           address: TOKEN_ADDRESS_TARGET_1_MOCK,
           amountRaw: SOURCE_AMOUNT_1_MOCK,
+          targetAmountHuman: MINIMUM_TOKEN_AMOUNT_1_MOCK,
         },
         {
           address: TOKEN_ADDRESS_TARGET_2_MOCK,
           amountRaw: SOURCE_AMOUNT_2_MOCK,
+          targetAmountHuman: MINIMUM_TOKEN_AMOUNT_2_MOCK,
         },
       ],
     } as ReturnType<typeof useTransactionPayTokenAmounts>);
@@ -100,6 +104,7 @@ describe('useTransactionBridgeQuotes', () => {
     expect(getBridgeQuotesMock).toHaveBeenCalledWith([
       {
         from: ACCOUNT_ADDRESS_MOCK,
+        minimumTargetAmount: MINIMUM_TOKEN_AMOUNT_1_MOCK,
         sourceChainId: CHAIN_ID_SOURCE_MOCK,
         sourceTokenAddress: TOKEN_ADDRESS_SOURCE_MOCK,
         sourceTokenAmount: SOURCE_AMOUNT_1_MOCK,
@@ -108,6 +113,7 @@ describe('useTransactionBridgeQuotes', () => {
       },
       {
         from: ACCOUNT_ADDRESS_MOCK,
+        minimumTargetAmount: MINIMUM_TOKEN_AMOUNT_2_MOCK,
         sourceChainId: CHAIN_ID_SOURCE_MOCK,
         sourceTokenAddress: TOKEN_ADDRESS_SOURCE_MOCK,
         sourceTokenAmount: SOURCE_AMOUNT_2_MOCK,

--- a/app/components/Views/confirmations/hooks/pay/useTransactionBridgeQuotes.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionBridgeQuotes.ts
@@ -55,10 +55,11 @@ export function useTransactionBridgeQuotes() {
 
     return sourceAmounts.map((sourceAmount, index) => {
       const { address: targetTokenAddress } = sourceAmounts[index] || {};
-      const { amountRaw: sourceTokenAmount } = sourceAmount;
+      const { amountRaw: sourceTokenAmount, targetAmountHuman } = sourceAmount;
 
       return {
         from: from as Hex,
+        minimumTargetAmount: targetAmountHuman,
         sourceChainId,
         sourceTokenAddress,
         sourceTokenAmount,

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayTokenAmounts.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayTokenAmounts.test.ts
@@ -40,8 +40,16 @@ describe('useTransactionPayTokenAmounts', () => {
 
     useTransactionRequiredFiatMock.mockReturnValue({
       values: [
-        { address: TOKEN_ADDRESS_1_MOCK, totalFiat: 16.123 },
-        { address: TOKEN_ADDRESS_2_MOCK, totalFiat: 40.456 },
+        {
+          address: TOKEN_ADDRESS_1_MOCK,
+          amountHumanOriginal: '1.23',
+          totalFiat: 16.123,
+        },
+        {
+          address: TOKEN_ADDRESS_2_MOCK,
+          amountHumanOriginal: '2.34',
+          totalFiat: 40.456,
+        },
       ],
       totalFiat: 56.579,
     } as unknown as ReturnType<typeof useTransactionRequiredFiat>);
@@ -70,11 +78,13 @@ describe('useTransactionPayTokenAmounts', () => {
         address: TOKEN_ADDRESS_1_MOCK,
         amountHuman: '4.03075',
         amountRaw: '40308',
+        targetAmountHuman: '1.23',
       },
       {
         address: TOKEN_ADDRESS_2_MOCK,
         amountHuman: '10.114',
         amountRaw: '101140',
+        targetAmountHuman: '2.34',
       },
     ]);
   });
@@ -85,6 +95,7 @@ describe('useTransactionPayTokenAmounts', () => {
         {
           address: TOKEN_ADDRESS_2_MOCK,
           amountFiat: 40.455,
+          amountHumanOriginal: '2.34',
           balanceFiat: 40.456,
           totalFiat: 41,
           skipIfBalance: false,
@@ -100,6 +111,7 @@ describe('useTransactionPayTokenAmounts', () => {
         address: TOKEN_ADDRESS_2_MOCK,
         amountHuman: '10.25',
         amountRaw: '102500',
+        targetAmountHuman: '2.34',
       },
     ]);
   });
@@ -110,6 +122,7 @@ describe('useTransactionPayTokenAmounts', () => {
         {
           address: TOKEN_ADDRESS_1_MOCK,
           amountFiat: 16.123,
+          amountHumanOriginal: '1.23',
           balanceFiat: 16.124,
           totalFiat: 17,
           skipIfBalance: true,
@@ -117,6 +130,7 @@ describe('useTransactionPayTokenAmounts', () => {
         {
           address: TOKEN_ADDRESS_2_MOCK,
           amountFiat: 40.456,
+          amountHumanOriginal: '2.34',
           balanceFiat: 40.455,
           totalFiat: 41,
           skipIfBalance: false,
@@ -132,6 +146,7 @@ describe('useTransactionPayTokenAmounts', () => {
         address: TOKEN_ADDRESS_2_MOCK,
         amountHuman: '10.25',
         amountRaw: '102500',
+        targetAmountHuman: '2.34',
       },
     ]);
   });
@@ -142,12 +157,14 @@ describe('useTransactionPayTokenAmounts', () => {
         {
           address: tokenAddress1Mock,
           amountFiat: 16.123,
+          amountHumanOriginal: '1.23',
           balanceFiat: 16.124,
           totalFiat: 17,
           skipIfBalance: false,
         },
         {
           address: TOKEN_ADDRESS_2_MOCK,
+          amountHumanOriginal: '2.34',
           amountFiat: 40.456,
           balanceFiat: 40.455,
           totalFiat: 41,
@@ -164,6 +181,7 @@ describe('useTransactionPayTokenAmounts', () => {
         address: TOKEN_ADDRESS_2_MOCK,
         amountHuman: '10.25',
         amountRaw: '102500',
+        targetAmountHuman: '2.34',
       },
     ]);
   });
@@ -174,6 +192,7 @@ describe('useTransactionPayTokenAmounts', () => {
         {
           address: TOKEN_ADDRESS_1_MOCK,
           amountFiat: 16.123,
+          amountHumanOriginal: '1.23',
           balanceFiat: 16.124,
           totalFiat: 17,
           skipIfBalance: false,
@@ -181,6 +200,7 @@ describe('useTransactionPayTokenAmounts', () => {
         {
           address: TOKEN_ADDRESS_2_MOCK,
           amountFiat: 40.456,
+          amountHumanOriginal: '2.34',
           balanceFiat: 40.455,
           totalFiat: 41,
           skipIfBalance: false,
@@ -196,6 +216,7 @@ describe('useTransactionPayTokenAmounts', () => {
         address: TOKEN_ADDRESS_2_MOCK,
         amountHuman: '10.25',
         amountRaw: '102500',
+        targetAmountHuman: '2.34',
       },
     ]);
   });

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayTokenAmounts.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayTokenAmounts.ts
@@ -85,13 +85,18 @@ export function useTransactionPayTokenAmounts({
         return true;
       })
       .map((value) => {
-        const amountHuman = new BigNumber(value.totalFiat).div(tokenFiatRate);
-        const amountRaw = amountHuman.shiftedBy(decimals).toFixed(0);
+        const amountHumanValue = new BigNumber(value.totalFiat).div(
+          tokenFiatRate,
+        );
+
+        const amountHuman = amountHumanValue.toString(10);
+        const amountRaw = amountHumanValue.shiftedBy(decimals).toFixed(0);
 
         return {
           address: value.address,
-          amountHuman: amountHuman.toString(10),
+          amountHuman,
           amountRaw,
+          targetAmountHuman: value.amountHumanOriginal,
         };
       });
   }, [address, chainId, decimals, tokenFiatRate, values]);

--- a/app/components/Views/confirmations/hooks/pay/useTransactionRequiredFiat.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionRequiredFiat.test.ts
@@ -72,6 +72,7 @@ describe('useTransactionRequiredFiat', () => {
       {
         address: tokenAddress1Mock,
         amountFiat: 8,
+        amountHumanOriginal: '2',
         balanceFiat: 40,
         feeFiat: 0.2,
         skipIfBalance: false,
@@ -80,6 +81,7 @@ describe('useTransactionRequiredFiat', () => {
       {
         address: tokenAddress2Mock,
         amountFiat: 15,
+        amountHumanOriginal: '3',
         balanceFiat: 100,
         feeFiat: 0.375,
         skipIfBalance: true,
@@ -104,6 +106,7 @@ describe('useTransactionRequiredFiat', () => {
       {
         address: tokenAddress1Mock,
         amountFiat: 16,
+        amountHumanOriginal: '4',
         balanceFiat: 40,
         feeFiat: 0.4,
         skipIfBalance: false,
@@ -112,6 +115,7 @@ describe('useTransactionRequiredFiat', () => {
       {
         address: tokenAddress2Mock,
         amountFiat: 15,
+        amountHumanOriginal: '3',
         balanceFiat: 100,
         feeFiat: 0.375,
         skipIfBalance: true,

--- a/app/components/Views/confirmations/hooks/pay/useTransactionRequiredFiat.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionRequiredFiat.ts
@@ -60,6 +60,7 @@ export function useTransactionRequiredFiat({
 
         return {
           address: target.address,
+          amountHumanOriginal: amountHuman,
           amountFiat: amountFiat.toNumber(),
           balanceFiat: balanceFiat.toNumber(),
           feeFiat: feeFiat.toNumber(),

--- a/app/components/Views/confirmations/hooks/pay/useTransactionTotalFiat.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionTotalFiat.test.ts
@@ -115,6 +115,67 @@ describe('useTransactionTotalFiat', () => {
     );
   });
 
+  it('excludes dust', () => {
+    useTransactionRequiredFiatMock.mockReturnValue({
+      values: [
+        {
+          address: ADDRESS_MOCK,
+          amountFiat: 12.34,
+          amountHumanOriginal: '1.22',
+        },
+        {
+          address: ADDRESS_2_MOCK,
+          amountFiat: 23.45,
+          amountHumanOriginal: '2.33',
+        },
+      ],
+    } as unknown as ReturnType<typeof useTransactionRequiredFiat>);
+
+    const { result } = runHook({
+      quotes: [
+        {
+          quote: {
+            destAsset: {
+              address: ADDRESS_MOCK,
+            },
+          },
+          sentAmount: {
+            valueInCurrency: '12.34',
+          },
+          totalMaxNetworkFee: {
+            valueInCurrency: '23.45',
+          },
+          toTokenAmount: {
+            valueInCurrency: '11.22',
+          },
+        },
+        {
+          quote: {
+            destAsset: {
+              address: ADDRESS_2_MOCK,
+            },
+          },
+          sentAmount: {
+            valueInCurrency: '34.56',
+          },
+          totalMaxNetworkFee: {
+            valueInCurrency: '45.67',
+          },
+          toTokenAmount: {
+            valueInCurrency: '22.33',
+          },
+        },
+      ] as TransactionBridgeQuote[],
+    });
+
+    expect(result.current).toStrictEqual(
+      expect.objectContaining({
+        value: '86.02',
+        formatted: '$86.02',
+      }),
+    );
+  });
+
   it('ignores balance cost if matching quote', () => {
     useTransactionRequiredFiatMock.mockReturnValue({
       values: [

--- a/app/components/Views/confirmations/hooks/pay/useTransactionTotalFiat.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionTotalFiat.ts
@@ -4,7 +4,7 @@ import { RootState } from '../../../../../reducers';
 import { selectTransactionBridgeQuotesById } from '../../../../../core/redux/slices/confirmationMetrics';
 import { useTransactionRequiredFiat } from './useTransactionRequiredFiat';
 import { BigNumber } from 'bignumber.js';
-import { createProjectLogger } from '@metamask/utils';
+import { Hex, createProjectLogger } from '@metamask/utils';
 import { useEffect } from 'react';
 import useFiatFormatter from '../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 import { TransactionBridgeQuote } from '../../utils/bridge';
@@ -54,30 +54,39 @@ export function useTransactionTotalFiat() {
       new BigNumber(0),
     ) ?? new BigNumber(0);
 
-  const total = quoteTotal.plus(balanceCost);
-  const value = total.toString(10);
-  const formatted = fiatFormatter(total);
-
   const totalNetworkFee = quoteNetworkFeeTotal.plus(
     new BigNumber(estimatedFeeFiatPrecise ?? 0),
   );
+
+  const dustTotal =
+    quotes?.reduce(
+      (acc, quote) => acc.plus(getQuoteDust(quote, requiredFiat)),
+      new BigNumber(0),
+    ) ?? new BigNumber(0);
+
+  const total = quoteTotal.plus(balanceCost).minus(dustTotal);
+  const value = total.toString(10);
+  const formatted = fiatFormatter(total);
 
   const totalNetworkFeeFormatted = fiatFormatter(totalNetworkFee);
   const bridgeFeeFormatted = fiatFormatter(quoteFeeTotal);
   const balanceCostString = balanceCost.toString(10);
   const quoteTotalString = quoteTotal.toString(10);
+  const dustTotalString = dustTotal.toString(10);
 
   useEffect(() => {
     log('Total fiat', {
       balances: balanceCostString,
-      quotes: quoteTotalString,
-      networkFees: totalNetworkFeeFormatted,
       bridgeFees: bridgeFeeFormatted,
+      dust: dustTotalString,
+      networkFees: totalNetworkFeeFormatted,
+      quotes: quoteTotalString,
       total: formatted,
     });
   }, [
     balanceCostString,
     bridgeFeeFormatted,
+    dustTotalString,
     formatted,
     quoteTotalString,
     totalNetworkFeeFormatted,
@@ -109,4 +118,23 @@ function getQuoteSourceFee(quote: TransactionBridgeQuote): BigNumber {
   return getQuoteSourceAmount(quote).minus(
     quote.toTokenAmount?.valueInCurrency ?? 0,
   );
+}
+
+function getQuoteDust(
+  quote: TransactionBridgeQuote,
+  requiredFiat: { address: Hex; amountHumanOriginal: string }[],
+): BigNumber {
+  const targetAmount = quote.toTokenAmount?.valueInCurrency ?? '0';
+
+  const requiredAmount = requiredFiat.find(
+    (token) =>
+      token.address.toLowerCase() ===
+      quote.quote.destAsset.address.toLowerCase(),
+  )?.amountHumanOriginal;
+
+  if (!requiredAmount) {
+    return new BigNumber(0);
+  }
+
+  return new BigNumber(targetAmount).minus(requiredAmount);
 }

--- a/app/components/Views/confirmations/utils/bridge.test.ts
+++ b/app/components/Views/confirmations/utils/bridge.test.ts
@@ -23,6 +23,7 @@ jest.useFakeTimers();
 
 const QUOTE_REQUEST_1_MOCK: BridgeQuoteRequest = {
   from: '0x123',
+  minimumTargetAmount: '1.23',
   sourceChainId: '0x1',
   sourceTokenAddress: '0xabc',
   sourceTokenAmount: '1000000000000000000',
@@ -41,6 +42,9 @@ const QUOTE_1_MOCK = {
       address: QUOTE_REQUEST_1_MOCK.targetTokenAddress,
     },
   },
+  toTokenAmount: {
+    amount: '1.24',
+  },
 } as unknown as QuoteResponse;
 
 const QUOTE_2_MOCK = {
@@ -48,6 +52,9 @@ const QUOTE_2_MOCK = {
     destAsset: {
       address: QUOTE_REQUEST_2_MOCK.targetTokenAddress,
     },
+  },
+  toTokenAmount: {
+    amount: '1.24',
   },
 } as unknown as QuoteResponse;
 
@@ -172,22 +179,37 @@ describe('Confirmations Bridge Utils', () => {
         {
           estimatedProcessingTimeInSeconds: 40,
           cost: { valueInCurrency: '0.5' },
+          toTokenAmount: {
+            amount: '1.24',
+          },
         },
         {
           estimatedProcessingTimeInSeconds: 10,
           cost: { valueInCurrency: '1.5' },
+          toTokenAmount: {
+            amount: '1.24',
+          },
         },
         {
           estimatedProcessingTimeInSeconds: 20,
           cost: { valueInCurrency: '1' },
+          toTokenAmount: {
+            amount: '1.24',
+          },
         },
         {
           estimatedProcessingTimeInSeconds: 30,
           cost: { valueInCurrency: '2' },
+          toTokenAmount: {
+            amount: '1.24',
+          },
         },
         {
           estimatedProcessingTimeInSeconds: 50,
           cost: { valueInCurrency: '0.9' },
+          toTokenAmount: {
+            amount: '1.24',
+          },
         },
       ] as TransactionBridgeQuote[];
 
@@ -197,6 +219,100 @@ describe('Confirmations Bridge Utils', () => {
       const quotes = await getBridgeQuotes([QUOTE_REQUEST_1_MOCK]);
 
       expect(quotes).toStrictEqual([QUOTES[2]]);
+    });
+
+    it('ignores quote if token amount if less than minimum', async () => {
+      const QUOTES = [
+        {
+          estimatedProcessingTimeInSeconds: 40,
+          cost: { valueInCurrency: '0.5' },
+          toTokenAmount: {
+            amount: '1.24',
+          },
+        },
+        {
+          estimatedProcessingTimeInSeconds: 10,
+          cost: { valueInCurrency: '1.5' },
+          toTokenAmount: {
+            amount: '1.24',
+          },
+        },
+        {
+          estimatedProcessingTimeInSeconds: 20,
+          cost: { valueInCurrency: '1' },
+          toTokenAmount: {
+            amount: '1.22',
+          },
+        },
+        {
+          estimatedProcessingTimeInSeconds: 30,
+          cost: { valueInCurrency: '2' },
+          toTokenAmount: {
+            amount: '1.24',
+          },
+        },
+        {
+          estimatedProcessingTimeInSeconds: 50,
+          cost: { valueInCurrency: '0.9' },
+          toTokenAmount: {
+            amount: '1.24',
+          },
+        },
+      ] as TransactionBridgeQuote[];
+
+      bridgeControllerMock.fetchQuotes.mockReset();
+      bridgeControllerMock.fetchQuotes.mockResolvedValue(QUOTES);
+
+      const quotes = await getBridgeQuotes([QUOTE_REQUEST_1_MOCK]);
+
+      expect(quotes).toStrictEqual([QUOTES[1]]);
+    });
+
+    it('returns undefined if all fastest quotes have token amount less than minimum', async () => {
+      const QUOTES = [
+        {
+          estimatedProcessingTimeInSeconds: 40,
+          cost: { valueInCurrency: '0.5' },
+          toTokenAmount: {
+            amount: '1.24',
+          },
+        },
+        {
+          estimatedProcessingTimeInSeconds: 10,
+          cost: { valueInCurrency: '1.5' },
+          toTokenAmount: {
+            amount: '1.22',
+          },
+        },
+        {
+          estimatedProcessingTimeInSeconds: 20,
+          cost: { valueInCurrency: '1' },
+          toTokenAmount: {
+            amount: '1.22',
+          },
+        },
+        {
+          estimatedProcessingTimeInSeconds: 30,
+          cost: { valueInCurrency: '2' },
+          toTokenAmount: {
+            amount: '1.22',
+          },
+        },
+        {
+          estimatedProcessingTimeInSeconds: 50,
+          cost: { valueInCurrency: '0.9' },
+          toTokenAmount: {
+            amount: '1.24',
+          },
+        },
+      ] as TransactionBridgeQuote[];
+
+      bridgeControllerMock.fetchQuotes.mockReset();
+      bridgeControllerMock.fetchQuotes.mockResolvedValue(QUOTES);
+
+      const quotes = await getBridgeQuotes([QUOTE_REQUEST_1_MOCK]);
+
+      expect(quotes).toBeUndefined();
     });
   });
 });

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5026,7 +5026,8 @@
       "switching_to": "Switching To",
       "bridge_estimated_time": "Est. time",
       "pay_with": "Pay with",
-      "total": "Total"
+      "total": "Total",
+      "bridge_fee": "Bridge Fee"
     },
     "title": {
       "signature": "Signature request",


### PR DESCRIPTION
## **Description**

Choose the fastest 3 bridge quotes, then ignore any that do not provide the required target amount.

Additional fixes:

- Add `Bridge Fee` row to Perps deposit confirmation.
- Subtract dust from `Total` in Perps deposit confirmation.
- Show correct status icon in transaction details summary.
- Show spinner in transaction details if in progress.
- Add tooltip to show error messages in transaction details.
- Change `Max` button to `90%`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #19018 [#5728](https://github.com/MetaMask/MetaMask-planning/issues/5728)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

<img width="350" alt="Bridge Fee" src="https://github.com/user-attachments/assets/2cd286bc-a681-418d-aba1-542bae446884" />

<img width="350" alt="Transaction Details" src="https://github.com/user-attachments/assets/3aac3e2c-a8c3-4230-933a-374a60d9c696" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
