### PR TITLE
chore: CaipAssetType in points estimation & Accept-Language

### DIFF
--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -1228,6 +1228,7 @@ export class Engine {
         allowedEvents: [],
       }),
       fetch,
+      locale: I18n.locale,
     });
 
     // Backwards compatibility for existing references

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
@@ -49,6 +49,7 @@ describe('RewardsDataService', () => {
       messenger: mockMessenger,
       fetch: mockFetch,
       appType: 'mobile',
+      locale: 'en-US',
     });
   });
 
@@ -305,6 +306,7 @@ describe('RewardsDataService', () => {
         expect.any(String),
         expect.objectContaining({
           headers: {
+            'Accept-Language': 'en-US',
             'Content-Type': 'application/json',
             'rewards-client-id': 'mobile-7.50.1',
             // Should not include rewards-api-key header
@@ -378,6 +380,7 @@ describe('RewardsDataService', () => {
           credentials: 'omit',
           method: 'GET',
           headers: {
+            'Accept-Language': 'en-US',
             'Content-Type': 'application/json',
             'rewards-api-key': 'test-bearer-token',
             'rewards-client-id': 'mobile-7.50.1',
@@ -622,6 +625,100 @@ describe('RewardsDataService', () => {
           headers: expect.objectContaining({
             'Content-Type': 'application/json',
             'rewards-client-id': 'mobile-7.50.1',
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('Accept-Language Header', () => {
+    it('should include Accept-Language header with default locale', async () => {
+      // Arrange - service already initialized with default locale 'en-US'
+      const mockResponse = {
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockLoginResponse),
+      } as unknown as Response;
+      mockFetch.mockResolvedValue(mockResponse);
+
+      // Act
+      await service.login({
+        account: '0x123',
+        timestamp: 1234567890,
+        signature: '0xsignature',
+      });
+
+      // Assert
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.rewards.test/auth/mobile-login',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'Accept-Language': 'en-US',
+          }),
+        }),
+      );
+    });
+
+    it('should include Accept-Language header with custom locale', async () => {
+      // Arrange - create service with custom locale
+      const customLocaleService = new RewardsDataService({
+        messenger: mockMessenger,
+        fetch: mockFetch,
+        appType: 'mobile',
+        locale: 'es-ES',
+      });
+
+      const mockResponse = {
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockLoginResponse),
+      } as unknown as Response;
+      mockFetch.mockResolvedValue(mockResponse);
+
+      // Act
+      await customLocaleService.login({
+        account: '0x123',
+        timestamp: 1234567890,
+        signature: '0xsignature',
+      });
+
+      // Assert
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.rewards.test/auth/mobile-login',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'Accept-Language': 'es-ES',
+          }),
+        }),
+      );
+    });
+
+    it('should not include Accept-Language header when locale is empty', async () => {
+      // Arrange - create service with empty locale
+      const emptyLocaleService = new RewardsDataService({
+        messenger: mockMessenger,
+        fetch: mockFetch,
+        appType: 'mobile',
+        locale: '',
+      });
+
+      const mockResponse = {
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockLoginResponse),
+      } as unknown as Response;
+      mockFetch.mockResolvedValue(mockResponse);
+
+      // Act
+      await emptyLocaleService.login({
+        account: '0x123',
+        timestamp: 1234567890,
+        signature: '0xsignature',
+      });
+
+      // Assert
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.rewards.test/auth/mobile-login',
+        expect.objectContaining({
+          headers: expect.not.objectContaining({
+            'Accept-Language': expect.any(String),
           }),
         }),
       );

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.ts
@@ -75,18 +75,23 @@ export class RewardsDataService {
 
   readonly #appType: 'mobile' | 'extension';
 
+  readonly #locale: string;
+
   constructor({
     messenger,
     fetch: fetchFunction,
     appType = 'mobile',
+    locale = 'en-US',
   }: {
     messenger: RewardsDataServiceMessenger;
     fetch: typeof fetch;
     appType?: 'mobile' | 'extension';
+    locale?: string;
   }) {
     this.#messenger = messenger;
     this.#fetch = fetchFunction;
     this.#appType = appType;
+    this.#locale = locale;
     // Register all action handlers
     this.#messenger.registerActionHandler(
       `${SERVICE_NAME}:login`,
@@ -148,6 +153,11 @@ export class RewardsDataService {
     } catch (error) {
       // Continue without bearer token if retrieval fails
       console.warn('Failed to retrieve bearer token:', error);
+    }
+
+    // Add locale header for internationalization
+    if (this.#locale) {
+      headers['Accept-Language'] = this.#locale;
     }
 
     const url = `${AppConstants.REWARDS_API_URL}${endpoint}`;

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -1,5 +1,5 @@
 import { ControllerGetStateAction } from '@metamask/base-controller';
-import { CaipAccountId } from '@metamask/utils';
+import { CaipAccountId, CaipAssetType } from '@metamask/utils';
 
 export interface LoginResponseDto {
   sessionId: string;
@@ -17,7 +17,7 @@ export interface EstimateAssetDto {
    * Asset identifier in CAIP-19 format
    * @example 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
    */
-  id: string;
+  id: CaipAssetType;
   /**
    * Amount of the asset as a string
    * @example '25739959426'


### PR DESCRIPTION
## **Description**

- We should be using the utility types for Caip related props as much as we can. In the input object for estimating points, I've used the CaipAssetType type.
- We are now passing in a Accept-Language header to the rewards backend API so it can return localized content if needed.

## **Changelog**

CHANGELOG entry: null

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
