### PR TITLE
fix: cp-7.55.0 fix unstake regression

### DIFF
--- a/app/selectors/assets/assets-list.test.ts
+++ b/app/selectors/assets/assets-list.test.ts
@@ -581,6 +581,7 @@ describe('selectAsset', () => {
       balanceFiat: '$24,000.00',
       isETH: true,
       isNative: true,
+      isStaked: false,
       logo: '../images/eth-logo-new.png',
       image: '',
       aggregators: [],
@@ -631,6 +632,7 @@ describe('selectAsset', () => {
       balanceFiat: '$960.00',
       isETH: false,
       isNative: false,
+      isStaked: false,
       logo: 'https://static.cx.metamask.io/api/v1/tokenIcons/1/0x6B175474E89094C44Da98b954EedeAC495271d0F.png',
       image:
         'https://static.cx.metamask.io/api/v1/tokenIcons/1/0x6B175474E89094C44Da98b954EedeAC495271d0F.png',
@@ -656,6 +658,7 @@ describe('selectAsset', () => {
       balanceFiat: '$1,635.50',
       isETH: false,
       isNative: true,
+      isStaked: false,
       logo: 'https://static.cx.metamask.io/api/v2/tokenIcons/assets/solana/5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44/501.png',
       image:
         'https://static.cx.metamask.io/api/v2/tokenIcons/assets/solana/5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44/501.png',
@@ -681,10 +684,26 @@ describe('selectAsset', () => {
       balanceFiat: '$21.60',
       isETH: false,
       isNative: false,
+      isStaked: false,
       logo: 'https://static.cx.metamask.io/api/v1/tokenIcons/10/0xae7ab96520de3a18e5e111b5eaab095312d7fe84.png',
       image:
         'https://static.cx.metamask.io/api/v1/tokenIcons/10/0xae7ab96520de3a18e5e111b5eaab095312d7fe84.png',
       aggregators: ['UniswapLabs', 'Metamask', 'Aave'],
     });
+  });
+
+  it('returns isStaked as false when asset.isStaked is undefined', () => {
+    // Arrange - Create a mock asset without the isStaked property
+    const state = mockState();
+
+    // Act - Get an asset that doesn't have isStaked property
+    const result = selectAsset(state, {
+      address: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+      chainId: '0x1',
+    });
+
+    // Assert - isStaked should be false instead of undefined
+    expect(result?.isStaked).toBe(false);
+    expect(result?.isStaked).not.toBeUndefined();
   });
 });

--- a/app/selectors/assets/assets-list.ts
+++ b/app/selectors/assets/assets-list.ts
@@ -296,7 +296,7 @@ function assetToToken(
       asset.type.startsWith('eip155') &&
       asset.isNative &&
       asset.symbol === 'ETH',
-    isStaked: asset.isStaked,
+    isStaked: asset.isStaked || false,
     chainId: asset.chainId,
     isNative: asset.isNative,
     ticker: asset.symbol,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes a critical crash that occurred when rendering token lists and interacting with staking functionality. The issue was caused by the `isStaked` property in the `TokenI` interface being `undefined` in some cases, which broke boolean operations in various components throughout the app.

**Root Cause:**
The `assetToToken` function was directly assigning `asset.isStaked` without ensuring it was always a boolean value. When this property was `undefined`, components that performed boolean operations like `!evmAsset?.isStaked` or `token.isETH && !token.isStaked` would behave unexpectedly, leading to crashes.

**Solution:**
Changed the assignment from `isStaked: asset.isStaked` to `isStaked: asset.isStaked || false` to ensure the property is always a boolean. This guarantees:
- `true` when `asset.isStaked` is `true`
- `false` when `asset.isStaked` is `false` or `undefined`

The fix is minimal, backward-compatible, and addresses the unstake regression by providing consistent behavior across all components using the `isStaked` property.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a crash that occurred when viewing token lists and interacting with staking functionality

## **Related issues**

Fixes: #19668 

## **Manual testing steps**

```gherkin
Feature: Token list and staking functionality stability

    When user taps on a token with staking available
    Then the app should not crash
    And the staking options should be displayed correctly
    And the isStaked property should be handled properly in all components
    And the unstake button should not crash the app
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- App crash when viewing token lists or interacting with staking functionality - crash logs would show undefined property errors -->

### **After**

<!-- Token lists render correctly, staking functionality works without crashes, all boolean operations on isStaked property work as expected -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.