### PR TITLE
fix: short positions can now find tpsl

### DIFF
--- a/app/components/UI/Perps/controllers/providers/HyperLiquidProvider.ts
+++ b/app/components/UI/Perps/controllers/providers/HyperLiquidProvider.ts
@@ -772,7 +772,8 @@ export class HyperLiquidProvider implements IPerpsProvider {
         (order) =>
           order.coin === coin &&
           order.reduceOnly === true &&
-          order.sz === position.size &&
+          Math.abs(parseFloat(order.sz)) ===
+            Math.abs(parseFloat(position.size)) &&
           order.isTrigger === true &&
           (order.orderType.includes('Take Profit') ||
             order.orderType.includes('Stop')),

--- a/app/components/UI/Perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/components/UI/Perps/services/HyperLiquidSubscriptionService.ts
@@ -325,7 +325,10 @@ export class HyperLiquidSubscriptionService {
               const coin = order.coin;
               const position = positions.find(
                 (p) =>
-                  p.coin === coin && order.reduceOnly && p.size === order.sz,
+                  p.coin === coin &&
+                  order.reduceOnly &&
+                  Math.abs(parseFloat(p.size)) ===
+                    Math.abs(parseFloat(order.sz)),
               );
 
               if (position) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
1. What is the reason for the change?
User cannot set tpsl on their position due to a regression. Short positions have a - size and to compare size need an absolute value
2. What is the improvement/solution?
Use absolute value of sizes when comparing to match order to position
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1645

## **Manual testing steps**

```gherkin
Feature: fix tpsl on short position

  Scenario: user makes a short position
    Given user updates tpsl

    When user submits position update 
    Then they should see updated tpsl
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="500" alt="Simulator Screenshot - iPhone 15 Pro - 2025-09-11 at 04 20 48" src="https://github.com/user-attachments/assets/8e12aa8d-95b3-4f04-b3d9-824463c03545" />
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**


- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
