### PR TITLE
fix: More perps chart adjustments

### DIFF
--- a/app/components/UI/Perps/components/PerpsCandlePeriodBottomSheet/PerpsCandlePeriodBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsCandlePeriodBottomSheet/PerpsCandlePeriodBottomSheet.tsx
@@ -87,7 +87,6 @@ const PerpsCandlePeriodBottomSheet: React.FC<
               CandlePeriod.ONE_DAY,
               CandlePeriod.THREE_DAYS, // 2d maps to 3d
               CandlePeriod.ONE_WEEK, // 7d
-              CandlePeriod.ONE_MONTH, // 30d
             ].includes(period.value),
           ),
         },

--- a/app/components/UI/Perps/components/PerpsCandlePeriodSelector/PerpsCandlePeriodSelector.tsx
+++ b/app/components/UI/Perps/components/PerpsCandlePeriodSelector/PerpsCandlePeriodSelector.tsx
@@ -3,7 +3,7 @@ import { Pressable } from 'react-native';
 import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
 import { useStyles } from '../../../../../component-library/hooks';
 import { strings } from '../../../../../../locales/i18n';
-import { CandlePeriod } from '../../constants/chartConfig';
+import { CandlePeriod, CANDLE_PERIODS } from '../../constants/chartConfig';
 import { getPerpsCandlePeriodSelector } from '../../../../../../e2e/selectors/Perps/Perps.selectors';
 import Icon, {
   IconColor,
@@ -19,6 +19,14 @@ const DEFAULT_CANDLE_PERIODS = [
   { label: '5min', value: CandlePeriod.FIVE_MINUTES },
   { label: '15min', value: CandlePeriod.FIFTEEN_MINUTES },
 ] as const;
+
+// Helper function to get the display label for a candle period
+const getCandlePeriodLabel = (period: CandlePeriod | string): string => {
+  const candlePeriod = CANDLE_PERIODS.find(
+    (p) => p.value.toLowerCase() === period.toLowerCase(),
+  );
+  return candlePeriod?.label || period;
+};
 
 interface PerpsCandlePeriodSelectorProps {
   selectedPeriod: CandlePeriod | string;
@@ -102,7 +110,9 @@ const PerpsCandlePeriodSelector: React.FC<PerpsCandlePeriodSelectorProps> = ({
               : styles.moreTextUnselected,
           ]}
         >
-          {strings('perps.chart.candle_period_selector.show_more')}
+          {isMorePeriodSelected
+            ? getCandlePeriodLabel(selectedPeriod)
+            : strings('perps.chart.candle_period_selector.show_more')}
         </Text>
         <Icon
           name={IconName.ArrowDown}

--- a/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.test.tsx
+++ b/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.test.tsx
@@ -1235,7 +1235,6 @@ describe('TradingViewChart', () => {
         CandlePeriod.ONE_DAY,
         CandlePeriod.THREE_DAYS,
         CandlePeriod.ONE_WEEK,
-        CandlePeriod.ONE_MONTH,
       ];
 
       periods.forEach((_, index) => {
@@ -2029,10 +2028,6 @@ describe('TradingViewChart', () => {
         { duration: TimeDuration.ONE_DAY, period: CandlePeriod.THREE_MINUTES },
         { duration: TimeDuration.ONE_WEEK, period: CandlePeriod.FIVE_MINUTES },
         {
-          duration: TimeDuration.ONE_MONTH,
-          period: CandlePeriod.FIFTEEN_MINUTES,
-        },
-        {
           duration: TimeDuration.YEAR_TO_DATE,
           period: CandlePeriod.THIRTY_MINUTES,
         },
@@ -2040,11 +2035,9 @@ describe('TradingViewChart', () => {
         { duration: 'unknown' as TimeDuration, period: CandlePeriod.TWO_HOURS },
         { duration: TimeDuration.ONE_DAY, period: CandlePeriod.FOUR_HOURS },
         { duration: TimeDuration.ONE_WEEK, period: CandlePeriod.EIGHT_HOURS },
-        { duration: TimeDuration.ONE_MONTH, period: CandlePeriod.TWELVE_HOURS },
         { duration: TimeDuration.YEAR_TO_DATE, period: CandlePeriod.ONE_DAY },
         { duration: TimeDuration.MAX, period: CandlePeriod.THREE_DAYS },
-        { duration: TimeDuration.ONE_MONTH, period: CandlePeriod.ONE_WEEK },
-        { duration: TimeDuration.YEAR_TO_DATE, period: CandlePeriod.ONE_MONTH },
+        { duration: TimeDuration.YEAR_TO_DATE, period: CandlePeriod.ONE_WEEK },
         { duration: TimeDuration.ONE_DAY, period: 'unknown' as CandlePeriod },
       ];
 

--- a/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.tsx
+++ b/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.tsx
@@ -395,7 +395,7 @@ const TradingViewChart = React.forwardRef<
             />
           )}
           {Platform.OS === 'android' ? (
-            <GestureDetector gesture={Gesture.Native()}>
+            <GestureDetector gesture={Gesture.Pinch()}>
               {webViewElement}
             </GestureDetector>
           ) : (

--- a/app/components/UI/Perps/components/TradingViewChart/TradingViewChartTemplate.tsx
+++ b/app/components/UI/Perps/components/TradingViewChart/TradingViewChartTemplate.tsx
@@ -789,6 +789,53 @@ export const createTradingViewChartTemplate = (
                             console.log('📊 TradingView: Zoomed to latest', candleCount, 'candles');
                         }
                         break;
+                    case 'CLEAR_TPSL_LINES':
+                        // Clear all TPSL lines except current price line
+                        if (window.candlestickSeries) {
+                            // Remove entry price line
+                            if (window.priceLines.entryPrice) {
+                                try {
+                                    window.candlestickSeries.removePriceLine(window.priceLines.entryPrice);
+                                    window.priceLines.entryPrice = null;
+                                } catch (error) {
+                                    console.error('TradingView: Error removing entry line:', error);
+                                }
+                            }
+                            
+                            // Remove take profit line
+                            if (window.priceLines.takeProfitPrice) {
+                                try {
+                                    window.candlestickSeries.removePriceLine(window.priceLines.takeProfitPrice);
+                                    window.priceLines.takeProfitPrice = null;
+                                } catch (error) {
+                                    console.error('TradingView: Error removing take profit line:', error);
+                                }
+                            }
+                            
+                            // Remove stop loss line
+                            if (window.priceLines.stopLossPrice) {
+                                try {
+                                    window.candlestickSeries.removePriceLine(window.priceLines.stopLossPrice);
+                                    window.priceLines.stopLossPrice = null;
+                                } catch (error) {
+                                    console.error('TradingView: Error removing stop loss line:', error);
+                                }
+                            }
+                            
+                            // Remove liquidation line
+                            if (window.priceLines.liquidationPrice) {
+                                try {
+                                    window.candlestickSeries.removePriceLine(window.priceLines.liquidationPrice);
+                                    window.priceLines.liquidationPrice = null;
+                                } catch (error) {
+                                    console.error('TradingView: Error removing liquidation line:', error);
+                                }
+                            }
+                            
+                            // Note: currentPrice line is intentionally preserved
+                            console.log('📊 TradingView: Cleared TPSL lines (preserved current price line)');
+                        }
+                        break;
                     case 'UPDATE_INTERVAL':
                         // Send confirmation back to React Native
                         if (window.ReactNativeWebView) {

--- a/app/components/UI/Perps/components/TradingViewChart/TradingViewChartTemplate.tsx
+++ b/app/components/UI/Perps/components/TradingViewChart/TradingViewChartTemplate.tsx
@@ -568,10 +568,19 @@ export const createTradingViewChartTemplate = (
                 const firstTime = visibleData[0].time;
                 const lastTime = visibleData[visibleData.length - 1].time;
                 
+                // Calculate the time interval between candles for padding
+                const timeInterval = visibleData.length > 1 
+                    ? visibleData[1].time - visibleData[0].time 
+                    : 60; // Default to 1 minute if only one candle
+                
+                // Add padding to ensure the latest candle is fully visible
+                // Add half a candle period to the end to ensure latest candle is visible
+                const paddedLastTime = lastTime + (timeInterval / 2);
+                
                 try {
                     window.chart.timeScale().setVisibleRange({
                         from: firstTime,
-                        to: lastTime,
+                        to: paddedLastTime,
                     });
                 } catch (error) {
                     console.error('TradingView: Error setting visible range:', error);

--- a/app/components/UI/Perps/components/TradingViewChart/TradingViewChartTemplate.tsx
+++ b/app/components/UI/Perps/components/TradingViewChart/TradingViewChartTemplate.tsx
@@ -303,10 +303,12 @@ export const createTradingViewChartTemplate = (
                             },
                             mouseWheel: false, // Disable mouse wheel zoom (mobile app)
                             pinch: true, // Enable pinch zoom on mobile
+                            pressedMouseMove: false, // Enable drag scroll for direct touch control
+                            horzTouchDrag: false, // Enable horizontal touch drag
                         },
                         handleScroll: {
                             mouseWheel: false, // Disable mouse wheel scroll (mobile app)
-                            pressedMouseMove: false, // Enable drag scroll for direct touch control
+                            pressedMouseMove: true, // Enable drag scroll for direct touch control
                             horzTouchDrag: true, // Enable horizontal touch drag
                             vertTouchDrag: false, // Disable vertical touch drag
                             // Optimize for direct press-and-drag responsiveness

--- a/app/components/UI/Perps/components/TradingViewChart/utils/chartCalculations.test.ts
+++ b/app/components/UI/Perps/components/TradingViewChart/utils/chartCalculations.test.ts
@@ -67,7 +67,7 @@ describe('chartCalculations', () => {
       expect(getCandleCount(TimeDuration.ONE_HOUR, CandlePeriod.ONE_DAY)).toBe(
         10,
       );
-      expect(getCandleCount(TimeDuration.ONE_DAY, CandlePeriod.ONE_MONTH)).toBe(
+      expect(getCandleCount(TimeDuration.ONE_DAY, CandlePeriod.ONE_WEEK)).toBe(
         10,
       );
     });
@@ -81,7 +81,7 @@ describe('chartCalculations', () => {
         500,
       );
       expect(
-        getCandleCount(TimeDuration.ONE_MONTH, CandlePeriod.ONE_MINUTE),
+        getCandleCount(TimeDuration.YEAR_TO_DATE, CandlePeriod.ONE_MINUTE),
       ).toBe(500);
     });
 

--- a/app/components/UI/Perps/constants/chartConfig.ts
+++ b/app/components/UI/Perps/constants/chartConfig.ts
@@ -176,7 +176,6 @@ export const CANDLE_PERIODS = [
   { label: '1d', value: CandlePeriod.ONE_DAY },
   { label: '2d', value: CandlePeriod.THREE_DAYS },
   { label: '7d', value: CandlePeriod.ONE_WEEK },
-  { label: '30d', value: CandlePeriod.ONE_MONTH },
 ] as const;
 
 /**


### PR DESCRIPTION
## **Description**

Further chart adjustments to fix several issues, including:

X-axis time formatting, which should not overlap, and change contextually based on the time series shown.

When a candle period is selected within the "More" menu, we should show the selected period, rather than the static text: "More"

Removes 30d candle period, as the data isn't helpful to the user.

When you close a position, the tpsl lines should update and be removed from the chart immediately

When you change candle periods, the "current candle" (the one with live updates) should be within bounds of the chart. This was a padding/off by one bug.

A fix to the GestureHandler where once you executed a pinch event, you could not execute a pan. It would think you are still pinching and zoom in/out while panning.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Various UX improvements to chart based on beta test

## **Related issues**

Fixes:

https://consensyssoftware.atlassian.net/browse/TAT-1624
https://consensyssoftware.atlassian.net/browse/TAT-1639
https://consensyssoftware.atlassian.net/browse/TAT-1542
https://consensyssoftware.atlassian.net/browse/TAT-1625
https://consensyssoftware.atlassian.net/browse/TAT-1622

## **Manual testing steps**

```gherkin
Feature: Perps chart beta review

  Scenario: user wants to use chart
    Given they have a Perps position open, and has an Android device

    When user they navigate the chart
    Then panning should go back and forward in time smoothly
    Then pinching should zoom in and out
    Then these gestures do not override eachother
    
    X axis should not overlap and logically represent the visible candle periods
    
    When closing positions
    Price lines should be removed
    
    When selecting candle period in "More" you should see the candle period in the "More" button text
```

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/dc57161f-5757-4d63-8b68-5800dc6e7333

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
