### PR TITLE
fix(rewards): removed prefix text on referral link

### DIFF
--- a/app/components/UI/Rewards/components/ReferralDetails/ReferralActionsSection.test.tsx
+++ b/app/components/UI/Rewards/components/ReferralDetails/ReferralActionsSection.test.tsx
@@ -143,7 +143,7 @@ describe('ReferralActionsSection', () => {
       fireEvent.press(copyButton);
 
       expect(mockOnCopyLink).toHaveBeenCalledWith(
-        'rewards.referral.share_referral_message_prefixhttps://link.metamask.io/rewards?referral=TEST123',
+        'https://link.metamask.io/rewards?referral=TEST123',
       );
     });
 

--- a/app/components/UI/Rewards/components/ReferralDetails/ReferralActionsSection.tsx
+++ b/app/components/UI/Rewards/components/ReferralDetails/ReferralActionsSection.tsx
@@ -41,13 +41,7 @@ const ReferralActionsSection: React.FC<ReferralActionsSectionProps> = ({
       label={strings('rewards.referral.referral_link')}
       value={referralCode ? `${REFERRAL_LINK_PATH}${referralCode}` : undefined}
       onCopy={() =>
-        referralCode
-          ? onCopyLink?.(
-              `${strings(
-                'rewards.referral.share_referral_message_prefix',
-              )}${buildReferralUrl(referralCode)}`,
-            )
-          : null
+        referralCode ? onCopyLink?.(buildReferralUrl(referralCode)) : null
       }
       valueLoading={referralCodeLoading}
     />

--- a/locales/languages/de.json
+++ b/locales/languages/de.json
@@ -5836,7 +5836,6 @@
     "referral": {
       "referral_code": "Referral code",
       "referral_link": "Referral link",
-      "share_referral_message_prefix": "I’m earning rewards with MetaMask! Sign up with my referral to claim 500 points: ",
       "actions": {
         "share_referral_link": "Einem Freund empfehlen",
         "share_referral_subject": "MetaMask-Belohnungen beitreten"

--- a/locales/languages/el.json
+++ b/locales/languages/el.json
@@ -5836,7 +5836,6 @@
     "referral": {
       "referral_code": "Referral code",
       "referral_link": "Referral link",
-      "share_referral_message_prefix": "I’m earning rewards with MetaMask! Sign up with my referral to claim 500 points: ",
       "actions": {
         "share_referral_link": "Συστήστε έναν φίλο",
         "share_referral_subject": "Συμμετάσχετε στο MetaMask Rewards"

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5856,7 +5856,6 @@
     "referral": {
       "referral_code": "Referral code",
       "referral_link": "Referral link",
-      "share_referral_message_prefix": "I’m earning rewards with MetaMask! Sign up with my referral to claim 500 points: ",
       "actions": {
         "share_referral_link": "Refer a friend",
         "share_referral_subject": "Join MetaMask Rewards"

--- a/locales/languages/es.json
+++ b/locales/languages/es.json
@@ -5836,7 +5836,6 @@
     "referral": {
       "referral_code": "Referral code",
       "referral_link": "Referral link",
-      "share_referral_message_prefix": "I’m earning rewards with MetaMask! Sign up with my referral to claim 500 points: ",
       "actions": {
         "share_referral_link": "Referir a un amigo",
         "share_referral_subject": "Únete a MetaMask Rewards"

--- a/locales/languages/fr.json
+++ b/locales/languages/fr.json
@@ -5836,7 +5836,6 @@
     "referral": {
       "referral_code": "Referral code",
       "referral_link": "Referral link",
-      "share_referral_message_prefix": "I’m earning rewards with MetaMask! Sign up with my referral to claim 500 points: ",
       "actions": {
         "share_referral_link": "Parrainer un ami",
         "share_referral_subject": "Rejoignez MetaMask Rewards"

--- a/locales/languages/hi.json
+++ b/locales/languages/hi.json
@@ -5836,7 +5836,6 @@
     "referral": {
       "referral_code": "Referral code",
       "referral_link": "Referral link",
-      "share_referral_message_prefix": "I’m earning rewards with MetaMask! Sign up with my referral to claim 500 points: ",
       "actions": {
         "share_referral_link": "एक मित्र को रेफर करें",
         "share_referral_subject": "MetaMask पुरस्कार में शामिल हों"

--- a/locales/languages/id.json
+++ b/locales/languages/id.json
@@ -5836,7 +5836,6 @@
     "referral": {
       "referral_code": "Referral code",
       "referral_link": "Referral link",
-      "share_referral_message_prefix": "I’m earning rewards with MetaMask! Sign up with my referral to claim 500 points: ",
       "actions": {
         "share_referral_link": "Rekomendasikan ke teman",
         "share_referral_subject": "Gabung dengan MetaMask Rewards"

--- a/locales/languages/ja.json
+++ b/locales/languages/ja.json
@@ -5836,7 +5836,6 @@
     "referral": {
       "referral_code": "Referral code",
       "referral_link": "Referral link",
-      "share_referral_message_prefix": "I’m earning rewards with MetaMask! Sign up with my referral to claim 500 points: ",
       "actions": {
         "share_referral_link": "友達を紹介",
         "share_referral_subject": "MetaMaskリワードにご参加ください"

--- a/locales/languages/ko.json
+++ b/locales/languages/ko.json
@@ -5836,7 +5836,6 @@
     "referral": {
       "referral_code": "Referral code",
       "referral_link": "Referral link",
-      "share_referral_message_prefix": "I’m earning rewards with MetaMask! Sign up with my referral to claim 500 points: ",
       "actions": {
         "share_referral_link": "친구 추천",
         "share_referral_subject": "MetaMask 보상 프로그램 가입"

--- a/locales/languages/pt.json
+++ b/locales/languages/pt.json
@@ -5836,7 +5836,6 @@
     "referral": {
       "referral_code": "Referral code",
       "referral_link": "Referral link",
-      "share_referral_message_prefix": "I’m earning rewards with MetaMask! Sign up with my referral to claim 500 points: ",
       "actions": {
         "share_referral_link": "Indique um amigo",
         "share_referral_subject": "Junte-se ao MetaMask Rewards"

--- a/locales/languages/ru.json
+++ b/locales/languages/ru.json
@@ -5836,7 +5836,6 @@
     "referral": {
       "referral_code": "Referral code",
       "referral_link": "Referral link",
-      "share_referral_message_prefix": "I’m earning rewards with MetaMask! Sign up with my referral to claim 500 points: ",
       "actions": {
         "share_referral_link": "Приведите друга",
         "share_referral_subject": "Присоединяйтесь к MetaMask Rewards"

--- a/locales/languages/tl.json
+++ b/locales/languages/tl.json
@@ -5836,7 +5836,6 @@
     "referral": {
       "referral_code": "Referral code",
       "referral_link": "Referral link",
-      "share_referral_message_prefix": "I’m earning rewards with MetaMask! Sign up with my referral to claim 500 points: ",
       "actions": {
         "share_referral_link": "Mag-refer ng kaibigan",
         "share_referral_subject": "Sumali sa Mga Reward ng MetaMask"

--- a/locales/languages/tr.json
+++ b/locales/languages/tr.json
@@ -5836,7 +5836,6 @@
     "referral": {
       "referral_code": "Referral code",
       "referral_link": "Referral link",
-      "share_referral_message_prefix": "I’m earning rewards with MetaMask! Sign up with my referral to claim 500 points: ",
       "actions": {
         "share_referral_link": "Bir arkadaşına öner",
         "share_referral_subject": "MetaMask Ödüllerine katıl"

--- a/locales/languages/vi.json
+++ b/locales/languages/vi.json
@@ -5836,7 +5836,6 @@
     "referral": {
       "referral_code": "Referral code",
       "referral_link": "Referral link",
-      "share_referral_message_prefix": "I’m earning rewards with MetaMask! Sign up with my referral to claim 500 points: ",
       "actions": {
         "share_referral_link": "Giới thiệu bạn bè",
         "share_referral_subject": "Tham gia MetaMask Phần thưởng"

--- a/locales/languages/zh.json
+++ b/locales/languages/zh.json
@@ -5836,7 +5836,6 @@
     "referral": {
       "referral_code": "Referral code",
       "referral_link": "Referral link",
-      "share_referral_message_prefix": "I’m earning rewards with MetaMask! Sign up with my referral to claim 500 points: ",
       "actions": {
         "share_referral_link": "推荐好友",
         "share_referral_subject": "加入 MetaMask Rewards"


### PR DESCRIPTION
## **Description**

This PR fixes the referral link copy paste issue. Currently there is an extra prefix text added to the referral link while copying.

The prefix text is removed, test is fixed.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

[Fix referral link copy-paste issue on Safari](https://consensyssoftware.atlassian.net/browse/RWDS-405)

## **Manual testing steps**

1. Open metamask app
2. Opt in for rewards if not done
3. Go to rewards dashboard
4. Scroll down and click on Referrals section
5. Click on copy referral link icon
6. Paste the text in any browser

## **Screenshots/Recordings**

<img width="465" height="632" alt="image" src="https://github.com/user-attachments/assets/193dd311-3942-4064-ba1d-c328533b764e" />

### **Before**

<img width="965" height="153" alt="image" src="https://github.com/user-attachments/assets/46147a2a-a122-4337-a512-a31a293a2490" />

### **After**

<img width="724" height="153" alt="image" src="https://github.com/user-attachments/assets/24e20b71-3756-440a-8f63-006661fda08b" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
