### PR TITLE
fix: updated border for network selectors to be muted

### DIFF
--- a/app/components/UI/CollectibleContracts/index.js
+++ b/app/components/UI/CollectibleContracts/index.js
@@ -114,7 +114,7 @@ const createStyles = (colors) =>
     },
     controlButton: {
       backgroundColor: colors.background.default,
-      borderColor: colors.border.default,
+      borderColor: colors.border.muted,
       marginRight: 4,
       borderWidth: isRemoveGlobalNetworkSelectorEnabled() ? 1 : 0,
       borderRadius: isRemoveGlobalNetworkSelectorEnabled() ? 8 : 0,
@@ -123,7 +123,7 @@ const createStyles = (colors) =>
     },
     controlButtonDisabled: {
       backgroundColor: colors.background.default,
-      borderColor: colors.border.default,
+      borderColor: colors.border.muted,
       marginRight: 4,
       borderWidth: isRemoveGlobalNetworkSelectorEnabled() ? 1 : 0,
       borderRadius: isRemoveGlobalNetworkSelectorEnabled() ? 8 : 0,

--- a/app/components/UI/shared/ControlBarStyles.ts
+++ b/app/components/UI/shared/ControlBarStyles.ts
@@ -31,7 +31,7 @@ const createControlBarStyles = (params: { theme: Theme }) => {
     },
     controlButton: {
       backgroundColor: colors.background.default,
-      borderColor: colors.border.default,
+      borderColor: colors.border.muted,
       borderWidth: isRemoveGlobalNetworkSelectorEnabled() ? 1 : 0,
       borderRadius: isRemoveGlobalNetworkSelectorEnabled() ? 8 : 0,
       maxWidth: isRemoveGlobalNetworkSelectorEnabled() ? '80%' : '60%',
@@ -39,7 +39,7 @@ const createControlBarStyles = (params: { theme: Theme }) => {
     },
     controlButtonDisabled: {
       backgroundColor: colors.background.default,
-      borderColor: colors.border.default,
+      borderColor: colors.border.muted,
       marginRight: 4,
       borderWidth: isRemoveGlobalNetworkSelectorEnabled() ? 1 : 0,
       borderRadius: isRemoveGlobalNetworkSelectorEnabled() ? 8 : 0,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR updated the network selector to be more muted
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
https://github.com/user-attachments/assets/fe19a4c6-53d6-4a7f-9db1-fe31069507c9

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
