### PR TITLE
feat: change Maskicons to Polycons for users cp-7.56.0

### DIFF
--- a/app/component-library/components/Avatars/Avatar/variants/AvatarAccount/AvatarAccount.types.ts
+++ b/app/component-library/components/Avatars/Avatar/variants/AvatarAccount/AvatarAccount.types.ts
@@ -7,7 +7,7 @@ import { AvatarBaseProps } from '../../foundation/AvatarBase';
 export enum AvatarAccountType {
   JazzIcon = 'JazzIcon',
   Blockies = 'Blockies',
-  Maskicon = 'Maskicon',
+  Maskicon = 'Maskicon', // Referred to as Polycons to users
 }
 
 /**

--- a/app/components/Views/Settings/GeneralSettings/index.js
+++ b/app/components/Views/Settings/GeneralSettings/index.js
@@ -498,7 +498,7 @@ class Settings extends PureComponent {
                       size={diameter}
                     />
                   </View>
-                  <Text style={styles.identiconText}>Maskicons</Text>
+                  <Text style={styles.identiconText}>Polycons</Text>
                 </TouchableOpacity>
                 <TouchableOpacity
                   onPress={() =>


### PR DESCRIPTION
## **Description**


1. What is the reason for the change?
- According to the marketing team, we should avoid user facing features that play off of the word "Mask"
- instead it was agreed upon to refer to these icons in settings as `Polycons`
2. What is the improvement/solution?
- rename `Maskicons` in the front end to `Polycons`
- Maskicons are still what this component is called in the code so there are still lots of references to this name in the codebase.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Rename Maskicons to Polycons

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/19770

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user general settings
    Given I am a user with a wallet created/imported

    When user navigates to settings/general
    Then user scrolls down to the bottom
    Then the user sees three account icon options
    And the first option is called Polycons
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="250" height="600" alt="Simulator Screenshot - iPhone 16 Plus - 2025-09-15 at 15 27 39" src="https://github.com/user-attachments/assets/505a3e24-c1fe-406c-85cb-ed61e507bf5b" />


### **After**

<img width="250" height="600" alt="Simulator Screenshot - iPhone 16 Plus - 2025-09-15 at 15 11 41" src="https://github.com/user-attachments/assets/9d1c3c16-7cd4-4bc8-a52a-e2e6af5255aa" />


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
