### PR TITLE
Fix jira ticket TAT-1640 order slider min value

### DIFF
--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -770,7 +770,7 @@ const PerpsOrderViewContentBase: React.FC = () => {
             <PerpsSlider
               value={parseFloat(orderForm.amount || '0')}
               onValueChange={(value) => setAmount(Math.floor(value).toString())}
-              minimumValue={0}
+              minimumValue={10}
               maximumValue={amountTimesLeverage}
               step={1}
               showPercentageLabels


### PR DESCRIPTION
Fixes TAT-1640: Set Perps order slider minimum value to $10 to align with the required minimum order size.

The previous slider allowed selection between $0 and $9, which conflicted with the existing protocol-level $10 minimum order validation, leading to a confusing user experience. This change updates the UI to reflect the actual minimum.

---
[Slack Thread](https://consensys.slack.com/archives/D09EHGLNK29/p1757560169436699?thread_ts=1757560169.436699&cid=D09EHGLNK29)

<a href="https://cursor.com/background-agent?bcId=bc-6475fbe3-3b65-4a15-8a5f-7127686d8b79">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6475fbe3-3b65-4a15-8a5f-7127686d8b79">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

