### PR TITLE
fix: Unresponsive PerpsTabView touchable opacities

### DIFF
--- a/app/component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase.tsx
+++ b/app/component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase.tsx
@@ -26,7 +26,7 @@ import {
 } from './ButtonBase.constants';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 
-const TouchableOpacity = ({
+export const TouchableOpacity = ({
   onPress,
   disabled,
   children,

--- a/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
@@ -1,6 +1,6 @@
 import { useNavigation, type NavigationProp } from '@react-navigation/native';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Modal, ScrollView, TouchableOpacity, View } from 'react-native';
+import { Modal, ScrollView, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useSelector } from 'react-redux';
 import { strings } from '../../../../../../locales/i18n';
@@ -47,6 +47,7 @@ import {
 } from '../../../../../../e2e/selectors/Perps/Perps.selectors';
 import PerpsBottomSheetTooltip from '../../components/PerpsBottomSheetTooltip';
 import { selectPerpsEligibility } from '../../selectors/perpsController';
+import { TouchableOpacity } from '../../../../../component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase';
 
 interface PerpsTabViewProps {}
 

--- a/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
@@ -47,7 +47,10 @@ import {
 } from '../../../../../../e2e/selectors/Perps/Perps.selectors';
 import PerpsBottomSheetTooltip from '../../components/PerpsBottomSheetTooltip';
 import { selectPerpsEligibility } from '../../selectors/perpsController';
-import { TouchableOpacity } from '../../../../../component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase';
+import {
+  TouchablePerpsComponent,
+  useCoordinatedPress,
+} from '../../components/PressablePerpsComponent/PressablePerpsComponent';
 
 interface PerpsTabViewProps {}
 
@@ -163,10 +166,16 @@ const PerpsTabView: React.FC<PerpsTabViewProps> = () => {
     }
   }, [navigation, isFirstTimeUser]);
 
+  const coordinatedPress = useCoordinatedPress();
+
+  const memoizedPressHandler = useCallback(() => {
+    coordinatedPress(handleNewTrade);
+  }, [coordinatedPress, handleNewTrade]);
+
   const renderStartTradeCTA = () => (
-    <TouchableOpacity
+    <TouchablePerpsComponent
       style={styles.startTradeCTA}
-      onPress={handleNewTrade}
+      onPress={memoizedPressHandler}
       testID={PerpsTabViewSelectorsIDs.START_NEW_TRADE_CTA}
     >
       <View style={styles.startTradeContent}>
@@ -181,7 +190,7 @@ const PerpsTabView: React.FC<PerpsTabViewProps> = () => {
           {strings('perps.position.list.start_new_trade')}
         </Text>
       </View>
-    </TouchableOpacity>
+    </TouchablePerpsComponent>
   );
 
   const renderOrdersSection = () => {

--- a/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
+++ b/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
@@ -18,7 +18,10 @@ import { usePerpsMarkets } from '../../hooks/usePerpsMarkets';
 import PerpsTokenLogo from '../PerpsTokenLogo';
 import styleSheet from './PerpsCard.styles';
 import type { PerpsCardProps } from './PerpsCard.types';
-import { TouchableOpacity } from '../../../../../component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase';
+import {
+  TouchablePerpsComponent,
+  useCoordinatedPress,
+} from '../PressablePerpsComponent/PressablePerpsComponent';
 
 /**
  * PerpsCard Component
@@ -34,6 +37,8 @@ const PerpsCard: React.FC<PerpsCardProps> = ({
 }) => {
   const { styles } = useStyles(styleSheet, {});
   const navigation = useNavigation<NavigationProp<PerpsNavigationParamList>>();
+
+  const coordinatedPress = useCoordinatedPress();
 
   // Determine which type of data we have
   const symbol = position?.coin || order?.symbol || '';
@@ -92,15 +97,19 @@ const PerpsCard: React.FC<PerpsCardProps> = ({
     }
   }, [onPress, markets, symbol, navigation, order, position]);
 
+  const memoizedPressHandler = useCallback(() => {
+    coordinatedPress(handlePress);
+  }, [coordinatedPress, handlePress]);
+
   if (!position && !order) {
     return null;
   }
 
   return (
-    <TouchableOpacity
+    <TouchablePerpsComponent
       style={styles.card}
       activeOpacity={0.7}
-      onPress={handlePress}
+      onPress={memoizedPressHandler}
       testID={testID}
     >
       <View style={styles.cardContent}>
@@ -133,7 +142,7 @@ const PerpsCard: React.FC<PerpsCardProps> = ({
           </Text>
         </View>
       </View>
-    </TouchableOpacity>
+    </TouchablePerpsComponent>
   );
 };
 

--- a/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
+++ b/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { TouchableOpacity, View } from 'react-native';
+import { View } from 'react-native';
 import { useNavigation, type NavigationProp } from '@react-navigation/native';
 import Text, {
   TextColor,
@@ -18,6 +18,7 @@ import { usePerpsMarkets } from '../../hooks/usePerpsMarkets';
 import PerpsTokenLogo from '../PerpsTokenLogo';
 import styleSheet from './PerpsCard.styles';
 import type { PerpsCardProps } from './PerpsCard.types';
+import { TouchableOpacity } from '../../../../../component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase';
 
 /**
  * PerpsCard Component
@@ -38,7 +39,7 @@ const PerpsCard: React.FC<PerpsCardProps> = ({
   const symbol = position?.coin || order?.symbol || '';
 
   // Get all markets data to find the specific market when navigating
-  const { markets } = usePerpsMarkets();
+  const { markets, isLoading: isLoadingMarkets } = usePerpsMarkets();
 
   // Calculate display values
   let primaryText = '';
@@ -89,6 +90,8 @@ const PerpsCard: React.FC<PerpsCardProps> = ({
         });
       }
     }
+    // Note: TouchableOpacity is now disabled when markets are loading or empty
+    // This prevents the appearance of inactive touchables
   }, [onPress, markets, symbol, navigation, order, position]);
 
   if (!position && !order) {
@@ -100,6 +103,7 @@ const PerpsCard: React.FC<PerpsCardProps> = ({
       style={styles.card}
       activeOpacity={0.7}
       onPress={handlePress}
+      disabled={isLoadingMarkets || markets.length === 0}
       testID={testID}
     >
       <View style={styles.cardContent}>

--- a/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
+++ b/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
@@ -103,7 +103,6 @@ const PerpsCard: React.FC<PerpsCardProps> = ({
       style={styles.card}
       activeOpacity={0.7}
       onPress={handlePress}
-      disabled={markets.length === 0}
       testID={testID}
     >
       <View style={styles.cardContent}>

--- a/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
+++ b/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
@@ -39,7 +39,7 @@ const PerpsCard: React.FC<PerpsCardProps> = ({
   const symbol = position?.coin || order?.symbol || '';
 
   // Get all markets data to find the specific market when navigating
-  const { markets, isLoading: isLoadingMarkets } = usePerpsMarkets();
+  const { markets } = usePerpsMarkets();
 
   // Calculate display values
   let primaryText = '';
@@ -103,7 +103,7 @@ const PerpsCard: React.FC<PerpsCardProps> = ({
       style={styles.card}
       activeOpacity={0.7}
       onPress={handlePress}
-      disabled={isLoadingMarkets || markets.length === 0}
+      disabled={markets.length === 0}
       testID={testID}
     >
       <View style={styles.cardContent}>

--- a/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
+++ b/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
@@ -90,8 +90,6 @@ const PerpsCard: React.FC<PerpsCardProps> = ({
         });
       }
     }
-    // Note: TouchableOpacity is now disabled when markets are loading or empty
-    // This prevents the appearance of inactive touchables
   }, [onPress, markets, symbol, navigation, order, position]);
 
   if (!position && !order) {

--- a/app/components/UI/Perps/components/PressablePerpsComponent/PressablePerpsComponent.tsx
+++ b/app/components/UI/Perps/components/PressablePerpsComponent/PressablePerpsComponent.tsx
@@ -1,0 +1,29 @@
+import { Platform, TouchableOpacity as RNTouchableOpacity } from 'react-native';
+import { TouchableOpacity as TemporaryTouchableOpacity } from '../../../../../component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase';
+import { useRef } from 'react';
+// Disable gesture wrapper in test environments to prevent test interference
+const isE2ETest =
+  process.env.IS_TEST === 'true' || process.env.METAMASK_ENVIRONMENT === 'e2e';
+const isUnitTest = process.env.NODE_ENV === 'test';
+
+export const TouchablePerpsComponent =
+  Platform.OS === 'android' && !isE2ETest && !isUnitTest
+    ? TemporaryTouchableOpacity
+    : RNTouchableOpacity;
+
+export const useCoordinatedPress = () => {
+  // Shared coordination system for maximum reliability
+  // Both custom TouchableOpacity and main component use the same timestamp reference
+  const lastPressTime = useRef(0);
+  const COORDINATION_WINDOW = 100; // 100ms window for TalkBack compatibility
+
+  return (onPress: () => void) => {
+    const now = Date.now();
+    const timeSinceLastPress = now - lastPressTime.current;
+
+    if (onPress && timeSinceLastPress > COORDINATION_WINDOW) {
+      lastPressTime.current = now;
+      onPress();
+    }
+  };
+};

--- a/app/components/UI/Perps/components/PressablePerpsComponent/PressablePerpsComponent.tsx
+++ b/app/components/UI/Perps/components/PressablePerpsComponent/PressablePerpsComponent.tsx
@@ -1,6 +1,31 @@
 import { Platform, TouchableOpacity as RNTouchableOpacity } from 'react-native';
 import { TouchableOpacity as TemporaryTouchableOpacity } from '../../../../../component-library/components/Buttons/Button/foundation/ButtonBase/ButtonBase';
 import { useRef } from 'react';
+
+/**
+ * TouchablePerpsComponent - Platform-specific TouchableOpacity for Perps components
+ *
+ * WHY THIS IS NECESSARY:
+ *
+ * This addresses a known React Native bug where TouchableOpacity components inside ScrollViews
+ * on Android often fail to respond to touch events. This is a common issue with React Native's
+ * new architecture update that affects scrollable views on Android.
+ *
+ * The issue is documented in this outstanding Facebook PR:
+ * https://github.com/facebook/react-native/pull/51835
+ *
+ * SOLUTION APPROACH:
+ *
+ * 1. Use Android-specific TouchableOpacity (from ButtonBase) in production Android environments
+ * 2. Use standard TouchableOpacity in test environments to prevent E2E test failures
+ * 3. Combine with press coordination system to prevent double-press issues with TalkBack
+ *
+ * This is a temporary workaround until React Native fixes the underlying issue on their side.
+ *
+ * REFERENCE:
+ * - React Native Issue: https://github.com/facebook/react-native/pull/51835
+ */
+
 // Disable gesture wrapper in test environments to prevent test interference
 const isE2ETest =
   process.env.IS_TEST === 'true' || process.env.METAMASK_ENVIRONMENT === 'e2e';
@@ -11,6 +36,15 @@ export const TouchablePerpsComponent =
     ? TemporaryTouchableOpacity
     : RNTouchableOpacity;
 
+/**
+ * useCoordinatedPress - Hook for preventing double-press issues
+ *
+ * This hook provides press coordination to prevent rapid successive presses,
+ * which is especially important for accessibility (TalkBack) and prevents
+ * accidental double-taps that could cause unintended actions.
+ *
+ * Uses a 100ms coordination window, matching the ButtonBase implementation.
+ */
 export const useCoordinatedPress = () => {
   // Shared coordination system for maximum reliability
   // Both custom TouchableOpacity and main component use the same timestamp reference


### PR DESCRIPTION
## **Description**

Fixes unresponsive touchable opacities on PerpsTab by importing custom `GestureDetector` from component library.

## **Changelog**

CHANGELOG entry: Fixes unresponsive PerpsTab buttons

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1565

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/12750adf-2952-4836-8be2-be5677f20fa6

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
