### PR TITLE
chore: Collect metrics for unavailable/degraded custom RPC 

### DIFF
--- a/app/core/Engine/controllers/network-controller/messenger-action-handlers.test.ts
+++ b/app/core/Engine/controllers/network-controller/messenger-action-handlers.test.ts
@@ -15,15 +15,26 @@ describe('onRpcEndpointUnavailable', () => {
     Parameters<typeof networkControllerUtilsModule.shouldCreateRpcServiceEvents>
   >;
 
+  let isPublicEndpointUrlMock: jest.SpyInstance<
+    ReturnType<typeof networkControllerUtilsModule.isPublicEndpointUrl>,
+    Parameters<typeof networkControllerUtilsModule.isPublicEndpointUrl>
+  >;
+
   beforeEach(() => {
     shouldCreateRpcServiceEventsMock = jest.spyOn(
       networkControllerUtilsModule,
       'shouldCreateRpcServiceEvents',
     );
+
+    isPublicEndpointUrlMock = jest.spyOn(
+      networkControllerUtilsModule,
+      'isPublicEndpointUrl',
+    );
   });
 
   it('calls shouldCreateRpcServiceEvents with the correct parameters', () => {
     shouldCreateRpcServiceEventsMock.mockReturnValue(true);
+    isPublicEndpointUrlMock.mockReturnValue(true);
     const trackEvent = jest.fn();
 
     onRpcEndpointUnavailable({
@@ -37,9 +48,7 @@ describe('onRpcEndpointUnavailable', () => {
     });
 
     expect(shouldCreateRpcServiceEventsMock).toHaveBeenCalledWith({
-      endpointUrl: 'https://example.com',
       error: new HttpError(420),
-      infuraProjectId: 'the-infura-project-id',
       metaMetricsId:
         '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
     });
@@ -48,6 +57,7 @@ describe('onRpcEndpointUnavailable', () => {
   describe('if the Segment event should be created', () => {
     it('calls trackEvent with the correct parameters', () => {
       shouldCreateRpcServiceEventsMock.mockReturnValue(true);
+      isPublicEndpointUrlMock.mockReturnValue(true);
       const trackEvent = jest.fn();
 
       onRpcEndpointUnavailable({
@@ -76,6 +86,7 @@ describe('onRpcEndpointUnavailable', () => {
 
     it('captures the HTTP status in the error if present', () => {
       shouldCreateRpcServiceEventsMock.mockReturnValue(true);
+      isPublicEndpointUrlMock.mockReturnValue(true);
       const trackEvent = jest.fn();
 
       onRpcEndpointUnavailable({
@@ -98,6 +109,35 @@ describe('onRpcEndpointUnavailable', () => {
           chain_id_caip: 'eip155:11155111',
           http_status: 420,
           rpc_endpoint_url: 'example.com',
+        },
+      });
+      /* eslint-enable @typescript-eslint/naming-convention */
+    });
+
+    it('anonymizes the endpoint URL if it is a custom endpoint', () => {
+      shouldCreateRpcServiceEventsMock.mockReturnValue(true);
+      isPublicEndpointUrlMock.mockReturnValue(false);
+      const trackEvent = jest.fn();
+
+      onRpcEndpointUnavailable({
+        chainId: '0xaa36a7',
+        endpointUrl: 'https://custom.com',
+        error: undefined,
+        infuraProjectId: 'the-infura-project-id',
+        trackEvent,
+        metaMetricsId:
+          '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
+      });
+
+      // The names of Segment properties have a particular case.
+      /* eslint-disable @typescript-eslint/naming-convention */
+      expect(trackEvent).toHaveBeenCalledWith({
+        event: {
+          category: 'RPC Service Unavailable',
+        },
+        properties: {
+          chain_id_caip: 'eip155:11155111',
+          rpc_endpoint_url: 'custom',
         },
       });
       /* eslint-enable @typescript-eslint/naming-convention */
@@ -132,15 +172,26 @@ describe('onRpcEndpointDegraded', () => {
     Parameters<typeof networkControllerUtilsModule.shouldCreateRpcServiceEvents>
   >;
 
+  let isPublicEndpointUrlMock: jest.SpyInstance<
+    ReturnType<typeof networkControllerUtilsModule.isPublicEndpointUrl>,
+    Parameters<typeof networkControllerUtilsModule.isPublicEndpointUrl>
+  >;
+
   beforeEach(() => {
     shouldCreateRpcServiceEventsMock = jest.spyOn(
       networkControllerUtilsModule,
       'shouldCreateRpcServiceEvents',
     );
+
+    isPublicEndpointUrlMock = jest.spyOn(
+      networkControllerUtilsModule,
+      'isPublicEndpointUrl',
+    );
   });
 
   it('calls shouldCreateRpcServiceEvents with the correct parameters', () => {
     shouldCreateRpcServiceEventsMock.mockReturnValue(true);
+    isPublicEndpointUrlMock.mockReturnValue(true);
     const trackEvent = jest.fn();
 
     onRpcEndpointDegraded({
@@ -154,9 +205,7 @@ describe('onRpcEndpointDegraded', () => {
     });
 
     expect(shouldCreateRpcServiceEventsMock).toHaveBeenCalledWith({
-      endpointUrl: 'https://example.com',
       error: new HttpError(420),
-      infuraProjectId: 'the-infura-project-id',
       metaMetricsId:
         '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
     });
@@ -165,6 +214,7 @@ describe('onRpcEndpointDegraded', () => {
   describe('if the Segment event should be created', () => {
     it('calls trackEvent with the correct parameters', () => {
       shouldCreateRpcServiceEventsMock.mockReturnValue(true);
+      isPublicEndpointUrlMock.mockReturnValue(true);
       const trackEvent = jest.fn();
 
       onRpcEndpointDegraded({
@@ -193,6 +243,7 @@ describe('onRpcEndpointDegraded', () => {
 
     it('captures the HTTP status in the error if present', () => {
       shouldCreateRpcServiceEventsMock.mockReturnValue(true);
+      isPublicEndpointUrlMock.mockReturnValue(true);
       const trackEvent = jest.fn();
 
       onRpcEndpointDegraded({
@@ -215,6 +266,35 @@ describe('onRpcEndpointDegraded', () => {
           chain_id_caip: 'eip155:11155111',
           http_status: 420,
           rpc_endpoint_url: 'example.com',
+        },
+      });
+      /* eslint-enable @typescript-eslint/naming-convention */
+    });
+
+    it('anonymizes the endpoint URL if it is a custom endpoint', () => {
+      shouldCreateRpcServiceEventsMock.mockReturnValue(true);
+      isPublicEndpointUrlMock.mockReturnValue(false);
+      const trackEvent = jest.fn();
+
+      onRpcEndpointDegraded({
+        chainId: '0xaa36a7',
+        endpointUrl: 'https://custom.com',
+        error: undefined,
+        infuraProjectId: 'the-infura-project-id',
+        trackEvent,
+        metaMetricsId:
+          '0x86bacb9b2bf9a7e8d2b147eadb95ac9aaa26842327cd24afc8bd4b3c1d136420',
+      });
+
+      // The names of Segment properties have a particular case.
+      /* eslint-disable @typescript-eslint/naming-convention */
+      expect(trackEvent).toHaveBeenCalledWith({
+        event: {
+          category: 'RPC Service Degraded',
+        },
+        properties: {
+          chain_id_caip: 'eip155:11155111',
+          rpc_endpoint_url: 'custom',
         },
       });
       /* eslint-enable @typescript-eslint/naming-convention */

--- a/app/core/Engine/controllers/network-controller/messenger-action-handlers.ts
+++ b/app/core/Engine/controllers/network-controller/messenger-action-handlers.ts
@@ -1,5 +1,5 @@
 import { type Hex, hexToNumber, isObject, isValidJson } from '@metamask/utils';
-import { shouldCreateRpcServiceEvents } from './utils';
+import { isPublicEndpointUrl, shouldCreateRpcServiceEvents } from './utils';
 import Logger from '../../../../util/Logger';
 import onlyKeepHost from '../../../../util/onlyKeepHost';
 import {
@@ -139,9 +139,7 @@ export function trackRpcEndpointEvent(
 ): void {
   if (
     !shouldCreateRpcServiceEvents({
-      endpointUrl,
       error,
-      infuraProjectId,
       metaMetricsId,
     })
   ) {
@@ -152,7 +150,9 @@ export function trackRpcEndpointEvent(
   /* eslint-disable @typescript-eslint/naming-convention */
   const properties = {
     chain_id_caip: `eip155:${hexToNumber(chainId)}`,
-    rpc_endpoint_url: onlyKeepHost(endpointUrl),
+    rpc_endpoint_url: isPublicEndpointUrl(endpointUrl, infuraProjectId)
+      ? onlyKeepHost(endpointUrl)
+      : 'custom',
     ...(isObject(error) &&
     'httpStatus' in error &&
     isValidJson(error.httpStatus)

--- a/app/core/Engine/controllers/network-controller/utils.ts
+++ b/app/core/Engine/controllers/network-controller/utils.ts
@@ -90,33 +90,25 @@ export function getIsQuicknodeEndpointUrl(endpointUrl: string): boolean {
  * - The RPC endpoint is slow
  * - The user does not have local connectivity issues
  * - The user is in the MetaMetrics sample
- * - Capturing the endpoint URL in Segment would not violate the user's privacy
  *
  * @param args - The arguments.
- * @param args.endpointUrl - The URL of the endpoint.
  * @param args.error - The connection or response error encountered after making
  * a request to the RPC endpoint.
- * @param args.infuraProjectId - Our Infura project ID.
  * @param args.metaMetricsId - The MetaMetrics ID of the user.
  * @returns True if Segment events should be created, false otherwise.
  */
 export function shouldCreateRpcServiceEvents({
-  endpointUrl,
   error,
-  infuraProjectId,
   metaMetricsId,
 }: {
-  endpointUrl: string;
   error?: unknown;
-  infuraProjectId: string;
   metaMetricsId: string | null | undefined;
 }) {
   return (
     (!error || !isConnectionError(error)) &&
     metaMetricsId !== undefined &&
     metaMetricsId !== null &&
-    isSamplingMetaMetricsUser(metaMetricsId) &&
-    isPublicEndpointUrl(endpointUrl, infuraProjectId)
+    isSamplingMetaMetricsUser(metaMetricsId)
   );
 }
 
@@ -152,7 +144,10 @@ function isSamplingMetaMetricsUser(metaMetricsId: string) {
  * @returns True if the endpoint URL is safe to share with external data
  * collection services, false otherwise.
  */
-function isPublicEndpointUrl(endpointUrl: string, infuraProjectId: string) {
+export function isPublicEndpointUrl(
+  endpointUrl: string,
+  infuraProjectId: string,
+) {
   const isMetaMaskInfuraEndpointUrl = getIsMetaMaskInfuraEndpointUrl(
     endpointUrl,
     infuraProjectId,


### PR DESCRIPTION
## **Description**

This allows for the unavailable/degraded metrics to trigger for custom RPCs without sending any private RPC urls by setting the RPC URL to custom if it is.

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
