### PR TITLE
perf: add trace on address copy

### DIFF
--- a/app/components/UI/AddressCopy/AddressCopy.tsx
+++ b/app/components/UI/AddressCopy/AddressCopy.tsx
@@ -28,6 +28,12 @@ import styleSheet from './AddressCopy.styles';
 import { useMetrics } from '../../../components/hooks/useMetrics';
 import { getFormattedAddressFromInternalAccount } from '../../../core/Multichain/utils';
 import type { AddressCopyProps } from './AddressCopy.types';
+import {
+  endTrace,
+  trace,
+  TraceName,
+  TraceOperation,
+} from '../../../util/trace';
 
 const AddressCopy = ({ account, iconColor, hitSlop }: AddressCopyProps) => {
   const { styles } = useStyles(styleSheet, {});
@@ -84,12 +90,25 @@ const AddressCopy = ({ account, iconColor, hitSlop }: AddressCopyProps) => {
   ]);
 
   const navigateToAddressList = useCallback(() => {
+    // Start the trace before navigating to the address list to include the
+    // navigation and render times in the trace.
+    trace({
+      name: TraceName.ShowAccountAddressList,
+      op: TraceOperation.AccountUi,
+      tags: {
+        screen: 'navbar.copy_address',
+      },
+    });
+
     navigate(
       ...createAddressListNavigationDetails({
         groupId: selectedAccountGroupId as AccountGroupId,
         title: `${strings(
           'multichain_accounts.address_list.receiving_address',
         )}`,
+        onLoad: () => {
+          endTrace({ name: TraceName.ShowAccountAddressList });
+        },
       }),
     );
   }, [navigate, selectedAccountGroupId]);


### PR DESCRIPTION
## **Description**

This PR adds a performance trace for address list navigation from the navbar copy button.

<!--
## **Changelog**
## **Screenshots/Recordings**
-->

## **Related issues**

Fixes: [MUL-671](https://consensyssoftware.atlassian.net/browse/MUL-671)

## **Manual testing steps**

1. Enable metrics in the privacy settings
2. On the main screen, click on the copy address button
3. Go to Sentry and look for a new trace using the following filter:

   ```
   span.op:account.ui span.description:"Show Account Address List" screen:navbar.copy_address
   ```

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MUL-671]: https://consensyssoftware.atlassian.net/browse/MUL-671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ