### PR TITLE
fix: disable skeleton animation in unit tests

### DIFF
--- a/app/component-library/components/Skeleton/Skeleton.tsx
+++ b/app/component-library/components/Skeleton/Skeleton.tsx
@@ -52,7 +52,7 @@ const Skeleton: React.FC<SkeletonProps> = ({
 
   useEffect(() => {
     // Only start animation if no children are present or if children should be hidden
-    if (!isE2E && (!children || hideChildren)) {
+    if (!isE2E && !process.env.JEST_WORKER_ID && (!children || hideChildren)) {
       startAnimation();
     }
 

--- a/app/components/Views/confirmations/components/pay-token-amount/pay-token-amount.test.tsx
+++ b/app/components/Views/confirmations/components/pay-token-amount/pay-token-amount.test.tsx
@@ -12,7 +12,6 @@ jest.mock('../../hooks/useTokenAmount');
 jest.mock('../../hooks/useTokenAsset');
 jest.mock('../../hooks/tokens/useTokenFiatRates');
 jest.mock('../../hooks/pay/useTransactionPayToken');
-jest.mock('../../../../../component-library/components/Skeleton');
 
 const ASSET_AMOUNT_MOCK = '100';
 const ASSET_FIAT_RATE_MOCK = 10;

--- a/app/components/Views/confirmations/components/rows/bridge-time-row/bridge-time-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/bridge-time-row/bridge-time-row.test.tsx
@@ -41,12 +41,6 @@ describe('BridgeTimeRow', () => {
     jest.resetAllMocks();
   });
 
-  afterEach(() => {
-    // Clean up any running animations to prevent Jest teardown issues
-    jest.clearAllTimers();
-    jest.useRealTimers();
-  });
-
   it('renders total estimated time', async () => {
     const { getByText } = render({
       quotes: [

--- a/app/components/Views/confirmations/components/rows/total-row/total-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/total-row/total-row.test.tsx
@@ -11,7 +11,6 @@ import { ConfirmationMetricsState } from '../../../../../../core/redux/slices/co
 import { transactionApprovalControllerMock } from '../../../__mocks__/controllers/approval-controller-mock';
 
 jest.mock('../../../hooks/pay/useTransactionTotalFiat');
-jest.mock('../../../../../../component-library/components/Skeleton');
 
 const TOTAL_FIAT_MOCK = '$123.456';
 

--- a/app/util/test/testSetup.js
+++ b/app/util/test/testSetup.js
@@ -255,6 +255,10 @@ jest.mock('react-native-reanimated', () =>
   require('react-native-reanimated/mock'),
 );
 
+jest.mock('react-native-reanimated/src/mockedRequestAnimationFrame', () => ({
+  mockedRequestAnimationFrame: () => () => undefined,
+}));
+
 NativeModules.RNGestureHandlerModule = {
   getConstants: jest.fn(() => ({
     State: {

--- a/app/util/test/testSetup.js
+++ b/app/util/test/testSetup.js
@@ -255,10 +255,6 @@ jest.mock('react-native-reanimated', () =>
   require('react-native-reanimated/mock'),
 );
 
-jest.mock('react-native-reanimated/src/mockedRequestAnimationFrame', () => ({
-  mockedRequestAnimationFrame: () => () => undefined,
-}));
-
 NativeModules.RNGestureHandlerModule = {
   getConstants: jest.fn(() => ({
     State: {


### PR DESCRIPTION
## **Description**

Fix flaky unit tests using `Skeleton` component by disabling animation in unit tests.

Cannot centrally mock `Skeleton` as it has unit tests of its own, nor can we mock the animation itself as we also have hooks with unit tests that verify animations.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
