### PR TITLE
refactor: remove RevealPrivateKey component and related references

### DIFF
--- a/app/components/Views/Settings/SecuritySettings/SecuritySettings.tsx
+++ b/app/components/Views/Settings/SecuritySettings/SecuritySettings.tsx
@@ -48,6 +48,7 @@ import {
 } from './Sections';
 import { selectProviderType } from '../../../../selectors/networkController';
 import { selectUseTransactionSimulations } from '../../../../selectors/preferencesController';
+import { selectMultichainAccountsState2Enabled } from '../../../../selectors/featureFlagController/multichainAccounts/enabledMultichainAccounts';
 import { SECURITY_PRIVACY_VIEW_ID } from '../../../../../wdio/screen-objects/testIDs/Screens/SecurityPrivacy.testIds';
 import createStyles from './SecuritySettings.styles';
 import { HeadingProps, SecuritySettingsParams } from './SecuritySettings.types';
@@ -154,6 +155,9 @@ const Settings: React.FC = () => {
   useCheckMultiRpcModal();
 
   const type = useSelector(selectProviderType);
+  const isMultichainAccountsState2Enabled = useSelector(
+    selectMultichainAccountsState2Enabled,
+  );
 
   const isMainnet = type === MAINNET;
 
@@ -540,7 +544,7 @@ const Settings: React.FC = () => {
         <View style={styles.setting}>
           <RememberMeOptionSection />
         </View>
-        <RevealPrivateKey />
+        {!isMultichainAccountsState2Enabled ? <RevealPrivateKey /> : null}
         <BlockaidSettings />
         <Heading>{strings('app_settings.privacy_heading')}</Heading>
         <View>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR removes an option to reveal private key from `Settings` -> `Security & Privacy`. We already have this functionality in Account details.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Removes "Show private key" fro Security & Privacy settings

## **Related issues**

Fixes:
Jira ticket: https://consensyssoftware.atlassian.net/browse/MUL-676

## **Manual testing steps**

```gherkin
Feature: Show private key

  Scenario: user wants to show private key
    Given user is already onboarded

    When user goes to Settings -> Security & Privacy
    Then "Show private key" section should not be visible
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="386" height="825" alt="Screenshot 2025-09-10 at 13 32 57" src="https://github.com/user-attachments/assets/973ae2a5-f478-4300-864b-41e1b666fc5b" />

<!-- [screenshots/recordings] -->

### **After**
<img width="387" height="831" alt="Screenshot 2025-09-10 at 13 34 31" src="https://github.com/user-attachments/assets/2ae9fe3d-d5a5-4521-9f4b-07f3a983c645" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
