### PR TITLE
fix: hide Solana in metamask pay

### DIFF
--- a/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/BridgeSourceNetworkSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/BridgeSourceNetworkSelector.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { initialState } from '../../_mocks_/initialState';
 import { fireEvent, waitFor } from '@testing-library/react-native';
 import { renderScreen } from '../../../../../util/test/renderWithProvider';
@@ -6,6 +7,8 @@ import Routes from '../../../../../constants/navigation/Routes';
 import { Hex } from '@metamask/utils';
 import { setSelectedSourceChainIds } from '../../../../../core/redux/slices/bridge';
 import { BridgeSourceNetworkSelectorSelectorsIDs } from '../../../../../../e2e/selectors/Bridge/BridgeSourceNetworkSelector.selectors';
+import { cloneDeep } from 'lodash';
+import { MultichainNetwork } from '@metamask/multichain-transactions-controller';
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
@@ -227,5 +230,55 @@ describe('BridgeSourceNetworkSelector', () => {
     // Make sure networks are sorted by fiat value in descending order
     expect(networkItems[0].props.testID).toBe(`chain-${mockChainId}`);
     expect(networkItems[1].props.testID).toBe(`chain-${optimismChainId}`);
+  });
+
+  it('renders non-EVM networks', async () => {
+    const state = cloneDeep(initialState);
+
+    state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags.bridgeConfigV2.chains[
+      MultichainNetwork.Solana
+    ] = {
+      isActiveSrc: true,
+      isActiveDest: true,
+      isUnifiedUIEnabled: true,
+    };
+
+    const { getByText } = renderScreen(
+      BridgeSourceNetworkSelector,
+      {
+        name: Routes.BRIDGE.MODALS.SOURCE_NETWORK_SELECTOR,
+      },
+      { state },
+    );
+
+    await waitFor(() => {
+      expect(getByText('Solana')).toBeTruthy();
+      expect(getByText('$30012.75599')).toBeTruthy();
+    });
+  });
+
+  it('does not render non-EVM networks if isEvmOnly set', async () => {
+    const state = cloneDeep(initialState);
+
+    state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags.bridgeConfigV2.chains[
+      MultichainNetwork.Solana
+    ] = {
+      isActiveSrc: true,
+      isActiveDest: true,
+      isUnifiedUIEnabled: true,
+    };
+
+    const { queryByText } = renderScreen(
+      () => <BridgeSourceNetworkSelector isEvmOnly />,
+      {
+        name: Routes.BRIDGE.MODALS.SOURCE_NETWORK_SELECTOR,
+      },
+      { state },
+    );
+
+    await waitFor(() => {
+      expect(queryByText('Solana')).toBeNull();
+      expect(queryByText('$30012.75599')).toBeNull();
+    });
   });
 });

--- a/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/index.tsx
+++ b/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/index.tsx
@@ -111,29 +111,35 @@ export const BridgeSourceNetworkSelector: React.FC<
   });
 
   const handleApply = useCallback(async () => {
+    const newSelectedSourceChainids = candidateSourceChainIds.filter((id) =>
+      enabledSourceChainIds.includes(id as CaipChainId),
+    );
+
     if (onApply) {
-      onApply(candidateSourceChainIds as Hex[]);
+      onApply(newSelectedSourceChainids as Hex[]);
       return;
     }
 
     // Update the Redux state with the candidate selections
     dispatch(
       setSelectedSourceChainIds(
-        candidateSourceChainIds as (Hex | CaipChainId)[],
+        newSelectedSourceChainids as (Hex | CaipChainId)[],
       ),
     );
 
     // If there's only 1 network selected, set the source token to native token of that chain and switch chains
-    if (candidateSourceChainIds.length === 1) {
+    if (newSelectedSourceChainids.length === 1) {
       const evmNetworkConfiguration =
-        evmNetworkConfigurations[candidateSourceChainIds[0] as Hex];
+        evmNetworkConfigurations[newSelectedSourceChainids[0] as Hex];
       if (evmNetworkConfiguration) {
         await onSetRpcTarget(evmNetworkConfiguration);
       }
 
       ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
       if (!evmNetworkConfiguration) {
-        await onNonEvmNetworkChange(candidateSourceChainIds[0] as CaipChainId);
+        await onNonEvmNetworkChange(
+          newSelectedSourceChainids[0] as CaipChainId,
+        );
       }
       ///: END:ONLY_INCLUDE_IF
 
@@ -147,6 +153,7 @@ export const BridgeSourceNetworkSelector: React.FC<
     navigation,
     dispatch,
     candidateSourceChainIds,
+    enabledSourceChainIds,
     evmNetworkConfigurations,
     onSetRpcTarget,
     ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)

--- a/app/components/Views/confirmations/components/modals/pay-with-network-modal/pay-with-network-modal.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-network-modal/pay-with-network-modal.tsx
@@ -17,5 +17,5 @@ export function PayWithNetworkModal() {
     [dispatch, navigation],
   );
 
-  return <BridgeSourceNetworkSelector onApply={handleApply} />;
+  return <BridgeSourceNetworkSelector onApply={handleApply} isEvmOnly />;
 }


### PR DESCRIPTION
## **Description**

Hide Solana in the payment token picker.

Add optional `isEvmOnly` prop to `BridgeSourceNetworkSelector` component.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#5758](https://github.com/MetaMask/MetaMask-planning/issues/5758)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
