### PR TITLE
chore: small design adjustments to tab view home

### DIFF
--- a/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.styles.ts
@@ -6,6 +6,9 @@ const styleSheet = (params: { theme: Theme }) => {
   const { colors } = theme;
 
   return StyleSheet.create({
+    tradeInfoContainer: {
+      paddingBottom: 12,
+    },
     firstTimeIcon: {
       width: 48,
       height: 48,
@@ -19,9 +22,10 @@ const styleSheet = (params: { theme: Theme }) => {
     content: {
       flex: 1,
     },
-    section: {
-      marginBottom: 24,
+    contentContainer: {
+      flexGrow: 1,
     },
+    section: {},
     sectionHeader: {
       flexDirection: 'row',
       justifyContent: 'space-between',
@@ -50,6 +54,7 @@ const styleSheet = (params: { theme: Theme }) => {
       alignItems: 'center',
     },
     firstTimeContent: {
+      flex: 1,
       justifyContent: 'center',
       alignItems: 'center',
     },
@@ -93,7 +98,8 @@ const styleSheet = (params: { theme: Theme }) => {
       alignItems: 'flex-end',
     },
     startTradeCTA: {
-      marginVertical: 4,
+      paddingVertical: 12,
+      marginVertical: 2,
       borderRadius: 8,
     },
     startTradeContent: {

--- a/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
@@ -226,12 +226,15 @@ const PerpsTabView: React.FC<PerpsTabViewProps> = () => {
             <View style={styles.startTradeContent}>
               <View style={styles.startTradeIconContainer}>
                 <Icon
-                  name={IconName.Arrow2Right}
+                  name={IconName.Add}
                   color={IconColor.Default}
                   size={IconSize.Sm}
                 />
               </View>
-              <Text variant={TextVariant.BodyMD} style={styles.startTradeText}>
+              <Text
+                variant={TextVariant.BodyMDMedium}
+                style={styles.startTradeText}
+              >
                 {strings('perps.position.list.start_new_trade')}
               </Text>
             </View>
@@ -254,14 +257,17 @@ const PerpsTabView: React.FC<PerpsTabViewProps> = () => {
   }
 
   return (
-    <SafeAreaView style={styles.wrapper} edges={['bottom', 'left', 'right']}>
+    <SafeAreaView style={styles.wrapper} edges={['left', 'right']}>
       <>
         <PerpsTabControlBar
           onManageBalancePress={handleManageBalancePress}
           hasPositions={hasPositions}
           hasOrders={hasOrders}
         />
-        <ScrollView style={styles.content}>
+        <ScrollView
+          style={styles.content}
+          contentContainerStyle={styles.contentContainer}
+        >
           {!isInitialLoading && hasNoPositionsOrOrders ? (
             <View style={styles.firstTimeContent}>
               <View style={styles.firstTimeContainer}>
@@ -296,10 +302,10 @@ const PerpsTabView: React.FC<PerpsTabViewProps> = () => {
               </View>
             </View>
           ) : (
-            <>
+            <View style={styles.tradeInfoContainer}>
               <View style={styles.section}>{renderPositionsSection()}</View>
               <View style={styles.section}>{renderOrdersSection()}</View>
-            </>
+            </View>
           )}
         </ScrollView>
       </>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

1. What is the reason for the change?
Noticed differences in figma for the tab view

2. What is the improvement/solution?
- Ensure that the tab view scrollable area takes up available space, removing the gap at the bottom of the view.
- Improve the spacing on the line items and section areas
- Update start new trade CTA font size

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: n/a

## **Manual testing steps**

```gherkin
Feature: design adjustments

  Scenario: user is on the perps tab view wallet home
    Given user is on the perps tab view

    When user scrolls and has positions
    Then the scroll area should go fill the available area
    Then the CTA start a new trade should be same font size as other line items
    Then spacing should match the figma design
```
<img width="376" height="469" alt="Screenshot 2025-09-03 at 6 23 14 PM" src="https://github.com/user-attachments/assets/caab8f31-72f5-4189-9ce8-63b4c08429c9" />

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1179" height="2556" alt="simulator_screenshot_E9F453D7-6E74-4672-9291-A8E9FDC8D2DA" src="https://github.com/user-attachments/assets/8a648932-8aad-4fc7-a19d-4f9d54b9d6bb" />

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/8de203cf-79f5-477e-b5f8-74cdee31df43

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
