### PR TITLE
Remove redundant leverage presets for 3x max

### DIFF
--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.test.tsx
@@ -617,6 +617,25 @@ describe('PerpsLeverageBottomSheet', () => {
       expect(screen.queryByText('20x')).toBeNull(); // Should not show 20x in quick select
       expect(screen.queryByText('40x')).toBeNull(); // Should not show 40x
     });
+
+    it('hides quick select buttons when maxLeverage is 3x or lower', () => {
+      // Arrange - maxLeverage: 3, should hide all preset buttons to avoid redundant UI
+      const props = { ...defaultProps, maxLeverage: 3, leverage: 2 };
+
+      // Act
+      render(<PerpsLeverageBottomSheet {...props} />);
+
+      // Assert - No quick select buttons should be visible
+      // Note: We look for buttons that would typically be in the quick select area
+      // The only "2x" visible should be in the main display and footer button
+      const allTexts = screen.getAllByText(/2x/);
+      // Should only find 2x in: 1) main display "2x" and 2) footer "Set 2x" button
+      expect(allTexts).toHaveLength(2);
+      
+      // Verify no other preset buttons are shown
+      expect(screen.queryByText('5x')).toBeNull();
+      expect(screen.queryByText('10x')).toBeNull();
+    });
   });
 
   describe('Leverage Risk Styling', () => {

--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.tsx
@@ -479,6 +479,15 @@ const PerpsLeverageBottomSheet: React.FC<PerpsLeverageBottomSheetProps> = ({
     );
     const baseOptions = [2, 5, 10, 20, 40];
     const filtered = baseOptions.filter((option) => option <= maxLeverage);
+    
+    // Hide preset buttons when max leverage is 3x or lower to avoid redundant UI
+    // When max leverage is 3x, only 2x would be available as a preset, creating
+    // a confusing experience with 2x shown at the top, as a button, and in footer
+    if (maxLeverage <= 3) {
+      DevLogger.log(`Hiding leverage presets for maxLeverage: ${maxLeverage} (≤3x)`);
+      return [];
+    }
+    
     DevLogger.log(`Available leverage options: ${filtered.join(', ')}`);
     return filtered;
   }, [maxLeverage]);
@@ -718,35 +727,37 @@ const PerpsLeverageBottomSheet: React.FC<PerpsLeverageBottomSheetProps> = ({
           </View>
         </View>
 
-        {/* Quick select buttons */}
-        <View style={styles.quickSelectButtons}>
-          {quickSelectValues.map((value) => (
-            <TouchableOpacity
-              key={value}
-              style={[
-                styles.quickSelectButton,
-                tempLeverage === value && styles.quickSelectButtonActive,
-              ]}
-              onPress={() => {
-                setIsDragging(false); // Ensure we're not in dragging state
-                setTempLeverage(value);
-                setInputMethod('preset');
-                // Add haptic feedback for quick select buttons
-                impactAsync(ImpactFeedbackStyle.Light);
-              }}
-            >
-              <Text
-                variant={TextVariant.BodyLGMedium}
-                color={
-                  tempLeverage === value ? TextColor.Primary : TextColor.Default
-                }
-                style={styles.quickSelectText}
+        {/* Quick select buttons - only show when preset options are available */}
+        {quickSelectValues.length > 0 && (
+          <View style={styles.quickSelectButtons}>
+            {quickSelectValues.map((value) => (
+              <TouchableOpacity
+                key={value}
+                style={[
+                  styles.quickSelectButton,
+                  tempLeverage === value && styles.quickSelectButtonActive,
+                ]}
+                onPress={() => {
+                  setIsDragging(false); // Ensure we're not in dragging state
+                  setTempLeverage(value);
+                  setInputMethod('preset');
+                  // Add haptic feedback for quick select buttons
+                  impactAsync(ImpactFeedbackStyle.Light);
+                }}
               >
-                {value}x
-              </Text>
-            </TouchableOpacity>
-          ))}
-        </View>
+                <Text
+                  variant={TextVariant.BodyLGMedium}
+                  color={
+                    tempLeverage === value ? TextColor.Primary : TextColor.Default
+                  }
+                  style={styles.quickSelectText}
+                >
+                  {value}x
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        )}
       </View>
 
       <BottomSheetFooter buttonPropsArray={footerButtonProps} />


### PR DESCRIPTION
Hide leverage preset buttons when max leverage is 3x or lower to prevent redundant UI elements.

When the maximum leverage is 3x, the only available quick select preset is 2x. This resulted in '2x' being displayed at the top, as a quick select button, and in the footer's 'Set 2x' button, creating a confusing and unnecessary repetition (JIRA TAT-1607).

---
[Slack Thread](https://consensys.slack.com/archives/D09EHGLNK29/p1757560342782519?thread_ts=1757560342.782519&cid=D09EHGLNK29)

<a href="https://cursor.com/background-agent?bcId=bc-1f23aaa6-17ff-4ab1-9eef-a5efe07bab31">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1f23aaa6-17ff-4ab1-9eef-a5efe07bab31">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

