### PR TITLE
fix: cp-7.56.0 Persisting toasts

### DIFF
--- a/app/component-library/components/Toast/Toast.tsx
+++ b/app/component-library/components/Toast/Toast.tsx
@@ -72,6 +72,8 @@ const Toast = forwardRef((_, ref: React.ForwardedRef<ToastRef>) => {
         cancelAnimation(translateYProgress);
       }
       timeoutDuration = 100;
+      // Clear existing toast state to prevent animation conflicts when showing rapid successive toasts
+      setToastOptions(undefined);
     }
     setTimeout(() => {
       setToastOptions(options);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR aims to fix an issue where Toasts would persist on screen. Toasts would not animate off the screen even if configured to and would sometimes get stuck mid-animation. This bug happens commonly when multiple Toasts render in quick succession or if the View frequently re-renders.

We see this bug more often in the Perps experience because we subscribe to live websocket updates which cause frequent re-rendering.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fixed persisting toast component

## **Related issues**

Fixes: [TAT-1634: Investigate: Fix persistent error toast (intermittent)](https://consensyssoftware.atlassian.net/browse/TAT-1634)

## **Manual testing steps**

```gherkin
Feature: Perp Trading

  Scenario: Toast component persists (is "stuck") when user cancels Perp orders
    Given the user has several open (unfilled) Perp orders

    When user cancels orders
    Then Toast components often get stuck
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
At 6:03 in the following video:
https://drive.google.com/file/d/1g2FTUtmdaBBjxKs_PKdwA0Zz97eI-m5h/view

### **After**

<!-- [screenshots/recordings] -->
Note: Please ignore the "Order failed" toasts. This is a separate issue that will be addressed in a separate PR. The thing to notice here is that the Toasts aren't getting "stuck".

The Toasts now get dismissed and animate off screen.

https://github.com/user-attachments/assets/a0ca7f9e-6bf7-4877-81d5-4a02ebc1e045

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
