### PR TITLE
Apply mobile spacing fix for percentage increase

### DIFF
--- a/app/component-library/components-temp/Price/AggregatedPercentage/AggregatedPercentage.tsx
+++ b/app/component-library/components-temp/Price/AggregatedPercentage/AggregatedPercentage.tsx
@@ -3,6 +3,7 @@ import {
   TextColor,
   TextVariant,
 } from '../../../../component-library/components/Texts/Text';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import SensitiveText from '../../../../component-library/components/Texts/SensitiveText';
 import { View } from 'react-native';
 import { renderFiat } from '../../../../util/number';
@@ -28,7 +29,7 @@ const AggregatedPercentage = ({
   privacyMode = false,
 }: AggregatedPercentageProps) => {
   const { styles } = useStyles(styleSheet, {});
-
+  const tw = useTailwind();
   const currentCurrency = useSelector(selectCurrentCurrency);
 
   const totalBalance = ethFiat + tokenFiat;
@@ -84,7 +85,7 @@ const AggregatedPercentage = ({
         color={percentageTextColor}
         variant={TextVariant.BodyMDMedium}
         testID={FORMATTED_PERCENTAGE_TEST_ID}
-        style={{ paddingLeft: 1 }}
+        style={tw`pl-1`}
       >
         {formattedPercentage}
       </SensitiveText>

--- a/app/component-library/components-temp/Price/AggregatedPercentage/AggregatedPercentage.tsx
+++ b/app/component-library/components-temp/Price/AggregatedPercentage/AggregatedPercentage.tsx
@@ -84,6 +84,7 @@ const AggregatedPercentage = ({
         color={percentageTextColor}
         variant={TextVariant.BodyMDMedium}
         testID={FORMATTED_PERCENTAGE_TEST_ID}
+        style={{ paddingLeft: 1 }}
       >
         {formattedPercentage}
       </SensitiveText>

--- a/app/component-library/components-temp/Price/AggregatedPercentage/NonEvmAggregatedPercentage.tsx
+++ b/app/component-library/components-temp/Price/AggregatedPercentage/NonEvmAggregatedPercentage.tsx
@@ -3,6 +3,7 @@ import {
   TextColor,
   TextVariant,
 } from '../../../../component-library/components/Texts/Text';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import SensitiveText from '../../../../component-library/components/Texts/SensitiveText';
 import { View } from 'react-native';
 import { useSelector } from 'react-redux';
@@ -35,7 +36,7 @@ const NonEvmAggregatedPercentage = ({
   privacyMode?: boolean;
 }) => {
   const { styles } = useStyles(styleSheet, {});
-
+  const tw = useTailwind();
   const currentCurrency = useSelector(selectCurrentCurrency);
 
   const account = useSelector(selectSelectedInternalAccount);
@@ -138,7 +139,7 @@ const NonEvmAggregatedPercentage = ({
         color={percentageTextColor}
         variant={TextVariant.BodyMDMedium}
         testID={FORMATTED_PERCENTAGE_TEST_ID}
-        style={{ paddingLeft: 1 }}
+        style={tw`pl-1`}
       >
         {formattedPercentage}
       </SensitiveText>

--- a/app/component-library/components-temp/Price/AggregatedPercentage/NonEvmAggregatedPercentage.tsx
+++ b/app/component-library/components-temp/Price/AggregatedPercentage/NonEvmAggregatedPercentage.tsx
@@ -138,6 +138,7 @@ const NonEvmAggregatedPercentage = ({
         color={percentageTextColor}
         variant={TextVariant.BodyMDMedium}
         testID={FORMATTED_PERCENTAGE_TEST_ID}
+        style={{ paddingLeft: 1 }}
       >
         {formattedPercentage}
       </SensitiveText>

--- a/app/component-library/components-temp/Price/AggregatedPercentage/__snapshots__/AggregatedPercentage.test.tsx.snap
+++ b/app/component-library/components-temp/Price/AggregatedPercentage/__snapshots__/AggregatedPercentage.test.tsx.snap
@@ -33,6 +33,7 @@ exports[`AggregatedPercentage should render correctly 1`] = `
         "fontSize": 16,
         "letterSpacing": 0,
         "lineHeight": 24,
+        "paddingLeft": 4,
       }
     }
     testID="formatted-percentage-test-id"


### PR DESCRIPTION
Add `paddingLeft={1}` to percentage `SensitiveText` components in mobile to improve spacing between dollar and percentage changes.

---
[Slack Thread](https://consensys.slack.com/archives/C09D9JVFJRZ/p1757075166054469?thread_ts=1757075166.054469&cid=C09D9JVFJRZ)

<a href="https://cursor.com/background-agent?bcId=bc-eca90148-6866-47bc-962b-97e54b95d747">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eca90148-6866-47bc-962b-97e54b95d747">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

