### PR TITLE
Fix perps chart dark mode flicker

### DIFF
--- a/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.tsx
+++ b/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.tsx
@@ -337,7 +337,7 @@ const TradingViewChart = React.forwardRef<
       >
         {/* Chart WebView */}
         <Box
-          twClassName="overflow-hidden rounded-lg"
+          twClassName="overflow-hidden rounded-lg bg-default"
           style={{ height, width: '100%', minHeight: height }} // eslint-disable-line react-native/no-inline-styles
         >
           {/* Show skeleton while chart is loading */}
@@ -354,7 +354,7 @@ const TradingViewChart = React.forwardRef<
           <WebView
             ref={webViewRef}
             source={{ html: htmlContent }}
-            style={[styles.webView, { height, width: '100%' }]} // eslint-disable-line react-native/no-inline-styles
+            style={[styles.webView, { height, width: '100%', backgroundColor: 'transparent' }]} // eslint-disable-line react-native/no-inline-styles
             onMessage={handleWebViewMessage}
             onError={handleWebViewError}
             onHttpError={(syntheticEvent) => {


### PR DESCRIPTION
Fix TAT-1563: Prevent Perps Chart loading state from flickering white in dark mode by adjusting container and WebView backgrounds.

---
<a href="https://cursor.com/background-agent?bcId=bc-4488eae0-94db-479c-bbbd-f874f48b5d1e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4488eae0-94db-479c-bbbd-f874f48b5d1e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

