### PR TITLE
feat: cp-7.56.0 TAT-1749: Added missing event properties when placing order and closing position

### DIFF
--- a/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.test.tsx
@@ -1874,6 +1874,15 @@ describe('PerpsClosePositionView', () => {
         '', // Empty string when closePercentage is 100
         'market',
         undefined,
+        {
+          error: null,
+          isLoadingMetamaskFee: false,
+          metamaskFee: 0,
+          metamaskFeeRate: 0,
+          protocolFee: 45,
+          protocolFeeRate: 0.00045,
+          totalFee: 45,
+        },
       );
     });
 

--- a/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
@@ -292,6 +292,7 @@ const PerpsClosePositionView: React.FC = () => {
       sizeToClose || '',
       orderType,
       orderType === 'limit' ? limitPrice : undefined,
+      feeResults,
     );
   };
 

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -393,6 +393,11 @@ const PerpsOrderViewContentBase: React.FC = () => {
           [PerpsEventProperties.ORDER_SIZE]: position?.size || orderForm.amount,
           [PerpsEventProperties.ASSET_PRICE]: position?.entryPrice,
           [PerpsEventProperties.MARGIN_USED]: position?.marginUsed,
+          [PerpsEventProperties.METAMASK_FEE]: feeResults?.metamaskFee,
+          [PerpsEventProperties.METAMASK_FEE_RATE]: feeResults?.metamaskFeeRate,
+          [PerpsEventProperties.DISCOUNT_PERCENTAGE]:
+            feeResults?.feeDiscountPercentage,
+          [PerpsEventProperties.ESTIMATED_REWARDS]: feeResults?.estimatedPoints,
         });
 
         showToast(

--- a/app/components/UI/Perps/constants/eventNames.ts
+++ b/app/components/UI/Perps/constants/eventNames.ts
@@ -22,6 +22,10 @@ export const PerpsEventProperties = {
   LIMIT_PRICE: 'Limit Price',
   FEES: 'Fees',
   FEE: 'Fee',
+  METAMASK_FEE: 'MetaMask Fee',
+  METAMASK_FEE_RATE: 'MetaMask Fee Rate',
+  DISCOUNT_PERCENTAGE: 'Discount Percentage',
+  ESTIMATED_REWARDS: 'estimatedRewards',
   ASSET_PRICE: 'Asset Price',
   COMPLETION_DURATION: 'completionDuration',
 
@@ -32,6 +36,7 @@ export const PerpsEventProperties = {
   UNREALIZED_PNL_PERCENT: 'Unrealized %PnL',
   CLOSE_VALUE: 'Close value',
   CLOSE_PERCENTAGE: 'Close percentage',
+  CLOSE_TYPE: 'Close type',
   PERCENTAGE_CLOSED: 'Percentage closed',
   PNL_DOLLAR: '$PnL',
   PNL_PERCENT: '%PnL',
@@ -61,7 +66,6 @@ export const PerpsEventProperties = {
   TAKE_PROFIT_PRICE: 'Take Profit Price',
   TAKE_PROFIT_PERCENT: 'Take Profit %',
   POSITION_SIZE: 'Position size',
-  ESTIMATED_REWARDS: 'estimatedRewards',
   POSITION_AGE: 'position age',
 
   // Notification properties
@@ -141,5 +145,9 @@ export const PerpsEventValues = {
     TP_EXECUTED: 'TP executed',
     SL_EXECUTED: 'SL executed',
     LIMIT_ORDER_EXECUTED: 'Limit order executed',
+  },
+  CLOSE_TYPE: {
+    FULL: 'full',
+    PARTIAL: 'partial',
   },
 } as const;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Added the following properties to events:

1. `PERPS_TRADE_TRANSACTION_EXECUTED` event
- `METAMASK_FEE`
- `METAMASK_FEE_RATE`
- `DISCOUNT_PERCENTAGE`
- `ESTIMATED_REWARDS`

Sample event 
```ts
{
	"event": "Perp Trade Transaction Executed",
	"properties": {
		"Asset": "BTC",
		"Asset Price": "115942.2",
		"Direction": "Short",
		"Discount Percentage": 0,
		"Leverage": 3,
		"Margin used": "8.479884",
		"MetaMask Fee": 0.01,
		"MetaMask Fee Rate": 0.001,
		"Order Size": "-0.00022",
		"Timestamp": 1758302390648,
		"estimatedRewards": 1,
		"orderType": "market"
	},
	"type": "track"
}
```

2. `PERPS_POSITION_CLOSE_EXECUTED` event
- `METAMASK_FEE`
- `METAMASK_FEE_RATE`
- `DISCOUNT_PERCENTAGE`
- `ESTIMATED_REWARDS`
- `PERCENTAGE_CLOSED`
- `CLOSE_TYPE`: full or partial close

Sample event:

```ts
{
	"event": "Perp Position Close Executed",
	"properties": {
		"Asset": "BTC",
		"Close type": "partial",
		"Direction": "Short",
		"Discount Percentage": 0,
		"MetaMask Fee": 0.015082209999999999,
		"MetaMask Fee Rate": 0.001,
		"Percentage closed": 50,
		"Timestamp": 1758301492207,
		"completionDuration": 3107.6898750066757,
		"estimatedRewards": 1,
		"orderType": "market"
	},
	"type": "track"
}
```

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: added fee, discount, estimated rewards properties to perps order and close position events

## **Related issues**

Fixes: [TAT-1749: Add fee for marketing tracking](https://consensyssoftware.atlassian.net/browse/TAT-1749)

## **Manual testing steps**

The events have be seen in terminal when placing any new trade and when closing a position.

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/a802a2bb-69d2-4977-a613-9de18740d875

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
