### PR TITLE
chore: Update @metamask/signature-controller

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -220,8 +220,9 @@ app/components/Views/Onboarding                             @MetaMask/web3auth
 app/reducers/onboarding                                     @MetaMask/web3auth
 
 # Delegation team
-app/core/Engine/controllers/gator-permissions-controller    @MetaMask/delegation
-app/core/Engine/messengers/gator-permissions-controller-messenger      @MetaMask/delegation
+app/core/Engine/controllers/gator-permissions-controller              @MetaMask/delegation
+app/core/Engine/messengers/gator-permissions-controller-messenger     @MetaMask/delegation
+
 # QA Team - E2E Framework
 e2e/api-mocking/                             @MetaMask/qa
 e2e/fixtures/                                @MetaMask/qa

--- a/app/core/Engine/messengers/signature-controller-messenger/signature-controller-messenger.ts
+++ b/app/core/Engine/messengers/signature-controller-messenger/signature-controller-messenger.ts
@@ -10,6 +10,7 @@ import {
 import { NetworkControllerGetNetworkClientByIdAction } from '@metamask/network-controller';
 
 import type { SignatureControllerMessenger } from '@metamask/signature-controller';
+import { GatorPermissionsControllerDecodePermissionFromPermissionContextForOriginAction } from '@metamask/gator-permissions-controller';
 
 type MessengerActions =
   | AccountsControllerGetStateAction
@@ -18,7 +19,8 @@ type MessengerActions =
   | NetworkControllerGetNetworkClientByIdAction
   | KeyringControllerSignMessageAction
   | KeyringControllerSignPersonalMessageAction
-  | KeyringControllerSignTypedMessageAction;
+  | KeyringControllerSignTypedMessageAction
+  | GatorPermissionsControllerDecodePermissionFromPermissionContextForOriginAction;
 
 type MessengerEvents = never;
 
@@ -35,6 +37,7 @@ export function getSignatureControllerMessenger(
       'KeyringController:signMessage',
       'KeyringController:signPersonalMessage',
       'KeyringController:signTypedMessage',
+      'GatorPermissionsController:decodePermissionFromPermissionContextForOrigin',
     ],
     allowedEvents: [],
   });

--- a/package.json
+++ b/package.json
@@ -281,7 +281,7 @@
     "@metamask/sdk-communication-layer": "0.33.1",
     "@metamask/seedless-onboarding-controller": "^4.0.0",
     "@metamask/selected-network-controller": "^24.0.0",
-    "@metamask/signature-controller": "^33.0.0",
+    "@metamask/signature-controller": "^34.0.0",
     "@metamask/slip44": "^4.2.0",
     "@metamask/smart-transactions-controller": "^19.2.1",
     "@metamask/snaps-controllers": "^15.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8487,24 +8487,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/signature-controller@npm:^33.0.0":
-  version: 33.0.0
-  resolution: "@metamask/signature-controller@npm:33.0.0"
+"@metamask/signature-controller@npm:^34.0.0":
+  version: 34.0.1
+  resolution: "@metamask/signature-controller@npm:34.0.1"
   dependencies:
-    "@metamask/base-controller": "npm:^8.1.0"
-    "@metamask/controller-utils": "npm:^11.12.0"
+    "@metamask/base-controller": "npm:^8.4.1"
+    "@metamask/controller-utils": "npm:^11.14.1"
     "@metamask/eth-sig-util": "npm:^8.2.0"
-    "@metamask/utils": "npm:^11.4.2"
+    "@metamask/utils": "npm:^11.8.1"
     jsonschema: "npm:^1.4.1"
     lodash: "npm:^4.17.21"
     uuid: "npm:^8.3.2"
   peerDependencies:
     "@metamask/accounts-controller": ^33.0.0
     "@metamask/approval-controller": ^7.0.0
+    "@metamask/gator-permissions-controller": ^0.2.0
     "@metamask/keyring-controller": ^23.0.0
     "@metamask/logging-controller": ^6.0.0
     "@metamask/network-controller": ^24.0.0
-  checksum: 10/9fb0c33fd14dba0d7389fbe581c6cdd8f92870aaaebe92fc610e16b591572bea025760d5dbd87d35a3c4408936fb08cc163623d6f22bfbd36f3921178f8688e5
+  checksum: 10/ea6df5afeb99f5859ab7ab3cc50cf67827b87907932e429dbff37f65818a58a139348aab9c7b0870e0d68f2ca1b5763afa1677722e50bf5179923b6dd6573f9a
   languageName: node
   linkType: hard
 
@@ -34164,7 +34165,7 @@ __metadata:
     "@metamask/sdk-communication-layer": "npm:0.33.1"
     "@metamask/seedless-onboarding-controller": "npm:^4.0.0"
     "@metamask/selected-network-controller": "npm:^24.0.0"
-    "@metamask/signature-controller": "npm:^33.0.0"
+    "@metamask/signature-controller": "npm:^34.0.0"
     "@metamask/slip44": "npm:^4.2.0"
     "@metamask/smart-transactions-controller": "npm:^19.2.1"
     "@metamask/snaps-controllers": "npm:^15.0.2"


### PR DESCRIPTION
## **Description**

Updates the dependency on @metamask/signature-controller to 34.0.0

This version bump introduces a dependency on @metamask/gator-permissions-controller via `GatorPermissionsControllerDecodePermissionFromPermissionContextForOriginAction` which has been added to signature-controller-messenger.

## **Changelog**

From SignatureController https://github.com/MetaMask/core/blob/main/packages/signature-controller/CHANGELOG.md:

### @metamask/signature-controller 34.0.0

#### Added

- Add two new controller state metadata properties: includeInStateLogs and usedInUi (https://github.com/MetaMask/core/pull/6473)
- Decode delegation permissions using `@metamask/gator-permissions-controller` when calling `newUnsignedTypedMessage` ([#6619](https://github.com/MetaMask/core/pull/6619))

#### Changed

- Bump @metamask/controller-utils from ^11.12.0 to ^11.14.0 (https://github.com/MetaMask/core/pull/6620, https://github.com/MetaMask/core/pull/6629)
- Bump @metamask/base-controller from ^8.1.0 to ^8.4.0 (https://github.com/MetaMask/core/pull/6355, https://github.com/MetaMask/core/pull/6465, https://github.com/MetaMask/core/pull/6632)
- Bump @metamask/utils from ^11.4.2 to ^11.8.0 (https://github.com/MetaMask/core/pull/6588)

### @metamask/signature-controller 33.0.0

#### Changed

- BREAKING: Bump peer dependency @metamask/accounts-controller from ^32.0.0 to ^33.0.0 (https://github.com/MetaMask/core/pull/6345)
- BREAKING: Bump peer dependency @metamask/keyring-controller from ^22.0.0 to ^23.0.0 (https://github.com/MetaMask/core/pull/6345)
- Bump @metamask/base-controller from ^8.0.1 to ^8.1.0 (https://github.com/MetaMask/core/pull/6284)
- Bump @metamask/controller-utils from ^11.11.0 to ^11.12.0 (https://github.com/MetaMask/core/pull/6303)

CHANGELOG entry: null

## **Screenshots/Recordings**

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrade @metamask/signature-controller to ^34 and allow GatorPermissionsController decode action in the signature controller messenger.
> 
> - **Dependencies**:
>   - Bump `@metamask/signature-controller` to `^34.0.0`.
> - **Engine**:
>   - **`app/core/Engine/messengers/signature-controller-messenger/signature-controller-messenger.ts`**:
>     - Add `GatorPermissionsControllerDecodePermissionFromPermissionContextForOriginAction` and allow `GatorPermissionsController:decodePermissionFromPermissionContextForOrigin` in `allowedActions`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 657705e727aa6e90754f92c30d5088175acae055. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->