### PR TITLE
fix: cp-7.56.0 missing bridge symbols in transaction details

### DIFF
--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.test.tsx
@@ -136,6 +136,27 @@ describe('TransactionDetailsSummary', () => {
     ).toBeDefined();
   });
 
+  it('renders bridge line alternate title if symbols loading', () => {
+    useBridgeTxHistoryDataMock.mockReturnValue({
+      bridgeTxHistoryItem: {
+        quote: {},
+        status: {
+          status: StatusTypes.COMPLETE,
+        },
+      },
+    } as unknown as ReturnType<typeof useBridgeTxHistoryData>);
+
+    const { getByText } = render({
+      transactions: [
+        { ...TRANSACTION_META_MOCK, type: TransactionType.bridge },
+      ],
+    });
+
+    expect(
+      getByText(strings('transaction_details.summary_title.bridge_loading')),
+    ).toBeDefined();
+  });
+
   it('renders bridge approval line title', () => {
     selectBridgeHistoryForAccountMock.mockReturnValue({
       test: {
@@ -157,6 +178,27 @@ describe('TransactionDetailsSummary', () => {
         strings('transaction_details.summary_title.bridge_approval', {
           approveSymbol: SYMBOL_MOCK,
         }),
+      ),
+    ).toBeDefined();
+  });
+
+  it('renders bridge approval line alternate title if symbol loading', () => {
+    selectBridgeHistoryForAccountMock.mockReturnValue({
+      test: {
+        approvalTxId: TRANSACTION_META_MOCK.id,
+        quote: {},
+      } as BridgeHistoryItem,
+    });
+
+    const { getByText } = render({
+      transactions: [
+        { ...TRANSACTION_META_MOCK, type: TransactionType.bridgeApproval },
+      ],
+    });
+
+    expect(
+      getByText(
+        strings('transaction_details.summary_title.bridge_approval_loading'),
       ),
     ).toBeDefined();
   });

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.tsx
@@ -188,20 +188,24 @@ function getLineTitle(
   approvalBridgeHistory?: BridgeHistoryItem,
 ): string | undefined {
   const { type } = transactionMeta;
-  const sourceSymbol = bridgeHistory?.quote.srcAsset.symbol;
-  const targetSymbol = bridgeHistory?.quote.destAsset.symbol;
-  const approveSymbol = approvalBridgeHistory?.quote.srcAsset.symbol;
+  const sourceSymbol = bridgeHistory?.quote?.srcAsset?.symbol;
+  const targetSymbol = bridgeHistory?.quote?.destAsset?.symbol;
+  const approveSymbol = approvalBridgeHistory?.quote?.srcAsset?.symbol;
 
   switch (type) {
     case TransactionType.bridge:
-      return strings('transaction_details.summary_title.bridge', {
-        sourceSymbol,
-        targetSymbol,
-      });
+      return sourceSymbol && targetSymbol
+        ? strings('transaction_details.summary_title.bridge', {
+            sourceSymbol,
+            targetSymbol,
+          })
+        : strings('transaction_details.summary_title.bridge_loading');
     case TransactionType.bridgeApproval:
-      return strings('transaction_details.summary_title.bridge_approval', {
-        approveSymbol,
-      });
+      return approveSymbol
+        ? strings('transaction_details.summary_title.bridge_approval', {
+            approveSymbol,
+          })
+        : strings('transaction_details.summary_title.bridge_approval_loading');
     case TransactionType.perpsDeposit:
       return strings('transaction_details.summary_title.perps_deposit');
     case TransactionType.swap:

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5906,6 +5906,8 @@
     "summary_title": {
       "bridge": "Bridge from {{sourceSymbol}} to {{targetSymbol}}",
       "bridge_approval": "Approve {{approveSymbol}}",
+      "bridge_approval_loading": "Approve",
+      "bridge_loading": "Bridge",
       "default": "Transaction",
       "perps_deposit": "Add funds",
       "swap": "Swap tokens",


### PR DESCRIPTION
## **Description**

Show alternate translations for bridge summary lines in transaction details while symbols are loading.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#5818](https://github.com/MetaMask/MetaMask-planning/issues/5818)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
