### PR TITLE
fix: cp-7.56.0 handle small fiat values in metamask pay

### DIFF
--- a/app/components/UI/SimulationDetails/FiatDisplay/useFiatFormatter.test.ts
+++ b/app/components/UI/SimulationDetails/FiatDisplay/useFiatFormatter.test.ts
@@ -40,6 +40,8 @@ describe('useFiatFormatter', () => {
     expect(formatFiat(new BigNumber(1000))).toBe('$1,000');
     expect(formatFiat(new BigNumber(500.5))).toBe('$500.50');
     expect(formatFiat(new BigNumber(0))).toBe('$0');
+    expect(formatFiat(new BigNumber(0.005))).toBe('<$0.01');
+    expect(formatFiat(new BigNumber(0.0049))).toBe('<$0.01');
   });
 
   it('should use the current locale and currency from the mocked functions', () => {

--- a/app/components/UI/SimulationDetails/FiatDisplay/useFiatFormatter.ts
+++ b/app/components/UI/SimulationDetails/FiatDisplay/useFiatFormatter.ts
@@ -24,19 +24,30 @@ const useFiatFormatter = (): FiatFormatter => {
   return (fiatAmount: BigNumber) => {
     const hasDecimals = !fiatAmount.isInteger();
 
+    const isSmall =
+      fiatAmount.toFixed(2, BigNumber.ROUND_DOWN) === '0.00' &&
+      !fiatAmount.isZero();
+
+    const value = isSmall ? 0.01 : fiatAmount.toFixed();
+    let result: string;
+
     try {
-      return getIntlNumberFormatter(I18n.locale, {
+      result = getIntlNumberFormatter(I18n.locale, {
         style: 'currency',
         currency: fiatCurrency,
         minimumFractionDigits: hasDecimals ? 2 : 0,
         // string is valid parameter for format function
         // for some reason it gives TS issue
         // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/format#number
-      }).format(fiatAmount.toFixed() as unknown as number);
+      }).format(value as unknown as number);
     } catch (error) {
       // Fallback for unknown or unsupported currencies
-      return `${fiatAmount.toFixed()} ${fiatCurrency}`;
+      result = `${value} ${fiatCurrency}`;
     }
+
+    result = result.replace('US$', '$');
+
+    return isSmall ? `<${result}` : result;
   };
 };
 

--- a/app/components/Views/confirmations/components/edit-amount/edit-amount.test.tsx
+++ b/app/components/Views/confirmations/components/edit-amount/edit-amount.test.tsx
@@ -124,6 +124,24 @@ describe('EditAmount', () => {
     expect(getByTestId('edit-amount-input')).toHaveProp('defaultValue', '5');
   });
 
+  it('appends zero if input starts with a decimal point', async () => {
+    const { getByTestId, getByText } = render();
+
+    await act(async () => {
+      fireEvent.press(getByTestId('edit-amount-input'));
+    });
+
+    await act(async () => {
+      fireEvent.press(getByText('.'));
+    });
+
+    await act(async () => {
+      fireEvent.press(getByText('5'));
+    });
+
+    expect(getByTestId('edit-amount-input')).toHaveProp('defaultValue', '0.5');
+  });
+
   it('displays keyboard automatically when autoKeyboard is true', () => {
     const { getByTestId } = render({ autoKeyboard: true });
 

--- a/app/components/Views/confirmations/components/edit-amount/edit-amount.tsx
+++ b/app/components/Views/confirmations/components/edit-amount/edit-amount.tsx
@@ -106,7 +106,11 @@ export function EditAmount({
   }, [autoKeyboard, inputChanged, handleInputPress]);
 
   const handleChange = useCallback((amount: string) => {
-    const newAmount = amount.replace(/^0+/, '') || '0';
+    let newAmount = amount.replace(/^0+/, '') || '0';
+
+    if (newAmount.startsWith('.') || newAmount.startsWith(',')) {
+      newAmount = '0' + newAmount;
+    }
 
     if (newAmount.length >= MAX_LENGTH) {
       return;

--- a/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
@@ -103,4 +103,16 @@ describe('BridgeFeeRow', () => {
     expect(getByTestId('bridge-fee-row-skeleton')).toBeDefined();
     expect(getByTestId('metamask-fee-row-skeleton')).toBeDefined();
   });
+
+  it('does not render tooltip if no quotes', async () => {
+    const { queryByTestId } = render({ quotes: [] });
+    expect(queryByTestId('info-row-tooltip-open-btn')).toBeNull();
+  });
+
+  it('does not render metamask fee if no quotes', async () => {
+    const { getByTestId, queryByTestId } = render({ quotes: [] });
+
+    expect(getByTestId('bridge-fee-row')).toBeDefined();
+    expect(queryByTestId('metamask-fee-row')).toBeNull();
+  });
 });

--- a/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
+++ b/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
@@ -32,11 +32,7 @@ export function BridgeFeeRow() {
     selectTransactionBridgeQuotesById(state, transactionId),
   );
 
-  const show = isQuotesLoading || Boolean(quotes?.length);
-
-  if (!show) {
-    return null;
-  }
+  const hasQuotes = Boolean(quotes?.length);
 
   if (isQuotesLoading) {
     return (
@@ -50,15 +46,21 @@ export function BridgeFeeRow() {
   return (
     <>
       <InfoRow
+        testID="bridge-fee-row"
         label={strings('confirm.label.transaction_fee')}
-        tooltip={getTooltip(type)}
+        tooltip={hasQuotes ? getTooltip(type) : undefined}
         tooltipTitle={strings('confirm.tooltip.title.transaction_fee')}
       >
         <Text>{totalTransactionFeeFormatted}</Text>
       </InfoRow>
-      <InfoRow label={strings('confirm.label.metamask_fee')}>
-        <Text>{fiatFormatter(new BigNumber(0))}</Text>
-      </InfoRow>
+      {hasQuotes && (
+        <InfoRow
+          testID="metamask-fee-row"
+          label={strings('confirm.label.metamask_fee')}
+        >
+          <Text>{fiatFormatter(new BigNumber(0))}</Text>
+        </InfoRow>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## **Description**

- Do not round small fiat values to `$0` and instead show `<$0.01`.
- Ensure Perps deposit amount starts with zero if using decimal point and less than 1.
- Show transaction fee if Perps deposit with Arbitrum USDC but hide tooltip and MetaMask fee row.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#5788](https://github.com/MetaMask/MetaMask-planning/issues/5788)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
