### PR TITLE
fix: flipped position pnl display in transaction list

### DIFF
--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsPositionTransactionView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsPositionTransactionView.test.tsx
@@ -158,7 +158,7 @@ describe('PerpsPositionTransactionView', () => {
     expect(getByText('Size')).toBeOnTheScreen();
   });
 
-  it('should only display P&L when action is Closed', () => {
+  it('should only display P&L when action is Closed or Flipped', () => {
     // Given a closed position with P&L
     const { getByText } = renderWithProvider(<PerpsPositionTransactionView />, {
       state: mockInitialState,
@@ -167,6 +167,33 @@ describe('PerpsPositionTransactionView', () => {
     // Then P&L should be displayed for closed position
     expect(getByText('Net P&L')).toBeOnTheScreen();
     expect(getByText('+$150.75')).toBeOnTheScreen();
+  });
+
+  it('should display P&L when action is Flipped', () => {
+    // Given a flipped position with P&L
+    const flippedTransaction = {
+      ...mockTransaction,
+      category: 'position_close' as const,
+      fill: {
+        ...mockTransaction.fill,
+        action: 'Flipped',
+        pnl: '225.50',
+        amount: '+$225.50',
+        amountNumber: 225.5,
+      },
+    };
+
+    mockUseRoute.mockReturnValue({
+      params: { transaction: flippedTransaction },
+    });
+
+    const { getByText } = renderWithProvider(<PerpsPositionTransactionView />, {
+      state: mockInitialState,
+    });
+
+    // Then P&L should be displayed for flipped position
+    expect(getByText('Net P&L')).toBeOnTheScreen();
+    expect(getByText('+$225.50')).toBeOnTheScreen();
   });
 
   it('should not display P&L for non-closed positions', () => {
@@ -247,6 +274,32 @@ describe('PerpsPositionTransactionView', () => {
     // Then P&L should be displayed with error color (negative)
     expect(getByText('Net P&L')).toBeOnTheScreen();
     expect(getByText('-$75.25')).toBeOnTheScreen();
+  });
+
+  it('should apply correct color for negative P&L on flipped positions', () => {
+    // Given a flipped position with negative P&L
+    const negativePnLFlippedTransaction = {
+      ...mockTransaction,
+      fill: {
+        ...mockTransaction.fill,
+        action: 'Flipped',
+        pnl: '-125.75',
+        amount: '-$125.75',
+        amountNumber: -125.75,
+      },
+    };
+
+    mockUseRoute.mockReturnValue({
+      params: { transaction: negativePnLFlippedTransaction },
+    });
+
+    const { getByText } = renderWithProvider(<PerpsPositionTransactionView />, {
+      state: mockInitialState,
+    });
+
+    // Then P&L should be displayed with error color (negative) for flipped position
+    expect(getByText('Net P&L')).toBeOnTheScreen();
+    expect(getByText('-$125.75')).toBeOnTheScreen();
   });
 
   it('should handle zero P&L correctly', () => {

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsPositionTransactionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsPositionTransactionView.tsx
@@ -115,7 +115,11 @@ const PerpsPositionTransactionView: React.FC = () => {
     },
   ].filter(Boolean);
 
-  if (transaction.fill?.pnl && transaction.fill?.action === 'Closed') {
+  if (
+    transaction.fill?.pnl &&
+    (transaction.fill?.action === 'Closed' ||
+      transaction.fill?.action === 'Flipped')
+  ) {
     const pnlValue = BigNumber(transaction.fill?.amountNumber || 0);
     const isPositive = pnlValue.isGreaterThanOrEqualTo(0);
 

--- a/app/components/UI/Perps/utils/transactionTransforms.test.ts
+++ b/app/components/UI/Perps/utils/transactionTransforms.test.ts
@@ -36,11 +36,14 @@ describe('transactionTransforms', () => {
         asset: 'ETH',
         fill: {
           shortTitle: 'Opened long',
+          amount: '-$5.00', // For opens: show fee paid (negative)
+          amountNumber: 5.0,
           isPositive: false, // Opens are negative (cost)
           size: '1.5',
           entryPrice: '2000.00',
           pnl: '100.50',
           fee: '5.00',
+          points: '0',
           feeToken: 'USDC',
           action: 'Opened',
         },
@@ -62,7 +65,9 @@ describe('transactionTransforms', () => {
         title: 'Closed ETH short',
         fill: {
           shortTitle: 'Closed short',
-          isPositive: true, // Closes are positive (profit/loss)
+          amount: '+$70.25', // For closes: PnL minus fee (75.25 - 5.00)
+          amountNumber: 70.25,
+          isPositive: true, // Positive PnL after fee
           action: 'Closed',
         },
       });
@@ -99,8 +104,9 @@ describe('transactionTransforms', () => {
 
       const result = transformFillsToTransactions([closedFill]);
 
-      // For closed positions, uses PnL - fee
+      // For closed positions, uses PnL - fee (150.75 - 5.00 = 145.75)
       expect(result[0].fill?.amount).toBe('+$145.75');
+      expect(result[0].fill?.amountNumber).toBe(145.75);
       expect(result[0].fill?.isPositive).toBe(true);
     });
 
@@ -115,6 +121,47 @@ describe('transactionTransforms', () => {
 
       // Should use PnL - fee = 0 - 5 = -5
       expect(result[0].fill?.amount).toBe('-$5.00');
+      expect(result[0].fill?.amountNumber).toBe(-5.0);
+      expect(result[0].fill?.isPositive).toBe(false);
+    });
+
+    it('should handle break-even PnL (PnL equals fee)', () => {
+      const breakEvenFill: OrderFill = {
+        ...mockOrderFill,
+        direction: 'Close Long',
+        pnl: '5.00', // Equals the fee
+        fee: '5.00',
+      };
+
+      const result = transformFillsToTransactions([breakEvenFill]);
+
+      // PnL - fee = 5 - 5 = 0, should show $0.00 and be treated as positive (green)
+      expect(result[0].fill?.amount).toBe('$0.00');
+      expect(result[0].fill?.amountNumber).toBe(0);
+      expect(result[0].fill?.isPositive).toBe(true); // Break-even treated as positive
+    });
+
+    it('should handle flipped positions correctly', () => {
+      const flippedFill: OrderFill = {
+        ...mockOrderFill,
+        direction: 'Short > Long',
+        pnl: '50.00',
+        fee: '10.00',
+      };
+
+      const result = transformFillsToTransactions([flippedFill]);
+
+      expect(result[0]).toMatchObject({
+        category: 'position_close', // Flips are treated as closes
+        title: 'Flipped ETH short > long',
+        fill: {
+          shortTitle: 'Flipped short > long',
+          amount: '+$40.00', // PnL minus fee (50 - 10)
+          amountNumber: 40.0,
+          isPositive: true,
+          action: 'Flipped',
+        },
+      });
     });
 
     it('should handle empty fills array', () => {
@@ -196,9 +243,10 @@ describe('transactionTransforms', () => {
         timestamp: 1640995200000,
         asset: 'BTC',
         order: {
-          text: '', // Open orders have empty text
+          text: '', // Open orders have empty text (PerpsOrderTransactionStatus.Open = '')
           statusType: 'pending',
           type: 'limit',
+          size: '45000', // originalSize * price
           limitPrice: '45000',
           filled: '50%', // (1.0 - 0.5) / 1.0 * 100
         },
@@ -218,6 +266,7 @@ describe('transactionTransforms', () => {
       expect(result[0].order).toMatchObject({
         text: 'Filled',
         statusType: 'filled',
+        size: '45000', // originalSize * price = 1.0 * 45000
         filled: '50%',
       });
     });
@@ -233,6 +282,7 @@ describe('transactionTransforms', () => {
       expect(result[0].order).toMatchObject({
         text: 'Canceled',
         statusType: 'canceled',
+        size: '45000',
       });
     });
 
@@ -247,6 +297,7 @@ describe('transactionTransforms', () => {
       expect(result[0].order).toMatchObject({
         text: 'Rejected',
         statusType: 'canceled', // Rejected maps to canceled
+        size: '45000',
       });
     });
 
@@ -261,6 +312,7 @@ describe('transactionTransforms', () => {
       expect(result[0].order).toMatchObject({
         text: 'Triggered',
         statusType: 'filled', // Triggered maps to filled
+        size: '45000',
       });
     });
 
@@ -273,6 +325,7 @@ describe('transactionTransforms', () => {
       const result = transformOrdersToTransactions([marketOrder]);
 
       expect(result[0].order?.type).toBe('market');
+      expect(result[0].order?.size).toBe('45000');
     });
 
     it('should handle sell orders', () => {
@@ -284,6 +337,7 @@ describe('transactionTransforms', () => {
       const result = transformOrdersToTransactions([sellOrder]);
 
       expect(result[0].title).toBe('Short limit');
+      expect(result[0].order?.size).toBe('45000');
     });
 
     it('should calculate order size correctly', () => {
@@ -291,6 +345,19 @@ describe('transactionTransforms', () => {
 
       // size = originalSize * price = 1.0 * 45000 = 45000
       expect(result[0].order?.size).toBe('45000');
+    });
+
+    it('should handle orders with zero remaining size (fully filled)', () => {
+      const fullyFilledOrder: Order = {
+        ...mockOrder,
+        size: '0', // No remaining size
+        status: 'filled',
+      };
+
+      const result = transformOrdersToTransactions([fullyFilledOrder]);
+
+      // When size is 0, filled should be 100%
+      expect(result[0].order?.filled).toBe('100%');
     });
 
     it('should handle empty orders array', () => {
@@ -407,6 +474,35 @@ describe('transactionTransforms', () => {
       const result = transformFundingToTransactions([largeRateFunding]);
 
       expect(result[0].fundingAmount?.rate).toBe('1%');
+    });
+
+    it('should sort funding by timestamp in descending order (newest first)', () => {
+      const olderFunding: Funding = {
+        symbol: 'BTC',
+        amountUsd: '10.00',
+        rate: '0.0001',
+        timestamp: 1640995200000, // Older timestamp
+      };
+
+      const newerFunding: Funding = {
+        symbol: 'ETH',
+        amountUsd: '15.00',
+        rate: '0.0002',
+        timestamp: 1640995300000, // Newer timestamp
+      };
+
+      // Pass in older first, newer second
+      const result = transformFundingToTransactions([
+        olderFunding,
+        newerFunding,
+      ]);
+
+      // Should be sorted with newer first
+      expect(result).toHaveLength(2);
+      expect(result[0].timestamp).toBe(1640995300000); // Newer first
+      expect(result[0].asset).toBe('ETH');
+      expect(result[1].timestamp).toBe(1640995200000); // Older second
+      expect(result[1].asset).toBe('BTC');
     });
   });
 });

--- a/app/components/UI/Perps/utils/transactionTransforms.ts
+++ b/app/components/UI/Perps/utils/transactionTransforms.ts
@@ -51,17 +51,22 @@ export function transformFillsToTransactions(
       return acc;
     }
 
-    let amount = 0;
     let amountBN = BigNumber(0);
     let displayAmount = '';
-
+    let fillSize = size;
+    if (isFlipped) {
+      fillSize = BigNumber(fill.startPosition || '0')
+        .minus(fill.size)
+        .absoluteValue()
+        .toString();
+    }
     // Calculate display amount based on action type
     if (isOpened) {
       // For opening positions: show fee paid (negative)
       amountBN = BigNumber(fill.fee || 0);
       displayAmount = `-$${Math.abs(amountBN.toNumber()).toFixed(2)}`;
       isPositive = false; // Fee is always a cost
-    } else if (isClosed) {
+    } else if (isClosed || isFlipped) {
       // For closing positions: show PnL minus fee
       const pnlValue = BigNumber(fill.pnl || 0);
       const feeValue = BigNumber(fill.fee || 0);
@@ -78,16 +83,6 @@ export function transformFillsToTransactions(
         displayAmount = `$${Math.abs(netPnL).toFixed(2)}`;
         isPositive = true; // Treat break-even as positive (green)
       }
-    } else if (isFlipped) {
-      // For flipped positions: calculate based on position change
-      amountBN = BigNumber(fill.startPosition || '0')
-        .minus(fill.size)
-        .times(fill.price);
-      amount = amountBN.toNumber();
-      displayAmount = `${amount >= 0 ? '+' : '-'}$${Math.abs(amount).toFixed(
-        2,
-      )}`;
-      isPositive = amount >= 0;
     } else {
       // Fallback: show order size value
       amountBN = BigNumber(fill.size).times(fill.price);
@@ -116,7 +111,7 @@ export function transformFillsToTransactions(
         amount: displayAmount,
         amountNumber: parseFloat(amountBN.toFixed(2)),
         isPositive,
-        size,
+        size: fillSize,
         entryPrice: price,
         pnl,
         fee,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
1. What is the reason for the change?
The pnl did not show for flipped positions which really are a close and an open and should show pnl
2. What is the improvement/solution?
Ensure we are showing pnl for the amount calc in transactions list for positions. Also update the detail for the position to include the pnl like closed positions

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1508

## **Manual testing steps**

```gherkin
Feature: position transactions flipped

  Scenario: user is viewing positions in transaction list
    Given user views a flipped position item

    When user sees the amount
    Then it should be a pnl amount
   When user clicks on the detail
   Then they should see pnl in the detail as well and it should be the same
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="500" height="auto" alt="Simulator Screenshot - iPhone 15 Pro - 2025-09-11 at 02 53 23" src="https://github.com/user-attachments/assets/ea0d7ea2-69e8-4fa9-a25d-fc399eee3836" />
<img width="500"  alt="Simulator Screenshot - iPhone 15 Pro - 2025-09-11 at 03 18 16" src="https://github.com/user-attachments/assets/bc97895d-ad0c-4b2e-a78d-997c2650c6a1" />
<img width="1483" height="51" alt="Screenshot 2025-09-11 at 2 53 45 AM" src="https://github.com/user-attachments/assets/137f06da-ef6d-4a4c-a8b8-57464158585a" />

<!-- [screenshots/recordings] -->



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
