### PR TITLE
fix: Funding cost

### DIFF
--- a/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
+++ b/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
@@ -279,11 +279,21 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
                 >
                   {strings('perps.position.card.funding_cost')}
                 </Text>
-                <Text variant={TextVariant.BodySM} color={TextColor.Default}>
-                  {formatPrice(position.cumulativeFunding.sinceOpen, {
-                    minimumDecimals: 2,
-                    maximumDecimals: 2,
-                  })}
+                <Text
+                  variant={TextVariant.BodySM}
+                  color={
+                    parseFloat(position.cumulativeFunding.sinceOpen) >= 0
+                      ? TextColor.Success
+                      : TextColor.Error
+                  }
+                >
+                  {formatPrice(
+                    Math.abs(parseFloat(position.cumulativeFunding.sinceOpen)),
+                    {
+                      minimumDecimals: 2,
+                      maximumDecimals: 2,
+                    },
+                  )}
                 </Text>
               </View>
             </View>


### PR DESCRIPTION
## **Description**

Small fix to show the funding cost as an absolute value, colored accordingly

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Implement logic for colored absolute value funding cost

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<img width="439" height="881" alt="Screenshot 2025-09-08 at 4 54 33 PM" src="https://github.com/user-attachments/assets/990d42b8-aa96-4d31-9213-ae2e25f3d2c8" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
