### PR TITLE
fix: cp-7.55.0 max mode should result on 0 value if native asset available is less than gas needed

### DIFF
--- a/app/components/Views/confirmations/hooks/send/usePercentageAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/send/usePercentageAmount.test.ts
@@ -121,6 +121,29 @@ describe('usePercentageAmount', () => {
     expect(result.current.getPercentageAmount(100)).toEqual('9685000000000');
   });
 
+  it('return zero if amount of asset available is less than gas', () => {
+    mockUseSendContext.mockReturnValue({
+      asset: {
+        chainId: '0x1',
+        address: '0xeDd1935e28b253C7905Cf5a944f0B5830FFA916a',
+        decimals: 2,
+        isNative: true,
+      },
+    } as unknown as ReturnType<typeof useSendContext>);
+    mockUseBalance.mockReturnValue({
+      balance: '100',
+      decimals: 2,
+      rawBalanceBN: new BN('100'),
+    });
+
+    const { result } = renderHookWithProvider(
+      () => usePercentageAmount(),
+      mockState,
+    );
+    expect(result.current.isMaxAmountSupported).toBeTruthy();
+    expect(result.current.getPercentageAmount(100)).toEqual('0');
+  });
+
   it('adjust L1 fee for optimism mainnet', async () => {
     mockUseSendContext.mockReturnValue({
       asset: {

--- a/app/components/Views/confirmations/hooks/send/usePercentageAmount.ts
+++ b/app/components/Views/confirmations/hooks/send/usePercentageAmount.ts
@@ -73,6 +73,10 @@ export const getPercentageValueFn = ({
     percentageValue = percentageValue.mul(new BN(percentage)).div(new BN(100));
   }
 
+  if (percentageValue.isNeg() || percentageValue.isZero()) {
+    return '0';
+  }
+
   return fromBNWithDecimals(percentageValue, asset.decimals);
 };
 

--- a/app/components/Views/confirmations/hooks/send/usePercentageAmount.ts
+++ b/app/components/Views/confirmations/hooks/send/usePercentageAmount.ts
@@ -88,19 +88,14 @@ export const usePercentageAmount = () => {
   const { gasFeeEstimates } = useGasFeeEstimatesForSend();
 
   const { value: layer1GasFee } = useAsyncResult(async () => {
-    if (
-      !isEvmNativeSendType ||
-      asset?.chainId === CHAIN_IDS.MAINNET ||
-      !from ||
-      value === undefined
-    ) {
+    if (!isEvmNativeSendType || asset?.chainId === CHAIN_IDS.MAINNET || !from) {
       return '0x0';
     }
     return await getLayer1GasFeeForSend({
       asset: asset as AssetType,
       chainId: chainId as Hex,
       from: from as Hex,
-      value: value as string,
+      value: (value ?? '0') as string,
     });
   }, [asset, chainId, from, value]);
 


### PR DESCRIPTION
## **Description**

Big fix max mode button result in invalid value.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/19178

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**
<img width="402" height="849" alt="Screenshot 2025-09-03 at 8 10 42 PM" src="https://github.com/user-attachments/assets/1ccdac71-10cd-4a84-b751-0598e64332c6" />


## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
