### PR TITLE
fix: Selected avatar account type styles in settings page

### DIFF
--- a/app/components/Views/Settings/GeneralSettings/index.js
+++ b/app/components/Views/Settings/GeneralSettings/index.js
@@ -39,6 +39,7 @@ import Text, {
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { MetricsEventBuilder } from '../../../../core/Analytics/MetricsEventBuilder';
 import { UserProfileProperty } from '../../../../util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types';
+import { colors as staticColors } from '../../../../styles/common';
 
 const diameter = 40;
 const spacing = 8;
@@ -146,21 +147,17 @@ const createStyles = (colors) =>
     },
     avatarWrapper: {
       borderRadius: 12,
-      width: diameter,
-      height: diameter,
+      width: diameter + 4, // 40 (diameter) + 2*2 (border width)
+      height: diameter + 4, // 40 (diameter) + 2*2 (border width)
       borderWidth: 2,
       justifyContent: 'center',
       alignItems: 'center',
     },
     selectedAvatarWrapper: {
-      width: diameter + 4, // 40 (diameter) + 2*2 (border width)
-      height: diameter + 4, // 40 (diameter) + 2*2 (border width)
-      borderWidth: 2,
       borderColor: colors.primary.default,
     },
     unselectedAvatarWrapper: {
-      borderWidth: 2,
-      borderColor: colors.background.transparent,
+      borderColor: staticColors.transparent,
     },
   });
 

--- a/app/components/Views/Settings/GeneralSettings/index.js
+++ b/app/components/Views/Settings/GeneralSettings/index.js
@@ -152,8 +152,6 @@ const createStyles = (colors) =>
       alignItems: 'center',
     },
     selectedAvatarWrapper: {
-      width: diameter + 4, // 40 (diameter) + 2*2 (border width)
-      height: diameter + 4, // 40 (diameter) + 2*2 (border width)
       borderWidth: 2,
       borderColor: colors.primary.default,
     },

--- a/app/components/Views/Settings/GeneralSettings/index.js
+++ b/app/components/Views/Settings/GeneralSettings/index.js
@@ -144,9 +144,19 @@ const createStyles = (colors) =>
       width: diameter,
       borderRadius: diameter / 2,
     },
-    selectedAvatar: {
+    avatarWrapper: {
+      borderRadius: 12,
+      width: diameter + 4, // 40 (diameter) + 2*2 (border width)
+      height: diameter + 4, // 40 (diameter) + 2*2 (border width)
       borderWidth: 2,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    selectedAvatarWrapper: {
       borderColor: colors.primary.default,
+    },
+    unselectedAvatarWrapper: {
+      borderColor: colors.background.transparent,
     },
   });
 
@@ -473,17 +483,21 @@ class Settings extends PureComponent {
                   }
                   style={styles.identicon_row}
                 >
-                  <AvatarAccount
-                    type={AvatarAccountType.Maskicon}
-                    accountAddress={selectedAddress}
-                    size={diameter}
-                    style={
+                  <View
+                    style={[
+                      styles.avatarWrapper,
                       avatarAccountType === AvatarAccountType.Maskicon
-                        ? styles.selectedAvatar
-                        : undefined
-                    }
-                  />
-                  <Text style={styles.identiconText}>Mask Icons</Text>
+                        ? styles.selectedAvatarWrapper
+                        : styles.unselectedAvatarWrapper,
+                    ]}
+                  >
+                    <AvatarAccount
+                      type={AvatarAccountType.Maskicon}
+                      accountAddress={selectedAddress}
+                      size={diameter}
+                    />
+                  </View>
+                  <Text style={styles.identiconText}>Maskicons</Text>
                 </TouchableOpacity>
                 <TouchableOpacity
                   onPress={() =>
@@ -491,16 +505,20 @@ class Settings extends PureComponent {
                   }
                   style={styles.identicon_row}
                 >
-                  <AvatarAccount
-                    type={AvatarAccountType.JazzIcon}
-                    accountAddress={selectedAddress}
-                    size={diameter}
-                    style={
+                  <View
+                    style={[
+                      styles.avatarWrapper,
                       avatarAccountType === AvatarAccountType.JazzIcon
-                        ? styles.selectedAvatar
-                        : undefined
-                    }
-                  />
+                        ? styles.selectedAvatarWrapper
+                        : styles.unselectedAvatarWrapper,
+                    ]}
+                  >
+                    <AvatarAccount
+                      type={AvatarAccountType.JazzIcon}
+                      accountAddress={selectedAddress}
+                      size={diameter}
+                    />
+                  </View>
                   <Text style={styles.identiconText}>
                     {strings('app_settings.jazzicons')}
                   </Text>
@@ -511,16 +529,20 @@ class Settings extends PureComponent {
                   }
                   style={styles.identicon_row}
                 >
-                  <AvatarAccount
-                    type={AvatarAccountType.Blockies}
-                    accountAddress={selectedAddress}
-                    size={diameter}
-                    style={
+                  <View
+                    style={[
+                      styles.avatarWrapper,
                       avatarAccountType === AvatarAccountType.Blockies
-                        ? styles.selectedAvatar
-                        : undefined
-                    }
-                  />
+                        ? styles.selectedAvatarWrapper
+                        : styles.unselectedAvatarWrapper,
+                    ]}
+                  >
+                    <AvatarAccount
+                      type={AvatarAccountType.Blockies}
+                      accountAddress={selectedAddress}
+                      size={diameter}
+                    />
+                  </View>
                   <Text style={styles.identiconText}>
                     {strings('app_settings.blockies')}
                   </Text>

--- a/app/components/Views/Settings/GeneralSettings/index.js
+++ b/app/components/Views/Settings/GeneralSettings/index.js
@@ -148,7 +148,7 @@ const createStyles = (colors) =>
       borderRadius: 12,
       width: diameter,
       height: diameter,
-      borderWidth: 0,
+      borderWidth: 2,
       justifyContent: 'center',
       alignItems: 'center',
     },
@@ -159,7 +159,7 @@ const createStyles = (colors) =>
       borderColor: colors.primary.default,
     },
     unselectedAvatarWrapper: {
-      borderWidth: 0,
+      borderWidth: 2,
       borderColor: colors.background.transparent,
     },
   });

--- a/app/components/Views/Settings/GeneralSettings/index.js
+++ b/app/components/Views/Settings/GeneralSettings/index.js
@@ -146,16 +146,20 @@ const createStyles = (colors) =>
     },
     avatarWrapper: {
       borderRadius: 12,
-      width: diameter + 4, // 40 (diameter) + 2*2 (border width)
-      height: diameter + 4, // 40 (diameter) + 2*2 (border width)
-      borderWidth: 2,
+      width: diameter,
+      height: diameter,
+      borderWidth: 0,
       justifyContent: 'center',
       alignItems: 'center',
     },
     selectedAvatarWrapper: {
+      width: diameter + 4, // 40 (diameter) + 2*2 (border width)
+      height: diameter + 4, // 40 (diameter) + 2*2 (border width)
+      borderWidth: 2,
       borderColor: colors.primary.default,
     },
     unselectedAvatarWrapper: {
+      borderWidth: 0,
       borderColor: colors.background.transparent,
     },
   });

--- a/app/components/Views/Settings/GeneralSettings/index.js
+++ b/app/components/Views/Settings/GeneralSettings/index.js
@@ -146,9 +146,8 @@ const createStyles = (colors) =>
     },
     avatarWrapper: {
       borderRadius: 12,
-      width: diameter,
-      height: diameter,
-      borderWidth: 2,
+      width: diameter + 4, // 40 (diameter) + 2*2 (border width)
+      height: diameter + 4, // 40 (diameter) + 2*2 (border width)
       justifyContent: 'center',
       alignItems: 'center',
     },
@@ -159,7 +158,7 @@ const createStyles = (colors) =>
       borderColor: colors.primary.default,
     },
     unselectedAvatarWrapper: {
-      borderWidth: 2,
+      borderWidth: 0,
       borderColor: colors.background.transparent,
     },
   });


### PR DESCRIPTION
## **Description**

1. What is the reason for the change?
- polish the selected style when you are changing your avatar account type
- change the setting title for Maskicons to ...`Maskicons`. It was `Mask Icons` before and this is technically not correct.
3. What is the improvement/solution?
- ensure that the hight of the Avatar box can accommodate the extra space from the border radius when it is selected. 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user changing avatar account type
    Given I am a user with the default avatar account type settings (MaskIcon)
    When I navigate to Settings/General and scroll to the botton
    Then I see my current avatar account setting as selected with a blue border
    And the other two options are not selected (with a black border)
    And my selected avatar type renders my account icon in the center of the box
   And changing my selection of Account icons does not change the positioning of the icons

```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="250" height="600" alt="simulator_screenshot_DF89BB0A-53EA-4E2A-B80A-93E4C0365392" src="https://github.com/user-attachments/assets/941d8c42-740b-4330-9663-4360b6749154" />

### **After**

<img width="250" height="600" alt="Simulator Screenshot - iPhone 16 Plus - 2025-09-10 at 16 30 48" src="https://github.com/user-attachments/assets/afb196b7-762d-44fa-af63-9e1afcd6e576" />

<img width="250" height="600" alt="Simulator Screenshot - iPhone 16 Plus - 2025-09-10 at 16 32 58" src="https://github.com/user-attachments/assets/d018adec-8b23-4c66-850c-701444cba271" />


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
