### PR TITLE
chore: improve quote rate formatting

### DIFF
--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
@@ -308,10 +308,16 @@ const QuoteDetailsCard = () => {
               },
             }}
             value={{
-              label: {
-                text: rate,
-                variant: TextVariant.BodyMD,
-              },
+              label: (
+                <Text
+                  variant={TextVariant.BodyMD}
+                  numberOfLines={1}
+                  adjustsFontSizeToFit
+                  minimumFontScale={0.5}
+                >
+                  {rate}
+                </Text>
+              ),
             }}
           />
           {!isExpanded && (

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/__snapshots__/QuoteDetailsCard.test.tsx.snap
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/__snapshots__/QuoteDetailsCard.test.tsx.snap
@@ -899,6 +899,9 @@ exports[`QuoteDetailsCard renders expanded state 1`] = `
                                 >
                                   <Text
                                     accessibilityRole="text"
+                                    adjustsFontSizeToFit={true}
+                                    minimumFontScale={0.5}
+                                    numberOfLines={1}
                                     style={
                                       {
                                         "color": "#121314",
@@ -908,7 +911,6 @@ exports[`QuoteDetailsCard renders expanded state 1`] = `
                                         "lineHeight": 24,
                                       }
                                     }
-                                    testID="label"
                                   >
                                     1 ETH = 24.4 USDC
                                   </Text>
@@ -2102,6 +2104,9 @@ exports[`QuoteDetailsCard renders initial state 1`] = `
                                 >
                                   <Text
                                     accessibilityRole="text"
+                                    adjustsFontSizeToFit={true}
+                                    minimumFontScale={0.5}
+                                    numberOfLines={1}
                                     style={
                                       {
                                         "color": "#121314",
@@ -2111,7 +2116,6 @@ exports[`QuoteDetailsCard renders initial state 1`] = `
                                         "lineHeight": 24,
                                       }
                                     }
-                                    testID="label"
                                   >
                                     1 ETH = 24.4 USDC
                                   </Text>

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/index.ts
@@ -29,6 +29,7 @@ import useFiatFormatter from '../../../SimulationDetails/FiatDisplay/useFiatForm
 import useIsInsufficientBalance from '../useInsufficientBalance';
 import { BigNumber as EthersBigNumber } from 'ethers';
 import useValidateBridgeTx from '../../../../../util/bridge/hooks/useValidateBridgeTx';
+import { getIntlNumberFormatter } from '../../../../../util/intl';
 
 interface UseBridgeQuoteDataParams {
   latestSourceAtomicBalance?: EthersBigNumber;
@@ -138,10 +139,14 @@ export const useBridgeQuoteData = ({
       priceImpactPercentage = `${(Number(priceImpact) * 100).toFixed(2)}%`;
     }
 
+    const quoteRateFormatter = getIntlNumberFormatter(locale, {
+      ...(quoteRate && quoteRate > 1
+        ? { minimumFractionDigits: 1, maximumFractionDigits: 2 }
+        : { minimumSignificantDigits: 2, maximumSignificantDigits: 3 }),
+    });
+    const formattedQuoteRate = quoteRateFormatter.format(quoteRate ?? 0);
     const rate = quoteRate
-      ? `1 ${sourceToken?.symbol} = ${quoteRate.toFixed(1)} ${
-          destToken?.symbol
-        }`
+      ? `1 ${sourceToken?.symbol} = ${formattedQuoteRate} ${destToken?.symbol}`
       : '--';
 
     return {
@@ -158,6 +163,7 @@ export const useBridgeQuoteData = ({
     destToken?.symbol,
     getNetworkFee,
     slippage,
+    locale,
   ]);
 
   const isLoading = quotesLoadingStatus === RequestStatus.LOADING;

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/index.ts
@@ -139,6 +139,9 @@ export const useBridgeQuoteData = ({
       priceImpactPercentage = `${(Number(priceImpact) * 100).toFixed(2)}%`;
     }
 
+    // Formats quote rate to show an appropriate number of decimal places
+    // For numbers greater than 1, we show 2 decimal places. Example: 1.23456 -> 1.23
+    // For numbers less than 1, we show 3 significant digits. Example: 0.00012345 -> 0.000123
     const quoteRateFormatter = getIntlNumberFormatter(locale, {
       ...(quoteRate && quoteRate > 1
         ? { minimumFractionDigits: 1, maximumFractionDigits: 2 }

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/useBridgeQuoteData.test.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/useBridgeQuoteData.test.ts
@@ -116,7 +116,7 @@ describe('useBridgeQuoteData', () => {
       formattedQuoteData: {
         networkFee: '-',
         estimatedTime: '1 min',
-        rate: '1 ETH = 0.0 USDC',
+        rate: '1 ETH = 0.0000000000000000571 USDC',
         priceImpact: '-0.20%',
         slippage: '0.5%',
       },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Improves formatting of swap quote rates

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Improved formatting of swap quote rates

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/19227

## **Manual testing steps**

```gherkin
Feature: Formatted quote rates

  Scenario: user receives a quote for USDC to ETH
    Given user is on the quote page

    When user receives quote
    Then quote rate is accurate
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
