### PR TITLE
feat: Prevent adding multiple txs in the BIP-44 send flow fix

### DIFF
--- a/app/components/Views/confirmations/components/recipient-list/recipient-list.tsx
+++ b/app/components/Views/confirmations/components/recipient-list/recipient-list.tsx
@@ -72,6 +72,7 @@ export function RecipientList({
         accountAvatarType={accountAvatarType}
         to={to}
         isBIP44={isBIP44}
+        disabled={disabled}
       />
     </Box>
   );
@@ -114,12 +115,14 @@ function BIP44RecipientList({
   accountAvatarType,
   to,
   isBIP44,
+  disabled,
 }: {
   data: RecipientType[];
   onRecipientSelected: (recipient: RecipientType) => void;
   accountAvatarType: AvatarAccountType;
   to?: string;
   isBIP44?: boolean;
+  disabled?: boolean;
 }) {
   const groupedData = useMemo(
     () =>
@@ -153,7 +156,7 @@ function BIP44RecipientList({
               accountAvatarType={accountAvatarType}
               isSelected={to === recipient.address}
               isBIP44={isBIP44}
-              onPress={onRecipientSelected}
+              onPress={disabled ? undefined : onRecipientSelected}
             />
           ))}
         </Box>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Previously on https://github.com/MetaMask/metamask-mobile/pull/19263/, we introduced a state property to ensure only one transaction could be added at once. However, we forgot to extend that pattern to the recipient list for after BIP-44 was rolled out, so this PR adds that.

We also do a precheck on `asset` and `chainId` to avoid a situation in which adding the transaction to the controller state would be prevented by these properties being falsy on `handleSubmitPress` inside `app/components/Views/confirmations/hooks/send/useSendActions.ts`. In that scenario, `setIsSubmittingTransaction` would be set to `true` but since we wouldn't have left the recipient page, the state variable would be stuck permanently in a `true` state, preventing future any selections.

Finally, we now reset `isRecipientSelectedFromList` and the recipient when navigating back to the recipient page, ensuring the greyed out previous selection is correctly cleared.
 
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
