### PR TITLE
feat: Multi-chain accounts list Icon

### DIFF
--- a/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.stories.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.stories.tsx
@@ -6,6 +6,13 @@ import { configureStore } from '@reduxjs/toolkit';
 import { Box } from '@metamask/design-system-react-native';
 import AccountCell from '.';
 import initialBackgroundState from '../../../../util/test/initial-background-state.json';
+import { AvatarAccountType } from '../../../components/Avatars/Avatar/variants/AvatarAccount';
+
+interface StoryArgs {
+  accountGroup: AccountGroupObject;
+  isSelected: boolean;
+  avatarAccountType: AvatarAccountType;
+}
 
 const SAMPLE_ACCOUNT_GROUP = {
   type: AccountGroupType.SingleAccount,
@@ -132,28 +139,38 @@ const MultichainAccountRowMeta = {
     ),
   ],
   argTypes: {
-    accountGroup: {
-      control: { type: 'object' },
-      defaultValue: SAMPLE_ACCOUNT_GROUP,
+    accountGroup: { control: { type: 'object' } },
+    isSelected: { control: { type: 'boolean' } },
+    avatarAccountType: {
+      control: {
+        type: 'select',
+        options: Object.values(AvatarAccountType),
+      },
     },
-    isSelected: {
-      control: { type: 'boolean' },
-      defaultValue: false,
-    },
+  },
+  args: {
+    accountGroup: SAMPLE_ACCOUNT_GROUP,
+    isSelected: false,
+    avatarAccountType: AvatarAccountType.Maskicon,
   },
 };
 export default MultichainAccountRowMeta;
 
 export const MultichainAddressSelectedRow = {
-  render: (args: { accountGroup: AccountGroupObject }) => (
-    <AccountCell accountGroup={args.accountGroup} isSelected />
+  render: (args: StoryArgs) => (
+    <AccountCell
+      accountGroup={args.accountGroup}
+      avatarAccountType={args.avatarAccountType}
+      isSelected
+    />
   ),
 };
 
 export const MultichainAddressRow = {
-  render: (args: { accountGroup: AccountGroupObject; isSelected: boolean }) => (
+  render: (args: StoryArgs) => (
     <AccountCell
       accountGroup={args.accountGroup}
+      avatarAccountType={args.avatarAccountType}
       isSelected={args.isSelected}
     />
   ),

--- a/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.styles.ts
+++ b/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.styles.ts
@@ -1,5 +1,6 @@
 import { StyleSheet } from 'react-native';
 import { Theme } from '../../../../util/theme/models';
+import { colors as staticColors } from '../../../../styles/common';
 
 const styleSheet = (params: {
   theme: Theme;
@@ -15,13 +16,20 @@ const styleSheet = (params: {
       paddingTop: 16,
       paddingBottom: 16,
     },
-    avatar: {
+    avatarWrapper: {
       borderRadius: 8,
+      width: 36, // 32 (avatar size) + 2*2 (border width)
+      height: 36, // 32 (avatar size) + 2*2 (border width)
+      borderWidth: 2,
+      borderColor: isSelected ? colors.info.default : staticColors.transparent,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    avatar: {
+      borderRadius: 6, // Slightly smaller to account for wrapper border
       width: 32,
       height: 32,
       backgroundColor: colors.background.muted,
-      borderWidth: isSelected ? 2 : 0,
-      borderColor: isSelected ? colors.info.default : colors.background.default,
     },
     accountName: {
       display: 'flex',

--- a/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.test.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.test.tsx
@@ -3,8 +3,17 @@ import { AccountGroupObject } from '@metamask/account-tree-controller';
 import AccountCell from './AccountCell';
 import renderWithProvider from '../../../../util/test/renderWithProvider';
 import { fireEvent } from '@testing-library/react-native';
-import { createMockAccountGroup } from '../test-utils';
+import {
+  createMockAccountGroup,
+  createMockInternalAccountsFromGroups,
+  createMockState,
+  createMockWallet,
+} from '../test-utils';
 import { AvatarAccountType } from '../../../components/Avatars/Avatar';
+import { Maskicon } from '@metamask/design-system-react-native';
+import JazzIcon from 'react-native-jazzicon';
+import { Image as RNImage } from 'react-native';
+import { AccountCellIds } from '../../../../../e2e/selectors/MultichainAccounts/AccountCell.selectors';
 
 // Configurable mock balance for selector
 const mockBalance: { value: number; currency: string } = {
@@ -45,17 +54,24 @@ const renderAccountCell = (
     accountGroup?: AccountGroupObject;
     isSelected?: boolean;
     hideMenu?: boolean;
+    avatarAccountType?: AvatarAccountType;
   } = {},
 ) => {
   const defaultProps = {
     accountGroup: mockAccountGroup,
+    avatarAccountType: AvatarAccountType.Maskicon,
     isSelected: false,
     hideMenu: false,
     ...props,
   };
 
+  const groups = [defaultProps.accountGroup];
+  const wallet = createMockWallet('test-group', 'Test Wallet', groups);
+  const internalAccounts = createMockInternalAccountsFromGroups(groups);
+  const baseState = createMockState([wallet], internalAccounts);
   return renderWithProvider(<AccountCell {...defaultProps} />, {
     state: {
+      ...baseState,
       settings: {
         avatarAccountType: AvatarAccountType.Maskicon,
       },
@@ -113,5 +129,29 @@ describe('AccountCell', () => {
         },
       },
     );
+  });
+
+  it('renders Maskicon AvatarAccount when avatarAccountType is Maskicon', () => {
+    const { getByTestId } = renderAccountCell({
+      avatarAccountType: AvatarAccountType.Maskicon,
+    });
+    const avatarContainer = getByTestId(AccountCellIds.AVATAR);
+    expect(() => avatarContainer.findByType(Maskicon)).not.toThrow();
+  });
+
+  it('renders JazzIcon AvatarAccount when avatarAccountType is JazzIcon', () => {
+    const { getByTestId } = renderAccountCell({
+      avatarAccountType: AvatarAccountType.JazzIcon,
+    });
+    const avatarContainer = getByTestId(AccountCellIds.AVATAR);
+    expect(() => avatarContainer.findByType(JazzIcon)).not.toThrow();
+  });
+
+  it('renders Blockies AvatarAccount when avatarAccountType is Blockies', () => {
+    const { getByTestId } = renderAccountCell({
+      avatarAccountType: AvatarAccountType.Blockies,
+    });
+    const avatarContainer = getByTestId(AccountCellIds.AVATAR);
+    expect(() => avatarContainer.findByType(RNImage)).not.toThrow();
   });
 });

--- a/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.tsx
@@ -18,15 +18,22 @@ import { selectBalanceByAccountGroup } from '../../../../selectors/assets/balanc
 import { formatWithThreshold } from '../../../../util/assets';
 import I18n from '../../../../../locales/i18n';
 import Routes from '../../../../constants/navigation/Routes';
+import AvatarAccount, {
+  AvatarAccountType,
+} from '../../../components/Avatars/Avatar/variants/AvatarAccount';
+import { AvatarSize } from '../../../components/Avatars/Avatar/Avatar.types';
+import { selectIconSeedAddressByAccountGroupId } from '../../../../selectors/multichainAccounts/accounts';
 
 interface AccountCellProps {
   accountGroup: AccountGroupObject;
+  avatarAccountType: AvatarAccountType;
   isSelected: boolean;
   hideMenu?: boolean;
 }
 
 const AccountCell = ({
   accountGroup,
+  avatarAccountType,
   isSelected,
   hideMenu = false,
 }: AccountCellProps) => {
@@ -48,6 +55,12 @@ const AccountCell = ({
   const totalBalance = groupBalance?.totalBalanceInUserCurrency;
   const userCurrency = groupBalance?.userCurrency;
 
+  const selectEvmAddress = useMemo(
+    () => selectIconSeedAddressByAccountGroupId(accountGroup.id),
+    [accountGroup.id],
+  );
+  const evmAddress = useSelector(selectEvmAddress);
+
   const displayBalance = useMemo(() => {
     if (totalBalance == null || !userCurrency) {
       return undefined;
@@ -66,7 +79,19 @@ const AccountCell = ({
       alignItems={AlignItems.center}
       testID={AccountCellIds.CONTAINER}
     >
-      <View style={styles.avatar} testID={AccountCellIds.AVATAR}></View>
+      <View style={styles.avatarWrapper}>
+        {evmAddress ? (
+          <AvatarAccount
+            accountAddress={evmAddress}
+            type={avatarAccountType}
+            size={AvatarSize.Md}
+            style={styles.avatar}
+            testID={AccountCellIds.AVATAR}
+          />
+        ) : (
+          <View style={styles.avatar} testID={AccountCellIds.AVATAR}></View>
+        )}
+      </View>
       <View style={styles.accountName}>
         <Text
           variant={TextVariant.BodyMDBold}

--- a/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.tsx
@@ -80,17 +80,13 @@ const AccountCell = ({
       testID={AccountCellIds.CONTAINER}
     >
       <View style={styles.avatarWrapper}>
-        {evmAddress ? (
-          <AvatarAccount
-            accountAddress={evmAddress}
-            type={avatarAccountType}
-            size={AvatarSize.Md}
-            style={styles.avatar}
-            testID={AccountCellIds.AVATAR}
-          />
-        ) : (
-          <View style={styles.avatar} testID={AccountCellIds.AVATAR}></View>
-        )}
+        <AvatarAccount
+          accountAddress={evmAddress}
+          type={avatarAccountType}
+          size={AvatarSize.Md}
+          style={styles.avatar}
+          testID={AccountCellIds.AVATAR}
+        />
       </View>
       <View style={styles.accountName}>
         <Text

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListCell/AccountListCell.test.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListCell/AccountListCell.test.tsx
@@ -2,7 +2,13 @@ import React from 'react';
 import { fireEvent } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import AccountListCell from './AccountListCell';
-import { createMockAccountGroup } from '../../test-utils';
+import {
+  createMockAccountGroup,
+  createMockInternalAccountsFromGroups,
+  createMockState,
+  createMockWallet,
+} from '../../test-utils';
+import { AvatarAccountType } from '../../../../components/Avatars/Avatar';
 
 const mockNavigate = jest.fn();
 
@@ -34,29 +40,56 @@ const mockAccountGroup = createMockAccountGroup(
 );
 
 describe('AccountListCell', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders correctly with account data', () => {
     const mockOnSelectAccount = jest.fn();
+    const groups = [mockAccountGroup];
+    const wallet = createMockWallet('test-group', 'Test Wallet', groups);
+    const internalAccounts = createMockInternalAccountsFromGroups(groups);
+    const baseState = createMockState([wallet], internalAccounts);
     const { getByText } = renderWithProvider(
       <AccountListCell
         accountGroup={mockAccountGroup}
+        avatarAccountType={AvatarAccountType.Maskicon}
         isSelected={false}
         onSelectAccount={mockOnSelectAccount}
       />,
+      {
+        state: {
+          ...baseState,
+          settings: { avatarAccountType: 'Maskicon' },
+        },
+      },
     );
-
     expect(getByText('Test Account')).toBeTruthy();
   });
 
   it('calls onSelectAccount when pressed', () => {
     const mockOnSelectAccount = jest.fn();
+    const groups2 = [mockAccountGroup];
+    const wallet2 = createMockWallet('test-group', 'Test Wallet', groups2);
+    const internalAccounts2 = createMockInternalAccountsFromGroups(groups2);
+    const baseState2 = createMockState([wallet2], internalAccounts2);
     const { getByText } = renderWithProvider(
       <AccountListCell
         accountGroup={mockAccountGroup}
+        avatarAccountType={AvatarAccountType.Maskicon}
         isSelected={false}
         onSelectAccount={mockOnSelectAccount}
       />,
+      {
+        state: {
+          ...baseState2,
+          settings: { avatarAccountType: 'Maskicon' },
+        },
+      },
     );
-
+    // Given a rendered cell
+    // When the user presses the account row
+    // Then it calls onSelectAccount with the account group
     fireEvent.press(getByText('Test Account'));
     expect(mockOnSelectAccount).toHaveBeenCalledWith(mockAccountGroup);
   });

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListCell/AccountListCell.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListCell/AccountListCell.tsx
@@ -7,7 +7,12 @@ import createStyles from '../MultichainAccountSelectorList.styles';
 import { AccountListCellProps } from './AccountListCell.types';
 
 const AccountListCell = memo(
-  ({ accountGroup, isSelected, onSelectAccount }: AccountListCellProps) => {
+  ({
+    accountGroup,
+    avatarAccountType,
+    isSelected,
+    onSelectAccount,
+  }: AccountListCellProps) => {
     const { styles } = useStyles(createStyles, {});
 
     const handlePress = useCallback(() => {
@@ -20,7 +25,11 @@ const AccountListCell = memo(
         onPress={handlePress}
         activeOpacity={0.7}
       >
-        <AccountCell accountGroup={accountGroup} isSelected={isSelected} />
+        <AccountCell
+          accountGroup={accountGroup}
+          avatarAccountType={avatarAccountType}
+          isSelected={isSelected}
+        />
       </TouchableOpacity>
     );
   },

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListCell/AccountListCell.types.ts
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListCell/AccountListCell.types.ts
@@ -1,7 +1,9 @@
 import { AccountGroupObject } from '@metamask/account-tree-controller';
+import { AvatarAccountType } from '../../../../components/Avatars/Avatar/variants/AvatarAccount';
 
 export interface AccountListCellProps {
   accountGroup: AccountGroupObject;
+  avatarAccountType: AvatarAccountType;
   isSelected: boolean;
   onSelectAccount: (accountGroup: AccountGroupObject) => void;
 }

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/MultichainAccountSelectorList.test.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/MultichainAccountSelectorList.test.tsx
@@ -97,8 +97,14 @@ describe('MultichainAccountSelectorList', () => {
   };
 
   it('shows accounts correctly', () => {
-    const account1 = createMockAccountGroup('group1', 'Account 1');
-    const account2 = createMockAccountGroup('group2', 'Account 2');
+    const account1 = createMockAccountGroup(
+      'keyring:wallet1/group1',
+      'Account 1',
+    );
+    const account2 = createMockAccountGroup(
+      'keyring:wallet2/group2',
+      'Account 2',
+    );
     const wallet1 = createMockWallet('wallet1', 'Wallet 1', [account1]);
     const wallet2 = createMockWallet('wallet2', 'Wallet 2', [account2]);
 
@@ -117,8 +123,14 @@ describe('MultichainAccountSelectorList', () => {
   });
 
   it('shows accounts correctly when there are multiple accounts with different categories', () => {
-    const srpAccount = createMockAccountGroup('srp-group', 'SRP Account');
-    const snapAccount = createMockAccountGroup('snap-group', 'Snap Account');
+    const srpAccount = createMockAccountGroup(
+      'keyring:srp-wallet/srp-group',
+      'SRP Account',
+    );
+    const snapAccount = createMockAccountGroup(
+      'keyring:snap-wallet/snap-group',
+      'Snap Account',
+    );
     const srpWallet = createMockWallet('srp-wallet', 'Wallet 1', [srpAccount]);
     const snapWallet = createMockWallet('snap-wallet', 'Simple Keyring', [
       snapAccount,
@@ -139,9 +151,12 @@ describe('MultichainAccountSelectorList', () => {
   });
 
   it('shows accounts correctly when there are multiple accounts with hardware wallets', () => {
-    const srpAccount = createMockAccountGroup('srp-group', 'SRP Account');
+    const srpAccount = createMockAccountGroup(
+      'keyring:srp-wallet/srp-group',
+      'SRP Account',
+    );
     const ledgerAccount = createMockAccountGroup(
-      'ledger-group',
+      'keyring:ledger-wallet/ledger-group',
       'Ledger Account',
     );
     const srpWallet = createMockWallet('srp-wallet', 'Wallet 1', [srpAccount]);
@@ -164,8 +179,14 @@ describe('MultichainAccountSelectorList', () => {
   });
 
   it('shows the correct account as selected', () => {
-    const account1 = createMockAccountGroup('group1', 'Account 1');
-    const account2 = createMockAccountGroup('group2', 'Account 2');
+    const account1 = createMockAccountGroup(
+      'keyring:wallet1/group1',
+      'Account 1',
+    );
+    const account2 = createMockAccountGroup(
+      'keyring:wallet1/group2',
+      'Account 2',
+    );
     const wallet1 = createMockWallet('wallet1', 'Wallet 1', [
       account1,
       account2,

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/MultichainAccountSelectorList.test.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/MultichainAccountSelectorList.test.tsx
@@ -210,15 +210,21 @@ describe('MultichainAccountSelectorList', () => {
 
   describe('Search functionality', () => {
     it('filters accounts by name', async () => {
-      const account1 = createMockAccountGroup('group1', 'My Account', [
-        'account1',
-      ]);
-      const account2 = createMockAccountGroup('group2', 'Test Account', [
-        'account2',
-      ]);
-      const account3 = createMockAccountGroup('group3', 'Another Account', [
-        'account3',
-      ]);
+      const account1 = createMockAccountGroup(
+        'keyring:wallet1/group1',
+        'My Account',
+        ['account1'],
+      );
+      const account2 = createMockAccountGroup(
+        'keyring:wallet1/group2',
+        'Test Account',
+        ['account2'],
+      );
+      const account3 = createMockAccountGroup(
+        'keyring:wallet1/group3',
+        'Another Account',
+        ['account3'],
+      );
       const wallet1 = createMockWallet('wallet1', 'Wallet 1', [
         account1,
         account2,
@@ -252,12 +258,16 @@ describe('MultichainAccountSelectorList', () => {
     });
 
     it('debounces search input with 300ms delay', async () => {
-      const account1 = createMockAccountGroup('group1', 'My Account', [
-        'account1',
-      ]);
-      const account2 = createMockAccountGroup('group2', 'Test Account', [
-        'account2',
-      ]);
+      const account1 = createMockAccountGroup(
+        'keyring:wallet1/group1',
+        'My Account',
+        ['account1'],
+      );
+      const account2 = createMockAccountGroup(
+        'keyring:wallet1/group2',
+        'Test Account',
+        ['account2'],
+      );
       const wallet1 = createMockWallet('wallet1', 'Wallet 1', [
         account1,
         account2,
@@ -298,15 +308,21 @@ describe('MultichainAccountSelectorList', () => {
     });
 
     it('filters accounts by address', async () => {
-      const account1 = createMockAccountGroup('group1', 'Account 1', [
-        'account1',
-      ]);
-      const account2 = createMockAccountGroup('group2', 'Account 2', [
-        'account2',
-      ]);
-      const account3 = createMockAccountGroup('group3', 'Account 3', [
-        'account3',
-      ]);
+      const account1 = createMockAccountGroup(
+        'keyring:wallet1/group1',
+        'Account 1',
+        ['account1'],
+      );
+      const account2 = createMockAccountGroup(
+        'keyring:wallet1/group2',
+        'Account 2',
+        ['account2'],
+      );
+      const account3 = createMockAccountGroup(
+        'keyring:wallet1/group3',
+        'Account 3',
+        ['account3'],
+      );
       const wallet1 = createMockWallet('wallet1', 'Wallet 1', [
         account1,
         account2,
@@ -344,14 +360,16 @@ describe('MultichainAccountSelectorList', () => {
     });
 
     it('filters account groups when any account in group matches', async () => {
-      const account1 = createMockAccountGroup('group1', 'Group 1', [
-        'account1',
-        'account2',
-      ]);
-      const account2 = createMockAccountGroup('group2', 'Group 2', [
-        'account3',
-        'account4',
-      ]);
+      const account1 = createMockAccountGroup(
+        'keyring:wallet1/group1',
+        'Group 1',
+        ['account1', 'account2'],
+      );
+      const account2 = createMockAccountGroup(
+        'keyring:wallet1/group2',
+        'Group 2',
+        ['account3', 'account4'],
+      );
       const wallet1 = createMockWallet('wallet1', 'Wallet 1', [
         account1,
         account2,
@@ -388,15 +406,21 @@ describe('MultichainAccountSelectorList', () => {
     });
 
     it('filters across multiple wallets', async () => {
-      const account1 = createMockAccountGroup('group1', 'Account 1', [
-        'account1',
-      ]);
-      const account2 = createMockAccountGroup('group2', 'Account 2', [
-        'account2',
-      ]);
-      const account3 = createMockAccountGroup('group3', 'Account 3', [
-        'account3',
-      ]);
+      const account1 = createMockAccountGroup(
+        'keyring:wallet1/group1',
+        'Account 1',
+        ['account1'],
+      );
+      const account2 = createMockAccountGroup(
+        'keyring:wallet2/group2',
+        'Account 2',
+        ['account2'],
+      );
+      const account3 = createMockAccountGroup(
+        'keyring:wallet2/group3',
+        'Account 3',
+        ['account3'],
+      );
       const wallet1 = createMockWallet('wallet1', 'Wallet 1', [account1]);
       const wallet2 = createMockWallet('wallet2', 'Wallet 2', [
         account2,
@@ -430,8 +454,14 @@ describe('MultichainAccountSelectorList', () => {
     });
 
     it('shows empty state when no accounts match search', async () => {
-      const account1 = createMockAccountGroup('group1', 'My Account');
-      const account2 = createMockAccountGroup('group2', 'Test Account');
+      const account1 = createMockAccountGroup(
+        'keyring:wallet1/group1',
+        'My Account',
+      );
+      const account2 = createMockAccountGroup(
+        'keyring:wallet1/group2',
+        'Test Account',
+      );
       const wallet1 = createMockWallet('wallet1', 'Wallet 1', [
         account1,
         account2,
@@ -468,8 +498,14 @@ describe('MultichainAccountSelectorList', () => {
     });
 
     it('is case insensitive', async () => {
-      const account1 = createMockAccountGroup('group1', 'My Account');
-      const account2 = createMockAccountGroup('group2', 'Test Account');
+      const account1 = createMockAccountGroup(
+        'keyring:wallet1/group1',
+        'My Account',
+      );
+      const account2 = createMockAccountGroup(
+        'keyring:wallet1/group2',
+        'Test Account',
+      );
       const wallet1 = createMockWallet('wallet1', 'Wallet 1', [
         account1,
         account2,
@@ -512,8 +548,14 @@ describe('MultichainAccountSelectorList', () => {
     });
 
     it('handles empty search input', async () => {
-      const account1 = createMockAccountGroup('group1', 'My Account');
-      const account2 = createMockAccountGroup('group2', 'Test Account');
+      const account1 = createMockAccountGroup(
+        'keyring:wallet1/group1',
+        'My Account',
+      );
+      const account2 = createMockAccountGroup(
+        'keyring:wallet1/group2',
+        'Test Account',
+      );
       const wallet1 = createMockWallet('wallet1', 'Wallet 1', [
         account1,
         account2,
@@ -559,8 +601,14 @@ describe('MultichainAccountSelectorList', () => {
     });
 
     it('trims whitespace from search input', async () => {
-      const account1 = createMockAccountGroup('group1', 'My Account');
-      const account2 = createMockAccountGroup('group2', 'Test Account');
+      const account1 = createMockAccountGroup(
+        'keyring:wallet1/group1',
+        'My Account',
+      );
+      const account2 = createMockAccountGroup(
+        'keyring:wallet1/group2',
+        'Test Account',
+      );
       const wallet1 = createMockWallet('wallet1', 'Wallet 1', [
         account1,
         account2,
@@ -594,7 +642,10 @@ describe('MultichainAccountSelectorList', () => {
 
   describe('Account Creation and Scrolling', () => {
     it('renders AccountListFooter with correct props', () => {
-      const account1 = createMockAccountGroup('group1', 'Account 1');
+      const account1 = createMockAccountGroup(
+        'keyring:wallet1/group1',
+        'Account 1',
+      );
       const wallet1 = createMockWallet('wallet1', 'Wallet 1', [account1]);
 
       const internalAccounts = createMockInternalAccountsFromGroups([account1]);
@@ -613,8 +664,14 @@ describe('MultichainAccountSelectorList', () => {
     });
 
     it('handles multiple wallets with AccountListFooter', () => {
-      const account1 = createMockAccountGroup('group1', 'Account 1');
-      const account2 = createMockAccountGroup('group2', 'Account 2');
+      const account1 = createMockAccountGroup(
+        'keyring:wallet1/group1',
+        'Account 1',
+      );
+      const account2 = createMockAccountGroup(
+        'keyring:wallet2/group2',
+        'Account 2',
+      );
       const wallet1 = createMockWallet('wallet1', 'Wallet 1', [account1]);
       const wallet2 = createMockWallet('wallet2', 'Wallet 2', [account2]);
 
@@ -637,7 +694,10 @@ describe('MultichainAccountSelectorList', () => {
     });
 
     it('passes walletId to AccountListFooter', () => {
-      const account1 = createMockAccountGroup('group1', 'Account 1');
+      const account1 = createMockAccountGroup(
+        'keyring:wallet1/group1',
+        'Account 1',
+      );
       const wallet1 = createMockWallet('wallet1', 'Wallet 1', [account1]);
 
       const internalAccounts = createMockInternalAccountsFromGroups([account1]);

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/MultichainAccountSelectorList.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/MultichainAccountSelectorList.tsx
@@ -33,6 +33,7 @@ import {
   MULTICHAIN_ACCOUNT_SELECTOR_EMPTY_STATE_TESTID,
 } from './MultichainAccountSelectorList.constants';
 import { strings } from '../../../../../locales/i18n';
+import { selectAvatarAccountType } from '../../../../selectors/settings';
 
 const MultichainAccountSelectorList = ({
   onSelectAccount,
@@ -60,6 +61,8 @@ const MultichainAccountSelectorList = ({
     () => new Set(selectedAccountGroups.map((g) => g.id)),
     [selectedAccountGroups],
   );
+
+  const avatarAccountType = useSelector(selectAvatarAccountType);
 
   // Debounce search text with 200ms delay
   useEffect(() => {
@@ -212,6 +215,7 @@ const MultichainAccountSelectorList = ({
             return (
               <AccountListCell
                 accountGroup={item.data}
+                avatarAccountType={avatarAccountType}
                 isSelected={isSelected}
                 onSelectAccount={handleSelectAccount}
               />
@@ -231,7 +235,12 @@ const MultichainAccountSelectorList = ({
             return null;
         }
       },
-      [selectedIdSet, handleSelectAccount, handleAccountCreated],
+      [
+        selectedIdSet,
+        handleSelectAccount,
+        handleAccountCreated,
+        avatarAccountType,
+      ],
     );
 
   const keyExtractor = useCallback(

--- a/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/MultichainAccountsConnectedList.test.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/MultichainAccountsConnectedList.test.tsx
@@ -33,16 +33,20 @@ jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ navigate: mockNavigate }),
 }));
 
-const MOCK_ACCOUNT_GROUP_1 = createMockAccountGroup('group-1', 'Account 1', [
-  'account-1',
-]);
+const MOCK_ACCOUNT_GROUP_1 = createMockAccountGroup(
+  'keyring:test-group/group-1',
+  'Account 1',
+  ['account-1'],
+);
 
-const MOCK_ACCOUNT_GROUP_2 = createMockAccountGroup('group-2', 'Account 2', [
-  'account-2',
-]);
+const MOCK_ACCOUNT_GROUP_2 = createMockAccountGroup(
+  'keyring:test-group/group-2',
+  'Account 2',
+  ['account-2'],
+);
 
 const MOCK_ACCOUNT_GROUP_3 = createMockAccountGroup(
-  'group-3',
+  'keyring:test-group/group-3',
   'Multichain Account',
   ['account-3a', 'account-3b'],
 );

--- a/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/__snapshots__/MultichainAccountsConnectedList.test.tsx.snap
+++ b/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/__snapshots__/MultichainAccountsConnectedList.test.tsx.snap
@@ -122,16 +122,38 @@ exports[`MultichainAccountsConnectedList renders component with different accoun
                   <View
                     style={
                       {
-                        "backgroundColor": "#3c4d9d0f",
+                        "alignItems": "center",
                         "borderColor": "#4459ff",
                         "borderRadius": 8,
                         "borderWidth": 2,
-                        "height": 32,
-                        "width": 32,
+                        "height": 36,
+                        "justifyContent": "center",
+                        "width": 36,
                       }
                     }
-                    testID="multichain-account-cell-avatar"
-                  />
+                  >
+                    <View
+                      style={
+                        {
+                          "backgroundColor": "#3c4d9d0f",
+                          "borderRadius": 6,
+                          "height": 32,
+                          "overflow": "hidden",
+                          "width": 32,
+                        }
+                      }
+                      testID="multichain-account-cell-avatar"
+                    >
+                      <View
+                        style={
+                          {
+                            "height": 32,
+                            "width": 32,
+                          }
+                        }
+                      />
+                    </View>
+                  </View>
                   <View
                     style={
                       {
@@ -287,16 +309,38 @@ exports[`MultichainAccountsConnectedList renders component with different accoun
                   <View
                     style={
                       {
-                        "backgroundColor": "#3c4d9d0f",
+                        "alignItems": "center",
                         "borderColor": "#4459ff",
                         "borderRadius": 8,
                         "borderWidth": 2,
-                        "height": 32,
-                        "width": 32,
+                        "height": 36,
+                        "justifyContent": "center",
+                        "width": 36,
                       }
                     }
-                    testID="multichain-account-cell-avatar"
-                  />
+                  >
+                    <View
+                      style={
+                        {
+                          "backgroundColor": "#3c4d9d0f",
+                          "borderRadius": 6,
+                          "height": 32,
+                          "overflow": "hidden",
+                          "width": 32,
+                        }
+                      }
+                      testID="multichain-account-cell-avatar"
+                    >
+                      <View
+                        style={
+                          {
+                            "height": 32,
+                            "width": 32,
+                          }
+                        }
+                      />
+                    </View>
+                  </View>
                   <View
                     style={
                       {

--- a/app/components/Views/MultichainAccounts/WalletDetails/BaseWalletDetails/index.test.tsx
+++ b/app/components/Views/MultichainAccounts/WalletDetails/BaseWalletDetails/index.test.tsx
@@ -254,10 +254,10 @@ describe('BaseWalletDetails', () => {
     ).mockReturnValue({
       accountTree: {
         wallets: {
-          [mockWallet.id]: {
+          [`keyring:${mockWallet.id}`]: {
             groups: {
-              group1: mockAccountGroup1,
-              group2: mockAccountGroup2,
+              [mockAccountGroup1.id]: mockAccountGroup1,
+              [mockAccountGroup2.id]: mockAccountGroup2,
             },
           },
         },

--- a/app/components/Views/MultichainAccounts/WalletDetails/BaseWalletDetails/index.tsx
+++ b/app/components/Views/MultichainAccounts/WalletDetails/BaseWalletDetails/index.tsx
@@ -73,6 +73,8 @@ export const BaseWalletDetails = ({
     selectMultichainAccountsState2Enabled,
   );
 
+  const avatarAccountType = useSelector(selectAvatarAccountType);
+
   const accountGroupsByWallet = useSelector(selectAccountGroupsByWallet);
   const accountGroups = useMemo(
     () =>
@@ -198,7 +200,12 @@ export const BaseWalletDetails = ({
 
     return (
       <View style={accountBoxStyle}>
-        <AccountCell accountGroup={accountGroup} isSelected={false} hideMenu />
+        <AccountCell
+          accountGroup={accountGroup}
+          avatarAccountType={avatarAccountType}
+          isSelected={false}
+          hideMenu
+        />
       </View>
     );
   };

--- a/app/selectors/multichainAccounts/accounts.ts
+++ b/app/selectors/multichainAccounts/accounts.ts
@@ -350,10 +350,6 @@ export const selectIconSeedAddressByAccountGroupId = (
     },
   );
 
-// Backwards compatibility alias (can be removed once all usages are migrated)
-export const selectEvmAddressByAccountGroupId = (groupId: AccountGroupId) =>
-  selectIconSeedAddressByAccountGroupId(groupId);
-
 /**
  * Selector to get account groups by a list of addresses.
  * Returns groups that contain at least one account matching any of the provided addresses.

--- a/app/selectors/multichainAccounts/accounts.ts
+++ b/app/selectors/multichainAccounts/accounts.ts
@@ -310,7 +310,7 @@ export const selectInternalAccountListSpreadByScopesByGroupId =
  * Priority:
  * 1) First EVM account address (any scope starting with 'eip155:')
  * 2) If no EVM account, fallback to the first internal account address in the group
- * 3) Otherwise undefined
+ * 3) Otherwise throw an error
  *
  */
 export const selectIconSeedAddressByAccountGroupId = (


### PR DESCRIPTION
## **Description**

1. What is the reason for the change?
- This change renders the AvatarAccount in the new multi chain accounts list. Prior to this change we were rendering an empty view in its place.
2. What is the improvement/solution?
- introduce `selectIconSeedAddressByAccountGroupId` which gets the EVM address from an account group and using that to render the Icons. This ensures that the icons match the icons that users see today for their EVM accounts. If we cannot find an evm address, we simply return the first address in the accountGroup array.
- render the AvatarAccount in the AccountCell component
- use the avatarAccountType from state to determine the users preferred account icon type.
- update tests.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**
- ensure that `export MM_ENABLE_MULTICHAIN_ACCOUNTS_STATE_2="false"` is in your `.js.env` (feature flag off)
- create a new wallet
- create a few evm accounts
- create a few solana accounts
- import a PK
- notice the icons that are renders in the account list
- turn on the feature flags by setting `export MM_ENABLE_MULTICHAIN_ACCOUNTS_STATE_2="true"` is in your `.js.env` (feature flagon)
- `source .js.env`
- `yarn watch:clean`
- reload the app
- open the account list
- the accounts are now grouped. the icons rendered in the account list should match the old icons of the EVM accounts (not solana). the pk icon should also be the same
- navigate to settings/general
- scroll to the bottom and change your preferred icon type to either blockies or jazzicons
- open the account list again, the icons should have changed to match your settings.

## **Screenshots/Recordings**

below is the before and after to the same account. Before with the feature flag disabled and after with the feature flag enabled. The bip44 icons should match the same evm account icons as before.

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

without the feature flag enabled

<img width="250" height="600" alt="Simulator Screenshot - iPhone 16 Plus - 2025-09-11 at 12 36 54" src="https://github.com/user-attachments/assets/3cb2e9b8-a6eb-47a1-be76-0c3b7df095e0" />

with the feature flag enabled

<img width="250" height="600" alt="Simulator Screenshot - iPhone 16 Plus - 2025-09-11 at 14 55 28" src="https://github.com/user-attachments/assets/63b67f53-1bd6-4cd9-af68-77ad02c4a84f" />
(account 5 was added after I took the before and after screenshots so no, this account did not go missing)



### **After**


<img width="250" height="600" alt="Simulator Screenshot - iPhone 16 Plus - 2025-09-11 at 12 46 31" src="https://github.com/user-attachments/assets/eb5685a7-a24e-469b-9eb6-55dc7dfe55d2" />


https://github.com/user-attachments/assets/c54c5c05-f245-47ba-bc5a-678a132b1623


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
