### PR TITLE
fix: add timeout to `net_version` request when getting the provider state

### DIFF
--- a/app/core/BackgroundBridge/BackgroundBridge.js
+++ b/app/core/BackgroundBridge/BackgroundBridge.js
@@ -351,7 +351,10 @@ export class BackgroundBridge extends EventEmitter {
     });
 
     const timeoutPromise = new Promise((_, reject) => {
-      setTimeout(() => reject(new Error('timed out fetching net_version')), GET_DEPRECATED_NETWORK_VERSION_TIMEOUT);
+      setTimeout(
+        () => reject(new Error('timed out fetching net_version')),
+        GET_DEPRECATED_NETWORK_VERSION_TIMEOUT,
+      );
     });
 
     try {

--- a/app/core/BackgroundBridge/BackgroundBridge.test.js
+++ b/app/core/BackgroundBridge/BackgroundBridge.test.js
@@ -678,7 +678,7 @@ describe('BackgroundBridge', () => {
       bridge.deprecatedNetworkVersions[networkClientId] = 1;
 
       const result = await bridge.getDeprecatedNetworkVersion({
-        networkClient: { provider: {}},
+        networkClient: { provider: {} },
         networkClientId,
       });
 
@@ -711,7 +711,7 @@ describe('BackgroundBridge', () => {
 
       mockSendAsync.mockImplementation((request, callback) => {
         expect(request).toEqual({ method: 'net_version' });
-        callback(null, 100)
+        callback(null, 100);
       });
 
       const result = await bridge.getDeprecatedNetworkVersion({
@@ -726,7 +726,7 @@ describe('BackgroundBridge', () => {
       expect(mockSendAsync).toHaveBeenCalledTimes(2);
       expect(mockSendAsync).toHaveBeenCalledWith(
         { method: 'net_version' },
-        expect.any(Function)
+        expect.any(Function),
       );
     });
 
@@ -738,7 +738,7 @@ describe('BackgroundBridge', () => {
 
       mockSendAsync.mockImplementation((request, callback) => {
         expect(request).toEqual({ method: 'net_version' });
-        callback(networkError)
+        callback(networkError);
       });
 
       const result = await bridge.getDeprecatedNetworkVersion({
@@ -754,7 +754,6 @@ describe('BackgroundBridge', () => {
       const url = 'https://www.mock.io';
       const bridge = setupBackgroundBridge(url);
       const networkClientId = 'test-network-id';
-
 
       mockSendAsync.mockImplementation((request, _callback) => {
         expect(request).toEqual({ method: 'net_version' });
@@ -775,15 +774,14 @@ describe('BackgroundBridge', () => {
       const bridge = setupBackgroundBridge(url);
       const networkClientId = 'test-network-id';
 
-
       const mockSendAsyncDeferredPromise = createDeferredPromise();
 
       mockSendAsync.mockImplementation((request, callback) => {
         expect(request).toEqual({ method: 'net_version' });
         // return result after the timeout
         setTimeout(() => {
-          callback(null, 100)
-          mockSendAsyncDeferredPromise.resolve()
+          callback(null, 100);
+          mockSendAsyncDeferredPromise.resolve();
         }, 5500);
       });
 

--- a/app/core/BackgroundBridge/BackgroundBridge.test.js
+++ b/app/core/BackgroundBridge/BackgroundBridge.test.js
@@ -9,7 +9,10 @@ import {
   SolAccountType,
   SolScope,
 } from '@metamask/keyring-api';
-import { addTransaction } from '../../util/transaction-controller';
+import EthQuery from '@metamask/eth-query';
+import { createDeferredPromise } from '@metamask/utils';
+
+const mockSendAsync = jest.fn().mockResolvedValue(1);
 
 jest.mock('../Permissions', () => ({
   ...jest.requireActual('../Permissions'),
@@ -17,7 +20,7 @@ jest.mock('../Permissions', () => ({
 }));
 
 jest.mock('@metamask/eth-query', () => () => ({
-  sendAsync: jest.fn().mockResolvedValue(1),
+  sendAsync: mockSendAsync,
 }));
 
 jest.mock('../../store', () => ({
@@ -152,7 +155,7 @@ describe('BackgroundBridge', () => {
         chainId: '0x2',
         networkVersion: '2',
       };
-      const url = 'https:www.mock.io';
+      const url = 'https://www.mock.io';
       const bridge = setupBackgroundBridge(url);
       const mmBridge = setupBackgroundBridge(url, true);
       // Mock the getProviderNetworkState method to return the expected network state
@@ -182,7 +185,7 @@ describe('BackgroundBridge', () => {
         chainId: '0x1',
         networkVersion: '1',
       };
-      const url = 'https:www.mock.io';
+      const url = 'https://www.mock.io';
       const bridge = setupBackgroundBridge(url);
       const sendNotificationSpy = jest.spyOn(bridge, 'sendNotificationEip1193');
       const getProviderSpy = jest.spyOn(bridge, 'getProviderNetworkState');
@@ -219,7 +222,7 @@ describe('BackgroundBridge', () => {
 
   describe('notifySolanaAccountChangedForCurrentAccount', () => {
     it('emits nothing if there is no CAIP-25 permission', () => {
-      const url = 'https:www.mock.io';
+      const url = 'https://www.mock.io';
       const bridge = setupBackgroundBridge(url);
       const sendNotificationSpy = jest.spyOn(
         bridge,
@@ -232,7 +235,7 @@ describe('BackgroundBridge', () => {
     });
 
     it('emits nothing if there are no permitted solana scopes and `solana_accountChanged_notifications` session property is set', () => {
-      const url = 'https:www.mock.io';
+      const url = 'https://www.mock.io';
       const bridge = setupBackgroundBridge(url);
       const sendNotificationSpy = jest.spyOn(
         bridge,
@@ -260,7 +263,7 @@ describe('BackgroundBridge', () => {
     });
 
     it('emits nothing if there are permitted solana accounts, but the `solana_accountChanged_notifications` session property is not set', () => {
-      const url = 'https:www.mock.io';
+      const url = 'https://www.mock.io';
       const bridge = setupBackgroundBridge(url);
       const sendNotificationSpy = jest.spyOn(
         bridge,
@@ -286,7 +289,7 @@ describe('BackgroundBridge', () => {
     });
 
     it('emits nothing if there are permitted solana scopes but no accounts and the `solana_accountChanged_notifications` session property is set', () => {
-      const url = 'https:www.mock.io';
+      const url = 'https://www.mock.io';
       const bridge = setupBackgroundBridge(url);
       const sendNotificationSpy = jest.spyOn(
         bridge,
@@ -314,7 +317,7 @@ describe('BackgroundBridge', () => {
     });
 
     it('emits a solana accountChanged event when there are permitted solana accounts and the `solana_accountChanged_notifications` session property is set', () => {
-      const url = 'https:www.mock.io';
+      const url = 'https://www.mock.io';
       const bridge = setupBackgroundBridge(url);
       const sendNotificationSpy = jest.spyOn(
         bridge,
@@ -353,7 +356,7 @@ describe('BackgroundBridge', () => {
 
   describe('handleSolanaAccountChangedFromScopeChanges', () => {
     it('emits nothing if the current and previous permissions both did not have `solana_accountChanged_notifications` session property set', () => {
-      const url = 'https:www.mock.io';
+      const url = 'https://www.mock.io';
       const bridge = setupBackgroundBridge(url);
       const sendNotificationSpy = jest.spyOn(
         bridge,
@@ -391,7 +394,7 @@ describe('BackgroundBridge', () => {
     });
 
     it('emits nothing if currently and previously selected solana accounts did not change', () => {
-      const url = 'https:www.mock.io';
+      const url = 'https://www.mock.io';
       const bridge = setupBackgroundBridge(url);
       const sendNotificationSpy = jest.spyOn(
         bridge,
@@ -433,7 +436,7 @@ describe('BackgroundBridge', () => {
     });
 
     it('emits the currently selected solana account if the currently selected solana accounts did change', () => {
-      const url = 'https:www.mock.io';
+      const url = 'https://www.mock.io';
       const bridge = setupBackgroundBridge(url);
       const sendNotificationSpy = jest.spyOn(
         bridge,
@@ -486,7 +489,7 @@ describe('BackgroundBridge', () => {
 
   describe('handleSolanaAccountChangedFromSelectedAccountChanges', () => {
     it('emits nothing if the selected account is not a solana account', () => {
-      const url = 'https:www.mock.io';
+      const url = 'https://www.mock.io';
       const bridge = setupBackgroundBridge(url);
       const sendNotificationSpy = jest.spyOn(
         bridge,
@@ -517,7 +520,7 @@ describe('BackgroundBridge', () => {
     });
 
     it('emits nothing if the selected account did not change from the last seen solana account', () => {
-      const url = 'https:www.mock.io';
+      const url = 'https://www.mock.io';
       const bridge = setupBackgroundBridge(url);
       const sendNotificationSpy = jest.spyOn(
         bridge,
@@ -549,7 +552,7 @@ describe('BackgroundBridge', () => {
     });
 
     it('emits nothing if there is no CAIP-25 permission', () => {
-      const url = 'https:www.mock.io';
+      const url = 'https://www.mock.io';
       const bridge = setupBackgroundBridge(url);
       const sendNotificationSpy = jest.spyOn(
         bridge,
@@ -566,7 +569,7 @@ describe('BackgroundBridge', () => {
     });
 
     it('emits nothing if the `solana_accountChanged_notifications` session property is not set', () => {
-      const url = 'https:www.mock.io';
+      const url = 'https://www.mock.io';
       const bridge = setupBackgroundBridge(url);
       const sendNotificationSpy = jest.spyOn(
         bridge,
@@ -595,7 +598,7 @@ describe('BackgroundBridge', () => {
     });
 
     it('emits nothing if the selected account does not match a permitted solana account', () => {
-      const url = 'https:www.mock.io';
+      const url = 'https://www.mock.io';
       const bridge = setupBackgroundBridge(url);
       const sendNotificationSpy = jest.spyOn(
         bridge,
@@ -626,7 +629,7 @@ describe('BackgroundBridge', () => {
     });
 
     it('emits a solana accountChanged event for the selected account if it does match a permitted solana account', () => {
-      const url = 'https:www.mock.io';
+      const url = 'https://www.mock.io';
       const bridge = setupBackgroundBridge(url);
       const sendNotificationSpy = jest.spyOn(
         bridge,
@@ -664,5 +667,144 @@ describe('BackgroundBridge', () => {
         },
       });
     });
+  });
+
+  describe('getDeprecatedNetworkVersion', () => {
+    it('returns cached network version when available', async () => {
+      const url = 'https://www.mock.io';
+      const bridge = setupBackgroundBridge(url);
+      const networkClientId = 'test-network-id';
+
+      bridge.deprecatedNetworkVersions[networkClientId] = 1;
+
+      const result = await bridge.getDeprecatedNetworkVersion({
+        networkClient: { provider: {}},
+        networkClientId,
+      });
+
+      // the constructor calls this once, and we don't expect it to be called again
+      expect(mockSendAsync).toHaveBeenCalledTimes(1);
+      expect(result).toBe(1);
+    });
+
+    it('returns cached null value when network version is cached as null', async () => {
+      const url = 'https://www.mock.io';
+      const bridge = setupBackgroundBridge(url);
+      const networkClientId = 'test-network-id';
+
+      bridge.deprecatedNetworkVersions[networkClientId] = null;
+
+      const result = await bridge.getDeprecatedNetworkVersion({
+        networkClient: { provider: {} },
+        networkClientId,
+      });
+
+      // the constructor calls this once, and we don't expect it to be called again
+      expect(mockSendAsync).toHaveBeenCalledTimes(1);
+      expect(result).toBeNull();
+    });
+
+    it('fetches and caches network version when not already cached', async () => {
+      const url = 'https://www.mock.io';
+      const bridge = setupBackgroundBridge(url);
+      const networkClientId = 'test-network-id';
+
+      mockSendAsync.mockImplementation((request, callback) => {
+        expect(request).toEqual({ method: 'net_version' });
+        callback(null, 100)
+      });
+
+      const result = await bridge.getDeprecatedNetworkVersion({
+        networkClient: { provider: {} },
+        networkClientId,
+      });
+
+      expect(result).toBe(100);
+      expect(bridge.deprecatedNetworkVersions[networkClientId]).toBe(100);
+
+      // the constructor calls this once, and we expect it to be called again
+      expect(mockSendAsync).toHaveBeenCalledTimes(2);
+      expect(mockSendAsync).toHaveBeenCalledWith(
+        { method: 'net_version' },
+        expect.any(Function)
+      );
+    });
+
+    it('handles network errors by caching and returning null', async () => {
+      const url = 'https://www.mock.io';
+      const bridge = setupBackgroundBridge(url);
+      const networkClientId = 'test-network-id';
+      const networkError = new Error('Network request failed');
+
+      mockSendAsync.mockImplementation((request, callback) => {
+        expect(request).toEqual({ method: 'net_version' });
+        callback(networkError)
+      });
+
+      const result = await bridge.getDeprecatedNetworkVersion({
+        networkClient: { provider: {} },
+        networkClientId,
+      });
+
+      expect(result).toBeNull();
+      expect(bridge.deprecatedNetworkVersions[networkClientId]).toBeNull();
+    });
+
+    it('timeouts out if the network request takes too long by caching and returning null', async () => {
+      const url = 'https://www.mock.io';
+      const bridge = setupBackgroundBridge(url);
+      const networkClientId = 'test-network-id';
+
+
+      mockSendAsync.mockImplementation((request, _callback) => {
+        expect(request).toEqual({ method: 'net_version' });
+        // purposely never call the callback
+      });
+
+      const result = await bridge.getDeprecatedNetworkVersion({
+        networkClient: { provider: {} },
+        networkClientId,
+      });
+
+      expect(result).toBeNull();
+      expect(bridge.deprecatedNetworkVersions[networkClientId]).toBeNull();
+    }, 10000);
+
+    it('caches a successful response even if the timeout has already been reached', async () => {
+      const url = 'https://www.mock.io';
+      const bridge = setupBackgroundBridge(url);
+      const networkClientId = 'test-network-id';
+
+
+      const mockSendAsyncDeferredPromise = createDeferredPromise();
+
+      mockSendAsync.mockImplementation((request, callback) => {
+        expect(request).toEqual({ method: 'net_version' });
+        // return result after the timeout
+        setTimeout(() => {
+          callback(null, 100)
+          mockSendAsyncDeferredPromise.resolve()
+        }, 5500);
+      });
+
+      const result = await bridge.getDeprecatedNetworkVersion({
+        networkClient: { provider: {} },
+        networkClientId,
+      });
+
+      expect(result).toBeNull();
+      expect(bridge.deprecatedNetworkVersions[networkClientId]).toBeNull();
+
+      // Test that subsequent calls return cached value
+      await mockSendAsyncDeferredPromise.promise;
+      expect(bridge.deprecatedNetworkVersions[networkClientId]).toBe(100);
+      const secondResult = await bridge.getDeprecatedNetworkVersion({
+        networkClient: { provider: {} },
+        networkClientId,
+      });
+      expect(secondResult).toBe(100);
+      // the constructor calls this once, we call it once, and we don't expect it to be called again
+      expect(mockSendAsync).toHaveBeenCalledTimes(2);
+    }, 10000);
   });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

During investigation of a suspected issue with `chainChanged` and `accountsChanged` events, we found that a hanging `net_version` call can block the `getProviderState` call from responding. This has the effect of making the `window.ethereum` provide not properly propagating subsequent chainChanged events. This PR introduces a timeout to the underlying `net_version` request that could previous cause `getProviderState` to hang.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug where sometimes an unresponsive RPC endpoint could cause the UI to be stuck on a loading spinner and/or the `window.ethereum` provider to be stuck in a bad state. 

## **Related issues**

See: https://consensyssoftware.atlassian.net/browse/WAPI-421
See: https://github.com/MetaMask/metamask-extension/pull/35516

## **Manual testing steps**

Testing this can be tricky as it's not possible to add an RPC endpoint when it's already non-responsive. Using ganache/hardhat and then turning off the server is one way to get around this.

```gherkin
Feature: Add timeout to networkVersion requests

   Scenario: user opens the in app browser selected network unresponsive 
    Given the RPC is unresponsive (to net_version, or all requests in general)

    When user opens the in app browser and visits a dapp
    Then `window.ethereum._state.initialized` should return true in the console
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
