### PR TITLE
fix: account maximum length name on account list

### DIFF
--- a/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.styles.ts
+++ b/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.styles.ts
@@ -41,6 +41,7 @@ const styleSheet = (params: {
     },
     accountNameText: {
       minWidth: 0,
+      flex: 1,
     },
     checkIcon: {
       marginLeft: 8,

--- a/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/__snapshots__/MultichainAccountsConnectedList.test.tsx.snap
+++ b/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/__snapshots__/MultichainAccountsConnectedList.test.tsx.snap
@@ -172,6 +172,7 @@ exports[`MultichainAccountsConnectedList renders component with different accoun
                       style={
                         {
                           "color": "#121314",
+                          "flex": 1,
                           "fontFamily": "Geist Bold",
                           "fontSize": 16,
                           "letterSpacing": 0,
@@ -361,6 +362,7 @@ exports[`MultichainAccountsConnectedList renders component with different accoun
                       style={
                         {
                           "color": "#121314",
+                          "flex": 1,
                           "fontFamily": "Geist Bold",
                           "fontSize": 16,
                           "letterSpacing": 0,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR fixes a bug causing select icon to be rendered under the balance on accounts list.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug causing select icon to be rendered under the balance on accounts list.

## **Related issues**

Fixes: 
Jira ticket: https://consensyssoftware.atlassian.net/browse/MUL-1030

## **Manual testing steps**

```gherkin
Feature: Multichain accounts lsit

  Scenario: user opens a list with long account name
    Given multichain accounts feature is enabled

    When user navigates to accounts list with selected account with long name
    Then the selected icon is rendered correctly
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="368" height="725" alt="Screenshot 2025-09-23 at 11 12 23" src="https://github.com/user-attachments/assets/36f1dd65-f44b-4095-99a5-cc38aaa4559e" />

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="372" height="719" alt="Screenshot 2025-09-23 at 11 12 14" src="https://github.com/user-attachments/assets/4f3964bc-88f1-46fd-b0fe-f439065d7251" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
