### PR TITLE
fix: TAT-1518 - Keyboard width causes wrapping issues on buttons

### DIFF
--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.styles.ts
@@ -76,7 +76,6 @@ const createStyles = (colors: Colors) =>
       marginBottom: 12,
     },
     bottomSection: {
-      paddingHorizontal: 24,
       paddingVertical: 24,
     },
     percentageButtonsContainer: {

--- a/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
+++ b/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
@@ -317,7 +317,16 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
               variant={ButtonVariants.Secondary}
               size={ButtonSize.Md}
               width={ButtonWidthTypes.Auto}
-              label={strings('perps.position.card.close_position')}
+              label={
+                  <Text
+                    variant={TextVariant.BodyMDMedium}
+                    color={TextColor.Default}
+                    numberOfLines={1}
+                    adjustsFontSizeToFit
+                  >
+                    {strings('perps.position.card.close_position')}
+                  </Text>
+              }
               onPress={handleClosePress}
               style={styles.footerButton}
               testID={PerpsPositionCardSelectorsIDs.CLOSE_BUTTON}

--- a/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
+++ b/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
@@ -318,14 +318,14 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
               size={ButtonSize.Md}
               width={ButtonWidthTypes.Auto}
               label={
-                  <Text
-                    variant={TextVariant.BodyMDMedium}
-                    color={TextColor.Default}
-                    numberOfLines={1}
-                    adjustsFontSizeToFit
-                  >
-                    {strings('perps.position.card.close_position')}
-                  </Text>
+                <Text
+                  variant={TextVariant.BodyMDMedium}
+                  color={TextColor.Default}
+                  numberOfLines={1}
+                  adjustsFontSizeToFit
+                >
+                  {strings('perps.position.card.close_position')}
+                </Text>
               }
               onPress={handleClosePress}
               style={styles.footerButton}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

https://consensyssoftware.atlassian.net/browse/TAT-1518

This PR fixes two issues:

1 - Keyboard width causes wrapping issues on buttons

Since we have evidence (https://consensyssoftware.atlassian.net/browse/TAT-1518) that the keypad on close position works correctly since it has the correct padding, I made sure the keypad in open position has the exact same padding.

2 - Close Position button wrapping incorrectly on small screens

Before:
<img width="315" height="274" alt="image" src="https://github.com/user-attachments/assets/6a293919-33f3-4977-bc01-636b5fa3a454" />

After:
<img width="311" height="276" alt="image" src="https://github.com/user-attachments/assets/6b50b516-b4aa-4e36-bb6e-38b0ce4fa390" />


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
