### PR TITLE
fix: Scroll to the selected account index automatically in MultichainAccountSelectorList

### DIFF
--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/MultichainAccountSelectorList.test.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/MultichainAccountSelectorList.test.tsx
@@ -6,6 +6,8 @@ import {
 } from '@metamask/account-tree-controller';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import MultichainAccountSelectorList from './MultichainAccountSelectorList';
+import { FlashListRef } from '@shopify/flash-list';
+import { FlattenedMultichainAccountListItem } from './MultichainAccountSelectorList.types';
 import renderWithProvider from '../../../../util/test/renderWithProvider';
 import {
   MULTICHAIN_ACCOUNT_SELECTOR_SEARCH_INPUT_TESTID,
@@ -713,6 +715,77 @@ describe('MultichainAccountSelectorList', () => {
       // Verify the component renders correctly
       expect(getByText('Account 1')).toBeTruthy();
       expect(getByText('Create account')).toBeTruthy();
+    });
+
+    it('scrolls to the first selected account', async () => {
+      const account1 = createMockAccountGroup(
+        'keyring:wallet1/group1',
+        'Account 1',
+      );
+      const account2 = createMockAccountGroup(
+        'keyring:wallet1/group2',
+        'Account 2',
+      );
+      const wallet1 = createMockWallet('wallet1', 'Wallet 1', [
+        account1,
+        account2,
+      ]);
+
+      const internalAccounts = createMockInternalAccountsFromGroups([
+        account1,
+        account2,
+      ]);
+
+      type TestFlashListRef = FlashListRef<FlattenedMultichainAccountListItem>;
+      const listRef = React.createRef<TestFlashListRef>();
+
+      // Mock RAF to queue callbacks so we can attach our mock ref before flushing
+      const rafCallbacks: FrameRequestCallback[] = [];
+      const rafSpy = jest
+        .spyOn(global, 'requestAnimationFrame')
+        .mockImplementation((cb: FrameRequestCallback) => {
+          rafCallbacks.push(cb);
+          return rafCallbacks.length as unknown as number;
+        });
+
+      try {
+        renderWithProvider(
+          <MultichainAccountSelectorList
+            onSelectAccount={mockOnSelectAccount}
+            selectedAccountGroups={[account2]}
+            listRef={listRef}
+          />,
+          { state: createMockState([wallet1], internalAccounts) },
+        );
+
+        // Attach mock imperative methods after render, before running RAF
+        interface MinimalFlashListRef {
+          scrollToIndex: jest.Mock;
+          scrollToOffset: jest.Mock;
+          scrollToEnd: jest.Mock;
+        }
+        const mockRefImpl: MinimalFlashListRef = {
+          scrollToIndex: jest.fn(),
+          scrollToOffset: jest.fn(),
+          scrollToEnd: jest.fn(),
+        };
+        const mockRef = mockRefImpl as unknown as TestFlashListRef;
+        (listRef as unknown as { current: TestFlashListRef | null }).current =
+          mockRef;
+
+        // Flush queued RAF callbacks to trigger the scroll effect
+        rafCallbacks.forEach((cb) => cb(0));
+
+        await waitFor(() => {
+          expect(mockRefImpl.scrollToIndex).toHaveBeenCalledWith({
+            index: 2, // header (0), Account 1 (1), Account 2 (2), footer (3)
+            animated: true,
+            viewPosition: 0.5,
+          });
+        });
+      } finally {
+        rafSpy.mockRestore();
+      }
     });
   });
 });

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/MultichainAccountSelectorList.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/MultichainAccountSelectorList.tsx
@@ -189,6 +189,31 @@ const MultichainAccountSelectorList = ({
     }
   }, [lastCreatedAccountId, flattenedData, listRefToUse]);
 
+  // Scroll to the first selected account whenever selection or data changes
+  useEffect(() => {
+    if (debouncedSearchText.trim()) return;
+    if (!listRefToUse.current) return;
+    if (!selectedAccountGroups?.length) return;
+
+    const targetId = selectedAccountGroups[0]?.id;
+    if (!targetId) return;
+
+    const index = flattenedData.findIndex(
+      (item) => item.type === 'cell' && item.data.id === targetId,
+    );
+
+    if (index !== -1) {
+      const raf = requestAnimationFrame(() => {
+        listRefToUse.current?.scrollToIndex({
+          index,
+          animated: true,
+          viewPosition: 0.5,
+        });
+      });
+      return () => cancelAnimationFrame(raf);
+    }
+  }, [selectedAccountGroups, flattenedData, debouncedSearchText, listRefToUse]);
+
   // Handle account creation callback
   const handleAccountCreated = useCallback((newAccountId: string) => {
     setLastCreatedAccountId(newAccountId);


### PR DESCRIPTION
## **Description**
This Pr addresses a small UX bug for mobile BIP44 where the user must scroll to find their current selected account with the new Multichain account list. This fix makes it so that when the list opens, it automatically scrolls to so that that the selected account is in view. This should also have smooth animations. The old version of this list also had this behaviour so this change ensures consistency with experiences. 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-841

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user interacting with the MultichainAccountSelectorList
    Given You are a user with multiple accounts created / imported (at least enough to make the account list long enough to scroll) and the user has multichain accounts state 2 enabled

    When user opens the account list
    Then the list automatically scrolls to the current selected account
    And when  the user changes the selected account and re opens the account list
    Then the account list scrolls to the newly selected account index in the list


```

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/a4961546-1b16-4fb7-bc61-2ef405559612

### **After**

https://github.com/user-attachments/assets/c831279b-4d3b-4135-8c93-cefc2c7459a8


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
