### PR TITLE
chore: Proposal to skip the modal for trusted dapps

### DIFF
--- a/app/core/AppConstants.ts
+++ b/app/core/AppConstants.ts
@@ -249,4 +249,5 @@ export default {
   TOKEN_DISCOVERY_BROWSER_ENABLED:
     process.env.TOKEN_DISCOVERY_BROWSER_ENABLED === 'true',
   EIP_7702_PUBLIC_KEY: '0x3c7a1cCCe462e96D186B8ca9a1BCB2010C3dABa3',
+  TRUSTED_DAPP_DOMAINS: ['portfolio.metamask.io'] as string[],
 } as const;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR implements a trusted domain allowlist that bypasses the deeplink warning modal for MetaMask's own services, improving user experience while maintaining security for unknown third-party dapps.

**What is the reason for the change?**
Currently, all dapp deeplinks (e.g., `https://metamask.app.link/dapp/portfolio.metamask.io`) show a warning modal stating "Proceed with caution - You were sent here by a third party, not MetaMask". This creates unnecessary friction when users navigate to MetaMask's own official services like Portfolio, and others that are not added in this PR.

**What is the improvement/solution?**
Added a `TRUSTED_DAPP_DOMAINS` allowlist in `AppConstants.ts` containing MetaMask's official domains. When a dapp deeplink targets a trusted domain, the modal is bypassed entirely and users navigate directly to the service. Non-trusted domains continue to show the existing warning modal, maintaining security for unknown third-party dapps.

## **Changelog**

CHANGELOG entry: Improved deeplink experience by removing unnecessary warning modals for MetaMask's official services

## **Related issues**

Fixes: [Issue number if applicable]

## **Manual testing steps**

```gherkin
Feature: Trusted domain deeplink handling

  Scenario: user navigates to MetaMask Portfolio via deeplink
    Given the app is installed and user is logged in
    When user clicks on deeplink "https://metamask.app.link/dapp/portfolio.metamask.io"
    Then user should navigate directly to Portfolio without seeing a warning modal

  Scenario: user navigates to unknown dapp via deeplink  
    Given the app is installed and user is logged in
    When user clicks on deeplink "https://metamask.app.link/dapp/uniswap.org"
    Then user should see "Proceed with caution" modal before navigating

  Scenario: user navigates to non-dapp deeplink
    Given the app is installed and user is logged in
    When user clicks on deeplink "https://metamask.app.link/swap"
    Then user should see the appropriate modal as before (unchanged behavior)
```

## **Screenshots/Recordings**

### **Before**

<!-- Screenshot showing "Proceed with caution" modal for portfolio.metamask.io deeplink -->

### **After**

<!-- Screenshot/recording showing direct navigation to Portfolio without modal -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.