### PR TITLE
feat: update AccountCell styles and add placeholder color to search input

### DIFF
--- a/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.styles.ts
+++ b/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.styles.ts
@@ -42,6 +42,9 @@ const styleSheet = (params: {
     accountNameText: {
       minWidth: 0,
     },
+    checkIcon: {
+      marginLeft: 8,
+    },
     endContainer: {
       display: 'flex',
       flexDirection: 'row',

--- a/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.tsx
@@ -102,6 +102,7 @@ const AccountCell = ({
           <Icon
             name={IconName.CheckBold}
             size={IconSize.Md}
+            style={styles.checkIcon}
             color={TextColor.Primary}
           />
         )}

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/MultichainAccountSelectorList.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/MultichainAccountSelectorList.tsx
@@ -279,6 +279,7 @@ const MultichainAccountSelectorList = ({
           value={searchText}
           onChangeText={setSearchText}
           placeholder={strings('accounts.search_your_accounts')}
+          placeholderTextColor={styles.searchPlaceholderText.color}
           testID={MULTICHAIN_ACCOUNT_SELECTOR_SEARCH_INPUT_TESTID}
           autoFocus={false}
           style={styles.searchTextField}

--- a/app/components/Views/AccountSelector/AccountSelector.tsx
+++ b/app/components/Views/AccountSelector/AccountSelector.tsx
@@ -26,6 +26,8 @@ import {
   ButtonVariants,
   ButtonWidthTypes,
 } from '../../../component-library/components/Buttons/Button';
+import { TextVariant } from '../../../component-library/components/Texts/Text';
+import Text from '../../../component-library/components/Texts/Text/Text';
 import AddAccountActions from '../AddAccountActions';
 import { AccountListBottomSheetSelectorsIDs } from '../../../../e2e/selectors/wallet/AccountListBottomSheet.selectors';
 import { selectPrivacyMode } from '../../../selectors/preferencesController';
@@ -191,9 +193,19 @@ const AccountSelector = ({ route }: AccountSelectorProps) => {
     () => [
       {
         variant: ButtonVariants.Secondary,
-        label: isMultichainAccountsState2Enabled
-          ? strings('multichain_accounts.add_wallet')
-          : strings('account_actions.add_account_or_hardware_wallet'),
+        label: (
+          <Text
+            variant={
+              isMultichainAccountsState2Enabled
+                ? TextVariant.BodyMDBold
+                : TextVariant.BodyMD
+            }
+          >
+            {isMultichainAccountsState2Enabled
+              ? strings('multichain_accounts.add_wallet')
+              : strings('account_actions.add_account_or_hardware_wallet')}
+          </Text>
+        ),
         size: ButtonSize.Lg,
         width: ButtonWidthTypes.Full,
         onPress: handleAddAccount,

--- a/app/components/Views/AccountSelector/__snapshots__/AccountSelector.test.tsx.snap
+++ b/app/components/Views/AccountSelector/__snapshots__/AccountSelector.test.tsx.snap
@@ -980,7 +980,7 @@ exports[`AccountSelector should render correctly 1`] = `
                                 style={
                                   {
                                     "color": "#121314",
-                                    "fontFamily": "Geist Medium",
+                                    "fontFamily": "Geist Regular",
                                     "fontSize": 16,
                                     "letterSpacing": 0,
                                     "lineHeight": 24,

--- a/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/__snapshots__/MultichainAccountsConnectedList.test.tsx.snap
+++ b/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/__snapshots__/MultichainAccountsConnectedList.test.tsx.snap
@@ -191,6 +191,7 @@ exports[`MultichainAccountsConnectedList renders component with different accoun
                       style={
                         {
                           "height": 20,
+                          "marginLeft": 8,
                           "width": 20,
                         }
                       }
@@ -378,6 +379,7 @@ exports[`MultichainAccountsConnectedList renders component with different accoun
                       style={
                         {
                           "height": 20,
+                          "marginLeft": 8,
                           "width": 20,
                         }
                       }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR updates styles in new Multichain Account List in three places:

1. Makes search placeholder text color a bit lighter
2. Increases distance between account name and check icon
3. Makes "Add wallet" text bolder
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
4. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
3. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updates styles in new Multichain Accounts List

## **Related issues**

Fixes:
Jira tickets:
https://consensyssoftware.atlassian.net/browse/MUL-741
https://consensyssoftware.atlassian.net/browse/MUL-742
https://consensyssoftware.atlassian.net/browse/MUL-743

## **Manual testing steps**

```gherkin
Feature: New Multichain Accounts list

  Scenario: user lists multichain accounts
    Given multichain accounts are enabled

    When user navigates to accounts list
    Then new styles are applied
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="397" height="61" alt="placeholder-before" src="https://github.com/user-attachments/assets/f4e9773f-2324-4886-90c4-aec5f4bcfb48" />
<img width="397" height="75" alt="check-before" src="https://github.com/user-attachments/assets/38a4df0b-31a5-4b67-9f80-28531ab837c9" />
<img width="378" height="61" alt="bold-before" src="https://github.com/user-attachments/assets/2aa294d2-a292-43f8-8d4e-c7dd6f47858e" />


<!-- [screenshots/recordings] -->

### **After**
<img width="395" height="60" alt="placeholder-after" src="https://github.com/user-attachments/assets/a78e371f-5665-48db-8b22-869862deadf5" />
<img width="399" height="76" alt="check-after" src="https://github.com/user-attachments/assets/389d0ed5-8c7f-4179-b1b3-d3adc73fd644" />
<img width="377" height="64" alt="bold-after" src="https://github.com/user-attachments/assets/2130f3b5-5454-4db7-b4ba-f25dace58aa4" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
