### PR TITLE
feat(perps): improve Perps UX with connection grace period on navigation

### DIFF
--- a/app/components/UI/Perps/constants/perpsConfig.ts
+++ b/app/components/UI/Perps/constants/perpsConfig.ts
@@ -5,7 +5,7 @@ export const PERPS_CONSTANTS = {
   FEATURE_FLAG_KEY: 'perpsEnabled',
   WEBSOCKET_TIMEOUT: 5000, // 5 seconds
   WEBSOCKET_CLEANUP_DELAY: 1000, // 1 second
-  BACKGROUND_DISCONNECT_DELAY: 20_000, // 20 seconds delay before disconnecting when app is backgrounded
+  BACKGROUND_DISCONNECT_DELAY: 30_000, // 30 seconds delay before disconnecting when app is backgrounded or when user exits perps UX
   DEFAULT_ASSET_PREVIEW_LIMIT: 5,
   DEFAULT_MAX_LEVERAGE: 3 as number, // Default fallback max leverage when market data is unavailable - conservative default
   FALLBACK_PRICE_DISPLAY: '$---', // Display when price data is unavailable

--- a/app/components/UI/Perps/constants/perpsConfig.ts
+++ b/app/components/UI/Perps/constants/perpsConfig.ts
@@ -5,7 +5,7 @@ export const PERPS_CONSTANTS = {
   FEATURE_FLAG_KEY: 'perpsEnabled',
   WEBSOCKET_TIMEOUT: 5000, // 5 seconds
   WEBSOCKET_CLEANUP_DELAY: 1000, // 1 second
-  BACKGROUND_DISCONNECT_DELAY: 30_000, // 30 seconds delay before disconnecting when app is backgrounded or when user exits perps UX
+  BACKGROUND_DISCONNECT_DELAY: 20_000, // 20 seconds delay before disconnecting when app is backgrounded or when user exits perps UX
   DEFAULT_ASSET_PREVIEW_LIMIT: 5,
   DEFAULT_MAX_LEVERAGE: 3 as number, // Default fallback max leverage when market data is unavailable - conservative default
   FALLBACK_PRICE_DISPLAY: '$---', // Display when price data is unavailable

--- a/app/components/UI/Perps/hooks/usePerpsConnectionLifecycle.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsConnectionLifecycle.test.ts
@@ -120,7 +120,7 @@ describe('usePerpsConnectionLifecycle', () => {
 
       // Fast-forward timer to trigger disconnection
       act(() => {
-        jest.advanceTimersByTime(30_000);
+        jest.advanceTimersByTime(20_000);
       });
       expect(mockOnDisconnect).toHaveBeenCalledTimes(1);
     });
@@ -153,7 +153,7 @@ describe('usePerpsConnectionLifecycle', () => {
 
       // Fast-forward past original disconnect time
       act(() => {
-        jest.advanceTimersByTime(30_000);
+        jest.advanceTimersByTime(20_000);
       });
 
       // Should not have disconnected

--- a/app/components/UI/Perps/hooks/usePerpsConnectionLifecycle.ts
+++ b/app/components/UI/Perps/hooks/usePerpsConnectionLifecycle.ts
@@ -18,12 +18,12 @@ interface UsePerpsConnectionLifecycleReturn {
 
 /**
  * Hook that manages the Perps WebSocket connection lifecycle based on:
- * - Tab visibility (connect when visible, disconnect after 30s when hidden)
- * - App state (disconnect after 30s when backgrounded)
+ * - Tab visibility (connect when visible, disconnect after 20s when hidden)
+ * - App state (disconnect after 20s when backgrounded)
  *
  * This hook ensures optimal battery and network usage by:
- * - Delaying disconnection by 30s when tab is not visible (for quick returns)
- * - Delaying disconnection by 30s when app is backgrounded (for quick returns)
+ * - Delaying disconnection by 20s when tab is not visible (for quick returns)
+ * - Delaying disconnection by 20s when app is backgrounded (for quick returns)
  * - Using BackgroundTimer to ensure timers run even when app is suspended
  * - Providing grace period for users who temporarily exit and return to perps UX
  */


### PR DESCRIPTION
## **Description**

This PR implements a 20-second grace period before disconnecting from the Perps SDK when users exit the Perps UX. Previously, the connection was immediately terminated when users navigated away from Perps screens, causing a ~2 second delay when returning. 

With this change, the connection remains active for 20 seconds after leaving Perps, allowing users to quickly return without experiencing connection delays. This improves the UX for users who temporarily navigate away and return to Perps trading.

## **Changelog**

CHANGELOG entry: Improved Perps connection management by adding a 20-second grace period when exiting Perps screens, eliminating reconnection delays for users who quickly return

## **Related issues**

Fixes: [TAT-1506](https://consensyssoftware.atlassian.net/browse/TAT-1506)

## **Manual testing steps**

```gherkin
Feature: Perps Connection Grace Period

  Scenario: User temporarily exits and returns to Perps within grace period
    Given the user is on the Perps trading screen
    And the WebSocket connection is established

    When the user navigates away from Perps (e.g., to Portfolio tab)
    And waits less than 20 seconds
    And returns to the Perps trading screen
    Then the connection should still be active
    And data should load immediately without reconnection delay

  Scenario: User exits Perps for longer than grace period
    Given the user is on the Perps trading screen
    And the WebSocket connection is established

    When the user navigates away from Perps
    And waits more than 20 seconds
    Then the connection should be disconnected (to save resources)
    And returning to Perps will establish a new connection

  Scenario: App backgrounding maintains existing behavior
    Given the user is on the Perps trading screen
    And the WebSocket connection is established

    When the user backgrounds the app
    And returns within 20 seconds
    Then the connection should still be active
```

## **Screenshots/Recordings**

### **Before**
- Connection immediately disconnects when leaving Perps screens
- ~2 second reconnection delay when returning to Perps

### **After**
- Connection remains active for 20 seconds after leaving Perps
- No reconnection delay when returning within the grace period
- Connection properly disconnects after 20 seconds to conserve resources

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[TAT-1506]: https://consensyssoftware.atlassian.net/browse/TAT-1506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ