### PR TITLE
fix: cp-7.56.0 metamask pay alert button flicker

### DIFF
--- a/app/components/Views/confirmations/components/edit-amount/edit-amount.tsx
+++ b/app/components/Views/confirmations/components/edit-amount/edit-amount.tsx
@@ -18,6 +18,8 @@ import Text, {
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
 import { Skeleton } from '../../../../../component-library/components/Skeleton';
+import { useDispatch } from 'react-redux';
+import { setTransactionBridgeQuotesLoading } from '../../../../../core/redux/slices/confirmationMetrics';
 
 const MAX_LENGTH = 28;
 
@@ -48,6 +50,7 @@ export function EditAmount({
   onKeyboardDone,
 }: EditAmountProps) {
   const fiatCurrency = PERPS_CURRENCY;
+  const dispatch = useDispatch();
   const [showKeyboard, setShowKeyboard] = useState<boolean>(false);
   const [inputChanged, setInputChanged] = useState<boolean>(false);
   const { setIsFooterVisible } = useConfirmationContext();
@@ -56,6 +59,7 @@ export function EditAmount({
   const transactionMeta = useTransactionMetadataRequest();
   const [amountFiat, setAmountFiat] = useState<string>('0');
 
+  const transactionId = transactionMeta?.id as string;
   const tokenAddress = transactionMeta?.txParams?.to as Hex;
   const chainId = transactionMeta?.chainId as Hex;
   const fiatRate = useTokenFiatRate(tokenAddress, chainId, fiatCurrency);
@@ -128,6 +132,10 @@ export function EditAmount({
   }, [amountHuman, inputChanged, onChange]);
 
   const handleKeyboardDone = useCallback(() => {
+    dispatch(
+      setTransactionBridgeQuotesLoading({ transactionId, isLoading: true }),
+    );
+
     updateTokenAmount(amountHuman);
     inputRef.current?.blur();
     setShowKeyboard(false);
@@ -136,10 +144,12 @@ export function EditAmount({
     onKeyboardDone?.();
   }, [
     amountHuman,
+    dispatch,
     inputRef,
     onKeyboardDone,
     onKeyboardHide,
     setIsFooterVisible,
+    transactionId,
     updateTokenAmount,
   ]);
 

--- a/app/components/Views/confirmations/components/edit-amount/edit-amount.tsx
+++ b/app/components/Views/confirmations/components/edit-amount/edit-amount.tsx
@@ -48,7 +48,7 @@ export function EditAmount({
   onKeyboardShow,
   onKeyboardHide,
   onKeyboardDone,
-}: EditAmountProps) {
+}: Readonly<EditAmountProps>) {
   const fiatCurrency = PERPS_CURRENCY;
   const dispatch = useDispatch();
   const [showKeyboard, setShowKeyboard] = useState<boolean>(false);
@@ -217,9 +217,9 @@ export function EditAmount({
 
 export function EditAmountSkeleton({
   children,
-}: {
+}: Readonly<{
   children: React.ReactNode;
-}) {
+}>) {
   const { styles } = useStyles(styleSheet, {
     amountLength: 1,
     hasAlert: false,

--- a/app/components/Views/confirmations/components/footer/footer.test.tsx
+++ b/app/components/Views/confirmations/components/footer/footer.test.tsx
@@ -357,5 +357,29 @@ describe('Footer', () => {
       });
       expect(mockTrackAlertMetrics).toHaveBeenCalledTimes(1);
     });
+
+    it('renders standard button label even if alerts if quotes loading', async () => {
+      (useAlerts as jest.Mock).mockReturnValue({
+        ...baseMockUseAlerts,
+        hasUnconfirmedDangerAlerts: true,
+      });
+
+      const { getByText } = renderWithProvider(<Footer />, {
+        state: merge(
+          {},
+          simpleSendTransactionControllerMock,
+          transactionApprovalControllerMock,
+          {
+            confirmationMetrics: {
+              isTransactionBridgeQuotesLoadingById: {
+                [transactionIdMock]: true,
+              },
+            },
+          },
+        ),
+      });
+
+      expect(getByText('Confirm')).toBeDefined();
+    });
   });
 });

--- a/app/components/Views/confirmations/components/footer/footer.tsx
+++ b/app/components/Views/confirmations/components/footer/footer.tsx
@@ -33,6 +33,7 @@ import Routes from '../../../../../constants/navigation/Routes';
 import { selectIsTransactionBridgeQuotesLoadingById } from '../../../../../core/redux/slices/confirmationMetrics';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../../../../reducers';
+import { TransactionType } from '@metamask/transaction-controller';
 
 export const Footer = () => {
   const {
@@ -52,12 +53,10 @@ export const Footer = () => {
   const transactionMetadata = useTransactionMetadataRequest();
   const { trackAlertMetrics } = useConfirmationAlertMetrics();
   const { isFullScreenConfirmation } = useFullScreenConfirmation();
+  const transactionType = transactionMetadata?.type as TransactionType;
+  const isStakingConfirmationBool = isStakingConfirmation(transactionType);
 
-  const isStakingConfirmationBool = isStakingConfirmation(
-    transactionMetadata?.type as string,
-  );
-
-  const { isFooterVisible, isTransactionValueUpdating } =
+  const { isFooterVisible: isFooterVisibleFlag, isTransactionValueUpdating } =
     useConfirmationContext();
 
   const navigation = useNavigation();
@@ -175,6 +174,9 @@ export const Footer = () => {
       startIconName: getStartIcon(),
     },
   ];
+
+  const isFooterVisible =
+    isFooterVisibleFlag ?? transactionType !== TransactionType.perpsDeposit;
 
   if (!isFooterVisible) {
     return null;

--- a/app/components/Views/confirmations/components/footer/footer.tsx
+++ b/app/components/Views/confirmations/components/footer/footer.tsx
@@ -88,7 +88,7 @@ export const Footer = () => {
     hideConfirmAlertModal();
     try {
       await onConfirm();
-    } catch (error) {
+    } catch {
       navigation.navigate(Routes.TRANSACTIONS_VIEW);
     }
   }, [hideConfirmAlertModal, onConfirm, navigation]);

--- a/app/components/Views/confirmations/components/footer/footer.tsx
+++ b/app/components/Views/confirmations/components/footer/footer.tsx
@@ -116,18 +116,29 @@ export const Footer = () => {
     if (isQRSigningInProgress) {
       return strings('confirm.qr_get_sign');
     }
+
+    if (isQuotesLoading) {
+      return strings('confirm.confirm');
+    }
+
     if (hasUnconfirmedDangerAlerts) {
       return fieldAlerts.length > 1
         ? strings('alert_system.review_alerts')
         : strings('alert_system.review_alert');
     }
+
     if (hasBlockingAlerts) {
       return strings('alert_system.review_alerts');
     }
+
     return strings('confirm.confirm');
   };
 
   const getStartIcon = () => {
+    if (isQuotesLoading) {
+      return undefined;
+    }
+
     if (hasUnconfirmedDangerAlerts) {
       return IconName.SecuritySearch;
     }
@@ -153,8 +164,9 @@ export const Footer = () => {
     {
       variant: ButtonVariants.Primary,
       isDanger:
-        securityAlertResponse?.result_type === ResultType.Malicious ||
-        hasDangerAlerts,
+        !isQuotesLoading &&
+        (securityAlertResponse?.result_type === ResultType.Malicious ||
+          hasDangerAlerts),
       isDisabled: isConfirmDisabled,
       label: confirmButtonLabel(),
       size: ButtonSize.Lg,

--- a/app/components/Views/confirmations/context/confirmation-context/confirmation-context.test.tsx
+++ b/app/components/Views/confirmations/context/confirmation-context/confirmation-context.test.tsx
@@ -14,7 +14,7 @@ describe('ConfirmationContext', () => {
     const { result } = renderHook(() => useConfirmationContext(), { wrapper });
 
     expect(result.current).toStrictEqual({
-      isFooterVisible: true,
+      isFooterVisible: undefined,
       isTransactionValueUpdating: false,
       setIsFooterVisible: expect.any(Function),
       setIsTransactionValueUpdating: expect.any(Function),

--- a/app/components/Views/confirmations/context/confirmation-context/confirmation-context.tsx
+++ b/app/components/Views/confirmations/context/confirmation-context/confirmation-context.tsx
@@ -27,7 +27,7 @@ export const ConfirmationContextProvider: React.FC<
   const [isTransactionValueUpdating, setIsTransactionValueUpdating] =
     useState(false);
 
-  const [isFooterVisible, setIsFooterVisible] = useState(true);
+  const [isFooterVisible, setIsFooterVisible] = useState<boolean>();
 
   const contextValue = useMemo(
     () => ({

--- a/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositView.test.ts
+++ b/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositView.test.ts
@@ -110,23 +110,6 @@ describe('usePerpsDepositView', () => {
     expect(result.current.isFullView).toBe(false);
   });
 
-  it('returns isFullView as false if amount is zero', () => {
-    useTokenAmountMock.mockReturnValue({
-      amountUnformatted: '0',
-    } as ReturnType<typeof useTokenAmount>);
-
-    const { result } = runHook(
-      {
-        isKeyboardVisible: false,
-      },
-      {
-        quotes: [{}],
-      },
-    );
-
-    expect(result.current.isFullView).toBe(false);
-  });
-
   it('returns isFullView as false if quotes are undefined', () => {
     const { result } = runHook(
       {

--- a/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositView.ts
+++ b/app/components/Views/confirmations/external/perps-temp/hooks/usePerpsDepositView.ts
@@ -1,6 +1,5 @@
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { useAutomaticTransactionPayToken } from '../../../hooks/pay/useAutomaticTransactionPayToken';
-import { useTokenAmount } from '../../../hooks/useTokenAmount';
 import { useTransactionMetadataOrThrow } from '../../../hooks/transactions/useTransactionMetadataRequest';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../../../../../reducers';
@@ -8,7 +7,6 @@ import {
   selectIsTransactionBridgeQuotesLoadingById,
   selectTransactionBridgeQuotesById,
 } from '../../../../../../core/redux/slices/confirmationMetrics';
-import { BigNumber } from 'bignumber.js';
 import { usePerpsDepositInit } from './usePerpsDepositInit';
 import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
 import { useTransactionPayTokenAmounts } from '../../../hooks/pay/useTransactionPayTokenAmounts';
@@ -25,11 +23,8 @@ export function usePerpsDepositView({
   usePerpsDepositInit();
 
   const { id: transactionId } = useTransactionMetadataOrThrow();
-  const { amountUnformatted } = useTokenAmount();
   const { payToken } = useTransactionPayToken();
   const { amounts: sourceAmounts } = useTransactionPayTokenAmounts();
-
-  const amountValue = new BigNumber(amountUnformatted ?? '0');
 
   const quotes = useSelector((state: RootState) =>
     selectTransactionBridgeQuotesById(state, transactionId),
@@ -41,7 +36,6 @@ export function usePerpsDepositView({
 
   const isFullView =
     !isKeyboardVisible &&
-    !amountValue.isZero() &&
     (isQuotesLoading || Boolean(quotes?.length) || sourceAmounts?.length === 0);
 
   useAutomaticTransactionPayToken({


### PR DESCRIPTION
## **Description**

Prevent confirm button showing alert state during initial page and quotes loading.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#5851](https://github.com/MetaMask/MetaMask-planning/issues/5851)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
