### PR TITLE
feat: automatically increase metamask pay buffer

### DIFF
--- a/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
@@ -29,6 +29,9 @@ jest.mock('../../../../hooks/AssetPolling/AssetPollingProvider', () => ({
 jest.mock(
   '../../../../../selectors/featureFlagController/confirmations',
   () => ({
+    ...jest.requireActual(
+      '../../../../../selectors/featureFlagController/confirmations',
+    ),
     selectConfirmationRedesignFlags: () => ({
       signatures: true,
       staking_confirmations: true,

--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
@@ -60,6 +60,7 @@ describe('PayWithRow', () => {
         address: ADDRESS_MOCK,
         balance: '0',
         balanceFiat: '$0',
+        balanceRaw: '0',
         chainId: CHAIN_ID_MOCK,
         decimals: 4,
         symbol: 'test',

--- a/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.test.tsx
+++ b/app/components/Views/confirmations/external/perps-temp/components/deposit/deposit.test.tsx
@@ -59,6 +59,7 @@ describe('PerpsDeposit', () => {
         address: '0x123',
         balance: '0',
         balanceFiat: '0',
+        balanceRaw: '0',
         chainId: '0x1',
         decimals: 18,
         symbol: 'TST',

--- a/app/components/Views/confirmations/hooks/pay/useTransactionBridgeQuotes.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionBridgeQuotes.test.ts
@@ -11,6 +11,11 @@ import { useTransactionMetadataOrThrow } from '../transactions/useTransactionMet
 import { Hex } from '@metamask/utils';
 import { useAlerts } from '../../context/alert-system-context';
 import { AlertKeys } from '../../constants/alerts';
+import {
+  BUFFER_STEP_DEFAULT,
+  INITIAL_BUFFER_DEFAULT,
+  MAX_ATTEMPTS_DEFAULT,
+} from '../../../../../selectors/featureFlagController/confirmations';
 
 jest.mock('./useTransactionPayToken');
 jest.mock('./useTransactionPayTokenAmounts');
@@ -29,6 +34,7 @@ const SOURCE_AMOUNT_1_MOCK = '1234';
 const SOURCE_AMOUNT_2_MOCK = '5678';
 const MINIMUM_TOKEN_AMOUNT_1_MOCK = '1.23';
 const MINIMUM_TOKEN_AMOUNT_2_MOCK = '2.34';
+const SOURCE_BALANCE_RAW_MOCK = '1234560';
 
 const QUOTE_MOCK = {
   quote: {},
@@ -68,6 +74,7 @@ describe('useTransactionBridgeQuotes', () => {
         address: TOKEN_ADDRESS_SOURCE_MOCK,
         balance: '123.456',
         balanceFiat: '123.456',
+        balanceRaw: SOURCE_BALANCE_RAW_MOCK,
         chainId: CHAIN_ID_SOURCE_MOCK,
         decimals: 4,
         symbol: 'TST',
@@ -103,20 +110,28 @@ describe('useTransactionBridgeQuotes', () => {
 
     expect(getBridgeQuotesMock).toHaveBeenCalledWith([
       {
+        bufferStep: BUFFER_STEP_DEFAULT,
         from: ACCOUNT_ADDRESS_MOCK,
-        minimumTargetAmount: MINIMUM_TOKEN_AMOUNT_1_MOCK,
+        initialBuffer: INITIAL_BUFFER_DEFAULT,
+        maxAttempts: MAX_ATTEMPTS_DEFAULT,
+        sourceBalanceRaw: SOURCE_BALANCE_RAW_MOCK,
         sourceChainId: CHAIN_ID_SOURCE_MOCK,
         sourceTokenAddress: TOKEN_ADDRESS_SOURCE_MOCK,
         sourceTokenAmount: SOURCE_AMOUNT_1_MOCK,
+        targetAmountMinimum: MINIMUM_TOKEN_AMOUNT_1_MOCK,
         targetChainId: CHAIN_ID_TARGET_MOCK,
         targetTokenAddress: TOKEN_ADDRESS_TARGET_1_MOCK,
       },
       {
+        bufferStep: BUFFER_STEP_DEFAULT,
         from: ACCOUNT_ADDRESS_MOCK,
-        minimumTargetAmount: MINIMUM_TOKEN_AMOUNT_2_MOCK,
+        initialBuffer: INITIAL_BUFFER_DEFAULT,
+        maxAttempts: MAX_ATTEMPTS_DEFAULT,
+        sourceBalanceRaw: SOURCE_BALANCE_RAW_MOCK,
         sourceChainId: CHAIN_ID_SOURCE_MOCK,
         sourceTokenAddress: TOKEN_ADDRESS_SOURCE_MOCK,
         sourceTokenAmount: SOURCE_AMOUNT_2_MOCK,
+        targetAmountMinimum: MINIMUM_TOKEN_AMOUNT_2_MOCK,
         targetChainId: CHAIN_ID_TARGET_MOCK,
         targetTokenAddress: TOKEN_ADDRESS_TARGET_2_MOCK,
       },

--- a/app/components/Views/confirmations/hooks/pay/useTransactionBridgeQuotes.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionBridgeQuotes.test.ts
@@ -34,8 +34,8 @@ const TOKEN_ADDRESS_TARGET_2_MOCK = '0x789' as Hex;
 const ACCOUNT_ADDRESS_MOCK = '0xabc';
 const SOURCE_AMOUNT_1_MOCK = '1234';
 const SOURCE_AMOUNT_2_MOCK = '5678';
-const MINIMUM_TOKEN_AMOUNT_1_MOCK = '1.23';
-const MINIMUM_TOKEN_AMOUNT_2_MOCK = '2.34';
+const MINIMUM_TOKEN_AMOUNT_1_MOCK = '123';
+const MINIMUM_TOKEN_AMOUNT_2_MOCK = '234';
 const SOURCE_BALANCE_RAW_MOCK = '1234560';
 
 const QUOTE_MOCK = {
@@ -90,12 +90,12 @@ describe('useTransactionBridgeQuotes', () => {
         {
           address: TOKEN_ADDRESS_TARGET_1_MOCK,
           amountRaw: SOURCE_AMOUNT_1_MOCK,
-          targetAmountHuman: MINIMUM_TOKEN_AMOUNT_1_MOCK,
+          targetAmountRaw: MINIMUM_TOKEN_AMOUNT_1_MOCK,
         },
         {
           address: TOKEN_ADDRESS_TARGET_2_MOCK,
           amountRaw: SOURCE_AMOUNT_2_MOCK,
-          targetAmountHuman: MINIMUM_TOKEN_AMOUNT_2_MOCK,
+          targetAmountRaw: MINIMUM_TOKEN_AMOUNT_2_MOCK,
         },
       ],
     } as ReturnType<typeof useTransactionPayTokenAmounts>);

--- a/app/components/Views/confirmations/hooks/pay/useTransactionBridgeQuotes.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionBridgeQuotes.test.ts
@@ -12,9 +12,11 @@ import { Hex } from '@metamask/utils';
 import { useAlerts } from '../../context/alert-system-context';
 import { AlertKeys } from '../../constants/alerts';
 import {
+  ATTEMPTS_MAX_DEFAULT,
+  BUFFER_INITIAL_DEFAULT,
   BUFFER_STEP_DEFAULT,
-  INITIAL_BUFFER_DEFAULT,
-  MAX_ATTEMPTS_DEFAULT,
+  SLIPPAGE_INITIAL_DEFAULT,
+  SLIPPAGE_SUBSEQUENT_DEFAULT,
 } from '../../../../../selectors/featureFlagController/confirmations';
 
 jest.mock('./useTransactionPayToken');
@@ -110,10 +112,12 @@ describe('useTransactionBridgeQuotes', () => {
 
     expect(getBridgeQuotesMock).toHaveBeenCalledWith([
       {
+        attemptsMax: ATTEMPTS_MAX_DEFAULT,
+        bufferInitial: BUFFER_INITIAL_DEFAULT,
         bufferStep: BUFFER_STEP_DEFAULT,
         from: ACCOUNT_ADDRESS_MOCK,
-        initialBuffer: INITIAL_BUFFER_DEFAULT,
-        maxAttempts: MAX_ATTEMPTS_DEFAULT,
+        slippageInitial: SLIPPAGE_INITIAL_DEFAULT,
+        slippageSubsequent: SLIPPAGE_SUBSEQUENT_DEFAULT,
         sourceBalanceRaw: SOURCE_BALANCE_RAW_MOCK,
         sourceChainId: CHAIN_ID_SOURCE_MOCK,
         sourceTokenAddress: TOKEN_ADDRESS_SOURCE_MOCK,
@@ -123,10 +127,12 @@ describe('useTransactionBridgeQuotes', () => {
         targetTokenAddress: TOKEN_ADDRESS_TARGET_1_MOCK,
       },
       {
+        attemptsMax: ATTEMPTS_MAX_DEFAULT,
+        bufferInitial: BUFFER_INITIAL_DEFAULT,
         bufferStep: BUFFER_STEP_DEFAULT,
         from: ACCOUNT_ADDRESS_MOCK,
-        initialBuffer: INITIAL_BUFFER_DEFAULT,
-        maxAttempts: MAX_ATTEMPTS_DEFAULT,
+        slippageInitial: SLIPPAGE_INITIAL_DEFAULT,
+        slippageSubsequent: SLIPPAGE_SUBSEQUENT_DEFAULT,
         sourceBalanceRaw: SOURCE_BALANCE_RAW_MOCK,
         sourceChainId: CHAIN_ID_SOURCE_MOCK,
         sourceTokenAddress: TOKEN_ADDRESS_SOURCE_MOCK,

--- a/app/components/Views/confirmations/hooks/pay/useTransactionBridgeQuotes.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionBridgeQuotes.ts
@@ -70,7 +70,7 @@ export function useTransactionBridgeQuotes() {
       const {
         address: targetTokenAddress,
         amountRaw: sourceTokenAmount,
-        targetAmountHuman,
+        targetAmountRaw,
       } = sourceAmount;
 
       return {
@@ -84,7 +84,7 @@ export function useTransactionBridgeQuotes() {
         sourceChainId,
         sourceTokenAddress,
         sourceTokenAmount,
-        targetAmountMinimum: targetAmountHuman,
+        targetAmountMinimum: targetAmountRaw,
         targetChainId,
         targetTokenAddress,
       };

--- a/app/components/Views/confirmations/hooks/pay/useTransactionBridgeQuotes.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionBridgeQuotes.ts
@@ -27,9 +27,13 @@ export function useTransactionBridgeQuotes() {
   const transactionMeta = useTransactionMetadataOrThrow();
   const { alerts } = useAlerts();
 
-  const { bufferStep, initialBuffer, maxAttempts } = useSelector(
-    selectMetaMaskPayFlags,
-  );
+  const {
+    attemptsMax,
+    bufferInitial,
+    bufferStep,
+    slippageInitial,
+    slippageSubsequent,
+  } = useSelector(selectMetaMaskPayFlags);
 
   const hasBlockingAlert = alerts.some(
     (a) => a.isBlocking && !EXCLUDED_ALERTS.includes(a.key as AlertKeys),
@@ -70,10 +74,12 @@ export function useTransactionBridgeQuotes() {
       } = sourceAmount;
 
       return {
+        attemptsMax,
+        bufferInitial,
         bufferStep,
         from: from as Hex,
-        initialBuffer,
-        maxAttempts,
+        slippageInitial,
+        slippageSubsequent,
         sourceBalanceRaw,
         sourceChainId,
         sourceTokenAddress,
@@ -84,11 +90,13 @@ export function useTransactionBridgeQuotes() {
       };
     });
   }, [
+    attemptsMax,
+    bufferInitial,
     bufferStep,
     from,
     hasBlockingAlert,
-    initialBuffer,
-    maxAttempts,
+    slippageInitial,
+    slippageSubsequent,
     sourceAmounts,
     sourceBalanceRaw,
     sourceChainId,

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.test.ts
@@ -76,7 +76,10 @@ describe('useTransactionPayToken', () => {
       payToken: PAY_TOKEN_MOCK,
     });
 
-    expect(result.current.payToken).toStrictEqual(BRIDGE_TOKEN_MOCK);
+    expect(result.current.payToken).toStrictEqual({
+      ...BRIDGE_TOKEN_MOCK,
+      balanceRaw: '1234560',
+    });
   });
 
   it('sets token in state', () => {

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
@@ -5,9 +5,10 @@ import {
   setTransactionPayToken,
 } from '../../../../../core/redux/slices/confirmationMetrics';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { RootState } from '../../../../../reducers';
 import { useTokenWithBalance } from '../tokens/useTokenWithBalance';
+import { BigNumber } from 'bignumber.js';
 
 export function useTransactionPayToken() {
   const dispatch = useDispatch();
@@ -17,7 +18,7 @@ export function useTransactionPayToken() {
     selectTransactionPayToken(state, transactionId as string),
   );
 
-  const payToken = useTokenWithBalance(
+  const payTokenRaw = useTokenWithBalance(
     selectedPayToken?.address ?? '0x0',
     selectedPayToken?.chainId ?? '0x0',
   );
@@ -33,6 +34,19 @@ export function useTransactionPayToken() {
     },
     [dispatch, transactionId],
   );
+
+  const payToken = useMemo(() => {
+    if (!payTokenRaw) return undefined;
+
+    const balanceRaw = new BigNumber(payTokenRaw.balance)
+      .shiftedBy(payTokenRaw.decimals)
+      .toFixed(0);
+
+    return {
+      ...payTokenRaw,
+      balanceRaw,
+    };
+  }, [payTokenRaw]);
 
   return {
     payToken,

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayTokenAmounts.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayTokenAmounts.test.ts
@@ -42,12 +42,12 @@ describe('useTransactionPayTokenAmounts', () => {
       values: [
         {
           address: TOKEN_ADDRESS_1_MOCK,
-          amountHumanOriginal: '1.23',
+          amountRaw: '123',
           totalFiat: 16.123,
         },
         {
           address: TOKEN_ADDRESS_2_MOCK,
-          amountHumanOriginal: '2.34',
+          amountRaw: '234',
           totalFiat: 40.456,
         },
       ],
@@ -79,13 +79,13 @@ describe('useTransactionPayTokenAmounts', () => {
         address: TOKEN_ADDRESS_1_MOCK,
         amountHuman: '4.03075',
         amountRaw: '40308',
-        targetAmountHuman: '1.23',
+        targetAmountRaw: '123',
       },
       {
         address: TOKEN_ADDRESS_2_MOCK,
         amountHuman: '10.114',
         amountRaw: '101140',
-        targetAmountHuman: '2.34',
+        targetAmountRaw: '234',
       },
     ]);
   });
@@ -96,7 +96,7 @@ describe('useTransactionPayTokenAmounts', () => {
         {
           address: TOKEN_ADDRESS_2_MOCK,
           amountFiat: 40.455,
-          amountHumanOriginal: '2.34',
+          amountRaw: '234',
           balanceFiat: 40.456,
           totalFiat: 41,
           skipIfBalance: false,
@@ -112,7 +112,7 @@ describe('useTransactionPayTokenAmounts', () => {
         address: TOKEN_ADDRESS_2_MOCK,
         amountHuman: '10.25',
         amountRaw: '102500',
-        targetAmountHuman: '2.34',
+        targetAmountRaw: '234',
       },
     ]);
   });
@@ -123,7 +123,7 @@ describe('useTransactionPayTokenAmounts', () => {
         {
           address: TOKEN_ADDRESS_1_MOCK,
           amountFiat: 16.123,
-          amountHumanOriginal: '1.23',
+          amountRaw: '123',
           balanceFiat: 16.124,
           totalFiat: 17,
           skipIfBalance: true,
@@ -131,7 +131,7 @@ describe('useTransactionPayTokenAmounts', () => {
         {
           address: TOKEN_ADDRESS_2_MOCK,
           amountFiat: 40.456,
-          amountHumanOriginal: '2.34',
+          amountRaw: '234',
           balanceFiat: 40.455,
           totalFiat: 41,
           skipIfBalance: false,
@@ -147,7 +147,7 @@ describe('useTransactionPayTokenAmounts', () => {
         address: TOKEN_ADDRESS_2_MOCK,
         amountHuman: '10.25',
         amountRaw: '102500',
-        targetAmountHuman: '2.34',
+        targetAmountRaw: '234',
       },
     ]);
   });
@@ -158,14 +158,14 @@ describe('useTransactionPayTokenAmounts', () => {
         {
           address: tokenAddress1Mock,
           amountFiat: 16.123,
-          amountHumanOriginal: '1.23',
+          amountRaw: '123',
           balanceFiat: 16.124,
           totalFiat: 17,
           skipIfBalance: false,
         },
         {
           address: TOKEN_ADDRESS_2_MOCK,
-          amountHumanOriginal: '2.34',
+          amountRaw: '234',
           amountFiat: 40.456,
           balanceFiat: 40.455,
           totalFiat: 41,
@@ -182,7 +182,7 @@ describe('useTransactionPayTokenAmounts', () => {
         address: TOKEN_ADDRESS_2_MOCK,
         amountHuman: '10.25',
         amountRaw: '102500',
-        targetAmountHuman: '2.34',
+        targetAmountRaw: '234',
       },
     ]);
   });
@@ -193,7 +193,7 @@ describe('useTransactionPayTokenAmounts', () => {
         {
           address: TOKEN_ADDRESS_1_MOCK,
           amountFiat: 16.123,
-          amountHumanOriginal: '1.23',
+          amountRaw: '123',
           balanceFiat: 16.124,
           totalFiat: 17,
           skipIfBalance: false,
@@ -201,7 +201,7 @@ describe('useTransactionPayTokenAmounts', () => {
         {
           address: TOKEN_ADDRESS_2_MOCK,
           amountFiat: 40.456,
-          amountHumanOriginal: '2.34',
+          amountRaw: '234',
           balanceFiat: 40.455,
           totalFiat: 41,
           skipIfBalance: false,
@@ -217,7 +217,7 @@ describe('useTransactionPayTokenAmounts', () => {
         address: TOKEN_ADDRESS_2_MOCK,
         amountHuman: '10.25',
         amountRaw: '102500',
-        targetAmountHuman: '2.34',
+        targetAmountRaw: '234',
       },
     ]);
   });

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayTokenAmounts.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayTokenAmounts.test.ts
@@ -61,6 +61,7 @@ describe('useTransactionPayTokenAmounts', () => {
         address: tokenAddress1Mock,
         balance: '123.456',
         balanceFiat: '123.456',
+        balanceRaw: '1234560',
         chainId: CHAIN_ID_MOCK,
         decimals: 4,
         symbol: 'TST',

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayTokenAmounts.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayTokenAmounts.ts
@@ -96,7 +96,7 @@ export function useTransactionPayTokenAmounts({
           address: value.address,
           amountHuman,
           amountRaw,
-          targetAmountHuman: value.amountHumanOriginal,
+          targetAmountRaw: value.amountRaw,
         };
       });
   }, [address, chainId, decimals, tokenFiatRate, values]);

--- a/app/components/Views/confirmations/hooks/pay/useTransactionRequiredFiat.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionRequiredFiat.test.ts
@@ -51,12 +51,14 @@ describe('useTransactionRequiredFiat', () => {
       {
         address: tokenAddress1Mock,
         amountHuman: '2',
+        amountRaw: '2000',
         balanceHuman: '10',
         skipIfBalance: false,
       },
       {
         address: tokenAddress2Mock,
         amountHuman: '3',
+        amountRaw: '3000',
         balanceHuman: '20',
         skipIfBalance: true,
       },
@@ -72,7 +74,7 @@ describe('useTransactionRequiredFiat', () => {
       {
         address: tokenAddress1Mock,
         amountFiat: 8,
-        amountHumanOriginal: '2',
+        amountRaw: '2000',
         balanceFiat: 40,
         feeFiat: 0.2,
         skipIfBalance: false,
@@ -81,7 +83,7 @@ describe('useTransactionRequiredFiat', () => {
       {
         address: tokenAddress2Mock,
         amountFiat: 15,
-        amountHumanOriginal: '3',
+        amountRaw: '3000',
         balanceFiat: 100,
         feeFiat: 0.375,
         skipIfBalance: true,
@@ -106,7 +108,7 @@ describe('useTransactionRequiredFiat', () => {
       {
         address: tokenAddress1Mock,
         amountFiat: 16,
-        amountHumanOriginal: '4',
+        amountRaw: '2000',
         balanceFiat: 40,
         feeFiat: 0.4,
         skipIfBalance: false,
@@ -115,7 +117,7 @@ describe('useTransactionRequiredFiat', () => {
       {
         address: tokenAddress2Mock,
         amountFiat: 15,
-        amountHumanOriginal: '3',
+        amountRaw: '3000',
         balanceFiat: 100,
         feeFiat: 0.375,
         skipIfBalance: true,

--- a/app/components/Views/confirmations/hooks/pay/useTransactionRequiredFiat.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionRequiredFiat.ts
@@ -58,8 +58,8 @@ export function useTransactionRequiredFiat({
 
         return {
           address: target.address,
-          amountHumanOriginal: amountHuman,
           amountFiat: amountFiat.toNumber(),
+          amountRaw: target.amountRaw,
           balanceFiat: balanceFiat.toNumber(),
           feeFiat: feeFiat.toNumber(),
           totalFiat: totalFiat.toNumber(),

--- a/app/components/Views/confirmations/hooks/pay/useTransactionRequiredFiat.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionRequiredFiat.ts
@@ -21,7 +21,7 @@ export function useTransactionRequiredFiat({
   const transactionMeta = useTransactionMetadataOrThrow();
   const { chainId } = transactionMeta;
   const requiredTokens = useTransactionRequiredTokens();
-  const { initialBuffer } = useSelector(selectMetaMaskPayFlags);
+  const { bufferInitial } = useSelector(selectMetaMaskPayFlags);
 
   const fiatRequests = useMemo(
     () =>
@@ -48,7 +48,7 @@ export function useTransactionRequiredFiat({
           targetFiatRate,
         );
 
-        const feeFiat = amountFiat.multipliedBy(initialBuffer);
+        const feeFiat = amountFiat.multipliedBy(bufferInitial);
 
         const balanceFiat = new BigNumber(target.balanceHuman).multipliedBy(
           targetFiatRate,
@@ -66,7 +66,7 @@ export function useTransactionRequiredFiat({
           skipIfBalance: target.skipIfBalance,
         };
       }),
-    [amountOverrides, initialBuffer, requiredTokens, tokenFiatRates],
+    [amountOverrides, bufferInitial, requiredTokens, tokenFiatRates],
   );
 
   const totalFiat = values.reduce<number>(

--- a/app/components/Views/confirmations/hooks/pay/useTransactionRequiredFiat.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionRequiredFiat.ts
@@ -4,11 +4,10 @@ import { useTransactionMetadataOrThrow } from '../transactions/useTransactionMet
 import { useTransactionRequiredTokens } from './useTransactionRequiredTokens';
 import { useTokenFiatRates } from '../tokens/useTokenFiatRates';
 import { Hex, createProjectLogger } from '@metamask/utils';
+import { selectMetaMaskPayFlags } from '../../../../../selectors/featureFlagController/confirmations';
+import { useSelector } from 'react-redux';
 
 const log = createProjectLogger('transaction-pay');
-
-export const PAY_BRIDGE_SLIPPAGE = 0.02;
-export const PAY_BRIDGE_FEE = 0.005;
 
 /**
  * Calculate the fiat value of any tokens required by the transaction.
@@ -22,6 +21,7 @@ export function useTransactionRequiredFiat({
   const transactionMeta = useTransactionMetadataOrThrow();
   const { chainId } = transactionMeta;
   const requiredTokens = useTransactionRequiredTokens();
+  const { initialBuffer } = useSelector(selectMetaMaskPayFlags);
 
   const fiatRequests = useMemo(
     () =>
@@ -48,9 +48,7 @@ export function useTransactionRequiredFiat({
           targetFiatRate,
         );
 
-        const feeFiat = amountFiat.multipliedBy(
-          PAY_BRIDGE_SLIPPAGE + PAY_BRIDGE_FEE,
-        );
+        const feeFiat = amountFiat.multipliedBy(initialBuffer);
 
         const balanceFiat = new BigNumber(target.balanceHuman).multipliedBy(
           targetFiatRate,
@@ -68,7 +66,7 @@ export function useTransactionRequiredFiat({
           skipIfBalance: target.skipIfBalance,
         };
       }),
-    [amountOverrides, requiredTokens, tokenFiatRates],
+    [amountOverrides, initialBuffer, requiredTokens, tokenFiatRates],
   );
 
   const totalFiat = values.reduce<number>(

--- a/app/components/Views/confirmations/hooks/pay/useTransactionRequiredTokens.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionRequiredTokens.ts
@@ -36,7 +36,7 @@ export function useTransactionRequiredTokens() {
   const tokenTransferToken = useTokenTransferToken(chainId);
 
   const result = useMemo(
-    () => [gasToken, tokenTransferToken].filter(Boolean) as TransactionToken[],
+    () => [tokenTransferToken, gasToken].filter(Boolean) as TransactionToken[],
     [gasToken, tokenTransferToken],
   );
 

--- a/app/components/Views/confirmations/hooks/pay/useTransactionTotalFiat.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionTotalFiat.test.ts
@@ -120,13 +120,11 @@ describe('useTransactionTotalFiat', () => {
       values: [
         {
           address: ADDRESS_MOCK,
-          amountFiat: 12.34,
-          amountHumanOriginal: '1.22',
+          amountFiat: 1.22,
         },
         {
           address: ADDRESS_2_MOCK,
-          amountFiat: 23.45,
-          amountHumanOriginal: '2.33',
+          amountFiat: 2.33,
         },
       ],
     } as unknown as ReturnType<typeof useTransactionRequiredFiat>);
@@ -145,7 +143,7 @@ describe('useTransactionTotalFiat', () => {
           totalMaxNetworkFee: {
             valueInCurrency: '23.45',
           },
-          toTokenAmount: {
+          minToTokenAmount: {
             valueInCurrency: '11.22',
           },
         },
@@ -161,7 +159,7 @@ describe('useTransactionTotalFiat', () => {
           totalMaxNetworkFee: {
             valueInCurrency: '45.67',
           },
-          toTokenAmount: {
+          minToTokenAmount: {
             valueInCurrency: '22.33',
           },
         },
@@ -198,6 +196,9 @@ describe('useTransactionTotalFiat', () => {
           },
           totalMaxNetworkFee: {
             valueInCurrency: '40',
+          },
+          minToTokenAmount: {
+            valueInCurrency: '1000',
           },
           quote: {
             destAsset: {
@@ -242,7 +243,7 @@ describe('useTransactionTotalFiat', () => {
           sentAmount: {
             valueInCurrency: '100',
           },
-          toTokenAmount: {
+          minToTokenAmount: {
             valueInCurrency: '90',
           },
           totalMaxNetworkFee: {
@@ -253,7 +254,7 @@ describe('useTransactionTotalFiat', () => {
           sentAmount: {
             valueInCurrency: '80',
           },
-          toTokenAmount: {
+          minToTokenAmount: {
             valueInCurrency: '60',
           },
           totalMaxNetworkFee: {
@@ -273,7 +274,7 @@ describe('useTransactionTotalFiat', () => {
           sentAmount: {
             valueInCurrency: '100',
           },
-          toTokenAmount: {
+          minToTokenAmount: {
             valueInCurrency: '90',
           },
           totalMaxNetworkFee: {
@@ -284,7 +285,7 @@ describe('useTransactionTotalFiat', () => {
           sentAmount: {
             valueInCurrency: '80',
           },
-          toTokenAmount: {
+          minToTokenAmount: {
             valueInCurrency: '60',
           },
           totalMaxNetworkFee: {

--- a/app/components/Views/confirmations/hooks/pay/useTransactionTotalFiat.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionTotalFiat.ts
@@ -122,15 +122,15 @@ function getQuoteSourceFee(quote: TransactionBridgeQuote): BigNumber {
 
 function getQuoteDust(
   quote: TransactionBridgeQuote,
-  requiredFiat: { address: Hex; amountHumanOriginal: string }[],
+  requiredFiat: { address: Hex; amountFiat: number }[],
 ): BigNumber {
-  const targetAmount = quote.toTokenAmount?.valueInCurrency ?? '0';
+  const targetAmount = quote.minToTokenAmount?.valueInCurrency ?? '0';
 
   const requiredAmount = requiredFiat.find(
     (token) =>
       token.address.toLowerCase() ===
       quote.quote.destAsset.address.toLowerCase(),
-  )?.amountHumanOriginal;
+  )?.amountFiat;
 
   if (!requiredAmount) {
     return new BigNumber(0);

--- a/app/components/Views/confirmations/hooks/pay/useTransactionTotalFiat.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionTotalFiat.ts
@@ -116,7 +116,7 @@ function getQuoteGasAndRelayFee(quote: TransactionBridgeQuote): BigNumber {
 
 function getQuoteSourceFee(quote: TransactionBridgeQuote): BigNumber {
   return getQuoteSourceAmount(quote).minus(
-    quote.toTokenAmount?.valueInCurrency ?? 0,
+    quote.minToTokenAmount?.valueInCurrency ?? 0,
   );
 }
 

--- a/app/components/Views/confirmations/utils/bridge.test.ts
+++ b/app/components/Views/confirmations/utils/bridge.test.ts
@@ -43,10 +43,8 @@ const QUOTE_REQUEST_2_MOCK: BridgeQuoteRequest = {
 };
 
 const QUOTE_1_MOCK = {
-  minToTokenAmount: {
-    amount: '124',
-  },
   quote: {
+    minDestTokenAmount: '124',
     destAsset: {
       address: QUOTE_REQUEST_1_MOCK.targetTokenAddress,
     },
@@ -54,10 +52,8 @@ const QUOTE_1_MOCK = {
 } as unknown as QuoteResponse;
 
 const QUOTE_2_MOCK = {
-  minToTokenAmount: {
-    amount: '124',
-  },
   quote: {
+    minDestTokenAmount: '124',
     destAsset: {
       address: QUOTE_REQUEST_2_MOCK.targetTokenAddress,
     },
@@ -185,36 +181,36 @@ describe('Confirmations Bridge Utils', () => {
         {
           estimatedProcessingTimeInSeconds: 40,
           cost: { valueInCurrency: '0.5' },
-          minToTokenAmount: {
-            amount: '124',
+          quote: {
+            minDestTokenAmount: '124',
           },
         },
         {
           estimatedProcessingTimeInSeconds: 10,
           cost: { valueInCurrency: '1.5' },
-          minToTokenAmount: {
-            amount: '124',
+          quote: {
+            minDestTokenAmount: '124',
           },
         },
         {
           estimatedProcessingTimeInSeconds: 20,
           cost: { valueInCurrency: '1' },
-          minToTokenAmount: {
-            amount: '124',
+          quote: {
+            minDestTokenAmount: '124',
           },
         },
         {
           estimatedProcessingTimeInSeconds: 30,
           cost: { valueInCurrency: '2' },
-          minToTokenAmount: {
-            amount: '124',
+          quote: {
+            minDestTokenAmount: '124',
           },
         },
         {
           estimatedProcessingTimeInSeconds: 50,
           cost: { valueInCurrency: '0.9' },
-          minToTokenAmount: {
-            amount: '124',
+          quote: {
+            minDestTokenAmount: '124',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -232,36 +228,36 @@ describe('Confirmations Bridge Utils', () => {
         {
           estimatedProcessingTimeInSeconds: 40,
           cost: { valueInCurrency: '0.5' },
-          minToTokenAmount: {
-            amount: '124',
+          quote: {
+            minDestTokenAmount: '124',
           },
         },
         {
           estimatedProcessingTimeInSeconds: 10,
           cost: { valueInCurrency: '1.5' },
-          minToTokenAmount: {
-            amount: '124',
+          quote: {
+            minDestTokenAmount: '124',
           },
         },
         {
           estimatedProcessingTimeInSeconds: 20,
           cost: { valueInCurrency: '1' },
-          minToTokenAmount: {
-            amount: '122',
+          quote: {
+            minDestTokenAmount: '122',
           },
         },
         {
           estimatedProcessingTimeInSeconds: 30,
           cost: { valueInCurrency: '2' },
-          minToTokenAmount: {
-            amount: '124',
+          quote: {
+            minDestTokenAmount: '124',
           },
         },
         {
           estimatedProcessingTimeInSeconds: 50,
           cost: { valueInCurrency: '0.9' },
-          minToTokenAmount: {
-            amount: '124',
+          quote: {
+            minDestTokenAmount: '124',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -279,36 +275,36 @@ describe('Confirmations Bridge Utils', () => {
         {
           estimatedProcessingTimeInSeconds: 40,
           cost: { valueInCurrency: '0.5' },
-          minToTokenAmount: {
-            amount: '124',
+          quote: {
+            minDestTokenAmount: '124',
           },
         },
         {
           estimatedProcessingTimeInSeconds: 10,
           cost: { valueInCurrency: '1.5' },
-          minToTokenAmount: {
-            amount: '122',
+          quote: {
+            minDestTokenAmount: '122',
           },
         },
         {
           estimatedProcessingTimeInSeconds: 20,
           cost: { valueInCurrency: '1' },
-          minToTokenAmount: {
-            amount: '122',
+          quote: {
+            minDestTokenAmount: '122',
           },
         },
         {
           estimatedProcessingTimeInSeconds: 30,
           cost: { valueInCurrency: '2' },
-          minToTokenAmount: {
-            amount: '122',
+          quote: {
+            minDestTokenAmount: '122',
           },
         },
         {
           estimatedProcessingTimeInSeconds: 50,
           cost: { valueInCurrency: '0.9' },
-          minToTokenAmount: {
-            amount: '124',
+          quote: {
+            minDestTokenAmount: '124',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -326,8 +322,8 @@ describe('Confirmations Bridge Utils', () => {
         {
           estimatedProcessingTimeInSeconds: 40,
           cost: { valueInCurrency: '0.5' },
-          minToTokenAmount: {
-            amount: '122',
+          quote: {
+            minDestTokenAmount: '122',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -335,8 +331,8 @@ describe('Confirmations Bridge Utils', () => {
       const QUOTES_ATTEMPT_2 = [
         {
           ...QUOTES_ATTEMPT_1[0],
-          minToTokenAmount: {
-            amount: '124',
+          quote: {
+            minDestTokenAmount: '124',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -374,8 +370,8 @@ describe('Confirmations Bridge Utils', () => {
         {
           estimatedProcessingTimeInSeconds: 40,
           cost: { valueInCurrency: '0.5' },
-          minToTokenAmount: {
-            amount: '120',
+          quote: {
+            minDestTokenAmount: '120',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -383,8 +379,8 @@ describe('Confirmations Bridge Utils', () => {
       const QUOTES_ATTEMPT_2 = [
         {
           ...QUOTES_ATTEMPT_1[0],
-          minToTokenAmount: {
-            amount: '121',
+          quote: {
+            minDestTokenAmount: '121',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -392,8 +388,8 @@ describe('Confirmations Bridge Utils', () => {
       const QUOTES_ATTEMPT_3 = [
         {
           ...QUOTES_ATTEMPT_1[0],
-          minToTokenAmount: {
-            amount: '122',
+          quote: {
+            minDestTokenAmount: '122',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -418,8 +414,8 @@ describe('Confirmations Bridge Utils', () => {
         {
           estimatedProcessingTimeInSeconds: 40,
           cost: { valueInCurrency: '0.5' },
-          minToTokenAmount: {
-            amount: '120',
+          quote: {
+            minDestTokenAmount: '120',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -427,8 +423,8 @@ describe('Confirmations Bridge Utils', () => {
       const QUOTES_ATTEMPT_2 = [
         {
           ...QUOTES_ATTEMPT_1[0],
-          minToTokenAmount: {
-            amount: '121',
+          quote: {
+            minDestTokenAmount: '121',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -456,8 +452,8 @@ describe('Confirmations Bridge Utils', () => {
         {
           estimatedProcessingTimeInSeconds: 40,
           cost: { valueInCurrency: '0.5' },
-          minToTokenAmount: {
-            amount: '120',
+          quote: {
+            minDestTokenAmount: '120',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -465,8 +461,8 @@ describe('Confirmations Bridge Utils', () => {
       const QUOTES_ATTEMPT_2 = [
         {
           ...QUOTES_ATTEMPT_1[0],
-          minToTokenAmount: {
-            amount: '123',
+          quote: {
+            minDestTokenAmount: '123',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -508,8 +504,8 @@ describe('Confirmations Bridge Utils', () => {
         {
           estimatedProcessingTimeInSeconds: 40,
           cost: { valueInCurrency: '0.5' },
-          minToTokenAmount: {
-            amount: '123',
+          quote: {
+            minDestTokenAmount: '123',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -517,8 +513,8 @@ describe('Confirmations Bridge Utils', () => {
       const QUOTES_ATTEMPT_2 = [
         {
           ...QUOTES_ATTEMPT_1[0],
-          minToTokenAmount: {
-            amount: '122',
+          quote: {
+            minDestTokenAmount: '122',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -567,8 +563,8 @@ describe('Confirmations Bridge Utils', () => {
         {
           estimatedProcessingTimeInSeconds: 40,
           cost: { valueInCurrency: '0.5' },
-          minToTokenAmount: {
-            amount: '122',
+          quote: {
+            minDestTokenAmount: '122',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -576,8 +572,8 @@ describe('Confirmations Bridge Utils', () => {
       const QUOTES_ATTEMPT_2 = [
         {
           ...QUOTES_ATTEMPT_1[0],
-          minToTokenAmount: {
-            amount: '123',
+          quote: {
+            minDestTokenAmount: '123',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -585,8 +581,8 @@ describe('Confirmations Bridge Utils', () => {
       const QUOTES_ATTEMPT_3 = [
         {
           ...QUOTES_ATTEMPT_1[0],
-          minToTokenAmount: {
-            amount: '123',
+          quote: {
+            minDestTokenAmount: '123',
           },
         },
       ] as TransactionBridgeQuote[];

--- a/app/components/Views/confirmations/utils/bridge.test.ts
+++ b/app/components/Views/confirmations/utils/bridge.test.ts
@@ -22,15 +22,17 @@ jest.mock('../../../../selectors/smartTransactionsController');
 jest.useFakeTimers();
 
 const QUOTE_REQUEST_1_MOCK: BridgeQuoteRequest = {
+  attemptsMax: 1,
+  bufferInitial: 1,
   bufferStep: 1,
   from: '0x123',
-  initialBuffer: 1,
-  maxAttempts: 1,
+  slippageInitial: 0.005,
+  slippageSubsequent: 0.02,
   sourceBalanceRaw: '10000000000000000000',
   sourceChainId: '0x1',
   sourceTokenAddress: '0xabc',
   sourceTokenAmount: '1000000000000000000',
-  targetAmountMinimum: '1.23',
+  targetAmountMinimum: '123',
   targetChainId: '0x2',
   targetTokenAddress: '0xdef',
 };
@@ -41,24 +43,24 @@ const QUOTE_REQUEST_2_MOCK: BridgeQuoteRequest = {
 };
 
 const QUOTE_1_MOCK = {
+  minToTokenAmount: {
+    amount: '124',
+  },
   quote: {
     destAsset: {
       address: QUOTE_REQUEST_1_MOCK.targetTokenAddress,
     },
   },
-  toTokenAmount: {
-    amount: '1.24',
-  },
 } as unknown as QuoteResponse;
 
 const QUOTE_2_MOCK = {
+  minToTokenAmount: {
+    amount: '124',
+  },
   quote: {
     destAsset: {
       address: QUOTE_REQUEST_2_MOCK.targetTokenAddress,
     },
-  },
-  toTokenAmount: {
-    amount: '1.24',
   },
 } as unknown as QuoteResponse;
 
@@ -143,7 +145,7 @@ describe('Confirmations Bridge Utils', () => {
           srcTokenAmount: QUOTE_REQUEST_1_MOCK.sourceTokenAmount,
           destChainId: QUOTE_REQUEST_1_MOCK.targetChainId,
           destTokenAddress: QUOTE_REQUEST_1_MOCK.targetTokenAddress,
-          slippage: 0.5,
+          slippage: QUOTE_REQUEST_1_MOCK.slippageInitial,
           insufficientBal: false,
         }),
         expect.any(Object),
@@ -158,7 +160,7 @@ describe('Confirmations Bridge Utils', () => {
           srcTokenAmount: QUOTE_REQUEST_2_MOCK.sourceTokenAmount,
           destChainId: QUOTE_REQUEST_2_MOCK.targetChainId,
           destTokenAddress: QUOTE_REQUEST_2_MOCK.targetTokenAddress,
-          slippage: 0.5,
+          slippage: QUOTE_REQUEST_2_MOCK.slippageSubsequent,
           insufficientBal: false,
         }),
         expect.any(Object),
@@ -183,36 +185,36 @@ describe('Confirmations Bridge Utils', () => {
         {
           estimatedProcessingTimeInSeconds: 40,
           cost: { valueInCurrency: '0.5' },
-          toTokenAmount: {
-            amount: '1.24',
+          minToTokenAmount: {
+            amount: '124',
           },
         },
         {
           estimatedProcessingTimeInSeconds: 10,
           cost: { valueInCurrency: '1.5' },
-          toTokenAmount: {
-            amount: '1.24',
+          minToTokenAmount: {
+            amount: '124',
           },
         },
         {
           estimatedProcessingTimeInSeconds: 20,
           cost: { valueInCurrency: '1' },
-          toTokenAmount: {
-            amount: '1.24',
+          minToTokenAmount: {
+            amount: '124',
           },
         },
         {
           estimatedProcessingTimeInSeconds: 30,
           cost: { valueInCurrency: '2' },
-          toTokenAmount: {
-            amount: '1.24',
+          minToTokenAmount: {
+            amount: '124',
           },
         },
         {
           estimatedProcessingTimeInSeconds: 50,
           cost: { valueInCurrency: '0.9' },
-          toTokenAmount: {
-            amount: '1.24',
+          minToTokenAmount: {
+            amount: '124',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -230,36 +232,36 @@ describe('Confirmations Bridge Utils', () => {
         {
           estimatedProcessingTimeInSeconds: 40,
           cost: { valueInCurrency: '0.5' },
-          toTokenAmount: {
-            amount: '1.24',
+          minToTokenAmount: {
+            amount: '124',
           },
         },
         {
           estimatedProcessingTimeInSeconds: 10,
           cost: { valueInCurrency: '1.5' },
-          toTokenAmount: {
-            amount: '1.24',
+          minToTokenAmount: {
+            amount: '124',
           },
         },
         {
           estimatedProcessingTimeInSeconds: 20,
           cost: { valueInCurrency: '1' },
-          toTokenAmount: {
-            amount: '1.22',
+          minToTokenAmount: {
+            amount: '122',
           },
         },
         {
           estimatedProcessingTimeInSeconds: 30,
           cost: { valueInCurrency: '2' },
-          toTokenAmount: {
-            amount: '1.24',
+          minToTokenAmount: {
+            amount: '124',
           },
         },
         {
           estimatedProcessingTimeInSeconds: 50,
           cost: { valueInCurrency: '0.9' },
-          toTokenAmount: {
-            amount: '1.24',
+          minToTokenAmount: {
+            amount: '124',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -277,36 +279,36 @@ describe('Confirmations Bridge Utils', () => {
         {
           estimatedProcessingTimeInSeconds: 40,
           cost: { valueInCurrency: '0.5' },
-          toTokenAmount: {
-            amount: '1.24',
+          minToTokenAmount: {
+            amount: '124',
           },
         },
         {
           estimatedProcessingTimeInSeconds: 10,
           cost: { valueInCurrency: '1.5' },
-          toTokenAmount: {
-            amount: '1.22',
+          minToTokenAmount: {
+            amount: '122',
           },
         },
         {
           estimatedProcessingTimeInSeconds: 20,
           cost: { valueInCurrency: '1' },
-          toTokenAmount: {
-            amount: '1.22',
+          minToTokenAmount: {
+            amount: '122',
           },
         },
         {
           estimatedProcessingTimeInSeconds: 30,
           cost: { valueInCurrency: '2' },
-          toTokenAmount: {
-            amount: '1.22',
+          minToTokenAmount: {
+            amount: '122',
           },
         },
         {
           estimatedProcessingTimeInSeconds: 50,
           cost: { valueInCurrency: '0.9' },
-          toTokenAmount: {
-            amount: '1.24',
+          minToTokenAmount: {
+            amount: '124',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -324,8 +326,8 @@ describe('Confirmations Bridge Utils', () => {
         {
           estimatedProcessingTimeInSeconds: 40,
           cost: { valueInCurrency: '0.5' },
-          toTokenAmount: {
-            amount: '1.22',
+          minToTokenAmount: {
+            amount: '122',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -333,8 +335,8 @@ describe('Confirmations Bridge Utils', () => {
       const QUOTES_ATTEMPT_2 = [
         {
           ...QUOTES_ATTEMPT_1[0],
-          toTokenAmount: {
-            amount: '1.24',
+          minToTokenAmount: {
+            amount: '124',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -345,7 +347,7 @@ describe('Confirmations Bridge Utils', () => {
         .mockResolvedValueOnce(QUOTES_ATTEMPT_2);
 
       const quotes = await getBridgeQuotes([
-        { ...QUOTE_REQUEST_1_MOCK, maxAttempts: 2 },
+        { ...QUOTE_REQUEST_1_MOCK, attemptsMax: 2 },
       ]);
 
       expect(quotes).toStrictEqual([QUOTES_ATTEMPT_2[0]]);
@@ -372,8 +374,8 @@ describe('Confirmations Bridge Utils', () => {
         {
           estimatedProcessingTimeInSeconds: 40,
           cost: { valueInCurrency: '0.5' },
-          toTokenAmount: {
-            amount: '1.20',
+          minToTokenAmount: {
+            amount: '120',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -381,8 +383,8 @@ describe('Confirmations Bridge Utils', () => {
       const QUOTES_ATTEMPT_2 = [
         {
           ...QUOTES_ATTEMPT_1[0],
-          toTokenAmount: {
-            amount: '1.21',
+          minToTokenAmount: {
+            amount: '121',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -390,8 +392,8 @@ describe('Confirmations Bridge Utils', () => {
       const QUOTES_ATTEMPT_3 = [
         {
           ...QUOTES_ATTEMPT_1[0],
-          toTokenAmount: {
-            amount: '1.22',
+          minToTokenAmount: {
+            amount: '122',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -403,7 +405,7 @@ describe('Confirmations Bridge Utils', () => {
         .mockResolvedValueOnce(QUOTES_ATTEMPT_3);
 
       const quotes = await getBridgeQuotes([
-        { ...QUOTE_REQUEST_1_MOCK, maxAttempts: 3 },
+        { ...QUOTE_REQUEST_1_MOCK, attemptsMax: 3 },
       ]);
 
       expect(quotes).toBeUndefined();
@@ -416,8 +418,8 @@ describe('Confirmations Bridge Utils', () => {
         {
           estimatedProcessingTimeInSeconds: 40,
           cost: { valueInCurrency: '0.5' },
-          toTokenAmount: {
-            amount: '1.20',
+          minToTokenAmount: {
+            amount: '120',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -425,8 +427,8 @@ describe('Confirmations Bridge Utils', () => {
       const QUOTES_ATTEMPT_2 = [
         {
           ...QUOTES_ATTEMPT_1[0],
-          toTokenAmount: {
-            amount: '1.21',
+          minToTokenAmount: {
+            amount: '121',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -439,7 +441,7 @@ describe('Confirmations Bridge Utils', () => {
       const quotes = await getBridgeQuotes([
         {
           ...QUOTE_REQUEST_1_MOCK,
-          maxAttempts: 3,
+          attemptsMax: 3,
           sourceBalanceRaw: '1500000000000000000',
         },
       ]);
@@ -454,8 +456,8 @@ describe('Confirmations Bridge Utils', () => {
         {
           estimatedProcessingTimeInSeconds: 40,
           cost: { valueInCurrency: '0.5' },
-          toTokenAmount: {
-            amount: '1.20',
+          minToTokenAmount: {
+            amount: '120',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -463,8 +465,8 @@ describe('Confirmations Bridge Utils', () => {
       const QUOTES_ATTEMPT_2 = [
         {
           ...QUOTES_ATTEMPT_1[0],
-          toTokenAmount: {
-            amount: '1.23',
+          minToTokenAmount: {
+            amount: '123',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -477,7 +479,7 @@ describe('Confirmations Bridge Utils', () => {
       const quotes = await getBridgeQuotes([
         {
           ...QUOTE_REQUEST_1_MOCK,
-          maxAttempts: 3,
+          attemptsMax: 3,
           sourceBalanceRaw: '1400000000000000000',
         },
       ]);
@@ -501,23 +503,22 @@ describe('Confirmations Bridge Utils', () => {
       );
     });
 
-    it('does not increase source amount if not last request', async () => {
+    it('does not increase source amount if not first request', async () => {
       const QUOTES_ATTEMPT_1 = [
         {
           estimatedProcessingTimeInSeconds: 40,
           cost: { valueInCurrency: '0.5' },
-          toTokenAmount: {
-            amount: '1.22',
+          minToTokenAmount: {
+            amount: '123',
           },
         },
       ] as TransactionBridgeQuote[];
 
       const QUOTES_ATTEMPT_2 = [
         {
-          estimatedProcessingTimeInSeconds: 40,
-          cost: { valueInCurrency: '0.5' },
-          toTokenAmount: {
-            amount: '1.23',
+          ...QUOTES_ATTEMPT_1[0],
+          minToTokenAmount: {
+            amount: '122',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -530,11 +531,11 @@ describe('Confirmations Bridge Utils', () => {
       const quotes = await getBridgeQuotes([
         {
           ...QUOTE_REQUEST_1_MOCK,
-          maxAttempts: 3,
+          attemptsMax: 3,
         },
         {
           ...QUOTE_REQUEST_2_MOCK,
-          maxAttempts: 3,
+          attemptsMax: 3,
         },
       ]);
 
@@ -561,13 +562,13 @@ describe('Confirmations Bridge Utils', () => {
       );
     });
 
-    it('limits increased source amount to balance minus source amount of previous requests', async () => {
+    it('limits increased source amount to balance minus source amount of subsequent requests', async () => {
       const QUOTES_ATTEMPT_1 = [
         {
           estimatedProcessingTimeInSeconds: 40,
           cost: { valueInCurrency: '0.5' },
-          toTokenAmount: {
-            amount: '1.23',
+          minToTokenAmount: {
+            amount: '122',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -575,8 +576,8 @@ describe('Confirmations Bridge Utils', () => {
       const QUOTES_ATTEMPT_2 = [
         {
           ...QUOTES_ATTEMPT_1[0],
-          toTokenAmount: {
-            amount: '1.22',
+          minToTokenAmount: {
+            amount: '123',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -584,8 +585,8 @@ describe('Confirmations Bridge Utils', () => {
       const QUOTES_ATTEMPT_3 = [
         {
           ...QUOTES_ATTEMPT_1[0],
-          toTokenAmount: {
-            amount: '1.23',
+          minToTokenAmount: {
+            amount: '123',
           },
         },
       ] as TransactionBridgeQuote[];
@@ -599,16 +600,16 @@ describe('Confirmations Bridge Utils', () => {
       const quotes = await getBridgeQuotes([
         {
           ...QUOTE_REQUEST_1_MOCK,
-          maxAttempts: 3,
+          attemptsMax: 3,
+          sourceBalanceRaw: '2400000000000000000',
         },
         {
           ...QUOTE_REQUEST_2_MOCK,
-          maxAttempts: 3,
-          sourceBalanceRaw: '2400000000000000000',
+          attemptsMax: 3,
         },
       ]);
 
-      expect(quotes).toStrictEqual([QUOTES_ATTEMPT_1[0], QUOTES_ATTEMPT_3[0]]);
+      expect(quotes).toStrictEqual([QUOTES_ATTEMPT_2[0], QUOTES_ATTEMPT_3[0]]);
 
       expect(bridgeControllerMock.fetchQuotes).toHaveBeenCalledTimes(3);
 
@@ -616,6 +617,7 @@ describe('Confirmations Bridge Utils', () => {
         1,
         expect.objectContaining({
           srcTokenAmount: '1000000000000000000',
+          destTokenAddress: QUOTE_REQUEST_1_MOCK.targetTokenAddress,
         }),
         expect.any(Object),
         expect.any(String),
@@ -625,6 +627,7 @@ describe('Confirmations Bridge Utils', () => {
         2,
         expect.objectContaining({
           srcTokenAmount: '1000000000000000000',
+          destTokenAddress: QUOTE_REQUEST_2_MOCK.targetTokenAddress,
         }),
         expect.any(Object),
         expect.any(String),
@@ -634,6 +637,7 @@ describe('Confirmations Bridge Utils', () => {
         3,
         expect.objectContaining({
           srcTokenAmount: '1400000000000000000',
+          destTokenAddress: QUOTE_REQUEST_1_MOCK.targetTokenAddress,
         }),
         expect.any(Object),
         expect.any(String),

--- a/app/components/Views/confirmations/utils/bridge.ts
+++ b/app/components/Views/confirmations/utils/bridge.ts
@@ -111,8 +111,16 @@ async function getSufficientSingleBridgeQuote(
         index,
       );
 
+      const dust = new BigNumber(result.quote.minDestTokenAmount)
+        .minus(request.targetAmountMinimum)
+        .toString(10);
+
       log('Found valid quote', {
         attempt: i + 1,
+        target: targetTokenAddress,
+        targetAmount: result.quote.minDestTokenAmount,
+        goalAmount: request.targetAmountMinimum,
+        dust,
         quote: result,
       });
 
@@ -253,7 +261,7 @@ function getBestQuote(
   ).slice(0, 3);
 
   const quotesOverMinimumTarget = fastestQuotes.filter((quote) =>
-    new BigNumber(quote.minToTokenAmount.amount).isGreaterThanOrEqualTo(
+    new BigNumber(quote.quote.minDestTokenAmount).isGreaterThanOrEqualTo(
       request.targetAmountMinimum,
     ),
   );

--- a/app/components/Views/confirmations/utils/bridge.ts
+++ b/app/components/Views/confirmations/utils/bridge.ts
@@ -13,17 +13,25 @@ import { orderBy } from 'lodash';
 import { toChecksumAddress } from '../../../../util/address';
 import { BigNumber } from 'bignumber.js';
 
+const ERROR_MESSAGE_NO_QUOTES = 'No quotes found';
+const ERROR_MESSAGE_ALL_QUOTES_UNDER_MINIMUM = 'All quotes under minimum';
+
 export type TransactionBridgeQuote = QuoteResponse & QuoteMetadata;
 
 const log = createProjectLogger('confirmation-bridge-utils');
+
 let abort: AbortController;
 
 export interface BridgeQuoteRequest {
+  bufferStep: number;
   from: Hex;
-  minimumTargetAmount: string;
+  initialBuffer: number;
+  maxAttempts: number;
+  sourceBalanceRaw: string;
   sourceChainId: Hex;
   sourceTokenAddress: Hex;
   sourceTokenAmount: string;
+  targetAmountMinimum: string;
   targetChainId: Hex;
   targetTokenAddress: Hex;
 }
@@ -45,8 +53,12 @@ export async function getBridgeQuotes(
 
     log('Fetched gas fee estimates', gasFeeEstimates);
 
+    const finalRequests = getFinalRequests(requests);
+
     const result = await Promise.all(
-      requests.map((request) => getSingleBridgeQuote(request, gasFeeEstimates)),
+      finalRequests.map((request) =>
+        getSufficientSingleBridgeQuote(request, gasFeeEstimates),
+      ),
     );
 
     return result;
@@ -54,6 +66,82 @@ export async function getBridgeQuotes(
     log('Error fetching bridge quotes', error);
     return undefined;
   }
+}
+
+async function getSufficientSingleBridgeQuote(
+  request: BridgeQuoteRequest,
+  gasFeeEstimates: GasFeeEstimates,
+): Promise<TransactionBridgeQuote> {
+  const {
+    bufferStep,
+    initialBuffer,
+    maxAttempts,
+    sourceBalanceRaw,
+    sourceTokenAmount,
+    targetTokenAddress,
+  } = request;
+
+  const sourceAmountValue = new BigNumber(sourceTokenAmount);
+  const originalSourceAmount = sourceAmountValue.div(1 + initialBuffer);
+
+  let currentSourceAmount = sourceTokenAmount;
+
+  for (let i = 0; i < maxAttempts; i++) {
+    const currentRequest = {
+      ...request,
+      sourceTokenAmount: currentSourceAmount,
+    };
+
+    try {
+      log('Bridge quotes attempt', {
+        attempt: i + 1,
+        bufferStep,
+        currentSourceAmount,
+        initialBuffer,
+        maxAttempts,
+        target: targetTokenAddress,
+      });
+
+      const result = await getSingleBridgeQuote(
+        currentRequest,
+        gasFeeEstimates,
+      );
+
+      log('Found valid quote', {
+        attempt: i + 1,
+        quote: result,
+      });
+
+      return result;
+    } catch (error) {
+      const errorMessage = (error as { message: string }).message;
+
+      if (errorMessage !== ERROR_MESSAGE_ALL_QUOTES_UNDER_MINIMUM) {
+        throw error;
+      }
+    }
+
+    if (
+      new BigNumber(currentSourceAmount).isGreaterThanOrEqualTo(
+        sourceBalanceRaw,
+      )
+    ) {
+      log('Reached balance limit', targetTokenAddress);
+      break;
+    }
+
+    const newSourceAmount = originalSourceAmount.multipliedBy(
+      1 + initialBuffer + bufferStep * (i + 1),
+    );
+
+    currentSourceAmount = newSourceAmount.isLessThan(sourceBalanceRaw)
+      ? newSourceAmount.toFixed(0)
+      : sourceBalanceRaw;
+  }
+
+  log('All attempts failed', request.targetTokenAddress);
+
+  throw new Error(ERROR_MESSAGE_ALL_QUOTES_UNDER_MINIMUM);
 }
 
 async function getSingleBridgeQuote(
@@ -92,21 +180,10 @@ async function getSingleBridgeQuote(
   );
 
   if (!quotes.length) {
-    throw new Error('No quotes found');
+    throw new Error(ERROR_MESSAGE_NO_QUOTES);
   }
 
-  const finalQuote = getActiveQuote(
-    quoteRequest,
-    quotes,
-    gasFeeEstimates,
-    request,
-  );
-
-  if (!finalQuote) {
-    throw new Error('No valid quote found');
-  }
-
-  return finalQuote;
+  return getActiveQuote(quoteRequest, quotes, gasFeeEstimates, request);
 }
 
 function getActiveQuote(
@@ -114,7 +191,7 @@ function getActiveQuote(
   quotes: QuoteResponse[],
   gasFeeEstimates: GasFeeEstimates,
   request: BridgeQuoteRequest,
-): TransactionBridgeQuote | undefined {
+): TransactionBridgeQuote {
   const fullState = store.getState();
 
   const state = {
@@ -161,22 +238,54 @@ async function getGasFeeEstimates(chainId: Hex) {
 function getBestQuote(
   quotes: TransactionBridgeQuote[],
   request: BridgeQuoteRequest,
-): TransactionBridgeQuote | undefined {
+): TransactionBridgeQuote {
   const fastestQuotes = orderBy(
     quotes,
     (quote) => quote.estimatedProcessingTimeInSeconds,
     'asc',
   ).slice(0, 3);
 
-  const sufficientTokenAmount = fastestQuotes.filter((quote) =>
+  const quotesOverMinimumTarget = fastestQuotes.filter((quote) =>
     new BigNumber(quote.toTokenAmount?.amount).isGreaterThanOrEqualTo(
-      request.minimumTargetAmount,
+      request.targetAmountMinimum,
     ),
   );
 
+  if (!quotesOverMinimumTarget.length) {
+    throw new Error(ERROR_MESSAGE_ALL_QUOTES_UNDER_MINIMUM);
+  }
+
   return orderBy(
-    sufficientTokenAmount,
+    quotesOverMinimumTarget,
     (quote) => BigNumber(quote.cost?.valueInCurrency ?? 0).toNumber(),
     'asc',
   )[0];
+}
+
+function getFinalRequests(requests: BridgeQuoteRequest[]) {
+  return requests.map((request, index) => {
+    const isFinalRequest = index === requests.length - 1;
+    const maxAttempts = !isFinalRequest ? 1 : request.maxAttempts;
+
+    const sourceBalanceRaw = requests
+      .reduce((acc, value, j) => {
+        const isSameSource =
+          value.sourceTokenAddress.toLowerCase() ===
+            request.sourceTokenAddress.toLowerCase() &&
+          value.sourceChainId === request.sourceChainId;
+
+        if (j < index && isFinalRequest && isSameSource) {
+          return acc.minus(value.sourceTokenAmount);
+        }
+
+        return acc;
+      }, new BigNumber(request.sourceBalanceRaw))
+      .toFixed(0);
+
+    return {
+      ...request,
+      maxAttempts,
+      sourceBalanceRaw,
+    };
+  });
 }

--- a/app/selectors/featureFlagController/confirmations/index.test.ts
+++ b/app/selectors/featureFlagController/confirmations/index.test.ts
@@ -1,8 +1,13 @@
+import { cloneDeep } from 'lodash';
 import {
   ConfirmationRedesignRemoteFlags,
   selectConfirmationRedesignFlags,
   SendRedesignFlags,
   selectSendRedesignFlags,
+  selectMetaMaskPayFlags,
+  BUFFER_STEP_DEFAULT,
+  INITIAL_BUFFER_DEFAULT,
+  MAX_ATTEMPTS_DEFAULT,
 } from '.';
 import mockedEngine from '../../../core/__mocks__/MockedEngine';
 import { mockedEmptyFlagsState, mockedUndefinedFlagsState } from '../mocks';
@@ -267,5 +272,64 @@ describe('Send Redesign Feature Flags', () => {
       selectSendRedesignFlags(stateWithUndefinedEnabled),
       sendRedesignFlagsDefaultValues,
     );
+  });
+});
+
+describe('MetaMask Pay Feature Flags', () => {
+  it('returns default buffer step if not in feature flags', () => {
+    expect(selectMetaMaskPayFlags(mockedEmptyFlagsState).bufferStep).toEqual(
+      BUFFER_STEP_DEFAULT,
+    );
+  });
+
+  it('returns default initial buffer if not in feature flags', () => {
+    expect(selectMetaMaskPayFlags(mockedEmptyFlagsState).initialBuffer).toEqual(
+      INITIAL_BUFFER_DEFAULT,
+    );
+  });
+
+  it('returns default max attempts if not in feature flags', () => {
+    expect(selectMetaMaskPayFlags(mockedEmptyFlagsState).maxAttempts).toEqual(
+      MAX_ATTEMPTS_DEFAULT,
+    );
+  });
+
+  it('returns buffer step from feature flag', () => {
+    const state = cloneDeep(mockedEmptyFlagsState);
+
+    state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
+      {
+        confirmation_pay: {
+          bufferStep: 1.234,
+        },
+      };
+
+    expect(selectMetaMaskPayFlags(state).bufferStep).toEqual(1.234);
+  });
+
+  it('returns initial buffer from feature flag', () => {
+    const state = cloneDeep(mockedEmptyFlagsState);
+
+    state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
+      {
+        confirmation_pay: {
+          initialBuffer: 2.345,
+        },
+      };
+
+    expect(selectMetaMaskPayFlags(state).initialBuffer).toEqual(2.345);
+  });
+
+  it('returns max attempts from feature flag', () => {
+    const state = cloneDeep(mockedEmptyFlagsState);
+
+    state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
+      {
+        confirmation_pay: {
+          maxAttempts: 3,
+        },
+      };
+
+    expect(selectMetaMaskPayFlags(state).maxAttempts).toEqual(3);
   });
 });

--- a/app/selectors/featureFlagController/confirmations/index.test.ts
+++ b/app/selectors/featureFlagController/confirmations/index.test.ts
@@ -6,8 +6,10 @@ import {
   selectSendRedesignFlags,
   selectMetaMaskPayFlags,
   BUFFER_STEP_DEFAULT,
-  INITIAL_BUFFER_DEFAULT,
-  MAX_ATTEMPTS_DEFAULT,
+  BUFFER_INITIAL_DEFAULT,
+  ATTEMPTS_MAX_DEFAULT,
+  SLIPPAGE_INITIAL_DEFAULT,
+  SLIPPAGE_SUBSEQUENT_DEFAULT,
 } from '.';
 import mockedEngine from '../../../core/__mocks__/MockedEngine';
 import { mockedEmptyFlagsState, mockedUndefinedFlagsState } from '../mocks';
@@ -282,16 +284,28 @@ describe('MetaMask Pay Feature Flags', () => {
     );
   });
 
-  it('returns default initial buffer if not in feature flags', () => {
-    expect(selectMetaMaskPayFlags(mockedEmptyFlagsState).initialBuffer).toEqual(
-      INITIAL_BUFFER_DEFAULT,
+  it('returns default buffer initial if not in feature flags', () => {
+    expect(selectMetaMaskPayFlags(mockedEmptyFlagsState).bufferInitial).toEqual(
+      BUFFER_INITIAL_DEFAULT,
     );
   });
 
-  it('returns default max attempts if not in feature flags', () => {
-    expect(selectMetaMaskPayFlags(mockedEmptyFlagsState).maxAttempts).toEqual(
-      MAX_ATTEMPTS_DEFAULT,
+  it('returns default attempts max if not in feature flags', () => {
+    expect(selectMetaMaskPayFlags(mockedEmptyFlagsState).attemptsMax).toEqual(
+      ATTEMPTS_MAX_DEFAULT,
     );
+  });
+
+  it('returns default initial slippage if not in feature flags', () => {
+    expect(
+      selectMetaMaskPayFlags(mockedEmptyFlagsState).slippageInitial,
+    ).toEqual(SLIPPAGE_INITIAL_DEFAULT);
+  });
+
+  it('returns default subsequent slippage if not in feature flags', () => {
+    expect(
+      selectMetaMaskPayFlags(mockedEmptyFlagsState).slippageSubsequent,
+    ).toEqual(SLIPPAGE_SUBSEQUENT_DEFAULT);
   });
 
   it('returns buffer step from feature flag', () => {
@@ -313,11 +327,11 @@ describe('MetaMask Pay Feature Flags', () => {
     state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
       {
         confirmation_pay: {
-          initialBuffer: 2.345,
+          bufferInitial: 2.345,
         },
       };
 
-    expect(selectMetaMaskPayFlags(state).initialBuffer).toEqual(2.345);
+    expect(selectMetaMaskPayFlags(state).bufferInitial).toEqual(2.345);
   });
 
   it('returns max attempts from feature flag', () => {
@@ -326,10 +340,36 @@ describe('MetaMask Pay Feature Flags', () => {
     state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
       {
         confirmation_pay: {
-          maxAttempts: 3,
+          attemptsMax: 3,
         },
       };
 
-    expect(selectMetaMaskPayFlags(state).maxAttempts).toEqual(3);
+    expect(selectMetaMaskPayFlags(state).attemptsMax).toEqual(3);
+  });
+
+  it('returns initial slippage from feature flag', () => {
+    const state = cloneDeep(mockedEmptyFlagsState);
+
+    state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
+      {
+        confirmation_pay: {
+          slippageInitial: 0.123,
+        },
+      };
+
+    expect(selectMetaMaskPayFlags(state).slippageInitial).toEqual(0.123);
+  });
+
+  it('returns subsequent slippage from feature flag', () => {
+    const state = cloneDeep(mockedEmptyFlagsState);
+
+    state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags =
+      {
+        confirmation_pay: {
+          slippageSubsequent: 0.234,
+        },
+      };
+
+    expect(selectMetaMaskPayFlags(state).slippageSubsequent).toEqual(0.234);
   });
 });

--- a/app/selectors/featureFlagController/confirmations/index.ts
+++ b/app/selectors/featureFlagController/confirmations/index.ts
@@ -1,6 +1,11 @@
 import { createSelector } from 'reselect';
 import { selectRemoteFeatureFlags } from '..';
 import { getFeatureFlagValue } from '../env';
+import { Json } from '@metamask/utils';
+
+export const BUFFER_STEP_DEFAULT = 0.025;
+export const INITIAL_BUFFER_DEFAULT = 0.025;
+export const MAX_ATTEMPTS_DEFAULT = 2;
 
 // A type predicate's type must be assignable to its parameter's type
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -17,6 +22,12 @@ export type ConfirmationRedesignRemoteFlags = {
 export type SendRedesignFlags = {
   enabled: boolean;
 };
+
+export interface MetaMaskPayFlags {
+  bufferStep: number;
+  initialBuffer: number;
+  maxAttempts: number;
+}
 
 /**
  * Determines the enabled state of confirmation redesign features by combining
@@ -124,4 +135,24 @@ export const selectConfirmationRedesignFlags = createSelector(
 export const selectSendRedesignFlags = createSelector(
   selectRemoteFeatureFlags,
   selectSendRedesignFlagsFromRemoteFeatureFlags,
+);
+
+export const selectMetaMaskPayFlags = createSelector(
+  selectRemoteFeatureFlags,
+  (featureFlags) => {
+    const metaMaskPayFlags = featureFlags?.confirmation_pay as
+      | Record<string, Json>
+      | undefined;
+
+    const initialBuffer =
+      metaMaskPayFlags?.initialBuffer ?? INITIAL_BUFFER_DEFAULT;
+    const maxAttempts = metaMaskPayFlags?.maxAttempts ?? MAX_ATTEMPTS_DEFAULT;
+    const bufferStep = metaMaskPayFlags?.bufferStep ?? BUFFER_STEP_DEFAULT;
+
+    return {
+      initialBuffer,
+      maxAttempts,
+      bufferStep,
+    } as MetaMaskPayFlags;
+  },
 );

--- a/app/selectors/featureFlagController/confirmations/index.ts
+++ b/app/selectors/featureFlagController/confirmations/index.ts
@@ -3,9 +3,11 @@ import { selectRemoteFeatureFlags } from '..';
 import { getFeatureFlagValue } from '../env';
 import { Json } from '@metamask/utils';
 
+export const ATTEMPTS_MAX_DEFAULT = 2;
+export const BUFFER_INITIAL_DEFAULT = 0.025;
 export const BUFFER_STEP_DEFAULT = 0.025;
-export const INITIAL_BUFFER_DEFAULT = 0.025;
-export const MAX_ATTEMPTS_DEFAULT = 2;
+export const SLIPPAGE_INITIAL_DEFAULT = 0.005;
+export const SLIPPAGE_SUBSEQUENT_DEFAULT = 0.02;
 
 // A type predicate's type must be assignable to its parameter's type
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -24,9 +26,11 @@ export type SendRedesignFlags = {
 };
 
 export interface MetaMaskPayFlags {
+  attemptsMax: number;
+  bufferInitial: number;
   bufferStep: number;
-  initialBuffer: number;
-  maxAttempts: number;
+  slippageInitial: number;
+  slippageSubsequent: number;
 }
 
 /**
@@ -144,15 +148,21 @@ export const selectMetaMaskPayFlags = createSelector(
       | Record<string, Json>
       | undefined;
 
-    const initialBuffer =
-      metaMaskPayFlags?.initialBuffer ?? INITIAL_BUFFER_DEFAULT;
-    const maxAttempts = metaMaskPayFlags?.maxAttempts ?? MAX_ATTEMPTS_DEFAULT;
+    const attemptsMax = metaMaskPayFlags?.attemptsMax ?? ATTEMPTS_MAX_DEFAULT;
+    const bufferInitial =
+      metaMaskPayFlags?.bufferInitial ?? BUFFER_INITIAL_DEFAULT;
     const bufferStep = metaMaskPayFlags?.bufferStep ?? BUFFER_STEP_DEFAULT;
+    const slippageInitial =
+      metaMaskPayFlags?.slippageInitial ?? SLIPPAGE_INITIAL_DEFAULT;
+    const slippageSubsequent =
+      metaMaskPayFlags?.slippageSubsequent ?? SLIPPAGE_SUBSEQUENT_DEFAULT;
 
     return {
-      initialBuffer,
-      maxAttempts,
+      attemptsMax,
+      bufferInitial,
       bufferStep,
+      slippageInitial,
+      slippageSubsequent,
     } as MetaMaskPayFlags;
   },
 );


### PR DESCRIPTION
## **Description**

When retrieving bridge quotes for MetaMask pay, automatically increase the source token amount by a given amount until the token amount has reached the required minimum, or the max attempts are reached.

Will also stop if the token balance is reached, and will only apply to the first bridge if multiple bridges are being requested.

Uses new MetaMask pay feature flags in `confirmation_pay`, specifically:

- `attemptsMax` - The total number of quotes requests, including the first request.
- `bufferInitial` - The initial buffer percentage added to all quotes requests. For example, `0.025` is `2.5%`.
- `bufferStep` - The percentage to increase the source amount by on each request. For example, `0.025` is `2.5%`.
- `slippageInitial` - The slippage used for the first bridge.
- `slippageSubsequent` - The slippage used for additional bridges.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
