### PR TITLE
feat: TAT-1697 update toast component to support animated loading spinner

### DIFF
--- a/app/__mocks__/spinnerMock.js
+++ b/app/__mocks__/spinnerMock.js
@@ -1,0 +1,5 @@
+/* eslint-disable import/no-commonjs */
+
+module.exports = {
+  Spinner: () => null,
+};

--- a/app/component-library/components/Toast/Toast.tsx
+++ b/app/component-library/components/Toast/Toast.tsx
@@ -210,7 +210,7 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
     } = options;
 
     const isStartAccessoryValid =
-      Boolean(startAccessory) && React.isValidElement(startAccessory);
+      startAccessory != null && React.isValidElement(startAccessory);
 
     return (
       <>

--- a/app/component-library/components/Toast/Toast.tsx
+++ b/app/component-library/components/Toast/Toast.tsx
@@ -202,11 +202,19 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
   };
 
   const renderToastContent = (options: ToastOptions) => {
-    const { labelOptions, linkButtonOptions, closeButtonOptions } = options;
+    const {
+      labelOptions,
+      linkButtonOptions,
+      closeButtonOptions,
+      startAccessory,
+    } = options;
+
+    const isStartAccessoryValid =
+      Boolean(startAccessory) && React.isValidElement(startAccessory);
 
     return (
       <>
-        {renderAvatar()}
+        {isStartAccessoryValid ? startAccessory : renderAvatar()}
         <View
           style={styles.labelsContainer}
           testID={ToastSelectorsIDs.CONTAINER}

--- a/app/component-library/components/Toast/Toast.types.ts
+++ b/app/component-library/components/Toast/Toast.types.ts
@@ -5,7 +5,7 @@ import { ImageSourcePropType } from 'react-native';
 import { AvatarAccountType } from '../Avatars/Avatar/variants/AvatarAccount';
 import { ButtonProps } from '../Buttons/Button/Button.types';
 import { IconName } from '../Icons/Icon';
-import { ReactNode } from 'react';
+import { ReactElement } from 'react';
 
 /**
  * Toast variants.
@@ -41,7 +41,7 @@ interface BaseToastVariants {
   labelOptions: ToastLabelOptions;
   linkButtonOptions?: ToastLinkButtonOptions;
   closeButtonOptions?: ButtonProps;
-  startAccessory?: ReactNode;
+  startAccessory?: ReactElement;
 }
 
 /**

--- a/app/component-library/components/Toast/Toast.types.ts
+++ b/app/component-library/components/Toast/Toast.types.ts
@@ -5,6 +5,7 @@ import { ImageSourcePropType } from 'react-native';
 import { AvatarAccountType } from '../Avatars/Avatar/variants/AvatarAccount';
 import { ButtonProps } from '../Buttons/Button/Button.types';
 import { IconName } from '../Icons/Icon';
+import { ReactNode } from 'react';
 
 /**
  * Toast variants.
@@ -40,6 +41,7 @@ interface BaseToastVariants {
   labelOptions: ToastLabelOptions;
   linkButtonOptions?: ToastLinkButtonOptions;
   closeButtonOptions?: ButtonProps;
+  startAccessory?: ReactNode;
 }
 
 /**

--- a/app/components/UI/Perps/Views/PerpsWithdrawView/PerpsWithdrawView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsWithdrawView/PerpsWithdrawView.test.tsx
@@ -133,6 +133,12 @@ jest.mock('@metamask/design-system-react-native', () => ({
     Between: 'Between',
   },
   ButtonBase: 'ButtonBase',
+  IconSize: {
+    Xl: 'Xl',
+  },
+  IconColor: {
+    PrimaryDefault: 'PrimaryDefault',
+  },
 }));
 
 // Mock Text component

--- a/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
+++ b/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
@@ -325,7 +325,7 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
                     </TouchableOpacity>
                   )}
                 </View>
-                <Text variant={TextVariant.BodySM} color={fundingColor}>
+                <Text variant={TextVariant.BodyMD} color={fundingColor}>
                   {fundingDisplay}
                 </Text>
               </View>

--- a/app/components/UI/Perps/hooks/usePerpsToasts.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.test.ts
@@ -34,8 +34,20 @@ jest.mock('../../../../util/theme', () => ({
       primary: { default: '#0376C9' },
       background: { default: '#FFFFFF' },
       error: { default: '#D73A49' },
+      accent03: { dark: '#000000', normal: '#FFFFFF' },
+      accent04: { dark: '#000000', normal: '#FFFFFF' },
+      accent01: { dark: '#000000', light: '#FFFFFF' },
     },
   }),
+}));
+
+jest.mock('@metamask/design-system-react-native', () => ({
+  IconSize: {
+    Xl: 'xl',
+  },
+  IconColor: {
+    PrimaryDefault: 'primary-default',
+  },
 }));
 
 jest.mock('../utils/perpsErrorHandler', () => ({
@@ -133,6 +145,9 @@ describe('usePerpsToasts', () => {
           iconName: IconName.Loading,
           hapticsType: NotificationFeedbackType.Warning,
         });
+        expect(config.startAccessory).toBeDefined();
+        expect(config.closeButtonOptions).toBeDefined();
+        expect(config.closeButtonOptions?.label).toBe('Track');
       });
 
       it('returns in progress configuration without processing time', () => {
@@ -172,6 +187,12 @@ describe('usePerpsToasts', () => {
         expect(config.labelOptions).toContainEqual({
           label: 'Withdrawal initiated',
           isBold: true,
+        });
+        expect(config.startAccessory).toBeDefined();
+        expect(config).toMatchObject({
+          variant: ToastVariants.Icon,
+          iconName: IconName.Loading,
+          hapticsType: NotificationFeedbackType.Warning,
         });
       });
 
@@ -232,6 +253,12 @@ describe('usePerpsToasts', () => {
           label: 'Long 0.5 ETH',
           isBold: false,
         });
+        expect(config.startAccessory).toBeDefined();
+        expect(config).toMatchObject({
+          variant: ToastVariants.Icon,
+          iconName: IconName.Loading,
+          hapticsType: NotificationFeedbackType.Warning,
+        });
       });
 
       it('returns market order confirmed configuration', () => {
@@ -279,6 +306,12 @@ describe('usePerpsToasts', () => {
         expect(config.labelOptions).toContainEqual({
           label: 'Cancelling order',
           isBold: true,
+        });
+        expect(config.startAccessory).toBeDefined();
+        expect(config).toMatchObject({
+          variant: ToastVariants.Icon,
+          iconName: IconName.Loading,
+          hapticsType: NotificationFeedbackType.Warning,
         });
       });
 
@@ -332,6 +365,12 @@ describe('usePerpsToasts', () => {
           label: 'long 1.5 ETH',
           isBold: false,
         });
+        expect(config.startAccessory).toBeDefined();
+        expect(config).toMatchObject({
+          variant: ToastVariants.Icon,
+          iconName: IconName.Loading,
+          hapticsType: NotificationFeedbackType.Warning,
+        });
       });
 
       it('returns close full position success configuration', () => {
@@ -364,6 +403,12 @@ describe('usePerpsToasts', () => {
         expect(marketConfig.labelOptions).toContainEqual({
           label: 'Partially closing position',
           isBold: true,
+        });
+        expect(marketConfig.startAccessory).toBeDefined();
+        expect(marketConfig).toMatchObject({
+          variant: ToastVariants.Icon,
+          iconName: IconName.Loading,
+          hapticsType: NotificationFeedbackType.Warning,
         });
         expect(limitConfig.labelOptions).toContainEqual({
           label: 'Partial close submitted',
@@ -459,6 +504,8 @@ describe('usePerpsToasts', () => {
       expect(inProgressToast.hapticsType).toBe(
         NotificationFeedbackType.Warning,
       );
+      expect(inProgressToast.startAccessory).toBeDefined();
+      expect(inProgressToast.closeButtonOptions).toBeDefined();
       expect(errorToast.hapticsType).toBe(NotificationFeedbackType.Error);
     });
   });

--- a/app/components/UI/Perps/hooks/usePerpsToasts.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useMemo } from 'react';
+import React, { useCallback, useContext, useMemo } from 'react';
 import { ToastContext } from '../../../../component-library/components/Toast';
 import {
   ToastOptions,
@@ -16,6 +16,12 @@ import { handlePerpsError } from '../utils/perpsErrorHandler';
 import { OrderDirection } from '../types';
 import { formatDurationForDisplay } from '../utils/time';
 import { formatPerpsFiat } from '../utils/formatUtils';
+import { Spinner } from '@metamask/design-system-react-native/dist/components/temp-components/Spinner/index.cjs';
+import {
+  IconSize as ReactNativeDsIconSize,
+  IconColor as ReactNativeDsIconColor,
+} from '@metamask/design-system-react-native';
+import { View, StyleSheet } from 'react-native';
 
 export type PerpsToastOptions = ToastOptions & {
   hapticsType: NotificationFeedbackType;
@@ -156,9 +162,17 @@ const getPerpsToastLabels = (primary: string, secondary?: string) => {
 };
 
 const PERPS_TOASTS_DEFAULT_OPTIONS: Partial<PerpsToastOptions> = {
-  // TODO: Determine if necessary or if it causes persistent toasts.
   hasNoTimeout: false,
 };
+
+const toastStyles = StyleSheet.create({
+  spinnerContainer: {
+    paddingRight: 12,
+    alignContent: 'center',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
 
 const usePerpsToasts = (): {
   showToast: (config: PerpsToastOptions) => void;
@@ -186,6 +200,14 @@ const usePerpsToasts = (): {
         iconColor: theme.colors.accent04.dark,
         backgroundColor: theme.colors.accent04.normal,
         hapticsType: NotificationFeedbackType.Warning,
+        startAccessory: (
+          <View style={toastStyles.spinnerContainer}>
+            <Spinner
+              color={ReactNativeDsIconColor.PrimaryDefault}
+              spinnerIconProps={{ size: ReactNativeDsIconSize.Xl }}
+            />
+          </View>
+        ),
       },
       info: {
         ...(PERPS_TOASTS_DEFAULT_OPTIONS as PerpsToastOptions),

--- a/jest.config.js
+++ b/jest.config.js
@@ -65,6 +65,8 @@ const config = {
       '<rootDir>/app/__mocks__/expo-apple-authentication.js',
     '^expo-haptics(/.*)?$': '<rootDir>/app/__mocks__/expo-haptics.js',
     '^expo-image$': '<rootDir>/app/__mocks__/expo-image.js',
+    '^@metamask/design-system-react-native/dist/components/temp-components/Spinner/index.cjs$':
+      '<rootDir>/app/__mocks__/spinnerMock.js',
   },
   // Disable jest cache
   cache: false,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Changes:
- Added optional `startAccessory` prop to Toast component
- Added animated spinner for `inProgress` Perps toast variants 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: added optional startAccessory prop to Toast component
CHANGELOG entry: added animated spinner for inProgress Perps toast variants 

 
## **Related issues**

Fixes: [TAT-1682: Reconsider icon for pending orders](https://consensyssoftware.atlassian.net/browse/TAT-1682)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
https://github.com/user-attachments/assets/948770df-f154-452d-ac03-b9acc8f1cdab

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
