### PR TITLE
fix: Initial scroll to selected account for MultichainAccountSelectorList

### DIFF
--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/MultichainAccountSelectorList.test.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/MultichainAccountSelectorList.test.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
-import { fireEvent, waitFor } from '@testing-library/react-native';
+import { fireEvent, waitFor, within } from '@testing-library/react-native';
+import '@shopify/flash-list/jestSetup';
 import {
   AccountGroupObject,
   AccountWalletObject,
 } from '@metamask/account-tree-controller';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import MultichainAccountSelectorList from './MultichainAccountSelectorList';
-import { FlashListRef } from '@shopify/flash-list';
-import { FlattenedMultichainAccountListItem } from './MultichainAccountSelectorList.types';
 import renderWithProvider from '../../../../util/test/renderWithProvider';
 import {
   MULTICHAIN_ACCOUNT_SELECTOR_SEARCH_INPUT_TESTID,
@@ -20,6 +19,7 @@ import {
   createMockInternalAccountsFromGroups,
   createMockInternalAccountsWithAddresses,
 } from '../test-utils';
+import { ReactTestInstance } from 'react-test-renderer';
 
 jest.mock('../../../../core/Engine', () => ({
   context: {
@@ -117,7 +117,7 @@ describe('MultichainAccountSelectorList', () => {
     const { getByText } = renderComponentWithMockState(
       [wallet1, wallet2],
       internalAccounts,
-      [account1],
+      [],
     );
 
     expect(getByText('Wallet 1')).toBeTruthy();
@@ -145,7 +145,7 @@ describe('MultichainAccountSelectorList', () => {
     const { getByText } = renderComponentWithMockState(
       [srpWallet, snapWallet],
       internalAccounts,
-      [srpAccount],
+      [],
     );
 
     expect(getByText('Wallet 1')).toBeTruthy();
@@ -173,7 +173,7 @@ describe('MultichainAccountSelectorList', () => {
     const { getByText } = renderComponentWithMockState(
       [srpWallet, ledgerWallet],
       internalAccounts,
-      [srpAccount],
+      [],
     );
 
     expect(getByText('Wallet 1')).toBeTruthy();
@@ -201,11 +201,15 @@ describe('MultichainAccountSelectorList', () => {
     const { getAllByTestId } = renderComponentWithMockState(
       [wallet1],
       internalAccounts,
-      [account2],
+      [],
     );
 
     const accountCells = getAllByTestId('multichain-account-cell-container');
-    fireEvent.press(accountCells[0]);
+    const account1Cell = accountCells.find((cell) =>
+      within(cell).queryByText('Account 1'),
+    );
+    expect(account1Cell).toBeTruthy();
+    fireEvent.press(account1Cell as ReactTestInstance);
 
     expect(mockOnSelectAccount).toHaveBeenCalledWith(account1);
   });
@@ -437,7 +441,7 @@ describe('MultichainAccountSelectorList', () => {
       const { getByTestId, queryByText } = renderComponentWithMockState(
         [wallet1, wallet2],
         internalAccounts,
-        [account1],
+        [],
       );
 
       // Initially all accounts should be visible
@@ -717,7 +721,7 @@ describe('MultichainAccountSelectorList', () => {
       expect(getByText('Create account')).toBeTruthy();
     });
 
-    it('scrolls to the first selected account', async () => {
+    it('positions the list so the first selected account is initially visible', () => {
       const account1 = createMockAccountGroup(
         'keyring:wallet1/group1',
         'Account 1',
@@ -735,57 +739,39 @@ describe('MultichainAccountSelectorList', () => {
         account1,
         account2,
       ]);
+      const { queryByText } = renderWithProvider(
+        <MultichainAccountSelectorList
+          onSelectAccount={mockOnSelectAccount}
+          selectedAccountGroups={[account2]}
+        />,
+        { state: createMockState([wallet1], internalAccounts) },
+      );
 
-      type TestFlashListRef = FlashListRef<FlattenedMultichainAccountListItem>;
-      const listRef = React.createRef<TestFlashListRef>();
+      expect(queryByText('Account 2')).toBeTruthy();
+    });
+    it('renders a far selected account in the initial viewport when provided as initial selection', () => {
+      // Create many accounts so the selected one is far enough to require initialScrollIndex
+      const total = 60;
+      const accounts = Array.from({ length: total }, (_, i) =>
+        createMockAccountGroup(
+          `keyring:wallet1/group${i + 1}`,
+          `Account ${i + 1}`,
+        ),
+      );
+      const selectedIdx = 36;
+      const selected = accounts[selectedIdx];
+      const wallet1 = createMockWallet('wallet1', 'Wallet 1', accounts);
 
-      // Mock RAF to queue callbacks so we can attach our mock ref before flushing
-      const rafCallbacks: FrameRequestCallback[] = [];
-      const rafSpy = jest
-        .spyOn(global, 'requestAnimationFrame')
-        .mockImplementation((cb: FrameRequestCallback) => {
-          rafCallbacks.push(cb);
-          return rafCallbacks.length as unknown as number;
-        });
+      const internalAccounts = createMockInternalAccountsFromGroups(accounts);
 
-      try {
-        renderWithProvider(
-          <MultichainAccountSelectorList
-            onSelectAccount={mockOnSelectAccount}
-            selectedAccountGroups={[account2]}
-            listRef={listRef}
-          />,
-          { state: createMockState([wallet1], internalAccounts) },
-        );
+      const { queryByText } = renderWithProvider(
+        <MultichainAccountSelectorList selectedAccountGroups={[selected]} />,
+        { state: createMockState([wallet1], internalAccounts) },
+      );
 
-        // Attach mock imperative methods after render, before running RAF
-        interface MinimalFlashListRef {
-          scrollToIndex: jest.Mock;
-          scrollToOffset: jest.Mock;
-          scrollToEnd: jest.Mock;
-        }
-        const mockRefImpl: MinimalFlashListRef = {
-          scrollToIndex: jest.fn(),
-          scrollToOffset: jest.fn(),
-          scrollToEnd: jest.fn(),
-        };
-        const mockRef = mockRefImpl as unknown as TestFlashListRef;
-        (listRef as unknown as { current: TestFlashListRef | null }).current =
-          mockRef;
-
-        // Flush queued RAF callbacks to trigger the scroll effect
-        rafCallbacks.forEach((cb) => cb(0));
-
-        await waitFor(() => {
-          expect(mockRefImpl.scrollToIndex).toHaveBeenCalledWith({
-            index: 2, // header (0), Account 1 (1), Account 2 (2), footer (3)
-            animated: true,
-            viewPosition: 0.5,
-          });
-        });
-      } finally {
-        rafSpy.mockRestore();
-      }
+      // Without initialScrollIndex, this would not be visible initially
+      expect(queryByText(`Account ${selectedIdx + 1}`)).toBeTruthy();
+      expect(queryByText('Account 1')).toBeFalsy();
     });
   });
 });

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/MultichainAccountSelectorList.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/MultichainAccountSelectorList.tsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react';
 import { View, ScrollViewProps } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
-import { FlashList, ListRenderItem } from '@shopify/flash-list';
+import { FlashList, ListRenderItem, FlashListRef } from '@shopify/flash-list';
 import { useSelector } from 'react-redux';
 import { AccountGroupObject } from '@metamask/account-tree-controller';
 
@@ -54,7 +54,8 @@ const MultichainAccountSelectorList = ({
   const [lastCreatedAccountId, setLastCreatedAccountId] = useState<
     string | null
   >(null);
-  const internalListRef = useRef(null);
+  const internalListRef =
+    useRef<FlashListRef<FlattenedMultichainAccountListItem>>(null);
   const listRefToUse = listRef || internalListRef;
 
   const selectedIdSet = useMemo(
@@ -155,6 +156,16 @@ const MultichainAccountSelectorList = ({
     return items;
   }, [filteredWalletSections]);
 
+  // Compute first selected account index for initial positioning only
+  const initialSelectedIndex = useMemo(() => {
+    const targetId = selectedAccountGroups?.[0]?.id;
+    if (!targetId) return undefined;
+    const idx = flattenedData.findIndex(
+      (item) => item.type === 'cell' && item.data.id === targetId,
+    );
+    return idx > 0 ? idx : undefined;
+  }, [flattenedData, selectedAccountGroups]);
+
   // Reset scroll to top when search text changes
   useEffect(() => {
     if (listRefToUse.current) {
@@ -189,31 +200,6 @@ const MultichainAccountSelectorList = ({
     }
   }, [lastCreatedAccountId, flattenedData, listRefToUse]);
 
-  // Scroll to the first selected account whenever selection or data changes
-  useEffect(() => {
-    if (debouncedSearchText.trim()) return;
-    if (!listRefToUse.current) return;
-    if (!selectedAccountGroups?.length) return;
-
-    const targetId = selectedAccountGroups[0]?.id;
-    if (!targetId) return;
-
-    const index = flattenedData.findIndex(
-      (item) => item.type === 'cell' && item.data.id === targetId,
-    );
-
-    if (index !== -1) {
-      const raf = requestAnimationFrame(() => {
-        listRefToUse.current?.scrollToIndex({
-          index,
-          animated: true,
-          viewPosition: 0.5,
-        });
-      });
-      return () => cancelAnimationFrame(raf);
-    }
-  }, [selectedAccountGroups, flattenedData, debouncedSearchText, listRefToUse]);
-
   // Handle account creation callback
   const handleAccountCreated = useCallback((newAccountId: string) => {
     setLastCreatedAccountId(newAccountId);
@@ -229,7 +215,7 @@ const MultichainAccountSelectorList = ({
 
   const renderItem: ListRenderItem<FlattenedMultichainAccountListItem> =
     useCallback(
-      ({ item }) => {
+      ({ item }: { item: FlattenedMultichainAccountListItem }) => {
         switch (item.type) {
           case 'header': {
             return <AccountListHeader title={item.data.title} />;
@@ -332,6 +318,7 @@ const MultichainAccountSelectorList = ({
             showsVerticalScrollIndicator={false}
             getItemType={getItemType}
             keyExtractor={keyExtractor}
+            initialScrollIndex={initialSelectedIndex}
             renderScrollComponent={
               ScrollView as React.ComponentType<ScrollViewProps>
             }

--- a/package.json
+++ b/package.json
@@ -339,7 +339,7 @@
     "@sentry/core": "~8.54.0",
     "@sentry/react": "~8.54.0",
     "@sentry/react-native": "~6.10.0",
-    "@shopify/flash-list": "2.0.1",
+    "@shopify/flash-list": "2.0.3",
     "@solana/addresses": "2.0.0",
     "@tradle/react-native-http": "2.0.1",
     "@types/he": "^1.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8404,10 +8404,10 @@
   dependencies:
     "@sentry/core" "8.54.0"
 
-"@shopify/flash-list@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@shopify/flash-list/-/flash-list-2.0.1.tgz#cde79aa41e9f677e1e5cdc542fe4f304a7338397"
-  integrity sha512-bLgwTcVOn1kzSL4q0qk6JxE+4je1xF2yUDVoIKmeI9miFPAvIxzI8cCoksUrGmRt/MXRj4mrOhAjvxQY1lSoVg==
+"@shopify/flash-list@2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@shopify/flash-list/-/flash-list-2.0.3.tgz#222427d1e09bf5cdd8a219d0a5a80f6f1d20465d"
+  integrity sha512-jUlHuZFoPdqRCDvOqsb2YkTttRPyV8Tb/EjCx3gE2wjr4UTM+fE0Ltv9bwBg0K7yo/SxRNXaW7xu5utusRb0xA==
   dependencies:
     tslib "2.8.1"
 


### PR DESCRIPTION
## **Description**


1. What is the reason for the change?
- fixes a bug that causes the list to constantly scroll back to the selected account, even if the user is already scrolling on the list
2. What is the improvement/solution?
- instead of a useEffect to trigger the scroll in favour of the [initialScrollIndex](https://shopify.github.io/flash-list/docs/usage/#initialscrollindex) prop from FlashList. This allows FlashList to handle the state of the selected account which means if does not get triggered on dependancy updates. This also offers slightly better UX as the list immediately renders with the selected account visible instead of scrolling to the selected index. 


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user User scrolling on Multichain account selector list
    Given I am a user with a wallet that has many accounts (over 10)
    And I am testing on a lower end device

    When user open the account list
    Then the list opens immediately with the selected account in view
    And when the user scrolls immediately after the list renders, there is not scroll event triggered

```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/2280f121-af31-4fcc-84e8-cd7ecd12edc9



### **After**


https://github.com/user-attachments/assets/e8669781-b24f-44dd-ba47-3bae27e93cf0


https://github.com/user-attachments/assets/0cba0625-2b30-4c41-acd8-bb370d6da7d0



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
