### PR TITLE
fix: cp-7.56.0 add multichain prices polling

### DIFF
--- a/app/components/UI/Tokens/index.test.tsx
+++ b/app/components/UI/Tokens/index.test.tsx
@@ -73,6 +73,10 @@ jest.mock('../../../core/Engine', () => ({
         },
       },
     },
+    MultichainAssetsRatesController: {
+      startPolling: jest.fn(),
+      stopPollingByPollingToken: jest.fn(),
+    },
     AccountsController: {
       state: {
         internalAccounts: {

--- a/app/components/hooks/AssetPolling/AssetPollingProvider.tsx
+++ b/app/components/hooks/AssetPolling/AssetPollingProvider.tsx
@@ -1,10 +1,13 @@
 import { useMemo, memo } from 'react';
 import { Hex } from '@metamask/utils';
+import { useSelector } from 'react-redux';
 import useCurrencyRatePolling from './useCurrencyRatePolling';
 import useTokenRatesPolling from './useTokenRatesPolling';
 import useTokenDetectionPolling from './useTokenDetectionPolling';
 import useTokenListPolling from './useTokenListPolling';
 import useTokenBalancesPolling from './useTokenBalancesPolling';
+import useMultichainAssetsRatePolling from './useMultichainAssetsRatePolling';
+import { selectSelectedInternalAccount } from '../../../selectors/accountsController';
 
 // This provider is a step towards making controller polling fully UI based.
 // Eventually, individual UI components will call the use*Polling hooks to
@@ -21,11 +24,17 @@ export const AssetPollingProvider = memo(
       [chainIds, address],
     );
 
+    const account = useSelector(selectSelectedInternalAccount);
+
     useCurrencyRatePolling(chainParams);
     useTokenRatesPolling(chainParams);
     useTokenDetectionPolling(tokenDetectionParams);
     useTokenListPolling(chainParams);
     useTokenBalancesPolling(chainParams);
+
+    useMultichainAssetsRatePolling(
+      account?.id ? { accountId: account.id } : { accountId: '' },
+    );
 
     return null;
   },

--- a/app/components/hooks/AssetPolling/useMultichainAssetsRatePolling.ts
+++ b/app/components/hooks/AssetPolling/useMultichainAssetsRatePolling.ts
@@ -1,0 +1,23 @@
+import usePolling from '../usePolling';
+import Engine from '../../../core/Engine';
+
+const useMultichainAssetsRatePolling = ({
+  accountId,
+}: {
+  accountId: string;
+}) => {
+  const { MultichainAssetsRatesController } = Engine.context;
+
+  usePolling({
+    startPolling: MultichainAssetsRatesController.startPolling.bind(
+      MultichainAssetsRatesController,
+    ),
+    stopPollingByPollingToken:
+      MultichainAssetsRatesController.stopPollingByPollingToken.bind(
+        MultichainAssetsRatesController,
+      ),
+    input: [{ accountId }],
+  });
+};
+
+export default useMultichainAssetsRatePolling;

--- a/app/components/hooks/AssetPolling/useMultichanAssetsRatePolling.test.ts
+++ b/app/components/hooks/AssetPolling/useMultichanAssetsRatePolling.test.ts
@@ -1,0 +1,210 @@
+import { renderHook } from '@testing-library/react-hooks';
+import useMultichainAssetsRatePolling from './useMultichainAssetsRatePolling';
+import Engine from '../../../core/Engine';
+
+// Mock Engine with MultichainAssetsRatesController
+jest.mock('../../../core/Engine', () => ({
+  context: {
+    MultichainAssetsRatesController: {
+      startPolling: jest.fn(),
+      stopPollingByPollingToken: jest.fn(),
+    },
+  },
+}));
+
+describe('useMultichainAssetsRatePolling', () => {
+  const mockStartPolling = jest.fn();
+  const mockStopPollingByPollingToken = jest.fn();
+
+  beforeEach(() => {
+    // Reset all mocks before each test
+    jest.resetAllMocks();
+
+    // Setup mock implementations
+    mockStartPolling.mockImplementation(() => 'mock-polling-token');
+    mockStopPollingByPollingToken.mockImplementation(() => undefined);
+
+    // Apply mocks to Engine context
+    (Engine.context.MultichainAssetsRatesController.startPolling as jest.Mock) =
+      mockStartPolling;
+    (Engine.context.MultichainAssetsRatesController
+      .stopPollingByPollingToken as jest.Mock) = mockStopPollingByPollingToken;
+  });
+
+  it('starts polling with provided accountId on mount', () => {
+    // Arrange
+    const accountId = 'test-account-id-123';
+
+    // Act
+    renderHook(() => useMultichainAssetsRatePolling({ accountId }));
+
+    // Assert
+    expect(mockStartPolling).toHaveBeenCalledTimes(1);
+    expect(mockStartPolling).toHaveBeenCalledWith({ accountId });
+    expect(mockStopPollingByPollingToken).not.toHaveBeenCalled();
+  });
+
+  it('stops polling on unmount', () => {
+    // Arrange
+    const accountId = 'test-account-id-123';
+
+    // Act
+    const { unmount } = renderHook(() =>
+      useMultichainAssetsRatePolling({ accountId }),
+    );
+
+    // Assert initial polling started
+    expect(mockStartPolling).toHaveBeenCalledTimes(1);
+    expect(mockStartPolling).toHaveBeenCalledWith({ accountId });
+
+    // Act - unmount the hook
+    unmount();
+
+    // Assert polling stopped
+    expect(mockStopPollingByPollingToken).toHaveBeenCalledTimes(1);
+    expect(mockStopPollingByPollingToken).toHaveBeenCalledWith(
+      'mock-polling-token',
+    );
+  });
+
+  it('restarts polling when accountId changes', () => {
+    // Arrange
+    const initialAccountId = 'account-1';
+    const newAccountId = 'account-2';
+
+    // Act
+    const { rerender } = renderHook(
+      ({ accountId }) => useMultichainAssetsRatePolling({ accountId }),
+      { initialProps: { accountId: initialAccountId } },
+    );
+
+    // Assert initial polling
+    expect(mockStartPolling).toHaveBeenCalledTimes(1);
+    expect(mockStartPolling).toHaveBeenCalledWith({
+      accountId: initialAccountId,
+    });
+
+    // Act - change accountId
+    rerender({ accountId: newAccountId });
+
+    // Assert old polling stopped and new polling started
+    expect(mockStopPollingByPollingToken).toHaveBeenCalledTimes(1);
+    expect(mockStopPollingByPollingToken).toHaveBeenCalledWith(
+      'mock-polling-token',
+    );
+    expect(mockStartPolling).toHaveBeenCalledTimes(2);
+    expect(mockStartPolling).toHaveBeenNthCalledWith(2, {
+      accountId: newAccountId,
+    });
+  });
+
+  it('handles empty accountId gracefully', () => {
+    // Arrange
+    const accountId = '';
+
+    // Act
+    renderHook(() => useMultichainAssetsRatePolling({ accountId }));
+
+    // Assert - should still start polling even with empty accountId
+    expect(mockStartPolling).toHaveBeenCalledTimes(1);
+    expect(mockStartPolling).toHaveBeenCalledWith({ accountId: '' });
+  });
+
+  it('handles multiple rapid accountId changes correctly', () => {
+    // Arrange
+    const accountIds = ['account-1', 'account-2', 'account-3'];
+
+    // Act
+    const { rerender } = renderHook(
+      ({ accountId }) => useMultichainAssetsRatePolling({ accountId }),
+      { initialProps: { accountId: accountIds[0] } },
+    );
+
+    // Change accountId multiple times
+    accountIds.slice(1).forEach((newAccountId) => {
+      rerender({ accountId: newAccountId });
+    });
+
+    // Assert
+    // Should have started polling for each accountId
+    expect(mockStartPolling).toHaveBeenCalledTimes(accountIds.length);
+    accountIds.forEach((accountId, index) => {
+      expect(mockStartPolling).toHaveBeenNthCalledWith(index + 1, {
+        accountId,
+      });
+    });
+
+    // Should have stopped polling for all but the last accountId
+    expect(mockStopPollingByPollingToken).toHaveBeenCalledTimes(
+      accountIds.length - 1,
+    );
+  });
+
+  it('maintains polling when same accountId is provided', () => {
+    // Arrange
+    const accountId = 'same-account-id';
+
+    // Act
+    const { rerender } = renderHook(
+      ({ accountId: hookAccountId }) =>
+        useMultichainAssetsRatePolling({ accountId: hookAccountId }),
+      { initialProps: { accountId } },
+    );
+
+    // Re-render with same accountId
+    rerender({ accountId });
+
+    // Assert - should not restart polling for same accountId
+    expect(mockStartPolling).toHaveBeenCalledTimes(1);
+    expect(mockStopPollingByPollingToken).not.toHaveBeenCalled();
+  });
+
+  it('handles controller methods being bound correctly', () => {
+    // Arrange - Verify that controller methods are properly bound
+    const accountId = 'test-account-id';
+
+    // Act
+    renderHook(() => useMultichainAssetsRatePolling({ accountId }));
+
+    // Assert - Methods should be called (proving they were bound correctly)
+    expect(mockStartPolling).toHaveBeenCalledTimes(1);
+    expect(mockStartPolling).toHaveBeenCalledWith({ accountId });
+  });
+
+  it('passes correct polling token to stop method', () => {
+    // Arrange
+    const customToken = 'custom-polling-token-xyz';
+    mockStartPolling.mockReturnValue(customToken);
+    const accountId = 'test-account-id';
+
+    // Act
+    const { unmount } = renderHook(() =>
+      useMultichainAssetsRatePolling({ accountId }),
+    );
+    unmount();
+
+    // Assert
+    expect(mockStopPollingByPollingToken).toHaveBeenCalledWith(customToken);
+  });
+
+  describe('accountId format variations', () => {
+    const accountIdVariations = [
+      'simple-id',
+      'account-with-dashes-123',
+      'AccountWithMixedCase',
+      '0x1234567890abcdef',
+      'very-long-account-id-with-many-characters-to-test-edge-cases-123456789',
+    ] as const;
+
+    it.each(accountIdVariations)(
+      'handles accountId format: %s',
+      (accountId) => {
+        // Act
+        renderHook(() => useMultichainAssetsRatePolling({ accountId }));
+
+        // Assert
+        expect(mockStartPolling).toHaveBeenCalledWith({ accountId });
+      },
+    );
+  });
+});

--- a/app/core/Engine/controllers/multichain-assets-rates-controller/multichain-assets-rates-controller-init.ts
+++ b/app/core/Engine/controllers/multichain-assets-rates-controller/multichain-assets-rates-controller-init.ts
@@ -23,6 +23,7 @@ export const multichainAssetsRatesControllerInit: ControllerInitFunction<
   const controller = new MultichainAssetsRatesController({
     messenger: controllerMessenger,
     state: multichainAssetsRatesControllerState,
+    interval: 180000,
   });
 
   return { controller };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR adds multichain assets rate polling to ensure that asset prices are properly updated across different chains. Previously, there was no polling mechanism for multichain assets, which resulted in stale price data not being refreshed automatically.

**What is the reason for the change?**
The multichain assets weren't being polled for rate updates, causing price information to become stale and not reflect current market values.

**What is the improvement/solution?**
- Added `useMultichainAssetsRatePolling` hook that polls the `MultichainAssetsRatesController` for rate updates
- Integrated the polling hook into the `AssetPollingProvider` to ensure it runs globally
- The polling is tied to the selected account ID to ensure proper scoping of rate updates

## **Changelog**

CHANGELOG entry: Fixed multichain assets price polling to ensure rates are updated automatically

## **Related issues**

Fixes: Asset prices not updating for multichain assets due to missing polling mechanism

## **Manual testing steps**

```gherkin
Feature: Multichain Assets Rate Polling

  Scenario: user views multichain assets with updated prices
    Given the app is running with multichain assets visible
    And market prices for assets have changed

    When user navigates to asset views or portfolio
    Then asset prices should automatically update to reflect current market rates
    And price updates should occur periodically without user intervention
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- Multichain asset prices would become stale and not update automatically -->

### **After**

<!-- Multichain asset prices update automatically through polling mechanism -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.