### PR TITLE
fix: account avatars in site cell

### DIFF
--- a/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.test.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.test.tsx
@@ -2014,7 +2014,7 @@ describe('MultichainAccountConnect', () => {
       await waitFor(() => {
         expect(
           getByTestId('permission-summary-account-text'),
-        ).toHaveTextContent('Requesting for 2 accounts');
+        ).toHaveTextContent('Requesting for');
       });
     });
   });

--- a/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.test.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.test.tsx
@@ -1969,7 +1969,7 @@ describe('MultichainAccountConnect', () => {
       );
 
       expect(getByTestId('permission-summary-account-text')).toHaveTextContent(
-        'Requesting for Account 1',
+        'Requesting for',
       );
 
       const editAccountsButton = getByTestId('permission-summary-container');

--- a/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.test.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.test.tsx
@@ -174,12 +174,12 @@ describe('MultichainPermissionsSummary', () => {
     jest.clearAllMocks();
   });
 
-  it('renders with default props', () => {
+  it('displays connect button when rendering with default props', () => {
     const { getByTestId } = renderMultichainPermissionsSummary();
-    expect(getByTestId(CommonSelectorsIDs.CONNECT_BUTTON)).toBeTruthy();
+    expect(getByTestId(CommonSelectorsIDs.CONNECT_BUTTON)).toBeOnTheScreen();
   });
 
-  it('renders for already connected state', () => {
+  it('displays disconnect all button when already connected and disconnect is shown', () => {
     const { getByTestId } = renderMultichainPermissionsSummary({
       isAlreadyConnected: true,
       isDisconnectAllShown: true,
@@ -188,38 +188,38 @@ describe('MultichainPermissionsSummary', () => {
       getByTestId(
         ConnectedAccountsSelectorsIDs.DISCONNECT_ALL_ACCOUNTS_NETWORKS,
       ),
-    ).toBeTruthy();
+    ).toBeOnTheScreen();
   });
 
-  it('renders for network switch scenario', () => {
+  it('displays connect button in network switch scenario', () => {
     const { getByTestId } = renderNetworkSwitchScenario();
-    expect(getByTestId(CommonSelectorsIDs.CONNECT_BUTTON)).toBeTruthy();
+    expect(getByTestId(CommonSelectorsIDs.CONNECT_BUTTON)).toBeOnTheScreen();
   });
 
-  it('renders for non-dapp network switch scenario', () => {
+  it('displays add network button in non-dapp network switch scenario', () => {
     const { getByTestId } = renderNonDappNetworkSwitchScenario();
     expect(
       getByTestId(
         NetworkNonPemittedBottomSheetSelectorsIDs.ADD_THIS_NETWORK_BUTTON,
       ),
-    ).toBeTruthy();
+    ).toBeOnTheScreen();
   });
 
-  it('renders with correct initial tab based on tabIndex prop', () => {
+  it('displays connect button when rendering with specific tab index', () => {
     const { getByTestId } = renderWithTabState(1);
-    expect(getByTestId(CommonSelectorsIDs.CONNECT_BUTTON)).toBeTruthy();
+    expect(getByTestId(CommonSelectorsIDs.CONNECT_BUTTON)).toBeOnTheScreen();
   });
 
-  it('renders only the account permissions card when showAccountsOnly is true', () => {
+  it('displays only account permissions card when showAccountsOnly is enabled', () => {
     const { getByTestId } = renderMultichainPermissionsSummary({
       showAccountsOnly: true,
     });
     expect(
       getByTestId(PermissionSummaryBottomSheetSelectorsIDs.CONTAINER),
-    ).toBeTruthy();
+    ).toBeOnTheScreen();
   });
 
-  it('renders only the network permissions card when showPermissionsOnly is true', () => {
+  it('displays only network permissions card when showPermissionsOnly is enabled', () => {
     const { getByTestId } = renderMultichainPermissionsSummary({
       showPermissionsOnly: true,
     });
@@ -227,15 +227,15 @@ describe('MultichainPermissionsSummary', () => {
       getByTestId(
         ConnectedAccountsSelectorsIDs.NAVIGATE_TO_EDIT_NETWORKS_PERMISSIONS_BUTTON,
       ),
-    ).toBeTruthy();
+    ).toBeOnTheScreen();
   });
 
-  it('renders the tab view when both showAccountsOnly and showPermissionsOnly are false', () => {
+  it('displays tab view when both showAccountsOnly and showPermissionsOnly are disabled', () => {
     const { getByTestId } = renderMultichainPermissionsSummary({
       showAccountsOnly: false,
       showPermissionsOnly: false,
     });
-    expect(getByTestId(CommonSelectorsIDs.CONNECT_BUTTON)).toBeTruthy();
+    expect(getByTestId(CommonSelectorsIDs.CONNECT_BUTTON)).toBeOnTheScreen();
   });
 
   it('calls onBack when back button is pressed', () => {
@@ -347,17 +347,19 @@ describe('MultichainPermissionsSummary', () => {
     ).toBeNull();
   });
 
-  it('shows disconnect all button when isAlreadyConnected and isDisconnectAllShown are true', () => {
+  it('displays disconnect all button when already connected and disconnect is enabled', () => {
+    // Given already connected state with disconnect enabled
     const { getByTestId } = renderMultichainPermissionsSummary({
       isAlreadyConnected: true,
       isDisconnectAllShown: true,
     });
 
+    // Then disconnect all button should be visible
     expect(
       getByTestId(
         ConnectedAccountsSelectorsIDs.DISCONNECT_ALL_ACCOUNTS_NETWORKS,
       ),
-    ).toBeTruthy();
+    ).toBeOnTheScreen();
   });
 
   it('hides back button in non-dapp network switch scenario', () => {
@@ -370,11 +372,13 @@ describe('MultichainPermissionsSummary', () => {
     ).toBeNull();
   });
 
-  it('shows confirm button for network switch', () => {
+  it('displays confirm button for network switch', () => {
+    // Given network switch scenario
     const { getByTestId } = renderNetworkSwitchScenario();
 
+    // Then confirm button should be visible
     const confirmButton = getByTestId(CommonSelectorsIDs.CONNECT_BUTTON);
-    expect(confirmButton).toBeTruthy();
+    expect(confirmButton).toBeOnTheScreen();
   });
 
   it('disables confirm button when no accounts or networks are selected', () => {
@@ -387,7 +391,7 @@ describe('MultichainPermissionsSummary', () => {
     expect(confirmButton.props.disabled).toBe(true);
   });
 
-  it('displays account label for single connected account', () => {
+  it('displays account permission container for single connected account', () => {
     const { getByTestId } = renderMultichainPermissionsSummary({
       isAlreadyConnected: true,
       selectedAccountGroupIds: [MOCK_GROUP_ID_1],
@@ -396,10 +400,10 @@ describe('MultichainPermissionsSummary', () => {
     const accountPermissionContainer = getByTestId(
       PermissionSummaryBottomSheetSelectorsIDs.ACCOUNT_PERMISSION_CONTAINER,
     );
-    expect(accountPermissionContainer).toBeTruthy();
+    expect(accountPermissionContainer).toBeOnTheScreen();
   });
 
-  it('displays account label for multiple connected accounts', () => {
+  it('displays account permission container for multiple connected accounts', () => {
     const { getByTestId } = renderMultichainPermissionsSummary({
       isAlreadyConnected: true,
       selectedAccountGroupIds: [MOCK_GROUP_ID_1, MOCK_GROUP_ID_2],
@@ -408,21 +412,24 @@ describe('MultichainPermissionsSummary', () => {
     const accountPermissionContainer = getByTestId(
       PermissionSummaryBottomSheetSelectorsIDs.ACCOUNT_PERMISSION_CONTAINER,
     );
-    expect(accountPermissionContainer).toBeTruthy();
+    expect(accountPermissionContainer).toBeOnTheScreen();
   });
 
-  it('displays network label for single network', () => {
+  it('displays edit networks button for single network', () => {
+    // Given single network
     const { getByTestId } = renderMultichainPermissionsSummary({
       networkAvatars: [MOCK_NETWORK_AVATARS[0]],
     });
+
+    // Then edit networks button should be visible
     expect(
       getByTestId(
         ConnectedAccountsSelectorsIDs.NAVIGATE_TO_EDIT_NETWORKS_PERMISSIONS_BUTTON,
       ),
-    ).toBeTruthy();
+    ).toBeOnTheScreen();
   });
 
-  it('displays network label for multiple networks', () => {
+  it('displays edit networks button for multiple networks', () => {
     const { getByTestId } = renderMultichainPermissionsSummary({
       networkAvatars: MOCK_NETWORK_AVATARS,
     });
@@ -430,7 +437,7 @@ describe('MultichainPermissionsSummary', () => {
       getByTestId(
         ConnectedAccountsSelectorsIDs.NAVIGATE_TO_EDIT_NETWORKS_PERMISSIONS_BUTTON,
       ),
-    ).toBeTruthy();
+    ).toBeOnTheScreen();
   });
 
   it('calls custom onRevokeAll when disconnect all button is pressed', () => {
@@ -448,9 +455,15 @@ describe('MultichainPermissionsSummary', () => {
     expect(mockNavigate).toHaveBeenCalledWith('RootModalFlow', {
       screen: 'RevokeAllAccountPermissions',
       params: expect.objectContaining({
+        hostInfo: expect.objectContaining({
+          metadata: expect.objectContaining({
+            origin: 'mock-dapp.example.com',
+          }),
+        }),
         onRevokeAll: expect.any(Function),
       }),
     });
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
   });
 
   it('falls back to default revoke behavior when no custom onRevokeAll is provided', () => {
@@ -468,19 +481,25 @@ describe('MultichainPermissionsSummary', () => {
     expect(mockNavigate).toHaveBeenCalledWith('RootModalFlow', {
       screen: 'RevokeAllAccountPermissions',
       params: expect.objectContaining({
+        hostInfo: expect.objectContaining({
+          metadata: expect.objectContaining({
+            origin: 'mock-dapp.example.com',
+          }),
+        }),
         onRevokeAll: expect.any(Function),
       }),
     });
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
   });
 
-  it('renders with empty network avatars array', () => {
+  it('displays connect button with empty network avatars', () => {
     const { getByTestId } = renderMultichainPermissionsSummary({
       networkAvatars: [],
     });
-    expect(getByTestId(CommonSelectorsIDs.CONNECT_BUTTON)).toBeTruthy();
+    expect(getByTestId(CommonSelectorsIDs.CONNECT_BUTTON)).toBeOnTheScreen();
   });
 
-  it('renders with single network avatar', () => {
+  it('displays edit networks button with single network avatar', () => {
     const { getByTestId } = renderMultichainPermissionsSummary({
       networkAvatars: [MOCK_NETWORK_AVATARS[0]],
     });
@@ -488,7 +507,7 @@ describe('MultichainPermissionsSummary', () => {
       getByTestId(
         ConnectedAccountsSelectorsIDs.NAVIGATE_TO_EDIT_NETWORKS_PERMISSIONS_BUTTON,
       ),
-    ).toBeTruthy();
+    ).toBeOnTheScreen();
   });
 
   it('disables confirm button when no account groups are selected', () => {
@@ -521,16 +540,15 @@ describe('MultichainPermissionsSummary', () => {
     expect(confirmButton.props.disabled).toBe(false);
   });
 
-  it('renders network avatars correctly', () => {
+  it('displays edit networks button with network avatars', () => {
     const { getByTestId } = renderMultichainPermissionsSummary({
       networkAvatars: MOCK_NETWORK_AVATARS,
     });
 
-    // Verify the component renders with network information
     expect(
       getByTestId(
         ConnectedAccountsSelectorsIDs.NAVIGATE_TO_EDIT_NETWORKS_PERMISSIONS_BUTTON,
       ),
-    ).toBeTruthy();
+    ).toBeOnTheScreen();
   });
 });

--- a/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.test.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.test.tsx
@@ -174,12 +174,12 @@ describe('MultichainPermissionsSummary', () => {
     jest.clearAllMocks();
   });
 
-  it('displays connect button when rendering with default props', () => {
+  it('renders with default props', () => {
     const { getByTestId } = renderMultichainPermissionsSummary();
-    expect(getByTestId(CommonSelectorsIDs.CONNECT_BUTTON)).toBeOnTheScreen();
+    expect(getByTestId(CommonSelectorsIDs.CONNECT_BUTTON)).toBeTruthy();
   });
 
-  it('displays disconnect all button when already connected and disconnect is shown', () => {
+  it('renders for already connected state', () => {
     const { getByTestId } = renderMultichainPermissionsSummary({
       isAlreadyConnected: true,
       isDisconnectAllShown: true,
@@ -188,38 +188,38 @@ describe('MultichainPermissionsSummary', () => {
       getByTestId(
         ConnectedAccountsSelectorsIDs.DISCONNECT_ALL_ACCOUNTS_NETWORKS,
       ),
-    ).toBeOnTheScreen();
+    ).toBeTruthy();
   });
 
-  it('displays connect button in network switch scenario', () => {
+  it('renders for network switch scenario', () => {
     const { getByTestId } = renderNetworkSwitchScenario();
-    expect(getByTestId(CommonSelectorsIDs.CONNECT_BUTTON)).toBeOnTheScreen();
+    expect(getByTestId(CommonSelectorsIDs.CONNECT_BUTTON)).toBeTruthy();
   });
 
-  it('displays add network button in non-dapp network switch scenario', () => {
+  it('renders for non-dapp network switch scenario', () => {
     const { getByTestId } = renderNonDappNetworkSwitchScenario();
     expect(
       getByTestId(
         NetworkNonPemittedBottomSheetSelectorsIDs.ADD_THIS_NETWORK_BUTTON,
       ),
-    ).toBeOnTheScreen();
+    ).toBeTruthy();
   });
 
-  it('displays connect button when rendering with specific tab index', () => {
+  it('renders with correct initial tab based on tabIndex prop', () => {
     const { getByTestId } = renderWithTabState(1);
-    expect(getByTestId(CommonSelectorsIDs.CONNECT_BUTTON)).toBeOnTheScreen();
+    expect(getByTestId(CommonSelectorsIDs.CONNECT_BUTTON)).toBeTruthy();
   });
 
-  it('displays only account permissions card when showAccountsOnly is enabled', () => {
+  it('renders only the account permissions card when showAccountsOnly is true', () => {
     const { getByTestId } = renderMultichainPermissionsSummary({
       showAccountsOnly: true,
     });
     expect(
       getByTestId(PermissionSummaryBottomSheetSelectorsIDs.CONTAINER),
-    ).toBeOnTheScreen();
+    ).toBeTruthy();
   });
 
-  it('displays only network permissions card when showPermissionsOnly is enabled', () => {
+  it('renders only the network permissions card when showPermissionsOnly is true', () => {
     const { getByTestId } = renderMultichainPermissionsSummary({
       showPermissionsOnly: true,
     });
@@ -227,15 +227,15 @@ describe('MultichainPermissionsSummary', () => {
       getByTestId(
         ConnectedAccountsSelectorsIDs.NAVIGATE_TO_EDIT_NETWORKS_PERMISSIONS_BUTTON,
       ),
-    ).toBeOnTheScreen();
+    ).toBeTruthy();
   });
 
-  it('displays tab view when both showAccountsOnly and showPermissionsOnly are disabled', () => {
+  it('renders the tab view when both showAccountsOnly and showPermissionsOnly are false', () => {
     const { getByTestId } = renderMultichainPermissionsSummary({
       showAccountsOnly: false,
       showPermissionsOnly: false,
     });
-    expect(getByTestId(CommonSelectorsIDs.CONNECT_BUTTON)).toBeOnTheScreen();
+    expect(getByTestId(CommonSelectorsIDs.CONNECT_BUTTON)).toBeTruthy();
   });
 
   it('calls onBack when back button is pressed', () => {
@@ -347,19 +347,17 @@ describe('MultichainPermissionsSummary', () => {
     ).toBeNull();
   });
 
-  it('displays disconnect all button when already connected and disconnect is enabled', () => {
-    // Given already connected state with disconnect enabled
+  it('shows disconnect all button when isAlreadyConnected and isDisconnectAllShown are true', () => {
     const { getByTestId } = renderMultichainPermissionsSummary({
       isAlreadyConnected: true,
       isDisconnectAllShown: true,
     });
 
-    // Then disconnect all button should be visible
     expect(
       getByTestId(
         ConnectedAccountsSelectorsIDs.DISCONNECT_ALL_ACCOUNTS_NETWORKS,
       ),
-    ).toBeOnTheScreen();
+    ).toBeTruthy();
   });
 
   it('hides back button in non-dapp network switch scenario', () => {
@@ -372,13 +370,11 @@ describe('MultichainPermissionsSummary', () => {
     ).toBeNull();
   });
 
-  it('displays confirm button for network switch', () => {
-    // Given network switch scenario
+  it('shows confirm button for network switch', () => {
     const { getByTestId } = renderNetworkSwitchScenario();
 
-    // Then confirm button should be visible
     const confirmButton = getByTestId(CommonSelectorsIDs.CONNECT_BUTTON);
-    expect(confirmButton).toBeOnTheScreen();
+    expect(confirmButton).toBeTruthy();
   });
 
   it('disables confirm button when no accounts or networks are selected', () => {
@@ -391,7 +387,7 @@ describe('MultichainPermissionsSummary', () => {
     expect(confirmButton.props.disabled).toBe(true);
   });
 
-  it('displays account permission container for single connected account', () => {
+  it('displays account label for single connected account', () => {
     const { getByTestId } = renderMultichainPermissionsSummary({
       isAlreadyConnected: true,
       selectedAccountGroupIds: [MOCK_GROUP_ID_1],
@@ -400,10 +396,10 @@ describe('MultichainPermissionsSummary', () => {
     const accountPermissionContainer = getByTestId(
       PermissionSummaryBottomSheetSelectorsIDs.ACCOUNT_PERMISSION_CONTAINER,
     );
-    expect(accountPermissionContainer).toBeOnTheScreen();
+    expect(accountPermissionContainer).toBeTruthy();
   });
 
-  it('displays account permission container for multiple connected accounts', () => {
+  it('displays account label for multiple connected accounts', () => {
     const { getByTestId } = renderMultichainPermissionsSummary({
       isAlreadyConnected: true,
       selectedAccountGroupIds: [MOCK_GROUP_ID_1, MOCK_GROUP_ID_2],
@@ -412,24 +408,21 @@ describe('MultichainPermissionsSummary', () => {
     const accountPermissionContainer = getByTestId(
       PermissionSummaryBottomSheetSelectorsIDs.ACCOUNT_PERMISSION_CONTAINER,
     );
-    expect(accountPermissionContainer).toBeOnTheScreen();
+    expect(accountPermissionContainer).toBeTruthy();
   });
 
-  it('displays edit networks button for single network', () => {
-    // Given single network
+  it('displays network label for single network', () => {
     const { getByTestId } = renderMultichainPermissionsSummary({
       networkAvatars: [MOCK_NETWORK_AVATARS[0]],
     });
-
-    // Then edit networks button should be visible
     expect(
       getByTestId(
         ConnectedAccountsSelectorsIDs.NAVIGATE_TO_EDIT_NETWORKS_PERMISSIONS_BUTTON,
       ),
-    ).toBeOnTheScreen();
+    ).toBeTruthy();
   });
 
-  it('displays edit networks button for multiple networks', () => {
+  it('displays network label for multiple networks', () => {
     const { getByTestId } = renderMultichainPermissionsSummary({
       networkAvatars: MOCK_NETWORK_AVATARS,
     });
@@ -437,7 +430,7 @@ describe('MultichainPermissionsSummary', () => {
       getByTestId(
         ConnectedAccountsSelectorsIDs.NAVIGATE_TO_EDIT_NETWORKS_PERMISSIONS_BUTTON,
       ),
-    ).toBeOnTheScreen();
+    ).toBeTruthy();
   });
 
   it('calls custom onRevokeAll when disconnect all button is pressed', () => {
@@ -492,14 +485,14 @@ describe('MultichainPermissionsSummary', () => {
     expect(mockNavigate).toHaveBeenCalledTimes(1);
   });
 
-  it('displays connect button with empty network avatars', () => {
+  it('renders with empty network avatars array', () => {
     const { getByTestId } = renderMultichainPermissionsSummary({
       networkAvatars: [],
     });
-    expect(getByTestId(CommonSelectorsIDs.CONNECT_BUTTON)).toBeOnTheScreen();
+    expect(getByTestId(CommonSelectorsIDs.CONNECT_BUTTON)).toBeTruthy();
   });
 
-  it('displays edit networks button with single network avatar', () => {
+  it('renders with single network avatar', () => {
     const { getByTestId } = renderMultichainPermissionsSummary({
       networkAvatars: [MOCK_NETWORK_AVATARS[0]],
     });
@@ -507,7 +500,7 @@ describe('MultichainPermissionsSummary', () => {
       getByTestId(
         ConnectedAccountsSelectorsIDs.NAVIGATE_TO_EDIT_NETWORKS_PERMISSIONS_BUTTON,
       ),
-    ).toBeOnTheScreen();
+    ).toBeTruthy();
   });
 
   it('disables confirm button when no account groups are selected', () => {
@@ -540,15 +533,16 @@ describe('MultichainPermissionsSummary', () => {
     expect(confirmButton.props.disabled).toBe(false);
   });
 
-  it('displays edit networks button with network avatars', () => {
+  it('renders network avatars correctly', () => {
     const { getByTestId } = renderMultichainPermissionsSummary({
       networkAvatars: MOCK_NETWORK_AVATARS,
     });
 
+    // Verify the component renders with network information
     expect(
       getByTestId(
         ConnectedAccountsSelectorsIDs.NAVIGATE_TO_EDIT_NETWORKS_PERMISSIONS_BUTTON,
       ),
-    ).toBeOnTheScreen();
+    ).toBeTruthy();
   });
 });

--- a/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.tsx
@@ -65,6 +65,8 @@ import { NetworkAvatarProps } from '../../AccountConnect/AccountConnect.types';
 import MultichainAccountsConnectedList from '../MultichainAccountsConnectedList/MultichainAccountsConnectedList';
 import { AccountGroupId } from '@metamask/account-api';
 import { selectAccountGroups } from '../../../../selectors/multichainAccounts/accountTreeController';
+import { AccountGroupObject } from '@metamask/account-tree-controller';
+import { selectIconSeedAddressByAccountGroupId } from '../../../../selectors/multichainAccounts/accounts';
 
 export interface MultichainPermissionsSummaryProps {
   currentPageInformation: {
@@ -375,6 +377,23 @@ const MultichainPermissionsSummary = ({
     [accountGroups, selectedAccountGroupIds],
   );
 
+  const renderAccountAvatar = useCallback(
+    (accountGroup: AccountGroupObject) => {
+      const selectEvmAddress = useMemo(
+        () => selectIconSeedAddressByAccountGroupId(accountGroup.id),
+        [accountGroup.id],
+      );
+      const evmAddress = useSelector(selectEvmAddress);
+
+      return {
+        variant: AvatarVariant.Account as const,
+        accountAddress: evmAddress,
+        size: AvatarSize.Xs,
+      };
+    },
+    [selectIconSeedAddressByAccountGroupId],
+  );
+
   function renderAccountPermissionsRequestInfoCard() {
     return (
       <TouchableOpacity onPress={handleEditAccountsButtonPress}>
@@ -410,13 +429,9 @@ const MultichainPermissionsSummary = ({
               </View>
               <View style={styles.avatarGroup}>
                 <AvatarGroup
-                  avatarPropsList={selectedAccountGroups.map(
-                    (accountGroup) => ({
-                      variant: AvatarVariant.Account,
-                      accountAddress: accountGroup.id,
-                      size: AvatarSize.Xs,
-                    }),
-                  )}
+                  avatarPropsList={selectedAccountGroups.map((accountGroup) => {
+                    return renderAccountAvatar(accountGroup);
+                  })}
                 />
               </View>
             </View>

--- a/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.tsx
@@ -355,7 +355,7 @@ const MultichainPermissionsSummary = ({
   const renderAccountAvatar = useCallback(
     (accountGroup: AccountGroupObject) => ({
       variant: AvatarVariant.Account as const,
-      accountAddress: iconSeedAddresses[accountGroup.id],
+      accountAddress: iconSeedAddresses[accountGroup.id] ?? accountGroup.id,
       size: AvatarSize.Xs,
     }),
     [iconSeedAddresses],

--- a/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.tsx
@@ -318,36 +318,6 @@ const MultichainPermissionsSummary = ({
     endTrace({ name: TraceName.DisconnectAllAccountPermissions });
   }, [onRevokeAllHandler, hostname, navigate]);
 
-  const getAccountLabel = useCallback(() => {
-    const firstAccountGroup = accountGroups.find((accountGroup) =>
-      selectedAccountGroupIds.includes(accountGroup.id),
-    );
-    if (isAlreadyConnected) {
-      if (selectedAccountGroupIds.length === 1) {
-        return `${strings('permissions.connected_to')} ${
-          firstAccountGroup?.metadata.name
-        }`;
-      }
-
-      return `${selectedAccountGroupIds.length} ${strings(
-        'accounts.accounts_connected',
-      )}`;
-    }
-
-    if (
-      selectedAccountGroupIds.length === 1 &&
-      selectedAccountGroupIds.length >= 1
-    ) {
-      return `${strings('permissions.requesting_for')}${
-        firstAccountGroup?.metadata.name
-      }`;
-    }
-
-    return strings('permissions.requesting_for_accounts', {
-      numberOfAccounts: selectedAccountGroupIds.length,
-    });
-  }, [accountGroups, selectedAccountGroupIds, isAlreadyConnected]);
-
   const getNetworkLabel = useCallback(() => {
     if (isAlreadyConnected) {
       return networkAvatars.length === 1
@@ -423,7 +393,7 @@ const MultichainPermissionsSummary = ({
                   ellipsizeMode="tail"
                 >
                   <TextComponent variant={TextVariant.BodySM}>
-                    {getAccountLabel()}
+                    {strings('permissions.requesting_for')}
                   </TextComponent>
                 </TextComponent>
               </View>

--- a/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.tsx
@@ -66,7 +66,8 @@ import MultichainAccountsConnectedList from '../MultichainAccountsConnectedList/
 import { AccountGroupId } from '@metamask/account-api';
 import { selectAccountGroups } from '../../../../selectors/multichainAccounts/accountTreeController';
 import { AccountGroupObject } from '@metamask/account-tree-controller';
-import { selectIconSeedAddressByAccountGroupId } from '../../../../selectors/multichainAccounts/accounts';
+import { selectIconSeedAddressesByAccountGroupIds } from '../../../../selectors/multichainAccounts/accounts';
+import { RootState } from '../../../../reducers';
 
 export interface MultichainPermissionsSummaryProps {
   currentPageInformation: {
@@ -347,21 +348,17 @@ const MultichainPermissionsSummary = ({
     [accountGroups, selectedAccountGroupIds],
   );
 
-  const renderAccountAvatar = useCallback(
-    (accountGroup: AccountGroupObject) => {
-      const selectEvmAddress = useMemo(
-        () => selectIconSeedAddressByAccountGroupId(accountGroup.id),
-        [accountGroup.id],
-      );
-      const evmAddress = useSelector(selectEvmAddress);
+  const iconSeedAddresses = useSelector((state: RootState) =>
+    selectIconSeedAddressesByAccountGroupIds(state, selectedAccountGroupIds),
+  );
 
-      return {
-        variant: AvatarVariant.Account as const,
-        accountAddress: evmAddress,
-        size: AvatarSize.Xs,
-      };
-    },
-    [selectIconSeedAddressByAccountGroupId],
+  const renderAccountAvatar = useCallback(
+    (accountGroup: AccountGroupObject) => ({
+      variant: AvatarVariant.Account as const,
+      accountAddress: iconSeedAddresses[accountGroup.id],
+      size: AvatarSize.Xs,
+    }),
+    [iconSeedAddresses],
   );
 
   function renderAccountPermissionsRequestInfoCard() {
@@ -399,9 +396,9 @@ const MultichainPermissionsSummary = ({
               </View>
               <View style={styles.avatarGroup}>
                 <AvatarGroup
-                  avatarPropsList={selectedAccountGroups.map((accountGroup) => {
-                    return renderAccountAvatar(accountGroup);
-                  })}
+                  avatarPropsList={selectedAccountGroups.map((accountGroup) =>
+                    renderAccountAvatar(accountGroup),
+                  )}
                 />
               </View>
             </View>

--- a/app/selectors/multichainAccounts/accounts.test.ts
+++ b/app/selectors/multichainAccounts/accounts.test.ts
@@ -18,6 +18,7 @@ import {
   selectInternalAccountListSpreadByScopesByGroupId,
   selectAccountGroupsByAddress,
   selectIconSeedAddressByAccountGroupId,
+  selectIconSeedAddressesByAccountGroupIds,
 } from './accounts';
 import {
   AccountWalletType,
@@ -1726,6 +1727,314 @@ describe('accounts selectors', () => {
       expect(() => selector(state)).toThrow(
         `Error in selectIconSeedAddressByAccountGroupId: No accounts found in the specified group ${unresolvedGroupId}`,
       );
+    });
+  });
+
+  describe('selectIconSeedAddressesByAccountGroupIds', () => {
+    const GROUP_1_ID = 'entropy:wallet1/0' as AccountGroupId;
+    const GROUP_2_ID = 'entropy:wallet2/0' as AccountGroupId;
+    const GROUP_3_ID = 'entropy:wallet3/0' as AccountGroupId;
+
+    const mockEvmAccount1: InternalAccount = {
+      ...createMockInternalAccount('0xevm1', 'EVM Account 1'),
+      id: 'evm-1' as AccountId,
+      scopes: ['eip155:1' as CaipChainId],
+    };
+
+    const mockSolanaAccount1: InternalAccount = {
+      ...createMockSnapInternalAccount('sol1', 'Solana Account 1'),
+      id: 'sol-1' as AccountId,
+      scopes: ['solana:mainnet' as CaipChainId],
+    };
+
+    const mockEvmAccount2: InternalAccount = {
+      ...createMockInternalAccount('0xevm2', 'EVM Account 2'),
+      id: 'evm-2' as AccountId,
+      scopes: ['eip155:137' as CaipChainId],
+    };
+
+    const mockBtcAccount: InternalAccount = {
+      ...createMockSnapInternalAccount('bc1btc', 'Bitcoin Account'),
+      id: 'btc-1' as AccountId,
+      scopes: ['bip122:mainnet' as CaipChainId],
+    };
+
+    it('returns icon seed addresses for multiple account groups efficiently', () => {
+      const state = createMockState(
+        {
+          accountTree: {
+            wallets: {
+              'entropy:wallet1': {
+                id: 'entropy:wallet1',
+                type: AccountWalletType.Entropy,
+                groups: {
+                  [GROUP_1_ID]: {
+                    type: AccountGroupType.MultichainAccount as AccountGroupType.MultichainAccount,
+                    accounts: [mockEvmAccount1.id, mockSolanaAccount1.id] as [
+                      AccountId,
+                      ...AccountId[],
+                    ],
+                  },
+                },
+              },
+              'entropy:wallet2': {
+                id: 'entropy:wallet2',
+                type: AccountWalletType.Entropy,
+                groups: {
+                  [GROUP_2_ID]: {
+                    type: AccountGroupType.MultichainAccount as AccountGroupType.MultichainAccount,
+                    accounts: [mockEvmAccount2.id] as [
+                      AccountId,
+                      ...AccountId[],
+                    ],
+                  },
+                },
+              },
+              'entropy:wallet3': {
+                id: 'entropy:wallet3',
+                type: AccountWalletType.Entropy,
+                groups: {
+                  [GROUP_3_ID]: {
+                    type: AccountGroupType.MultichainAccount as AccountGroupType.MultichainAccount,
+                    accounts: [mockBtcAccount.id] as [
+                      AccountId,
+                      ...AccountId[],
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        },
+        {
+          [mockEvmAccount1.id]: mockEvmAccount1,
+          [mockSolanaAccount1.id]: mockSolanaAccount1,
+          [mockEvmAccount2.id]: mockEvmAccount2,
+          [mockBtcAccount.id]: mockBtcAccount,
+        },
+      );
+
+      const result = selectIconSeedAddressesByAccountGroupIds(state, [
+        GROUP_1_ID,
+        GROUP_2_ID,
+        GROUP_3_ID,
+      ]);
+
+      expect(result).toEqual({
+        [GROUP_1_ID]: mockEvmAccount1.address,
+        [GROUP_2_ID]: mockEvmAccount2.address,
+        [GROUP_3_ID]: mockBtcAccount.address,
+      });
+    });
+
+    it('prefers EVM addresses over non-EVM addresses for each group', () => {
+      const state = createMockState(
+        {
+          accountTree: {
+            wallets: {
+              'entropy:wallet1': {
+                id: 'entropy:wallet1',
+                type: AccountWalletType.Entropy,
+                groups: {
+                  [GROUP_1_ID]: {
+                    type: AccountGroupType.MultichainAccount as AccountGroupType.MultichainAccount,
+                    // Solana account comes first, but EVM should be preferred
+                    accounts: [mockSolanaAccount1.id, mockEvmAccount1.id] as [
+                      AccountId,
+                      ...AccountId[],
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        },
+        {
+          [mockSolanaAccount1.id]: mockSolanaAccount1,
+          [mockEvmAccount1.id]: mockEvmAccount1,
+        },
+      );
+
+      const result = selectIconSeedAddressesByAccountGroupIds(state, [
+        GROUP_1_ID,
+      ]);
+      expect(result[GROUP_1_ID]).toBe(mockEvmAccount1.address);
+    });
+
+    it('falls back to first account when no EVM account exists', () => {
+      const state = createMockState(
+        {
+          accountTree: {
+            wallets: {
+              'entropy:wallet1': {
+                id: 'entropy:wallet1',
+                type: AccountWalletType.Entropy,
+                groups: {
+                  [GROUP_1_ID]: {
+                    type: AccountGroupType.MultichainAccount as AccountGroupType.MultichainAccount,
+                    accounts: [mockSolanaAccount1.id, mockBtcAccount.id] as [
+                      AccountId,
+                      ...AccountId[],
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        },
+        {
+          [mockSolanaAccount1.id]: mockSolanaAccount1,
+          [mockBtcAccount.id]: mockBtcAccount,
+        },
+      );
+
+      const result = selectIconSeedAddressesByAccountGroupIds(state, [
+        GROUP_1_ID,
+      ]);
+
+      expect(result[GROUP_1_ID]).toBe(mockSolanaAccount1.address);
+    });
+
+    it('handles empty account group IDs array', () => {
+      const state = createMockState({}, {});
+
+      const result = selectIconSeedAddressesByAccountGroupIds(state, []);
+
+      expect(result).toEqual({});
+    });
+
+    it('handles missing wallets gracefully', () => {
+      const state = createMockState(
+        {
+          accountTree: {
+            wallets: {},
+          },
+        },
+        {},
+      );
+
+      const result = selectIconSeedAddressesByAccountGroupIds(state, [
+        GROUP_1_ID,
+      ]);
+
+      expect(result).toEqual({});
+    });
+
+    it('handles missing account groups gracefully', () => {
+      const nonExistentGroupId = 'entropy:nonexistent/0' as AccountGroupId;
+      const state = createMockState(
+        {
+          accountTree: {
+            wallets: {
+              'entropy:nonexistent': {
+                id: 'entropy:nonexistent',
+                type: AccountWalletType.Entropy,
+                groups: {}, // No groups
+              },
+            },
+          },
+        },
+        {},
+      );
+
+      const result = selectIconSeedAddressesByAccountGroupIds(state, [
+        nonExistentGroupId,
+      ]);
+
+      expect(result).toEqual({});
+    });
+
+    it('handles missing internal accounts', () => {
+      const missingAccountId = 'missing-account' as AccountId;
+      const state = createMockState(
+        {
+          accountTree: {
+            wallets: {
+              'entropy:wallet1': {
+                id: 'entropy:wallet1',
+                type: AccountWalletType.Entropy,
+                groups: {
+                  [GROUP_1_ID]: {
+                    type: AccountGroupType.MultichainAccount as AccountGroupType.MultichainAccount,
+                    accounts: [missingAccountId] as [AccountId, ...AccountId[]],
+                  },
+                },
+              },
+            },
+          },
+        },
+        {}, // No internal accounts
+      );
+
+      const result = selectIconSeedAddressesByAccountGroupIds(state, [
+        GROUP_1_ID,
+      ]);
+
+      expect(result).toEqual({});
+    });
+
+    it('handles mixed valid and invalid groups', () => {
+      const validGroupId = GROUP_1_ID;
+      const invalidGroupId = 'entropy:invalid/0' as AccountGroupId;
+      const state = createMockState(
+        {
+          accountTree: {
+            wallets: {
+              'entropy:wallet1': {
+                id: 'entropy:wallet1',
+                type: AccountWalletType.Entropy,
+                groups: {
+                  [validGroupId]: {
+                    type: AccountGroupType.MultichainAccount as AccountGroupType.MultichainAccount,
+                    accounts: [mockEvmAccount1.id] as [
+                      AccountId,
+                      ...AccountId[],
+                    ],
+                  },
+                },
+              },
+              'entropy:invalid': {
+                id: 'entropy:invalid',
+                type: AccountWalletType.Entropy,
+                groups: {}, // No groups
+              },
+            },
+          },
+        },
+        {
+          [mockEvmAccount1.id]: mockEvmAccount1,
+        },
+      );
+
+      const result = selectIconSeedAddressesByAccountGroupIds(state, [
+        validGroupId,
+        invalidGroupId,
+      ]);
+
+      expect(result).toEqual({
+        [validGroupId]: mockEvmAccount1.address,
+        // Invalid group should not be included
+      });
+    });
+
+    it('handles null accountTree state', () => {
+      const state = {
+        ...createMockState({}, {}),
+        engine: {
+          ...createMockState({}, {}).engine,
+          backgroundState: {
+            ...createMockState({}, {}).engine.backgroundState,
+            AccountTreeController:
+              null as unknown as AccountTreeControllerState,
+          },
+        },
+      };
+
+      const result = selectIconSeedAddressesByAccountGroupIds(state, [
+        GROUP_1_ID,
+      ]);
+
+      expect(result).toEqual({});
     });
   });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR aligns the avatar used in the account list row and the site cell for bip44 accounts. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Aligns the avatar used in the account list row and the site cell for bip44 accounts. 

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-882?atlOrigin=eyJpIjoiZTg5NWZlY2Y0MDY1NGM1NjllYmVlNGM4NzFmZmZlMWIiLCJwIjoiaiJ9

## **Manual testing steps**

With `export MM_ENABLE_MULTICHAIN_ACCOUNTS_STATE_2="true"` in `.js.env`

```gherkin
Feature: Dapp connection site icons

  Scenario: user connects to a dapp
    Given the user initiates a new dapp connection

    When the connect account page appear
    Then the avatar icon should match the avatar icon in the permissions tab.
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/1aa8b631-34ec-473e-bdd8-ad2d50ff7c69


<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/bc3415ed-85cf-4720-8f39-a0e8667013ab



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
