### PR TITLE
fix: cp-7.56.0 add fiat formatting utility settings for liquidation price

### DIFF
--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.test.tsx
@@ -50,6 +50,7 @@ jest.mock('../../../../../util/theme', () => ({
 
 // Mock format utilities
 jest.mock('../../utils/formatUtils', () => ({
+  ...jest.requireActual('../../utils/formatUtils'),
   formatPrice: jest.fn((value) => {
     const num = typeof value === 'string' ? parseFloat(value) : value;
     return isNaN(num) ? '$0.00' : `$${num.toFixed(2)}`;
@@ -583,6 +584,32 @@ describe('PerpsLeverageBottomSheet', () => {
         }),
         expect.objectContaining({ debounceMs: 500 }),
       );
+    });
+
+    it('truncates liquidation price to 2 decimals when price is above 1', () => {
+      // Arrange - Mock hook to return liquidation price with many decimal places
+      const mockUsePerpsLiquidationPrice = jest.requireMock(
+        '../../hooks/usePerpsLiquidationPrice',
+      );
+      mockUsePerpsLiquidationPrice.usePerpsLiquidationPrice.mockReturnValueOnce(
+        {
+          liquidationPrice: '1234.3552435', // Price above 1 with many decimals
+          isCalculating: false,
+          error: null,
+        },
+      );
+
+      const props = {
+        ...defaultProps,
+        leverage: 5,
+        currentPrice: 3000,
+      };
+
+      // Act
+      render(<PerpsLeverageBottomSheet {...props} />);
+
+      // Assert - Should display truncated price with 2 decimal places
+      expect(screen.getByText('$1,234.36')).toBeOnTheScreen();
     });
   });
 

--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.tsx
@@ -50,7 +50,11 @@ import {
 import { PerpsMeasurementName } from '../../constants/performanceMetrics';
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
 import { usePerpsScreenTracking } from '../../hooks/usePerpsScreenTracking';
-import { formatPrice } from '../../utils/formatUtils';
+import {
+  formatPerpsFiat,
+  formatPrice,
+  PRICE_RANGES_DETAILED_VIEW,
+} from '../../utils/formatUtils';
 import { createStyles } from './PerpsLeverageBottomSheet.styles';
 import {
   LEVERAGE_COLORS,
@@ -653,7 +657,9 @@ const PerpsLeverageBottomSheet: React.FC<PerpsLeverageBottomSheetProps> = ({
                     variant={TextVariant.BodyMD}
                     style={{ color: warningStyles.priceColor }}
                   >
-                    {formatPrice(dynamicLiquidationPrice)}
+                    {formatPerpsFiat(dynamicLiquidationPrice, {
+                      ranges: PRICE_RANGES_DETAILED_VIEW,
+                    })}
                   </Text>
                 )}
               </View>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
1. What is the reason for the change?
We have some formatting changes that we want to make, but we still need to take some time and think about them as a whole. For now, we want to ensure that the liquidation price on the leverage bottom sheet is matching the formatting for liquidation price on the order page.

2. What is the improvement/solution?
Ensure that the liquidation price on the leverage bottom sheet is matching the formatting for liquidation price on the order page.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1653

## **Manual testing steps**

```gherkin
Feature: fix liquidation price formatting leverage bottom sheet

  Scenario: user places an order
    Given user edits leverage

    When user sees the leverage bottom sheet
    Then the liquidation price is formatted in the same way the liquidation price on the order page
    Then if it is > 1 it has 2 decimals and if < 1 it has 3 significant digits
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/09338e88-3b71-4337-afef-e0b148826d72

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
