### PR TITLE
fix: add `autoCapitalize=none` to password input fields in PrivateKeyList and RevealPrivateCredential components

### DIFF
--- a/app/components/Views/MultichainAccounts/PrivateKeyList/PrivateKeyList.tsx
+++ b/app/components/Views/MultichainAccounts/PrivateKeyList/PrivateKeyList.tsx
@@ -213,6 +213,7 @@ export const PrivateKeyList = () => {
               'multichain_accounts.private_key_list.password_placeholder',
             )}
             secureTextEntry
+            autoCapitalize="none"
             testID={PrivateKeyListIds.PASSWORD_INPUT}
           />
 

--- a/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
+++ b/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
@@ -487,6 +487,7 @@ const RevealPrivateCredential = ({
         placeholderTextColor={colors.text.muted}
         onChangeText={onPasswordChange}
         secureTextEntry
+        autoCapitalize="none"
         onSubmitEditing={tryUnlock}
         keyboardAppearance={themeAppearance}
         testID={RevealSeedViewSelectorsIDs.PASSWORD_INPUT_BOX_ID}

--- a/app/components/Views/RevealPrivateCredential/__snapshots__/RevealPrivateCredential.test.tsx.snap
+++ b/app/components/Views/RevealPrivateCredential/__snapshots__/RevealPrivateCredential.test.tsx.snap
@@ -284,6 +284,7 @@ exports[`RevealPrivateCredential handles keyring ID parameter correctly 1`] = `
               Enter password to continue
             </Text>
             <TextInput
+              autoCapitalize="none"
               keyboardAppearance="light"
               onChangeText={[Function]}
               onSubmitEditing={[Function]}
@@ -663,6 +664,7 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
               Enter password to continue
             </Text>
             <TextInput
+              autoCapitalize="none"
               keyboardAppearance="light"
               onChangeText={[Function]}
               onSubmitEditing={[Function]}
@@ -1042,6 +1044,7 @@ exports[`RevealPrivateCredential renders reveal SRP correctly when the credentia
               Enter password to continue
             </Text>
             <TextInput
+              autoCapitalize="none"
               keyboardAppearance="light"
               onChangeText={[Function]}
               onSubmitEditing={[Function]}
@@ -1509,6 +1512,7 @@ exports[`RevealPrivateCredential renders reveal private key correctly 1`] = `
               Enter password to continue
             </Text>
             <TextInput
+              autoCapitalize="none"
               keyboardAppearance="light"
               onChangeText={[Function]}
               onSubmitEditing={[Function]}
@@ -1976,6 +1980,7 @@ exports[`RevealPrivateCredential renders with a custom selectedAddress 1`] = `
               Enter password to continue
             </Text>
             <TextInput
+              autoCapitalize="none"
               keyboardAppearance="light"
               onChangeText={[Function]}
               onSubmitEditing={[Function]}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR fixes a bug causing keyboard on Android to default to capital letters on password input on reveal private key flow and srp flow
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixes a bug causing keyboard on Android to default to capital letters on reveal private kry flow

## **Related issues**

Fixes: 
Jira ticket: https://consensyssoftware.atlassian.net/browse/MUL-929

## **Manual testing steps**

```gherkin
Feature: Reveal Private Key

  Scenario: user wants to reveal private key
    Given account details has an option to show private key

    When user clicks on "Enter password to continue" input
    Then keyboard will appear with the lower case letters by default
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="411" height="905" alt="Screenshot 2025-09-23 at 11 46 07" src="https://github.com/user-attachments/assets/9d5c8435-8917-401b-92e4-28b15ede858a" />

<!-- [screenshots/recordings] -->

### **After**
<img width="408" height="903" alt="Screenshot 2025-09-23 at 11 44 29" src="https://github.com/user-attachments/assets/85dab20d-c998-4453-a111-afa044899c87" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
