### PR TITLE
fix: seedless controller lock - cp-7.56.0

### DIFF
--- a/app/core/Authentication/Authentication.test.ts
+++ b/app/core/Authentication/Authentication.test.ts
@@ -918,6 +918,7 @@ describe('Authentication', () => {
         exportEncryptionKey: jest.fn(),
         storeKeyringEncryptionKey: jest.fn(),
         updateBackupMetadataState: jest.fn(),
+        setLocked: jest.fn().mockReturnValue(undefined),
       };
       Engine.context.KeyringController.state.keyrings = [
         { metadata: { id: 'test-keyring' } },
@@ -953,6 +954,7 @@ describe('Authentication', () => {
           .fn()
           .mockRejectedValue(new Error('Backup failed')),
         clearState: jest.fn(),
+        setLocked: jest.fn().mockReturnValue(undefined),
       };
       Engine.context.KeyringController.state.keyrings = [
         { metadata: { id: 'test-keyring' } },
@@ -1107,6 +1109,7 @@ describe('Authentication', () => {
         loadKeyringEncryptionKey: jest.fn(),
         submitGlobalPassword: jest.fn(),
         checkIsPasswordOutdated: jest.fn(),
+        setLocked: jest.fn().mockReturnValue(undefined),
       } as unknown as SeedlessOnboardingController<EncryptionKey>;
       Engine.context.KeyringController = {
         setLocked: jest.fn(),
@@ -1514,6 +1517,7 @@ describe('Authentication', () => {
         submitGlobalPassword: jest.fn(),
         fetchAllSecretData: jest.fn(),
         revokeRefreshToken: jest.fn().mockResolvedValue(undefined),
+        setLocked: jest.fn().mockReturnValue(undefined),
       } as unknown as SeedlessOnboardingController<EncryptionKey>;
 
       jest.spyOn(Authentication, 'resetPassword');
@@ -1830,6 +1834,11 @@ describe('Authentication', () => {
       await expect(
         Authentication.syncPasswordAndUnlockWallet(mockGlobalPassword),
       ).rejects.toThrow('change password failed');
+
+      // expect SeedlessOnboardingController.setLocked to be called
+      expect(
+        Engine.context.SeedlessOnboardingController.setLocked,
+      ).toHaveBeenCalled();
 
       expect(Authentication.lockApp).toHaveBeenCalledWith({ locked: true });
     });

--- a/app/core/Authentication/Authentication.test.ts
+++ b/app/core/Authentication/Authentication.test.ts
@@ -918,7 +918,7 @@ describe('Authentication', () => {
         exportEncryptionKey: jest.fn(),
         storeKeyringEncryptionKey: jest.fn(),
         updateBackupMetadataState: jest.fn(),
-        setLocked: jest.fn().mockReturnValue(undefined),
+        setLocked: jest.fn().mockResolvedValue(undefined),
       };
       Engine.context.KeyringController.state.keyrings = [
         { metadata: { id: 'test-keyring' } },
@@ -954,7 +954,7 @@ describe('Authentication', () => {
           .fn()
           .mockRejectedValue(new Error('Backup failed')),
         clearState: jest.fn(),
-        setLocked: jest.fn().mockReturnValue(undefined),
+        setLocked: jest.fn().mockResolvedValue(undefined),
       };
       Engine.context.KeyringController.state.keyrings = [
         { metadata: { id: 'test-keyring' } },
@@ -1109,7 +1109,7 @@ describe('Authentication', () => {
         loadKeyringEncryptionKey: jest.fn(),
         submitGlobalPassword: jest.fn(),
         checkIsPasswordOutdated: jest.fn(),
-        setLocked: jest.fn().mockReturnValue(undefined),
+        setLocked: jest.fn().mockResolvedValue(undefined),
       } as unknown as SeedlessOnboardingController<EncryptionKey>;
       Engine.context.KeyringController = {
         setLocked: jest.fn(),
@@ -1517,7 +1517,7 @@ describe('Authentication', () => {
         submitGlobalPassword: jest.fn(),
         fetchAllSecretData: jest.fn(),
         revokeRefreshToken: jest.fn().mockResolvedValue(undefined),
-        setLocked: jest.fn().mockReturnValue(undefined),
+        setLocked: jest.fn().mockResolvedValue(undefined),
       } as unknown as SeedlessOnboardingController<EncryptionKey>;
 
       jest.spyOn(Authentication, 'resetPassword');

--- a/app/core/Authentication/Authentication.ts
+++ b/app/core/Authentication/Authentication.ts
@@ -683,6 +683,7 @@ class AuthenticationService {
     }
 
     if (selectSeedlessOnboardingLoginFlow(ReduxService.store.getState())) {
+      // SeedlessOnboardingController.setLocked() will not throw, it swallow the error in the function
       await SeedlessOnboardingController.setLocked();
     }
 

--- a/app/core/Authentication/Authentication.ts
+++ b/app/core/Authentication/Authentication.ts
@@ -676,11 +676,16 @@ class AuthenticationService {
     locked = false,
     navigateToLogin = true,
   } = {}): Promise<void> => {
-    const { KeyringController } = Engine.context;
+    const { KeyringController, SeedlessOnboardingController } = Engine.context;
     if (reset) await this.resetPassword();
     if (KeyringController.isUnlocked()) {
       await KeyringController.setLocked();
     }
+
+    if (selectSeedlessOnboardingLoginFlow(ReduxService.store.getState())) {
+      await SeedlessOnboardingController.setLocked();
+    }
+
     // async check seedless password outdated skip cache when app lock
     // the function swallowed the error
     this.checkIsSeedlessPasswordOutdated(true);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
The new seedless controller 4.0.0 require controller to be lock manually instead of depend on the keyring controller's lock event.

This pr added the manual lock of the seedless controller when the app is locked.



## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:
https://github.com/MetaMask/metamask-mobile/issues/20154

## **Manual testing steps**

```gherkin
Feature: manual lock seedless onboarding controller

  Scenario: user lock app
    Given user login with seedless flow

    When user lock app
    Then seedless controller should be locked
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
