### PR TITLE
fix: cp-7.56.0 make performance e2e account for [skip-ci]

### DIFF
--- a/.github/workflows/run-performance-e2e-release.yml
+++ b/.github/workflows/run-performance-e2e-release.yml
@@ -1,0 +1,76 @@
+name: Performance E2E Tests for Release Builds
+on:
+  schedule:
+    - cron: '*/30 * * * *'  # Every 30 minutes to check for metamaskbot commits
+  workflow_dispatch:
+  push:
+    branches:
+      - 'release/*'
+
+jobs:
+  check-release-trigger:
+    name: Check if Release Performance Tests Should Run
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Check release trigger conditions
+        id: check
+        run: |
+          # Always run for manual dispatch or release branch pushes
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" || ("${{ github.event_name }}" == "push" && "${{ github.ref_name }}" =~ ^release/) ]]; then
+            echo "should-run=true" >> "$GITHUB_OUTPUT"
+            echo "Performance tests triggered by ${{ github.event_name }}"
+          # For scheduled runs, check for recent metamaskbot version bumps
+          elif [[ "${{ github.event_name }}" == "schedule" ]]; then
+            git fetch --all
+            
+            # Get the most recent metamaskbot version bump commit
+            RECENT_VERSION_BUMP=$(git log --oneline --grep="Bump version number" --author="metamaskbot" --since="2 hours ago" --all | head -1)
+            
+            if [[ -n "$RECENT_VERSION_BUMP" ]]; then
+              # Extract the commit hash
+              COMMIT_HASH=$(echo "$RECENT_VERSION_BUMP" | cut -d' ' -f1)
+              
+              # Check if the commit message contains "Bump version number" (ignore [skip ci])
+              COMMIT_MESSAGE=$(git log -1 --format="%s" "$COMMIT_HASH")
+              if [[ "$COMMIT_MESSAGE" =~ "Bump version number" ]]; then
+                # Check if we've already processed this commit by looking for a workflow run with this commit
+                # We'll use a simple approach: check if the commit is from the last 30 minutes
+                COMMIT_TIME=$(git log -1 --format="%ct" "$COMMIT_HASH")
+                CURRENT_TIME=$(date +%s)
+                TIME_DIFF=$((CURRENT_TIME - COMMIT_TIME))
+                
+                # Only run if the commit is from the last 30 minutes (to avoid re-running the same commit)
+                if [[ $TIME_DIFF -lt 1800 ]]; then
+                  echo "should-run=true" >> "$GITHUB_OUTPUT"
+                  echo "Recent metamaskbot version bump found (within last 30 min): $RECENT_VERSION_BUMP"
+                  echo "Commit message: $COMMIT_MESSAGE"
+                else
+                  echo "should-run=false" >> "$GITHUB_OUTPUT"
+                  echo "Metamaskbot version bump found but older than 30 minutes: $RECENT_VERSION_BUMP"
+                fi
+              else
+                echo "should-run=false" >> "$GITHUB_OUTPUT"
+                echo "Metamaskbot commit found but not a version bump: $RECENT_VERSION_BUMP"
+                echo "Commit message: $COMMIT_MESSAGE"
+              fi
+            else
+              echo "should-run=false" >> "$GITHUB_OUTPUT"
+              echo "No recent metamaskbot version bumps found"
+            fi
+          else
+            echo "should-run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  run-performance-e2e-release:
+    name: Run Performance E2E Tests for Release Builds
+    uses: ./.github/workflows/run-performance-e2e.yml
+    needs: [check-release-trigger]
+    if: needs.check-release-trigger.outputs.should-run == 'true'
+    secrets: inherit

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -3,6 +3,7 @@ on:
   schedule:
     - cron: '0 3 * * 1-6'
   workflow_dispatch:
+  workflow_call:
     inputs:
       description:
         description: 'Optional description for this test run'

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -25,9 +25,6 @@ on:
         description: 'BrowserStack iOS Imported Wallet App URL (bs://...)'
         required: false
         type: string
-  push:
-    branches:
-      - 'release/*'
 
 permissions:
   contents: read
@@ -45,37 +42,9 @@ env:
   DISABLE_VIDEO_DOWNLOAD: true
 
 jobs:
-  check-metamaskbot-commit:
-    name: Check if Metamaskbot Version Bump
-    runs-on: ubuntu-latest
-    outputs:
-      should-run: ${{ steps.check.outputs.should-run }}
-    if: always()
-    steps:
-      - name: Check if metamaskbot version bump
-        id: check
-        env:
-          COMMIT_AUTHOR: ${{ github.event.head_commit.author.name || '' }}
-          COMMIT_MESSAGE: ${{ github.event.head_commit.message || '' }}
-        run: |
-          # Always run for schedule and workflow_dispatch events
-          if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "should-run=true" >> "$GITHUB_OUTPUT"
-            echo "Performance tests triggered by ${{ github.event_name }}"
-          # For push events, only run on metamaskbot version bumps
-          elif [[ "${{ github.event_name }}" == "push" && "$COMMIT_AUTHOR" == "metamaskbot" && "$COMMIT_MESSAGE" =~ "Bump version number" ]]; then
-            echo "should-run=true" >> "$GITHUB_OUTPUT"
-            echo "RC version bump detected from metamaskbot commit"
-          else
-            echo "should-run=false" >> "$GITHUB_OUTPUT"
-            echo "Not a valid trigger for performance tests"
-          fi
-
   read-device-matrix:
     name: Read Device Matrix
     runs-on: ubuntu-latest
-    needs: [check-metamaskbot-commit]
-    if: always() && (needs.check-metamaskbot-commit.result == 'skipped' || needs.check-metamaskbot-commit.outputs.should-run == 'true')
     outputs:
       android_matrix: ${{ steps.read-matrix.outputs.android_matrix }}
       ios_matrix: ${{ steps.read-matrix.outputs.ios_matrix }}
@@ -114,8 +83,6 @@ jobs:
   set-build-names:
     name: Set Unified BrowserStack Build Names
     runs-on: ubuntu-latest
-    needs: [check-metamaskbot-commit]
-    if: always() && (needs.check-metamaskbot-commit.result == 'skipped' || needs.check-metamaskbot-commit.outputs.should-run == 'true')
     outputs:
       android_build_name: ${{ steps.set-builds.outputs.android_build_name }}
       ios_build_name: ${{ steps.set-builds.outputs.ios_build_name }}
@@ -125,22 +92,20 @@ jobs:
         run: |
           echo "android_build_name=Android-Performance-${{ github.ref_name }}-Branch" >> "$GITHUB_OUTPUT"
           echo "ios_build_name=iOS-Performance-${{ github.ref_name }}-Branch" >> "$GITHUB_OUTPUT"
-          echo "✅ Set unified build names:"
+          echo "Set unified build names:"
           echo "  Android: Android-Performance-${{ github.ref_name }}-Branch"
           echo "  iOS: iOS-Performance-${{ github.ref_name }}-Branch"
 
   trigger-android-dual-versions:
     name: Trigger Android Dual Versions and Extract BrowserStack URLs
     uses: ./.github/workflows/build-android-upload-to-browserstack.yml
-    needs: [check-metamaskbot-commit]
-    if: always() && (needs.check-metamaskbot-commit.result == 'skipped' || needs.check-metamaskbot-commit.outputs.should-run == 'true') && (!inputs.browserstack_app_url_android_onboarding && !inputs.browserstack_app_url_android_imported_wallet)
+    if: (!inputs.browserstack_app_url_android_onboarding && !inputs.browserstack_app_url_android_imported_wallet)
     secrets: inherit
 
   trigger-ios-dual-versions:
     name: Trigger iOS Dual Versions and Extract BrowserStack URLs
     uses: ./.github/workflows/build-ios-upload-to-browserstack.yml
-    needs: [check-metamaskbot-commit]
-    if: always() && (needs.check-metamaskbot-commit.result == 'skipped' || needs.check-metamaskbot-commit.outputs.should-run == 'true') && (!inputs.browserstack_app_url_ios_onboarding && !inputs.browserstack_app_url_ios_imported_wallet)
+    if: (!inputs.browserstack_app_url_ios_onboarding && !inputs.browserstack_app_url_ios_imported_wallet)
     secrets: inherit
 
 
@@ -151,8 +116,8 @@ jobs:
   run-android-onboarding-tests:
     name: Run Android Onboarding Tests
     uses: ./.github/workflows/performance-test-runner.yml
-    needs: [check-metamaskbot-commit, read-device-matrix, trigger-android-dual-versions, set-build-names]
-    if: always() && (needs.check-metamaskbot-commit.result == 'skipped' || needs.check-metamaskbot-commit.outputs.should-run == 'true') && !failure() && !cancelled() && (needs.trigger-android-dual-versions.result == 'skipped' || needs.trigger-android-dual-versions.result == 'success') && (inputs.browserstack_app_url_android_onboarding || needs.trigger-android-dual-versions.result == 'success')
+    needs: [read-device-matrix, trigger-android-dual-versions, set-build-names]
+    if: always() && !failure() && !cancelled() && (needs.trigger-android-dual-versions.result == 'skipped' || needs.trigger-android-dual-versions.result == 'success') && (inputs.browserstack_app_url_android_onboarding || needs.trigger-android-dual-versions.result == 'success')
     with:
       platform: android
       build_type: onboarding
@@ -166,8 +131,8 @@ jobs:
   run-ios-onboarding-tests:
     name: Run iOS Onboarding Tests
     uses: ./.github/workflows/performance-test-runner.yml
-    needs: [check-metamaskbot-commit, read-device-matrix, trigger-ios-dual-versions, set-build-names]
-    if: always() && (needs.check-metamaskbot-commit.result == 'skipped' || needs.check-metamaskbot-commit.outputs.should-run == 'true') && !failure() && !cancelled() && (needs.trigger-ios-dual-versions.result == 'skipped' || needs.trigger-ios-dual-versions.result == 'success') && (inputs.browserstack_app_url_ios_onboarding || needs.trigger-ios-dual-versions.result == 'success')
+    needs: [read-device-matrix, trigger-ios-dual-versions, set-build-names]
+    if: always() && !failure() && !cancelled() && (needs.trigger-ios-dual-versions.result == 'skipped' || needs.trigger-ios-dual-versions.result == 'success') && (inputs.browserstack_app_url_ios_onboarding || needs.trigger-ios-dual-versions.result == 'success')
     with:
       platform: ios
       build_type: onboarding
@@ -185,8 +150,8 @@ jobs:
   wait-for-onboarding-completion:
     name: Wait for Onboarding Completion
     runs-on: ubuntu-latest
-    needs: [check-metamaskbot-commit, run-android-onboarding-tests, run-ios-onboarding-tests]
-    if: always() && (needs.check-metamaskbot-commit.result == 'skipped' || needs.check-metamaskbot-commit.outputs.should-run == 'true')
+    needs: [run-android-onboarding-tests, run-ios-onboarding-tests]
+    if: always()
     steps:
       - name: Wait for onboarding tests to complete
         run: |
@@ -196,8 +161,8 @@ jobs:
   run-android-imported-wallet-tests:
     name: Run Android Imported Wallet Tests
     uses: ./.github/workflows/performance-test-runner.yml
-    needs: [check-metamaskbot-commit, read-device-matrix, trigger-android-dual-versions, wait-for-onboarding-completion, set-build-names]
-    if: always() && (needs.check-metamaskbot-commit.result == 'skipped' || needs.check-metamaskbot-commit.outputs.should-run == 'true') && (needs.trigger-android-dual-versions.result == 'skipped' || needs.trigger-android-dual-versions.result == 'success') && (inputs.browserstack_app_url_android_imported_wallet || needs.trigger-android-dual-versions.result == 'success')
+    needs: [read-device-matrix, trigger-android-dual-versions, wait-for-onboarding-completion, set-build-names]
+    if: always() && (needs.trigger-android-dual-versions.result == 'skipped' || needs.trigger-android-dual-versions.result == 'success') && (inputs.browserstack_app_url_android_imported_wallet || needs.trigger-android-dual-versions.result == 'success')
     with:
       platform: android
       build_type: imported-wallet
@@ -211,8 +176,8 @@ jobs:
   run-ios-imported-wallet-tests:
     name: Run iOS Imported Wallet Tests
     uses: ./.github/workflows/performance-test-runner.yml
-    needs: [check-metamaskbot-commit, read-device-matrix, trigger-ios-dual-versions, wait-for-onboarding-completion, set-build-names]
-    if: always() && (needs.check-metamaskbot-commit.result == 'skipped' || needs.check-metamaskbot-commit.outputs.should-run == 'true') && (needs.trigger-ios-dual-versions.result == 'skipped' || needs.trigger-ios-dual-versions.result == 'success') && (inputs.browserstack_app_url_ios_imported_wallet || needs.trigger-ios-dual-versions.result == 'success')
+    needs: [read-device-matrix, trigger-ios-dual-versions, wait-for-onboarding-completion, set-build-names]
+    if: always() && (needs.trigger-ios-dual-versions.result == 'skipped' || needs.trigger-ios-dual-versions.result == 'success') && (inputs.browserstack_app_url_ios_imported_wallet || needs.trigger-ios-dual-versions.result == 'success')
     with:
       platform: ios
       build_type: imported-wallet
@@ -226,8 +191,8 @@ jobs:
   aggregate-results:
     name: Aggregate All Test Results
     runs-on: ubuntu-latest
-    needs: [check-metamaskbot-commit, run-android-imported-wallet-tests, run-android-onboarding-tests, run-ios-imported-wallet-tests, run-ios-onboarding-tests, wait-for-onboarding-completion]
-    if: always() && (needs.check-metamaskbot-commit.result == 'skipped' || needs.check-metamaskbot-commit.outputs.should-run == 'true')
+    needs: [run-android-imported-wallet-tests, run-android-onboarding-tests, run-ios-imported-wallet-tests, run-ios-onboarding-tests, wait-for-onboarding-completion]
+    if: always()
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -258,8 +223,8 @@ jobs:
   slack-notification:
     name: Send Slack Notification
     runs-on: ubuntu-latest
-    needs: [check-metamaskbot-commit, run-android-imported-wallet-tests, run-android-onboarding-tests, run-ios-imported-wallet-tests, run-ios-onboarding-tests, aggregate-results]
-    if: always() && (needs.check-metamaskbot-commit.result == 'skipped' || needs.check-metamaskbot-commit.outputs.should-run == 'true')
+    needs: [run-android-imported-wallet-tests, run-android-onboarding-tests, run-ios-imported-wallet-tests, run-ios-onboarding-tests, aggregate-results]
+    if: always()
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The performance e2e are not being triggered automatically on the release branch whenever we bump the release version. The main reason for such is `[skip ci]` as part of the commit message whenever we bump the builds. For example:

`[skip ci] Bump version number to 2463 `

Having `[skip ci]` as part of the commit message skips all ci jobs, including the performance e2e. 

The purpose of this PR is to ensure that we trigger the performance e2e tests each time we create a release branch AND new release builds. 

### The Approach
We are going to have a new CI job specifically for the performance tests on releases that runs every 30 mins on the release branch.

Scenario 1: Normal Version Bump
```
3:00 PM - Metamaskbot commits: "[skip ci] Bump version number to 2463"
         → GitHub skips normal workflows (due to [skip ci])
         → No performance tests run

3:30 PM - Our 30-min cron runs
         → Finds commit: "[skip ci] Bump version number to 2463"
         → Checks message: Contains "Bump version number" 
         → Checks timing: 30 minutes old 
         → Runs performance tests 

4:00 PM - Our 30-min cron runs
         → Finds same commit: "[skip ci] Bump version number to 2463"
         → Checks message: Contains "Bump version number" 
         → Checks timing: 60 minutes old 
         → Skips (prevents duplicate runs) 
```


Scenario 2: Multiple Version Bumps
```
3:00 PM - Metamaskbot commits: "[skip ci] Bump version number to 2463"
         → GitHub skips normal workflows
         → No performance tests run

3:30 PM - Our 30-min cron runs
         → Finds commit: "[skip ci] Bump version number to 2463"
         → Runs performance tests 

4:00 PM - Metamaskbot commits: "[skip ci] Bump version number to 2464"
         → GitHub skips normal workflows
         → No performance tests run

4:30 PM - Our 30-min cron runs
         → Finds commit: "[skip ci] Bump version number to 2464" (newer)
         → Runs performance tests 
```

Scenario 3 Non-Version Commit
```
3:00 PM - Metamaskbot commits: "[skip ci] Update dependencies"
         → GitHub skips normal workflows
         → No performance tests run

3:30 PM - Our 30-min cron runs
         → Finds commit: "[skip ci] Update dependencies"
         → Checks message: Does NOT contain "Bump version number" 
         → Skips performance tests 
```

 
 
## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
