### PR TITLE
fix: full screen error retry has no back button

### DIFF
--- a/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.test.tsx
+++ b/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.test.tsx
@@ -216,7 +216,7 @@ describe('PerpsConnectionErrorView', () => {
       />,
     );
 
-    const backButton = getByText('navigation.go_back');
+    const backButton = getByText('perps.errors.connectionFailed.go_back');
     expect(backButton).toBeTruthy();
   });
 
@@ -229,7 +229,7 @@ describe('PerpsConnectionErrorView', () => {
       />,
     );
 
-    const backButton = queryByText('navigation.go_back');
+    const backButton = queryByText('perps.errors.connectionFailed.go_back');
     expect(backButton).toBeNull();
   });
 });

--- a/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.tsx
+++ b/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.tsx
@@ -47,7 +47,6 @@ const PerpsConnectionErrorView: React.FC<PerpsConnectionErrorViewProps> = ({
 
   // Determine if back button should be shown
   const shouldShowBackButton = showBackButton || retryAttempts > 0;
-
   const handleGoBack = () => {
     // Navigate back to the previous screen or wallet home
     if (navigation.canGoBack()) {
@@ -119,7 +118,7 @@ const PerpsConnectionErrorView: React.FC<PerpsConnectionErrorViewProps> = ({
             variant={ButtonVariants.Secondary}
             size={ButtonSize.Lg}
             width={ButtonWidthTypes.Full}
-            label={strings('navigation.go_back')}
+            label={strings('perps.errors.connectionFailed.go_back')}
             onPress={handleGoBack}
             style={styles.backButton}
           />

--- a/app/components/UI/Perps/providers/PerpsConnectionProvider.test.tsx
+++ b/app/components/UI/Perps/providers/PerpsConnectionProvider.test.tsx
@@ -38,9 +38,13 @@ jest.mock('../components/PerpsConnectionErrorView', () => ({
   default: ({
     error,
     onRetry,
+    showBackButton,
+    retryAttempts,
   }: {
     error: string | Error;
     onRetry: () => void;
+    showBackButton?: boolean;
+    retryAttempts?: number;
   }) => {
     const { View, Text, TouchableOpacity } = jest.requireActual('react-native');
     return (
@@ -49,6 +53,12 @@ jest.mock('../components/PerpsConnectionErrorView', () => ({
         <TouchableOpacity onPress={onRetry} testID="retry-button">
           <Text>Retry</Text>
         </TouchableOpacity>
+        {showBackButton && (
+          <Text testID="back-button-indicator">Back button shown</Text>
+        )}
+        {retryAttempts !== undefined && (
+          <Text testID="retry-attempts">{retryAttempts}</Text>
+        )}
       </View>
     );
   },
@@ -496,6 +506,293 @@ describe('PerpsConnectionProvider', () => {
 
     // Reset mock for next tests
     mockDisconnect.mockResolvedValue(undefined);
+  });
+
+  describe('isFullScreen prop behavior', () => {
+    it('should show back button immediately when isFullScreen is true', async () => {
+      // Mock error state
+      mockGetConnectionState.mockReturnValue({
+        isConnected: false,
+        isConnecting: false,
+        isInitialized: false,
+        error: 'Connection failed',
+      });
+
+      const { getByTestId } = render(
+        <PerpsConnectionProvider isFullScreen>
+          <Text>Test</Text>
+        </PerpsConnectionProvider>,
+      );
+
+      // Back button should be shown immediately when isFullScreen is true
+      await waitFor(() => {
+        expect(getByTestId('perps-connection-error')).toBeDefined();
+        expect(getByTestId('back-button-indicator')).toBeDefined();
+      });
+    });
+
+    it('should not show back button initially when isFullScreen is false', async () => {
+      // Mock error state
+      mockGetConnectionState.mockReturnValue({
+        isConnected: false,
+        isConnecting: false,
+        isInitialized: false,
+        error: 'Connection failed',
+      });
+
+      const { getByTestId, queryByTestId } = render(
+        <PerpsConnectionProvider isFullScreen={false}>
+          <Text>Test</Text>
+        </PerpsConnectionProvider>,
+      );
+
+      // Back button should NOT be shown initially when isFullScreen is false
+      await waitFor(() => {
+        expect(getByTestId('perps-connection-error')).toBeDefined();
+        expect(queryByTestId('back-button-indicator')).toBeNull();
+      });
+    });
+
+    it('should show back button after retry when isFullScreen is false', async () => {
+      // Mock error state
+      mockGetConnectionState.mockReturnValue({
+        isConnected: false,
+        isConnecting: false,
+        isInitialized: false,
+        error: 'Connection failed',
+      });
+
+      const { getByTestId, queryByTestId } = render(
+        <PerpsConnectionProvider isFullScreen={false}>
+          <Text>Test</Text>
+        </PerpsConnectionProvider>,
+      );
+
+      // Initially no back button
+      expect(queryByTestId('back-button-indicator')).toBeNull();
+
+      // Mock connection failure on retry
+      mockConnect.mockRejectedValueOnce(new Error('Retry failed'));
+
+      // Click retry button
+      const retryButton = getByTestId('retry-button');
+      act(() => {
+        retryButton.props.onPress();
+      });
+
+      // After retry attempt, back button should be shown
+      await waitFor(() => {
+        expect(getByTestId('back-button-indicator')).toBeDefined();
+        expect(getByTestId('retry-attempts')).toHaveTextContent('1');
+      });
+    });
+  });
+
+  describe('retry logic behavior', () => {
+    it('should call PerpsConnectionManager.connect directly on retry', async () => {
+      // Mock error state
+      mockGetConnectionState.mockReturnValue({
+        isConnected: false,
+        isConnecting: false,
+        isInitialized: false,
+        error: 'Connection failed',
+      });
+
+      const { getByTestId } = render(
+        <PerpsConnectionProvider>
+          <Text>Test</Text>
+        </PerpsConnectionProvider>,
+      );
+
+      // Clear previous mock calls
+      mockConnect.mockClear();
+
+      // Click retry button
+      const retryButton = getByTestId('retry-button');
+      act(() => {
+        retryButton.props.onPress();
+      });
+
+      await waitFor(() => {
+        // Should call PerpsConnectionManager.connect directly
+        expect(mockConnect).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('should update state after retry attempt', async () => {
+      // Mock initial error state
+      mockGetConnectionState.mockReturnValue({
+        isConnected: false,
+        isConnecting: false,
+        isInitialized: false,
+        error: 'Connection failed',
+      });
+
+      const { getByTestId, queryByTestId, getByText } = render(
+        <PerpsConnectionProvider>
+          <Text>Child Component</Text>
+        </PerpsConnectionProvider>,
+      );
+
+      // Should show error view
+      expect(getByTestId('perps-connection-error')).toBeDefined();
+
+      // Mock successful connection on retry
+      mockConnect.mockResolvedValueOnce(undefined);
+
+      // Update mock to return connected state after retry
+      mockGetConnectionState.mockReturnValue({
+        isConnected: true,
+        isConnecting: false,
+        isInitialized: true,
+        error: null,
+      });
+
+      // Click retry button
+      const retryButton = getByTestId('retry-button');
+      await act(async () => {
+        retryButton.props.onPress();
+      });
+
+      // Should now show children instead of error view
+      await waitFor(() => {
+        expect(queryByTestId('perps-connection-error')).toBeNull();
+        expect(getByText('Child Component')).toBeDefined();
+      });
+    });
+
+    it('should increment retry attempts on each retry', async () => {
+      // Mock error state
+      mockGetConnectionState.mockReturnValue({
+        isConnected: false,
+        isConnecting: false,
+        isInitialized: false,
+        error: 'Connection failed',
+      });
+
+      const { getByTestId } = render(
+        <PerpsConnectionProvider>
+          <Text>Test</Text>
+        </PerpsConnectionProvider>,
+      );
+
+      // Mock connection failures
+      mockConnect.mockRejectedValue(new Error('Connection failed'));
+
+      // First retry
+      const retryButton = getByTestId('retry-button');
+      act(() => {
+        retryButton.props.onPress();
+      });
+
+      await waitFor(() => {
+        expect(getByTestId('retry-attempts')).toHaveTextContent('1');
+      });
+
+      // Second retry
+      act(() => {
+        retryButton.props.onPress();
+      });
+
+      await waitFor(() => {
+        expect(getByTestId('retry-attempts')).toHaveTextContent('2');
+      });
+
+      // Third retry
+      act(() => {
+        retryButton.props.onPress();
+      });
+
+      await waitFor(() => {
+        expect(getByTestId('retry-attempts')).toHaveTextContent('3');
+      });
+    });
+
+    it('should reset retry attempts on successful connection', async () => {
+      // Mock initial error state
+      mockGetConnectionState.mockReturnValue({
+        isConnected: false,
+        isConnecting: false,
+        isInitialized: false,
+        error: 'Connection failed',
+      });
+
+      const { getByTestId, queryByTestId } = render(
+        <PerpsConnectionProvider>
+          <Text>Child Component</Text>
+        </PerpsConnectionProvider>,
+      );
+
+      // Mock connection failure then success
+      mockConnect
+        .mockRejectedValueOnce(new Error('First retry failed'))
+        .mockResolvedValueOnce(undefined);
+
+      // First retry (fails)
+      const retryButton = getByTestId('retry-button');
+      act(() => {
+        retryButton.props.onPress();
+      });
+
+      await waitFor(() => {
+        expect(getByTestId('retry-attempts')).toHaveTextContent('1');
+      });
+
+      // Update mock to return connected state for second retry
+      mockGetConnectionState.mockReturnValue({
+        isConnected: true,
+        isConnecting: false,
+        isInitialized: true,
+        error: null,
+      });
+
+      // Second retry (succeeds)
+      act(() => {
+        retryButton.props.onPress();
+      });
+
+      // Should clear retry attempts and show children
+      await waitFor(() => {
+        expect(queryByTestId('perps-connection-error')).toBeNull();
+        expect(queryByTestId('retry-attempts')).toBeNull();
+      });
+    });
+
+    it('should not call resetError during retry', async () => {
+      // Mock resetError
+      const mockResetError = jest.fn();
+      (PerpsConnectionManager.resetError as jest.Mock) = mockResetError;
+
+      // Mock error state
+      mockGetConnectionState.mockReturnValue({
+        isConnected: false,
+        isConnecting: false,
+        isInitialized: false,
+        error: 'Connection failed',
+      });
+
+      const { getByTestId } = render(
+        <PerpsConnectionProvider>
+          <Text>Test</Text>
+        </PerpsConnectionProvider>,
+      );
+
+      // Clear previous mock calls
+      mockResetError.mockClear();
+
+      // Click retry button
+      const retryButton = getByTestId('retry-button');
+      act(() => {
+        retryButton.props.onPress();
+      });
+
+      await waitFor(() => {
+        // resetError should NOT be called during retry
+        expect(mockResetError).not.toHaveBeenCalled();
+        // But connect should be called
+        expect(mockConnect).toHaveBeenCalled();
+      });
+    });
   });
 
   it('should clean up polling interval on unmount', () => {

--- a/app/components/UI/Perps/providers/PerpsConnectionProvider.tsx
+++ b/app/components/UI/Perps/providers/PerpsConnectionProvider.tsx
@@ -31,6 +31,7 @@ const PerpsConnectionContext =
 interface PerpsConnectionProviderProps {
   children: React.ReactNode;
   isVisible?: boolean;
+  isFullScreen?: boolean;
 }
 
 /**
@@ -41,7 +42,7 @@ interface PerpsConnectionProviderProps {
  */
 export const PerpsConnectionProvider: React.FC<
   PerpsConnectionProviderProps
-> = ({ children, isVisible }) => {
+> = ({ children, isVisible, isFullScreen = false }) => {
   const [connectionState, setConnectionState] = useState(() =>
     PerpsConnectionManager.getConnectionState(),
   );
@@ -194,23 +195,30 @@ export const PerpsConnectionProvider: React.FC<
   // This ensures NO Perps screen can render when there's a connection error
   if (connectionState.error) {
     // Determine if back button should be shown based on navigation context
-    // For now, only show back button after retry failures (conservative approach)
-    // This prevents showing back button in wallet tabs while ensuring escape route exists
-    const shouldShowBackButton = retryAttempts > 0;
+    // Always show back button when in full screen mode (e.g., stack navigator)
+    // Also show it after retry attempts for other contexts
+    const shouldShowBackButton = isFullScreen || retryAttempts > 0;
 
     const handleRetry = async () => {
+      // Increment retry attempts first to ensure back button shows immediately
       setRetryAttempts((prev) => prev + 1);
 
       try {
-        resetError(); // Clear normal errors
-        await connect(); // Attempt reconnection
+        // Attempt to connect directly using the singleton
+        // This will either succeed or throw an error
+        await PerpsConnectionManager.connect();
 
-        // Reset retry attempts on successful connection
+        // If we reach here, connection succeeded
+        // Reset retry attempts and let polling update the state
         setRetryAttempts(0);
       } catch (err) {
         // Keep retry attempts count for showing back button after failed attempts
         console.error('Retry connection failed:', err);
       }
+
+      // Force update to get the latest error state
+      const state = PerpsConnectionManager.getConnectionState();
+      setConnectionState(state);
     };
 
     return (

--- a/app/components/UI/Perps/routes/index.tsx
+++ b/app/components/UI/Perps/routes/index.tsx
@@ -46,7 +46,7 @@ const PerpsModalStack = () => (
 );
 
 const PerpsScreenStack = () => (
-  <PerpsConnectionProvider>
+  <PerpsConnectionProvider isFullScreen>
     <PerpsStreamProvider>
       <Stack.Navigator initialRouteName={Routes.PERPS.TRADING_VIEW}>
         {/* Redirect to wallet perps tab */}

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1168,7 +1168,8 @@
       "connectionFailed": {
         "title": "Perps is temporarily offline",
         "description": "We're working to get it back online soon.",
-        "retry": "Retry"
+        "retry": "Retry",
+        "go_back": "Go Back"
       },
       "networkError": {
         "title": "Network Error",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
1. What is the reason for the change?

The connection error screen does not have a back button when full screen and there is no way to exit out of it if connection retry fails

2. What is the improvement/solution?

Add a back button for any fullScreen error. Also ensure retry logic works so that a back button appears after > 0 retries in either view, full screen or not.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Adds a back button for full screen perps connection error screen

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1547

## **Manual testing steps**

```gherkin
Feature: fix: full screen error retry has no back button

  Scenario: user loses connection and cannot reconnect
    Given user has no connection and tries to go to the tab view perps

    When user cannot connect after a while
    Then the error view should show a retry with no back button
    When user retries  and cannot connect after a while
    Then the error view should show a retry with back button


  Scenario: user loses connection and cannot reconnect
    Given user has no connection and tries to go to the market view perps

    When user cannot connect after a while
    Then the error view should show a retry with back button on the full screen always
    When user retries  and cannot connect after a while
    Then the error view should show a retry with back button as well
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/335676a6-2cc9-4b78-a132-8eef82370201

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
