### PR TITLE
fix(perps): remaining issues on perps UI

### DIFF
--- a/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
@@ -409,7 +409,9 @@ const PerpsClosePositionView: React.FC = () => {
             })}
           </Text>
           <View style={styles.inclusiveFeeRow}>
-            <Text variant={TextVariant.BodySM}>includes</Text>
+            <Text variant={TextVariant.BodySM} color={TextColor.Default}>
+              {strings('perps.close_position.includes_pnl')}
+            </Text>
             <Text
               variant={TextVariant.BodySM}
               color={

--- a/app/components/UI/Perps/components/LivePriceDisplay/LivePriceHeader.test.tsx
+++ b/app/components/UI/Perps/components/LivePriceDisplay/LivePriceHeader.test.tsx
@@ -65,7 +65,7 @@ describe('LivePriceHeader', () => {
 
     expect(getByText('$50000.00')).toBeTruthy();
     // 5.5% of 50000 = 2750
-    expect(getByText('+$2750.00')).toBeTruthy();
+    expect(getByText('5.5%')).toBeTruthy();
   });
 
   it('should use fallback values when no live data', () => {
@@ -81,7 +81,7 @@ describe('LivePriceHeader', () => {
 
     expect(getByText('$3000.00')).toBeTruthy();
     // 2.5% of 3000 = 75
-    expect(getByText('+$75.00')).toBeTruthy();
+    expect(getByText('2.5%')).toBeTruthy();
   });
 
   it('should handle negative price change', () => {
@@ -98,7 +98,7 @@ describe('LivePriceHeader', () => {
 
     expect(getByText('$100.00')).toBeTruthy();
     // -10% of 100 = -10
-    expect(getByText('-$10.00')).toBeTruthy();
+    expect(getByText('-10%')).toBeTruthy();
   });
 
   it('should handle positive price change color', () => {
@@ -113,7 +113,7 @@ describe('LivePriceHeader', () => {
 
     const { getByText } = render(<LivePriceHeader symbol="AVAX" />);
 
-    expect(getByText('+$2.00')).toBeTruthy();
+    expect(getByText('8%')).toBeTruthy();
   });
 
   it('should handle zero price change', () => {
@@ -129,7 +129,7 @@ describe('LivePriceHeader', () => {
     const { getByText } = render(<LivePriceHeader symbol="MATIC" />);
 
     expect(getByText('$1.00')).toBeTruthy();
-    expect(getByText('+$0.00')).toBeTruthy();
+    expect(getByText('0%')).toBeTruthy();
   });
 
   it('should use custom throttle value', () => {
@@ -203,7 +203,7 @@ describe('LivePriceHeader', () => {
     const { getByText } = render(<LivePriceHeader symbol="DOT" />);
 
     expect(getByText('$5.00')).toBeTruthy();
-    expect(getByText('+$0.00')).toBeTruthy(); // Defaults to 0
+    expect(getByText('0%')).toBeTruthy(); // Defaults to 0
   });
 
   it('should calculate change amount correctly', () => {
@@ -220,7 +220,7 @@ describe('LivePriceHeader', () => {
 
     expect(getByText('$0.50')).toBeTruthy();
     // 20% of 0.5 = 0.1
-    expect(getByText('+$0.10')).toBeTruthy();
+    expect(getByText('20%')).toBeTruthy();
   });
 
   it('should use fallback values as defaults', () => {
@@ -232,7 +232,7 @@ describe('LivePriceHeader', () => {
 
     expect(getByText('$0.60')).toBeTruthy();
     // -5% of 0.6 = -0.03
-    expect(getByText('-$0.03')).toBeTruthy();
+    expect(getByText('-5%')).toBeTruthy();
   });
 
   it('should prefer live data over fallback', () => {
@@ -252,6 +252,6 @@ describe('LivePriceHeader', () => {
     // Should use live data, not fallback
     expect(getByText('$0.20')).toBeTruthy();
     // 15% of 0.2 = 0.03
-    expect(getByText('+$0.03')).toBeTruthy();
+    expect(getByText('15%')).toBeTruthy();
   });
 });

--- a/app/components/UI/Perps/components/LivePriceDisplay/LivePriceHeader.tsx
+++ b/app/components/UI/Perps/components/LivePriceDisplay/LivePriceHeader.tsx
@@ -6,9 +6,9 @@ import Text, {
 } from '../../../../../component-library/components/Texts/Text';
 import { usePerpsLivePrices } from '../../hooks/stream';
 import {
-  formatPnl,
   formatPerpsFiat,
   PRICE_RANGES_DETAILED_VIEW,
+  formatPercentage,
 } from '../../utils/formatUtils';
 import { useStyles } from '../../../../../component-library/hooks';
 
@@ -61,9 +61,6 @@ const LivePriceHeader: React.FC<LivePriceHeaderProps> = ({
   const isPositiveChange = displayChange >= 0;
   const changeColor = isPositiveChange ? TextColor.Success : TextColor.Error;
 
-  // Calculate fiat change amount (exactly as original)
-  const changeAmount = (displayChange / 100) * displayPrice;
-
   return (
     <View style={styles.container}>
       <Text
@@ -78,7 +75,7 @@ const LivePriceHeader: React.FC<LivePriceHeaderProps> = ({
         color={changeColor}
         testID={testIDChange}
       >
-        {formatPnl(changeAmount)}
+        {formatPercentage(displayChange.toString())}
       </Text>
     </View>
   );

--- a/app/components/UI/Perps/components/PerpsGTMModal/PerpsGTMModal.styles.ts
+++ b/app/components/UI/Perps/components/PerpsGTMModal/PerpsGTMModal.styles.ts
@@ -1,4 +1,4 @@
-import { StyleSheet } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 import { colors as importedColors } from '../../../../../styles/common';
 import Device from '../../../../../util/device';
 import { Theme } from '@metamask/design-tokens';
@@ -24,6 +24,7 @@ const createStyles = (_theme: Theme) =>
       fontFamily: 'MM Poly Regular',
       color: importedColors.gettingStartedTextColor,
       letterSpacing: -1,
+      ...(Platform.OS === 'ios' ? { fontWeight: '900' } : {}),
     },
     titleDescription: {
       paddingTop: 20,

--- a/app/components/UI/Perps/hooks/usePerpsToasts.ts
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.ts
@@ -388,7 +388,7 @@ const usePerpsToasts = (): {
             amount: string,
             assetSymbol: string,
           ) => ({
-            ...perpsBaseToastOptions.success,
+            ...perpsBaseToastOptions.inProgress,
             labelOptions: getPerpsToastLabels(
               strings('perps.order.order_submitted'),
               strings('perps.order.order_placement_subtitle', {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1118,6 +1118,7 @@
       "your_funds_will_be_available_momentarily": "Your funds will be available momentarily",
       "cancel": "Cancel",
       "margin": "Margin",
+      "includes_pnl":"includes P&L",
       "pnl": "PnL",
       "estimated_pnl": "Estimated PnL",
       "fees": "Fees",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR solves a couple of issues left for Perps:
- We see $24hr price change instead of %24hr price change
- Change "includes" copy to "includes P&L"
- Submit limit order: incorrect toast logo
- GTM Modal with incorrect font on iOS

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Show %24hrs price change on Perps
CHANGELOG entry: Change "includes" copy to "includes P&L" on Perps
CHANGELOG entry: Submit limit order: incorrect toast logo on Perps
CHANGELOG entry: Perps GTM Modal with incorrect font on iOS

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

**Submit limit order: incorrect toast logo**

https://github.com/user-attachments/assets/d1b9dc73-b279-4653-b069-30e0b4dd6b48

**We see $24hr price change instead of %24hr price change** 

<img width="300" height="900" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-12 at 11 11 23" src="https://github.com/user-attachments/assets/4e589044-43b8-4565-9bae-7c78d118aca6" />

**Change "includes" copy to "includes P&L"**

<img width="300" height="900" alt="simulator_screenshot_247EAE39-8951-435E-8FF4-B539AB3D154F" src="https://github.com/user-attachments/assets/89313cc8-db04-42e8-99bd-35965b9bc206" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
