### PR TITLE
fix: cp-7.56.0 TAT-1761 no toast displayed for deposit transaction failure

### DIFF
--- a/app/components/UI/Perps/controllers/PerpsController.test.ts
+++ b/app/components/UI/Perps/controllers/PerpsController.test.ts
@@ -1691,10 +1691,8 @@ describe('PerpsController', () => {
           txHash: mockTxHash,
         });
         expect(controller.state.depositInProgress).toBe(false);
-        // Transaction ID should still be stored
-        expect(controller.state.lastDepositTransactionId).toBe(
-          'deposit-tx-456',
-        );
+        // Transaction ID should be cleared after successful deposit
+        expect(controller.state.lastDepositTransactionId).toBeNull();
       });
     });
 

--- a/app/components/UI/Perps/controllers/PerpsController.ts
+++ b/app/components/UI/Perps/controllers/PerpsController.ts
@@ -1032,6 +1032,7 @@ export class PerpsController extends BaseController<
           setTimeout(() => {
             this.update((state) => {
               state.depositInProgress = false;
+              state.lastDepositTransactionId = null;
             });
           }, 100);
         })

--- a/app/components/UI/Perps/controllers/PerpsController.ts
+++ b/app/components/UI/Perps/controllers/PerpsController.ts
@@ -133,7 +133,6 @@ export type PerpsControllerState = {
 
   // Simple deposit state (transient, for UI feedback)
   depositInProgress: boolean;
-  // TODO: Update tests
   // Internal transaction id for the deposit transaction
   // We use this to fetch the bridge quotes and get the estimated time.
   lastDepositTransactionId: string | null;

--- a/app/components/UI/Perps/hooks/usePerpsToasts.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.tsx
@@ -336,7 +336,7 @@ const usePerpsToasts = (): {
           error: {
             ...perpsBaseToastOptions.error,
             labelOptions: getPerpsToastLabels(
-              strings('perps.deposit.error_toast'),
+              strings('perps.deposit.deposit_failed'),
               strings('perps.deposit.error_generic'),
             ),
           },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Updated the `usePerpsDepositStatus` hook's transaction event listener to display the Perps deposit failed toast when the deposit transaction fails. Also updated the `PerpsController` to clear the `lastDepositTransactionId` after a successful deposit. Previously we kept this in state indefinitely. 
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: updated the `usePerpsDepositStatus` hook's transaction event listener to display the Perps deposit failed toast when the deposit transaction fails.

## **Related issues**

Fixes: [TAT-1761: No toast displayed despite deposit transaction failure](https://consensyssoftware.atlassian.net/browse/TAT-1761)

## **Manual testing steps**

```ts
// Event handler
  const triggerTestFailedDeposit = () => {
    Engine.controllerMessenger.publish(
      'TransactionController:transactionStatusUpdated',
      {
        transactionMeta: {
          id: `test-failed-deposit-${Date.now()}`,
          type: TransactionType.perpsDeposit,
          status: TransactionStatus.failed,
          txParams: {
            from: '0x1234567890123456789012345678901234567890',
            to: '0x0987654321098765432109876543210987654321',
            value: '0x0',
          },
          time: Date.now(),
          chainId: '0x1',
          networkClientId: 'mainnet',
          error: {
            name: 'Test deposit failure',
            message: 'Test deposit failure',
            code: '-1',
          },
        },
      },
    );
  };

// In component - Button (e.g. PerpsTabView)
<Button
  variant={ButtonVariants.Primary}
  onPress={triggerTestFailedDeposit}
  label="Simulate Failed Transaction"
/>
```


```gherkin
Feature: Perps Deposits

  Scenario: user wants to fund perp account
    Given user submits perp deposit transaction

    When user's perp deposit transaction fails
    Then perps deposit failed toast is displayed
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
I'm simulating the deposit failure in this video since I'm not sure how to intentionally break/fail the deposit.

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/4e00b400-2783-44d1-9c3d-f7628a399bec



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
