### PR TITLE
chore: faster usePerpsMarket hook

### DIFF
--- a/app/components/UI/Perps/hooks/usePerpsMarkets.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarkets.ts
@@ -5,11 +5,15 @@ import { PERPS_CONSTANTS } from '../constants/perpsConfig';
 import { usePerpsStream } from '../providers/PerpsStreamManager';
 import { parseCurrencyString } from '../utils/formatUtils';
 
+type PerpsMarketDataWithVolumeNumber = PerpsMarketData & {
+  volumeNumber: number;
+};
+
 export interface UsePerpsMarketsResult {
   /**
    * Transformed market data ready for UI consumption
    */
-  markets: PerpsMarketData[];
+  markets: PerpsMarketDataWithVolumeNumber[];
   /**
    * Loading state for initial data fetch
    */
@@ -46,6 +50,49 @@ export interface UsePerpsMarketsOptions {
   skipInitialFetch?: boolean;
 }
 
+const multipliers: Record<string, number> = {
+  K: 1e3,
+  M: 1e6,
+  B: 1e9,
+  T: 1e12,
+} as const;
+
+// Pre-compiled regex for better performance - avoids regex compilation on every call
+const VOLUME_SUFFIX_REGEX = /\$?([\d.,]+)([KMBT])?/;
+
+// Helper function to remove commas using for loop (~2x faster than regex for short strings)
+const removeCommas = (str: string): string => {
+  let result = '';
+  // eslint-disable-next-line @typescript-eslint/prefer-for-of
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+    if (char !== ',') result += char;
+  }
+  return result;
+};
+
+export const parseVolume = (volumeStr: string | undefined): number => {
+  if (!volumeStr) return -1; // Put undefined at the end
+
+  // Handle special cases
+  if (volumeStr === PERPS_CONSTANTS.FALLBACK_PRICE_DISPLAY) return -1;
+  if (volumeStr === '$<1') return 0.5; // Treat as very small but not zero
+
+  // Handle suffixed values (e.g., "$1.5M", "$2.3B", "$500K")
+  const suffixMatch = volumeStr.match(VOLUME_SUFFIX_REGEX);
+  if (suffixMatch) {
+    const [, numberPart, suffix] = suffixMatch;
+    const baseValue = parseFloat(removeCommas(numberPart));
+
+    if (isNaN(baseValue)) return -1;
+
+    return suffix ? baseValue * multipliers[suffix] : baseValue;
+  }
+
+  // Fallback to currency parser for regular values
+  return parseCurrencyString(volumeStr) || -1;
+};
+
 /**
  * Custom hook to fetch and manage Perps market data from the active provider
  * Uses the StreamManager's marketData channel for caching and deduplication
@@ -60,49 +107,22 @@ export const usePerpsMarkets = (
   } = options;
 
   const streamManager = usePerpsStream();
-  const [markets, setMarkets] = useState<PerpsMarketData[]>([]);
+  const [markets, setMarkets] = useState<PerpsMarketDataWithVolumeNumber[]>([]);
   const [isLoading, setIsLoading] = useState(!skipInitialFetch);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   // Helper function to sort markets by volume
   const sortMarketsByVolume = useCallback(
-    (marketData: PerpsMarketData[]): PerpsMarketData[] => {
-      const parseVolume = (volumeStr: string | undefined): number => {
-        if (!volumeStr) return -1; // Put undefined at the end
-
-        // Handle special cases
-        if (volumeStr === PERPS_CONSTANTS.FALLBACK_PRICE_DISPLAY) return -1;
-        if (volumeStr === '$<1') return 0.5; // Treat as very small but not zero
-
-        // Handle suffixed values (e.g., "$1.5M", "$2.3B", "$500K")
-        const suffixMatch = volumeStr.match(/\$?([\d.,]+)([KMBT])?/);
-        if (suffixMatch) {
-          const [, numberPart, suffix] = suffixMatch;
-          const baseValue = parseFloat(numberPart.replace(/,/g, ''));
-
-          if (isNaN(baseValue)) return -1;
-
-          const multipliers: Record<string, number> = {
-            K: 1e3,
-            M: 1e6,
-            B: 1e9,
-            T: 1e12,
-          };
-
-          return suffix ? baseValue * multipliers[suffix] : baseValue;
-        }
-
-        // Fallback to currency parser for regular values
-        return parseCurrencyString(volumeStr) || -1;
-      };
-
-      return [...marketData].sort((a, b) => {
-        const volumeA = parseVolume(a.volume);
-        const volumeB = parseVolume(b.volume);
-        return volumeB - volumeA; // Descending order
-      });
-    },
+    (marketData: PerpsMarketData[]): PerpsMarketDataWithVolumeNumber[] =>
+      marketData
+        // pregenerate volumeNumber for sorting to avoid recalculating it on every sort
+        .map((item) => ({ ...item, volumeNumber: parseVolume(item.volume) }))
+        .sort((a, b) => {
+          const volumeA = a.volumeNumber;
+          const volumeB = b.volumeNumber;
+          return volumeB - volumeA;
+        }),
     [],
   );
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Hook `usePerpsMarkets` was quite slow ~100-300ms and it was used in multiple places across the Perps. I optimized sorting to not call `parseVolume` that often and also optimized `parseVolume` itself. Hook should be around ~6x faster now (100ms => 15ms).

This will again reduce lag after switching to Perps tab and overall improve perf of dashboard.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open Perps tab
2. Everything should work

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Before 95ms

<img width="880" height="304" alt="Screenshot 2025-09-09 at 15 22 30" src="https://github.com/user-attachments/assets/ab2f3c60-c3dc-48f9-ab5e-f6611c4c04d3" />


### **After**

After 15ms

<img width="536" height="188" alt="Screenshot 2025-09-09 at 15 22 40" src="https://github.com/user-attachments/assets/eaeca8ec-66e1-4d0d-92b6-ef962b71be00" />


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
