### PR TITLE
fix: Account group details Mask icon to match the account list

### DIFF
--- a/app/components/Views/MultichainAccounts/AccountGroupDetails/AccountGroupDetails.test.tsx
+++ b/app/components/Views/MultichainAccounts/AccountGroupDetails/AccountGroupDetails.test.tsx
@@ -10,11 +10,26 @@ import { isHDOrFirstPartySnapAccount } from '../../../../util/address';
 import {
   createMockAccountGroup,
   createMockInternalAccount,
+  createMockWallet,
+  createMockInternalAccountsFromGroups,
+  createMockState,
 } from '../../../../component-library/components-temp/MultichainAccounts/test-utils';
 import { AvatarAccountType } from '../../../../component-library/components/Avatars/Avatar';
 
 const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();
+
+jest.mock('../../../../selectors/multichainAccounts/accounts', () => {
+  const actual = jest.requireActual(
+    '../../../../selectors/multichainAccounts/accounts',
+  );
+  return {
+    ...actual,
+    selectIconSeedAddressByAccountGroupId: jest.fn(() =>
+      jest.fn(() => '0xseed'),
+    ),
+  };
+});
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -41,11 +56,14 @@ const mockAccount = createMockInternalAccount(
   'Test Account',
 );
 mockAccount.options.entropySource = 'keyring:test-wallet';
-const mockWallet = {
-  id: 'wallet-1',
-  metadata: { name: 'Test Wallet' },
-  type: 'keyring',
-};
+const groups = [mockAccountGroup];
+const mockWallet = createMockWallet(
+  'keyring:test-wallet',
+  'Test Wallet',
+  groups,
+);
+const internalAccounts = createMockInternalAccountsFromGroups(groups);
+const baseState = createMockState([mockWallet], internalAccounts);
 
 const mockNetworkControllerState = {
   networkConfigurationsByChainId: {
@@ -103,6 +121,7 @@ describe('AccountGroupDetails', () => {
   };
 
   const mockState = {
+    ...baseState,
     settings: {
       avatarAccountType: AvatarAccountType.Maskicon,
     },
@@ -110,33 +129,9 @@ describe('AccountGroupDetails', () => {
       seedphraseBackedUp: false,
     },
     engine: {
+      ...baseState.engine,
       backgroundState: {
-        AccountTreeController: {
-          accountTree: {
-            wallets: {
-              'wallet-1': mockWallet,
-            },
-          },
-        },
-        AccountsController: {
-          internalAccounts: {
-            accounts: {
-              'account-1': mockAccount,
-            },
-            selectedAccount: 'account-1',
-          },
-        },
-        KeyringController: {
-          keyrings: [
-            {
-              type: 'HD Key Tree',
-              accounts: [mockAccount.address],
-              metadata: {
-                id: 'keyring:test-wallet',
-              },
-            },
-          ],
-        },
+        ...baseState.engine.backgroundState,
         NetworkController: mockNetworkControllerState,
         MultichainNetworkController: mockMultichainNetworkController,
       },
@@ -333,5 +328,24 @@ describe('AccountGroupDetails', () => {
         params: { accountGroup: mockAccountGroup },
       },
     );
+  });
+
+  it('uses the group icon seed address to render the avatar', () => {
+    const { getByTestId } = renderWithProvider(
+      <AccountGroupDetails {...defaultProps} />,
+      {
+        state: mockState,
+      },
+    );
+
+    // Assert that the selector selectIconSeedAddressByAccountGroupId was called
+    const { selectIconSeedAddressByAccountGroupId: mockedFactory } =
+      jest.requireMock('../../../../selectors/multichainAccounts/accounts');
+    expect(mockedFactory).toHaveBeenCalledWith(mockAccountGroup.id);
+
+    // Assert that the avatar is rendered
+    expect(
+      getByTestId(AccountDetailsIds.ACCOUNT_GROUP_DETAILS_AVATAR),
+    ).toBeTruthy();
   });
 });

--- a/app/components/Views/MultichainAccounts/AccountGroupDetails/AccountGroupDetails.tsx
+++ b/app/components/Views/MultichainAccounts/AccountGroupDetails/AccountGroupDetails.tsx
@@ -181,6 +181,7 @@ export const AccountGroupDetails = (props: AccountGroupDetailsProps) => {
             size={AvatarSize.Xl}
             accountAddress={iconSeedAddress}
             type={accountAvatarType}
+            testID={AccountDetailsIds.ACCOUNT_GROUP_DETAILS_AVATAR}
           />
         </Box>
         <TouchableOpacity

--- a/app/components/Views/MultichainAccounts/AccountGroupDetails/AccountGroupDetails.tsx
+++ b/app/components/Views/MultichainAccounts/AccountGroupDetails/AccountGroupDetails.tsx
@@ -34,6 +34,7 @@ import {
 import {
   selectInternalAccountListSpreadByScopesByGroupId,
   getWalletIdFromAccountGroup,
+  selectIconSeedAddressByAccountGroupId,
 } from '../../../../selectors/multichainAccounts/accounts';
 import { AccountGroupType } from '@metamask/account-api';
 import { isHDOrFirstPartySnapAccount } from '../../../../util/address';
@@ -84,6 +85,11 @@ export const AccountGroupDetails = (props: AccountGroupDetailsProps) => {
   const { styles, theme } = useStyles(styleSheet, {});
   const { colors } = theme;
   const accountAvatarType = useSelector(selectAvatarAccountType);
+  const selectIconSeedAddress = React.useMemo(
+    () => selectIconSeedAddressByAccountGroupId(id),
+    [id],
+  );
+  const iconSeedAddress = useSelector(selectIconSeedAddress);
 
   const selectWallet = useSelector(selectWalletById);
   const wallet = selectWallet?.(walletId);
@@ -173,7 +179,7 @@ export const AccountGroupDetails = (props: AccountGroupDetailsProps) => {
           <Avatar
             variant={AvatarVariant.Account}
             size={AvatarSize.Xl}
-            accountAddress={id}
+            accountAddress={iconSeedAddress}
             type={accountAvatarType}
           />
         </Box>

--- a/e2e/selectors/MultichainAccounts/AccountDetails.selectors.ts
+++ b/e2e/selectors/MultichainAccounts/AccountDetails.selectors.ts
@@ -9,4 +9,5 @@ export const AccountDetailsIds = {
   SMART_ACCOUNT_LINK: 'account-details-smart-account-link',
   BACK_BUTTON: 'account-details-back-button',
   REMOVE_ACCOUNT_BUTTON: 'remove-account-button',
+  ACCOUNT_GROUP_DETAILS_AVATAR: 'account-group-details-avatar',
 };


### PR DESCRIPTION
## **Description**


1. What is the reason for the change?
- Ensures that the icon shown on the account details page is the same as the account list
2. What is the improvement/solution?
- Use the same icon seed that we do in the account list. This leverages the `selectIconSeedAddressByAccountGroupId` selector which extract the first evm address from the account group to generate the icon. 


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-829

## **Manual testing steps**

```gherkin
Feature: Account group details icon

  Scenario: user has a wallet with at least one account and has Multichain accounts state 2 enabled
    Given A user opens the account list and clicks on the kebab menu for a given account
    Then the user should be directed to the account details page and the icon in the header should match the one on the account list
```

## **Screenshots/Recordings**


https://github.com/user-attachments/assets/1fa58cf1-0561-4e4d-8616-c73aa26fa820


### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/6d6dad91-6390-44be-8980-3781b92ed28d

without mask icons


https://github.com/user-attachments/assets/1f594530-54b8-4844-807d-11b0bb8ad43c


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
