### PR TITLE
fix: return a 7 day fundings range to avoid clipping

### DIFF
--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.test.tsx
@@ -196,6 +196,9 @@ describe('PerpsTransactionsView', () => {
         skipInitialFetch: false,
       });
       expect(mockUsePerpsFunding).toHaveBeenCalledWith({
+        params: {
+          startTime: expect.any(Number),
+        },
         skipInitialFetch: false,
       });
     });
@@ -224,6 +227,9 @@ describe('PerpsTransactionsView', () => {
       skipInitialFetch: true,
     });
     expect(mockUsePerpsFunding).toHaveBeenCalledWith({
+      params: {
+        startTime: expect.any(Number),
+      },
       skipInitialFetch: true,
     });
   });

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx
@@ -46,6 +46,7 @@ import {
 import { styleSheet } from './PerpsTransactionsView.styles';
 import { PerpsMeasurementName } from '../../constants/performanceMetrics';
 import { usePerpsScreenTracking } from '../../hooks/usePerpsScreenTracking';
+import { getUserFundingsListTimePeriod } from '../../utils/transactionUtils';
 
 const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = () => {
   const { styles } = useStyles(styleSheet, {});
@@ -76,7 +77,16 @@ const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = () => {
     skipInitialFetch: !isConnected,
   });
 
+  // Memoize the funding params to prevent infinite re-renders
+  const fundingParams = useMemo(
+    () => ({
+      startTime: getUserFundingsListTimePeriod(),
+    }),
+    [], // Empty dependency array since we want this to be stable
+  );
+
   const { funding: fundingData, refresh: refreshFunding } = usePerpsFunding({
+    params: fundingParams,
     skipInitialFetch: !isConnected,
   });
 

--- a/app/components/UI/Perps/utils/transactionUtils.test.ts
+++ b/app/components/UI/Perps/utils/transactionUtils.test.ts
@@ -1,0 +1,55 @@
+import { getUserFundingsListTimePeriod } from './transactionUtils';
+
+describe('getUserFundingsListTimePeriod', () => {
+  beforeEach(() => {
+    // Mock Date.now to ensure consistent test results
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should return timestamp for 7 days ago from current time', () => {
+    // Arrange
+    const mockCurrentTime = 1700000000000; // Fixed timestamp for testing
+    jest.setSystemTime(mockCurrentTime);
+    const expectedSevenDaysAgo = mockCurrentTime - 7 * 24 * 60 * 60 * 1000;
+
+    // Act
+    const result = getUserFundingsListTimePeriod();
+
+    // Assert
+    expect(result).toBe(expectedSevenDaysAgo);
+  });
+
+  it('should return different values when called at different times', () => {
+    // Arrange
+    const firstTime = 1700000000000;
+    const secondTime = 1700000000000 + 1000; // 1 second later
+
+    // Act
+    jest.setSystemTime(firstTime);
+    const firstResult = getUserFundingsListTimePeriod();
+
+    jest.setSystemTime(secondTime);
+    const secondResult = getUserFundingsListTimePeriod();
+
+    // Assert
+    expect(secondResult).toBe(firstResult + 1000);
+  });
+
+  it('should return a valid timestamp format', () => {
+    // Arrange
+    const mockCurrentTime = 1700000000000;
+    jest.setSystemTime(mockCurrentTime);
+
+    // Act
+    const result = getUserFundingsListTimePeriod();
+
+    // Assert
+    expect(typeof result).toBe('number');
+    expect(result).toBeGreaterThan(0);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+});

--- a/app/components/UI/Perps/utils/transactionUtils.ts
+++ b/app/components/UI/Perps/utils/transactionUtils.ts
@@ -1,0 +1,10 @@
+/**
+ * Get the timestamp for 14 days ago from now
+ * Used for userFundingsListTimePeriod to fetch funding data from the last 14 days
+ * @returns Unix timestamp in milliseconds for 14 days ago
+ */
+export const getUserFundingsListTimePeriod = (): number => {
+  const now = Date.now();
+  const sevenDaysAgo = now - 7 * 24 * 60 * 60 * 1000; // 7 days in milliseconds
+  return sevenDaysAgo;
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
1. What is the reason for the change?
The fundings were inconsistently returning at different lengths and would clip data

2. What is the improvement/solution?
Pass an explicit startTime so that we don't default to zero which is all time. Eventually the data will be clipped and we are returning possibly a huge array in this case. With the staking testing account we have quite a lot of line items for even 14 days. I have then limited to the past 7 days of fundings for now.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1498

## **Manual testing steps**

```gherkin
Feature: fix for fundings list history

  Scenario: user goes to the transactions history
    Given user clicks the perps tab and the fundings tab under that

    When user views data
    Then it starts from today and has 7 days of history
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="400" height="auto" alt="Simulator Screenshot - iPhone 15 Pro - 2025-09-11 at 00 09 22" src="https://github.com/user-attachments/assets/60b7fcaa-ac08-4a58-8c2c-b9298e424099" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
