### PR TITLE
fix: close position limit display info is based on market price

### DIFF
--- a/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
@@ -117,20 +117,31 @@ const PerpsClosePositionView: React.FC = () => {
   // Determine position direction
   const isLong = parseFloat(position.size) > 0;
   const absSize = Math.abs(parseFloat(position.size));
+  // Calculate effective price for calculations
+  // For limit orders, use limit price when available; otherwise use current market price
+  const effectivePrice = useMemo(() => {
+    if (orderType === 'limit' && limitPrice) {
+      const parsed = parseFloat(limitPrice);
+      if (!isNaN(parsed) && parsed > 0) {
+        return parsed;
+      }
+    }
+    return currentPrice;
+  }, [orderType, limitPrice, currentPrice]);
 
   // Calculate display values directly from closePercentage for immediate updates
   const { closeAmount, calculatedUSDString } = useMemo(() => {
     const { tokenAmount, usdValue } = calculateCloseAmountFromPercentage({
       percentage: closePercentage,
       positionSize: absSize,
-      currentPrice,
+      currentPrice: effectivePrice,
     });
 
     return {
       closeAmount: tokenAmount.toString(),
       calculatedUSDString: usdValue.toFixed(2),
     };
-  }, [closePercentage, absSize, currentPrice]);
+  }, [closePercentage, absSize, effectivePrice]);
 
   // Use calculated USD string when not in input mode, user input when typing
   const displayUSDString =
@@ -139,11 +150,28 @@ const PerpsClosePositionView: React.FC = () => {
       : calculatedUSDString;
 
   // Calculate position value and effective margin
-  const positionValue = absSize * currentPrice;
-  // Use the actual margin from the position instead of recalculating
-  const effectiveMargin = parseFloat(position.marginUsed);
+  // For limit orders, use limit price for display calculations
+  const positionValue = absSize * effectivePrice;
 
-  // Use unrealized PnL from position
+  // Calculate P&L based on effective price (limit price for limit orders)
+  const entryPrice = parseFloat(position.entryPrice);
+  const effectivePnL = useMemo(() => {
+    // Calculate P&L based on the effective price (limit price for limit orders)
+    // For long positions: (effectivePrice - entryPrice) * absSize
+    // For short positions: (entryPrice - effectivePrice) * absSize
+    const priceDiff = isLong
+      ? effectivePrice - entryPrice
+      : entryPrice - effectivePrice;
+    return priceDiff * absSize;
+  }, [effectivePrice, entryPrice, absSize, isLong]);
+
+  // Use the actual initial margin from the position
+  const initialMargin = parseFloat(position.marginUsed);
+
+  // Calculate effective margin (initial margin + P&L at effective price)
+  const effectiveMargin = initialMargin + effectivePnL;
+
+  // Use unrealized PnL from position for current market price (for reference/tracking)
   const pnl = parseFloat(position.unrealizedPnl);
 
   // Calculate fees using the unified fee hook
@@ -154,7 +182,7 @@ const PerpsClosePositionView: React.FC = () => {
     isMaker: false, // Closing positions are typically taker orders
   });
 
-  // Calculate what user will receive (margin - fees, P&L is settled separately)
+  // Calculate what user will receive (initial margin + P&L at effective price - fees)
   const receiveAmount =
     (closePercentage / 100) * effectiveMargin - feeResults.totalFee;
 
@@ -174,7 +202,7 @@ const PerpsClosePositionView: React.FC = () => {
     closeAmount: closeAmount.toString(),
     orderType,
     limitPrice,
-    currentPrice,
+    currentPrice: effectivePrice,
     positionSize: absSize,
     positionValue,
     minimumOrderAmount,
@@ -203,9 +231,9 @@ const PerpsClosePositionView: React.FC = () => {
 
   // Initialize USD values when price data is available (only once, not on price updates)
   useEffect(() => {
-    const initialUSDAmount = absSize * currentPrice;
+    const initialUSDAmount = absSize * effectivePrice;
     setCloseAmountUSDString(initialUSDAmount.toFixed(2));
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- Intentionally excluding currentPrice to prevent updates on price changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Intentionally excluding effectivePrice to prevent updates on price changes
   }, [absSize]);
 
   // Auto-open limit price bottom sheet when switching to limit order
@@ -225,7 +253,7 @@ const PerpsClosePositionView: React.FC = () => {
       [PerpsEventProperties.ORDER_TYPE]: orderType,
       [PerpsEventProperties.CLOSE_PERCENTAGE]: closePercentage,
       [PerpsEventProperties.CLOSE_VALUE]: closingValue,
-      [PerpsEventProperties.PNL_DOLLAR]: pnl * (closePercentage / 100),
+      [PerpsEventProperties.PNL_DOLLAR]: effectivePnL * (closePercentage / 100),
       [PerpsEventProperties.RECEIVED_AMOUNT]: receiveAmount,
     });
 
@@ -336,7 +364,7 @@ const PerpsClosePositionView: React.FC = () => {
     setClosePercentage(newPercentage);
 
     // Update USD input to match calculated value for keypad display consistency
-    const newUSDAmount = (newPercentage / 100) * absSize * currentPrice;
+    const newUSDAmount = (newPercentage / 100) * absSize * effectivePrice;
     setCloseAmountUSDString(newUSDAmount.toFixed(2));
   };
 
@@ -344,7 +372,7 @@ const PerpsClosePositionView: React.FC = () => {
     setClosePercentage(100);
 
     // Update USD input to match calculated value for keypad display consistency
-    const newUSDAmount = absSize * currentPrice;
+    const newUSDAmount = absSize * effectivePrice;
     setCloseAmountUSDString(newUSDAmount.toFixed(2));
   };
 
@@ -366,13 +394,13 @@ const PerpsClosePositionView: React.FC = () => {
   }, []);
 
   const realizedPnl = useMemo(() => {
-    const price = Math.abs(pnl * (closePercentage / 100));
+    const price = Math.abs(effectivePnL * (closePercentage / 100));
     const formattedPrice = formatPrice(price, {
       maximumDecimals: 2,
     });
 
-    return { formattedPrice, price, isNegative: pnl < 0 };
-  }, [pnl, closePercentage]);
+    return { formattedPrice, price, isNegative: effectivePnL < 0 };
+  }, [effectivePnL, closePercentage]);
 
   // Hide provider-level limit price required error on this UI
   // Only display the minimum amount error (e.g. minimum $10) and suppress others


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
1. What is the reason for the change? 
On the close position page when making a limit order, the information on the page considerrs price as the market price isntead of the limit price causing incorrect values.
2. What is the improvement/solution?
Use limit price when closing with a limit order and ensure other calculations consider limit price if limit close is selected.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1630

## **Manual testing steps**

```gherkin
Feature: fix close position limit info

  Scenario: user wants to close a position
    Given user enters the limit close bottomsheet

    When user enters a limit price and sets it
    Then the information in the close position view is based on the limit price and not the market price
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/743c68fa-cf5a-41ee-a8d8-aefab2586d8b

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
