### PR TITLE
chore: improve Sentry rewriteBreadcrumb performance

### DIFF
--- a/app/components/Views/MultichainAccounts/AccountGroupDetails/AccountGroupDetails.styles.ts
+++ b/app/components/Views/MultichainAccounts/AccountGroupDetails/AccountGroupDetails.styles.ts
@@ -88,6 +88,11 @@ const styleSheet = (params: { theme: Theme }) => {
     text: {
       color: colors.text.alternative,
     },
+
+    groupNameText: {
+      color: colors.text.alternative,
+      maxWidth: 150,
+    },
   });
 };
 

--- a/app/components/Views/MultichainAccounts/AccountGroupDetails/AccountGroupDetails.tsx
+++ b/app/components/Views/MultichainAccounts/AccountGroupDetails/AccountGroupDetails.tsx
@@ -190,7 +190,12 @@ export const AccountGroupDetails = (props: AccountGroupDetailsProps) => {
             alignItems={AlignItems.center}
             gap={8}
           >
-            <Text style={styles.text} variant={TextVariant.BodyMDMedium}>
+            <Text
+              style={styles.groupNameText}
+              variant={TextVariant.BodyMDMedium}
+              numberOfLines={1}
+              ellipsizeMode="tail"
+            >
               {groupName}
             </Text>
             <Icon

--- a/app/selectors/permissions/index.js
+++ b/app/selectors/permissions/index.js
@@ -24,17 +24,23 @@ const getSubjects = (state) => state.subjects;
 /**
  * Get the authorized CAIP-25 scopes for the subject.
  * The returned value is an immutable value from the PermissionController state,
- * or undefined if no authorization exists.
+ * or an empty Caip25CaveatValue if no authorization exists.
  *
  * @param origin - The origin to match the subject state from.
- * @returns {Caip25CaveatValue | undefined} The current authorization or undefined if no authorization exists.
+ * @returns {Caip25CaveatValue} The current authorization or undefined if no authorization exists.
  */
 export const getAuthorizedScopes = (origin) =>
   createSelector(getSubjects, (subjects) => {
     const subject = subjects[origin];
 
+    const emptyPermission = {
+      requiredScopes: {},
+      optionalScopes: {},
+      sessionProperties: {},
+    };
+
     if (!subject) {
-      return undefined;
+      return emptyPermission;
     }
 
     const caveats =
@@ -42,5 +48,5 @@ export const getAuthorizedScopes = (origin) =>
 
     const caveat = caveats.find(({ type }) => type === Caip25CaveatType);
 
-    return caveat?.value;
+    return caveat?.value ?? emptyPermission;
   });

--- a/app/selectors/permissions/index.test.js
+++ b/app/selectors/permissions/index.test.js
@@ -93,16 +93,20 @@ describe('PermissionController selectors', () => {
       expect(selected2).toBe(getAuthorizedScopes('foo.bar')(state2));
     });
 
-    it('returns undefined for empty subjects', () => {
+    it('returns an empty Caip25CaveatValue for empty subjects', () => {
       const state = {
         subjects: {},
       };
 
       const selected = getAuthorizedScopes('foo.bar')(state);
-      expect(selected).toBeUndefined();
+      expect(selected).toStrictEqual({
+        requiredScopes: {},
+        optionalScopes: {},
+        sessionProperties: {},
+      });
     });
 
-    it('returns undefined for subject without CAIP-25 permissions', () => {
+    it('returns an empty Caip25CaveatValue for subject without CAIP-25 permissions', () => {
       const state = {
         subjects: {
           'foo.bar': {
@@ -117,10 +121,14 @@ describe('PermissionController selectors', () => {
       };
 
       const selected = getAuthorizedScopes('foo.bar')(state);
-      expect(selected).toBeUndefined();
+      expect(selected).toStrictEqual({
+        requiredScopes: {},
+        optionalScopes: {},
+        sessionProperties: {},
+      });
     });
 
-    it('returns undefined for subject with CAIP-25 permissions but wrong caveat type', () => {
+    it('returns an empty Caip25CaveatValue for subject with CAIP-25 permissions but wrong caveat type', () => {
       const state = {
         subjects: {
           'foo.bar': {
@@ -142,7 +150,11 @@ describe('PermissionController selectors', () => {
       };
 
       const selected = getAuthorizedScopes('foo.bar')(state);
-      expect(selected).toBeUndefined();
+      expect(selected).toStrictEqual({
+        requiredScopes: {},
+        optionalScopes: {},
+        sessionProperties: {},
+      });
     });
   });
 });

--- a/app/util/sentry/utils.js
+++ b/app/util/sentry/utils.js
@@ -274,7 +274,12 @@ export const captureSentryFeedback = ({ sentryId, comments }) => {
 };
 
 function getProtocolFromURL(url) {
-  return new URL(url).protocol;
+  // Don't use URL api because it's slow in React Native
+  const colonIndex = url.indexOf(':');
+  if (colonIndex === -1) {
+    throw new Error('Invalid URL');
+  }
+  return url.substring(0, colonIndex + 1);
 }
 
 export function rewriteBreadcrumb(breadcrumb) {

--- a/e2e/selectors/wallet/AccountListBottomSheet.selectors.ts
+++ b/e2e/selectors/wallet/AccountListBottomSheet.selectors.ts
@@ -11,6 +11,6 @@ export const AccountListBottomSheetSelectorsIDs = {
 export const AccountListBottomSheetSelectorsText = {
   ACCOUNTS_LIST_TITLE: enContent.accounts.accounts_title,
   REMOVE_IMPORTED_ACCOUNT: enContent.accounts.yes_remove_it,
-  ACCOUNT_TYPE_LABEL_TEXT: enContent.accounts.imported,
+  ACCOUNT_TYPE_LABEL_TEXT: 'Imported accounts',
   ADD_ETHEREUM_ACCOUNT: enContent.account_actions.add_new_account,
 };

--- a/e2e/specs/accounts/imported-account-remove-and-import.spec.ts
+++ b/e2e/specs/accounts/imported-account-remove-and-import.spec.ts
@@ -6,14 +6,17 @@ import { withFixtures } from '../../framework/fixtures/FixtureHelper';
 import { loginToApp } from '../../viewHelper';
 import WalletView from '../../pages/wallet/WalletView';
 import AccountListBottomSheet from '../../pages/wallet/AccountListBottomSheet';
+import AccountActionsBottomSheet from '../../pages/wallet/AccountActionsBottomSheet';
 import ImportAccountView from '../../pages/importAccount/ImportAccountView';
 import Assertions from '../../framework/Assertions';
 import AddAccountBottomSheet from '../../pages/wallet/AddAccountBottomSheet';
 import SuccessImportAccountView from '../../pages/importAccount/SuccessImportAccountView';
 import { AccountListBottomSheetSelectorsText } from '../../selectors/wallet/AccountListBottomSheet.selectors';
 import { Mockttp } from 'mockttp';
-import { remoteFeatureMultichainAccountsAccountDetails } from '../../api-mocking/mock-responses/feature-flags-mocks';
+import { remoteFeatureMultichainAccountsAccountDetailsV2 } from '../../api-mocking/mock-responses/feature-flags-mocks';
 import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper';
+import AccountDetails from '../../pages/MultichainAccounts/AccountDetails';
+import DeleteAccount from '../../pages/MultichainAccounts/DeleteAccount';
 
 // This key is for testing private key import only
 // It should NEVER hold any eth or token
@@ -24,7 +27,7 @@ const ACCOUNT_INDEX = 1;
 const testSpecificMock = async (mockServer: Mockttp) => {
   await setupRemoteFeatureFlagsMock(
     mockServer,
-    remoteFeatureMultichainAccountsAccountDetails(false),
+    remoteFeatureMultichainAccountsAccountDetailsV2(true),
   );
 };
 
@@ -36,6 +39,7 @@ describe(
         {
           fixture: new FixtureBuilder()
             .withImportedAccountKeyringController()
+            .ensureMultichainIntroModalSuppressed()
             .build(),
           restartDevice: true,
           testSpecificMock,
@@ -46,13 +50,15 @@ describe(
           await WalletView.tapIdenticon();
 
           // Remove the imported account
-          await AccountListBottomSheet.longPressAccountAtIndex(ACCOUNT_INDEX);
-          await AccountListBottomSheet.tapYesToRemoveImportedAccountAlertButton();
-          await Assertions.expectElementToNotBeVisible(
-            AccountListBottomSheet.accountTypeLabel,
+          await AccountListBottomSheet.tapAccountEllipsisButtonV2(
+            ACCOUNT_INDEX,
           );
+          await AccountActionsBottomSheet.tapAccountDetails();
+          await AccountDetails.tapDeleteAccountLink();
+          await DeleteAccount.tapDeleteAccount();
 
           // Import account again
+          await WalletView.tapIdenticon();
           await AccountListBottomSheet.tapAddAccountButton();
           await AddAccountBottomSheet.tapImportAccount();
           await Assertions.expectElementToBeVisible(

--- a/e2e/specs/multichain-accounts/common.ts
+++ b/e2e/specs/multichain-accounts/common.ts
@@ -47,6 +47,7 @@ export const withMultichainAccountDetailsEnabledFixtures = async (
     {
       fixture: new FixtureBuilder()
         .withImportedHdKeyringAndTwoDefaultAccountsOneImportedHdAccountOneQrAccountOneSimpleKeyPairAccount()
+        .ensureMultichainIntroModalSuppressed()
         .build(),
       restartDevice: true,
       testSpecificMock,


### PR DESCRIPTION
## **Description**

Sentry `rewriteBreadcrumbs` function took around ~600ms during login and that app freeze after login.  This simple change  improve performance to just ~20ms (30x faster). This solves big part of Sentry perf issues, but some smaller remains.

It was using `URL` api that is quite slow in React Native and app must use another polyfill for `URL` `react-native-url-polyfill` which is even slower than React Native default one. For simple getting of protocol from URL we can use string manipulation instead which is magnitudes faster.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

-

## **Screenshots/Recordings**


### **Before**

<img width="464" height="151" alt="Screenshot 2025-09-17 at 20 30 23" src="https://github.com/user-attachments/assets/73099e75-6fd1-4efc-bd75-0cd8206c0a01" />

### **After**

<img width="488" height="155" alt="Screenshot 2025-09-17 at 20 30 05" src="https://github.com/user-attachments/assets/1d19f64a-22ff-4a5a-a018-c59b44339927" />


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
