### PR TITLE
chore: faster Perps format functions + transformMarketData

### DIFF
--- a/app/components/UI/Perps/utils/formatUtils.ts
+++ b/app/components/UI/Perps/utils/formatUtils.ts
@@ -2,6 +2,10 @@
  * Shared formatting utilities for Perps components
  */
 import { formatWithThreshold } from '../../../../util/assets';
+import {
+  getIntlDateTimeFormatter,
+  getIntlNumberFormatter,
+} from '../../../../util/intl';
 import { FUNDING_RATE_CONFIG } from '../constants/perpsConfig';
 
 /**
@@ -83,7 +87,7 @@ export const formatPnl = (pnl: string | number): string => {
     return '$0.00';
   }
 
-  const formatted = new Intl.NumberFormat('en-US', {
+  const formatted = getIntlNumberFormatter('en-US', {
     style: 'currency',
     currency: 'USD',
     minimumFractionDigits: 2,
@@ -363,12 +367,12 @@ export const parsePercentageString = (formattedValue: string): number => {
  */
 export const formatTransactionDate = (timestamp: number): string => {
   const date = new Date(timestamp);
-  const dateStr = new Intl.DateTimeFormat('en-US', {
+  const dateStr = getIntlDateTimeFormatter('en-US', {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
   }).format(date);
-  const timeStr = new Intl.DateTimeFormat('en-US', {
+  const timeStr = getIntlDateTimeFormatter('en-US', {
     hour: 'numeric',
     minute: '2-digit',
     hour12: true,
@@ -406,10 +410,10 @@ export const formatDateSection = (timestamp: number): string => {
     return 'Yesterday';
   }
 
-  const month = new Intl.DateTimeFormat('en-US', {
+  const month = getIntlDateTimeFormatter('en-US', {
     month: 'short',
   }).format(new Date(timestamp));
-  const day = new Intl.DateTimeFormat('en-US', {
+  const day = getIntlDateTimeFormatter('en-US', {
     day: 'numeric',
   }).format(new Date(timestamp));
 

--- a/app/components/UI/Perps/utils/marketDataTransform.ts
+++ b/app/components/UI/Perps/utils/marketDataTransform.ts
@@ -7,6 +7,7 @@ import type {
 import { PERPS_CONSTANTS } from '../constants/perpsConfig';
 import type { PerpsMarketData } from '../controllers/types';
 import { formatVolume } from './formatUtils';
+import { getIntlNumberFormatter } from '../../../../util/intl';
 
 /**
  * HyperLiquid-specific market data structure
@@ -139,7 +140,7 @@ export function formatPrice(price: number): string {
   const absPrice = Math.abs(price);
 
   if (absPrice >= 1000) {
-    return new Intl.NumberFormat('en-US', {
+    getIntlNumberFormatter('en-US', {
       style: 'currency',
       currency: 'USD',
       minimumFractionDigits: 2,
@@ -147,7 +148,7 @@ export function formatPrice(price: number): string {
     }).format(price);
   }
   if (absPrice >= 1) {
-    return new Intl.NumberFormat('en-US', {
+    getIntlNumberFormatter('en-US', {
       style: 'currency',
       currency: 'USD',
       minimumFractionDigits: 2,
@@ -155,14 +156,14 @@ export function formatPrice(price: number): string {
     }).format(price);
   }
   if (absPrice >= 0.01) {
-    return new Intl.NumberFormat('en-US', {
+    return getIntlNumberFormatter('en-US', {
       style: 'currency',
       currency: 'USD',
       minimumFractionDigits: 4,
       maximumFractionDigits: 4,
     }).format(price);
   }
-  return new Intl.NumberFormat('en-US', {
+  return getIntlNumberFormatter('en-US', {
     style: 'currency',
     currency: 'USD',
     minimumFractionDigits: 6,
@@ -182,7 +183,7 @@ export function formatChange(change: number): string {
   const absChange = Math.abs(change);
   const decimalPlaces = absChange >= 1 ? 2 : absChange >= 0.01 ? 4 : 6;
 
-  const formatted = new Intl.NumberFormat('en-US', {
+  const formatted = getIntlNumberFormatter('en-US', {
     style: 'currency',
     currency: 'USD',
     minimumFractionDigits: decimalPlaces,
@@ -199,7 +200,7 @@ export function formatPercentage(percent: number): string {
   if (isNaN(percent) || !isFinite(percent)) return '0.00%';
   if (percent === 0) return '0.00%';
 
-  const formatted = new Intl.NumberFormat('en-US', {
+  const formatted = getIntlNumberFormatter('en-US', {
     style: 'percent',
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Formatting functions in Perps didn't use cached version of Intl instaces which caused significant slowdowns all across the perps. Most significant one was for `transformMarketData` which previously run for 2s a now runs only ~40ms (50x faster).
This caused Perps to be unresponsive for that time after it was loaded. 

It should also help in all other places in Perps as these formatters are used everywhere.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Takes nearly 2s

<img width="1097" height="222" alt="Screenshot%202025-09-08%20at%2021 24 22" src="https://github.com/user-attachments/assets/86ac9d9c-ef50-43a2-98cf-495d28168f6b" />


### **After**

Only 40ms

<img width="753" height="314" alt="Screenshot 2025-09-09 at 14 20 26" src="https://github.com/user-attachments/assets/3e0a1e87-fbc9-4ae2-a1a6-73df82ed514b" />


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
