### PR TITLE
[NOT TESTED] fix: prevent perps from navigating to arb if already enabled

### DIFF
--- a/app/components/UI/Perps/hooks/usePerpsNetworkManagement.ts
+++ b/app/components/UI/Perps/hooks/usePerpsNetworkManagement.ts
@@ -21,7 +21,7 @@ const infuraProjectId = InfuraKey === 'null' ? '' : InfuraKey;
  */
 export const usePerpsNetworkManagement = () => {
   const currentNetwork = usePerpsNetwork();
-  const { enableNetwork } = useNetworkEnablement();
+  const { enableNetwork, isNetworkEnabled } = useNetworkEnablement();
   const networkConfigurations = useSelector(
     selectEvmNetworkConfigurationsByChainId,
   );
@@ -45,8 +45,11 @@ export const usePerpsNetworkManagement = () => {
     const arbitrumCaipChainId = getArbitrumChainId();
     const chainId = toHex(parseInt(arbitrumCaipChainId.split(':')[1], 10));
 
-    // Check if network already exists
-    if (networkConfigurations[chainId]) {
+    // Check if network already exists & doesn't contain arbitrum in selected networks
+    if (
+      networkConfigurations[chainId] &&
+      !isNetworkEnabled(arbitrumCaipChainId)
+    ) {
       // Network exists, just enable it
       enableNetwork(arbitrumCaipChainId);
       return;
@@ -93,10 +96,11 @@ export const usePerpsNetworkManagement = () => {
       throw error;
     }
   }, [
-    currentNetwork,
-    networkConfigurations,
-    enableNetwork,
     getArbitrumChainId,
+    networkConfigurations,
+    isNetworkEnabled,
+    enableNetwork,
+    currentNetwork,
   ]);
 
   /**


### PR DESCRIPTION
## **Description**

When perp users are sending funds, the network switches to arb which causes some confusion with users balances changing (from all networks to arb).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
