### PR TITLE
fix: subscriptions lose connection after coming back from background

### DIFF
--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -269,6 +269,7 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
    */
   public async prewarm(): Promise<() => void> {
     if (this.prewarmUnsubscribe) {
+      DevLogger.log('PriceStreamChannel: Already pre-warmed');
       return this.prewarmUnsubscribe;
     }
 
@@ -314,7 +315,11 @@ class PriceStreamChannel extends StreamChannel<Record<string, PriceUpdate>> {
         },
       });
 
-      return this.prewarmUnsubscribe;
+      // Return a cleanup function that properly clears internal state
+      return () => {
+        DevLogger.log('PriceStreamChannel: Cleaning up prewarm subscription');
+        this.cleanupPrewarm();
+      };
     } catch (error) {
       DevLogger.log('PriceStreamChannel: Failed to prewarm prices', error);
       // Return no-op cleanup function
@@ -369,6 +374,7 @@ class OrderStreamChannel extends StreamChannel<Order[]> {
    */
   public prewarm(): () => void {
     if (this.prewarmUnsubscribe) {
+      DevLogger.log('OrderStreamChannel: Already pre-warmed');
       return this.prewarmUnsubscribe;
     }
 
@@ -380,7 +386,11 @@ class OrderStreamChannel extends StreamChannel<Order[]> {
       throttleMs: 0, // No throttle for pre-warm
     });
 
-    return this.prewarmUnsubscribe;
+    // Return cleanup function that clears internal state
+    return () => {
+      DevLogger.log('OrderStreamChannel: Cleaning up prewarm subscription');
+      this.cleanupPrewarm();
+    };
   }
 
   /**
@@ -434,6 +444,7 @@ class PositionStreamChannel extends StreamChannel<Position[]> {
    */
   public prewarm(): () => void {
     if (this.prewarmUnsubscribe) {
+      DevLogger.log('PositionStreamChannel: Already pre-warmed');
       return this.prewarmUnsubscribe;
     }
 
@@ -445,7 +456,11 @@ class PositionStreamChannel extends StreamChannel<Position[]> {
       throttleMs: 0, // No throttle for pre-warm
     });
 
-    return this.prewarmUnsubscribe;
+    // Return cleanup function that clears internal state
+    return () => {
+      DevLogger.log('PositionStreamChannel: Cleaning up prewarm subscription');
+      this.cleanupPrewarm();
+    };
   }
 
   public clearCache(): void {
@@ -530,6 +545,7 @@ class AccountStreamChannel extends StreamChannel<AccountState | null> {
    */
   public prewarm(): () => void {
     if (this.prewarmUnsubscribe) {
+      DevLogger.log('AccountStreamChannel: Already pre-warmed');
       return this.prewarmUnsubscribe;
     }
 
@@ -541,7 +557,11 @@ class AccountStreamChannel extends StreamChannel<AccountState | null> {
       throttleMs: 0, // No throttle for pre-warm
     });
 
-    return this.prewarmUnsubscribe;
+    // Return cleanup function that clears internal state
+    return () => {
+      DevLogger.log('AccountStreamChannel: Cleaning up prewarm subscription');
+      this.cleanupPrewarm();
+    };
   }
 
   /**


### PR DESCRIPTION
…after 20 sec period

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

🐛 Fix: Perps live prices stop updating after app returns from background

1. What is the reason for the change?
- Live prices in the Perps feature would stop updating when the app was backgrounded for more than 20 seconds (the WebSocket grace period) and then brought back to the foreground. Users would see stale prices that never refreshed, requiring a full app restart to restore functionality.
- The issue was caused by improper cleanup of WebSocket subscription state during disconnect:
- The cleanup functions returned by prewarm() methods weren't clearing internal state (prewarmUnsubscribe variable)
When reconnecting, prewarm() would return the old, dead cleanup function instead of creating new subscriptions
This prevented the WebSocket from re-establishing price subscriptions

2. What is the improvement/solution?
PerpsStreamManager: Modified all prewarm() cleanup functions to call cleanupPrewarm(), ensuring internal state is properly cleared
This ensures fresh WebSocket subscriptions are created when the app returns from background
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1481

## **Manual testing steps**

```gherkin
Fix: subscriptions lose connection after coming back from background

Given I have MetaMask Mobile open with Perps enabled
  And I am on the Perps Markets tab
  And I can see live prices updating for market symbols
When I put the app in the background
  And I wait for 25 seconds (beyond the 20-second grace period)
  And I bring the app back to the foreground
  And I unlock the app with my password/biometric if required
Then I should see prices start updating within 3 seconds
  And the price values should change every few seconds
  And all market data should be current
  
  
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/1d3971fe-6547-461b-9d12-6a6c70c88237


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
