### PR TITLE
fix: tutorial navigation issues

### DIFF
--- a/app/components/UI/Perps/components/PerpsTutorialCarousel/PerpsTutorialCarousel.test.tsx
+++ b/app/components/UI/Perps/components/PerpsTutorialCarousel/PerpsTutorialCarousel.test.tsx
@@ -160,6 +160,22 @@ describe('PerpsTutorialCarousel', () => {
     setParams: jest.fn(),
   };
 
+  // Helper function to navigate through screens
+  const navigateToScreen = async (screenIndex: number) => {
+    for (let i = 0; i < screenIndex; i++) {
+      const continueButton = screen.getByText(
+        strings('perps.tutorial.continue'),
+      );
+      await act(async () => {
+        fireEvent.press(continueButton);
+      });
+      // Advance timers to clear the debounce
+      act(() => {
+        jest.advanceTimersByTime(100);
+      });
+    }
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
@@ -212,14 +228,7 @@ describe('PerpsTutorialCarousel', () => {
       render(<PerpsTutorialCarousel />);
 
       // Navigate through all screens by pressing Continue 5 times (6 screens total)
-      for (let i = 0; i < 5; i++) {
-        const continueButton = screen.getByText(
-          strings('perps.tutorial.continue'),
-        );
-        await act(async () => {
-          fireEvent.press(continueButton);
-        });
-      }
+      await navigateToScreen(5);
 
       // Verify we're on the last screen
       expect(
@@ -244,28 +253,28 @@ describe('PerpsTutorialCarousel', () => {
       expect(mockDepositWithConfirmation).toHaveBeenCalled();
     });
 
-    it('should go back when pressing Skip on first screen', () => {
+    it('should navigate to markets list when pressing Skip on first screen', () => {
       render(<PerpsTutorialCarousel />);
 
       act(() => {
         fireEvent.press(screen.getByText(strings('perps.tutorial.skip')));
       });
 
-      expect(mockNavigation.goBack).toHaveBeenCalled();
+      expect(mockNavigationServiceMethods.navigate).toHaveBeenCalledWith(
+        Routes.PERPS.ROOT,
+        {
+          screen: Routes.PERPS.MARKETS,
+        },
+      );
       expect(mockMarkTutorialCompleted).not.toHaveBeenCalled();
       expect(mockDepositWithConfirmation).not.toHaveBeenCalled();
     });
 
-    it('should mark tutorial as completed and go back when pressing Skip on last screen', async () => {
+    it('should mark tutorial as completed and navigate to markets list when pressing Skip on last screen', async () => {
       render(<PerpsTutorialCarousel />);
 
       // Navigate to the last screen
-      for (let i = 0; i < 5; i++) {
-        const continueButton = screen.getByText(
-          strings('perps.tutorial.continue'),
-        );
-        fireEvent.press(continueButton);
-      }
+      await navigateToScreen(5);
 
       // Verify we're on the last screen
       expect(
@@ -282,9 +291,14 @@ describe('PerpsTutorialCarousel', () => {
         fireEvent.press(screen.getByText(strings('perps.tutorial.got_it')));
       });
 
-      // Should mark tutorial as completed and go back, but NOT initialize deposit
+      // Should mark tutorial as completed and navigate to markets list, but NOT initialize deposit
       expect(mockMarkTutorialCompleted).toHaveBeenCalled();
-      expect(mockNavigation.goBack).toHaveBeenCalled();
+      expect(mockNavigationServiceMethods.navigate).toHaveBeenCalledWith(
+        Routes.PERPS.ROOT,
+        {
+          screen: Routes.PERPS.MARKETS,
+        },
+      );
       expect(mockDepositWithConfirmation).not.toHaveBeenCalled();
     });
 
@@ -292,14 +306,7 @@ describe('PerpsTutorialCarousel', () => {
       render(<PerpsTutorialCarousel />);
 
       // Navigate through all screens by pressing Continue 5 times to get to last screen
-      for (let i = 0; i < 5; i++) {
-        const continueButton = screen.getByText(
-          strings('perps.tutorial.continue'),
-        );
-        await act(async () => {
-          fireEvent.press(continueButton);
-        });
-      }
+      await navigateToScreen(5);
 
       // Press Add funds button on last screen
       await act(async () => {
@@ -315,14 +322,7 @@ describe('PerpsTutorialCarousel', () => {
       render(<PerpsTutorialCarousel />);
 
       // Navigate through all screens by pressing Continue 5 times
-      for (let i = 0; i < 5; i++) {
-        const continueButton = screen.getByText(
-          strings('perps.tutorial.continue'),
-        );
-        await act(async () => {
-          fireEvent.press(continueButton);
-        });
-      }
+      await navigateToScreen(5);
 
       // Press Add funds button on last screen
       await act(async () => {
@@ -380,12 +380,7 @@ describe('PerpsTutorialCarousel', () => {
       render(<PerpsTutorialCarousel />);
 
       // Navigate to the last screen
-      for (let i = 0; i < 5; i++) {
-        const continueButton = screen.getByText(
-          strings('perps.tutorial.continue'),
-        );
-        fireEvent.press(continueButton);
-      }
+      await navigateToScreen(5);
 
       // Press "Got it" button on last screen
       act(() => {
@@ -442,7 +437,7 @@ describe('PerpsTutorialCarousel', () => {
       });
     });
 
-    it('should use goBack when not from deeplink', () => {
+    it('should navigate to markets list when not from deeplink', () => {
       // Default params (not from deeplink)
       (useRoute as jest.Mock).mockReturnValue({
         params: {},
@@ -455,8 +450,13 @@ describe('PerpsTutorialCarousel', () => {
         fireEvent.press(screen.getByText(strings('perps.tutorial.skip')));
       });
 
-      // Should use goBack instead of navigate
-      expect(mockNavigation.goBack).toHaveBeenCalled();
+      // Should navigate to markets list
+      expect(mockNavigationServiceMethods.navigate).toHaveBeenCalledWith(
+        Routes.PERPS.ROOT,
+        {
+          screen: Routes.PERPS.MARKETS,
+        },
+      );
       expect(mockNavigation.navigate).not.toHaveBeenCalled();
     });
 
@@ -473,8 +473,13 @@ describe('PerpsTutorialCarousel', () => {
         fireEvent.press(screen.getByText(strings('perps.tutorial.skip')));
       });
 
-      // Should default to goBack behavior
-      expect(mockNavigation.goBack).toHaveBeenCalled();
+      // Should default to navigating to markets list
+      expect(mockNavigationServiceMethods.navigate).toHaveBeenCalledWith(
+        Routes.PERPS.ROOT,
+        {
+          screen: Routes.PERPS.MARKETS,
+        },
+      );
       expect(mockNavigation.navigate).not.toHaveBeenCalled();
     });
 
@@ -488,14 +493,7 @@ describe('PerpsTutorialCarousel', () => {
       render(<PerpsTutorialCarousel />);
 
       // Navigate to last screen and press Add funds
-      for (let i = 0; i < 5; i++) {
-        const continueButton = screen.getByText(
-          strings('perps.tutorial.continue'),
-        );
-        await act(async () => {
-          fireEvent.press(continueButton);
-        });
-      }
+      await navigateToScreen(5);
 
       // Press Add funds button
       await act(async () => {
@@ -555,6 +553,10 @@ describe('PerpsTutorialCarousel', () => {
           await act(async () => {
             fireEvent.press(continueButton);
           });
+          // Advance timers to clear the debounce
+          act(() => {
+            jest.advanceTimersByTime(100);
+          });
 
           // Check that the correct artboard is rendered for current screen
           expect(screen.getByTestId('mock-rive-animation')).toBeOnTheScreen();
@@ -568,14 +570,7 @@ describe('PerpsTutorialCarousel', () => {
         render(<PerpsTutorialCarousel />);
 
         // Navigate through all screens to get to last screen
-        for (let i = 0; i < 5; i++) {
-          const continueButton = screen.getByText(
-            strings('perps.tutorial.continue'),
-          );
-          await act(async () => {
-            fireEvent.press(continueButton);
-          });
-        }
+        await navigateToScreen(5);
 
         // Verify we're on the ready_to_trade screen
         expect(
@@ -592,14 +587,7 @@ describe('PerpsTutorialCarousel', () => {
         render(<PerpsTutorialCarousel />);
 
         // Navigate through all screens by pressing Continue 5 times
-        for (let i = 0; i < 5; i++) {
-          const continueButton = screen.getByText(
-            strings('perps.tutorial.continue'),
-          );
-          await act(async () => {
-            fireEvent.press(continueButton);
-          });
-        }
+        await navigateToScreen(5);
 
         // Press the "Add funds" button
         await act(async () => {
@@ -660,6 +648,10 @@ describe('PerpsTutorialCarousel', () => {
           await act(async () => {
             fireEvent.press(continueButton);
           });
+          // Advance timers to clear the debounce
+          act(() => {
+            jest.advanceTimersByTime(100);
+          });
 
           // Check that the correct artboard is rendered for current screen
           expect(screen.getByTestId('mock-rive-animation')).toBeOnTheScreen();
@@ -683,14 +675,7 @@ describe('PerpsTutorialCarousel', () => {
         render(<PerpsTutorialCarousel />);
 
         // Navigate through all screens to get to last screen (4 clicks for 5 screens)
-        for (let i = 0; i < 4; i++) {
-          const continueButton = screen.getByText(
-            strings('perps.tutorial.continue'),
-          );
-          await act(async () => {
-            fireEvent.press(continueButton);
-          });
-        }
+        await navigateToScreen(4);
 
         // Verify we're on the close_anytime screen (last for non-eligible)
         expect(
@@ -713,14 +698,7 @@ describe('PerpsTutorialCarousel', () => {
         render(<PerpsTutorialCarousel />);
 
         // Navigate through all screens by pressing Continue 4 times (5 screens total)
-        for (let i = 0; i < 4; i++) {
-          const continueButton = screen.getByText(
-            strings('perps.tutorial.continue'),
-          );
-          await act(async () => {
-            fireEvent.press(continueButton);
-          });
-        }
+        await navigateToScreen(4);
 
         // Press the main "Got it" button (first one found, which is the main button)
         await act(async () => {
@@ -730,9 +708,14 @@ describe('PerpsTutorialCarousel', () => {
           fireEvent.press(gotItButtons[0]); // Main button is first
         });
 
-        // Should mark tutorial as completed and go back
+        // Should mark tutorial as completed and navigate to markets list
         expect(mockMarkTutorialCompleted).toHaveBeenCalled();
-        expect(mockNavigation.goBack).toHaveBeenCalled();
+        expect(mockNavigationServiceMethods.navigate).toHaveBeenCalledWith(
+          Routes.PERPS.ROOT,
+          {
+            screen: Routes.PERPS.MARKETS,
+          },
+        );
         // Should NOT navigate to deposit screen or call deposit
         expect(mockNavigation.navigate).not.toHaveBeenCalled();
         expect(mockDepositWithConfirmation).not.toHaveBeenCalled();

--- a/app/components/Views/WalletActions/WalletActions.test.tsx
+++ b/app/components/Views/WalletActions/WalletActions.test.tsx
@@ -23,6 +23,7 @@ import {
 import { EarnTokenDetails } from '../../UI/Earn/types/lending.types';
 import WalletActions from './WalletActions';
 import { selectPerpsEnabledFlag } from '../../UI/Perps';
+import { selectIsFirstTimePerpsUser } from '../../UI/Perps/selectors/perpsController';
 
 jest.mock('react-native-device-info', () => ({
   getVersion: jest.fn().mockReturnValue('1.0.0'),
@@ -30,6 +31,10 @@ jest.mock('react-native-device-info', () => ({
 
 jest.mock('../../UI/Perps', () => ({
   selectPerpsEnabledFlag: jest.fn(),
+}));
+
+jest.mock('../../UI/Perps/selectors/perpsController', () => ({
+  selectIsFirstTimePerpsUser: jest.fn(),
 }));
 
 jest.mock('../../UI/Earn/selectors/featureFlags', () => ({
@@ -444,10 +449,44 @@ describe('WalletActions', () => {
     ).toBeDefined();
   });
 
-  it('should call the onPerps function when the Perpetuals button is pressed', () => {
+  it('should navigate to Perps markets when returning user presses Perpetuals button', async () => {
     (
       selectPerpsEnabledFlag as jest.MockedFunction<
         typeof selectPerpsEnabledFlag
+      >
+    ).mockReturnValue(true);
+    (
+      selectIsFirstTimePerpsUser as jest.MockedFunction<
+        typeof selectIsFirstTimePerpsUser
+      >
+    ).mockReturnValue(false);
+
+    const { getByTestId } = renderWithProvider(<WalletActions />, {
+      state: mockInitialState,
+    });
+
+    fireEvent.press(
+      getByTestId(WalletActionsBottomSheetSelectorsIDs.PERPS_BUTTON),
+    );
+
+    // Wait for the bottom sheet close callback to execute
+    // closeBottomSheetAndNavigate wraps navigation in a callback
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockNavigate).toHaveBeenCalledWith('Perps', {
+      screen: 'PerpsMarketListView',
+    });
+  });
+
+  it('should navigate to Perps tutorial when first-time user presses Perpetuals button', async () => {
+    (
+      selectPerpsEnabledFlag as jest.MockedFunction<
+        typeof selectPerpsEnabledFlag
+      >
+    ).mockReturnValue(true);
+    (
+      selectIsFirstTimePerpsUser as jest.MockedFunction<
+        typeof selectIsFirstTimePerpsUser
       >
     ).mockReturnValue(true);
 
@@ -459,8 +498,12 @@ describe('WalletActions', () => {
       getByTestId(WalletActionsBottomSheetSelectorsIDs.PERPS_BUTTON),
     );
 
+    // Wait for the bottom sheet close callback to execute
+    // closeBottomSheetAndNavigate wraps navigation in a callback
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
     expect(mockNavigate).toHaveBeenCalledWith('Perps', {
-      screen: 'PerpsMarketListView',
+      screen: 'PerpsTutorial',
     });
   });
 

--- a/app/components/Views/WalletActions/WalletActions.tsx
+++ b/app/components/Views/WalletActions/WalletActions.tsx
@@ -39,6 +39,7 @@ import {
 import { RootState } from '../../../reducers';
 import { selectIsSwapsLive } from '../../../core/redux/slices/bridge';
 import { selectIsEvmNetworkSelected } from '../../../selectors/multichainNetworkController';
+import { selectIsFirstTimePerpsUser } from '../../UI/Perps/selectors/perpsController';
 
 const WalletActions = () => {
   const { styles } = useStyles(styleSheet, {});
@@ -47,6 +48,7 @@ const WalletActions = () => {
   const isPooledStakingEnabled = useSelector(selectPooledStakingEnabledFlag);
   const { earnTokens } = useSelector(earnSelectors.selectEarnTokens);
 
+  const isFirstTimePerpsUser = useSelector(selectIsFirstTimePerpsUser);
   const chainId = useSelector(selectChainId);
   const swapsIsLive = useSelector((state: RootState) =>
     selectIsSwapsLive(state, chainId),
@@ -127,12 +129,20 @@ const WalletActions = () => {
   ]);
 
   const onPerps = useCallback(() => {
-    closeBottomSheetAndNavigate(() => {
-      navigate(Routes.PERPS.ROOT, {
+    let params: Record<string, string> | null = null;
+    if (isFirstTimePerpsUser) {
+      params = {
+        screen: Routes.PERPS.TUTORIAL,
+      };
+    } else {
+      params = {
         screen: Routes.PERPS.MARKETS,
-      });
+      };
+    }
+    closeBottomSheetAndNavigate(() => {
+      navigate(Routes.PERPS.ROOT, params);
     });
-  }, [closeBottomSheetAndNavigate, navigate]);
+  }, [closeBottomSheetAndNavigate, navigate, isFirstTimePerpsUser]);
 
   const isEarnWalletActionEnabled = useMemo(() => {
     if (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
1. What is the reason for the change?
There were a few issues with tutorial flow. On android there was a double continue when button was clicked and also we sometimes would redirect to the last page instead of defaulting to the markets list view. Also the wallet action button did not have a tutorial condition on it
2. What is the improvement/solution?
Ensure that we can not double click buttons. Ensure that we are defaulting to the markets list view on escape routes. Wallet action button now has a tutorial condition on it when the user is a first time user
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1378

## **Manual testing steps**

```gherkin
Feature: tutorial navigation fix
  Scenario: user is a first time user and is not geoblocked entering from GTM full screen perps ad
    Given user enters the tutorial from the GTM full screen perps ad

    When user clicks start trading and goes through the flow of tutorial
    Then if they click skip or got it they will go to the markets list

  Scenario: user is a first time user and is geoblocked entering from GTM full screen perps ad
    Given user enters the tutorial from the GTM full screen perps ad

    When user clicks start trading and goes through the flow of tutorial
    Then if they click skip or got it they will go to the markets list

  Scenario: user is a first time user and is not geoblocked and has clicked not now on GTM full screen perps ad
    Given user enters the tutorial from the wallet view perps tab

    When user clicks start trading and goes through the flow of tutorial
    Then if they click skip or got it they will go to the markets list

  Scenario: user is a first time user and is geoblocked and has clicked not now on GTM full screen perps ad
    Given user enters the tutorial from the wallet view perps tab

    When user clicks start trading and goes through the flow of tutorial
    Then if they click skip or got it they will go to the markets list


  Scenario: user is a first time user
    Given user is logged in

    When user clicks on the wallet action button for perps
    Then the tutorial shows
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://www.loom.com/share/281f4e93c36843e7abe8ce7ab7482a52?sid=ea06fb96-65ca-412a-b62f-bae023440a3d

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
