### PR TITLE
fix: ui price formatting and input logic

### DIFF
--- a/app/components/UI/Perps/components/LivePriceDisplay/LivePriceHeader.test.tsx
+++ b/app/components/UI/Perps/components/LivePriceDisplay/LivePriceHeader.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react-native';
 import LivePriceHeader from './LivePriceHeader';
 import { usePerpsLivePrices } from '../../hooks/stream';
 import {
-  formatPrice,
+  formatPerpsFiat,
   formatPercentage,
   formatPnl,
 } from '../../utils/formatUtils';
@@ -18,8 +18,8 @@ describe('LivePriceHeader', () => {
   const mockUsePerpsLivePrices = usePerpsLivePrices as jest.MockedFunction<
     typeof usePerpsLivePrices
   >;
-  const mockFormatPrice = formatPrice as jest.MockedFunction<
-    typeof formatPrice
+  const mockFormatPerpsFiat = formatPerpsFiat as jest.MockedFunction<
+    typeof formatPerpsFiat
   >;
   const mockFormatPercentage = formatPercentage as jest.MockedFunction<
     typeof formatPercentage
@@ -29,7 +29,7 @@ describe('LivePriceHeader', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockFormatPrice.mockImplementation((price) => {
+    mockFormatPerpsFiat.mockImplementation((price) => {
       const num = typeof price === 'string' ? parseFloat(price) : price;
       return `$${num.toFixed(2)}`;
     });

--- a/app/components/UI/Perps/components/LivePriceDisplay/LivePriceHeader.tsx
+++ b/app/components/UI/Perps/components/LivePriceDisplay/LivePriceHeader.tsx
@@ -6,9 +6,10 @@ import Text, {
 } from '../../../../../component-library/components/Texts/Text';
 import { usePerpsLivePrices } from '../../hooks/stream';
 import {
-  formatPrice,
   formatPercentage,
   formatPnl,
+  formatPerpsFiat,
+  PRICE_RANGES_DETAILED_VIEW,
 } from '../../utils/formatUtils';
 import { useStyles } from '../../../../../component-library/hooks';
 
@@ -71,7 +72,7 @@ const LivePriceHeader: React.FC<LivePriceHeaderProps> = ({
         color={TextColor.Default}
         testID={testIDPrice}
       >
-        {formatPrice(displayPrice)}
+        {formatPerpsFiat(displayPrice, { ranges: PRICE_RANGES_DETAILED_VIEW })}
       </Text>
       <Text
         variant={TextVariant.BodyMD}

--- a/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.styles.ts
+++ b/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.styles.ts
@@ -29,6 +29,7 @@ export const createStyles = (colors: Theme['colors']) =>
       fontSize: 16,
       fontWeight: '500',
       color: colors.text.default,
+      flex: 1,
     },
     limitPriceCurrency: {
       fontSize: 16,

--- a/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.styles.ts
+++ b/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.styles.ts
@@ -29,7 +29,6 @@ export const createStyles = (colors: Theme['colors']) =>
       fontSize: 16,
       fontWeight: '500',
       color: colors.text.default,
-      flex: 1,
     },
     limitPriceCurrency: {
       fontSize: 16,

--- a/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.test.tsx
@@ -24,6 +24,31 @@ jest.mock('react-native-gesture-handler', () => ({
 
 jest.mock('react-native-linear-gradient', () => 'LinearGradient');
 
+// Mock React Native Animated
+jest.mock('react-native', () => {
+  const RN = jest.requireActual('react-native');
+  return {
+    ...RN,
+    Animated: {
+      ...RN.Animated,
+      Value: jest.fn(() => ({
+        setValue: jest.fn(),
+        stopAnimation: jest.fn(),
+      })),
+      timing: jest.fn(() => ({
+        start: jest.fn(),
+      })),
+      sequence: jest.fn(() => ({
+        start: jest.fn(),
+      })),
+      loop: jest.fn(() => ({
+        start: jest.fn(),
+      })),
+      View: RN.View,
+    },
+  };
+});
+
 // Mock safe area context (required for BottomSheet)
 jest.mock('react-native-safe-area-context', () => {
   const inset = { top: 0, right: 0, bottom: 0, left: 0 };
@@ -44,25 +69,75 @@ jest.mock('../../../../../util/theme', () => ({
   useTheme: mockUseTheme,
   mockTheme: {
     colors: {
-      background: { default: '#FFFFFF' },
-      text: { default: '#000000', alternative: '#666666' },
+      background: { default: '#FFFFFF', alternative: '#f0f0f0' },
+      text: { default: '#000000', alternative: '#666666', muted: '#999999' },
       border: { muted: '#CCCCCC' },
       success: { default: '#00FF00' },
+      primary: { default: '#0066cc' },
+      error: { default: '#ff0000' },
     },
   },
 }));
 
+// Mock useTailwind
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  useTailwind: jest.fn(() => ({
+    style: jest.fn((styles) => {
+      if (Array.isArray(styles)) {
+        return styles.reduce((acc, style) => ({ ...acc, ...style }), {});
+      }
+      return styles || {};
+    }),
+  })),
+}));
+
 // Mock format utilities
 jest.mock('../../utils/formatUtils', () => ({
-  formatPrice: jest.fn((value) => {
+  formatPerpsFiat: jest.fn((value, options = {}) => {
     const num = typeof value === 'string' ? parseFloat(value) : value;
-    return isNaN(num) ? '$0.00' : `$${num.toFixed(2)}`;
+    if (isNaN(num)) return '$0.00';
+    // Handle dynamic decimals from ranges config - match component behavior
+    if (options.ranges && options.ranges.length > 0) {
+      const range = options.ranges[0];
+      if (
+        range.minimumDecimals !== undefined &&
+        range.maximumDecimals !== undefined
+      ) {
+        // Use the minimumDecimals as set by the component logic
+        return `$${num.toFixed(range.minimumDecimals)}`;
+      }
+    }
+    return `$${num.toFixed(2)}`;
   }),
+  formatWithSignificantDigits: jest.fn((value, significantDigits) => {
+    const num = typeof value === 'number' ? value : parseFloat(value);
+    if (isNaN(num)) return { value: '0', formatted: '$0.00' };
+    return {
+      value: num.toFixed(significantDigits || 2),
+      formatted: `$${num.toFixed(significantDigits || 2)}`,
+    };
+  }),
+  PRICE_RANGES_POSITION_VIEW: [
+    {
+      condition: () => true,
+      minimumDecimals: 2,
+      maximumDecimals: 2,
+      threshold: 0.01,
+    },
+  ],
 }));
 
 // Mock strings
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: jest.fn((key) => key),
+}));
+
+// Mock BigNumber
+jest.mock('bignumber.js', () => ({
+  BigNumber: jest.fn().mockImplementation((value) => ({
+    multipliedBy: jest.fn().mockReturnThis(),
+    toString: jest.fn(() => value.toString()),
+  })),
 }));
 
 // Mock stream hooks
@@ -283,6 +358,7 @@ describe('PerpsLimitPriceBottomSheet', () => {
     onConfirm: jest.fn(),
     asset: 'ETH',
     currentPrice: 3000,
+    direction: 'long' as const,
   };
 
   beforeEach(() => {
@@ -337,7 +413,8 @@ describe('PerpsLimitPriceBottomSheet', () => {
 
       // Assert
       expect(screen.getByText('perps.order.limit_price')).toBeOnTheScreen(); // Placeholder
-      expect(screen.getAllByText('USD')).toHaveLength(2); // Currency label + keypad currency
+      expect(screen.getByText('USD')).toBeOnTheScreen(); // Currency label
+      expect(screen.getByText('USD_PERPS')).toBeOnTheScreen(); // Keypad currency
     });
 
     it('displays initial limit price when provided', () => {
@@ -348,7 +425,7 @@ describe('PerpsLimitPriceBottomSheet', () => {
       render(<PerpsLimitPriceBottomSheet {...props} />);
 
       // Assert
-      expect(screen.getByText('$3100.00')).toBeOnTheScreen(); // Formatted limit price display
+      expect(screen.getByText(/\$3100/)).toBeOnTheScreen(); // Formatted limit price display
       expect(screen.getByText('3100')).toBeOnTheScreen(); // Keypad value
     });
 
@@ -358,7 +435,9 @@ describe('PerpsLimitPriceBottomSheet', () => {
 
       // Assert
       expect(screen.getByTestId('keypad-component')).toBeOnTheScreen();
-      expect(screen.getByTestId('keypad-currency')).toHaveTextContent('USD');
+      expect(screen.getByTestId('keypad-currency')).toHaveTextContent(
+        'USD_PERPS',
+      ); // Updated to match component
     });
   });
 
@@ -400,58 +479,59 @@ describe('PerpsLimitPriceBottomSheet', () => {
       );
 
       // Assert
-      expect(screen.getByTestId('keypad-currency')).toHaveTextContent('USD');
+      expect(screen.getByTestId('keypad-currency')).toHaveTextContent(
+        'USD_PERPS',
+      ); // Updated to match component
       expect(screen.getByTestId('keypad-value')).toHaveTextContent('3100'); // Initial value
     });
   });
 
   describe('Quick Action Buttons', () => {
-    it('calculates -1% price when -1% button is pressed', () => {
+    it('displays direction-specific preset buttons for long orders', () => {
       // Act
-      render(<PerpsLimitPriceBottomSheet {...defaultProps} />);
+      render(<PerpsLimitPriceBottomSheet {...defaultProps} direction="long" />);
 
-      const onePercentButton = screen.getByText('-1%');
-      fireEvent.press(onePercentButton);
-
-      // Assert - Button exists and is pressable
-      expect(onePercentButton).toBeOnTheScreen();
+      // Assert - Long orders show negative percentages (buy below market)
+      expect(screen.getByText('-1%')).toBeOnTheScreen();
+      expect(screen.getByText('-2%')).toBeOnTheScreen();
+      expect(screen.getByText('-5%')).toBeOnTheScreen();
+      expect(screen.getByText('-10%')).toBeOnTheScreen();
     });
 
-    it('calculates -2% price when -2% button is pressed', () => {
+    it('displays direction-specific preset buttons for short orders', () => {
       // Act
-      render(<PerpsLimitPriceBottomSheet {...defaultProps} />);
-
-      const twoPercentButton = screen.getByText('-2%');
-      fireEvent.press(twoPercentButton);
-
-      // Assert - Button exists and is pressable
-      expect(twoPercentButton).toBeOnTheScreen();
-    });
-
-    it('uses current price as base for percentage calculations when no limit price set', () => {
-      // Arrange - No initial limit price
-      render(<PerpsLimitPriceBottomSheet {...defaultProps} />);
-
-      // Act
-      const onePercentButton = screen.getByText('-1%');
-      fireEvent.press(onePercentButton);
-
-      // Assert - Should calculate based on current price ($3000)
-      // -1% of 3000 = 2970
-      expect(onePercentButton).toBeOnTheScreen();
-    });
-
-    it('uses existing limit price as base for percentage calculations when set', () => {
-      // Arrange - With initial limit price
       render(
-        <PerpsLimitPriceBottomSheet {...defaultProps} limitPrice="3100" />,
+        <PerpsLimitPriceBottomSheet {...defaultProps} direction="short" />,
       );
 
+      // Assert - Short orders show positive percentages (sell above market)
+      expect(screen.getByText('+1%')).toBeOnTheScreen();
+      expect(screen.getByText('+2%')).toBeOnTheScreen();
+      expect(screen.getByText('+5%')).toBeOnTheScreen();
+      expect(screen.getByText('+10%')).toBeOnTheScreen();
+    });
+
+    it('calculates price based on current market price for long orders', () => {
       // Act
+      render(<PerpsLimitPriceBottomSheet {...defaultProps} direction="long" />);
+
       const onePercentButton = screen.getByText('-1%');
       fireEvent.press(onePercentButton);
 
-      // Assert - Should calculate based on limit price ($3100)
+      // Assert - Button exists and is pressable
+      expect(onePercentButton).toBeOnTheScreen();
+    });
+
+    it('calculates price based on current market price for short orders', () => {
+      // Act
+      render(
+        <PerpsLimitPriceBottomSheet {...defaultProps} direction="short" />,
+      );
+
+      const onePercentButton = screen.getByText('+1%');
+      fireEvent.press(onePercentButton);
+
+      // Assert - Button exists and is pressable
       expect(onePercentButton).toBeOnTheScreen();
     });
   });
@@ -562,9 +642,6 @@ describe('PerpsLimitPriceBottomSheet', () => {
 
     it('handles percentage calculations with zero base price', () => {
       // Arrange - No price data available
-      const { usePerpsPrices } = jest.requireMock('../../hooks/usePerpsPrices');
-      usePerpsPrices.mockReturnValue({});
-
       render(<PerpsLimitPriceBottomSheet {...defaultProps} currentPrice={0} />);
 
       // Act

--- a/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.tsx
@@ -124,6 +124,60 @@ const PerpsLimitPriceBottomSheet: React.FC<PerpsLimitPriceBottomSheetProps> = ({
   );
 
   /**
+   * Format limit price with proper decimal handling
+   * @param price - Price string to format
+   * @returns Formatted price string
+   */
+  const formatLimitPriceValue = useCallback((price: string) => {
+    if (!price || price === '0') {
+      return '';
+    }
+
+    const formatConfig = {
+      ranges: [
+        {
+          condition: () => true,
+          threshold: 0.00000001,
+          maximumDecimals: 7,
+          minimumDecimals: Math.min(price.split('.')[1]?.length || 0, 7),
+        },
+      ],
+    };
+
+    return formatPerpsFiat(price, formatConfig);
+  }, []);
+
+  /**
+   * Get text color for limit price based on value
+   * @param price - Price string to check
+   * @returns Style object with color
+   */
+  const getLimitPriceTextStyle = useCallback(
+    (price: string) => {
+      const baseStyle = styles.limitPriceValue;
+      const isEmptyOrZero = !price || price === '0';
+
+      return [baseStyle, isEmptyOrZero && { color: colors.text.muted }];
+    },
+    [colors.text.muted, styles.limitPriceValue],
+  );
+
+  /**
+   * Get animated cursor style
+   * @returns Style array for animated cursor
+   */
+  const getCursorStyle = useCallback(
+    () => [
+      tw.style('w-0.5 h-5'),
+      {
+        backgroundColor: colors.primary.default,
+        opacity: cursorOpacity,
+      },
+    ],
+    [colors.primary.default, cursorOpacity, tw],
+  );
+
+  /**
    * Calculate limit price based on percentage from current market price
    * @param percentage - Percentage to add/subtract from current price
    * @returns Calculated price as string (e.g., "45123.50")
@@ -186,40 +240,11 @@ const PerpsLimitPriceBottomSheet: React.FC<PerpsLimitPriceBottomSheetProps> = ({
         </Text>
         <View style={styles.limitPriceDisplay}>
           <View style={tw.style('flex-row items-center flex-1')}>
-            <Text
-              style={[
-                styles.limitPriceValue,
-                (!limitPrice || limitPrice === '0') && {
-                  color: colors.text.muted,
-                },
-              ]}
-            >
-              {!limitPrice || limitPrice === '0'
-                ? ''
-                : formatPerpsFiat(limitPrice, {
-                    ranges: [
-                      {
-                        condition: () => true,
-                        threshold: 0.00000001,
-                        maximumDecimals: 7,
-                        minimumDecimals: Math.min(
-                          limitPrice.split('.')[1]?.length || 0,
-                          7,
-                        ),
-                      },
-                    ],
-                  })}
+            <Text style={getLimitPriceTextStyle(limitPrice)}>
+              {formatLimitPriceValue(limitPrice)}
             </Text>
             {/* Blinking cursor */}
-            <Animated.View
-              style={[
-                tw.style('w-0.5 h-5'),
-                {
-                  backgroundColor: colors.primary.default,
-                  opacity: cursorOpacity,
-                },
-              ]}
-            />
+            <Animated.View style={getCursorStyle()} />
           </View>
           <Text style={styles.limitPriceCurrency}>USD</Text>
         </View>

--- a/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.test.tsx
@@ -489,8 +489,8 @@ describe('PerpsMarketRowItem', () => {
 
       render(<PerpsMarketRowItem market={mockMarketData} />);
 
-      // With 2 decimal enforcement, very small prices show as $0.00
-      expect(screen.getByText('$0.00')).toBeOnTheScreen();
+      // With PRICE_RANGES_DETAILED_VIEW, small prices preserve 3 significant digits
+      expect(screen.getByText('$0.000123')).toBeOnTheScreen();
     });
 
     it('handles very large price values', () => {

--- a/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.tsx
@@ -43,9 +43,13 @@ const PerpsMarketRowItem = ({ market, onPress }: PerpsMarketRowItemProps) => {
     const formattedPrice = formatPerpsFiat(currentPrice, {
       ranges: PRICE_RANGES_DETAILED_VIEW,
     });
+    const comparisonPrice = formatPerpsFiat(currentPrice, {
+      minimumDecimals: 2,
+      maximumDecimals: 2,
+    });
 
     // Only update if price actually changed
-    if (livePrice.price === market.price) {
+    if (comparisonPrice === market.price) {
       return market;
     }
 

--- a/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.tsx
@@ -1,24 +1,25 @@
 import React, { useMemo } from 'react';
-import { View, TouchableOpacity } from 'react-native';
-import { useStyles } from '../../../../../component-library/hooks';
+import { TouchableOpacity, View } from 'react-native';
+import { getPerpsMarketRowItemSelector } from '../../../../../../e2e/selectors/Perps/Perps.selectors';
 import Text, {
-  TextVariant,
   TextColor,
+  TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
-import { PerpsMarketRowItemProps } from './PerpsMarketRowItem.types';
-import styleSheet from './PerpsMarketRowItem.styles';
-import PerpsTokenLogo from '../PerpsTokenLogo';
-import { usePerpsLivePrices } from '../../hooks/stream';
+import { useStyles } from '../../../../../component-library/hooks';
+import { PERPS_CONSTANTS } from '../../constants/perpsConfig';
 import type { PerpsMarketData } from '../../controllers/types';
+import { usePerpsLivePrices } from '../../hooks/stream';
 import {
-  formatPrice,
   formatPercentage,
+  formatPerpsFiat,
   formatPnl,
   formatVolume,
+  PRICE_RANGES_DETAILED_VIEW,
 } from '../../utils/formatUtils';
-import { getPerpsMarketRowItemSelector } from '../../../../../../e2e/selectors/Perps/Perps.selectors';
-import { PERPS_CONSTANTS } from '../../constants/perpsConfig';
 import PerpsLeverage from '../PerpsLeverage/PerpsLeverage';
+import PerpsTokenLogo from '../PerpsTokenLogo';
+import styleSheet from './PerpsMarketRowItem.styles';
+import { PerpsMarketRowItemProps } from './PerpsMarketRowItem.types';
 
 const PerpsMarketRowItem = ({ market, onPress }: PerpsMarketRowItemProps) => {
   const { styles } = useStyles(styleSheet, {});
@@ -38,13 +39,13 @@ const PerpsMarketRowItem = ({ market, onPress }: PerpsMarketRowItemProps) => {
 
     // Parse and format the price with exactly 2 decimals for consistency
     const currentPrice = parseFloat(livePrice.price);
-    const formattedPrice = formatPrice(currentPrice, {
-      minimumDecimals: 2,
-      maximumDecimals: 2,
+
+    const formattedPrice = formatPerpsFiat(currentPrice, {
+      ranges: PRICE_RANGES_DETAILED_VIEW,
     });
 
     // Only update if price actually changed
-    if (formattedPrice === market.price) {
+    if (livePrice.price === market.price) {
       return market;
     }
 

--- a/app/components/UI/Perps/components/PerpsOpenOrderCard/PerpsOpenOrderCard.tsx
+++ b/app/components/UI/Perps/components/PerpsOpenOrderCard/PerpsOpenOrderCard.tsx
@@ -203,7 +203,9 @@ const PerpsOpenOrderCard: React.FC<PerpsOpenOrderCardProps> = ({
                 variant={TextVariant.BodySMMedium}
                 color={TextColor.Default}
               >
-                {formatPrice(order.price)}
+                {formatPerpsFiat(order.price, {
+                  ranges: PRICE_RANGES_DETAILED_VIEW,
+                })}
               </Text>
             </View>
             {/* Only show TP/SL for non-trigger orders */}
@@ -239,7 +241,9 @@ const PerpsOpenOrderCard: React.FC<PerpsOpenOrderCardProps> = ({
                     color={TextColor.Default}
                   >
                     {order.stopLossPrice
-                      ? formatPrice(order.stopLossPrice)
+                      ? formatPerpsFiat(order.stopLossPrice, {
+                          ranges: PRICE_RANGES_DETAILED_VIEW,
+                        })
                       : strings('perps.position.card.not_set')}
                   </Text>
                 </View>

--- a/app/components/UI/Perps/components/PerpsOpenOrderCard/PerpsOpenOrderCard.tsx
+++ b/app/components/UI/Perps/components/PerpsOpenOrderCard/PerpsOpenOrderCard.tsx
@@ -21,6 +21,8 @@ import {
   formatPrice,
   formatPositionSize,
   formatTransactionDate,
+  PRICE_RANGES_DETAILED_VIEW,
+  formatPerpsFiat,
 } from '../../utils/formatUtils';
 import styleSheet from './PerpsOpenOrderCard.styles';
 import { PerpsOpenOrderCardSelectorsIDs } from '../../../../../../e2e/selectors/Perps/Perps.selectors';
@@ -219,7 +221,9 @@ const PerpsOpenOrderCard: React.FC<PerpsOpenOrderCardProps> = ({
                     color={TextColor.Default}
                   >
                     {order.takeProfitPrice
-                      ? formatPrice(order.takeProfitPrice)
+                      ? formatPerpsFiat(order.takeProfitPrice, {
+                          ranges: PRICE_RANGES_DETAILED_VIEW,
+                        })
                       : strings('perps.position.card.not_set')}
                   </Text>
                 </View>

--- a/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
+++ b/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
@@ -29,9 +29,12 @@ import type {
 } from '../../controllers/types';
 import { usePerpsMarkets, usePerpsTPSLUpdate } from '../../hooks';
 import {
+  formatPerpsFiat,
   formatPnl,
   formatPositionSize,
   formatPrice,
+  PRICE_RANGES_MINIMAL_VIEW,
+  PRICE_RANGES_POSITION_VIEW,
 } from '../../utils/formatUtils';
 import PerpsTPSLBottomSheet from '../PerpsTPSLBottomSheet';
 import PerpsTokenLogo from '../PerpsTokenLogo';
@@ -134,6 +137,7 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
       return;
     }
 
+    DevLogger.log('PerpsPositionCard: Editing TPSL', { position });
     setSelectedPosition(position);
     setIsTPSLVisible(true);
   };
@@ -213,9 +217,8 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
                   {strings('perps.position.card.entry_price')}
                 </Text>
                 <Text variant={TextVariant.BodySM} color={TextColor.Default}>
-                  {formatPrice(position.entryPrice, {
-                    minimumDecimals: 2,
-                    maximumDecimals: 2,
+                  {formatPerpsFiat(position.entryPrice, {
+                    ranges: PRICE_RANGES_POSITION_VIEW,
                   })}
                 </Text>
               </View>
@@ -228,9 +231,8 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
                 </Text>
                 <Text variant={TextVariant.BodySM} color={TextColor.Default}>
                   {position.liquidationPrice
-                    ? formatPrice(position.liquidationPrice, {
-                        minimumDecimals: 2,
-                        maximumDecimals: 2,
+                    ? formatPerpsFiat(position.liquidationPrice, {
+                        ranges: PRICE_RANGES_POSITION_VIEW,
                       })
                     : 'N/A'}
                 </Text>
@@ -243,9 +245,8 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
                   {strings('perps.position.card.margin')}
                 </Text>
                 <Text variant={TextVariant.BodySM} color={TextColor.Default}>
-                  {formatPrice(position.marginUsed, {
-                    minimumDecimals: 2,
-                    maximumDecimals: 2,
+                  {formatPerpsFiat(position.marginUsed, {
+                    ranges: PRICE_RANGES_MINIMAL_VIEW,
                   })}
                 </Text>
               </View>
@@ -261,9 +262,8 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
                 </Text>
                 <Text variant={TextVariant.BodySM} color={TextColor.Default}>
                   {position.takeProfitPrice
-                    ? formatPrice(position.takeProfitPrice, {
-                        minimumDecimals: 2,
-                        maximumDecimals: 2,
+                    ? formatPerpsFiat(position.takeProfitPrice, {
+                        ranges: PRICE_RANGES_POSITION_VIEW,
                       })
                     : strings('perps.position.card.not_set')}
                 </Text>
@@ -277,9 +277,8 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
                 </Text>
                 <Text variant={TextVariant.BodySM} color={TextColor.Default}>
                   {position.stopLossPrice
-                    ? formatPrice(position.stopLossPrice, {
-                        minimumDecimals: 2,
-                        maximumDecimals: 2,
+                    ? formatPerpsFiat(position.stopLossPrice, {
+                        ranges: PRICE_RANGES_POSITION_VIEW,
                       })
                     : strings('perps.position.card.not_set')}
                 </Text>
@@ -321,11 +320,10 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
                   {parseFloat(position.cumulativeFunding.sinceOpen) >= 0
                     ? '-'
                     : '+'}
-                  {formatPrice(
+                  {formatPerpsFiat(
                     Math.abs(parseFloat(position.cumulativeFunding.sinceOpen)),
                     {
-                      minimumDecimals: 2,
-                      maximumDecimals: 2,
+                      ranges: PRICE_RANGES_MINIMAL_VIEW,
                     },
                   )}
                 </Text>

--- a/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.tsx
+++ b/app/components/UI/Perps/components/PerpsSlider/PerpsSlider.tsx
@@ -94,7 +94,9 @@ const PerpsSlider: React.FC<PerpsSliderProps> = ({
       // Handle case where min and max are equal (e.g., zero balance)
       const range = maximumValue - minimumValue;
       const percentage = range === 0 ? 0 : (value - minimumValue) / range;
-      translateX.value = percentage * width;
+      // Clamp percentage between 0 and 1 to prevent thumb from exceeding track width
+      const clampedPercentage = Math.max(0, Math.min(1, percentage));
+      translateX.value = clampedPercentage * width;
     },
     [value, minimumValue, maximumValue, sliderWidth, translateX],
   );

--- a/app/components/UI/Perps/components/PerpsTPSLBottomSheet/PerpsTPSLBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsTPSLBottomSheet/PerpsTPSLBottomSheet.test.tsx
@@ -179,6 +179,25 @@ jest.mock('../../utils/formatUtils', () => ({
     const num = typeof value === 'string' ? parseFloat(value) : value;
     return isNaN(num) ? '$0.00' : `$${num.toFixed(2)}`;
   }),
+  formatPerpsFiat: jest.fn((value) => {
+    const num = typeof value === 'string' ? parseFloat(value) : value;
+    return isNaN(num) ? '$0.00' : `$${num.toFixed(2)}`;
+  }),
+  PRICE_RANGES_POSITION_VIEW: [
+    {
+      condition: (v: number) => v >= 1,
+      minimumDecimals: 2,
+      maximumDecimals: 2,
+      threshold: 1,
+    },
+    {
+      condition: (v: number) => v < 1,
+      minimumDecimals: 2,
+      maximumDecimals: 7,
+      significantDigits: 4,
+      threshold: 0.0000001,
+    },
+  ],
 }));
 
 // Mock strings

--- a/app/components/UI/Perps/components/PerpsTPSLBottomSheet/PerpsTPSLBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsTPSLBottomSheet/PerpsTPSLBottomSheet.tsx
@@ -39,7 +39,10 @@ import {
 import { usePerpsTPSLForm } from '../../hooks/usePerpsTPSLForm';
 import { usePerpsLiquidationPrice } from '../../hooks/usePerpsLiquidationPrice';
 import { createStyles } from './PerpsTPSLBottomSheet.styles';
-import { formatPrice } from '../../utils/formatUtils';
+import {
+  formatPerpsFiat,
+  PRICE_RANGES_POSITION_VIEW,
+} from '../../utils/formatUtils';
 
 // Quick percentage buttons constants - RoE percentages
 const TAKE_PROFIT_PERCENTAGES = [10, 25, 50, 100]; // +10%, +25%, +50%, +100% RoE
@@ -59,6 +62,8 @@ interface PerpsTPSLBottomSheetProps {
   isUpdating?: boolean;
   leverage?: number; // For new orders
   marginRequired?: string; // For new orders
+  orderType?: 'market' | 'limit'; // Order type for new orders
+  limitPrice?: string; // Limit price for limit orders
 }
 
 const PerpsTPSLBottomSheet: React.FC<PerpsTPSLBottomSheetProps> = ({
@@ -73,6 +78,8 @@ const PerpsTPSLBottomSheet: React.FC<PerpsTPSLBottomSheetProps> = ({
   initialStopLossPrice,
   isUpdating = false,
   leverage: propLeverage,
+  orderType,
+  limitPrice,
 }) => {
   const { colors } = useTheme();
   const styles = createStyles(colors);
@@ -99,6 +106,18 @@ const PerpsTPSLBottomSheet: React.FC<PerpsTPSLBottomSheetProps> = ({
     initialCurrentPrice ||
     (position?.entryPrice ? parseFloat(position.entryPrice) : 0);
 
+  // Determine the entry price based on order type
+  // For limit orders, use the limit price as entry price if available
+  // For market orders or when limit price is not set, use current price
+  // Ensure we always have a valid price > 0 for calculations
+  const effectiveEntryPrice = position?.entryPrice
+    ? parseFloat(position.entryPrice)
+    : orderType === 'limit' && limitPrice && parseFloat(limitPrice) > 0
+    ? parseFloat(limitPrice)
+    : currentPrice > 0
+    ? currentPrice
+    : livePrice || initialCurrentPrice || 0;
+
   // Use the TPSL form hook for all state management and business logic
   const tpslForm = usePerpsTPSLForm({
     asset,
@@ -108,9 +127,7 @@ const PerpsTPSLBottomSheet: React.FC<PerpsTPSLBottomSheetProps> = ({
     initialTakeProfitPrice,
     initialStopLossPrice,
     leverage: propLeverage,
-    entryPrice: position?.entryPrice
-      ? parseFloat(position.entryPrice)
-      : currentPrice,
+    entryPrice: effectiveEntryPrice,
     isVisible,
   });
 
@@ -186,10 +203,11 @@ const PerpsTPSLBottomSheet: React.FC<PerpsTPSLBottomSheetProps> = ({
 
   const handleConfirm = useCallback(() => {
     // Parse the formatted prices back to plain numbers for storage
-    const parseTakeProfitPrice = takeProfitPrice
+    // Check for non-empty strings (empty strings should be treated as undefined)
+    const parseTakeProfitPrice = takeProfitPrice?.trim()
       ? takeProfitPrice.replace(/[$,]/g, '')
       : undefined;
-    const parseStopLossPrice = stopLossPrice
+    const parseStopLossPrice = stopLossPrice?.trim()
       ? stopLossPrice.replace(/[$,]/g, '')
       : undefined;
 
@@ -284,7 +302,11 @@ const PerpsTPSLBottomSheet: React.FC<PerpsTPSLBottomSheetProps> = ({
               {strings('perps.tpsl.current_price')}
             </Text>
             <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
-              {currentPrice ? formatPrice(currentPrice) : '--'}
+              {currentPrice
+                ? formatPerpsFiat(currentPrice, {
+                    ranges: PRICE_RANGES_POSITION_VIEW,
+                  })
+                : '--'}
             </Text>
           </View>
           <View style={styles.priceInfoRow}>
@@ -295,7 +317,9 @@ const PerpsTPSLBottomSheet: React.FC<PerpsTPSLBottomSheetProps> = ({
               {displayLiquidationPrice &&
               displayLiquidationPrice !== 'null' &&
               displayLiquidationPrice !== '0.00'
-                ? formatPrice(parseFloat(displayLiquidationPrice))
+                ? formatPerpsFiat(displayLiquidationPrice, {
+                    ranges: PRICE_RANGES_POSITION_VIEW,
+                  })
                 : '--'}
             </Text>
           </View>
@@ -369,6 +393,8 @@ const PerpsTPSLBottomSheet: React.FC<PerpsTPSLBottomSheetProps> = ({
                 keyboardType="numeric"
                 onFocus={handleTakeProfitPriceFocus}
                 onBlur={handleTakeProfitPriceBlur}
+                selectionColor={colors.primary.default}
+                cursorColor={colors.primary.default}
               />
               <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
                 {strings('perps.tpsl.usd_label')}
@@ -391,6 +417,8 @@ const PerpsTPSLBottomSheet: React.FC<PerpsTPSLBottomSheetProps> = ({
                 keyboardType="numeric"
                 onFocus={handleTakeProfitPercentageFocus}
                 onBlur={handleTakeProfitPercentageBlur}
+                selectionColor={colors.primary.default}
+                cursorColor={colors.primary.default}
               />
               <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
                 %
@@ -474,6 +502,8 @@ const PerpsTPSLBottomSheet: React.FC<PerpsTPSLBottomSheetProps> = ({
                 keyboardType="numeric"
                 onFocus={handleStopLossPriceFocus}
                 onBlur={handleStopLossPriceBlur}
+                selectionColor={colors.primary.default}
+                cursorColor={colors.primary.default}
               />
               <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
                 {strings('perps.tpsl.usd_label')}
@@ -496,6 +526,8 @@ const PerpsTPSLBottomSheet: React.FC<PerpsTPSLBottomSheetProps> = ({
                 keyboardType="numeric"
                 onFocus={handleStopLossPercentageFocus}
                 onBlur={handleStopLossPercentageBlur}
+                selectionColor={colors.primary.default}
+                cursorColor={colors.primary.default}
               />
               <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
                 %

--- a/app/components/UI/Perps/controllers/providers/HyperLiquidProvider.ts
+++ b/app/components/UI/Perps/controllers/providers/HyperLiquidProvider.ts
@@ -438,7 +438,7 @@ export class HyperLiquidProvider implements IPerpsProvider {
          *
          * IMPORTANT: Use 'FrontendMarket' for market orders, NOT 'Ioc'
          * Using 'Ioc' causes market orders to be treated as limit orders by HyperLiquid,
-         * leading to incorrect order type display in transaction history (TAT-1447)
+         * leading to incorrect order type display in transaction history (TAT-1475)
          */
         t:
           params.orderType === 'limit'
@@ -765,6 +765,7 @@ export class HyperLiquidProvider implements IPerpsProvider {
         (order) =>
           order.coin === coin &&
           order.reduceOnly === true &&
+          order.sz === position.size &&
           order.isTrigger === true &&
           (order.orderType.includes('Take Profit') ||
             order.orderType.includes('Stop')),
@@ -2082,14 +2083,14 @@ export class HyperLiquidProvider implements IPerpsProvider {
       const denominator = 1 - l * side;
       if (Math.abs(denominator) < 0.0001) {
         // Avoid division by very small numbers
-        return entryPrice.toFixed(2);
+        return String(entryPrice);
       }
 
       const liquidationPrice =
         entryPrice - (side * marginAvailable * entryPrice) / denominator;
 
       // Ensure liquidation price is non-negative
-      return Math.max(0, liquidationPrice).toFixed(2);
+      return String(Math.max(0, liquidationPrice));
     } catch (error) {
       DevLogger.log('Error calculating liquidation price:', error);
       return '0.00';

--- a/app/components/UI/Perps/hooks/usePerpsMarketStats.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketStats.test.ts
@@ -89,8 +89,8 @@ describe('usePerpsMarketStats', () => {
     expect(result.current.currentPrice).toBe(45000);
     expect(result.current.high24h).toBe('$46,000.00');
     expect(result.current.low24h).toBe('$43,500.00');
-    expect(result.current.volume24h).toBe('$1B');
-    expect(result.current.openInterest).toBe('$990M');
+    expect(result.current.volume24h).toBe('$1.23B');
+    expect(result.current.openInterest).toBe('$990.00M');
     expect(result.current.fundingRate).toBe('1.0000%');
     expect(result.current.isLoading).toBe(false);
   });
@@ -160,8 +160,8 @@ describe('usePerpsMarketStats', () => {
 
     const { result } = renderHook(() => usePerpsMarketStats('BTC'));
 
-    expect(result.current.volume24h).toBe('$12T'); // No decimals in formatVolume
-    expect(result.current.openInterest).toBe('$99T'); // No decimals in formatLargeNumber
+    expect(result.current.volume24h).toBe('$12.35T'); // Decimals in formatVolume for detailed view
+    expect(result.current.openInterest).toBe('$99.00T'); // Decimals in formatLargeNumber for detailed view
   });
 
   it('formats negative funding rates with proper sign and decimals', () => {

--- a/app/components/UI/Perps/hooks/usePerpsMarketStats.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketStats.ts
@@ -3,9 +3,11 @@ import Engine from '../../../../core/Engine';
 import { usePerpsPositionData } from './usePerpsPositionData';
 import type { PriceUpdate } from '../controllers/types';
 import {
-  formatPrice,
   formatLargeNumber,
   formatFundingRate,
+  PRICE_RANGES_DETAILED_VIEW,
+  LARGE_NUMBER_RANGES_DETAILED,
+  formatPerpsFiat,
 } from '../utils/formatUtils';
 import { calculate24hHighLow } from '../utils/marketUtils';
 import { CandlePeriod, TimeDuration } from '../constants/chartConfig';
@@ -110,23 +112,25 @@ export const usePerpsMarketStats = (
       // 24h high/low from candlestick data, with fallback estimates
       high24h:
         high > 0
-          ? formatPrice(high, { minimumDecimals: 2, maximumDecimals: 2 })
-          : formatPrice(fallbackPrice, {
-              minimumDecimals: 2,
-              maximumDecimals: 2,
+          ? formatPerpsFiat(high, { ranges: PRICE_RANGES_DETAILED_VIEW })
+          : formatPerpsFiat(fallbackPrice, {
+              ranges: PRICE_RANGES_DETAILED_VIEW,
             }),
       low24h:
         low > 0
-          ? formatPrice(low, { minimumDecimals: 2, maximumDecimals: 2 })
-          : formatPrice(fallbackPrice, {
-              minimumDecimals: 2,
-              maximumDecimals: 2,
+          ? formatPerpsFiat(low, { ranges: PRICE_RANGES_DETAILED_VIEW })
+          : formatPerpsFiat(fallbackPrice, {
+              ranges: PRICE_RANGES_DETAILED_VIEW,
             }),
       volume24h: marketData.volume24h
-        ? `$${formatLargeNumber(marketData.volume24h)}`
+        ? `$${formatLargeNumber(marketData.volume24h, {
+            ranges: LARGE_NUMBER_RANGES_DETAILED,
+          })}`
         : '$0.00',
       openInterest: marketData.openInterest
-        ? `$${formatLargeNumber(marketData.openInterest)}`
+        ? `$${formatLargeNumber(marketData.openInterest, {
+            ranges: LARGE_NUMBER_RANGES_DETAILED,
+          })}`
         : '$0.00',
       fundingRate: formatFundingRate(marketData.funding),
       currentPrice: fallbackPrice,

--- a/app/components/UI/Perps/hooks/usePerpsOrderForm.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderForm.test.ts
@@ -78,6 +78,47 @@ describe('usePerpsOrderForm', () => {
         TRADING_DEFAULTS.amount.testnet.toString(),
       );
     });
+
+    it('should set amount to maxPossibleAmount when available balance times leverage is less than default amount', () => {
+      // Arrange - Set low available balance
+      mockUsePerpsAccount.mockReturnValue({
+        availableBalance: '2', // $2 available balance
+        totalBalance: '2',
+        marginUsed: '0',
+        unrealizedPnl: '0',
+        returnOnEquity: '0',
+        totalValue: '2',
+      });
+
+      // Act
+      const { result } = renderHook(() => usePerpsOrderForm());
+
+      // Assert
+      // With $2 balance and 3x leverage = $6 max amount, which is less than $10 default
+      // Should use the max possible amount ($6) instead of the default ($10)
+      expect(result.current.orderForm.amount).toBe('6');
+    });
+
+    it('should use default amount when available balance times leverage is greater than default amount', () => {
+      // Arrange - Set sufficient available balance
+      mockUsePerpsAccount.mockReturnValue({
+        availableBalance: '5', // $5 available balance
+        totalBalance: '5',
+        marginUsed: '0',
+        unrealizedPnl: '0',
+        returnOnEquity: '0',
+        totalValue: '5',
+      });
+
+      // Act
+      const { result } = renderHook(() => usePerpsOrderForm());
+
+      // Assert
+      // With $5 balance and 3x leverage = $15 max amount, which is greater than $10 default
+      expect(result.current.orderForm.amount).toBe(
+        TRADING_DEFAULTS.amount.mainnet.toString(),
+      );
+    });
   });
 
   describe('form updates', () => {

--- a/app/components/UI/Perps/hooks/usePerpsTPSLForm.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLForm.ts
@@ -18,6 +18,7 @@ import {
   formatPerpsFiat,
   PRICE_RANGES_POSITION_VIEW,
 } from '../utils/formatUtils';
+import { regex } from '../../../../util/regex';
 
 interface UsePerpsTPSLFormParams {
   asset: string;
@@ -620,11 +621,15 @@ export function usePerpsTPSLForm(
 
       // Only set values if we got a valid price
       if (price && price !== '' && parseFloat(price) > 0) {
-        setTakeProfitPrice(
-          formatPerpsFiat(price.toString(), {
-            ranges: PRICE_RANGES_POSITION_VIEW,
-          }).replace(/[^0-9.]/g, ''),
+        const priceString = price.toString();
+        const formattedPriceString = formatPerpsFiat(priceString, {
+          ranges: PRICE_RANGES_POSITION_VIEW,
+        });
+        const sanitizedPriceString = formattedPriceString.replace(
+          regex.nonNumber,
+          '',
         );
+        setTakeProfitPrice(sanitizedPriceString);
         setTakeProfitPercentage(
           safeParseRoEPercentage(roePercentage.toString()),
         );
@@ -669,11 +674,15 @@ export function usePerpsTPSLForm(
 
       // Only set values if we got a valid price
       if (price && price !== '' && parseFloat(price) > 0) {
-        setStopLossPrice(
-          formatPerpsFiat(price.toString(), {
-            ranges: PRICE_RANGES_POSITION_VIEW,
-          }).replace(/[^0-9.]/g, ''),
+        const priceString = price.toString();
+        const formattedPriceString = formatPerpsFiat(priceString, {
+          ranges: PRICE_RANGES_POSITION_VIEW,
+        });
+        const sanitizedPriceString = formattedPriceString.replace(
+          regex.nonNumber,
+          '',
         );
+        setStopLossPrice(sanitizedPriceString);
         // Show the percentage as positive in the UI (magnitude of loss)
         setStopLossPercentage(safeParseRoEPercentage(roePercentage.toString()));
       } else {

--- a/app/components/UI/Perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/components/UI/Perps/services/HyperLiquidSubscriptionService.ts
@@ -323,7 +323,10 @@ export class HyperLiquidSubscriptionService {
             // Process trigger orders for TP/SL
             if (order.triggerPx) {
               const coin = order.coin;
-              const position = positions.find((p) => p.coin === coin);
+              const position = positions.find(
+                (p) =>
+                  p.coin === coin && order.reduceOnly && p.size === order.sz,
+              );
 
               if (position) {
                 const existing = tpslMap.get(coin) || {};

--- a/app/components/UI/Perps/utils/formatUtils.ts
+++ b/app/components/UI/Perps/utils/formatUtils.ts
@@ -9,66 +9,316 @@ import {
 } from '../../../../util/intl';
 
 /**
- * Formats a balance value as USD currency with appropriate decimal places
- * @param balance - Raw numeric balance value (e.g., 1234.56, not token minimal denomination)
- * @returns USD formatted string: "$X,XXX.XX" (always 2 decimal places with commas for thousands)
- * @example formatPerpsFiat(1234.56) => "$1,234.56"
- * @example formatPerpsFiat(0.01) => "$0.01"
- * @example formatPerpsFiat(50000) => "$50,000.00"
+ * Configuration for a specific number range formatting
  */
-export const formatPerpsFiat = (balance: string | number): string => {
-  const num = typeof balance === 'string' ? parseFloat(balance) : balance;
-
-  if (isNaN(num)) {
-    return '$0.00';
-  }
-
-  return formatWithThreshold(num, 0.01, 'en-US', {
-    style: 'currency',
-    currency: 'USD',
-  });
-};
+export interface FiatRangeConfig {
+  /**
+   * The condition to match for this range (e.g., < 0.0001, < 1, >= 1000)
+   * Function should return true if this config should be applied
+   */
+  condition: (value: number) => boolean;
+  /** Minimum decimal places for this range */
+  minimumDecimals: number;
+  /** Maximum decimal places for this range */
+  maximumDecimals: number;
+  /** Optional threshold for formatWithThreshold (defaults to the range boundary) */
+  threshold?: number;
+  /** Optional significant digits for this range (overrides decimal places when set) */
+  significantDigits?: number;
+  /** Optional custom formatting logic for this range */
+  customFormat?: (value: number, locale: string, currency: string) => string;
+}
 
 /**
- * Formats a price value as USD currency with variable decimal places based on magnitude
- * @param price - Raw numeric price value
- * @param options - Optional formatting options
- * @param options.minimumDecimals - Minimum decimal places (default: 2, use 0 for whole numbers)
- * @returns USD formatted string with variable decimals:
- * - Prices >= $1000: "$X,XXX.XX" (2-4 decimals)
- * - Prices < $1000: "$X.XXXX" (up to 4 decimals)
- * @example formatPrice(1234.5678) => "$1,234.57"
- * @example formatPrice(0.1234) => "$0.1234"
- * @example formatPrice(50000, { minimumDecimals: 0 }) => "$50,000"
+ * Default fiat formatting range configurations
+ * Applied in order - first matching condition wins
  */
-export const formatPrice = (
-  price: string | number,
-  options?: { minimumDecimals?: number; maximumDecimals?: number },
-): string => {
-  const num = typeof price === 'string' ? parseFloat(price) : price;
-  const minDecimals = options?.minimumDecimals ?? 2;
-  const maxDecimals = options?.maximumDecimals ?? 4;
+export const DEFAULT_FIAT_RANGES: FiatRangeConfig[] = [
+  {
+    // Standard fiat formatting (default for backward compatibility)
+    condition: () => true,
+    minimumDecimals: 2,
+    maximumDecimals: 2,
+    threshold: 0.01,
+  },
+];
 
-  if (isNaN(num)) {
-    return minDecimals === 0 ? '$0' : '$0.00';
+/**
+ * Formats a number to a specific number of significant digits
+ * @param value - The numeric value to format
+ * @param significantDigits - Number of significant digits to maintain
+ * @param minDecimals - Minimum decimal places to show (may add zeros)
+ * @param maxDecimals - Maximum decimal places allowed
+ * @returns Formatted number with appropriate precision
+ */
+export function formatWithSignificantDigits(
+  value: number,
+  significantDigits: number,
+  minDecimals?: number,
+  maxDecimals?: number,
+): { value: number; decimals: number } {
+  // Handle special cases
+  if (value === 0) {
+    return { value: 0, decimals: minDecimals ?? 2 };
   }
 
-  // For prices >= 1000, use specified decimal places
-  if (num >= 1000) {
-    return formatWithThreshold(num, 1000, 'en-US', {
+  const absValue = Math.abs(value);
+
+  // Use toPrecision for significant digits, then parse back
+  const precisionStr = absValue.toPrecision(significantDigits);
+  const precisionNum = parseFloat(precisionStr);
+
+  // Determine decimal places from the precision string
+  const [, decPart = ''] = precisionStr.split('.');
+  let actualDecimals = decPart.length;
+
+  // Apply min/max decimal constraints
+  if (minDecimals !== undefined && actualDecimals < minDecimals) {
+    actualDecimals = minDecimals; // Will add zeros if needed
+  }
+  if (maxDecimals !== undefined && actualDecimals > maxDecimals) {
+    actualDecimals = maxDecimals;
+  }
+
+  // Return the value with sign restored and decimal count
+  return {
+    value: value < 0 ? -precisionNum : precisionNum,
+    decimals: actualDecimals,
+  };
+}
+
+/**
+ * Formats a balance value as USD currency with appropriate decimal places
+ * @param balance - Raw numeric balance value (e.g., 1234.56, not token minimal denomination)
+ * @param options - Optional formatting options
+ * @param options.minimumDecimals - Global minimum decimal places (overrides range configs)
+ * @param options.maximumDecimals - Global maximum decimal places (overrides range configs)
+ * @param options.significantDigits - Global significant digits (overrides decimal settings when set)
+ * @param options.ranges - Custom range configurations (defaults to DEFAULT_FIAT_RANGES)
+ * @param options.currency - Currency code (default: 'USD')
+ * @param options.locale - Locale for formatting (default: 'en-US')
+ * @returns Formatted currency string with variable decimals based on configured ranges
+ * @example
+ * // Using defaults
+ * formatPerpsFiat(1234.56) => "$1,234.56"
+ * formatPerpsFiat(0.01) => "$0.01"
+ * formatPerpsFiat(50000) => "$50,000.00"
+ *
+ * // With custom ranges
+ * formatPerpsFiat(0.00001, {
+ *   ranges: [
+ *     { condition: (v) => v < 0.001, minimumDecimals: 6, maximumDecimals: 8 },
+ *     { condition: () => true, minimumDecimals: 2, maximumDecimals: 2 }
+ *   ]
+ * }) => "$0.000010"
+ *
+ * // With significant digits
+ * formatPerpsFiat(1234.56789, { significantDigits: 5 }) => "$1,234.6"
+ * formatPerpsFiat(0.0001234, { significantDigits: 3 }) => "$0.000123"
+ *
+ * // With per-range significant digits
+ * formatPerpsFiat(0.0001234, {
+ *   ranges: [
+ *     { condition: (v) => v < 0.01, significantDigits: 4, minimumDecimals: 6 }
+ *   ]
+ * }) => "$0.0001234"
+ */
+export const formatPerpsFiat = (
+  balance: string | number,
+  options?: {
+    minimumDecimals?: number;
+    maximumDecimals?: number;
+    significantDigits?: number;
+    ranges?: FiatRangeConfig[];
+    currency?: string;
+    locale?: string;
+  },
+): string => {
+  const num = typeof balance === 'string' ? parseFloat(balance) : balance;
+  const currency = options?.currency ?? 'USD';
+  const locale = options?.locale ?? 'en-US';
+
+  if (isNaN(num)) {
+    // Use the formatter to get proper currency symbol and locale formatting
+    // Use global settings if provided, otherwise use defaults
+    const minDecimals = options?.minimumDecimals ?? 2;
+    const maxDecimals = options?.maximumDecimals ?? 2;
+    return formatWithThreshold(0, 0, locale, {
       style: 'currency',
-      currency: 'USD',
+      currency,
       minimumFractionDigits: minDecimals,
       maximumFractionDigits: maxDecimals,
     });
   }
 
-  // For prices < 1000, use specified decimal places
-  return formatWithThreshold(num, 0.0001, 'en-US', {
+  // Use custom ranges or defaults
+  const ranges = options?.ranges || DEFAULT_FIAT_RANGES;
+
+  // Find the first matching range configuration
+  const rangeConfig = ranges.find((range) => range.condition(num));
+
+  if (!rangeConfig) {
+    // Fallback if no range matches (shouldn't happen with proper default config)
+    const fallbackMin = options?.minimumDecimals ?? 2;
+    const fallbackMax = options?.maximumDecimals ?? 2;
+    return formatWithThreshold(num, 0.01, locale, {
+      style: 'currency',
+      currency,
+      minimumFractionDigits: fallbackMin,
+      maximumFractionDigits: fallbackMax,
+    });
+  }
+
+  // Check for significant digits (global or range-specific)
+  const sigDigits = options?.significantDigits ?? rangeConfig.significantDigits;
+
+  // If significant digits are specified, use them
+  if (sigDigits) {
+    // Get min/max decimals (global overrides range, range overrides default)
+    const minDecimals = options?.minimumDecimals ?? rangeConfig.minimumDecimals;
+    const maxDecimals = options?.maximumDecimals ?? rangeConfig.maximumDecimals;
+
+    // Calculate appropriate formatting based on significant digits
+    const { value: formattedValue, decimals } = formatWithSignificantDigits(
+      num,
+      sigDigits,
+      minDecimals,
+      maxDecimals,
+    );
+
+    // Format with the calculated decimal places
+    return formatWithThreshold(
+      formattedValue,
+      rangeConfig.threshold || 0.01,
+      locale,
+      {
+        style: 'currency',
+        currency,
+        minimumFractionDigits: decimals,
+        maximumFractionDigits: decimals,
+      },
+    );
+  }
+
+  // Standard decimal-based formatting (existing logic)
+  const minDecimals = options?.minimumDecimals ?? rangeConfig.minimumDecimals;
+  const maxDecimals = options?.maximumDecimals ?? rangeConfig.maximumDecimals;
+
+  // Use custom formatting if provided
+  if (rangeConfig.customFormat) {
+    return rangeConfig.customFormat(num, locale, currency);
+  }
+
+  // Use standard formatting with threshold
+  return formatWithThreshold(num, rangeConfig.threshold || 0.01, locale, {
     style: 'currency',
-    currency: 'USD',
+    currency,
     minimumFractionDigits: minDecimals,
     maximumFractionDigits: maxDecimals,
+  });
+};
+
+/**
+ * Default price range configurations
+ * Applied in order - first matching condition wins
+ */
+export const DEFAULT_PRICE_RANGES: FiatRangeConfig[] = [
+  {
+    // Medium-large numbers (>= 1000)
+    condition: (val: number) => Math.abs(val) >= 1000,
+    minimumDecimals: 2,
+    maximumDecimals: 4,
+    threshold: 100,
+  },
+  {
+    // Default range (1 <= val < 1000)
+    condition: () => true,
+    minimumDecimals: 2,
+    maximumDecimals: 4,
+    threshold: 0.0001,
+  },
+];
+
+export const PRICE_RANGES_DETAILED_VIEW: FiatRangeConfig[] = [
+  {
+    condition: (v) => v >= 1,
+    minimumDecimals: 2,
+    maximumDecimals: 2,
+    threshold: 1,
+  },
+  {
+    condition: (v) => v < 1,
+    minimumDecimals: 2,
+    maximumDecimals: 7,
+    significantDigits: 3,
+    threshold: 0.0000001,
+  },
+];
+
+export const PRICE_RANGES_POSITION_VIEW: FiatRangeConfig[] = [
+  {
+    condition: (v) => v >= 1,
+    minimumDecimals: 2,
+    maximumDecimals: 2,
+    threshold: 1,
+  },
+  {
+    condition: (v) => v < 1,
+    minimumDecimals: 2,
+    maximumDecimals: 7,
+    significantDigits: 4,
+    threshold: 0.0000001,
+  },
+];
+
+export const PRICE_RANGES_MINIMAL_VIEW: FiatRangeConfig[] = [
+  {
+    condition: () => true,
+    minimumDecimals: 2,
+    maximumDecimals: 2,
+    threshold: 0.01,
+  },
+];
+
+/**
+ * Formats a price value as USD currency with variable decimal places based on magnitude
+ * @param price - Raw numeric price value
+ * @param options - Optional formatting options
+ * @param options.minimumDecimals - Global minimum decimal places (overrides range configs)
+ * @param options.maximumDecimals - Global maximum decimal places (overrides range configs)
+ * @param options.ranges - Custom range configurations (defaults to DEFAULT_PRICE_RANGES)
+ * @returns USD formatted string with variable decimals based on configured ranges
+ * @example
+ * // Using defaults
+ * formatPrice(0.00001234) => "$0.000012"
+ * formatPrice(0.1234) => "$0.1234"
+ * formatPrice(1234.5678) => "$1,234.57"
+ * formatPrice(50000) => "$50,000"
+ *
+ * // With custom ranges
+ * formatPrice(0.00001, {
+ *   ranges: [
+ *     { condition: (v) => v < 0.001, minimumDecimals: 8, maximumDecimals: 10 },
+ *     { condition: () => true, minimumDecimals: 2, maximumDecimals: 2 }
+ *   ]
+ * }) => "$0.00001000"
+ */
+export const formatPrice = (
+  price: string | number,
+  options?: {
+    minimumDecimals?: number;
+    maximumDecimals?: number;
+  },
+): string => {
+  // Default to min 2, max 4 decimals for prices
+  const minimumDecimals = options?.minimumDecimals ?? 2;
+  const maximumDecimals = options?.maximumDecimals ?? 4;
+  // Use formatPerpsFiat with price-specific defaults or custom ranges
+  return formatPerpsFiat(price, {
+    minimumDecimals,
+    maximumDecimals,
+    ...options,
+    ranges: DEFAULT_PRICE_RANGES,
   });
 };
 
@@ -151,24 +401,120 @@ export const formatFundingRate = (
 };
 
 /**
- * Formats large numbers with magnitude suffixes
- * @param value - Raw numeric value
+ * Configuration for large number range formatting
+ */
+export interface LargeNumberRangeConfig {
+  /** The minimum value threshold for this range (inclusive). Use 0 to catch numbers below the lowest suffix threshold */
+  threshold: number;
+  /** The suffix to use for this range (e.g., 'T', 'B', 'M', 'K', or '' for no suffix) */
+  suffix: string;
+  /** Number of decimal places for this range */
+  decimals: number;
+}
+
+/**
+ * Default large number range configurations
+ * Applied in order from largest to smallest
+ */
+export const DEFAULT_LARGE_NUMBER_RANGES: LargeNumberRangeConfig[] = [
+  {
+    threshold: 1000000000000, // >= 1T
+    suffix: 'T',
+    decimals: 0,
+  },
+  {
+    threshold: 1000000000, // >= 1B
+    suffix: 'B',
+    decimals: 0,
+  },
+  {
+    threshold: 1000000, // >= 1M
+    suffix: 'M',
+    decimals: 0,
+  },
+  {
+    threshold: 1000, // >= 1K
+    suffix: 'K',
+    decimals: 0,
+  },
+  {
+    threshold: 0, // < 1K (all remaining numbers)
+    suffix: '',
+    decimals: 2,
+  },
+];
+
+/**
+ * Preset for detailed large number formatting with more decimal precision
+ * Useful for displaying precise statistics or detailed financial data
+ */
+export const LARGE_NUMBER_RANGES_DETAILED: LargeNumberRangeConfig[] = [
+  {
+    threshold: 1000000000000, // >= 1T
+    suffix: 'T',
+    decimals: 2,
+  },
+  {
+    threshold: 1000000000, // >= 1B
+    suffix: 'B',
+    decimals: 2,
+  },
+  {
+    threshold: 1000000, // >= 1M
+    suffix: 'M',
+    decimals: 2,
+  },
+  {
+    threshold: 1000, // >= 1K
+    suffix: 'K',
+    decimals: 0,
+  },
+  {
+    threshold: 0, // < 1K (all remaining numbers)
+    suffix: '',
+    decimals: 0,
+  },
+];
+
+/**
+ * Formats large numbers with magnitude suffixes (K, M, B, T)
+ * @param value - The number to format
  * @param options - Optional formatting options
- * @param options.decimals - Number of decimal places for suffixed values (default: 0)
- * @param options.rawDecimals - Number of decimal places for non-suffixed values (default: 2)
- * @returns Format: "X.XXB" / "X.XXM" / "X.XXK" / "X.XX" (configurable decimals)
- * @example formatLargeNumber(1500000) => "2M"
- * @example formatLargeNumber(1500000, { decimals: 1 }) => "1.5M"
- * @example formatLargeNumber(1234, { decimals: 2 }) => "1.23K"
- * @example formatLargeNumber(999) => "999.00"
+ * @param options.decimals - Legacy: Number of decimal places for all suffixed values (overrides range configs)
+ * @param options.rawDecimals - Legacy: Number of decimal places for numbers below all thresholds (overrides range config for threshold: 0)
+ * @param options.ranges - Custom range configurations for fine-grained control over decimals per range
+ * @returns Formatted string with appropriate suffix
+ * @example
+ * // Using defaults
+ * formatLargeNumber(1500000) => "2M"
+ * formatLargeNumber(1234) => "1K"
+ * formatLargeNumber(999) => "999.00"
+ *
+ * // Legacy: same decimals for all ranges
+ * formatLargeNumber(1500000, { decimals: 1 }) => "1.5M"
+ * formatLargeNumber(1234, { decimals: 2 }) => "1.23K"
+ *
+ * // New: custom decimals per range (including all remaining numbers)
+ * formatLargeNumber(1500000, {
+ *   ranges: [
+ *     { threshold: 1000000000000, suffix: 'T', decimals: 2 },
+ *     { threshold: 1000000000, suffix: 'B', decimals: 1 },
+ *     { threshold: 1000000, suffix: 'M', decimals: 1 },
+ *     { threshold: 1000, suffix: 'K', decimals: 0 },
+ *     { threshold: 0, suffix: '', decimals: 4 }, // < 1K (all remaining numbers)
+ *   ]
+ * }) => "1.5M"
  */
 export const formatLargeNumber = (
   value: string | number,
-  options?: { decimals?: number; rawDecimals?: number },
+  options?: {
+    decimals?: number; // Legacy: applies to all suffixed ranges
+    rawDecimals?: number; // Legacy: applies to numbers below all thresholds
+    ranges?: LargeNumberRangeConfig[]; // Custom range configurations
+  },
 ): string => {
   const num = typeof value === 'string' ? parseFloat(value) : value;
-  const decimals = options?.decimals ?? 0;
-  const rawDecimals = options?.rawDecimals ?? 2;
+  const ranges = options?.ranges ?? DEFAULT_LARGE_NUMBER_RANGES;
 
   if (isNaN(num)) {
     return '0';
@@ -177,24 +523,33 @@ export const formatLargeNumber = (
   const absNum = Math.abs(num);
   const sign = num < 0 ? '-' : '';
 
-  if (absNum >= 1000000000000) {
-    const trillions = absNum / 1000000000000;
-    return `${sign}${trillions.toFixed(decimals)}T`;
-  }
-  if (absNum >= 1000000000) {
-    const billions = absNum / 1000000000;
-    return `${sign}${billions.toFixed(decimals)}B`;
-  }
-  if (absNum >= 1000000) {
-    const millions = absNum / 1000000;
-    return `${sign}${millions.toFixed(decimals)}M`;
-  }
-  if (absNum >= 1000) {
-    const thousands = absNum / 1000;
-    return `${sign}${thousands.toFixed(decimals)}K`;
+  // Check each range in order
+  for (const range of ranges) {
+    if (absNum >= range.threshold) {
+      // Calculate divisor based on threshold (or 1 for no scaling)
+      const divisor = range.threshold > 0 ? range.threshold : 1;
+      const scaledValue = absNum / divisor;
+
+      // Determine decimals to use
+      let decimalPlaces = range.decimals;
+
+      // Legacy support: override with options.decimals for suffixed values
+      if (options?.decimals !== undefined && range.suffix !== '') {
+        decimalPlaces = options.decimals;
+      }
+
+      // Legacy support: override with options.rawDecimals for non-suffixed values
+      if (options?.rawDecimals !== undefined && range.suffix === '') {
+        decimalPlaces = options.rawDecimals;
+      }
+
+      return `${sign}${scaledValue.toFixed(decimalPlaces)}${range.suffix}`;
+    }
   }
 
-  return num.toFixed(rawDecimals);
+  // This should never be reached if ranges includes a threshold: 0 entry
+  // But keep as fallback for safety
+  return num.toFixed(options?.rawDecimals ?? 2);
 };
 
 /**

--- a/app/components/UI/Perps/utils/tpslValidation.ts
+++ b/app/components/UI/Perps/utils/tpslValidation.ts
@@ -209,9 +209,7 @@ export const calculatePriceForRoE = (
   // Use entry price if available (for existing positions), otherwise use current price
   const basePrice = entryPrice || currentPrice;
   if (!basePrice || basePrice <= 0) {
-    // Return a reasonable default instead of empty string
-    // For stop loss, return a value that's 1% away from 0 to avoid division by zero
-    return isProfit ? '' : '0.01';
+    return '';
   }
 
   const isLong = direction === 'long';

--- a/app/components/UI/Perps/utils/tpslValidation.ts
+++ b/app/components/UI/Perps/utils/tpslValidation.ts
@@ -208,14 +208,21 @@ export const calculatePriceForRoE = (
 ): string => {
   // Use entry price if available (for existing positions), otherwise use current price
   const basePrice = entryPrice || currentPrice;
-  if (!basePrice) {
-    DevLogger.log(
-      '[TPSL Debug] No basePrice available in calculatePriceForRoE',
-    );
-    return '';
+  if (!basePrice || basePrice <= 0) {
+    // Return a reasonable default instead of empty string
+    // For stop loss, return a value that's 1% away from 0 to avoid division by zero
+    return isProfit ? '' : '0.01';
   }
 
   const isLong = direction === 'long';
+
+  // Prevent stop loss from exceeding maximum possible loss
+  // Maximum theoretical loss is 100% * leverage (before liquidation)
+  // But we'll cap it at 99% to avoid negative prices
+  if (!isProfit && Math.abs(roePercentage) >= leverage * 99) {
+    // Cap at 99% of max loss to prevent negative prices
+    roePercentage = -(leverage * 99);
+  }
 
   DevLogger.log('[TPSL Debug] calculatePriceForRoE inputs:', {
     roePercentage,
@@ -253,6 +260,10 @@ export const calculatePriceForRoE = (
     // For stop loss (negative RoE)
     // Long SL: price needs to go down
     calculatedPrice = basePrice * (1 - Math.abs(priceChangeRatio));
+    // Ensure price never goes negative
+    if (calculatedPrice <= 0) {
+      calculatedPrice = basePrice * 0.01; // Minimum 1% of base price
+    }
   } else {
     // Short SL: price needs to go up
     calculatedPrice = basePrice * (1 + Math.abs(priceChangeRatio));
@@ -307,10 +318,12 @@ export const calculateRoEForPrice = (
 ): string => {
   // Use entry price if available (for existing positions), otherwise use current price
   const basePrice = entryPrice || currentPrice;
-  if (!basePrice || !price) return '';
+  if (!basePrice || basePrice <= 0 || !price) {
+    return '';
+  }
 
   const priceNum = parseFloat(price.replace(/[$,]/g, ''));
-  if (isNaN(priceNum)) return '';
+  if (isNaN(priceNum) || priceNum <= 0) return '';
 
   const isLong = direction === 'long';
 
@@ -329,6 +342,10 @@ export const calculateRoEForPrice = (
     // For stop loss, check if price moved in the wrong direction (loss)
     const isValidLoss = isLong ? priceNum < basePrice : priceNum > basePrice;
     if (!isValidLoss) roePercentage = -roePercentage;
+  }
+
+  if (roePercentage < 0) {
+    roePercentage = 0;
   }
 
   return roePercentage.toFixed(2);
@@ -368,6 +385,14 @@ export const formatRoEPercentageDisplay = (
     return '';
   }
 
+  // When focused, preserve the exact user input including decimal points
+  if (isFocused) {
+    // Only allow valid numeric patterns
+    if (value === '.' || /^\d*\.?\d*$/.test(value)) {
+      return value;
+    }
+  }
+
   const parsed = parseFloat(value);
   if (isNaN(parsed)) {
     return '';
@@ -376,10 +401,35 @@ export const formatRoEPercentageDisplay = (
   const absValue = Math.abs(parsed);
 
   if (isFocused) {
-    // When focused, preserve user input precision
+    // This branch shouldn't be reached now, but keep as fallback
     return absValue.toString();
   }
 
   // When not focused, show clean display format
   return absValue % 1 === 0 ? absValue.toFixed(0) : absValue.toFixed(2);
+};
+
+/**
+ * Calculate the maximum allowed stop loss percentage based on leverage
+ * @param leverage The position leverage
+ * @returns The maximum stop loss percentage (as a positive number)
+ */
+export const getMaxStopLossPercentage = (leverage: number): number =>
+  // Maximum theoretical loss is 100% * leverage (before liquidation)
+  // But we cap it at 99% to avoid negative prices and leave room for fees
+  Math.min(leverage * 99, 999);
+
+/**
+ * Validate if a stop loss percentage is within allowed bounds
+ * @param percentage The stop loss percentage (as a positive number)
+ * @param leverage The position leverage
+ * @returns True if valid, false otherwise
+ */
+export const isValidStopLossPercentage = (
+  percentage: number,
+  leverage: number,
+): boolean => {
+  if (percentage <= 0) return false;
+  const maxAllowed = getMaxStopLossPercentage(leverage);
+  return percentage <= maxAllowed;
 };

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1257,7 +1257,8 @@
         "unrealized_pnl": "Unrealized P&L"
       },
       "tpsl": {
-        "update_success": "TP/SL updated successfully"
+        "update_success": "TP/SL updated successfully",
+        "update_failed": "Failed to update TP/SL"
       }
     },
     "markets": {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

1. What is the reason for the change?

Various ui price formatting inconsistencies especially for smaller priced coins like PUMP

2. What is the improvement/solution?

This commit implements comprehensive decimal precision improvements across the Perps trading interface
Enhanced formatting utilities with configurable range-based decimal precision and significant digits support
Improved price input validation with better decimal handling for limit orders and TP/SL values
Consistent UI formatting across market data, position cards, and order forms
Better user experience with smarter decimal truncation and validation that prevents input errors

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updates the precision of various fiat display text in the perps flow

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1521
Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1510
Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1480
Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1494
Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1574

## **Manual testing steps**

```
Fees, there should always be 2 decimals (users don’t care if they pay $1.12345 or $1.12)
It applies:
Funding fee in the position component
Fee in the trade screen

On perps market screen  it seems all token prices when price is <$1 don’t follow the same logic: some have 4 and other 5 significant numbers.
Can we use 3 significant numbers for all?

On the perp asset screen
In the header: I see PUMP price has 2 significant numbers. Can we increase to 3 for all numbers which price is <$1 ?

In the position component, I see
Entry price and liq price have 4 significant numbers
TP and SL have 2 significant numbers (actually at 5:45 I see 3 significant numbers for stop loss)
I think we should display 4 significant numbers for all

On the TP/SL bottom sheet
Current price has 2 significant numbers
Liq price has 4 significant numbers
Imo both should have 4

On theLimit order tpsL bottom sheet
It seems that when you tap on the preset, it inputs 5 significant numbers.
imo we should display 4 significant numbers, just like the $price below

On the Limit price input
It seems that when you tap the preset, it display 6 significant numbers
imo if should display 4 significant numbers

Not related to decimals, but you mention you discovered a bug you discovered, is it this one? https://consensyssoftware.atlassian.net/browse/TAT-1574

At 6:00 I saw margin also was 9.6060604, I think margin can be 2 decimals unless 0 sig figs in that
```

```gherkin
Feature: wip

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/971f06de-d79f-443a-a9d2-337b754e3dd9

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
