### PR TITLE
chore: Update `ppom-validator`

### DIFF
--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -1536,7 +1536,6 @@ export class Engine {
         chainId: getGlobalChainId(networkController),
         blockaidPublicKey: process.env.BLOCKAID_PUBLIC_KEY as string,
         cdnBaseUrl: process.env.BLOCKAID_FILE_CDN as string,
-        // @ts-expect-error TODO: Resolve mismatch between base-controller versions.
         messenger: this.controllerMessenger.getRestricted({
           name: 'PPOMController',
           allowedActions: ['NetworkController:getNetworkClientById'],

--- a/package.json
+++ b/package.json
@@ -275,7 +275,7 @@
     "@metamask/permission-controller": "^11.0.6",
     "@metamask/phishing-controller": "^13.1.0",
     "@metamask/post-message-stream": "^10.0.0",
-    "@metamask/ppom-validator": "0.36.0",
+    "@metamask/ppom-validator": "^0.38.0",
     "@metamask/preferences-controller": "^18.4.0",
     "@metamask/preinstalled-example-snap": "^0.7.1",
     "@metamask/profile-sync-controller": "^25.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5931,12 +5931,12 @@
     "@metamask/utils" "^11.4.0"
     readable-stream "3.6.2"
 
-"@metamask/ppom-validator@0.36.0":
-  version "0.36.0"
-  resolved "https://registry.yarnpkg.com/@metamask/ppom-validator/-/ppom-validator-0.36.0.tgz#cc8ace84ead3521c1b079650fa4169d1020bc070"
-  integrity sha512-9PN+QZpQCq0ctu0b7LeHFWeZQ5phKavVQ7t0tp2ZYtea6ql7zayjDhZQitoFUEHN3R6BuHxn5ORfDGFJgNDL9Q==
+"@metamask/ppom-validator@^0.38.0":
+  version "0.38.0"
+  resolved "https://registry.yarnpkg.com/@metamask/ppom-validator/-/ppom-validator-0.38.0.tgz#11f195144e01e3d02c0cd6fb2a9c2d8f71311d2e"
+  integrity sha512-9ADyGyX2LKzV/VxQGeRTF+vu1Iyc6/M9vHbJqxttv3YD2f1hety3ukVjCSXgdF2nRZ2w23o2gGfNWubhl70fjw==
   dependencies:
-    "@metamask/base-controller" "^7.0.1"
+    "@metamask/base-controller" "^8.3.0"
     "@metamask/controller-utils" "^11.3.0"
     "@metamask/utils" "^9.2.1"
     await-semaphore "^0.1.3"


### PR DESCRIPTION
## **Description**

Update the `@metamask/ppom-validator` package from 0.36 to 0.38. This update includes the introduction of new controller metadata properties, and some dependency updates.

The peer dependency changes included in this update resolve one peer dependency warning (about the dependency of `ppom-validator` on `network-controller`), and no new warnings are introduced.

Changelog: https://github.com/MetaMask/ppom-validator/blob/main/CHANGELOG.md#0380

## **Changelog**

CHANGELOG entry: null

## **Related issues**

This update relates to this recent ADR: https://github.com/MetaMask/decisions/blob/main/decisions/core/0014-Expand-Controller-Metadata.md

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
