### PR TITLE
fix: cp-7.56.0 hide networks with no tokens in metamask pay

### DIFF
--- a/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/BridgeSourceNetworkSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/BridgeSourceNetworkSelector.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { evmAccountAddress, initialState } from '../../_mocks_/initialState';
+import { initialState } from '../../_mocks_/initialState';
 import { fireEvent, waitFor } from '@testing-library/react-native';
 import { renderScreen } from '../../../../../util/test/renderWithProvider';
 import { BridgeSourceNetworkSelector } from '.';
@@ -9,7 +9,7 @@ import { setSelectedSourceChainIds } from '../../../../../core/redux/slices/brid
 import { BridgeSourceNetworkSelectorSelectorsIDs } from '../../../../../../e2e/selectors/Bridge/BridgeSourceNetworkSelector.selectors';
 import { cloneDeep } from 'lodash';
 import { MultichainNetwork } from '@metamask/multichain-transactions-controller';
-import { optimismToken1Address } from '../../_mocks_/bridgeControllerState';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
@@ -258,51 +258,18 @@ describe('BridgeSourceNetworkSelector', () => {
     });
   });
 
-  it('does not render non-EVM networks if isEvmOnly set', async () => {
-    const state = cloneDeep(initialState);
-
-    state.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags.bridgeConfigV2.chains[
-      MultichainNetwork.Solana
-    ] = {
-      isActiveSrc: true,
-      isActiveDest: true,
-      isUnifiedUIEnabled: true,
-    };
-
-    const { queryByText } = renderScreen(
-      () => <BridgeSourceNetworkSelector isEvmOnly />,
+  it('does not render networks if not in chain IDs', async () => {
+    const { getByText, queryByText } = renderScreen(
+      () => <BridgeSourceNetworkSelector chainIds={[CHAIN_IDS.OPTIMISM]} />,
       {
         name: Routes.BRIDGE.MODALS.SOURCE_NETWORK_SELECTOR,
       },
-      { state },
+      { state: initialState },
     );
 
     await waitFor(() => {
-      expect(queryByText('Solana')).toBeNull();
-      expect(queryByText('$30012.75599')).toBeNull();
+      expect(queryByText('Ethereum Mainnet')).toBeNull();
+      expect(getByText('Optimism')).toBeTruthy();
     });
-  });
-
-  it('hides networks with no fiat value if isBalanceOnly set', async () => {
-    const state = cloneDeep(initialState);
-
-    state.engine.backgroundState.TokenBalancesController.tokenBalances[
-      evmAccountAddress
-    ][optimismChainId][optimismToken1Address] = '0x0';
-
-    state.engine.backgroundState.AccountTrackerController.accountsByChainId[
-      optimismChainId
-    ][evmAccountAddress].balance = '0x0';
-
-    const { getByTestId, queryByTestId } = renderScreen(
-      () => <BridgeSourceNetworkSelector isBalanceOnly />,
-      {
-        name: Routes.BRIDGE.MODALS.SOURCE_NETWORK_SELECTOR,
-      },
-      { state },
-    );
-
-    expect(getByTestId(`chain-${mockChainId}`)).toBeDefined();
-    expect(queryByTestId(`chain-${optimismChainId}`)).toBeNull();
   });
 });

--- a/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/BridgeSourceNetworkSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/BridgeSourceNetworkSelector.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { initialState } from '../../_mocks_/initialState';
+import { evmAccountAddress, initialState } from '../../_mocks_/initialState';
 import { fireEvent, waitFor } from '@testing-library/react-native';
 import { renderScreen } from '../../../../../util/test/renderWithProvider';
 import { BridgeSourceNetworkSelector } from '.';
@@ -9,6 +9,7 @@ import { setSelectedSourceChainIds } from '../../../../../core/redux/slices/brid
 import { BridgeSourceNetworkSelectorSelectorsIDs } from '../../../../../../e2e/selectors/Bridge/BridgeSourceNetworkSelector.selectors';
 import { cloneDeep } from 'lodash';
 import { MultichainNetwork } from '@metamask/multichain-transactions-controller';
+import { optimismToken1Address } from '../../_mocks_/bridgeControllerState';
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
@@ -280,5 +281,28 @@ describe('BridgeSourceNetworkSelector', () => {
       expect(queryByText('Solana')).toBeNull();
       expect(queryByText('$30012.75599')).toBeNull();
     });
+  });
+
+  it('hides networks with no fiat value if isBalanceOnly set', async () => {
+    const state = cloneDeep(initialState);
+
+    state.engine.backgroundState.TokenBalancesController.tokenBalances[
+      evmAccountAddress
+    ][optimismChainId][optimismToken1Address] = '0x0';
+
+    state.engine.backgroundState.AccountTrackerController.accountsByChainId[
+      optimismChainId
+    ][evmAccountAddress].balance = '0x0';
+
+    const { getByTestId, queryByTestId } = renderScreen(
+      () => <BridgeSourceNetworkSelector isBalanceOnly />,
+      {
+        name: Routes.BRIDGE.MODALS.SOURCE_NETWORK_SELECTOR,
+      },
+      { state },
+    );
+
+    expect(getByTestId(`chain-${mockChainId}`)).toBeDefined();
+    expect(queryByTestId(`chain-${optimismChainId}`)).toBeNull();
   });
 });

--- a/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/index.tsx
+++ b/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/index.tsx
@@ -69,18 +69,19 @@ export const BridgeSourceNetworkSelector: React.FC<
     useSortedSourceNetworks();
 
   const enabledSourceChainIds = useMemo(
-    () => enabledSourceChains.map((chain) => chain.chainId),
-    [enabledSourceChains],
+    () =>
+      enabledSourceChains
+        .filter((chain) => !chainIds || chainIds.includes(chain.chainId as Hex))
+        .map((chain) => chain.chainId),
+    [chainIds, enabledSourceChains],
   );
 
   const sortedSourceNetworks = useMemo(
     () =>
-      sortedSourceNetworksRaw.filter(
-        (chain) =>
-          enabledSourceChainIds.includes(chain.chainId) &&
-          (!chainIds || chainIds.includes(chain.chainId as Hex)),
+      sortedSourceNetworksRaw.filter((chain) =>
+        enabledSourceChainIds.includes(chain.chainId),
       ),
-    [chainIds, enabledSourceChainIds, sortedSourceNetworksRaw],
+    [enabledSourceChainIds, sortedSourceNetworksRaw],
   );
 
   const evmNetworkConfigurations = useSelector(

--- a/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/index.tsx
+++ b/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/index.tsx
@@ -31,7 +31,6 @@ import { useNetworkInfo } from '../../../../../selectors/selectedNetworkControll
 import { useSwitchNetworks } from '../../../../Views/NetworkSelector/useSwitchNetworks';
 import { CaipChainId, Hex } from '@metamask/utils';
 import { selectEvmNetworkConfigurationsByChainId } from '../../../../../selectors/networkController';
-import { isSolanaChainId } from '@metamask/bridge-controller';
 
 const createStyles = () =>
   StyleSheet.create({
@@ -53,14 +52,13 @@ const createStyles = () =>
   });
 
 export interface BridgeSourceNetworkSelectorProps {
-  isBalanceOnly?: boolean;
-  isEvmOnly?: boolean;
+  chainIds?: Hex[];
   onApply?: (selectedChainIds: Hex[]) => void;
 }
 
 export const BridgeSourceNetworkSelector: React.FC<
   BridgeSourceNetworkSelectorProps
-> = ({ isBalanceOnly, isEvmOnly, onApply }) => {
+> = ({ chainIds, onApply }) => {
   const { styles } = useStyles(createStyles, {});
   const navigation = useNavigation();
   const dispatch = useDispatch();
@@ -71,11 +69,8 @@ export const BridgeSourceNetworkSelector: React.FC<
     useSortedSourceNetworks();
 
   const enabledSourceChainIds = useMemo(
-    () =>
-      enabledSourceChains
-        .filter((chain) => (isEvmOnly ? !isSolanaChainId(chain.chainId) : true))
-        .map((chain) => chain.chainId),
-    [enabledSourceChains, isEvmOnly],
+    () => enabledSourceChains.map((chain) => chain.chainId),
+    [enabledSourceChains],
   );
 
   const sortedSourceNetworks = useMemo(
@@ -83,9 +78,9 @@ export const BridgeSourceNetworkSelector: React.FC<
       sortedSourceNetworksRaw.filter(
         (chain) =>
           enabledSourceChainIds.includes(chain.chainId) &&
-          (!isBalanceOnly || chain.totalFiatValue > 0),
+          (!chainIds || chainIds.includes(chain.chainId as Hex)),
       ),
-    [enabledSourceChainIds, isBalanceOnly, sortedSourceNetworksRaw],
+    [chainIds, enabledSourceChainIds, sortedSourceNetworksRaw],
   );
 
   const evmNetworkConfigurations = useSelector(

--- a/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/index.tsx
+++ b/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/index.tsx
@@ -53,13 +53,14 @@ const createStyles = () =>
   });
 
 export interface BridgeSourceNetworkSelectorProps {
+  isBalanceOnly?: boolean;
   isEvmOnly?: boolean;
   onApply?: (selectedChainIds: Hex[]) => void;
 }
 
 export const BridgeSourceNetworkSelector: React.FC<
   BridgeSourceNetworkSelectorProps
-> = ({ isEvmOnly, onApply }) => {
+> = ({ isBalanceOnly, isEvmOnly, onApply }) => {
   const { styles } = useStyles(createStyles, {});
   const navigation = useNavigation();
   const dispatch = useDispatch();
@@ -79,10 +80,12 @@ export const BridgeSourceNetworkSelector: React.FC<
 
   const sortedSourceNetworks = useMemo(
     () =>
-      sortedSourceNetworksRaw.filter((chain) =>
-        enabledSourceChainIds.includes(chain.chainId),
+      sortedSourceNetworksRaw.filter(
+        (chain) =>
+          enabledSourceChainIds.includes(chain.chainId) &&
+          (!isBalanceOnly || chain.totalFiatValue > 0),
       ),
-    [enabledSourceChainIds, sortedSourceNetworksRaw],
+    [enabledSourceChainIds, isBalanceOnly, sortedSourceNetworksRaw],
   );
 
   const evmNetworkConfigurations = useSelector(

--- a/app/components/UI/Perps/routes/index.tsx
+++ b/app/components/UI/Perps/routes/index.tsx
@@ -141,6 +141,9 @@ const PerpsScreenStack = () => (
         <Stack.Screen
           name={Routes.FULL_SCREEN_CONFIRMATIONS.REDESIGNED_CONFIRMATIONS}
           component={Confirm}
+          options={{
+            title: '',
+          }}
         />
       </Stack.Navigator>
     </PerpsStreamProvider>

--- a/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
@@ -2,11 +2,9 @@ import { renderScreen } from '../../../../../../util/test/renderWithProvider';
 import { fireEvent, waitFor } from '@testing-library/react-native';
 import { PayWithModal } from './pay-with-modal';
 import Routes from '../../../../../../constants/navigation/Routes';
-import { useTokens } from '../../../../../UI/Bridge/hooks/useTokens';
 import { BridgeToken } from '../../../../../UI/Bridge/types';
 import { NATIVE_TOKEN_ADDRESS } from '../../../constants/tokens';
-import { cloneDeep, merge } from 'lodash';
-import { useTransactionRequiredTokens } from '../../../hooks/pay/useTransactionRequiredTokens';
+import { merge } from 'lodash';
 import { transactionApprovalControllerMock } from '../../../__mocks__/controllers/approval-controller-mock';
 import { simpleSendTransactionControllerMock } from '../../../__mocks__/controllers/transaction-controller-mock';
 import { otherControllersMock } from '../../../__mocks__/controllers/other-controllers-mock';
@@ -15,6 +13,7 @@ import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToke
 import { BridgeSourceNetworksBar } from '../../../../../UI/Bridge/components/BridgeSourceNetworksBar';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { useSortedSourceNetworks } from '../../../../../UI/Bridge/hooks/useSortedSourceNetworks';
+import { useTransactionPayAvailableTokens } from '../../../hooks/pay/useTransactionPayAvailableTokens';
 
 jest.useFakeTimers();
 
@@ -22,11 +21,10 @@ const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
 const mockSetPayToken = jest.fn();
 
-jest.mock('../../../../../UI/Bridge/hooks/useTokens');
-jest.mock('../../../hooks/pay/useTransactionRequiredTokens');
 jest.mock('../../../hooks/pay/useTransactionPayToken');
 jest.mock('../../../../../UI/Bridge/components/BridgeSourceNetworksBar');
 jest.mock('../../../../../UI/Bridge/hooks/useSortedSourceNetworks');
+jest.mock('../../../hooks/pay/useTransactionPayAvailableTokens');
 
 jest.mock(
   '../../../../../../core/redux/slices/bridge/utils/hasMinimumRequiredVersion',
@@ -121,24 +119,21 @@ function render({ minimumFiatBalance }: { minimumFiatBalance?: number } = {}) {
 }
 
 describe('PayWithModal', () => {
-  const useTokensMock = jest.mocked(useTokens);
   const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
   const BridgeSourceNetworksBarMock = jest.mocked(BridgeSourceNetworksBar);
   const useSortedSourceNetworksMock = jest.mocked(useSortedSourceNetworks);
 
-  const useTransactionRequiredTokensMock = jest.mocked(
-    useTransactionRequiredTokens,
+  const useTransactionPayAvailableTokensMock = jest.mocked(
+    useTransactionPayAvailableTokens,
   );
 
   beforeEach(() => {
     jest.clearAllMocks();
 
-    useTokensMock.mockReturnValue({
-      tokens: TOKENS_MOCK,
-      pending: false,
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableChainIds: [CHAIN_ID_1_MOCK, CHAIN_ID_2_MOCK],
+      availableTokens: TOKENS_MOCK,
     });
-
-    useTransactionRequiredTokensMock.mockReturnValue([]);
 
     useTransactionPayTokenMock.mockReturnValue({
       payToken: { address: '0x0', chainId: '0x0' },
@@ -183,104 +178,6 @@ describe('PayWithModal', () => {
     });
   });
 
-  it('renders tokens above minimum fiat balance', async () => {
-    const { getByText, queryByText } = render({ minimumFiatBalance: 6.12 });
-
-    await waitFor(() => {
-      expect(getByText('Test Token 3')).toBeDefined();
-      expect(getByText('789 TST3')).toBeDefined();
-      expect(getByText('$7.89')).toBeDefined();
-    });
-
-    await waitFor(() => {
-      expect(queryByText('Test Token 1')).toBeNull();
-    });
-
-    await waitFor(() => {
-      expect(queryByText('Test Token 2')).toBeNull();
-    });
-  });
-
-  it('renders tokens if required and below minimum fiat balance', async () => {
-    useTransactionRequiredTokensMock.mockReturnValue([
-      { ...TOKENS_MOCK[0], skipIfBalance: false } as never,
-    ]);
-
-    const { getByText, queryByText } = render({ minimumFiatBalance: 6.12 });
-
-    await waitFor(() => {
-      expect(getByText('Test Token 3')).toBeDefined();
-      expect(getByText('789 TST3')).toBeDefined();
-      expect(getByText('$7.89')).toBeDefined();
-    });
-
-    await waitFor(() => {
-      expect(getByText('Test Token 1')).toBeDefined();
-      expect(getByText('123 TST1')).toBeDefined();
-      expect(getByText('$1.23')).toBeDefined();
-    });
-
-    await waitFor(() => {
-      expect(queryByText('Test Token 2')).toBeNull();
-    });
-  });
-
-  it('renders tokens if selected payment token and below minimum fiat balance', async () => {
-    useTransactionPayTokenMock.mockReturnValue({
-      payToken: { address: TOKENS_MOCK[0].address, chainId: CHAIN_ID_1_MOCK },
-      setPayToken: mockSetPayToken,
-    } as unknown as ReturnType<typeof useTransactionPayToken>);
-
-    const { getByText, queryByText } = render({ minimumFiatBalance: 6.12 });
-
-    await waitFor(() => {
-      expect(getByText('Test Token 3')).toBeDefined();
-      expect(getByText('789 TST3')).toBeDefined();
-      expect(getByText('$7.89')).toBeDefined();
-    });
-
-    await waitFor(() => {
-      expect(getByText('Test Token 1')).toBeDefined();
-      expect(getByText('123 TST1')).toBeDefined();
-      expect(getByText('$1.23')).toBeDefined();
-    });
-
-    await waitFor(() => {
-      expect(queryByText('Test Token 2')).toBeNull();
-    });
-  });
-
-  it('does not render tokens if no native balance on chain', async () => {
-    const tokens = cloneDeep(TOKENS_MOCK);
-
-    tokens[4].tokenFiatAmount = 0;
-
-    useTokensMock.mockReturnValue({
-      tokens,
-      pending: false,
-    });
-
-    const { getByText, queryByText } = render();
-
-    await waitFor(() => {
-      expect(getByText('Test Token 1')).toBeDefined();
-      expect(getByText('123 TST1')).toBeDefined();
-      expect(getByText('$1.23')).toBeDefined();
-    });
-
-    await waitFor(() => {
-      expect(queryByText('Test Token 2')).toBeNull();
-      expect(queryByText('456 TST2')).toBeNull();
-      expect(queryByText('$4.56')).toBeNull();
-    });
-
-    await waitFor(() => {
-      expect(getByText('Test Token 3')).toBeDefined();
-      expect(getByText('789 TST3')).toBeDefined();
-      expect(getByText('$7.89')).toBeDefined();
-    });
-  });
-
   it('displays supported networks in networks bar', async () => {
     render();
 
@@ -295,37 +192,6 @@ describe('PayWithModal', () => {
           expect.objectContaining({ chainId: CHAIN_ID_2_MOCK }),
         ],
         selectedSourceChainIds: [CHAIN_ID_1_MOCK, CHAIN_ID_2_MOCK],
-      }),
-      expect.anything(),
-    );
-  });
-
-  it('hides networks with no fiat value', async () => {
-    useSortedSourceNetworksMock.mockReturnValue({
-      sortedSourceNetworks: [
-        {
-          chainId: CHAIN_ID_1_MOCK,
-          totalFiatValue: 0,
-        },
-        {
-          chainId: CHAIN_ID_2_MOCK,
-          totalFiatValue: 1,
-        },
-      ] as unknown as ReturnType<
-        typeof useSortedSourceNetworks
-      >['sortedSourceNetworks'],
-    });
-
-    render();
-
-    expect(BridgeSourceNetworksBarMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        networksToShow: [expect.objectContaining({ chainId: CHAIN_ID_2_MOCK })],
-        enabledSourceChains: [
-          expect.objectContaining({ chainId: CHAIN_ID_1_MOCK }),
-          expect.objectContaining({ chainId: CHAIN_ID_2_MOCK }),
-        ],
-        selectedSourceChainIds: [CHAIN_ID_2_MOCK],
       }),
       expect.anything(),
     );

--- a/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
@@ -158,21 +158,28 @@ export function PayWithModal() {
     navigation.navigate(Routes.CONFIRMATION_PAY_WITH_NETWORK_MODAL);
   }, [navigation]);
 
-  const networksToShow = useMemo(
+  const networks = useMemo(
     () =>
-      sortedSourceNetworks.filter(({ chainId }) =>
-        selectedSourceChainIds.includes(chainId),
+      sortedSourceNetworks.filter(
+        (chain) =>
+          selectedSourceChainIds.includes(chain.chainId) &&
+          chain.totalFiatValue > 0,
       ),
     [selectedSourceChainIds, sortedSourceNetworks],
+  );
+
+  const networkChainIds = useMemo(
+    () => networks.map((n) => n.chainId),
+    [networks],
   );
 
   return (
     <BridgeTokenSelectorBase
       networksBar={
         <BridgeSourceNetworksBar
-          networksToShow={networksToShow}
+          networksToShow={networks}
           networkConfigurations={allNetworkConfigurations}
-          selectedSourceChainIds={selectedSourceChainIds as Hex[]}
+          selectedSourceChainIds={networkChainIds as Hex[]}
           enabledSourceChains={supportedSourceChains}
           onPress={handleNetworkPress}
         />

--- a/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
@@ -30,17 +30,27 @@ export function PayWithModal() {
   const { payToken, setPayToken } = useTransactionPayToken();
 
   const { availableTokens, availableChainIds } =
-    useTransactionPayAvailableTokens({
-      chainIds: selectedSourceChainIds as Hex[],
-    });
+    useTransactionPayAvailableTokens();
+
+  const tokens = useMemo(
+    () =>
+      availableTokens.filter((token) =>
+        selectedSourceChainIds.includes(token.chainId as Hex),
+      ),
+    [availableTokens, selectedSourceChainIds],
+  );
 
   const { sortedSourceNetworks: sortedSourceNetworksRaw } =
     useSortedSourceNetworks();
 
   const supportedChains = useMemo(
     () =>
-      enabledSourceChains.filter((chain) => !isSolanaChainId(chain.chainId)),
-    [enabledSourceChains],
+      enabledSourceChains.filter(
+        (chain) =>
+          !isSolanaChainId(chain.chainId) &&
+          availableChainIds.includes(chain.chainId as Hex),
+      ),
+    [availableChainIds, enabledSourceChains],
   );
 
   const networksWithIcon = useMemo(
@@ -48,15 +58,9 @@ export function PayWithModal() {
       sortedSourceNetworksRaw.filter(
         (chain) =>
           supportedChains.some((c) => c.chainId === chain.chainId) &&
-          availableChainIds.includes(chain.chainId as Hex) &&
           selectedSourceChainIds.includes(chain.chainId),
       ),
-    [
-      availableChainIds,
-      selectedSourceChainIds,
-      sortedSourceNetworksRaw,
-      supportedChains,
-    ],
+    [selectedSourceChainIds, sortedSourceNetworksRaw, supportedChains],
   );
 
   const chainIdsInCount = useMemo(
@@ -122,7 +126,7 @@ export function PayWithModal() {
         />
       }
       renderTokenItem={renderItem}
-      tokensList={availableTokens}
+      tokensList={tokens}
       title={strings('pay_with_modal.title')}
     />
   );

--- a/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
@@ -13,103 +13,55 @@ import {
 } from '../../../../../../core/redux/slices/bridge';
 import { useSortedSourceNetworks } from '../../../../../UI/Bridge/hooks/useSortedSourceNetworks';
 import { BridgeToken } from '../../../../../UI/Bridge/types';
-import { useTokens } from '../../../../../UI/Bridge/hooks/useTokens';
 import { TokenSelectorItem } from '../../../../../UI/Bridge/components/TokenSelectorItem';
 import { getNetworkImageSource } from '../../../../../../util/networks';
 import Routes from '../../../../../../constants/navigation/Routes';
 import { useNavigation } from '@react-navigation/native';
 import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
-import { useParams } from '../../../../../../util/navigation/navUtils';
 import { strings } from '../../../../../../../locales/i18n';
-import { NATIVE_TOKEN_ADDRESS } from '../../../constants/tokens';
-import { useTransactionRequiredTokens } from '../../../hooks/pay/useTransactionRequiredTokens';
-import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
 import { isSolanaChainId } from '@metamask/bridge-controller';
+import { useTransactionPayAvailableTokens } from '../../../hooks/pay/useTransactionPayAvailableTokens';
 
 export function PayWithModal() {
   const allNetworkConfigurations = useSelector(selectNetworkConfigurations);
   const enabledSourceChains = useSelector(selectEnabledSourceChains);
   const selectedSourceChainIds = useSelector(selectSelectedSourceChainIds);
-  const { sortedSourceNetworks: sortedSourceNetworksRaw } =
-    useSortedSourceNetworks();
   const navigation = useNavigation();
   const { payToken, setPayToken } = useTransactionPayToken();
-  const { minimumFiatBalance } = useParams<{ minimumFiatBalance?: number }>();
-  const { chainId: transactionChainId } = useTransactionMetadataRequest() ?? {};
-  const requiredTokens = useTransactionRequiredTokens();
 
-  const supportedSourceChains = useMemo(
+  const { availableTokens, availableChainIds } =
+    useTransactionPayAvailableTokens({
+      chainIds: selectedSourceChainIds as Hex[],
+    });
+
+  const { sortedSourceNetworks: sortedSourceNetworksRaw } =
+    useSortedSourceNetworks();
+
+  const supportedChains = useMemo(
     () =>
       enabledSourceChains.filter((chain) => !isSolanaChainId(chain.chainId)),
     [enabledSourceChains],
   );
 
-  const sortedSourceNetworks = useMemo(
+  const networksWithIcon = useMemo(
     () =>
-      sortedSourceNetworksRaw.filter((chain) =>
-        supportedSourceChains.some((c) => c.chainId === chain.chainId),
+      sortedSourceNetworksRaw.filter(
+        (chain) =>
+          supportedChains.some((c) => c.chainId === chain.chainId) &&
+          availableChainIds.includes(chain.chainId as Hex) &&
+          selectedSourceChainIds.includes(chain.chainId),
       ),
-    [sortedSourceNetworksRaw, supportedSourceChains],
-  );
-
-  const targetTokens = useMemo(
-    () => requiredTokens.filter((t) => !t.skipIfBalance),
-    [requiredTokens],
-  );
-
-  const { tokens: tokensList, pending } = useTokens({
-    balanceChainIds: selectedSourceChainIds,
-    tokensToExclude: [],
-  });
-
-  const isTokenSupported = useCallback(
-    (token: BridgeToken) => {
-      const isSelected =
-        payToken?.address.toLowerCase() === token.address.toLowerCase() &&
-        payToken?.chainId === token.chainId;
-
-      if (isSelected) {
-        return true;
-      }
-
-      const isRequiredToken = targetTokens.some(
-        (t) =>
-          t.address.toLowerCase() === token.address.toLowerCase() &&
-          transactionChainId === token.chainId,
-      );
-
-      if (isRequiredToken) {
-        return true;
-      }
-
-      const isTokenBalanceSufficient =
-        (token?.tokenFiatAmount ?? 0) >= (minimumFiatBalance ?? 0);
-
-      if (!isTokenBalanceSufficient) {
-        return false;
-      }
-
-      const nativeToken = tokensList.find(
-        (t) =>
-          t.address === NATIVE_TOKEN_ADDRESS && t.chainId === token.chainId,
-      );
-
-      const hasNativeBalance = (nativeToken?.tokenFiatAmount ?? 0) > 0;
-
-      return hasNativeBalance;
-    },
     [
-      minimumFiatBalance,
-      payToken,
-      targetTokens,
-      tokensList,
-      transactionChainId,
+      availableChainIds,
+      selectedSourceChainIds,
+      sortedSourceNetworksRaw,
+      supportedChains,
     ],
   );
 
-  const filteredTokensList = useMemo(
-    () => tokensList.filter(isTokenSupported),
-    [isTokenSupported, tokensList],
+  const chainIdsInCount = useMemo(
+    () => networksWithIcon.map((n) => n.chainId),
+    [networksWithIcon],
   );
 
   const handleTokenSelect = useCallback(
@@ -158,35 +110,19 @@ export function PayWithModal() {
     navigation.navigate(Routes.CONFIRMATION_PAY_WITH_NETWORK_MODAL);
   }, [navigation]);
 
-  const networks = useMemo(
-    () =>
-      sortedSourceNetworks.filter(
-        (chain) =>
-          selectedSourceChainIds.includes(chain.chainId) &&
-          chain.totalFiatValue > 0,
-      ),
-    [selectedSourceChainIds, sortedSourceNetworks],
-  );
-
-  const networkChainIds = useMemo(
-    () => networks.map((n) => n.chainId),
-    [networks],
-  );
-
   return (
     <BridgeTokenSelectorBase
       networksBar={
         <BridgeSourceNetworksBar
-          networksToShow={networks}
+          networksToShow={networksWithIcon}
           networkConfigurations={allNetworkConfigurations}
-          selectedSourceChainIds={networkChainIds as Hex[]}
-          enabledSourceChains={supportedSourceChains}
+          selectedSourceChainIds={chainIdsInCount as Hex[]}
+          enabledSourceChains={supportedChains}
           onPress={handleNetworkPress}
         />
       }
       renderTokenItem={renderItem}
-      tokensList={filteredTokensList}
-      pending={pending}
+      tokensList={availableTokens}
       title={strings('pay_with_modal.title')}
     />
   );

--- a/app/components/Views/confirmations/components/modals/pay-with-network-modal/pay-with-network-modal.test.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-network-modal/pay-with-network-modal.test.tsx
@@ -5,8 +5,11 @@ import Routes from '../../../../../../constants/navigation/Routes';
 import { fireEvent, waitFor } from '@testing-library/react-native';
 // eslint-disable-next-line import/no-namespace
 import * as bridgeReducer from '../../../../../../core/redux/slices/bridge';
+import { useTransactionPayAvailableTokens } from '../../../hooks/pay/useTransactionPayAvailableTokens';
 
 const mockGoBack = jest.fn();
+
+jest.mock('../../../hooks/pay/useTransactionPayAvailableTokens');
 
 jest.mock(
   '../../../../../../core/redux/slices/bridge/utils/hasMinimumRequiredVersion',
@@ -35,8 +38,17 @@ function render() {
 }
 
 describe('PayWithNetworkModal', () => {
+  const useTransactionPayAvailableTokensMock = jest.mocked(
+    useTransactionPayAvailableTokens,
+  );
+
   beforeEach(() => {
     jest.clearAllMocks();
+
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableChainIds: ['0x1', '0xa'],
+      availableTokens: [],
+    });
   });
 
   it('renders networks', async () => {

--- a/app/components/Views/confirmations/components/modals/pay-with-network-modal/pay-with-network-modal.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-network-modal/pay-with-network-modal.tsx
@@ -4,10 +4,12 @@ import { useNavigation } from '@react-navigation/native';
 import { useDispatch } from 'react-redux';
 import { setSelectedSourceChainIds } from '../../../../../../core/redux/slices/bridge';
 import { Hex } from '@metamask/utils';
+import { useTransactionPayAvailableTokens } from '../../../hooks/pay/useTransactionPayAvailableTokens';
 
 export function PayWithNetworkModal() {
   const dispatch = useDispatch();
   const navigation = useNavigation();
+  const { availableChainIds } = useTransactionPayAvailableTokens();
 
   const handleApply = useCallback(
     (selectedChainIds: Hex[]) => {
@@ -19,9 +21,8 @@ export function PayWithNetworkModal() {
 
   return (
     <BridgeSourceNetworkSelector
+      chainIds={availableChainIds}
       onApply={handleApply}
-      isBalanceOnly
-      isEvmOnly
     />
   );
 }

--- a/app/components/Views/confirmations/components/modals/pay-with-network-modal/pay-with-network-modal.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-network-modal/pay-with-network-modal.tsx
@@ -1,15 +1,21 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { BridgeSourceNetworkSelector } from '../../../../../UI/Bridge/components/BridgeSourceNetworkSelector';
 import { useNavigation } from '@react-navigation/native';
 import { useDispatch } from 'react-redux';
 import { setSelectedSourceChainIds } from '../../../../../../core/redux/slices/bridge';
 import { Hex } from '@metamask/utils';
 import { useTransactionPayAvailableTokens } from '../../../hooks/pay/useTransactionPayAvailableTokens';
+import { isSolanaChainId } from '@metamask/bridge-controller';
 
 export function PayWithNetworkModal() {
   const dispatch = useDispatch();
   const navigation = useNavigation();
   const { availableChainIds } = useTransactionPayAvailableTokens();
+
+  const chainIds = useMemo(
+    () => availableChainIds.filter((chainId) => !isSolanaChainId(chainId)),
+    [availableChainIds],
+  );
 
   const handleApply = useCallback(
     (selectedChainIds: Hex[]) => {
@@ -20,9 +26,6 @@ export function PayWithNetworkModal() {
   );
 
   return (
-    <BridgeSourceNetworkSelector
-      chainIds={availableChainIds}
-      onApply={handleApply}
-    />
+    <BridgeSourceNetworkSelector chainIds={chainIds} onApply={handleApply} />
   );
 }

--- a/app/components/Views/confirmations/components/modals/pay-with-network-modal/pay-with-network-modal.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-network-modal/pay-with-network-modal.tsx
@@ -17,5 +17,11 @@ export function PayWithNetworkModal() {
     [dispatch, navigation],
   );
 
-  return <BridgeSourceNetworkSelector onApply={handleApply} isEvmOnly />;
+  return (
+    <BridgeSourceNetworkSelector
+      onApply={handleApply}
+      isBalanceOnly
+      isEvmOnly
+    />
+  );
 }

--- a/app/components/Views/confirmations/constants/perps.ts
+++ b/app/components/Views/confirmations/constants/perps.ts
@@ -1,1 +1,6 @@
+import { Hex } from '@metamask/utils';
+
 export const PERPS_CURRENCY = 'usd';
+export const PERPS_MINIMUM_DEPOSIT = 10;
+export const ARBITRUM_USDC_ADDRESS =
+  '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' as Hex;

--- a/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositAlerts.ts
+++ b/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositAlerts.ts
@@ -2,8 +2,8 @@ import { useMemo } from 'react';
 import { usePerpsDepositMinimumAlert } from '../../../hooks/alerts/usePerpsDepositMinimumAlert';
 import { Alert } from '../../../types/alerts';
 import { useInsufficientPayTokenBalanceAlert } from '../../../hooks/alerts/useInsufficientPayTokenBalanceAlert';
-import { ARBITRUM_USDC_ADDRESS } from './usePerpsDepositInit';
 import { usePerpsHardwareAccountAlert } from '../../../hooks/alerts/usePerpsHardwareAccountAlert';
+import { ARBITRUM_USDC_ADDRESS } from '../../../constants/perps';
 
 export function usePerpsDepositAlerts({
   pendingTokenAmount,

--- a/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositInit.test.ts
+++ b/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositInit.test.ts
@@ -2,11 +2,9 @@ import { Token } from '@metamask/assets-controllers';
 import Engine from '../../../../../../core/Engine';
 import { selectTokensByChainIdAndAddress } from '../../../../../../selectors/tokensController';
 import { renderHookWithProvider } from '../../../../../../util/test/renderWithProvider';
-import {
-  ARBITRUM_USDC_ADDRESS,
-  usePerpsDepositInit,
-} from './usePerpsDepositInit';
+import { usePerpsDepositInit } from './usePerpsDepositInit';
 import { act } from '@testing-library/react-native';
+import { ARBITRUM_USDC_ADDRESS } from '../../../constants/perps';
 
 const NETWORK_CLIENT_ID = 'mockNetworkClientId';
 

--- a/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositInit.ts
+++ b/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositInit.ts
@@ -2,13 +2,8 @@ import Engine from '../../../../../../core/Engine';
 import { useSelector } from 'react-redux';
 import { selectTokensByChainIdAndAddress } from '../../../../../../selectors/tokensController';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
-import { HYPERLIQUID_ASSET_CONFIGS } from '../../../../../UI/Perps/constants/hyperLiquidConfig';
-import { Hex, parseCaipAssetId } from '@metamask/utils';
 import { useAsyncResult } from '../../../../../hooks/useAsyncResult';
-
-export const ARBITRUM_USDC_ADDRESS = parseCaipAssetId(
-  HYPERLIQUID_ASSET_CONFIGS.USDC.mainnet,
-).assetReference.toLowerCase() as Hex;
+import { ARBITRUM_USDC_ADDRESS } from '../../../constants/perps';
 
 const USDC_SYMBOL = 'USDC';
 const USDC_DECIMALS = 6;
@@ -21,7 +16,8 @@ export function usePerpsDepositInit() {
   );
 
   const hasToken = Object.values(tokens).some(
-    (token) => token.address.toLowerCase() === ARBITRUM_USDC_ADDRESS,
+    (token) =>
+      token.address.toLowerCase() === ARBITRUM_USDC_ADDRESS.toLowerCase(),
   );
 
   const { error } = useAsyncResult(async () => {

--- a/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositView.ts
+++ b/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositView.ts
@@ -12,6 +12,10 @@ import { BigNumber } from 'bignumber.js';
 import { usePerpsDepositInit } from './usePerpsDepositInit';
 import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
 import { useTransactionPayTokenAmounts } from '../../../hooks/pay/useTransactionPayTokenAmounts';
+import {
+  ARBITRUM_USDC_ADDRESS,
+  PERPS_MINIMUM_DEPOSIT,
+} from '../../../constants/perps';
 
 export function usePerpsDepositView({
   isKeyboardVisible,
@@ -43,8 +47,8 @@ export function usePerpsDepositView({
   useAutomaticTransactionPayToken({
     balanceOverrides: [
       {
-        address: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' as const,
-        balance: 10,
+        address: ARBITRUM_USDC_ADDRESS,
+        balance: PERPS_MINIMUM_DEPOSIT,
         chainId: CHAIN_IDS.ARBITRUM,
       },
     ],

--- a/app/components/Views/confirmations/hooks/alerts/usePerpsDepositMinimumAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/usePerpsDepositMinimumAlert.ts
@@ -7,8 +7,7 @@ import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
 import { strings } from '../../../../../../locales/i18n';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { TransactionType } from '@metamask/transaction-controller';
-
-export const MINIMUM_DEPOSIT_USD = 10;
+import { PERPS_MINIMUM_DEPOSIT } from '../../constants/perps';
 
 export function usePerpsDepositMinimumAlert({
   pendingTokenAmount,
@@ -20,7 +19,7 @@ export function usePerpsDepositMinimumAlert({
 
   const underMinimum =
     new BigNumber(pendingTokenAmount ?? amountUnformatted ?? '0').isLessThan(
-      MINIMUM_DEPOSIT_USD,
+      PERPS_MINIMUM_DEPOSIT,
     ) && type === TransactionType.perpsDeposit;
 
   return useMemo(() => {

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.test.ts
@@ -47,10 +47,7 @@ const NATIVE_TOKEN_1_MOCK = {
   address: NATIVE_TOKEN_ADDRESS,
 } as BridgeToken;
 
-function runHook({
-  chainIds,
-  type,
-}: { chainIds?: Hex[]; type?: TransactionType } = {}) {
+function runHook({ type }: { type?: TransactionType } = {}) {
   const state = merge(
     {},
     simpleSendTransactionControllerMock,
@@ -64,12 +61,9 @@ function runHook({
     ).transactions[0].type = type;
   }
 
-  return renderHookWithProvider(
-    () => useTransactionPayAvailableTokens({ chainIds }),
-    {
-      state,
-    },
-  );
+  return renderHookWithProvider(() => useTransactionPayAvailableTokens(), {
+    state,
+  });
 }
 
 describe('useTransactionPayAvailableTokens', () => {
@@ -141,22 +135,6 @@ describe('useTransactionPayAvailableTokens', () => {
     const { result } = runHook();
 
     expect(result.current.availableTokens).toStrictEqual([]);
-  });
-
-  it('does not return token if chain IDs provided and do not match', () => {
-    useTokensWithBalanceMock.mockReturnValue([
-      TOKEN_1_MOCK,
-      { ...TOKEN_2_MOCK, chainId: CHAIN_ID_2_MOCK },
-      NATIVE_TOKEN_1_MOCK,
-      { ...NATIVE_TOKEN_1_MOCK, chainId: CHAIN_ID_2_MOCK },
-    ]);
-
-    const { result } = runHook({ chainIds: [CHAIN_ID_2_MOCK] });
-
-    expect(result.current.availableTokens).toStrictEqual([
-      { ...TOKEN_2_MOCK, chainId: CHAIN_ID_2_MOCK },
-      { ...NATIVE_TOKEN_1_MOCK, chainId: CHAIN_ID_2_MOCK },
-    ]);
   });
 
   it('returns required token even if no fiat or native balance', () => {

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.test.ts
@@ -1,0 +1,189 @@
+import { merge, noop } from 'lodash';
+import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
+import { useTokensWithBalance } from '../../../../UI/Bridge/hooks/useTokensWithBalance';
+import { BridgeToken } from '../../../../UI/Bridge/types';
+import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
+import { useTransactionPayToken } from './useTransactionPayToken';
+import {
+  TransactionToken,
+  useTransactionRequiredTokens,
+} from './useTransactionRequiredTokens';
+import { selectEnabledSourceChains } from '../../../../../core/redux/slices/bridge';
+import { simpleSendTransactionControllerMock } from '../../__mocks__/controllers/transaction-controller-mock';
+import { transactionApprovalControllerMock } from '../../__mocks__/controllers/approval-controller-mock';
+import { Hex } from '@metamask/utils';
+import { NATIVE_TOKEN_ADDRESS } from '../../constants/tokens';
+import {
+  TransactionControllerState,
+  TransactionType,
+} from '@metamask/transaction-controller';
+
+jest.mock('../../../../UI/Bridge/hooks/useTokensWithBalance');
+jest.mock('./useTransactionPayToken');
+jest.mock('./useTransactionRequiredTokens');
+
+jest.mock('../../../../../core/redux/slices/bridge', () => ({
+  ...jest.requireActual('../../../../../core/redux/slices/bridge'),
+  selectEnabledSourceChains: jest.fn(),
+}));
+
+const CHAIN_ID_MOCK = '0x1' as Hex;
+
+const TOKEN_1_MOCK = {
+  address: '0xToken1',
+  chainId: CHAIN_ID_MOCK,
+  tokenFiatAmount: 1,
+} as BridgeToken;
+
+const TOKEN_2_MOCK = {
+  address: '0xToken2',
+  chainId: CHAIN_ID_MOCK,
+  tokenFiatAmount: 1,
+} as BridgeToken;
+
+const NATIVE_TOKEN_1_MOCK = {
+  ...TOKEN_1_MOCK,
+  address: NATIVE_TOKEN_ADDRESS,
+} as BridgeToken;
+
+function runHook({ type }: { type?: TransactionType } = {}) {
+  const state = merge(
+    {},
+    simpleSendTransactionControllerMock,
+    transactionApprovalControllerMock,
+  );
+
+  if (type) {
+    (
+      state.engine.backgroundState
+        .TransactionController as TransactionControllerState
+    ).transactions[0].type = type;
+  }
+
+  return renderHookWithProvider(useTransactionPayAvailableTokens, {
+    state,
+  });
+}
+
+describe('useTransactionPayAvailableTokens', () => {
+  const useTokensWithBalanceMock = jest.mocked(useTokensWithBalance);
+  const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
+  const selectEnabledSourceChainsMock = jest.mocked(selectEnabledSourceChains);
+
+  const useTransactionRequiredTokensMock = jest.mocked(
+    useTransactionRequiredTokens,
+  );
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    useTransactionRequiredTokensMock.mockReturnValue([]);
+    selectEnabledSourceChainsMock.mockReturnValue([]);
+
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: undefined,
+      setPayToken: noop,
+    });
+  });
+
+  it('returns tokens if has fiat and native balance', () => {
+    useTokensWithBalanceMock.mockReturnValue([
+      TOKEN_1_MOCK,
+      TOKEN_2_MOCK,
+      NATIVE_TOKEN_1_MOCK,
+    ]);
+
+    const { result } = runHook();
+
+    expect(result.current.availableTokens).toStrictEqual([
+      TOKEN_1_MOCK,
+      TOKEN_2_MOCK,
+      NATIVE_TOKEN_1_MOCK,
+    ]);
+  });
+
+  it('does not return token if no fiat', () => {
+    useTokensWithBalanceMock.mockReturnValue([
+      { ...TOKEN_1_MOCK, tokenFiatAmount: 0 },
+      TOKEN_2_MOCK,
+      NATIVE_TOKEN_1_MOCK,
+    ]);
+
+    const { result } = runHook();
+
+    expect(result.current.availableTokens).toStrictEqual([
+      TOKEN_2_MOCK,
+      NATIVE_TOKEN_1_MOCK,
+    ]);
+  });
+
+  it('does not return token if perps deposit and insufficient fiat', () => {
+    useTokensWithBalanceMock.mockReturnValue([
+      { ...TOKEN_1_MOCK, tokenFiatAmount: 9.99 },
+      NATIVE_TOKEN_1_MOCK,
+    ]);
+
+    const { result } = runHook({ type: TransactionType.perpsDeposit });
+
+    expect(result.current.availableTokens).toStrictEqual([]);
+  });
+
+  it('does not return token if no native', () => {
+    useTokensWithBalanceMock.mockReturnValue([TOKEN_1_MOCK, TOKEN_2_MOCK]);
+
+    const { result } = runHook();
+
+    expect(result.current.availableTokens).toStrictEqual([]);
+  });
+
+  it('returns required token even if no fiat or native balance', () => {
+    useTransactionRequiredTokensMock.mockReturnValue([
+      TOKEN_1_MOCK as unknown as TransactionToken,
+    ]);
+
+    useTokensWithBalanceMock.mockReturnValue([
+      { ...TOKEN_1_MOCK, tokenFiatAmount: 0 },
+      TOKEN_2_MOCK,
+    ]);
+
+    const { result } = runHook();
+
+    expect(result.current.availableTokens).toStrictEqual([
+      { ...TOKEN_1_MOCK, tokenFiatAmount: 0 },
+    ]);
+  });
+
+  it('returns selected token even if no fiat or native balance', () => {
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: TOKEN_1_MOCK as never,
+      setPayToken: noop,
+    });
+
+    useTokensWithBalanceMock.mockReturnValue([
+      { ...TOKEN_1_MOCK, tokenFiatAmount: 0 },
+      TOKEN_2_MOCK,
+    ]);
+
+    const { result } = runHook();
+
+    expect(result.current.availableTokens).toStrictEqual([
+      { ...TOKEN_1_MOCK, tokenFiatAmount: 0 },
+    ]);
+  });
+
+  it('returns available chain IDs', () => {
+    useTokensWithBalanceMock.mockReturnValue([
+      TOKEN_1_MOCK,
+      { ...TOKEN_2_MOCK, chainId: '0x2' as Hex },
+      NATIVE_TOKEN_1_MOCK,
+      { ...NATIVE_TOKEN_1_MOCK, chainId: '0x2' as Hex },
+    ]);
+
+    const { result } = runHook();
+
+    expect(result.current.availableChainIds).toStrictEqual([
+      CHAIN_ID_MOCK,
+      '0x2',
+    ]);
+  });
+});

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.ts
@@ -12,9 +12,7 @@ import { TransactionType } from '@metamask/transaction-controller';
 import { PERPS_MINIMUM_DEPOSIT } from '../../constants/perps';
 import { Hex } from '@metamask/utils';
 
-export function useTransactionPayAvailableTokens({
-  chainIds: chainIdsProp,
-}: { chainIds?: Hex[] } = {}) {
+export function useTransactionPayAvailableTokens() {
   const supportedChains = useSelector(selectEnabledSourceChains);
   const { payToken } = useTransactionPayToken();
   const requiredTokens = useTransactionRequiredTokens();
@@ -47,10 +45,6 @@ export function useTransactionPayAvailableTokens({
         return true;
       }
 
-      if (chainIdsProp && !chainIdsProp.includes(token.chainId as Hex)) {
-        return false;
-      }
-
       const isRequiredToken = targetTokens.some(
         (t) =>
           t.address.toLowerCase() === token.address.toLowerCase() &&
@@ -77,14 +71,7 @@ export function useTransactionPayAvailableTokens({
 
       return hasNativeBalance;
     },
-    [
-      allTokens,
-      chainIdsProp,
-      minimumFiat,
-      payToken,
-      targetTokens,
-      transactionChainId,
-    ],
+    [allTokens, minimumFiat, payToken, targetTokens, transactionChainId],
   );
 
   const availableTokens = useMemo(

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.ts
@@ -55,8 +55,11 @@ export function useTransactionPayAvailableTokens() {
         return true;
       }
 
-      const isTokenBalanceSufficient =
-        (token?.tokenFiatAmount ?? 0) > (minimumFiat ?? 0);
+      const fiatAmount = token.tokenFiatAmount ?? 0;
+
+      const isTokenBalanceSufficient = minimumFiat
+        ? fiatAmount >= minimumFiat
+        : fiatAmount > 0;
 
       if (!isTokenBalanceSufficient) {
         return false;

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.ts
@@ -1,0 +1,91 @@
+import { useCallback, useMemo } from 'react';
+import { useTokensWithBalance } from '../../../../UI/Bridge/hooks/useTokensWithBalance';
+import { BridgeToken } from '../../../../UI/Bridge/types';
+import { selectEnabledSourceChains } from '../../../../../core/redux/slices/bridge';
+import { useSelector } from 'react-redux';
+import { useTransactionPayToken } from './useTransactionPayToken';
+import { useTransactionRequiredTokens } from './useTransactionRequiredTokens';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { NATIVE_TOKEN_ADDRESS } from '../../constants/tokens';
+import { uniq } from 'lodash';
+import { TransactionType } from '@metamask/transaction-controller';
+import { PERPS_MINIMUM_DEPOSIT } from '../../constants/perps';
+import { Hex } from '@metamask/utils';
+
+export function useTransactionPayAvailableTokens() {
+  const supportedChains = useSelector(selectEnabledSourceChains);
+  const { payToken } = useTransactionPayToken();
+  const requiredTokens = useTransactionRequiredTokens();
+
+  const { chainId: transactionChainId, type } =
+    useTransactionMetadataRequest() ?? {};
+
+  const chainIds = useMemo(
+    () => supportedChains.map((c) => c.chainId),
+    [supportedChains],
+  );
+
+  const allTokens = useTokensWithBalance({ chainIds });
+
+  const targetTokens = useMemo(
+    () => requiredTokens.filter((t) => !t.skipIfBalance),
+    [requiredTokens],
+  );
+
+  const minimumFiat =
+    type === TransactionType.perpsDeposit ? PERPS_MINIMUM_DEPOSIT : 0;
+
+  const isTokenAvailable = useCallback(
+    (token: BridgeToken) => {
+      const isSelected =
+        payToken?.address.toLowerCase() === token.address.toLowerCase() &&
+        payToken?.chainId === token.chainId;
+
+      if (isSelected) {
+        return true;
+      }
+
+      const isRequiredToken = targetTokens.some(
+        (t) =>
+          t.address.toLowerCase() === token.address.toLowerCase() &&
+          transactionChainId === token.chainId,
+      );
+
+      if (isRequiredToken) {
+        return true;
+      }
+
+      const isTokenBalanceSufficient =
+        (token?.tokenFiatAmount ?? 0) > (minimumFiat ?? 0);
+
+      if (!isTokenBalanceSufficient) {
+        return false;
+      }
+
+      const nativeToken = allTokens.find(
+        (t) =>
+          t.address === NATIVE_TOKEN_ADDRESS && t.chainId === token.chainId,
+      );
+
+      const hasNativeBalance = (nativeToken?.tokenFiatAmount ?? 0) > 0;
+
+      return hasNativeBalance;
+    },
+    [allTokens, minimumFiat, payToken, targetTokens, transactionChainId],
+  );
+
+  const availableTokens = useMemo(
+    () => allTokens.filter(isTokenAvailable),
+    [allTokens, isTokenAvailable],
+  );
+
+  const availableChainIds = useMemo(
+    () => uniq(availableTokens.map((t) => t.chainId as Hex)),
+    [availableTokens],
+  );
+
+  return {
+    availableChainIds,
+    availableTokens,
+  };
+}

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.ts
@@ -12,7 +12,9 @@ import { TransactionType } from '@metamask/transaction-controller';
 import { PERPS_MINIMUM_DEPOSIT } from '../../constants/perps';
 import { Hex } from '@metamask/utils';
 
-export function useTransactionPayAvailableTokens() {
+export function useTransactionPayAvailableTokens({
+  chainIds: chainIdsProp,
+}: { chainIds?: Hex[] } = {}) {
   const supportedChains = useSelector(selectEnabledSourceChains);
   const { payToken } = useTransactionPayToken();
   const requiredTokens = useTransactionRequiredTokens();
@@ -45,6 +47,10 @@ export function useTransactionPayAvailableTokens() {
         return true;
       }
 
+      if (chainIdsProp && !chainIdsProp.includes(token.chainId as Hex)) {
+        return false;
+      }
+
       const isRequiredToken = targetTokens.some(
         (t) =>
           t.address.toLowerCase() === token.address.toLowerCase() &&
@@ -71,7 +77,14 @@ export function useTransactionPayAvailableTokens() {
 
       return hasNativeBalance;
     },
-    [allTokens, minimumFiat, payToken, targetTokens, transactionChainId],
+    [
+      allTokens,
+      chainIdsProp,
+      minimumFiat,
+      payToken,
+      targetTokens,
+      transactionChainId,
+    ],
   );
 
   const availableTokens = useMemo(

--- a/app/components/Views/confirmations/hooks/tokens/useTokenFiatRates.test.ts
+++ b/app/components/Views/confirmations/hooks/tokens/useTokenFiatRates.test.ts
@@ -1,8 +1,8 @@
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { backgroundState } from '../../../../../util/test/initial-root-state';
 import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
-import { ARBITRUM_USDC_ADDRESS } from '../../external/perps-temp/hooks/usePerpsDepositInit';
 import { TokenFiatRateRequest, useTokenFiatRates } from './useTokenFiatRates';
+import { ARBITRUM_USDC_ADDRESS } from '../../constants/perps';
 
 jest.mock('../../../../../util/address', () => ({
   toChecksumAddress: jest.fn((address) => address),

--- a/app/components/Views/confirmations/hooks/tokens/useTokenFiatRates.ts
+++ b/app/components/Views/confirmations/hooks/tokens/useTokenFiatRates.ts
@@ -9,8 +9,8 @@ import { selectNetworkConfigurations } from '../../../../../selectors/networkCon
 import { useMemo } from 'react';
 import { useDeepMemo } from '../useDeepMemo';
 import { toChecksumAddress } from '../../../../../util/address';
-import { ARBITRUM_USDC_ADDRESS } from '../../external/perps-temp/hooks/usePerpsDepositInit';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
+import { ARBITRUM_USDC_ADDRESS } from '../../constants/perps';
 
 export interface TokenFiatRateRequest {
   address: Hex;


### PR DESCRIPTION
## **Description**

Hide networks in MetaMask Pay token picker if no tokens with sufficient balance.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#5795](https://github.com/MetaMask/MetaMask-planning/issues/5795) #19822 [#19814](https://github.com/MetaMask/metamask-mobile/issues/19814)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
