### PR TITLE
fix: tp sl solution in perps proposal B

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -120,19 +120,87 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
 
   const [refreshing, setRefreshing] = useState(false);
 
+  // TP/SL order selection state - track TP and SL separately
+  const [activeTPOrderId, setActiveTPOrderId] = useState<string | null>(null);
+  const [activeSLOrderId, setActiveSLOrderId] = useState<string | null>(null);
+
   const account = usePerpsAccount();
 
   usePerpsConnection();
   const { depositWithConfirmation } = usePerpsTrading();
   const { ensureArbitrumNetworkExists } = usePerpsNetworkManagement();
   // Get real-time open orders via WebSocket
-  const ordersData = usePerpsLiveOrders({ hideTpSl: true }); // Instant updates with TP/SL filtered
-
+  const ordersData = usePerpsLiveOrders({});
   // Filter orders for the current market
   const openOrders = useMemo(() => {
     if (!ordersData?.length || !market?.symbol) return [];
     return ordersData.filter((order) => order.symbol === market.symbol);
   }, [ordersData, market?.symbol]);
+
+  // Filter orders that have TP/SL data for chart integration
+  const ordersWithTPSL = useMemo(
+    () =>
+      openOrders.filter((order) => {
+        // Check if order has TP/SL prices directly
+        if (order.takeProfitPrice || order.stopLossPrice) return true;
+
+        // Check if it's a trigger order (TP/SL orders are stored as trigger orders)
+        if (order.isTrigger && order.detailedOrderType) {
+          const orderType = order.detailedOrderType.toLowerCase();
+          return (
+            orderType.includes('take profit') || orderType.includes('stop')
+          );
+        }
+
+        return false;
+      }),
+    [openOrders],
+  );
+
+  // Determine which TP/SL lines to show on the chart
+  const selectedOrderTPSL = useMemo(() => {
+    // Find the active TP order
+    let activeTPOrder = ordersWithTPSL.find(
+      (order) => order.orderId === activeTPOrderId,
+    );
+    // Only use default TP if no TP has ever been explicitly selected
+    if (!activeTPOrder && activeTPOrderId === null) {
+      activeTPOrder = ordersWithTPSL.find((order) => {
+        if (order.takeProfitPrice) return true;
+        if (
+          order.isTrigger &&
+          order.detailedOrderType?.toLowerCase().includes('take profit')
+        )
+          return true;
+        return false;
+      });
+    }
+
+    // Find the active SL order
+    let activeSLOrder = ordersWithTPSL.find(
+      (order) => order.orderId === activeSLOrderId,
+    );
+    // Only use default SL if no SL has ever been explicitly selected
+    if (!activeSLOrder && activeSLOrderId === null) {
+      activeSLOrder = ordersWithTPSL.find((order) => {
+        if (order.stopLossPrice) return true;
+        if (
+          order.isTrigger &&
+          order.detailedOrderType?.toLowerCase().includes('stop')
+        )
+          return true;
+        return false;
+      });
+    }
+
+    const result = {
+      takeProfitPrice: activeTPOrder?.takeProfitPrice || activeTPOrder?.price,
+      stopLossPrice: activeSLOrder?.stopLossPrice || activeSLOrder?.price,
+      activeTPOrderId: activeTPOrder?.orderId,
+      activeSLOrderId: activeSLOrder?.orderId,
+    };
+    return result;
+  }, [ordersWithTPSL, activeTPOrderId, activeSLOrderId]);
 
   const hasZeroBalance = useMemo(
     () => parseFloat(account?.availableBalance || '0') === 0,
@@ -229,6 +297,53 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
       setRefreshing(false);
     }
   }, [candleData, refreshCandleData]);
+
+  // Handle order selection for chart integration
+  const handleOrderSelect = useCallback(
+    (orderId: string) => {
+      const selectedOrder = ordersWithTPSL.find(
+        (order) => order.orderId === orderId,
+      );
+
+      if (selectedOrder) {
+        const hasBothTPSL =
+          selectedOrder.takeProfitPrice && selectedOrder.stopLossPrice;
+
+        if (hasBothTPSL) {
+          setActiveTPOrderId(orderId);
+          setActiveSLOrderId(orderId);
+        } else if (selectedOrder.isTrigger && selectedOrder.detailedOrderType) {
+          const orderType = selectedOrder.detailedOrderType.toLowerCase();
+          if (orderType.includes('take profit')) {
+            setActiveTPOrderId(orderId);
+          } else if (orderType.includes('stop')) {
+            setActiveSLOrderId(orderId);
+          }
+        } else if (selectedOrder.takeProfitPrice) {
+          setActiveTPOrderId(orderId);
+        } else if (selectedOrder.stopLossPrice) {
+          setActiveSLOrderId(orderId);
+        }
+      }
+    },
+    [ordersWithTPSL],
+  );
+
+  // Handle order cancellation to update chart
+  const handleOrderCancelled = useCallback(
+    (cancelledOrderId: string) => {
+      // If the cancelled order was the active TP order, clear it
+      if (activeTPOrderId === cancelledOrderId) {
+        setActiveTPOrderId(null);
+      }
+
+      // If the cancelled order was the active SL order, clear it
+      if (activeSLOrderId === cancelledOrderId) {
+        setActiveSLOrderId(null);
+      }
+    },
+    [activeTPOrderId, activeSLOrderId],
+  );
 
   // Check if notifications feature is enabled once
   const isNotificationsEnabled = isNotificationsFeatureEnabled();
@@ -372,10 +487,20 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
                 existingPosition
                   ? {
                       entryPrice: existingPosition.entryPrice,
-                      takeProfitPrice: existingPosition.takeProfitPrice,
-                      stopLossPrice: existingPosition.stopLossPrice,
+                      takeProfitPrice:
+                        selectedOrderTPSL.takeProfitPrice ||
+                        existingPosition.takeProfitPrice,
+                      stopLossPrice:
+                        selectedOrderTPSL.stopLossPrice ||
+                        existingPosition.stopLossPrice,
                       liquidationPrice:
                         existingPosition.liquidationPrice || undefined,
+                    }
+                  : selectedOrderTPSL.takeProfitPrice ||
+                    selectedOrderTPSL.stopLossPrice
+                  ? {
+                      takeProfitPrice: selectedOrderTPSL.takeProfitPrice,
+                      stopLossPrice: selectedOrderTPSL.stopLossPrice,
                     }
                   : undefined
               }
@@ -402,6 +527,10 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
               initialTab={initialTab}
               nextFundingTime={market?.nextFundingTime}
               fundingIntervalHours={market?.fundingIntervalHours}
+              onOrderSelect={handleOrderSelect}
+              onOrderCancelled={handleOrderCancelled}
+              activeTPOrderId={selectedOrderTPSL?.activeTPOrderId}
+              activeSLOrderId={selectedOrderTPSL?.activeSLOrderId}
             />
           </View>
 

--- a/app/components/UI/Perps/Views/PerpsPositionsView/PerpsPositionsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsPositionsView/PerpsPositionsView.test.tsx
@@ -121,6 +121,8 @@ const mockPositions: Position[] = [
     },
     takeProfitPrice: '2200',
     stopLossPrice: '1900',
+    takeProfitCount: 0,
+    stopLossCount: 0,
   },
   {
     coin: 'BTC',
@@ -141,6 +143,8 @@ const mockPositions: Position[] = [
       sinceOpen: '5',
       sinceChange: '2',
     },
+    takeProfitCount: 0,
+    stopLossCount: 0,
   },
 ];
 

--- a/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.test.tsx
@@ -200,6 +200,8 @@ describe('PerpsTabView', () => {
       sinceOpen: '5.00',
       sinceChange: '2.00',
     },
+    takeProfitCount: 0,
+    stopLossCount: 0,
   };
 
   beforeEach(() => {

--- a/app/components/UI/Perps/__mocks__/perpsHooksMocks.ts
+++ b/app/components/UI/Perps/__mocks__/perpsHooksMocks.ts
@@ -94,6 +94,8 @@ export const defaultPerpsPositionMock: Position = {
     sinceOpen: '0',
     sinceChange: '0',
   },
+  takeProfitCount: 0,
+  stopLossCount: 0,
 };
 
 export const defaultPerpsOrderMock: Order = {

--- a/app/components/UI/Perps/components/PerpsBottomSheetTooltip/PerpsBottomSheetTooltip.tsx
+++ b/app/components/UI/Perps/components/PerpsBottomSheetTooltip/PerpsBottomSheetTooltip.tsx
@@ -15,7 +15,6 @@ import {
   ButtonSize,
   ButtonVariants,
 } from '../../../../../component-library/components/Buttons/Button';
-import { ButtonProps } from '../../../../../component-library/components/Buttons/Button/Button.types';
 import { useStyles } from '../../../../hooks/useStyles';
 import { strings } from '../../../../../../locales/i18n';
 import { PerpsBottomSheetTooltipProps } from './PerpsBottomSheetTooltip.types';
@@ -29,6 +28,7 @@ const PerpsBottomSheetTooltip = React.memo<PerpsBottomSheetTooltipProps>(
     onClose,
     contentKey,
     testID = PerpsBottomSheetTooltipSelectorsIDs.TOOLTIP,
+    buttonConfig: buttonConfigProps,
     data,
   }) => {
     const { styles } = useStyles(createStyles, {});
@@ -75,7 +75,7 @@ const PerpsBottomSheetTooltip = React.memo<PerpsBottomSheetTooltipProps>(
       [],
     );
 
-    const footerButtons = useMemo<ButtonProps[]>(
+    const buttonConfigDefault = useMemo(
       () => [
         {
           label: buttonLabel,
@@ -86,6 +86,11 @@ const PerpsBottomSheetTooltip = React.memo<PerpsBottomSheetTooltipProps>(
         },
       ],
       [buttonLabel, handleGotItPress],
+    );
+
+    const footerButtons = useMemo(
+      () => buttonConfigProps || buttonConfigDefault,
+      [buttonConfigProps, buttonConfigDefault],
     );
 
     // Only render when visible and title is defined

--- a/app/components/UI/Perps/components/PerpsBottomSheetTooltip/PerpsBottomSheetTooltip.types.ts
+++ b/app/components/UI/Perps/components/PerpsBottomSheetTooltip/PerpsBottomSheetTooltip.types.ts
@@ -1,3 +1,5 @@
+import { ButtonProps } from '../../../../../component-library/components/Buttons/Button/Button.types';
+
 export interface PerpsBottomSheetTooltipProps {
   /**
    * Visibility state of the bottom sheet
@@ -24,6 +26,11 @@ export interface PerpsBottomSheetTooltipProps {
    * Optional data to pass to custom content renderers
    */
   data?: Record<string, unknown>;
+
+  /**
+   * Optional button config to pass to custom content renderers
+   */
+  buttonConfig?: ButtonProps[];
 }
 
 export type PerpsTooltipContentKey =
@@ -40,4 +47,5 @@ export type PerpsTooltipContentKey =
   | 'estimated_pnl'
   | 'limit_price'
   | 'tp_sl'
-  | 'close_position_you_receive';
+  | 'close_position_you_receive'
+  | 'tpsl_count_warning';

--- a/app/components/UI/Perps/components/PerpsBottomSheetTooltip/content/TPSLCountWarningTooltipContent.test.tsx
+++ b/app/components/UI/Perps/components/PerpsBottomSheetTooltip/content/TPSLCountWarningTooltipContent.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import TPSLCountWarningTooltipContent from './TPSLCountWarningTooltipContent';
+
+// Mock the strings function
+jest.mock('../../../../../../../locales/i18n', () => ({
+  strings: jest.fn((key) => {
+    const mockStrings: Record<string, string> = {
+      'perps.tooltips.tpsl_count_warning.content':
+        'TP/SL count warning content',
+    };
+    return mockStrings[key] || key;
+  }),
+}));
+
+describe('TPSLCountWarningTooltipContent', () => {
+  it('renders without crashing', () => {
+    const { getByTestId } = render(
+      <TPSLCountWarningTooltipContent testID="test-tooltip" />,
+    );
+
+    expect(getByTestId('test-tooltip')).toBeTruthy();
+  });
+
+  it('displays the warning content text', () => {
+    const { getByText } = render(
+      <TPSLCountWarningTooltipContent testID="test-tooltip" />,
+    );
+
+    expect(getByText('TP/SL count warning content')).toBeTruthy();
+  });
+
+  it('accepts data prop without crashing', () => {
+    const mockData = {
+      metamaskFeeRate: 0.1,
+      protocolFeeRate: 0.05,
+    };
+
+    const { getByTestId } = render(
+      <TPSLCountWarningTooltipContent testID="test-tooltip" data={mockData} />,
+    );
+
+    expect(getByTestId('test-tooltip')).toBeTruthy();
+  });
+});

--- a/app/components/UI/Perps/components/PerpsBottomSheetTooltip/content/TPSLCountWarningTooltipContent.tsx
+++ b/app/components/UI/Perps/components/PerpsBottomSheetTooltip/content/TPSLCountWarningTooltipContent.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { View } from 'react-native';
+import Text, {
+  TextColor,
+  TextVariant,
+} from '../../../../../../component-library/components/Texts/Text';
+import { useStyles } from '../../../../../hooks/useStyles';
+import { strings } from '../../../../../../../locales/i18n';
+import { TooltipContentProps } from './types';
+import createStyles from './FeesTooltipContent.styles';
+
+interface TPSLCountWarningTooltipContentProps extends TooltipContentProps {
+  data?: {
+    metamaskFeeRate?: number;
+    protocolFeeRate?: number;
+  };
+}
+
+const TPSLCountWarningTooltipContent = ({
+  testID,
+}: TPSLCountWarningTooltipContentProps) => {
+  const { styles } = useStyles(createStyles, {});
+
+  return (
+    <View testID={testID}>
+      <View style={styles.feeRow}>
+        <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+          {strings('perps.tooltips.tpsl_count_warning.content')}
+        </Text>
+      </View>
+    </View>
+  );
+};
+
+export default TPSLCountWarningTooltipContent;

--- a/app/components/UI/Perps/components/PerpsBottomSheetTooltip/content/contentRegistry.ts
+++ b/app/components/UI/Perps/components/PerpsBottomSheetTooltip/content/contentRegistry.ts
@@ -1,4 +1,5 @@
 import FeesTooltipContent from './FeesTooltipContent';
+import TPSLCountWarningTooltipContent from './TPSLCountWarningTooltipContent';
 import WithdrawalFeesTooltipContent from './WithdrawalFeesTooltipContent';
 import { ContentRegistry } from './types';
 
@@ -27,4 +28,5 @@ export const tooltipContentRegistry: ContentRegistry = {
   limit_price: undefined,
   tp_sl: undefined,
   close_position_you_receive: undefined,
+  tpsl_count_warning: TPSLCountWarningTooltipContent,
 };

--- a/app/components/UI/Perps/components/PerpsMarketTabs/PerpsMarketTabs.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketTabs/PerpsMarketTabs.tsx
@@ -450,7 +450,7 @@ const PerpsMarketTabs: React.FC<PerpsMarketTabsProps> = ({
               expanded
               showIcon
               onTooltipPress={handleTooltipPress}
-              onTpslCountPress={() => handleTabChange('orders')}
+              onTpslCountPress={handleTabChange}
             />
           </View>
         );

--- a/app/components/UI/Perps/components/PerpsMarketTabs/PerpsMarketTabs.types.ts
+++ b/app/components/UI/Perps/components/PerpsMarketTabs/PerpsMarketTabs.types.ts
@@ -30,4 +30,20 @@ export interface PerpsMarketTabsProps {
    * Funding interval in hours (optional, market-specific)
    */
   fundingIntervalHours?: number;
+  /**
+   * Callback when an order is selected for chart integration
+   */
+  onOrderSelect?: (orderId: string) => void;
+  /**
+   * Callback when an order is cancelled to update chart
+   */
+  onOrderCancelled?: (orderId: string) => void;
+  /**
+   * ID of the currently active TP order shown on chart
+   */
+  activeTPOrderId?: string | null;
+  /**
+   * ID of the currently active SL order shown on chart
+   */
+  activeSLOrderId?: string | null;
 }

--- a/app/components/UI/Perps/components/PerpsOpenOrderCard/PerpsOpenOrderCard.styles.ts
+++ b/app/components/UI/Perps/components/PerpsOpenOrderCard/PerpsOpenOrderCard.styles.ts
@@ -104,6 +104,33 @@ const styleSheet = (params: { theme: Theme }) => {
       borderRadius: 4,
       marginRight: 4,
     },
+
+    // Chart activity indicator styles
+    indicatorContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginLeft: 6,
+      gap: 4,
+    },
+    activeChartIndicator: {
+      borderRadius: 16,
+      paddingHorizontal: 8,
+      paddingVertical: 0,
+    },
+    // eslint-disable-next-line react-native/no-color-literals
+    tpIndicator: {
+      // eslint-disable-next-line @metamask/design-tokens/color-no-hex
+      backgroundColor: '#BAF24A', // Light Green - matches chart TP line color
+    },
+    // eslint-disable-next-line react-native/no-color-literals
+    slIndicator: {
+      // eslint-disable-next-line @metamask/design-tokens/color-no-hex
+      backgroundColor: '#484848', // Dark Gray - matches chart SL line color
+    },
+    activeChartText: {
+      fontSize: 8,
+      fontWeight: '600',
+    },
   });
 };
 

--- a/app/components/UI/Perps/components/PerpsOpenOrderCard/PerpsOpenOrderCard.styles.ts
+++ b/app/components/UI/Perps/components/PerpsOpenOrderCard/PerpsOpenOrderCard.styles.ts
@@ -117,15 +117,11 @@ const styleSheet = (params: { theme: Theme }) => {
       paddingHorizontal: 8,
       paddingVertical: 0,
     },
-    // eslint-disable-next-line react-native/no-color-literals
     tpIndicator: {
-      // eslint-disable-next-line @metamask/design-tokens/color-no-hex
-      backgroundColor: '#BAF24A', // Light Green - matches chart TP line color
+      backgroundColor: colors.success.default, // Light Green - matches chart TP line color
     },
-    // eslint-disable-next-line react-native/no-color-literals
     slIndicator: {
-      // eslint-disable-next-line @metamask/design-tokens/color-no-hex
-      backgroundColor: '#484848', // Dark Gray - matches chart SL line color
+      backgroundColor: colors.background.muted, // Dark Gray - matches chart SL line color
     },
     activeChartText: {
       fontSize: 8,

--- a/app/components/UI/Perps/components/PerpsOpenOrderCard/PerpsOpenOrderCard.test.tsx
+++ b/app/components/UI/Perps/components/PerpsOpenOrderCard/PerpsOpenOrderCard.test.tsx
@@ -454,4 +454,198 @@ describe('PerpsOpenOrderCard', () => {
       expect(toJSON()).toBeNull();
     });
   });
+
+  describe('Additional Coverage Tests', () => {
+    const mockOnSelect = jest.fn();
+
+    beforeEach(() => {
+      mockOnSelect.mockClear();
+    });
+
+    it('calls onSelect when card is pressed and not disabled', () => {
+      render(<PerpsOpenOrderCard order={mockOrder} onSelect={mockOnSelect} />);
+
+      fireEvent.press(screen.getByTestId(PerpsOpenOrderCardSelectorsIDs.CARD));
+
+      expect(mockOnSelect).toHaveBeenCalledWith(mockOrder.orderId);
+    });
+
+    it('does not call onSelect when card is pressed and disabled', () => {
+      render(
+        <PerpsOpenOrderCard
+          order={mockOrder}
+          onSelect={mockOnSelect}
+          disabled
+        />,
+      );
+
+      fireEvent.press(screen.getByTestId(PerpsOpenOrderCardSelectorsIDs.CARD));
+
+      expect(mockOnSelect).not.toHaveBeenCalled();
+    });
+
+    it('renders chart activity indicators for TP', () => {
+      render(
+        <PerpsOpenOrderCard
+          order={mockOrder}
+          isActiveOnChart
+          activeType="TP"
+        />,
+      );
+
+      expect(screen.getByText('TP on Chart')).toBeOnTheScreen();
+    });
+
+    it('renders chart activity indicators for SL', () => {
+      render(
+        <PerpsOpenOrderCard
+          order={mockOrder}
+          isActiveOnChart
+          activeType="SL"
+        />,
+      );
+
+      expect(screen.getByText('SL on Chart')).toBeOnTheScreen();
+    });
+
+    it('renders chart activity indicators for BOTH', () => {
+      render(
+        <PerpsOpenOrderCard
+          order={mockOrder}
+          isActiveOnChart
+          activeType="BOTH"
+        />,
+      );
+
+      expect(screen.getByText('TP on Chart')).toBeOnTheScreen();
+      expect(screen.getByText('SL on Chart')).toBeOnTheScreen();
+    });
+
+    it('handles reduce-only sell order direction (Close Long)', () => {
+      const reduceOnlySellOrder = {
+        ...mockOrder,
+        side: 'sell' as const,
+        reduceOnly: true,
+        detailedOrderType: undefined,
+      };
+
+      render(<PerpsOpenOrderCard order={reduceOnlySellOrder} />);
+
+      expect(screen.getByText('Close Long')).toBeOnTheScreen();
+    });
+
+    it('handles reduce-only buy order direction (Close Short)', () => {
+      const reduceOnlyBuyOrder = {
+        ...mockOrder,
+        side: 'buy' as const,
+        reduceOnly: true,
+        detailedOrderType: undefined,
+      };
+
+      render(<PerpsOpenOrderCard order={reduceOnlyBuyOrder} />);
+
+      expect(screen.getByText('Close Short')).toBeOnTheScreen();
+    });
+
+    it('handles trigger order direction for sell (Close Long)', () => {
+      const triggerSellOrder = {
+        ...mockOrder,
+        side: 'sell' as const,
+        isTrigger: true,
+        detailedOrderType: undefined,
+      };
+
+      render(<PerpsOpenOrderCard order={triggerSellOrder} />);
+
+      expect(screen.getByText('Close Long')).toBeOnTheScreen();
+    });
+
+    it('handles trigger order direction for buy (Close Short)', () => {
+      const triggerBuyOrder = {
+        ...mockOrder,
+        side: 'buy' as const,
+        isTrigger: true,
+        detailedOrderType: undefined,
+      };
+
+      render(<PerpsOpenOrderCard order={triggerBuyOrder} />);
+
+      expect(screen.getByText('Close Short')).toBeOnTheScreen();
+    });
+
+    it('does not render chart indicators when isActiveOnChart is false', () => {
+      render(
+        <PerpsOpenOrderCard
+          order={mockOrder}
+          isActiveOnChart={false}
+          activeType="TP"
+        />,
+      );
+
+      expect(screen.queryByText('TP on Chart')).not.toBeOnTheScreen();
+    });
+
+    it('does not call onSelect when onSelect is not provided', () => {
+      render(<PerpsOpenOrderCard order={mockOrder} />);
+
+      // Should not throw when card is pressed without onSelect handler
+      expect(() => {
+        fireEvent.press(
+          screen.getByTestId(PerpsOpenOrderCardSelectorsIDs.CARD),
+        );
+      }).not.toThrow();
+    });
+  });
+
+  describe('Additional Coverage Tests', () => {
+    it('handles order without takeProfitPrice and stopLossPrice', () => {
+      const orderWithoutTPSL: Order = {
+        ...mockOrder,
+        takeProfitPrice: undefined,
+        stopLossPrice: undefined,
+      };
+
+      render(<PerpsOpenOrderCard order={orderWithoutTPSL} expanded />);
+
+      expect(screen.getByText('Limit Order')).toBeOnTheScreen();
+    });
+
+    it('handles trigger order', () => {
+      const triggerOrder: Order = {
+        ...mockOrder,
+        isTrigger: true,
+        detailedOrderType: 'Stop Market',
+      };
+
+      render(<PerpsOpenOrderCard order={triggerOrder} />);
+
+      expect(screen.getByText('Stop Market')).toBeOnTheScreen();
+    });
+
+    it('handles reduce-only order', () => {
+      const reduceOnlyOrder: Order = {
+        ...mockOrder,
+        reduceOnly: true,
+      };
+
+      render(<PerpsOpenOrderCard order={reduceOnlyOrder} />);
+
+      expect(screen.getByText('Limit Order')).toBeOnTheScreen();
+    });
+
+    it('handles order with right accessory', () => {
+      const RightAccessory = () => (
+        <Text testID="right-accessory">Accessory</Text>
+      );
+
+      render(
+        <PerpsOpenOrderCard
+          order={mockOrder}
+          rightAccessory={<RightAccessory />}
+        />,
+      );
+
+      expect(screen.getByTestId('right-accessory')).toBeOnTheScreen();
+    });
+  });
 });

--- a/app/components/UI/Perps/components/PerpsOpenOrderCard/PerpsOpenOrderCard.tsx
+++ b/app/components/UI/Perps/components/PerpsOpenOrderCard/PerpsOpenOrderCard.tsx
@@ -64,10 +64,13 @@ import { selectPerpsEligibility } from '../../selectors/perpsController';
 const PerpsOpenOrderCard: React.FC<PerpsOpenOrderCardProps> = ({
   order,
   onCancel,
+  onSelect,
   disabled = false,
   expanded = false,
   showIcon = false,
   rightAccessory,
+  isActiveOnChart = false,
+  activeType,
 }) => {
   const { styles } = useStyles(styleSheet, {});
 
@@ -126,11 +129,18 @@ const PerpsOpenOrderCard: React.FC<PerpsOpenOrderCardProps> = ({
     onCancel?.(order);
   };
 
+  const handleCardPress = () => {
+    if (onSelect && !disabled) {
+      onSelect(order.orderId);
+    }
+  };
+
   return (
     <TouchableOpacity
       style={expanded ? styles.expandedContainer : styles.collapsedContainer}
       testID={PerpsOpenOrderCardSelectorsIDs.CARD}
-      disabled={expanded}
+      disabled={disabled}
+      onPress={handleCardPress}
     >
       {/* Header - Always shown */}
       <View style={[styles.header, expanded && styles.headerExpanded]}>
@@ -147,6 +157,35 @@ const PerpsOpenOrderCard: React.FC<PerpsOpenOrderCardProps> = ({
             <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
               {order.detailedOrderType || derivedData.direction}
             </Text>
+            {/* Chart activity indicators */}
+            {isActiveOnChart && (
+              <View style={styles.indicatorContainer}>
+                {activeType === 'TP' || activeType === 'BOTH' ? (
+                  <View
+                    style={[styles.activeChartIndicator, styles.tpIndicator]}
+                  >
+                    <Text
+                      variant={TextVariant.BodyXS}
+                      color={TextColor.Inverse}
+                    >
+                      TP on Chart
+                    </Text>
+                  </View>
+                ) : null}
+                {activeType === 'SL' || activeType === 'BOTH' ? (
+                  <View
+                    style={[styles.activeChartIndicator, styles.slIndicator]}
+                  >
+                    <Text
+                      variant={TextVariant.BodyXS}
+                      color={TextColor.Default}
+                    >
+                      SL on Chart
+                    </Text>
+                  </View>
+                ) : null}
+              </View>
+            )}
             {/* Fill percentage badge with icon */}
             {derivedData.fillPercentage > 0 &&
               derivedData.fillPercentage < 100 && (

--- a/app/components/UI/Perps/components/PerpsOpenOrderCard/PerpsOpenOrderCard.types.ts
+++ b/app/components/UI/Perps/components/PerpsOpenOrderCard/PerpsOpenOrderCard.types.ts
@@ -3,10 +3,13 @@ import type { Order } from '../../controllers/types';
 export interface PerpsOpenOrderCardProps {
   order: Order;
   onCancel?: (order: Order) => void;
+  onSelect?: (orderId: string) => void;
   disabled?: boolean;
   expanded?: boolean;
   showIcon?: boolean;
   rightAccessory?: React.ReactNode;
+  isActiveOnChart?: boolean;
+  activeType?: 'TP' | 'SL' | 'BOTH';
 }
 
 export interface OpenOrderCardDerivedData {

--- a/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.styles.ts
+++ b/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.styles.ts
@@ -42,6 +42,10 @@ const styleSheet = (params: { theme: Theme }) => {
       justifyContent: 'center',
       overflow: 'hidden',
     },
+    tpslCountPress: {
+      textDecorationLine: 'underline',
+      textDecorationStyle: 'dotted',
+    },
     headerLeft: {
       flex: 1,
       alignItems: 'flex-start',

--- a/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.test.tsx
+++ b/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.test.tsx
@@ -173,6 +173,8 @@ describe('PerpsPositionCard', () => {
       sinceOpen: '5.00',
       sinceChange: '2.00',
     },
+    takeProfitCount: 0,
+    stopLossCount: 0,
   };
 
   const mockTheme = {

--- a/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.test.tsx
+++ b/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.test.tsx
@@ -25,7 +25,12 @@ jest.mock('react-redux', () => ({
 
 // Mock i18n
 jest.mock('../../../../../../locales/i18n', () => ({
-  strings: jest.fn((key) => key),
+  strings: jest.fn((key, params) => {
+    if (key === 'perps.position.card.tpsl_count_multiple' && params?.count) {
+      return `${params.count} orders`;
+    }
+    return key;
+  }),
 }));
 
 const mockUseTheme = jest.fn();
@@ -72,6 +77,18 @@ jest.mock('../../providers/PerpsStreamManager', () => ({
 jest.mock('../../hooks/stream', () => ({
   usePerpsLivePrices: jest.fn(() => ({})),
   usePerpsLivePositions: jest.fn(() => ({})),
+}));
+
+// Mock TP_SL_CONFIG
+const mockTPSLConfig = {
+  USE_POSITION_BOUND_TPSL: true,
+};
+
+// Create a getter that references the mutable mock object
+jest.mock('../../constants/perpsConfig', () => ({
+  get TP_SL_CONFIG() {
+    return mockTPSLConfig;
+  },
 }));
 
 // Mock the new hooks from ../../hooks
@@ -132,18 +149,25 @@ jest.mock('../PerpsBottomSheetTooltip/PerpsBottomSheetTooltip', () => ({
   default: ({
     isVisible,
     onClose,
+    contentKey,
   }: {
     isVisible: boolean;
     onClose?: () => void;
+    contentKey?: string;
   }) => {
     if (!isVisible) return null;
     const { TouchableOpacity, Text } = jest.requireActual('react-native');
+    const text =
+      contentKey === 'geo_block'
+        ? 'Geo Block Tooltip'
+        : 'TPSL Count Warning Tooltip';
+    const testID =
+      contentKey === 'geo_block'
+        ? 'perps-position-card-geo-block-tooltip'
+        : 'perps-position-card-tpsl-count-warning-tooltip';
     return (
-      <TouchableOpacity
-        testID="perps-position-card-geo-block-tooltip"
-        onPress={onClose}
-      >
-        <Text>Geo Block Tooltip</Text>
+      <TouchableOpacity testID={testID} onPress={onClose}>
+        <Text>{text}</Text>
       </TouchableOpacity>
     );
   },
@@ -891,6 +915,289 @@ describe('PerpsPositionCard', () => {
 
       // Should format to 2 decimal places - includes dollar sign
       expect(screen.getByText('-$12.35')).toBeOnTheScreen();
+    });
+  });
+
+  describe('TP/SL Count Functionality', () => {
+    beforeEach(() => {
+      // Reset mock config to default
+      mockTPSLConfig.USE_POSITION_BOUND_TPSL = true;
+    });
+
+    it('displays take profit count when multiple TP orders exist', () => {
+      const positionWithMultipleTP = {
+        ...mockPosition,
+        takeProfitCount: 3,
+        takeProfitPrice: undefined, // No single price when multiple orders
+        stopLossCount: 0,
+      };
+
+      render(<PerpsPositionCard position={positionWithMultipleTP} />);
+
+      expect(screen.getByText('3 orders')).toBeOnTheScreen();
+    });
+
+    it('displays stop loss count when multiple SL orders exist', () => {
+      const positionWithMultipleSL = {
+        ...mockPosition,
+        takeProfitCount: 0,
+        stopLossCount: 2,
+        stopLossPrice: undefined, // No single price when multiple orders
+      };
+
+      render(<PerpsPositionCard position={positionWithMultipleSL} />);
+
+      expect(screen.getByText('2 orders')).toBeOnTheScreen();
+    });
+
+    it('displays single TP price when only one TP order exists', () => {
+      const positionWithSingleTP = {
+        ...mockPosition,
+        takeProfitCount: 1,
+        takeProfitPrice: '2500.00',
+        stopLossCount: 0,
+      };
+
+      render(<PerpsPositionCard position={positionWithSingleTP} />);
+
+      expect(screen.getByText('$2,500.00')).toBeOnTheScreen();
+      expect(screen.queryByText(/1.*orders/)).not.toBeOnTheScreen();
+    });
+
+    it('displays single SL price when only one SL order exists', () => {
+      const positionWithSingleSL = {
+        ...mockPosition,
+        takeProfitCount: 0,
+        stopLossCount: 1,
+        stopLossPrice: '1500.00',
+      };
+
+      render(<PerpsPositionCard position={positionWithSingleSL} />);
+
+      expect(screen.getByText('$1,500.00')).toBeOnTheScreen();
+      expect(screen.queryByText(/1.*orders/)).not.toBeOnTheScreen();
+    });
+
+    it('displays "Not Set" when no TP/SL orders exist', () => {
+      const positionWithoutTPSL = {
+        ...mockPosition,
+        takeProfitCount: 0,
+        stopLossCount: 0,
+        takeProfitPrice: undefined,
+        stopLossPrice: undefined,
+      };
+
+      render(<PerpsPositionCard position={positionWithoutTPSL} />);
+
+      // Should show "Not Set" for both TP and SL
+      const notSetTexts = screen.getAllByText('perps.position.card.not_set');
+      expect(notSetTexts).toHaveLength(2); // One for TP, one for SL
+    });
+  });
+
+  describe('TP/SL Count Warning Modal', () => {
+    beforeEach(() => {
+      // Disable position bound TP/SL for these tests
+      mockTPSLConfig.USE_POSITION_BOUND_TPSL = false;
+    });
+
+    afterEach(() => {
+      // Reset to default
+      mockTPSLConfig.USE_POSITION_BOUND_TPSL = true;
+    });
+
+    it('shows warning modal when editing TP/SL with multiple orders but no single price', () => {
+      const positionWithMultipleTPNoPrice = {
+        ...mockPosition,
+        takeProfitCount: 2,
+        takeProfitPrice: undefined, // Multiple orders but no single price
+        stopLossCount: 0,
+      };
+
+      render(<PerpsPositionCard position={positionWithMultipleTPNoPrice} />);
+
+      // Press edit TP/SL button
+      fireEvent.press(
+        screen.getByTestId(PerpsPositionCardSelectorsIDs.EDIT_BUTTON),
+      );
+
+      // Should show warning modal instead of TP/SL bottom sheet since position bound TP/SL is disabled
+      expect(screen.getByText('TPSL Count Warning Tooltip')).toBeOnTheScreen();
+      expect(
+        screen.queryByTestId('perps-tpsl-bottomsheet'),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('shows warning modal when editing TP/SL with multiple SL orders but no single price', () => {
+      const positionWithMultipleSLNoPrice = {
+        ...mockPosition,
+        takeProfitCount: 0,
+        stopLossCount: 3,
+        stopLossPrice: undefined, // Multiple orders but no single price
+      };
+
+      render(<PerpsPositionCard position={positionWithMultipleSLNoPrice} />);
+
+      // Press edit TP/SL button
+      fireEvent.press(
+        screen.getByTestId(PerpsPositionCardSelectorsIDs.EDIT_BUTTON),
+      );
+
+      // Should show warning modal instead of TP/SL bottom sheet since position bound TP/SL is disabled
+      expect(screen.getByText('TPSL Count Warning Tooltip')).toBeOnTheScreen();
+      expect(
+        screen.queryByTestId('perps-tpsl-bottomsheet'),
+      ).not.toBeOnTheScreen();
+    });
+
+    it('does not show warning modal when position bound TP/SL is enabled', () => {
+      // Temporarily enable position bound TP/SL
+      mockTPSLConfig.USE_POSITION_BOUND_TPSL = true;
+
+      const positionWithMultipleTPNoPrice = {
+        ...mockPosition,
+        takeProfitCount: 2,
+        takeProfitPrice: undefined,
+        stopLossCount: 0,
+      };
+
+      render(<PerpsPositionCard position={positionWithMultipleTPNoPrice} />);
+
+      // Press edit TP/SL button
+      fireEvent.press(
+        screen.getByTestId(PerpsPositionCardSelectorsIDs.EDIT_BUTTON),
+      );
+
+      // Should show TP/SL bottom sheet, not warning modal
+      expect(screen.getByTestId('perps-tpsl-bottomsheet')).toBeOnTheScreen();
+      expect(
+        screen.queryByText('TPSL Count Warning Tooltip'),
+      ).not.toBeOnTheScreen();
+
+      // Reset back to disabled for other tests in this describe block
+      mockTPSLConfig.USE_POSITION_BOUND_TPSL = false;
+    });
+
+    it('does not show warning modal when single TP/SL prices are available', () => {
+      const positionWithSinglePrices = {
+        ...mockPosition,
+        takeProfitCount: 1,
+        takeProfitPrice: '2500.00',
+        stopLossCount: 1,
+        stopLossPrice: '1500.00',
+      };
+
+      render(<PerpsPositionCard position={positionWithSinglePrices} />);
+
+      // Press edit TP/SL button
+      fireEvent.press(
+        screen.getByTestId(PerpsPositionCardSelectorsIDs.EDIT_BUTTON),
+      );
+
+      // Should show TP/SL bottom sheet, not warning modal
+      expect(screen.getByTestId('perps-tpsl-bottomsheet')).toBeOnTheScreen();
+      expect(screen.queryByText('Geo Block Tooltip')).not.toBeOnTheScreen();
+    });
+  });
+
+  describe('TP/SL Configuration Behavior', () => {
+    it('renders count as clickable when position bound TP/SL is enabled and count > 1', () => {
+      // Ensure position bound TP/SL is enabled (default)
+      mockTPSLConfig.USE_POSITION_BOUND_TPSL = true;
+
+      const positionWithMultipleTP = {
+        ...mockPosition,
+        takeProfitCount: 3,
+        takeProfitPrice: undefined,
+        stopLossCount: 0,
+      };
+
+      render(<PerpsPositionCard position={positionWithMultipleTP} />);
+
+      const tpCountText = screen.getByText('3 orders');
+      // TouchableOpacity should be pressable
+      expect(tpCountText).toBeTruthy();
+    });
+
+    it('renders count as clickable when position bound TP/SL is disabled and count > 0 with no price', () => {
+      // Disable position bound TP/SL for this test
+      mockTPSLConfig.USE_POSITION_BOUND_TPSL = false;
+
+      const positionWithMultipleSLNoPrice = {
+        ...mockPosition,
+        takeProfitCount: 0,
+        stopLossCount: 2,
+        stopLossPrice: undefined, // No single price
+      };
+
+      render(<PerpsPositionCard position={positionWithMultipleSLNoPrice} />);
+
+      const slCountText = screen.getByText('2 orders');
+      // TouchableOpacity should be pressable
+      expect(slCountText).toBeTruthy();
+
+      // Reset to default
+      mockTPSLConfig.USE_POSITION_BOUND_TPSL = true;
+    });
+
+    it('handles navigation error gracefully when pressing TP/SL count', () => {
+      const { usePerpsMarkets } = jest.requireMock('../../hooks');
+      usePerpsMarkets.mockReturnValue({
+        markets: [],
+        error: 'Network error',
+        isLoading: false,
+      });
+
+      const mockOnTpslCountPress = jest.fn();
+      const positionWithMultipleTP = {
+        ...mockPosition,
+        takeProfitCount: 3,
+        takeProfitPrice: undefined,
+        stopLossCount: 0,
+      };
+
+      render(
+        <PerpsPositionCard
+          position={positionWithMultipleTP}
+          onTpslCountPress={mockOnTpslCountPress}
+        />,
+      );
+
+      const tpCountText = screen.getByText('3 orders');
+      fireEvent.press(tpCountText);
+
+      // Should not call onTpslCountPress due to error
+      expect(mockOnTpslCountPress).not.toHaveBeenCalled();
+    });
+
+    it('handles missing market data gracefully when pressing TP/SL count', () => {
+      const { usePerpsMarkets } = jest.requireMock('../../hooks');
+      usePerpsMarkets.mockReturnValue({
+        markets: [], // Empty markets array
+        error: null,
+        isLoading: false,
+      });
+
+      const mockOnTpslCountPress = jest.fn();
+      const positionWithMultipleSL = {
+        ...mockPosition,
+        takeProfitCount: 0,
+        stopLossCount: 2,
+        stopLossPrice: undefined,
+      };
+
+      render(
+        <PerpsPositionCard
+          position={positionWithMultipleSL}
+          onTpslCountPress={mockOnTpslCountPress}
+        />,
+      );
+
+      const slCountText = screen.getByText('2 orders');
+      fireEvent.press(slCountText);
+
+      // Should not call onTpslCountPress due to missing market data
+      expect(mockOnTpslCountPress).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
+++ b/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
@@ -52,7 +52,7 @@ interface PerpsPositionCardProps {
   rightAccessory?: React.ReactNode;
   onPositionUpdate?: () => Promise<void>;
   onTooltipPress?: (contentKey: PerpsTooltipContentKey) => void;
-  onTpslCountPress?: () => void;
+  onTpslCountPress?: (tabId: string) => void;
 }
 
 const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
@@ -173,7 +173,7 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
     }
 
     if (onTpslCountPress) {
-      onTpslCountPress();
+      onTpslCountPress('orders');
     }
   };
 
@@ -203,31 +203,8 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
 
   const renderStopLossText = () => {
     if (TP_SL_CONFIG.USE_POSITION_BOUND_TPSL) {
-      return (
-        <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
-          {positionStopLossCount > 1 ? (
-            <TouchableOpacity onPress={handleTpslCountPress}>
-              <Text style={styles.tpslCountPress}>
-                {strings('perps.position.card.tpsl_count_multiple', {
-                  count: position.stopLossCount,
-                })}
-              </Text>
-            </TouchableOpacity>
-          ) : null}
-          {positionStopLossCount <= 1
-            ? position.stopLossPrice
-              ? formatPerpsFiat(position.stopLossPrice, {
-                  ranges: PRICE_RANGES_POSITION_VIEW,
-                })
-              : strings('perps.position.card.not_set')
-            : null}
-        </Text>
-      );
-    }
-
-    return (
-      <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
-        {!position.stopLossPrice ? (
+      if (positionStopLossCount > 1) {
+        return (
           <TouchableOpacity onPress={handleTpslCountPress}>
             <Text style={styles.tpslCountPress}>
               {strings('perps.position.card.tpsl_count_multiple', {
@@ -235,44 +212,47 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
               })}
             </Text>
           </TouchableOpacity>
-        ) : position.stopLossPrice ? (
-          formatPerpsFiat(position.stopLossPrice, {
-            ranges: PRICE_RANGES_POSITION_VIEW,
-          })
-        ) : (
-          strings('perps.position.card.not_set')
-        )}
+        );
+      }
+
+      return (
+        <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+          {position.stopLossPrice
+            ? formatPerpsFiat(position.stopLossPrice, {
+                ranges: PRICE_RANGES_POSITION_VIEW,
+              })
+            : strings('perps.position.card.not_set')}
+        </Text>
+      );
+    }
+
+    if (positionStopLossCount > 0 && !position.stopLossPrice) {
+      return (
+        <TouchableOpacity onPress={handleTpslCountPress}>
+          <Text style={styles.tpslCountPress}>
+            {strings('perps.position.card.tpsl_count_multiple', {
+              count: position.stopLossCount,
+            })}
+          </Text>
+        </TouchableOpacity>
+      );
+    }
+
+    return (
+      <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+        {position.stopLossPrice
+          ? formatPerpsFiat(position.stopLossPrice, {
+              ranges: PRICE_RANGES_POSITION_VIEW,
+            })
+          : strings('perps.position.card.not_set')}
       </Text>
     );
   };
 
   const renderTakeProfitText = () => {
     if (TP_SL_CONFIG.USE_POSITION_BOUND_TPSL) {
-      return (
-        <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
-          {positionTakeProfitCount > 1 ? (
-            <TouchableOpacity onPress={handleTpslCountPress}>
-              <Text style={styles.tpslCountPress}>
-                {strings('perps.position.card.tpsl_count_multiple', {
-                  count: position.takeProfitCount,
-                })}
-              </Text>
-            </TouchableOpacity>
-          ) : null}
-          {positionTakeProfitCount <= 1
-            ? position.takeProfitPrice
-              ? formatPerpsFiat(position.takeProfitPrice, {
-                  ranges: PRICE_RANGES_POSITION_VIEW,
-                })
-              : strings('perps.position.card.not_set')
-            : null}
-        </Text>
-      );
-    }
-
-    return (
-      <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
-        {!position.takeProfitPrice ? (
+      if (positionTakeProfitCount > 1) {
+        return (
           <TouchableOpacity onPress={handleTpslCountPress}>
             <Text style={styles.tpslCountPress}>
               {strings('perps.position.card.tpsl_count_multiple', {
@@ -280,13 +260,39 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
               })}
             </Text>
           </TouchableOpacity>
-        ) : position.takeProfitPrice ? (
-          formatPerpsFiat(position.takeProfitPrice, {
-            ranges: PRICE_RANGES_POSITION_VIEW,
-          })
-        ) : (
-          strings('perps.position.card.not_set')
-        )}
+        );
+      }
+
+      return (
+        <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+          {position.takeProfitPrice
+            ? formatPerpsFiat(position.takeProfitPrice, {
+                ranges: PRICE_RANGES_POSITION_VIEW,
+              })
+            : strings('perps.position.card.not_set')}
+        </Text>
+      );
+    }
+
+    if (positionTakeProfitCount > 0 && !position.takeProfitPrice) {
+      return (
+        <TouchableOpacity onPress={handleTpslCountPress}>
+          <Text style={styles.tpslCountPress}>
+            {strings('perps.position.card.tpsl_count_multiple', {
+              count: position.takeProfitCount,
+            })}
+          </Text>
+        </TouchableOpacity>
+      );
+    }
+
+    return (
+      <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
+        {position.takeProfitPrice
+          ? formatPerpsFiat(position.takeProfitPrice, {
+              ranges: PRICE_RANGES_POSITION_VIEW,
+            })
+          : strings('perps.position.card.not_set')}
       </Text>
     );
   };

--- a/app/components/UI/Perps/components/PerpsTPSLBottomSheet/PerpsTPSLBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsTPSLBottomSheet/PerpsTPSLBottomSheet.test.tsx
@@ -369,6 +369,8 @@ describe('PerpsTPSLBottomSheet', () => {
       sinceOpen: '8.00',
       sinceChange: '3.00',
     },
+    takeProfitCount: 0,
+    stopLossCount: 0,
   };
 
   beforeEach(() => {

--- a/app/components/UI/Perps/constants/orderTypes.ts
+++ b/app/components/UI/Perps/constants/orderTypes.ts
@@ -7,6 +7,7 @@ export const DETAILED_ORDER_TYPES = {
   STOP_LIMIT: 'Stop Limit',
   STOP_MARKET: 'Stop Market',
   TAKE_PROFIT_LIMIT: 'Take Profit Limit',
+  TAKE_PROFIT_MARKET: 'Take Profit Market',
 } as const;
 
 /**
@@ -17,6 +18,7 @@ export const isTPSLOrder = (detailedOrderType?: string): boolean => {
   return (
     detailedOrderType === DETAILED_ORDER_TYPES.STOP_LIMIT ||
     detailedOrderType === DETAILED_ORDER_TYPES.STOP_MARKET ||
-    detailedOrderType === DETAILED_ORDER_TYPES.TAKE_PROFIT_LIMIT
+    detailedOrderType === DETAILED_ORDER_TYPES.TAKE_PROFIT_LIMIT ||
+    detailedOrderType === DETAILED_ORDER_TYPES.TAKE_PROFIT_MARKET
   );
 };

--- a/app/components/UI/Perps/constants/perpsConfig.ts
+++ b/app/components/UI/Perps/constants/perpsConfig.ts
@@ -114,6 +114,10 @@ export const LEVERAGE_SLIDER_CONFIG = {
   MAX_LEVERAGE_MEDIUM_THRESHOLD: 50,
 } as const;
 
+export const TP_SL_CONFIG = {
+  USE_POSITION_BOUND_TPSL: true,
+} as const;
+
 /**
  * Limit price configuration
  * Controls preset percentages and behavior for limit orders

--- a/app/components/UI/Perps/controllers/PerpsController.test.ts
+++ b/app/components/UI/Perps/controllers/PerpsController.test.ts
@@ -300,6 +300,8 @@ describe('PerpsController', () => {
               sinceOpen: '0',
               sinceChange: '0',
             },
+            takeProfitCount: 0,
+            stopLossCount: 0,
           },
         ],
       };
@@ -601,6 +603,8 @@ describe('PerpsController', () => {
             sinceOpen: '5',
             sinceChange: '2',
           },
+          takeProfitCount: 0,
+          stopLossCount: 0,
         },
       ];
 

--- a/app/components/UI/Perps/controllers/providers/HyperLiquidProvider.test.ts
+++ b/app/components/UI/Perps/controllers/providers/HyperLiquidProvider.test.ts
@@ -4184,4 +4184,61 @@ describe('HyperLiquidProvider', () => {
       ).not.toHaveBeenCalled();
     });
   });
+
+  describe('Additional Coverage Tests', () => {
+    it('should handle getUserFills with empty response', async () => {
+      mockClientService.getInfoClient = jest.fn().mockReturnValue({
+        userFills: jest.fn().mockResolvedValue(null),
+      });
+
+      const result = await provider.getOrderFills();
+      expect(result).toEqual([]);
+    });
+
+    it('should handle getOrders with empty response', async () => {
+      mockClientService.getInfoClient = jest.fn().mockReturnValue({
+        historicalOrders: jest.fn().mockResolvedValue(null),
+      });
+
+      const result = await provider.getOrders();
+      expect(result).toEqual([]);
+    });
+
+    it('should handle getFunding with empty response', async () => {
+      mockClientService.getInfoClient = jest.fn().mockReturnValue({
+        userFunding: jest.fn().mockResolvedValue(null),
+      });
+
+      const result = await provider.getFunding();
+      expect(result).toEqual([]);
+    });
+
+    it('should handle validateWithdrawal returning true', async () => {
+      const params = {
+        amount: '100',
+        destination: '0x123' as Hex,
+        assetId: 'eip155:1/native' as CaipAssetId,
+      };
+
+      const result = await provider.validateWithdrawal(params);
+      expect(result.isValid).toBe(true);
+    });
+
+    it('should handle clearFeeCache with specific user', () => {
+      const userAddress = '0x123';
+      provider.clearFeeCache(userAddress);
+      // Method should complete without error
+    });
+
+    it('should handle private method getUserVolume edge case', async () => {
+      // Access private method for edge case testing
+      interface ProviderWithPrivateMethods {
+        isFeeCacheValid(userAddress: string): boolean;
+      }
+      const testableProvider =
+        provider as unknown as ProviderWithPrivateMethods;
+      const result = testableProvider.isFeeCacheValid('0xnonexistent');
+      expect(result).toBe(false);
+    });
+  });
 });

--- a/app/components/UI/Perps/controllers/providers/HyperLiquidProvider.test.ts
+++ b/app/components/UI/Perps/controllers/providers/HyperLiquidProvider.test.ts
@@ -2570,6 +2570,12 @@ describe('HyperLiquidProvider', () => {
       });
 
       it('should handle canceling existing TP/SL orders', async () => {
+        // Set up asset mapping for BTC
+        Object.defineProperty(provider, 'coinToAssetId', {
+          value: new Map([['BTC', 0]]),
+          writable: true,
+        });
+
         // Mock position exists
         mockClientService.getInfoClient = jest.fn().mockReturnValue({
           clearinghouseState: jest.fn().mockResolvedValue({
@@ -2608,6 +2614,7 @@ describe('HyperLiquidProvider', () => {
               isTrigger: true,
               orderType: 'Take Profit',
               sz: '0.1',
+              isPositionTpsl: true,
             },
             {
               coin: 'BTC',
@@ -2616,6 +2623,7 @@ describe('HyperLiquidProvider', () => {
               isTrigger: true,
               orderType: 'Stop Loss',
               sz: '0.1',
+              isPositionTpsl: true,
             },
           ]),
           referral: jest.fn().mockResolvedValue({

--- a/app/components/UI/Perps/controllers/types/index.ts
+++ b/app/components/UI/Perps/controllers/types/index.ts
@@ -65,6 +65,8 @@ export type Position = {
   };
   takeProfitPrice?: string; // Take profit price (if set)
   stopLossPrice?: string; // Stop loss price (if set)
+  takeProfitCount: number; // Take profit count, how many tps can affect the position
+  stopLossCount: number; // Stop loss count, how many sls can affect the position
 };
 
 export type AccountState = {

--- a/app/components/UI/Perps/hooks/stream/useLivePositions.test.ts
+++ b/app/components/UI/Perps/hooks/stream/useLivePositions.test.ts
@@ -36,6 +36,8 @@ describe('usePerpsLivePositions', () => {
       sinceOpen: '0',
       sinceChange: '0',
     },
+    takeProfitCount: 0,
+    stopLossCount: 0,
   };
 
   beforeEach(() => {

--- a/app/components/UI/Perps/hooks/useHasExistingPosition.test.ts
+++ b/app/components/UI/Perps/hooks/useHasExistingPosition.test.ts
@@ -32,6 +32,8 @@ describe('useHasExistingPosition', () => {
         sinceOpen: '30',
         sinceChange: '10',
       },
+      takeProfitCount: 0,
+      stopLossCount: 0,
     },
     {
       coin: 'ETH',
@@ -52,6 +54,8 @@ describe('useHasExistingPosition', () => {
         sinceOpen: '15',
         sinceChange: '5',
       },
+      takeProfitCount: 0,
+      stopLossCount: 0,
     },
   ];
 

--- a/app/components/UI/Perps/hooks/usePerpsClosePosition.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsClosePosition.test.ts
@@ -75,6 +75,8 @@ describe('usePerpsClosePosition', () => {
       sinceOpen: '5',
       sinceChange: '2',
     },
+    takeProfitCount: 0,
+    stopLossCount: 0,
   };
 
   beforeEach(() => {

--- a/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderExecution.test.ts
@@ -62,6 +62,8 @@ describe('usePerpsOrderExecution', () => {
       sinceOpen: '0',
       sinceChange: '0',
     },
+    takeProfitCount: 0,
+    stopLossCount: 0,
   };
 
   describe('successful order placement', () => {

--- a/app/components/UI/Perps/hooks/usePerpsTPSLForm.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLForm.test.ts
@@ -34,6 +34,8 @@ describe('usePerpsTPSLForm', () => {
       sinceOpen: '0',
       sinceChange: '0',
     },
+    takeProfitCount: 0,
+    stopLossCount: 0,
   };
 
   const defaultParams = {

--- a/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTPSLUpdate.test.ts
@@ -63,6 +63,8 @@ describe('usePerpsTPSLUpdate', () => {
       sinceOpen: '2',
       sinceChange: '1',
     },
+    takeProfitCount: 0,
+    stopLossCount: 0,
     ...overrides,
   });
 
@@ -89,7 +91,7 @@ describe('usePerpsTPSLUpdate', () => {
     const takeProfitPrice = '3300';
     const stopLossPrice = '2700';
 
-    mockUpdatePositionTPSL.mockResolvedValue(undefined);
+    mockUpdatePositionTPSL.mockResolvedValue({ success: true });
 
     await act(async () => {
       await result.current.handleUpdateTPSL(
@@ -217,7 +219,7 @@ describe('usePerpsTPSLUpdate', () => {
     const { result } = renderHookWithToast();
     const position = createMockPosition();
 
-    mockUpdatePositionTPSL.mockResolvedValue(undefined);
+    mockUpdatePositionTPSL.mockResolvedValue({ success: true });
 
     await act(async () => {
       await result.current.handleUpdateTPSL(position, undefined, undefined);

--- a/app/components/UI/Perps/hooks/usePerpsTrading.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsTrading.test.ts
@@ -247,6 +247,8 @@ describe('usePerpsTrading', () => {
             sinceOpen: '10',
             sinceChange: '5',
           },
+          takeProfitCount: 0,
+          stopLossCount: 0,
         },
       ];
 

--- a/app/components/UI/Perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/components/UI/Perps/services/HyperLiquidSubscriptionService.ts
@@ -37,6 +37,7 @@ import type { HyperLiquidClientService } from './HyperLiquidClientService';
 import type { HyperLiquidWalletService } from './HyperLiquidWalletService';
 import type { CaipAccountId } from '@metamask/utils';
 import { strings } from '../../../../../locales/i18n';
+import { TP_SL_CONFIG } from '../constants/perpsConfig';
 
 /**
  * Service for managing HyperLiquid WebSocket subscriptions
@@ -313,32 +314,68 @@ export class HyperLiquidSubscriptionService {
           // Extract TP/SL from openOrders for positions
           const tpslMap = new Map<
             string,
-            { takeProfitPrice?: string; stopLossPrice?: string }
+            {
+              takeProfitPrice?: string;
+              stopLossPrice?: string;
+            }
+          >();
+
+          const tpslCountMap = new Map<
+            string,
+            {
+              takeProfitCount?: number;
+              stopLossCount?: number;
+            }
           >();
 
           // Also extract regular orders for order subscribers
           const orders: Order[] = [];
 
           (data.openOrders || []).forEach((order) => {
+            let position: Position | undefined;
+            let positionForCoin: Position | undefined;
+            const matchPositionToTpsl = (p: Position) => {
+              if (TP_SL_CONFIG.USE_POSITION_BOUND_TPSL) {
+                return (
+                  p.coin === order.coin &&
+                  order.reduceOnly &&
+                  order.isPositionTpsl
+                );
+              }
+
+              return (
+                p.coin === order.coin &&
+                Math.abs(parseFloat(order.sz)) >= Math.abs(parseFloat(p.size))
+              );
+            };
+            const matchPositionToCoin = (p: Position) => p.coin === order.coin;
             // Process trigger orders for TP/SL
             if (order.triggerPx) {
+              const isTakeProfit = order.orderType?.includes('Take Profit');
+              const isStop = order.orderType?.includes('Stop');
+              const currentTakeProfitCount =
+                tpslCountMap.get(order.coin)?.takeProfitCount || 0;
+              const currentStopLossCount =
+                tpslCountMap.get(order.coin)?.stopLossCount || 0;
+              tpslCountMap.set(order.coin, {
+                takeProfitCount: isTakeProfit
+                  ? currentTakeProfitCount + 1
+                  : currentTakeProfitCount,
+                stopLossCount: isStop
+                  ? currentStopLossCount + 1
+                  : currentStopLossCount,
+              });
               const coin = order.coin;
-              const position = positions.find(
-                (p) =>
-                  p.coin === coin &&
-                  order.reduceOnly &&
-                  Math.abs(parseFloat(p.size)) ===
-                    Math.abs(parseFloat(order.sz)),
-              );
-
+              position = positions.find(matchPositionToTpsl);
+              positionForCoin = positions.find(matchPositionToCoin);
               if (position) {
                 const existing = tpslMap.get(coin) || {};
                 const isLong = parseFloat(position.size) > 0;
 
                 // Determine if it's TP or SL based on order type
-                if (order.orderType?.includes('Take Profit')) {
+                if (isTakeProfit) {
                   existing.takeProfitPrice = order.triggerPx;
-                } else if (order.orderType?.includes('Stop')) {
+                } else if (isStop) {
                   existing.stopLossPrice = order.triggerPx;
                 } else {
                   // Fallback: determine based on trigger price vs entry price
@@ -367,17 +404,23 @@ export class HyperLiquidSubscriptionService {
             // TP/SL orders are both:
             // 1. Used to populate position TP/SL fields (done above)
             // 2. Shown as separate orders in the orders list (done here)
-            const convertedOrder = adaptOrderFromSDK(order);
+            const convertedOrder = adaptOrderFromSDK(
+              order,
+              position || positionForCoin,
+            );
             orders.push(convertedOrder);
           });
 
           // Merge positions with TP/SL data, ensuring fields are always present
           const positionsWithTPSL = positions.map((position) => {
             const tpsl = tpslMap.get(position.coin) || {};
+            const tpslCount = tpslCountMap.get(position.coin) || {};
             return {
               ...position,
               takeProfitPrice: tpsl.takeProfitPrice || undefined,
               stopLossPrice: tpsl.stopLossPrice || undefined,
+              takeProfitCount: tpslCount.takeProfitCount || 0,
+              stopLossCount: tpslCount.stopLossCount || 0,
             };
           });
 

--- a/app/components/UI/Perps/types/navigation.ts
+++ b/app/components/UI/Perps/types/navigation.ts
@@ -67,6 +67,7 @@ export interface PerpsNavigationParamList extends ParamListBase {
 
   PerpsMarketDetails: {
     market: PerpsMarketData;
+    initialTab?: 'position' | 'orders' | 'info';
   };
 
   PerpsPositions: undefined;

--- a/app/components/UI/Perps/utils/hyperLiquidAdapter.test.ts
+++ b/app/components/UI/Perps/utils/hyperLiquidAdapter.test.ts
@@ -560,6 +560,8 @@ describe('hyperLiquidAdapter', () => {
           sinceOpen: '50',
           sinceChange: '25',
         },
+        takeProfitCount: 0,
+        stopLossCount: 0,
       });
     });
   });

--- a/app/components/UI/Perps/utils/orderUtils.test.ts
+++ b/app/components/UI/Perps/utils/orderUtils.test.ts
@@ -1,5 +1,7 @@
-import { getOrderDirection } from './orderUtils';
+import { getOrderDirection, willFlipPosition } from './orderUtils';
 import { strings } from '../../../../../locales/i18n';
+import { OrderParams } from '../controllers/types';
+import { Position } from '../hooks';
 
 // Mock the i18n module
 jest.mock('../../../../../locales/i18n', () => ({
@@ -57,5 +59,137 @@ describe('getOrderDirection', () => {
       expect(result).toBe('Long');
       expect(mockStrings).toHaveBeenCalledWith('perps.market.long');
     });
+  });
+});
+
+describe('willFlipPosition', () => {
+  const mockPosition: Position = {
+    size: '100',
+    entryPrice: '50000',
+    unrealizedPnl: '100',
+    liquidationPrice: '40000',
+    leverage: { type: 'isolated', value: 2 },
+    coin: 'BTC',
+    positionValue: '100000',
+    marginUsed: '2500',
+    maxLeverage: 20,
+    returnOnEquity: '0',
+    cumulativeFunding: {
+      allTime: '0',
+      sinceOpen: '0',
+      sinceChange: '0',
+    },
+    takeProfitCount: 0,
+    stopLossCount: 0,
+  };
+
+  const mockOrderParams: OrderParams = {
+    coin: 'BTC',
+    isBuy: false,
+    size: '150',
+    orderType: 'market',
+    reduceOnly: false,
+  };
+
+  it('returns false when reduceOnly is true', () => {
+    const orderParams = { ...mockOrderParams, reduceOnly: true };
+    const result = willFlipPosition(mockPosition, orderParams);
+    expect(result).toBe(false);
+  });
+
+  it('returns false when orderType is not market', () => {
+    const orderParams = {
+      ...mockOrderParams,
+      orderType: 'limit' as OrderParams['orderType'],
+    };
+    const result = willFlipPosition(mockPosition, orderParams);
+    expect(result).toBe(false);
+  });
+
+  it('returns false when position and order direction match', () => {
+    const orderParams = { ...mockOrderParams, isBuy: true };
+    const result = willFlipPosition(mockPosition, orderParams);
+    expect(result).toBe(false);
+  });
+
+  it('returns true when order size exceeds absolute position size', () => {
+    const result = willFlipPosition(mockPosition, mockOrderParams);
+    expect(result).toBe(true);
+  });
+
+  it('returns false when order size does not exceed absolute position size', () => {
+    const orderParams = { ...mockOrderParams, size: '50' };
+    const result = willFlipPosition(mockPosition, orderParams);
+    expect(result).toBe(false);
+  });
+
+  it('handles negative position sizes correctly', () => {
+    const negativePosition = { ...mockPosition, size: '-100' };
+    const result = willFlipPosition(negativePosition, mockOrderParams);
+    expect(result).toBe(false);
+  });
+
+  it('returns false when order size equals position size', () => {
+    const currentPosition: Position = {
+      coin: 'BTC',
+      size: '0.5',
+      entryPrice: '45000',
+      positionValue: '22500',
+      unrealizedPnl: '0',
+      marginUsed: '500',
+      leverage: { type: 'isolated', value: 5 },
+      liquidationPrice: '40000',
+      maxLeverage: 20,
+      returnOnEquity: '0',
+      cumulativeFunding: {
+        allTime: '0',
+        sinceOpen: '0',
+        sinceChange: '0',
+      },
+      takeProfitCount: 0,
+      stopLossCount: 0,
+    };
+
+    const orderParams: OrderParams = {
+      coin: 'BTC',
+      isBuy: false,
+      size: '0.5',
+      orderType: 'market',
+    };
+
+    const result = willFlipPosition(currentPosition, orderParams);
+    expect(result).toBe(false);
+  });
+
+  it('handles negative position sizes correctly', () => {
+    const currentPosition: Position = {
+      coin: 'BTC',
+      size: '-0.5',
+      entryPrice: '45000',
+      positionValue: '22500',
+      unrealizedPnl: '0',
+      marginUsed: '500',
+      leverage: { type: 'isolated', value: 5 },
+      liquidationPrice: '40000',
+      maxLeverage: 20,
+      returnOnEquity: '0',
+      cumulativeFunding: {
+        allTime: '0',
+        sinceOpen: '0',
+        sinceChange: '0',
+      },
+      takeProfitCount: 0,
+      stopLossCount: 0,
+    };
+
+    const orderParams: OrderParams = {
+      coin: 'BTC',
+      isBuy: true,
+      size: '1.0',
+      orderType: 'market',
+    };
+
+    const result = willFlipPosition(currentPosition, orderParams);
+    expect(result).toBe(true);
   });
 });

--- a/app/components/UI/Perps/utils/orderUtils.ts
+++ b/app/components/UI/Perps/utils/orderUtils.ts
@@ -1,4 +1,6 @@
 import { strings } from '../../../../../locales/i18n';
+import { OrderParams } from '../controllers/types';
+import { Position } from '../hooks';
 
 /**
  * Get the order direction based on the side and position size
@@ -25,4 +27,32 @@ export const getOrderDirection = (
   }
 
   return strings('perps.market.short');
+};
+
+export const willFlipPosition = (
+  currentPosition: Position,
+  orderParams: OrderParams,
+): boolean => {
+  const currentPositionSize = parseFloat(currentPosition.size);
+  const positionDirection = currentPositionSize > 0 ? 'long' : 'short';
+  const orderDirection = orderParams.isBuy ? 'long' : 'short';
+  const orderSize = parseFloat(orderParams.size);
+
+  if (orderParams.reduceOnly === true) {
+    return false;
+  }
+
+  if (orderParams.orderType !== 'market') {
+    return false;
+  }
+
+  if (positionDirection === orderDirection) {
+    return false;
+  }
+
+  if (orderSize > Math.abs(currentPositionSize)) {
+    return true;
+  }
+
+  return false;
 };

--- a/app/components/UI/Perps/utils/pnlCalculations.test.ts
+++ b/app/components/UI/Perps/utils/pnlCalculations.test.ts
@@ -261,6 +261,8 @@ describe('pnlCalculations', () => {
           maxLeverage: 100,
           returnOnEquity: '2.0',
           cumulativeFunding: { allTime: '0', sinceOpen: '0', sinceChange: '0' },
+          takeProfitCount: 0,
+          stopLossCount: 0,
         },
         {
           coin: 'ETH',
@@ -274,6 +276,8 @@ describe('pnlCalculations', () => {
           maxLeverage: 50,
           returnOnEquity: '3.33',
           cumulativeFunding: { allTime: '5', sinceOpen: '2', sinceChange: '1' },
+          takeProfitCount: 0,
+          stopLossCount: 0,
         },
       ];
 
@@ -296,6 +300,8 @@ describe('pnlCalculations', () => {
           maxLeverage: 100,
           returnOnEquity: '-2.0',
           cumulativeFunding: { allTime: '0', sinceOpen: '0', sinceChange: '0' },
+          takeProfitCount: 0,
+          stopLossCount: 0,
         },
         {
           coin: 'ETH',
@@ -309,6 +315,8 @@ describe('pnlCalculations', () => {
           maxLeverage: 50,
           returnOnEquity: '-3.33',
           cumulativeFunding: { allTime: '5', sinceOpen: '2', sinceChange: '1' },
+          takeProfitCount: 0,
+          stopLossCount: 0,
         },
       ];
 
@@ -337,6 +345,8 @@ describe('pnlCalculations', () => {
           maxLeverage: 100,
           returnOnEquity: '2.0',
           cumulativeFunding: { allTime: '0', sinceOpen: '0', sinceChange: '0' },
+          takeProfitCount: 0,
+          stopLossCount: 0,
         },
       ];
 
@@ -361,6 +371,8 @@ describe('pnlCalculations', () => {
           maxLeverage: 100,
           returnOnEquity: '2.0',
           cumulativeFunding: { allTime: '0', sinceOpen: '0', sinceChange: '0' },
+          takeProfitCount: 0,
+          stopLossCount: 0,
         },
         {
           coin: 'ETH',
@@ -374,6 +386,8 @@ describe('pnlCalculations', () => {
           maxLeverage: 50,
           returnOnEquity: '3.33',
           cumulativeFunding: { allTime: '5', sinceOpen: '2', sinceChange: '1' },
+          takeProfitCount: 0,
+          stopLossCount: 0,
         },
       ];
 
@@ -400,6 +414,8 @@ describe('pnlCalculations', () => {
           maxLeverage: 100,
           returnOnEquity: '-2.0',
           cumulativeFunding: { allTime: '0', sinceOpen: '0', sinceChange: '0' },
+          takeProfitCount: 0,
+          stopLossCount: 0,
         },
       ];
 
@@ -432,6 +448,8 @@ describe('pnlCalculations', () => {
           maxLeverage: 100,
           returnOnEquity: '0',
           cumulativeFunding: { allTime: '0', sinceOpen: '0', sinceChange: '0' },
+          takeProfitCount: 0,
+          stopLossCount: 0,
         },
       ];
 
@@ -454,6 +472,8 @@ describe('pnlCalculations', () => {
           maxLeverage: 100,
           returnOnEquity: '0',
           cumulativeFunding: { allTime: '0', sinceOpen: '0', sinceChange: '0' },
+          takeProfitCount: 0,
+          stopLossCount: 0,
         },
       ];
 

--- a/app/core/Engine/controllers/perps-controller/index.test.ts
+++ b/app/core/Engine/controllers/perps-controller/index.test.ts
@@ -78,6 +78,8 @@ describe('perps controller init', () => {
             sinceOpen: '-8.20',
             sinceChange: '-3.10',
           },
+          takeProfitCount: 0,
+          stopLossCount: 0,
         },
       ],
       accountState: null,

--- a/e2e/controller-mocking/mock-responses/perps/perps-e2e-mocks.ts
+++ b/e2e/controller-mocking/mock-responses/perps/perps-e2e-mocks.ts
@@ -97,6 +97,8 @@ export class PerpsE2EMockService {
           maxLeverage: 40,
           returnOnEquity: '0.05', // 5%
           cumulativeFunding: { allTime: '0', sinceChange: '0', sinceOpen: '0' },
+          takeProfitCount: 0,
+          stopLossCount: 0,
         },
         {
           coin: 'BTC',
@@ -110,6 +112,8 @@ export class PerpsE2EMockService {
           maxLeverage: 40,
           returnOnEquity: '-0.02', // -2%
           cumulativeFunding: { allTime: '0', sinceChange: '0', sinceOpen: '0' },
+          takeProfitCount: 0,
+          stopLossCount: 0,
         },
         {
           coin: 'SOL',
@@ -123,6 +127,8 @@ export class PerpsE2EMockService {
           maxLeverage: 40,
           returnOnEquity: '0.10', // 10%
           cumulativeFunding: { allTime: '0', sinceChange: '0', sinceOpen: '0' },
+          takeProfitCount: 0,
+          stopLossCount: 0,
         },
       ];
     } else {
@@ -146,6 +152,8 @@ export class PerpsE2EMockService {
             sinceChange: '0',
             sinceOpen: '0',
           },
+          takeProfitCount: 0,
+          stopLossCount: 0,
         },
       ];
     }
@@ -243,6 +251,8 @@ export class PerpsE2EMockService {
         sinceChange: '0',
         sinceOpen: '0',
       },
+      takeProfitCount: 0,
+      stopLossCount: 0,
     };
 
     // Add to mock state
@@ -647,6 +657,8 @@ export class PerpsE2EMockService {
               sinceChange: '0',
               sinceOpen: '0',
             },
+            takeProfitCount: 0,
+            stopLossCount: 0,
           };
           this.mockPositions.push(newPosition);
 

--- a/e2e/selectors/Perps/Perps.selectors.ts
+++ b/e2e/selectors/Perps/Perps.selectors.ts
@@ -50,6 +50,10 @@ export const PerpsPositionCardSelectorsIDs = {
   PNL: 'position-card-pnl',
   CLOSE_BUTTON: 'position-card-close',
   EDIT_BUTTON: 'position-card-edit',
+  TPSL_COUNT_WARNING_TOOLTIP_VIEW_ORDERS_BUTTON:
+    'position-card-tpsl-count-warning-tooltip-view-orders',
+  TPSL_COUNT_WARNING_TOOLTIP_GOT_IT_BUTTON:
+    'position-card-tpsl-count-warning-tooltip-got-it',
 };
 
 // ========================================

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1263,7 +1263,9 @@
         "margin": "Margin",
         "not_set": "Not set",
         "edit_tpsl": "Edit TP/SL",
-        "close_position": "Close position"
+        "close_position": "Close position",
+        "tpsl_count_multiple": "{{count}} orders",
+        "tpsl_count_single": "{{count}} order"
       },
       "list": {
         "loading": "Loading positions...",
@@ -1391,7 +1393,13 @@
         "description": "Get notified about important perps trading events like order fills, liquidations, and market updates.",
         "turn_on_button": "Turn on"
       },
-      "got_it_button": "Got it"
+      "got_it_button": "Got it",
+      "tpsl_count_warning": {
+        "title": "Multiple TP/SL orders are active",
+        "content": "To set TP/SL for the whole position, cancel your existing TP/SL orders first.",
+        "view_orders_button": "View orders",
+        "got_it_button": "Got it"
+      }
     },
     "connection": {
       "failed": "Connection Failed",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
1. What is the reason for the change?
- https://consensys.slack.com/archives/C08U6DYNJ1G/p1757700508107169
- In MetaMask mobile perps, we associate TP/SL orders with a position, which isn’t the case on Hyperliquid order book.
  - This creates complexity when users execute trades with an open position or an open order.

For example, let’s consider this scenario:
First, user opens a Long position of size Z, with a TP at $X and SL at $Y
Then user opens a Long position of size Z’, with a TP at $X’ and SL at $Y’

In Hyperliquid, user will have 1 position of size Z + Z’ and 4 open orders (see [recording](https://www.loom.com/share/8a570ab01322419c967ad0275008b025)):
TP of size Z at price $X
TP of size Z’ at price $X’
SL of size Z at price $Y
SL of size Z’ at price $Y’

From there, if the user creates a limit order with a TP/SL, it will create 3 new orders (cf. [recording](https://www.loom.com/share/5330714a85984a839073dbda215876e5))

The current MetaMask mobile perps UI doesn’t support this: we associate one position with one TP/SL, and this TP/SL is expected to apply to the entire position. Given multiple orders are created in Hyperliquid order book, MetaMask UI doesn’t know which TP/SL to associate with this position, and returns TP/SL as “Not set”

2. What is the improvement/solution?

https://consensyssoftware.atlassian.net/browse/TAT-1691 Explains Solution A

Solution B is similar to A except it does not block the user from adding a tpsl on the position page when there are multiple orders and with B we use position bound tpsl which resizes with the position. When a user places a tpsl order and then resizes their position, they do not need to worry about adjusting tpsls that no longer match the order size.
  - If tpsl order size is lower then the current position size after buying more of a token pair, then in A the user is left to handle that on their own. 
  - Because of this possible mismatch, in A we block the user from making position tpsl if there is not a match for the position size or higher. We tell them to close all of their tpsl orders instead
 
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1691

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
https://github.com/user-attachments/assets/9eec2173-19cf-45a0-9540-55cf6f8daacf

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
