### PR TITLE
fix: cp-7.56.0 force USD currency in perps deposit

### DIFF
--- a/app/components/UI/SimulationDetails/FiatDisplay/useFiatFormatter.test.ts
+++ b/app/components/UI/SimulationDetails/FiatDisplay/useFiatFormatter.test.ts
@@ -69,4 +69,13 @@ describe('useFiatFormatter', () => {
     expect(formatFiat(new BigNumber(500.5))).toBe('500.5 storj');
     expect(formatFiat(new BigNumber(0))).toBe('0 storj');
   });
+
+  it('overrides currency if specified', () => {
+    const { result } = renderHook(() => useFiatFormatter({ currency: 'gbp' }));
+    const formatFiat = result.current;
+
+    expect(formatFiat(new BigNumber(1000))).toBe('£1,000');
+    expect(formatFiat(new BigNumber(500.5))).toBe('£500.50');
+    expect(formatFiat(new BigNumber(0))).toBe('£0');
+  });
 });

--- a/app/components/UI/SimulationDetails/FiatDisplay/useFiatFormatter.ts
+++ b/app/components/UI/SimulationDetails/FiatDisplay/useFiatFormatter.ts
@@ -18,8 +18,13 @@ type FiatFormatter = (fiatAmount: BigNumber) => string;
  *
  * @returns A function that takes a fiat amount as a number and returns a formatted string.
  */
-const useFiatFormatter = (): FiatFormatter => {
-  const fiatCurrency = useSelector(selectCurrentCurrency);
+const useFiatFormatter = ({
+  currency,
+}: {
+  currency?: string;
+} = {}): FiatFormatter => {
+  const currencyCurrency = useSelector(selectCurrentCurrency);
+  const fiatCurrency = currency ?? currencyCurrency;
 
   return (fiatAmount: BigNumber) => {
     const hasDecimals = !fiatAmount.isInteger();

--- a/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
@@ -132,7 +132,7 @@ describe('PayWithModal', () => {
 
     useTransactionPayAvailableTokensMock.mockReturnValue({
       availableChainIds: [CHAIN_ID_1_MOCK, CHAIN_ID_2_MOCK],
-      availableTokens: TOKENS_MOCK,
+      availableTokens: TOKENS_MOCK as never,
     });
 
     useTransactionPayTokenMock.mockReturnValue({

--- a/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositAlerts.ts
+++ b/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositAlerts.ts
@@ -16,7 +16,7 @@ export function usePerpsDepositAlerts({
 
   const insufficientTokenFundsAlert = useInsufficientPayTokenBalanceAlert({
     amountOverrides: {
-      [ARBITRUM_USDC_ADDRESS]: pendingTokenAmount ?? '0',
+      [ARBITRUM_USDC_ADDRESS.toLowerCase()]: pendingTokenAmount ?? '0',
     },
   });
 

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.test.ts
@@ -17,6 +17,7 @@ import {
   TransactionControllerState,
   TransactionType,
 } from '@metamask/transaction-controller';
+import { otherControllersMock } from '../../__mocks__/controllers/other-controllers-mock';
 
 jest.mock('../../../../UI/Bridge/hooks/useTokensWithBalance');
 jest.mock('./useTransactionPayToken');
@@ -32,15 +33,19 @@ const CHAIN_ID_2_MOCK = '0x2' as Hex;
 
 const TOKEN_1_MOCK = {
   address: '0xToken1',
+  balanceFiat: '$1',
+  balanceUsd: 1,
   chainId: CHAIN_ID_MOCK,
   tokenFiatAmount: 1,
-} as BridgeToken;
+} as BridgeToken & { balanceUsd: number };
 
 const TOKEN_2_MOCK = {
   address: '0xToken2',
+  balanceFiat: '$1',
+  balanceUsd: 1,
   chainId: CHAIN_ID_MOCK,
   tokenFiatAmount: 1,
-} as BridgeToken;
+} as BridgeToken & { balanceUsd: number };
 
 const NATIVE_TOKEN_1_MOCK = {
   ...TOKEN_1_MOCK,
@@ -52,6 +57,7 @@ function runHook({ type }: { type?: TransactionType } = {}) {
     {},
     simpleSendTransactionControllerMock,
     transactionApprovalControllerMock,
+    otherControllersMock,
   );
 
   if (type) {
@@ -137,7 +143,7 @@ describe('useTransactionPayAvailableTokens', () => {
     expect(result.current.availableTokens).toStrictEqual([]);
   });
 
-  it('returns required token even if no fiat or native balance', () => {
+  it('returns required token even if no usd or native balance', () => {
     useTransactionRequiredTokensMock.mockReturnValue([
       TOKEN_1_MOCK as unknown as TransactionToken,
     ]);
@@ -150,7 +156,7 @@ describe('useTransactionPayAvailableTokens', () => {
     const { result } = runHook();
 
     expect(result.current.availableTokens).toStrictEqual([
-      { ...TOKEN_1_MOCK, tokenFiatAmount: 0 },
+      { ...TOKEN_1_MOCK, balanceFiat: '$0', balanceUsd: 0, tokenFiatAmount: 0 },
     ]);
   });
 
@@ -168,7 +174,7 @@ describe('useTransactionPayAvailableTokens', () => {
     const { result } = runHook();
 
     expect(result.current.availableTokens).toStrictEqual([
-      { ...TOKEN_1_MOCK, tokenFiatAmount: 0 },
+      { ...TOKEN_1_MOCK, balanceFiat: '$0', balanceUsd: 0, tokenFiatAmount: 0 },
     ]);
   });
 

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.ts
@@ -11,11 +11,13 @@ import { uniq } from 'lodash';
 import { TransactionType } from '@metamask/transaction-controller';
 import { PERPS_MINIMUM_DEPOSIT } from '../../constants/perps';
 import { Hex } from '@metamask/utils';
+import { useTransactionPayFiat } from './useTransactionPayFiat';
 
 export function useTransactionPayAvailableTokens() {
   const supportedChains = useSelector(selectEnabledSourceChains);
   const { payToken } = useTransactionPayToken();
   const requiredTokens = useTransactionRequiredTokens();
+  const { convert: fiatConvert, fiatFormatter } = useTransactionPayFiat();
 
   const { chainId: transactionChainId, type } =
     useTransactionMetadataRequest() ?? {};
@@ -36,7 +38,7 @@ export function useTransactionPayAvailableTokens() {
     type === TransactionType.perpsDeposit ? PERPS_MINIMUM_DEPOSIT : 0;
 
   const isTokenAvailable = useCallback(
-    (token: BridgeToken) => {
+    (token: BridgeToken & { balanceUsd: number }) => {
       const isSelected =
         payToken?.address.toLowerCase() === token.address.toLowerCase() &&
         payToken?.chainId === token.chainId;
@@ -55,7 +57,7 @@ export function useTransactionPayAvailableTokens() {
         return true;
       }
 
-      const fiatAmount = token.tokenFiatAmount ?? 0;
+      const fiatAmount = token.balanceUsd ?? 0;
 
       const isTokenBalanceSufficient = minimumFiat
         ? fiatAmount >= minimumFiat
@@ -77,9 +79,23 @@ export function useTransactionPayAvailableTokens() {
     [allTokens, minimumFiat, payToken, targetTokens, transactionChainId],
   );
 
+  const updateFiatValues = useCallback(
+    (token: BridgeToken) => {
+      const balanceFiat = fiatFormatter(token.tokenFiatAmount ?? '0');
+      const balanceUsd = fiatConvert(token.tokenFiatAmount ?? '0');
+
+      return {
+        ...token,
+        balanceFiat,
+        balanceUsd,
+      };
+    },
+    [fiatConvert, fiatFormatter],
+  );
+
   const availableTokens = useMemo(
-    () => allTokens.filter(isTokenAvailable),
-    [allTokens, isTokenAvailable],
+    () => allTokens.map(updateFiatValues).filter(isTokenAvailable),
+    [allTokens, isTokenAvailable, updateFiatValues],
   );
 
   const availableChainIds = useMemo(

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.ts
@@ -17,7 +17,7 @@ export function useTransactionPayAvailableTokens() {
   const supportedChains = useSelector(selectEnabledSourceChains);
   const { payToken } = useTransactionPayToken();
   const requiredTokens = useTransactionRequiredTokens();
-  const { convert: fiatConvert, fiatFormatter } = useTransactionPayFiat();
+  const { convertFiat, formatFiat } = useTransactionPayFiat();
 
   const { chainId: transactionChainId, type } =
     useTransactionMetadataRequest() ?? {};
@@ -81,8 +81,8 @@ export function useTransactionPayAvailableTokens() {
 
   const updateFiatValues = useCallback(
     (token: BridgeToken) => {
-      const balanceFiat = fiatFormatter(token.tokenFiatAmount ?? '0');
-      const balanceUsd = fiatConvert(token.tokenFiatAmount ?? '0');
+      const balanceFiat = formatFiat(token.tokenFiatAmount ?? '0');
+      const balanceUsd = convertFiat(token.tokenFiatAmount ?? '0');
 
       return {
         ...token,
@@ -90,7 +90,7 @@ export function useTransactionPayAvailableTokens() {
         balanceUsd,
       };
     },
-    [fiatConvert, fiatFormatter],
+    [convertFiat, formatFiat],
   );
 
   const availableTokens = useMemo(

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayFiat.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayFiat.test.ts
@@ -1,0 +1,76 @@
+import { merge } from 'lodash';
+import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
+import { simpleSendTransactionControllerMock } from '../../__mocks__/controllers/transaction-controller-mock';
+import { transactionApprovalControllerMock } from '../../__mocks__/controllers/approval-controller-mock';
+import { useTransactionPayFiat } from './useTransactionPayFiat';
+import { otherControllersMock } from '../../__mocks__/controllers/other-controllers-mock';
+import { CurrencyRateState } from '@metamask/assets-controllers';
+import {
+  TransactionControllerState,
+  TransactionType,
+} from '@metamask/transaction-controller';
+
+function runHook({ type }: { type?: TransactionType } = {}) {
+  const state = merge(
+    {},
+    simpleSendTransactionControllerMock,
+    transactionApprovalControllerMock,
+    otherControllersMock,
+  );
+
+  (state.engine.backgroundState.CurrencyRateController as CurrencyRateState) = {
+    currentCurrency: 'gbp',
+    currencyRates: {
+      ETH: {
+        conversionDate: 1732887955.694,
+        conversionRate: 2,
+        usdConversionRate: 4,
+      },
+    },
+  };
+
+  if (type) {
+    (
+      state.engine.backgroundState
+        .TransactionController as TransactionControllerState
+    ).transactions[0].type = type;
+  }
+
+  return renderHookWithProvider(useTransactionPayFiat, {
+    state,
+  });
+}
+
+describe('useTransactionPayFiat', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('formatFiat', () => {
+    it('returns formatted fiat value', () => {
+      const { result } = runHook();
+
+      expect(result.current.formatFiat(1.23)).toBe('£1.23');
+    });
+
+    it('returns formatted fiat value after multiplier if perps deposit', () => {
+      const { result } = runHook({ type: TransactionType.perpsDeposit });
+
+      expect(result.current.formatFiat(1.23)).toBe('$2.46');
+    });
+  });
+
+  describe('convertFiat', () => {
+    it('returns same value', () => {
+      const { result } = runHook();
+
+      expect(result.current.convertFiat(1.23)).toBe(1.23);
+    });
+
+    it('returns multiplied value if perps deposit', () => {
+      const { result } = runHook({ type: TransactionType.perpsDeposit });
+
+      expect(result.current.convertFiat(1.23)).toBe(2.46);
+    });
+  });
+});

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayFiat.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayFiat.ts
@@ -30,20 +30,20 @@ export function useTransactionPayFiat() {
 
   const fiatFormatterOriginal = useFiatFormatter({ currency });
 
-  const fiatFormatter = useCallback(
+  const formatFiat = useCallback(
     (value: number | string | BigNumber) =>
       fiatFormatterOriginal(new BigNumber(value).multipliedBy(multiplier)),
     [fiatFormatterOriginal, multiplier],
   );
 
-  const convert = useCallback(
+  const convertFiat = useCallback(
     (value: number | string | BigNumber) =>
       new BigNumber(value).multipliedBy(multiplier).toNumber(),
     [multiplier],
   );
 
   return {
-    convert,
-    fiatFormatter,
+    convertFiat,
+    formatFiat,
   };
 }

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayFiat.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayFiat.ts
@@ -1,0 +1,49 @@
+import { useSelector } from 'react-redux';
+import {
+  selectConversionRateByChainId,
+  selectUSDConversionRateByChainId,
+} from '../../../../../selectors/currencyRateController';
+import { CHAIN_IDS, TransactionType } from '@metamask/transaction-controller';
+import { RootState } from '../../../../../reducers';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import useFiatFormatter from '../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
+import { PERPS_CURRENCY } from '../../constants/perps';
+import { useCallback } from 'react';
+import { BigNumber } from 'bignumber.js';
+
+export function useTransactionPayFiat() {
+  const { type } = useTransactionMetadataRequest() ?? {};
+
+  const fiatRate = useSelector((state: RootState) =>
+    selectConversionRateByChainId(state, CHAIN_IDS.MAINNET),
+  );
+
+  const usdRate = useSelector((state: RootState) =>
+    selectUSDConversionRateByChainId(state, CHAIN_IDS.MAINNET),
+  );
+
+  const usdMultiplier = usdRate && fiatRate ? usdRate / fiatRate : 1;
+  const multiplier = type === TransactionType.perpsDeposit ? usdMultiplier : 1;
+
+  const currency =
+    type === TransactionType.perpsDeposit ? PERPS_CURRENCY : undefined;
+
+  const fiatFormatterOriginal = useFiatFormatter({ currency });
+
+  const fiatFormatter = useCallback(
+    (value: number | string | BigNumber) =>
+      fiatFormatterOriginal(new BigNumber(value).multipliedBy(multiplier)),
+    [fiatFormatterOriginal, multiplier],
+  );
+
+  const convert = useCallback(
+    (value: number | string | BigNumber) =>
+      new BigNumber(value).multipliedBy(multiplier).toNumber(),
+    [multiplier],
+  );
+
+  return {
+    convert,
+    fiatFormatter,
+  };
+}

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
@@ -14,7 +14,7 @@ import { useTransactionPayFiat } from './useTransactionPayFiat';
 export function useTransactionPayToken() {
   const dispatch = useDispatch();
   const { id: transactionId } = useTransactionMetadataRequest() || {};
-  const { fiatFormatter } = useTransactionPayFiat();
+  const { formatFiat } = useTransactionPayFiat();
 
   const selectedPayToken = useSelector((state: RootState) =>
     selectTransactionPayToken(state, transactionId as string),
@@ -44,14 +44,14 @@ export function useTransactionPayToken() {
       .shiftedBy(payTokenRaw.decimals)
       .toFixed(0);
 
-    const balanceFiat = fiatFormatter(payTokenRaw?.tokenFiatAmount ?? '0');
+    const balanceFiat = formatFiat(payTokenRaw?.tokenFiatAmount ?? '0');
 
     return {
       ...payTokenRaw,
       balanceFiat,
       balanceRaw,
     };
-  }, [fiatFormatter, payTokenRaw]);
+  }, [formatFiat, payTokenRaw]);
 
   return {
     payToken,

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
@@ -9,10 +9,12 @@ import { useCallback, useMemo } from 'react';
 import { RootState } from '../../../../../reducers';
 import { useTokenWithBalance } from '../tokens/useTokenWithBalance';
 import { BigNumber } from 'bignumber.js';
+import { useTransactionPayFiat } from './useTransactionPayFiat';
 
 export function useTransactionPayToken() {
   const dispatch = useDispatch();
   const { id: transactionId } = useTransactionMetadataRequest() || {};
+  const { fiatFormatter } = useTransactionPayFiat();
 
   const selectedPayToken = useSelector((state: RootState) =>
     selectTransactionPayToken(state, transactionId as string),
@@ -42,11 +44,14 @@ export function useTransactionPayToken() {
       .shiftedBy(payTokenRaw.decimals)
       .toFixed(0);
 
+    const balanceFiat = fiatFormatter(payTokenRaw?.tokenFiatAmount ?? '0');
+
     return {
       ...payTokenRaw,
+      balanceFiat,
       balanceRaw,
     };
-  }, [payTokenRaw]);
+  }, [fiatFormatter, payTokenRaw]);
 
   return {
     payToken,

--- a/app/components/Views/confirmations/hooks/pay/useTransactionTotalFiat.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionTotalFiat.ts
@@ -38,7 +38,7 @@ export function useTransactionTotalFiat({
     selectTransactionBridgeQuotesById(state, transactionId),
   );
 
-  const { fiatFormatter } = useTransactionPayFiat();
+  const { formatFiat: fiatFormatter } = useTransactionPayFiat();
 
   const quotes: TransactionBridgeQuoteExtended[] = (quotesRaw ?? []).map(
     (quote) => {


### PR DESCRIPTION
## **Description**

Force USD fiat values in Perps Deposit, including token balances, totals, and transaction details.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#19881](https://github.com/MetaMask/metamask-mobile/issues/19881)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
