### PR TITLE
feat(card): add badge on Card button

### DIFF
--- a/app/components/UI/Card/components/CardButton/CardButton.test.tsx
+++ b/app/components/UI/Card/components/CardButton/CardButton.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import CardButton from './CardButton';
+import { renderScreen } from '../../../../../util/test/renderWithProvider';
+import { backgroundState } from '../../../../../util/test/initial-root-state';
+import { WalletViewSelectorsIDs } from '../../../../../../e2e/selectors/wallet/WalletView.selectors';
+jest.mock('../../../../hooks/useMetrics', () => {
+  const actual = jest.requireActual('../../../../hooks/useMetrics');
+  return {
+    ...actual,
+    useMetrics: () => ({
+      trackEvent: jest.fn(),
+      createEventBuilder: jest.fn(() => ({
+        build: jest
+          .fn()
+          .mockReturnValue({ event: actual.MetaMetricsEvents.CARD_VIEWED }),
+      })),
+    }),
+  };
+});
+
+interface PartialCardState {
+  hasViewedCardButton?: boolean;
+}
+
+function renderWithProvider(
+  component: React.ComponentType,
+  stateOverride: PartialCardState = {},
+) {
+  return renderScreen(
+    component,
+    { name: 'CardButton' },
+    {
+      state: {
+        engine: { backgroundState },
+        card: {
+          cardholderAccounts: [],
+          priorityTokensByAddress: {},
+          lastFetchedByAddress: {},
+          hasViewedCardButton: false,
+          isLoaded: false,
+          ...stateOverride,
+        },
+      },
+    },
+  );
+}
+
+describe('CardButton Component', () => {
+  const mockOnPress = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders with badge (not yet viewed) and matches snapshot', () => {
+    const { toJSON, getByTestId } = renderWithProvider(() => (
+      <CardButton
+        onPress={mockOnPress}
+        touchAreaSlop={{ top: 0, bottom: 0, left: 0, right: 0 }}
+      />
+    ));
+
+    expect(getByTestId(WalletViewSelectorsIDs.CARD_BUTTON_BADGE)).toBeTruthy();
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('dispatches setHasViewedCardButton(true) and hides badge on first press', () => {
+    const { getByTestId, store, queryByTestId } = renderWithProvider(() => (
+      <CardButton
+        onPress={mockOnPress}
+        touchAreaSlop={{ top: 0, bottom: 0, left: 0, right: 0 }}
+      />
+    ));
+
+    const button = getByTestId(WalletViewSelectorsIDs.CARD_BUTTON);
+    fireEvent.press(button);
+
+    expect(mockOnPress).toHaveBeenCalledTimes(1);
+    expect(store.getState().card.hasViewedCardButton).toBe(true);
+    expect(queryByTestId(WalletViewSelectorsIDs.CARD_BUTTON_BADGE)).toBeNull();
+  });
+
+  it('does not dispatch setHasViewedCardButton again if already viewed', () => {
+    const { getByTestId, store } = renderWithProvider(
+      () => (
+        <CardButton
+          onPress={mockOnPress}
+          touchAreaSlop={{ top: 0, bottom: 0, left: 0, right: 0 }}
+        />
+      ),
+      { hasViewedCardButton: true },
+    );
+
+    const button = getByTestId(WalletViewSelectorsIDs.CARD_BUTTON);
+    fireEvent.press(button);
+
+    expect(mockOnPress).toHaveBeenCalledTimes(1);
+    expect(store.getState().card.hasViewedCardButton).toBe(true);
+  });
+
+  it('renders without badge when already viewed', () => {
+    const { toJSON, queryByTestId } = renderWithProvider(
+      () => (
+        <CardButton
+          onPress={mockOnPress}
+          touchAreaSlop={{ top: 0, bottom: 0, left: 0, right: 0 }}
+        />
+      ),
+      { hasViewedCardButton: true },
+    );
+
+    expect(queryByTestId(WalletViewSelectorsIDs.CARD_BUTTON_BADGE)).toBeNull();
+    expect(toJSON()).toMatchSnapshot();
+  });
+});

--- a/app/components/UI/Card/components/CardButton/CardButton.tsx
+++ b/app/components/UI/Card/components/CardButton/CardButton.tsx
@@ -1,4 +1,9 @@
 import {
+  BadgeStatus,
+  BadgeStatusStatus,
+  BadgeWrapper,
+  BadgeWrapperPosition,
+  BadgeWrapperPositionAnchorShape,
   ButtonIcon,
   ButtonIconSize,
   IconName,
@@ -8,6 +13,11 @@ import {
 import React, { useEffect } from 'react';
 import { WalletViewSelectorsIDs } from '../../../../../../e2e/selectors/wallet/WalletView.selectors';
 import { MetaMetricsEvents, useMetrics } from '../../../../hooks/useMetrics';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  selectHasViewedCardButton,
+  setHasViewedCardButton,
+} from '../../../../../core/redux/slices/card';
 
 interface CardButtonProps {
   onPress: () => void;
@@ -20,21 +30,43 @@ interface CardButtonProps {
 }
 
 const CardButton: React.FC<CardButtonProps> = ({ onPress, touchAreaSlop }) => {
+  const dispatch = useDispatch();
+  const hasViewedCardButton = useSelector(selectHasViewedCardButton);
   const { trackEvent, createEventBuilder } = useMetrics();
 
   useEffect(() => {
     trackEvent(createEventBuilder(MetaMetricsEvents.CARD_VIEWED).build());
   }, [trackEvent, createEventBuilder]);
 
+  const onPressHandler = () => {
+    if (!hasViewedCardButton) {
+      dispatch(setHasViewedCardButton(true));
+    }
+    onPress();
+  };
+
   return (
-    <ButtonIcon
-      iconProps={{ color: MMDSIconColor.IconDefault }}
-      onPress={onPress}
-      iconName={IconName.Card}
-      size={ButtonIconSize.Lg}
-      testID={WalletViewSelectorsIDs.CARD_BUTTON}
-      hitSlop={touchAreaSlop}
-    />
+    <BadgeWrapper
+      position={BadgeWrapperPosition.TopRight}
+      positionAnchorShape={BadgeWrapperPositionAnchorShape.Circular}
+      badge={
+        !hasViewedCardButton ? (
+          <BadgeStatus
+            testID={WalletViewSelectorsIDs.CARD_BUTTON_BADGE}
+            status={BadgeStatusStatus.New}
+          />
+        ) : null
+      }
+    >
+      <ButtonIcon
+        iconProps={{ color: MMDSIconColor.IconDefault }}
+        onPress={onPressHandler}
+        iconName={IconName.Card}
+        size={ButtonIconSize.Lg}
+        testID={WalletViewSelectorsIDs.CARD_BUTTON}
+        hitSlop={touchAreaSlop}
+      />
+    </BadgeWrapper>
   );
 };
 

--- a/app/components/UI/Card/components/CardButton/__snapshots__/CardButton.test.tsx.snap
+++ b/app/components/UI/Card/components/CardButton/__snapshots__/CardButton.test.tsx.snap
@@ -1,0 +1,913 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CardButton Component renders with badge (not yet viewed) and matches snapshot 1`] = `
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <RNCSafeAreaProvider
+    onInsetsChange={[Function]}
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      pointerEvents="box-none"
+      style={
+        {
+          "zIndex": 1,
+        }
+      }
+    >
+      <View
+        accessibilityElementsHidden={false}
+        importantForAccessibility="auto"
+        onLayout={[Function]}
+        pointerEvents="box-none"
+        style={null}
+      >
+        <View
+          collapsable={false}
+          pointerEvents="box-none"
+          style={
+            {
+              "bottom": 0,
+              "left": 0,
+              "opacity": 1,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "zIndex": 0,
+            }
+          }
+        >
+          <View
+            collapsable={false}
+            style={
+              {
+                "backgroundColor": "rgb(255, 255, 255)",
+                "borderBottomColor": "rgb(216, 216, 216)",
+                "flex": 1,
+                "shadowColor": "rgb(216, 216, 216)",
+                "shadowOffset": {
+                  "height": 0.5,
+                  "width": 0,
+                },
+                "shadowOpacity": 0.85,
+                "shadowRadius": 0,
+              }
+            }
+          />
+        </View>
+        <View
+          collapsable={false}
+          pointerEvents="box-none"
+          style={
+            {
+              "height": 64,
+              "maxHeight": undefined,
+              "minHeight": undefined,
+              "opacity": undefined,
+              "transform": undefined,
+            }
+          }
+        >
+          <View
+            pointerEvents="none"
+            style={
+              {
+                "height": 20,
+              }
+            }
+          />
+          <View
+            pointerEvents="box-none"
+            style={
+              {
+                "alignItems": "center",
+                "flex": 1,
+                "flexDirection": "row",
+                "justifyContent": "center",
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              pointerEvents="box-none"
+              style={
+                {
+                  "marginHorizontal": 16,
+                  "opacity": 1,
+                }
+              }
+            >
+              <Text
+                accessibilityRole="header"
+                aria-level="1"
+                collapsable={false}
+                numberOfLines={1}
+                onLayout={[Function]}
+                style={
+                  {
+                    "color": "rgb(28, 28, 30)",
+                    "fontSize": 17,
+                    "fontWeight": "600",
+                  }
+                }
+              >
+                CardButton
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <RNSScreenContainer
+      onLayout={[Function]}
+      style={
+        {
+          "flex": 1,
+        }
+      }
+    >
+      <RNSScreen
+        activityState={2}
+        collapsable={false}
+        gestureResponseDistance={
+          {
+            "bottom": -1,
+            "end": -1,
+            "start": -1,
+            "top": -1,
+          }
+        }
+        onGestureCancel={[Function]}
+        pointerEvents="box-none"
+        sheetAllowedDetents="large"
+        sheetCornerRadius={-1}
+        sheetExpandsWhenScrolledToEdge={true}
+        sheetGrabberVisible={false}
+        sheetLargestUndimmedDetent="all"
+        style={
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "zIndex": undefined,
+          }
+        }
+      >
+        <View
+          collapsable={false}
+          style={
+            {
+              "opacity": 1,
+            }
+          }
+        />
+        <View
+          accessibilityElementsHidden={false}
+          closing={false}
+          gestureVelocityImpact={0.3}
+          importantForAccessibility="auto"
+          onClose={[Function]}
+          onGestureBegin={[Function]}
+          onGestureCanceled={[Function]}
+          onGestureEnd={[Function]}
+          onOpen={[Function]}
+          onTransition={[Function]}
+          pointerEvents="box-none"
+          style={
+            [
+              {
+                "overflow": undefined,
+              },
+              {
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+            ]
+          }
+          transitionSpec={
+            {
+              "close": {
+                "animation": "spring",
+                "config": {
+                  "damping": 500,
+                  "mass": 3,
+                  "overshootClamping": true,
+                  "restDisplacementThreshold": 10,
+                  "restSpeedThreshold": 10,
+                  "stiffness": 1000,
+                },
+              },
+              "open": {
+                "animation": "spring",
+                "config": {
+                  "damping": 500,
+                  "mass": 3,
+                  "overshootClamping": true,
+                  "restDisplacementThreshold": 10,
+                  "restSpeedThreshold": 10,
+                  "stiffness": 1000,
+                },
+              },
+            }
+          }
+        >
+          <View
+            collapsable={false}
+            needsOffscreenAlphaCompositing={false}
+            pointerEvents="box-none"
+            style={
+              {
+                "flex": 1,
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              enabled={false}
+              handlerTag={-1}
+              handlerType="PanGestureHandler"
+              onGestureHandlerEvent={[Function]}
+              onGestureHandlerStateChange={[Function]}
+              style={
+                {
+                  "flex": 1,
+                  "transform": [
+                    {
+                      "translateX": 0,
+                    },
+                    {
+                      "translateX": 0,
+                    },
+                  ],
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                pointerEvents="none"
+                style={
+                  {
+                    "backgroundColor": "rgb(242, 242, 242)",
+                    "bottom": 0,
+                    "left": 0,
+                    "position": "absolute",
+                    "shadowColor": "#000",
+                    "shadowOffset": {
+                      "height": 1,
+                      "width": -1,
+                    },
+                    "shadowOpacity": 0.3,
+                    "shadowRadius": 5,
+                    "top": 0,
+                    "width": 3,
+                  }
+                }
+              />
+              <View
+                style={
+                  [
+                    {
+                      "flex": 1,
+                      "overflow": "hidden",
+                    },
+                    [
+                      {
+                        "backgroundColor": "rgb(242, 242, 242)",
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+              >
+                <View
+                  style={
+                    {
+                      "flex": 1,
+                      "flexDirection": "column-reverse",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        [
+                          {
+                            "alignSelf": "flex-start",
+                            "position": "relative",
+                          },
+                          undefined,
+                        ]
+                      }
+                    >
+                      <View
+                        onLayout={[Function]}
+                      >
+                        <View
+                          style={
+                            [
+                              {
+                                "transform": [
+                                  {
+                                    "scale": 1,
+                                  },
+                                ],
+                              },
+                              {
+                                "alignItems": "center",
+                                "justifyContent": "center",
+                              },
+                            ]
+                          }
+                        >
+                          <View
+                            accessibilityState={
+                              {
+                                "busy": undefined,
+                                "checked": undefined,
+                                "disabled": false,
+                                "expanded": undefined,
+                                "selected": undefined,
+                              }
+                            }
+                            accessibilityValue={
+                              {
+                                "max": undefined,
+                                "min": undefined,
+                                "now": undefined,
+                                "text": undefined,
+                              }
+                            }
+                            accessible={true}
+                            collapsable={false}
+                            focusable={true}
+                            hitSlop={
+                              {
+                                "bottom": 0,
+                                "left": 0,
+                                "right": 0,
+                                "top": 0,
+                              }
+                            }
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onResponderGrant={[Function]}
+                            onResponderMove={[Function]}
+                            onResponderRelease={[Function]}
+                            onResponderTerminate={[Function]}
+                            onResponderTerminationRequest={[Function]}
+                            onStartShouldSetResponder={[Function]}
+                            style={
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "backgroundColor": "transparent",
+                                  "borderRadius": 2,
+                                  "height": 40,
+                                  "justifyContent": "center",
+                                  "opacity": 1,
+                                  "width": 40,
+                                },
+                                undefined,
+                              ]
+                            }
+                            testID="card-button"
+                          >
+                            <SvgMock
+                              fill="currentColor"
+                              name="Card"
+                              style={
+                                [
+                                  {
+                                    "color": "#121314",
+                                    "height": 24,
+                                    "width": 24,
+                                  },
+                                  undefined,
+                                ]
+                              }
+                            />
+                          </View>
+                        </View>
+                      </View>
+                      <View
+                        onLayout={[Function]}
+                        style={
+                          [
+                            {
+                              "position": "absolute",
+                            },
+                            {
+                              "right": 0,
+                              "top": 0,
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            [
+                              {
+                                "alignSelf": "flex-start",
+                                "borderColor": "#ffffff",
+                                "borderRadius": 9999,
+                                "borderWidth": 2,
+                              },
+                              undefined,
+                            ]
+                          }
+                          testID="card-button-badge"
+                        >
+                          <View
+                            style={
+                              [
+                                {
+                                  "backgroundColor": "#4459ff",
+                                  "borderColor": "#4459ff",
+                                  "borderRadius": 9999,
+                                  "borderWidth": 2,
+                                  "height": 8,
+                                  "width": 8,
+                                },
+                              ]
+                            }
+                          />
+                        </View>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </RNSScreen>
+    </RNSScreenContainer>
+  </RNCSafeAreaProvider>
+</View>
+`;
+
+exports[`CardButton Component renders without badge when already viewed 1`] = `
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <RNCSafeAreaProvider
+    onInsetsChange={[Function]}
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      pointerEvents="box-none"
+      style={
+        {
+          "zIndex": 1,
+        }
+      }
+    >
+      <View
+        accessibilityElementsHidden={false}
+        importantForAccessibility="auto"
+        onLayout={[Function]}
+        pointerEvents="box-none"
+        style={null}
+      >
+        <View
+          collapsable={false}
+          pointerEvents="box-none"
+          style={
+            {
+              "bottom": 0,
+              "left": 0,
+              "opacity": 1,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "zIndex": 0,
+            }
+          }
+        >
+          <View
+            collapsable={false}
+            style={
+              {
+                "backgroundColor": "rgb(255, 255, 255)",
+                "borderBottomColor": "rgb(216, 216, 216)",
+                "flex": 1,
+                "shadowColor": "rgb(216, 216, 216)",
+                "shadowOffset": {
+                  "height": 0.5,
+                  "width": 0,
+                },
+                "shadowOpacity": 0.85,
+                "shadowRadius": 0,
+              }
+            }
+          />
+        </View>
+        <View
+          collapsable={false}
+          pointerEvents="box-none"
+          style={
+            {
+              "height": 64,
+              "maxHeight": undefined,
+              "minHeight": undefined,
+              "opacity": undefined,
+              "transform": undefined,
+            }
+          }
+        >
+          <View
+            pointerEvents="none"
+            style={
+              {
+                "height": 20,
+              }
+            }
+          />
+          <View
+            pointerEvents="box-none"
+            style={
+              {
+                "alignItems": "center",
+                "flex": 1,
+                "flexDirection": "row",
+                "justifyContent": "center",
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              pointerEvents="box-none"
+              style={
+                {
+                  "marginHorizontal": 16,
+                  "opacity": 1,
+                }
+              }
+            >
+              <Text
+                accessibilityRole="header"
+                aria-level="1"
+                collapsable={false}
+                numberOfLines={1}
+                onLayout={[Function]}
+                style={
+                  {
+                    "color": "rgb(28, 28, 30)",
+                    "fontSize": 17,
+                    "fontWeight": "600",
+                  }
+                }
+              >
+                CardButton
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <RNSScreenContainer
+      onLayout={[Function]}
+      style={
+        {
+          "flex": 1,
+        }
+      }
+    >
+      <RNSScreen
+        activityState={2}
+        collapsable={false}
+        gestureResponseDistance={
+          {
+            "bottom": -1,
+            "end": -1,
+            "start": -1,
+            "top": -1,
+          }
+        }
+        onGestureCancel={[Function]}
+        pointerEvents="box-none"
+        sheetAllowedDetents="large"
+        sheetCornerRadius={-1}
+        sheetExpandsWhenScrolledToEdge={true}
+        sheetGrabberVisible={false}
+        sheetLargestUndimmedDetent="all"
+        style={
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "zIndex": undefined,
+          }
+        }
+      >
+        <View
+          collapsable={false}
+          style={
+            {
+              "opacity": 1,
+            }
+          }
+        />
+        <View
+          accessibilityElementsHidden={false}
+          closing={false}
+          gestureVelocityImpact={0.3}
+          importantForAccessibility="auto"
+          onClose={[Function]}
+          onGestureBegin={[Function]}
+          onGestureCanceled={[Function]}
+          onGestureEnd={[Function]}
+          onOpen={[Function]}
+          onTransition={[Function]}
+          pointerEvents="box-none"
+          style={
+            [
+              {
+                "overflow": undefined,
+              },
+              {
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+            ]
+          }
+          transitionSpec={
+            {
+              "close": {
+                "animation": "spring",
+                "config": {
+                  "damping": 500,
+                  "mass": 3,
+                  "overshootClamping": true,
+                  "restDisplacementThreshold": 10,
+                  "restSpeedThreshold": 10,
+                  "stiffness": 1000,
+                },
+              },
+              "open": {
+                "animation": "spring",
+                "config": {
+                  "damping": 500,
+                  "mass": 3,
+                  "overshootClamping": true,
+                  "restDisplacementThreshold": 10,
+                  "restSpeedThreshold": 10,
+                  "stiffness": 1000,
+                },
+              },
+            }
+          }
+        >
+          <View
+            collapsable={false}
+            needsOffscreenAlphaCompositing={false}
+            pointerEvents="box-none"
+            style={
+              {
+                "flex": 1,
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              enabled={false}
+              handlerTag={-1}
+              handlerType="PanGestureHandler"
+              onGestureHandlerEvent={[Function]}
+              onGestureHandlerStateChange={[Function]}
+              style={
+                {
+                  "flex": 1,
+                  "transform": [
+                    {
+                      "translateX": 0,
+                    },
+                    {
+                      "translateX": 0,
+                    },
+                  ],
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                pointerEvents="none"
+                style={
+                  {
+                    "backgroundColor": "rgb(242, 242, 242)",
+                    "bottom": 0,
+                    "left": 0,
+                    "position": "absolute",
+                    "shadowColor": "#000",
+                    "shadowOffset": {
+                      "height": 1,
+                      "width": -1,
+                    },
+                    "shadowOpacity": 0.3,
+                    "shadowRadius": 5,
+                    "top": 0,
+                    "width": 3,
+                  }
+                }
+              />
+              <View
+                style={
+                  [
+                    {
+                      "flex": 1,
+                      "overflow": "hidden",
+                    },
+                    [
+                      {
+                        "backgroundColor": "rgb(242, 242, 242)",
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+              >
+                <View
+                  style={
+                    {
+                      "flex": 1,
+                      "flexDirection": "column-reverse",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        [
+                          {
+                            "alignSelf": "flex-start",
+                            "position": "relative",
+                          },
+                          undefined,
+                        ]
+                      }
+                    >
+                      <View
+                        onLayout={[Function]}
+                      >
+                        <View
+                          style={
+                            [
+                              {
+                                "transform": [
+                                  {
+                                    "scale": 1,
+                                  },
+                                ],
+                              },
+                              {
+                                "alignItems": "center",
+                                "justifyContent": "center",
+                              },
+                            ]
+                          }
+                        >
+                          <View
+                            accessibilityState={
+                              {
+                                "busy": undefined,
+                                "checked": undefined,
+                                "disabled": false,
+                                "expanded": undefined,
+                                "selected": undefined,
+                              }
+                            }
+                            accessibilityValue={
+                              {
+                                "max": undefined,
+                                "min": undefined,
+                                "now": undefined,
+                                "text": undefined,
+                              }
+                            }
+                            accessible={true}
+                            collapsable={false}
+                            focusable={true}
+                            hitSlop={
+                              {
+                                "bottom": 0,
+                                "left": 0,
+                                "right": 0,
+                                "top": 0,
+                              }
+                            }
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onResponderGrant={[Function]}
+                            onResponderMove={[Function]}
+                            onResponderRelease={[Function]}
+                            onResponderTerminate={[Function]}
+                            onResponderTerminationRequest={[Function]}
+                            onStartShouldSetResponder={[Function]}
+                            style={
+                              [
+                                {
+                                  "alignItems": "center",
+                                  "backgroundColor": "transparent",
+                                  "borderRadius": 2,
+                                  "height": 40,
+                                  "justifyContent": "center",
+                                  "opacity": 1,
+                                  "width": 40,
+                                },
+                                undefined,
+                              ]
+                            }
+                            testID="card-button"
+                          >
+                            <SvgMock
+                              fill="currentColor"
+                              name="Card"
+                              style={
+                                [
+                                  {
+                                    "color": "#121314",
+                                    "height": 24,
+                                    "width": 24,
+                                  },
+                                  undefined,
+                                ]
+                              }
+                            />
+                          </View>
+                        </View>
+                      </View>
+                      <View
+                        onLayout={[Function]}
+                        style={
+                          [
+                            {
+                              "position": "absolute",
+                            },
+                            {
+                              "right": 0,
+                              "top": 0,
+                            },
+                          ]
+                        }
+                      />
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </RNSScreen>
+    </RNSScreenContainer>
+  </RNCSafeAreaProvider>
+</View>
+`;

--- a/app/core/redux/slices/card/index.test.ts
+++ b/app/core/redux/slices/card/index.test.ts
@@ -11,6 +11,8 @@ import cardReducer, {
   setCardPriorityToken,
   setCardPriorityTokenLastFetched,
   initialState,
+  setHasViewedCardButton,
+  selectHasViewedCardButton,
 } from '.';
 import {
   CardTokenAllowance,
@@ -67,6 +69,7 @@ const CARD_STATE_MOCK: CardSliceState = {
     [testAddress.toLowerCase()]: new Date('2025-08-21T10:00:00Z'),
   },
   isLoaded: true,
+  hasViewedCardButton: true,
 };
 
 const EMPTY_CARD_STATE_MOCK: CardSliceState = {
@@ -74,6 +77,7 @@ const EMPTY_CARD_STATE_MOCK: CardSliceState = {
   priorityTokensByAddress: {},
   lastFetchedByAddress: {},
   isLoaded: false,
+  hasViewedCardButton: false,
 };
 
 // Mock account object that matches the expected structure
@@ -111,6 +115,22 @@ describe('Card Selectors', () => {
       } as unknown as RootState;
 
       expect(selectCardholderAccounts(mockRootState)).toEqual([]);
+    });
+  });
+
+  describe('selectHasViewedCardButton', () => {
+    it('returns false by default from initial state', () => {
+      const mockRootState = { card: initialState } as unknown as RootState;
+      expect(selectHasViewedCardButton(mockRootState)).toBe(false);
+    });
+
+    it('returns true when hasViewedCardButton is true', () => {
+      const stateWithFlag: CardSliceState = {
+        ...initialState,
+        hasViewedCardButton: true,
+      };
+      const mockRootState = { card: stateWithFlag } as unknown as RootState;
+      expect(selectHasViewedCardButton(mockRootState)).toBe(true);
     });
   });
 
@@ -250,11 +270,32 @@ describe('Card Reducer', () => {
           '0x123': new Date(),
         },
         isLoaded: true,
+        hasViewedCardButton: true,
       };
 
       const state = cardReducer(currentState, resetCardState());
 
       expect(state).toEqual(initialState);
+    });
+
+    describe('setHasViewedCardButton', () => {
+      it('should set hasViewedCardButton to true', () => {
+        const state = cardReducer(initialState, setHasViewedCardButton(true));
+        expect(state.hasViewedCardButton).toBe(true);
+        // ensure other parts of state untouched
+        expect(state.cardholderAccounts).toEqual(
+          initialState.cardholderAccounts,
+        );
+      });
+
+      it('should set hasViewedCardButton to false when previously true', () => {
+        const current: CardSliceState = {
+          ...initialState,
+          hasViewedCardButton: true,
+        };
+        const state = cardReducer(current, setHasViewedCardButton(false));
+        expect(state.hasViewedCardButton).toBe(false);
+      });
     });
   });
 });

--- a/app/core/redux/slices/card/index.ts
+++ b/app/core/redux/slices/card/index.ts
@@ -11,6 +11,7 @@ export interface CardSliceState {
   cardholderAccounts: string[];
   priorityTokensByAddress: Record<string, CardTokenAllowance | null>;
   lastFetchedByAddress: Record<string, Date | string | null>;
+  hasViewedCardButton: boolean;
   isLoaded: boolean;
 }
 
@@ -18,6 +19,7 @@ export const initialState: CardSliceState = {
   cardholderAccounts: [],
   priorityTokensByAddress: {},
   lastFetchedByAddress: {},
+  hasViewedCardButton: false,
   isLoaded: false,
 };
 
@@ -34,6 +36,9 @@ const slice = createSlice({
   initialState,
   reducers: {
     resetCardState: () => initialState,
+    setHasViewedCardButton: (state, action: PayloadAction<boolean>) => {
+      state.hasViewedCardButton = action.payload;
+    },
     setCardPriorityToken: (
       state,
       action: PayloadAction<{
@@ -123,9 +128,15 @@ export const selectIsCardholder = createSelector(
   },
 );
 
+export const selectHasViewedCardButton = createSelector(
+  selectCardState,
+  (card) => card.hasViewedCardButton,
+);
+
 // Actions
 export const {
   resetCardState,
   setCardPriorityToken,
   setCardPriorityTokenLastFetched,
+  setHasViewedCardButton,
 } = actions;

--- a/e2e/pages/wallet/WalletView.ts
+++ b/e2e/pages/wallet/WalletView.ts
@@ -66,6 +66,10 @@ class WalletView {
     return Matchers.getElementByID(WalletViewSelectorsIDs.CARD_BUTTON);
   }
 
+  get navbarCardButtonBadge(): DetoxElement {
+    return Matchers.getElementByID(WalletViewSelectorsIDs.CARD_BUTTON_BADGE);
+  }
+
   get nftTab(): DetoxElement {
     return Matchers.getElementByText(WalletViewSelectorsText.NFTS_TAB);
   }

--- a/e2e/selectors/wallet/WalletView.selectors.ts
+++ b/e2e/selectors/wallet/WalletView.selectors.ts
@@ -9,6 +9,7 @@ export const WalletViewSelectorsIDs = {
   WALLET_TOKEN_DETECTION_LINK_BUTTON: 'wallet-token-detection-link-button',
   TOTAL_BALANCE_TEXT: 'total-balance-text',
   CARD_BUTTON: 'card-button',
+  CARD_BUTTON_BADGE: 'card-button-badge',
   STAKE_BUTTON: 'stake-button',
   EARN_EARNINGS_HISTORY_BUTTON: 'earn-earnings-history-button',
   UNSTAKE_BUTTON: 'unstake-button',

--- a/e2e/specs/card/card-button.spec.ts
+++ b/e2e/specs/card/card-button.spec.ts
@@ -54,6 +54,9 @@ describe(SmokeCard('Card NavBar Button'), () => {
   it('should open Card Home when pressing card navbar button', async () => {
     await setupCardTest(async () => {
       await Assertions.expectElementToBeVisible(WalletView.navbarCardButton);
+      await Assertions.expectElementToBeVisible(
+        WalletView.navbarCardButtonBadge,
+      );
       await WalletView.tapNavbarCardButton();
       await Assertions.expectElementToBeVisible(CardHomeView.cardViewTitle);
     });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR introduces a badge (dot) on the Card button that becomes visible if the user has not yet opened the Card home screen. Its purpose is to draw attention to the new Card on Mobile feature.
Current Behavior
- The dot appears and remains visible even if the user switches between cardholder accounts.
- It only disappears once the user presses the Card button.
- Once dismissed, it does not reappear, unless the user deletes the account or reinstalls the app and reloads their SRP, in which case the dot will show again.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added a new Badge on the Card button

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Card button badge

  Scenario: user sees the badge before opening Card home
    Given the user has not opened the Card home screen
    When the user views the app home screen
    Then a badge should be visible on the Card button

  Scenario: user opens the Card home screen
    Given a badge is visible on the Card button
    When the user presses the Card button
    Then the badge should disappear

  Scenario: user switches between cardholder accounts
    Given a badge is visible on the Card button
    When the user switches to another cardholder account
    Then the badge should remain visible

  Scenario: user reinstalls app or reloads SRP
    Given the user has previously dismissed the badge
    When the user reinstalls the app or reloads their SRP
    Then the badge should reappear on the Card button
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/0bdfa22e-262a-46ec-89c0-3a6e1600fbea

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/8f3dabec-5087-4ed9-bfac-ef6745d59872

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
