### PR TITLE
Feat/default-biometric-choice cp-7.56.0

### DIFF
--- a/app/components/Views/ChoosePassword/index.js
+++ b/app/components/Views/ChoosePassword/index.js
@@ -450,7 +450,7 @@ class ChoosePassword extends PureComponent {
       // latest ux changes - we are forcing user to enable biometric by default
       const authType = await Authentication.componentAuthenticationType(
         true,
-        true,
+        false,
       );
 
       authType.oauth2Login = this.getOauth2LoginSuccess();

--- a/app/components/Views/ImportFromSecretRecoveryPhrase/index.js
+++ b/app/components/Views/ImportFromSecretRecoveryPhrase/index.js
@@ -595,7 +595,7 @@ const ImportFromSecretRecoveryPhrase = ({
         // latest ux changes - we are forcing user to enable biometric by default
         const authData = await Authentication.componentAuthenticationType(
           true,
-          true,
+          false,
         );
 
         try {

--- a/app/components/Views/ImportFromSecretRecoveryPhrase/index.test.tsx
+++ b/app/components/Views/ImportFromSecretRecoveryPhrase/index.test.tsx
@@ -1599,7 +1599,7 @@ describe('ImportFromSecretRecoveryPhrase', () => {
       expect(mockComponentAuthenticationType).toHaveBeenNthCalledWith(
         1,
         true,
-        true,
+        false,
       );
       expect(mockComponentAuthenticationType).toHaveBeenNthCalledWith(
         2,
@@ -1656,7 +1656,7 @@ describe('ImportFromSecretRecoveryPhrase', () => {
       expect(mockComponentAuthenticationType).toHaveBeenNthCalledWith(
         1,
         true,
-        true,
+        false,
       );
       expect(mockComponentAuthenticationType).toHaveBeenNthCalledWith(
         2,

--- a/app/components/Views/Login/index.tsx
+++ b/app/components/Views/Login/index.tsx
@@ -113,6 +113,7 @@ import FOX_LOGO from '../../../images/branding/fox.png';
 import { usePromptSeedlessRelogin } from '../../hooks/SeedlessHooks';
 import { useNetInfo } from '@react-native-community/netinfo';
 import { SuccessErrorSheetParams } from '../SuccessErrorSheet/interface';
+import { LoginOptionsSwitch } from '../../UI/LoginOptionsSwitch';
 
 // In android, having {} will cause the styles to update state
 // using a constant will prevent this
@@ -146,6 +147,8 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [errorToThrow, setErrorToThrow] = useState<Error | null>(null);
+  const [biometryPreviouslyDisabled, setBiometryPreviouslyDisabled] =
+    useState(false);
   const [hasBiometricCredentials, setHasBiometricCredentials] = useState(false);
   const [rehydrationFailedAttempts, setRehydrationFailedAttempts] = useState(0);
   const navigation = useNavigation<StackNavigationProp<ParamListBase>>();
@@ -252,6 +255,7 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
         setBiometryChoice(
           !(passcodePreviouslyDisabled && passcodePreviouslyDisabled === TRUE),
         );
+        setBiometryPreviouslyDisabled(!!passcodePreviouslyDisabled);
       } else if (authData.currentAuthType === AUTHENTICATION_TYPE.REMEMBER_ME) {
         setHasBiometricCredentials(false);
         setRememberMe(true);
@@ -262,6 +266,7 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
         setHasBiometricCredentials(
           authData.currentAuthType === AUTHENTICATION_TYPE.BIOMETRIC,
         );
+        setBiometryPreviouslyDisabled(!!previouslyDisabled);
         setBiometryChoice(!(previouslyDisabled && previouslyDisabled === TRUE));
       }
     };
@@ -661,6 +666,24 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
     fieldRef.current?.blur();
   };
 
+  const shouldRenderBiometricLogin =
+    biometryType && !biometryPreviouslyDisabled ? biometryType : null;
+
+  const renderSwitch = () => {
+    const handleUpdateRememberMe = (rememberMeChoice: boolean) => {
+      setRememberMe(rememberMeChoice);
+    };
+
+    return (
+      <LoginOptionsSwitch
+        shouldRenderBiometricOption={shouldRenderBiometricLogin}
+        biometryChoiceState={biometryChoice}
+        onUpdateBiometryChoice={updateBiometryChoice}
+        onUpdateRememberMe={handleUpdateRememberMe}
+      />
+    );
+  };
+
   const toggleWarningModal = () => {
     track(MetaMetricsEvents.FORGOT_PASSWORD_CLICKED, {});
 
@@ -791,6 +814,7 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
             </View>
 
             <View style={styles.ctaWrapper}>
+              {renderSwitch()}
               <Button
                 variant={ButtonVariants.Primary}
                 width={ButtonWidthTypes.Full}

--- a/app/components/Views/Login/index.tsx
+++ b/app/components/Views/Login/index.tsx
@@ -273,10 +273,7 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
       }
     };
 
-    getUserAuthPreferences().finally(() => {
-      // force default choice to true
-      updateBiometryChoice(true);
-    });
+    getUserAuthPreferences();
   }, [route?.params?.locked, refreshAuthPref]);
 
   const handleVaultCorruption = async () => {
@@ -666,7 +663,7 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
     fieldRef.current?.blur();
   };
 
-  // force default switch to true for disabled biometric
+  // show biometric switch to true even if biometric is disabled
   const shouldRenderBiometricLogin = biometryType;
 
   const renderSwitch = () => {

--- a/app/components/Views/ResetPassword/index.js
+++ b/app/components/Views/ResetPassword/index.js
@@ -654,6 +654,8 @@ class ResetPassword extends PureComponent {
     try {
       // Just try
       await this.tryExportSeedPhrase(password);
+
+      this.updateBiometryChoice(true);
       this.setState({
         password: null,
         originalPassword: password,

--- a/app/components/Views/ResetPassword/index.js
+++ b/app/components/Views/ResetPassword/index.js
@@ -654,8 +654,6 @@ class ResetPassword extends PureComponent {
     try {
       // Just try
       await this.tryExportSeedPhrase(password);
-
-      this.updateBiometryChoice(true);
       this.setState({
         password: null,
         originalPassword: password,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The PR is trying to force user to enable biometric by default.
However, user could disable the face id, and this is not  proper handled in the lock(login) screen where the biometric switch is removed.

This PR try to revert the switch and always show the biometric switch when biometric is available .



<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**


<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:
The biometric switch is visible even when user disabled the face id in the setting.

## **Related issues**

Fixes:
https://github.com/MetaMask/metamask-mobile/issues/20156

## **Manual testing steps**

```gherkin
Feature: default biometric switch enabled

  Scenario: user disabled biometric
    Given user locked the app

    When user try to unlock the app
    Then the biometric switch is visible
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/8bb58ea7-8032-4722-adfe-d6bea130d3c1


### **After**

<!-- [screenshots/recordings] -->
https://github.com/user-attachments/assets/5e36f9ff-c343-417a-8ab4-85ce7f1f2599



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
