### PR TITLE
chore: rwds-475

### DIFF
--- a/app/components/UI/Rewards/Views/RewardsDashboard.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsDashboard.test.tsx
@@ -100,11 +100,6 @@ jest.mock('../../../Views/ErrorBoundary', () => ({
   },
 }));
 
-const mockUseUnlockedRewards = jest.fn();
-jest.mock('../hooks/useUnlockedRewards', () => ({
-  useUnlockedRewards: () => mockUseUnlockedRewards(),
-}));
-
 // Mock child components
 jest.mock('../components/SeasonStatus/SeasonStatus', () => ({
   __esModule: true,
@@ -531,16 +526,6 @@ describe('RewardsDashboard', () => {
 
       // Assert
       expect(settingsButton.props.disabled).toBe(false);
-    });
-  });
-
-  describe('hooks integration', () => {
-    it('should call useUnlockedRewards hook', () => {
-      // Act
-      render(<RewardsDashboard />);
-
-      // Assert
-      expect(mockUseUnlockedRewards).toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Rewards/Views/RewardsDashboard.tsx
+++ b/app/components/UI/Rewards/Views/RewardsDashboard.tsx
@@ -52,7 +52,6 @@ import RewardsLevels from '../components/Tabs/RewardsLevels';
 import RewardsActivity from '../components/Tabs/RewardsActivity';
 import { TabsList } from '../../../../component-library/components-temp/Tabs';
 import { TabsListRef } from '../../../../component-library/components-temp/Tabs/TabsList/TabsList.types';
-import { useUnlockedRewards } from '../hooks/useUnlockedRewards';
 import Toast, {
   ToastContext,
 } from '../../../../component-library/components/Toast';
@@ -86,9 +85,6 @@ const RewardsDashboard: React.FC = () => {
   const { unlinkedAccounts } = useRewardOptinSummary({
     enabled: !hideUnlinkedAccountsBanner,
   });
-
-  // Sync rewards controller state with UI store
-  useUnlockedRewards();
 
   // Set navigation title
   useEffect(() => {
@@ -209,7 +205,9 @@ const RewardsDashboard: React.FC = () => {
               title={
                 <Box twClassName="mb-3">
                   <AccountDisplayItem account={selectedAccount} />
-                  {strings('rewards.unlinked_account_info.title')}
+                  <Text variant={TextVariant.BodyMd}>
+                    {strings('rewards.unlinked_account_info.title')}
+                  </Text>
                 </Box>
               }
               description={

--- a/app/components/UI/Rewards/components/Tabs/LevelsTab/UnlockedRewards.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/LevelsTab/UnlockedRewards.test.tsx
@@ -13,6 +13,7 @@ import {
   selectUnlockedRewardLoading,
   selectUnlockedRewards,
 } from '../../../../../../reducers/rewards/selectors';
+import { useUnlockedRewards } from '../../../hooks/useUnlockedRewards';
 
 // Mock dependencies
 jest.mock('react-redux', () => ({
@@ -92,11 +93,19 @@ jest.mock('../../../../../../images/rewards/rewards-placeholder.svg', () => {
   );
 });
 
+// Mock the useUnlockedRewards hook
+jest.mock('../../../hooks/useUnlockedRewards', () => ({
+  useUnlockedRewards: jest.fn(),
+}));
+
 const mockUseSelector = useSelector as jest.Mock;
 const mockUseDispatch = useDispatch as jest.Mock;
 const mockSelectUnlockedRewardLoading =
   selectUnlockedRewardLoading as jest.Mock;
 const mockSelectUnlockedRewards = selectUnlockedRewards as jest.Mock;
+const mockUseUnlockedRewards = useUnlockedRewards as jest.MockedFunction<
+  typeof useUnlockedRewards
+>;
 
 // Mock data
 const mockSeasonReward: SeasonRewardDto = {
@@ -128,6 +137,7 @@ describe('UnlockedRewards', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseDispatch.mockReturnValue(jest.fn());
+    mockUseUnlockedRewards.mockClear();
   });
 
   const setupMocks = ({
@@ -153,16 +163,24 @@ describe('UnlockedRewards', () => {
     });
   };
 
+  it('should call useUnlockedRewards hook', () => {
+    setupMocks({ rewards: [] });
+    render(<UnlockedRewards />);
+    expect(mockUseUnlockedRewards).toHaveBeenCalledTimes(1);
+  });
+
   it('should render unlocked rewards container with testID', () => {
     setupMocks({ rewards: [mockUnlockedReward] });
     const { getByTestId } = render(<UnlockedRewards />);
     expect(getByTestId(REWARDS_VIEW_SELECTORS.UNLOCKED_REWARDS)).toBeDefined();
+    expect(mockUseUnlockedRewards).toHaveBeenCalledTimes(1);
   });
 
   it('should render the unlocked rewards title', () => {
     setupMocks({ rewards: [mockUnlockedReward] });
     const { getByText } = render(<UnlockedRewards />);
     expect(getByText('Unlocked rewards')).toBeDefined();
+    expect(mockUseUnlockedRewards).toHaveBeenCalledTimes(1);
   });
 
   it('should render a list of reward items', () => {
@@ -175,6 +193,7 @@ describe('UnlockedRewards', () => {
     setupMocks({ loading: true });
     const { queryByTestId } = render(<UnlockedRewards />);
     expect(queryByTestId(REWARDS_VIEW_SELECTORS.UNLOCKED_REWARDS)).toBeNull();
+    expect(mockUseUnlockedRewards).toHaveBeenCalledTimes(1);
   });
 
   it('should show an empty state message when there are no rewards', () => {
@@ -182,12 +201,14 @@ describe('UnlockedRewards', () => {
     const { getByText, getByTestId } = render(<UnlockedRewards />);
     expect(getByText('No unlocked rewards yet')).toBeDefined();
     expect(getByTestId('unlocked-rewards-placeholder')).toBeDefined();
+    expect(mockUseUnlockedRewards).toHaveBeenCalledTimes(1);
   });
 
   it('should render a "View ways to earn" button in the empty state', () => {
     setupMocks({ rewards: [] });
     const { getByText } = render(<UnlockedRewards />);
     expect(getByText('View ways to earn')).toBeDefined();
+    expect(mockUseUnlockedRewards).toHaveBeenCalledTimes(1);
   });
 
   it('should dispatch setActiveTab when "View ways to earn" is pressed', () => {
@@ -201,11 +222,13 @@ describe('UnlockedRewards', () => {
 
     expect(dispatch).toHaveBeenCalledTimes(1);
     expect(dispatch).toHaveBeenCalledWith('MOCKED_ACTION');
+    expect(mockUseUnlockedRewards).toHaveBeenCalledTimes(1);
   });
 
   it('should not render a reward item if season reward is not found', () => {
     setupMocks({ rewards: [mockUnlockedReward], seasonReward: undefined });
     const { getByTestId } = render(<UnlockedRewards />);
     expect(getByTestId(REWARDS_VIEW_SELECTORS.UNLOCKED_REWARDS)).toBeDefined();
+    expect(mockUseUnlockedRewards).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/components/UI/Rewards/components/Tabs/LevelsTab/UnlockedRewards.tsx
+++ b/app/components/UI/Rewards/components/Tabs/LevelsTab/UnlockedRewards.tsx
@@ -14,6 +14,7 @@ import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { REWARDS_VIEW_SELECTORS } from '../../../Views/RewardsView.constants';
 import { setActiveTab } from '../../../../../../actions/rewards';
 import RewardItem from './RewardItem';
+import { useUnlockedRewards } from '../../../hooks/useUnlockedRewards';
 
 interface UnlockedRewardItemProps {
   reward: RewardDto;
@@ -48,6 +49,8 @@ const UnlockedRewards: React.FC = () => {
   const unlockedRewards = useSelector(selectUnlockedRewards);
   const isLoading = useSelector(selectUnlockedRewardLoading);
   const tw = useTailwind();
+
+  useUnlockedRewards();
 
   if (isLoading) {
     return null;

--- a/app/components/UI/Rewards/components/Tabs/OverviewTab/ActiveBoosts.tsx
+++ b/app/components/UI/Rewards/components/Tabs/OverviewTab/ActiveBoosts.tsx
@@ -31,7 +31,6 @@ import {
 import { getNativeAssetForChainId } from '@metamask/bridge-controller';
 import { REWARDS_VIEW_SELECTORS } from '../../../Views/RewardsView.constants';
 import { formatTimeRemaining } from '../../../utils/formatUtils';
-import Logger from '../../../../../../util/Logger';
 import { Skeleton } from '../../../../../../component-library/components/Skeleton';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
@@ -194,13 +193,6 @@ const ActiveBoosts: React.FC = () => {
   const hasError = useSelector(selectActiveBoostsError);
 
   const numBoosts = useMemo(() => activeBoosts?.length || 0, [activeBoosts]);
-
-  Logger.log('ActiveBoosts', {
-    isLoading,
-    numBoosts,
-    hasError,
-    activeBoosts: activeBoosts?.length,
-  });
 
   // Platform-specific gesture handling to prevent parent tab swipe
   const scrollNativeGesture = useMemo(() => Gesture.Native(), []);

--- a/app/components/UI/Rewards/hooks/useActivePointsBoosts.test.ts
+++ b/app/components/UI/Rewards/hooks/useActivePointsBoosts.test.ts
@@ -1,4 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks';
+import { useFocusEffect } from '@react-navigation/native';
 import { useActivePointsBoosts } from './useActivePointsBoosts';
 import Engine from '../../../../core/Engine';
 import {
@@ -47,8 +48,16 @@ jest.mock('./useInvalidateByRewardEvents', () => ({
   useInvalidateByRewardEvents: jest.fn(),
 }));
 
+// Mock React Navigation hooks
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: jest.fn(),
+}));
+
 describe('useActivePointsBoosts', () => {
   const mockDispatch = jest.fn();
+  const mockUseFocusEffect = useFocusEffect as jest.MockedFunction<
+    typeof useFocusEffect
+  >;
   const mockUseDispatch = useDispatch as jest.MockedFunction<
     typeof useDispatch
   >;
@@ -103,10 +112,17 @@ describe('useActivePointsBoosts', () => {
       }
       return null;
     });
+
+    // Reset the mocked hooks
+    mockUseFocusEffect.mockClear();
   });
 
   it('should return void', () => {
     const { result } = renderHook(() => useActivePointsBoosts());
+
+    // Verify that the focus effect callback was registered
+    expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+
     expect(result.current).toBeUndefined();
   });
 
@@ -125,15 +141,15 @@ describe('useActivePointsBoosts', () => {
 
     renderHook(() => useActivePointsBoosts());
 
+    // Verify that the focus effect callback was registered
+    expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+
+    // Execute the focus effect callback to trigger the fetch logic
+    const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+    focusCallback();
+
     expect(mockDispatch).toHaveBeenCalledWith(setActiveBoostsLoading(false));
     expect(mockDispatch).toHaveBeenCalledWith(setActiveBoostsError(false));
-    expect(mockLogger).toHaveBeenCalledWith(
-      'useActivePointsBoosts: Missing seasonId or subscriptionId',
-      expect.objectContaining({
-        seasonId: null,
-        subscriptionId: 'test-subscription-id',
-      }),
-    );
     expect(mockEngineCall).not.toHaveBeenCalled();
   });
 
@@ -152,15 +168,15 @@ describe('useActivePointsBoosts', () => {
 
     renderHook(() => useActivePointsBoosts());
 
+    // Verify that the focus effect callback was registered
+    expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+
+    // Execute the focus effect callback to trigger the fetch logic
+    const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+    focusCallback();
+
     expect(mockDispatch).toHaveBeenCalledWith(setActiveBoostsLoading(false));
     expect(mockDispatch).toHaveBeenCalledWith(setActiveBoostsError(false));
-    expect(mockLogger).toHaveBeenCalledWith(
-      'useActivePointsBoosts: Missing seasonId or subscriptionId',
-      expect.objectContaining({
-        seasonId: 'test-season-id',
-        subscriptionId: null,
-      }),
-    );
     expect(mockEngineCall).not.toHaveBeenCalled();
   });
 
@@ -168,6 +184,13 @@ describe('useActivePointsBoosts', () => {
     mockEngineCall.mockResolvedValue(mockActiveBoosts);
 
     renderHook(() => useActivePointsBoosts());
+
+    // Verify that the focus effect callback was registered
+    expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+
+    // Execute the focus effect callback to trigger the fetch logic
+    const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+    focusCallback();
 
     // Wait for async operations
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -191,6 +214,13 @@ describe('useActivePointsBoosts', () => {
     mockEngineCall.mockRejectedValue(mockError);
 
     renderHook(() => useActivePointsBoosts());
+
+    // Verify that the focus effect callback was registered
+    expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+
+    // Execute the focus effect callback to trigger the fetch logic
+    const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+    focusCallback();
 
     // Wait for async operations
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -222,6 +252,13 @@ describe('useActivePointsBoosts', () => {
 
     renderHook(() => useActivePointsBoosts());
 
+    // Verify that the focus effect callback was registered
+    expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+
+    // Execute the focus effect callback to trigger the fetch logic
+    const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+    focusCallback();
+
     // Wait for async operations
     await new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -236,6 +273,13 @@ describe('useActivePointsBoosts', () => {
     mockEngineCall.mockResolvedValue(null);
 
     renderHook(() => useActivePointsBoosts());
+
+    // Verify that the focus effect callback was registered
+    expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+
+    // Execute the focus effect callback to trigger the fetch logic
+    const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+    focusCallback();
 
     // Wait for async operations
     await new Promise((resolve) => setTimeout(resolve, 0));

--- a/app/components/UI/Rewards/hooks/useActivePointsBoosts.ts
+++ b/app/components/UI/Rewards/hooks/useActivePointsBoosts.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
 import {
@@ -7,10 +7,11 @@ import {
   setActiveBoostsLoading,
 } from '../../../../reducers/rewards';
 import Engine from '../../../../core/Engine';
-import type { PointsBoostDto } from '../../../../core/Engine/controllers/rewards-controller/types';
+import { type PointsBoostDto } from '../../../../core/Engine/controllers/rewards-controller/types';
 import Logger from '../../../../util/Logger';
 import { selectSeasonId } from '../../../../reducers/rewards/selectors';
 import { useInvalidateByRewardEvents } from './useInvalidateByRewardEvents';
+import { useFocusEffect } from '@react-navigation/native';
 
 /**
  * Custom hook to fetch and manage active points boosts data from the rewards API
@@ -25,10 +26,6 @@ export const useActivePointsBoosts = (): void => {
   const fetchActivePointsBoosts = useCallback(async (): Promise<void> => {
     // Don't fetch if required parameters are missing
     if (!seasonId || !subscriptionId) {
-      Logger.log('useActivePointsBoosts: Missing seasonId or subscriptionId', {
-        seasonId,
-        subscriptionId,
-      });
       dispatch(setActiveBoostsLoading(false));
       dispatch(setActiveBoostsError(false));
       return;
@@ -36,7 +33,6 @@ export const useActivePointsBoosts = (): void => {
 
     // Skip fetch if already loading (prevents duplicate requests)
     if (isLoadingRef.current) {
-      Logger.log('useActivePointsBoosts: Fetch already in progress, skipping');
       return;
     }
 
@@ -69,9 +65,11 @@ export const useActivePointsBoosts = (): void => {
   }, [dispatch, seasonId, subscriptionId]);
 
   // Initial fetch and refetch when dependencies change
-  useEffect(() => {
-    fetchActivePointsBoosts();
-  }, [fetchActivePointsBoosts]);
+  useFocusEffect(
+    useCallback(() => {
+      fetchActivePointsBoosts();
+    }, [fetchActivePointsBoosts]),
+  );
 
   // Listen for events that should trigger a refetch of active boosts
   useInvalidateByRewardEvents(

--- a/app/components/UI/Rewards/hooks/useGeoRewardsMetadata.test.ts
+++ b/app/components/UI/Rewards/hooks/useGeoRewardsMetadata.test.ts
@@ -1,5 +1,6 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import { useDispatch } from 'react-redux';
+import { useFocusEffect } from '@react-navigation/native';
 import { useGeoRewardsMetadata } from './useGeoRewardsMetadata';
 import Engine from '../../../../core/Engine';
 import {
@@ -32,11 +33,14 @@ jest.mock('react', () => ({
 
 // Mock React Navigation hooks
 jest.mock('@react-navigation/native', () => ({
-  useFocusEffect: jest.fn((callback) => callback()),
+  useFocusEffect: jest.fn(),
 }));
 
 describe('useGeoRewardsMetadata', () => {
   const mockDispatch = jest.fn();
+  const mockUseFocusEffect = useFocusEffect as jest.MockedFunction<
+    typeof useFocusEffect
+  >;
   const mockEngineCall = Engine.controllerMessenger.call as jest.MockedFunction<
     typeof Engine.controllerMessenger.call
   >;
@@ -69,11 +73,106 @@ describe('useGeoRewardsMetadata', () => {
       type: 'rewards/setGeoRewardsMetadataLoading',
       payload: false,
     });
+
+    // Reset the mocked hooks
+    mockUseFocusEffect.mockClear();
   });
 
   describe('hook initialization', () => {
     it('should return null', () => {
       const { result } = renderHook(() => useGeoRewardsMetadata());
+
+      // Verify that the focus effect callback was registered
+      expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+
+      expect(result.current).toBeNull();
+    });
+  });
+
+  describe('useFocusEffect integration', () => {
+    it('should fetch metadata when focus effect is triggered successfully', async () => {
+      const mockMetadata = createMockMetadata('US', true);
+      mockEngineCall.mockResolvedValueOnce(mockMetadata);
+
+      const { result } = renderHook(() => useGeoRewardsMetadata());
+
+      // Verify that the focus effect callback was registered
+      expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+
+      // Execute the focus effect callback to trigger the fetch logic
+      const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+
+      await act(async () => {
+        focusCallback();
+      });
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        mockSetGeoRewardsMetadataLoading(true),
+      );
+      expect(mockEngineCall).toHaveBeenCalledWith(
+        'RewardsController:getGeoRewardsMetadata',
+      );
+      expect(mockDispatch).toHaveBeenCalledWith(
+        mockSetGeoRewardsMetadata(mockMetadata),
+      );
+      expect(mockDispatch).toHaveBeenCalledWith(
+        mockSetGeoRewardsMetadataLoading(false),
+      );
+      expect(result.current).toBeNull();
+    });
+
+    it('should handle errors when focus effect is triggered', async () => {
+      const mockError = new Error('Network failed');
+      mockEngineCall.mockRejectedValueOnce(mockError);
+
+      const { result } = renderHook(() => useGeoRewardsMetadata());
+
+      // Verify that the focus effect callback was registered
+      expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+
+      // Execute the focus effect callback to trigger the fetch logic
+      const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+
+      await act(async () => {
+        focusCallback();
+      });
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        mockSetGeoRewardsMetadataLoading(true),
+      );
+      expect(mockEngineCall).toHaveBeenCalledWith(
+        'RewardsController:getGeoRewardsMetadata',
+      );
+      expect(mockDispatch).toHaveBeenCalledWith(
+        mockSetGeoRewardsMetadata(null),
+      );
+      expect(mockDispatch).toHaveBeenCalledWith(
+        mockSetGeoRewardsMetadataLoading(false),
+      );
+      expect(result.current).toBeNull();
+    });
+
+    it('should not make duplicate calls when already loading', async () => {
+      // Mock a never-resolving promise to simulate loading state
+      mockEngineCall.mockImplementation(
+        () =>
+          new Promise(() => {
+            // Never resolves
+          }),
+      );
+
+      const { result } = renderHook(() => useGeoRewardsMetadata());
+
+      // Execute the focus effect callback twice quickly
+      const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+
+      await act(async () => {
+        focusCallback();
+        focusCallback(); // Second call should be ignored
+      });
+
+      // Should only be called once despite two focus triggers
+      expect(mockEngineCall).toHaveBeenCalledTimes(1);
       expect(result.current).toBeNull();
     });
   });

--- a/app/components/UI/Rewards/hooks/useGeoRewardsMetadata.ts
+++ b/app/components/UI/Rewards/hooks/useGeoRewardsMetadata.ts
@@ -2,7 +2,7 @@
  * Custom hook to fetch geo rewards metadata including location and support status
  */
 
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { useFocusEffect } from '@react-navigation/native';
 import Engine from '../../../../core/Engine';
 import { useDispatch } from 'react-redux';
@@ -13,8 +13,14 @@ import {
 
 export const useGeoRewardsMetadata = (): null => {
   const dispatch = useDispatch();
+  const isLoadingRef = useRef(false);
 
   const fetchGeoRewardsMetadata = useCallback(async (): Promise<void> => {
+    // Skip fetch if already loading (prevents duplicate requests)
+    if (isLoadingRef.current) {
+      return;
+    }
+    isLoadingRef.current = true;
     dispatch(setGeoRewardsMetadataLoading(true));
 
     try {
@@ -28,6 +34,7 @@ export const useGeoRewardsMetadata = (): null => {
       // Keep existing data on error to prevent UI flash
       dispatch(setGeoRewardsMetadata(null));
     } finally {
+      isLoadingRef.current = false;
       dispatch(setGeoRewardsMetadataLoading(false));
     }
   }, [dispatch]);

--- a/app/components/UI/Rewards/hooks/usePointsEvents.test.ts
+++ b/app/components/UI/Rewards/hooks/usePointsEvents.test.ts
@@ -1,5 +1,6 @@
 import { act, renderHook } from '@testing-library/react-hooks';
 import { waitFor } from '@testing-library/react-native';
+import { useFocusEffect } from '@react-navigation/native';
 
 // Add longer timeout for waitFor to prevent test flakiness
 const waitForOptions = { timeout: 5000 };
@@ -57,7 +58,16 @@ jest.mock('./useInvalidateByRewardEvents', () => ({
     mockUseInvalidateByRewardEvents(...args),
 }));
 
+// Mock React Navigation hooks
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: jest.fn(),
+}));
+
 describe('usePointsEvents', () => {
+  const mockUseFocusEffect = useFocusEffect as jest.MockedFunction<
+    typeof useFocusEffect
+  >;
+
   const mockPointsEvent = {
     id: 'event-1',
     title: 'Test Event',
@@ -76,6 +86,12 @@ describe('usePointsEvents', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockCall.mockResolvedValue(mockPaginatedResponse);
+
+    // Reset the mocked hooks
+    mockUseFocusEffect.mockClear();
+    mockUseInvalidateByRewardEvents.mockImplementation(() => {
+      // Mock implementation
+    });
   });
 
   describe('initialization', () => {
@@ -86,6 +102,13 @@ describe('usePointsEvents', () => {
           subscriptionId: 'sub-1',
         }),
       );
+
+      // Verify that the focus effect callback was registered
+      expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+
+      // Execute the focus effect callback to trigger the fetch logic
+      const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+      focusCallback();
 
       expect(result.current.pointsEvents).toEqual([]);
       expect(result.current.isLoading).toBe(false);
@@ -101,6 +124,13 @@ describe('usePointsEvents', () => {
           subscriptionId: '',
         }),
       );
+
+      // Verify that the focus effect callback was registered
+      expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+
+      // Execute the focus effect callback to trigger the fetch logic
+      const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+      focusCallback();
 
       expect(result.current.pointsEvents).toEqual([]);
       expect(result.current.isLoading).toBe(false);
@@ -119,6 +149,13 @@ describe('usePointsEvents', () => {
 
       // Initial state should show loading
       expect(result.current.isLoading).toBe(true);
+
+      // Verify that the focus effect callback was registered
+      expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+
+      // Execute the focus effect callback to trigger the fetch logic
+      const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+      focusCallback();
 
       // Wait for the data to load
       await waitFor(
@@ -155,6 +192,13 @@ describe('usePointsEvents', () => {
         }),
       );
 
+      // Verify that the focus effect callback was registered
+      expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+
+      // Execute the focus effect callback to trigger the fetch logic
+      const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+      focusCallback();
+
       // Wait for the error to be set
       await waitFor(
         () => expect(result.current.error).not.toBeNull(),
@@ -176,6 +220,13 @@ describe('usePointsEvents', () => {
         }),
       );
 
+      // Verify that the focus effect callback was registered
+      expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+
+      // Execute the focus effect callback to trigger the fetch logic
+      const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+      focusCallback();
+
       // Wait for the error to be set
       await waitFor(
         () => expect(result.current.error).not.toBeNull(),
@@ -196,6 +247,13 @@ describe('usePointsEvents', () => {
           subscriptionId: 'sub-1',
         }),
       );
+
+      // Verify that the focus effect callback was registered
+      expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+
+      // Execute the focus effect callback to trigger the fetch logic
+      const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+      focusCallback();
 
       // Wait for initial load
       await waitFor(
@@ -245,6 +303,13 @@ describe('usePointsEvents', () => {
         }),
       );
 
+      // Verify that the focus effect callback was registered
+      expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+
+      // Execute the focus effect callback to trigger the fetch logic
+      const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+      focusCallback();
+
       // Wait for initial load
       await waitFor(
         () => expect(result.current.isLoading).toBe(false),
@@ -287,6 +352,13 @@ describe('usePointsEvents', () => {
           subscriptionId: 'sub-1',
         }),
       );
+
+      // Verify that the focus effect callback was registered
+      expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+
+      // Execute the focus effect callback to trigger the fetch logic
+      const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+      focusCallback();
 
       // Wait for initial load
       await waitFor(
@@ -333,6 +405,13 @@ describe('usePointsEvents', () => {
         }),
       );
 
+      // Verify that the focus effect callback was registered
+      expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+
+      // Execute the focus effect callback to trigger the fetch logic
+      const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+      focusCallback();
+
       // Wait for initial load
       await waitFor(
         () => expect(result.current.isLoading).toBe(false),
@@ -375,6 +454,13 @@ describe('usePointsEvents', () => {
         }),
       );
 
+      // Verify that the focus effect callback was registered
+      expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+
+      // Execute the focus effect callback to trigger the fetch logic
+      const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+      focusCallback();
+
       // Wait for initial load
       await waitFor(
         () => expect(result.current.isLoading).toBe(false),
@@ -408,6 +494,9 @@ describe('usePointsEvents', () => {
           subscriptionId: 'sub-1',
         }),
       );
+
+      // Verify that the focus effect callback was registered
+      expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
 
       // Verify subscription to events
       expect(mockUseInvalidateByRewardEvents).toHaveBeenCalledWith(

--- a/app/components/UI/Rewards/hooks/usePointsEvents.ts
+++ b/app/components/UI/Rewards/hooks/usePointsEvents.ts
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import Engine from '../../../../core/Engine/Engine';
 import { PointsEventDto } from '../../../../core/Engine/controllers/rewards-controller/types';
 import { useInvalidateByRewardEvents } from './useInvalidateByRewardEvents';
+import { useFocusEffect } from '@react-navigation/native';
 
 export interface UsePointsEventsOptions {
   seasonId: string | undefined;
@@ -30,6 +31,7 @@ export const usePointsEvents = (
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [hasMore, setHasMore] = useState(true);
   const [cursor, setCursor] = useState<string | null>(null);
+  const isLoadingRef = useRef(false);
   const [error, setError] = useState<string | null>(null);
 
   const fetchPointsEvents = useCallback(
@@ -37,6 +39,10 @@ export const usePointsEvents = (
       isInitial: boolean,
       currentCursor: string | null = null,
     ): Promise<void> => {
+      if (isLoadingRef.current) {
+        return;
+      }
+      isLoadingRef.current = true;
       if (isInitial) {
         setIsLoading(true);
         setError(null);
@@ -73,6 +79,7 @@ export const usePointsEvents = (
           setPointsEvents([]);
         }
       } finally {
+        isLoadingRef.current = false;
         if (isInitial) {
           setIsLoading(false);
         } else {
@@ -97,12 +104,11 @@ export const usePointsEvents = (
     setIsRefreshing(false);
   }, [fetchPointsEvents]);
 
-  // Initial data fetch
-  useEffect(() => {
-    if (seasonId && subscriptionId) {
+  useFocusEffect(
+    useCallback(() => {
       fetchPointsEvents(true);
-    }
-  }, [seasonId, subscriptionId, fetchPointsEvents]);
+    }, [fetchPointsEvents]),
+  );
 
   // Listen for reward claimed events to trigger refetch
   useInvalidateByRewardEvents(

--- a/app/components/UI/Rewards/hooks/useReferralDetails.test.ts
+++ b/app/components/UI/Rewards/hooks/useReferralDetails.test.ts
@@ -3,7 +3,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { useReferralDetails } from './useReferralDetails';
 import Engine from '../../../../core/Engine';
 import { setReferralDetailsLoading } from '../../../../reducers/rewards';
-import Logger from '../../../../util/Logger';
+import { useFocusEffect } from '@react-navigation/native';
 
 // Mock dependencies
 jest.mock('react-redux', () => ({
@@ -30,6 +30,11 @@ jest.mock('../../../../util/Logger', () => ({
   log: jest.fn(),
 }));
 
+// Mock React Navigation hooks
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: jest.fn(),
+}));
+
 describe('useReferralDetails', () => {
   const mockDispatch = jest.fn();
   const mockUseSelector = useSelector as jest.MockedFunction<
@@ -38,14 +43,19 @@ describe('useReferralDetails', () => {
   const mockEngineCall = Engine.controllerMessenger.call as jest.MockedFunction<
     typeof Engine.controllerMessenger.call
   >;
-  const mockLogger = Logger.log as jest.MockedFunction<typeof Logger.log>;
   const mockUseDispatch = useDispatch as jest.MockedFunction<
     typeof useDispatch
+  >;
+  const mockUseFocusEffect = useFocusEffect as jest.MockedFunction<
+    typeof useFocusEffect
   >;
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseDispatch.mockReturnValue(mockDispatch);
+
+    // Reset the mocked hook
+    mockUseFocusEffect.mockClear();
   });
 
   it('should return null', () => {
@@ -59,9 +69,6 @@ describe('useReferralDetails', () => {
 
     renderHook(() => useReferralDetails());
 
-    expect(mockLogger).toHaveBeenCalledWith(
-      'useReferralDetails: No subscription ID available',
-    );
     expect(mockEngineCall).not.toHaveBeenCalled();
   });
 
@@ -77,18 +84,65 @@ describe('useReferralDetails', () => {
 
     renderHook(() => useReferralDetails());
 
+    // Get the focus effect callback and trigger it
+    const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+    await focusCallback();
+
     expect(mockDispatch).toHaveBeenCalledWith(setReferralDetailsLoading(true));
   });
 
-  it('should handle fetch errors gracefully', async () => {
-    const mockSubscriptionId = 'test-subscription-id';
-    const mockError = new Error('Network error');
-
-    mockUseSelector.mockReturnValue(mockSubscriptionId);
-    mockEngineCall.mockRejectedValueOnce(mockError);
+  it('should register focus effect callback', () => {
+    mockUseSelector.mockReturnValue('test-subscription-id');
 
     renderHook(() => useReferralDetails());
 
-    expect(mockDispatch).toHaveBeenCalledWith(setReferralDetailsLoading(true));
+    expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('should prevent duplicate fetch calls when already loading', async () => {
+    const mockSubscriptionId = 'test-subscription-id';
+    mockUseSelector.mockReturnValue(mockSubscriptionId);
+
+    // First call will start loading
+    mockEngineCall.mockImplementation(
+      () =>
+        new Promise(() => {
+          // Never resolves
+        }),
+    );
+
+    renderHook(() => useReferralDetails());
+
+    // Trigger focus effect callback multiple times
+    const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+    focusCallback();
+    focusCallback();
+
+    // Should only be called once despite multiple focus triggers
+    expect(mockEngineCall).toHaveBeenCalledTimes(1);
+  });
+
+  it('should fetch data when focus effect callback is triggered', async () => {
+    const mockSubscriptionId = 'test-subscription-id';
+    const mockReferralDetails = {
+      referralCode: 'ABC123',
+      totalReferees: 5,
+    };
+
+    mockUseSelector.mockReturnValue(mockSubscriptionId);
+    mockEngineCall.mockResolvedValueOnce(mockReferralDetails);
+
+    renderHook(() => useReferralDetails());
+
+    // Get the focus effect callback and trigger it
+    const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+    expect(focusCallback).toBeDefined();
+
+    await focusCallback();
+
+    expect(mockEngineCall).toHaveBeenCalledWith(
+      'RewardsController:getReferralDetails',
+      mockSubscriptionId,
+    );
   });
 });

--- a/app/components/UI/Rewards/hooks/useReferralDetails.ts
+++ b/app/components/UI/Rewards/hooks/useReferralDetails.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
 import {
@@ -7,17 +7,21 @@ import {
 } from '../../../../reducers/rewards';
 import Engine from '../../../../core/Engine';
 import type { SubscriptionReferralDetailsState } from '../../../../core/Engine/controllers/rewards-controller/types';
-import Logger from '../../../../util/Logger';
+import { useFocusEffect } from '@react-navigation/native';
 
 export const useReferralDetails = (): null => {
   const dispatch = useDispatch();
   const subscriptionId = useSelector(selectRewardsSubscriptionId);
+  const isLoadingRef = useRef(false);
 
   const fetchReferralDetails = useCallback(async (): Promise<void> => {
     if (!subscriptionId) {
-      Logger.log('useReferralDetails: No subscription ID available');
       return;
     }
+    if (isLoadingRef.current) {
+      return;
+    }
+    isLoadingRef.current = true;
 
     try {
       dispatch(setReferralDetailsLoading(true));
@@ -34,29 +38,20 @@ export const useReferralDetails = (): null => {
           refereeCount: referralDetails?.totalReferees,
         }),
       );
-
-      if (referralDetails) {
-        Logger.log(
-          'useReferralDetails: Successfully fetched referral details',
-          {
-            referralCode: referralDetails.referralCode,
-            refereeCount: referralDetails.totalReferees,
-          },
-        );
-      }
-    } catch (fetchError) {
-      Logger.log(
-        'useReferralDetails: Failed to fetch referral details:',
-        fetchError instanceof Error ? fetchError.message : 'Unknown error',
-      );
+    } catch (error) {
+      // Silently handle errors - the loading state will be reset in finally
+      console.error('Failed to fetch referral details:', error);
     } finally {
+      isLoadingRef.current = false;
       dispatch(setReferralDetailsLoading(false));
     }
   }, [dispatch, subscriptionId]);
 
-  useEffect(() => {
-    fetchReferralDetails();
-  }, [fetchReferralDetails]);
+  useFocusEffect(
+    useCallback(() => {
+      fetchReferralDetails();
+    }, [fetchReferralDetails]),
+  );
 
   return null;
 };

--- a/app/components/UI/Rewards/hooks/useRewardOptinSummary.ts
+++ b/app/components/UI/Rewards/hooks/useRewardOptinSummary.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import {
   selectInternalAccounts,
@@ -8,6 +8,7 @@ import { InternalAccount } from '@metamask/keyring-internal-api';
 import Engine from '../../../../core/Engine';
 import { OptInStatusDto } from '../../../../core/Engine/controllers/rewards-controller/types';
 import Logger from '../../../../util/Logger';
+import { useFocusEffect } from '@react-navigation/native';
 
 interface AccountWithOptInStatus extends InternalAccount {
   hasOptedIn: boolean;
@@ -41,19 +42,25 @@ export const useRewardOptinSummary = (
   const [currentAccountOptedIn, setCurrentAccountOptedIn] = useState<
     boolean | null
   >(null);
+  const isLoadingRef = useRef(false);
 
   // Memoize accounts to avoid unnecessary re-renders
   const accounts = useMemo(() => internalAccounts || [], [internalAccounts]);
 
   // Fetch opt-in status for all accounts
-  const fetchOptInStatus = useCallback(async () => {
+  const fetchOptInStatus = useCallback(async (): Promise<void> => {
     if (!enabled || !accounts.length) {
       setIsLoading(false);
       return;
     }
+    if (isLoadingRef.current) {
+      return;
+    }
+    isLoadingRef.current = true;
 
     try {
       setIsLoading(true);
+
       setHasError(false);
       const addresses = accounts.map((account) => account.address);
 
@@ -86,16 +93,17 @@ export const useRewardOptinSummary = (
       setOptedInAccounts([]);
       setCurrentAccountOptedIn(null);
     } finally {
+      isLoadingRef.current = false;
       setIsLoading(false);
     }
   }, [accounts, selectedAccount, enabled]);
 
   // Fetch opt-in status when accounts change or enabled changes
-  useEffect(() => {
-    if (enabled) {
+  useFocusEffect(
+    useCallback(() => {
       fetchOptInStatus();
-    }
-  }, [fetchOptInStatus, enabled]);
+    }, [fetchOptInStatus]),
+  );
 
   // Separate accounts into linked and unlinked
   const { linkedAccounts, unlinkedAccounts } = useMemo(() => {
@@ -107,7 +115,7 @@ export const useRewardOptinSummary = (
   return {
     linkedAccounts,
     unlinkedAccounts,
-    isLoading,
+    isLoading: isLoading && !optedInAccounts.length, // prevent flickering if accounts are being populated via i.e. profile sync
     hasError,
     refresh: fetchOptInStatus,
     currentAccountOptedIn,

--- a/app/components/UI/Rewards/hooks/useSeasonStatus.test.ts
+++ b/app/components/UI/Rewards/hooks/useSeasonStatus.test.ts
@@ -4,6 +4,8 @@ import Engine from '../../../../core/Engine';
 import { setSeasonStatus } from '../../../../actions/rewards';
 import { setSeasonStatusLoading } from '../../../../reducers/rewards';
 import { useDispatch, useSelector } from 'react-redux';
+import { CURRENT_SEASON_ID } from '../../../../core/Engine/controllers/rewards-controller/types';
+import { useFocusEffect } from '@react-navigation/native';
 
 // Mock dependencies
 jest.mock('react-redux', () => ({
@@ -13,10 +15,6 @@ jest.mock('react-redux', () => ({
 
 jest.mock('../../../../selectors/rewards', () => ({
   selectRewardsSubscriptionId: jest.fn(),
-}));
-
-jest.mock('../../../../reducers/rewards/selectors', () => ({
-  selectSeasonId: jest.fn(),
 }));
 
 jest.mock('../../../../core/Engine', () => ({
@@ -36,20 +34,21 @@ jest.mock('../../../../reducers/rewards', () => ({
 }));
 
 // Mock the useInvalidateByRewardEvents hook
+const mockUseInvalidateByRewardEvents = jest.fn();
 jest.mock('./useInvalidateByRewardEvents', () => ({
-  useInvalidateByRewardEvents: jest.fn(),
+  useInvalidateByRewardEvents: mockUseInvalidateByRewardEvents,
 }));
 
 // Mock React Navigation hooks
 jest.mock('@react-navigation/native', () => ({
-  useFocusEffect: jest.fn((callback) => {
-    // Simulate the focus effect by calling the callback immediately
-    callback();
-  }),
+  useFocusEffect: jest.fn(),
 }));
 
 describe('useSeasonStatus', () => {
   const mockDispatch = jest.fn();
+  const mockUseFocusEffect = useFocusEffect as jest.MockedFunction<
+    typeof useFocusEffect
+  >;
   const mockUseDispatch = useDispatch as jest.MockedFunction<
     typeof useDispatch
   >;
@@ -63,39 +62,26 @@ describe('useSeasonStatus', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseDispatch.mockReturnValue(mockDispatch);
-    // Mock useSelector calls in order: first call is seasonId, second is subscriptionId
-    let callCount = 0;
-    mockUseSelector.mockImplementation(() => {
-      callCount++;
-      if (callCount === 1) {
-        return 'test-season-id'; // selectSeasonId
-      }
-      if (callCount === 2) {
-        return 'test-subscription-id'; // selectRewardsSubscriptionId
-      }
-      return null;
-    });
-  });
+    mockUseSelector.mockReturnValue('test-subscription-id'); // selectRewardsSubscriptionId
 
-  it('should return void', () => {
-    const { result } = renderHook(() => useSeasonStatus());
-    expect(result.current).toBeUndefined();
+    // Reset the mocked hooks
+    mockUseFocusEffect.mockClear();
+    mockUseInvalidateByRewardEvents.mockImplementation(() => {
+      // Mock implementation
+    });
   });
 
   it('should skip fetch when subscriptionId is missing', () => {
-    let callCount = 0;
-    mockUseSelector.mockImplementation(() => {
-      callCount++;
-      if (callCount === 1) {
-        return 'test-season-id'; // selectSeasonId
-      }
-      if (callCount === 2) {
-        return null; // selectRewardsSubscriptionId - missing
-      }
-      return null;
-    });
+    mockUseSelector.mockReturnValue(null); // selectRewardsSubscriptionId - missing
 
     renderHook(() => useSeasonStatus());
+
+    // Verify that the focus effect callback was registered
+    expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+
+    // Execute the focus effect callback to trigger the fetch logic
+    const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+    focusCallback();
 
     expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatus(null));
     expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatusLoading(false));
@@ -147,6 +133,13 @@ describe('useSeasonStatus', () => {
 
     renderHook(() => useSeasonStatus());
 
+    // Verify that the focus effect callback was registered
+    expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+
+    // Execute the focus effect callback to trigger the fetch logic
+    const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+    focusCallback();
+
     // Wait for async operations
     await new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -154,7 +147,7 @@ describe('useSeasonStatus', () => {
     expect(mockEngineCall).toHaveBeenCalledWith(
       'RewardsController:getSeasonStatus',
       'test-subscription-id',
-      'test-season-id',
+      CURRENT_SEASON_ID,
     );
     expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatus(mockStatusData));
     expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatusLoading(false));
@@ -166,6 +159,13 @@ describe('useSeasonStatus', () => {
 
     renderHook(() => useSeasonStatus());
 
+    // Verify that the focus effect callback was registered
+    expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+
+    // Execute the focus effect callback to trigger the fetch logic
+    const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+    focusCallback();
+
     // Wait for async operations
     await new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -173,54 +173,38 @@ describe('useSeasonStatus', () => {
     expect(mockEngineCall).toHaveBeenCalledWith(
       'RewardsController:getSeasonStatus',
       'test-subscription-id',
-      'test-season-id',
+      CURRENT_SEASON_ID,
     );
     expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatus(null));
     expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatusLoading(false));
   });
 
-  it('should use current as fallback when seasonId is null', async () => {
-    let callCount = 0;
-    mockUseSelector.mockImplementation(() => {
-      callCount++;
-      if (callCount === 1) {
-        return null; // selectSeasonId - null
-      }
-      if (callCount === 2) {
-        return 'test-subscription-id'; // selectRewardsSubscriptionId
-      }
-      return null;
-    });
+  it('should register focus effect callback', () => {
+    renderHook(() => useSeasonStatus());
 
-    const mockStatusData = {
-      season: {
-        id: 'current',
-        name: 'Current Season',
-        startDate: 1640995200000,
-        endDate: 1672531200000,
-        tiers: [],
-      },
-      balance: {
-        total: 0,
-        refereePortion: 0,
-      },
-      tier: {
-        currentTier: { id: 'bronze', name: 'Bronze', pointsNeeded: 0 },
-        nextTier: null,
-        nextTierPointsNeeded: null,
-      },
-    };
-    mockEngineCall.mockResolvedValueOnce(mockStatusData);
+    expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('should prevent duplicate fetch calls when already loading', async () => {
+    // First call will start loading
+    mockEngineCall.mockImplementation(
+      () =>
+        new Promise(() => {
+          // Never resolves
+        }),
+    ); // Never resolves
 
     renderHook(() => useSeasonStatus());
 
-    // Wait for async operations
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    // Verify that the focus effect callback was registered
+    expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
 
-    expect(mockEngineCall).toHaveBeenCalledWith(
-      'RewardsController:getSeasonStatus',
-      'test-subscription-id',
-      'current',
-    );
+    // Trigger focus effect callback multiple times
+    const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+    focusCallback();
+    focusCallback();
+
+    // Should only be called once despite multiple focus triggers
+    expect(mockEngineCall).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/components/UI/Rewards/hooks/useSeasonStatus.ts
+++ b/app/components/UI/Rewards/hooks/useSeasonStatus.ts
@@ -1,10 +1,9 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import Engine from '../../../../core/Engine';
 import { setSeasonStatus } from '../../../../actions/rewards';
 import { useDispatch, useSelector } from 'react-redux';
 import { setSeasonStatusLoading } from '../../../../reducers/rewards';
 import { CURRENT_SEASON_ID } from '../../../../core/Engine/controllers/rewards-controller/types';
-import { selectSeasonId } from '../../../../reducers/rewards/selectors';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
 import { useInvalidateByRewardEvents } from './useInvalidateByRewardEvents';
 import { useFocusEffect } from '@react-navigation/native';
@@ -14,9 +13,9 @@ import { useFocusEffect } from '@react-navigation/native';
  * Uses the RewardsController to get data from the rewards data service
  */
 export const useSeasonStatus = (): void => {
-  const seasonId = useSelector(selectSeasonId);
   const subscriptionId = useSelector(selectRewardsSubscriptionId);
   const dispatch = useDispatch();
+  const isLoadingRef = useRef(false);
 
   const fetchSeasonStatus = useCallback(async (): Promise<void> => {
     // Don't fetch if no subscriptionId
@@ -26,13 +25,18 @@ export const useSeasonStatus = (): void => {
       return;
     }
 
+    if (isLoadingRef.current) {
+      return;
+    }
+    isLoadingRef.current = true;
+
     dispatch(setSeasonStatusLoading(true));
 
     try {
       const statusData = await Engine.controllerMessenger.call(
         'RewardsController:getSeasonStatus',
         subscriptionId,
-        seasonId || CURRENT_SEASON_ID,
+        CURRENT_SEASON_ID,
       );
 
       dispatch(setSeasonStatus(statusData));
@@ -40,9 +44,10 @@ export const useSeasonStatus = (): void => {
       // Keep existing data on error to prevent UI flash
       dispatch(setSeasonStatus(null));
     } finally {
+      isLoadingRef.current = false;
       dispatch(setSeasonStatusLoading(false));
     }
-  }, [dispatch, seasonId, subscriptionId]);
+  }, [dispatch, subscriptionId]);
 
   // Refresh data when screen comes into focus (each time page is visited)
   useFocusEffect(

--- a/app/components/UI/Rewards/hooks/useUnlockedRewards.test.ts
+++ b/app/components/UI/Rewards/hooks/useUnlockedRewards.test.ts
@@ -7,6 +7,12 @@ import {
 } from '../../../../reducers/rewards';
 import { useDispatch, useSelector } from 'react-redux';
 import { RewardClaimStatus } from '../../../../core/Engine/controllers/rewards-controller/types';
+import { useFocusEffect } from '@react-navigation/native';
+
+// Mock React Navigation hooks first
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: jest.fn(),
+}));
 
 // Mock dependencies
 jest.mock('react-redux', () => ({
@@ -36,12 +42,16 @@ jest.mock('../../../../reducers/rewards/selectors', () => ({
 }));
 
 // Mock the useInvalidateByRewardEvents hook
+const mockUseInvalidateByRewardEvents = jest.fn();
 jest.mock('./useInvalidateByRewardEvents', () => ({
-  useInvalidateByRewardEvents: jest.fn(),
+  useInvalidateByRewardEvents: mockUseInvalidateByRewardEvents,
 }));
 
 describe('useUnlockedRewards', () => {
   const mockDispatch = jest.fn();
+  const mockUseFocusEffect = useFocusEffect as jest.MockedFunction<
+    typeof useFocusEffect
+  >;
   const mockUseDispatch = useDispatch as jest.MockedFunction<
     typeof useDispatch
   >;
@@ -81,11 +91,15 @@ describe('useUnlockedRewards', () => {
       }
       return null;
     });
-  });
 
-  it('should return void', () => {
-    const { result } = renderHook(() => useUnlockedRewards());
-    expect(result.current).toBeUndefined();
+    // Reset the mocked hooks
+    mockUseFocusEffect.mockImplementation((callback) => {
+      // Simulate the focus effect by calling the callback immediately
+      callback();
+    });
+    mockUseInvalidateByRewardEvents.mockImplementation(() => {
+      // Mock implementation
+    });
   });
 
   it('should skip fetch when seasonId is missing', () => {
@@ -269,5 +283,31 @@ describe('useUnlockedRewards', () => {
     expect(mockDispatch).toHaveBeenCalledWith(setUnlockedRewards([]));
     expect(mockDispatch).toHaveBeenCalledWith(setUnlockedRewardLoading(false));
     expect(mockEngineCall).not.toHaveBeenCalled();
+  });
+
+  it('should register focus effect callback', () => {
+    renderHook(() => useUnlockedRewards());
+
+    expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('should prevent duplicate fetch calls when already loading', async () => {
+    // First call will start loading
+    mockEngineCall.mockImplementation(
+      () =>
+        new Promise(() => {
+          // Never resolves
+        }),
+    );
+
+    renderHook(() => useUnlockedRewards());
+
+    // Trigger focus effect callback multiple times
+    const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+    focusCallback();
+    focusCallback();
+
+    // Should only be called once despite multiple focus triggers
+    expect(mockEngineCall).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/components/UI/Rewards/hooks/useUnlockedRewards.ts
+++ b/app/components/UI/Rewards/hooks/useUnlockedRewards.ts
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import Engine from '../../../../core/Engine';
 import { useDispatch, useSelector } from 'react-redux';
 import {
@@ -8,6 +8,7 @@ import {
 import { selectSeasonId } from '../../../../reducers/rewards/selectors';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
 import { useInvalidateByRewardEvents } from './useInvalidateByRewardEvents';
+import { useFocusEffect } from '@react-navigation/native';
 
 /**
  * Custom hook to fetch and manage unlocked rewards data from the rewards API
@@ -17,7 +18,7 @@ export const useUnlockedRewards = (): void => {
   const seasonId = useSelector(selectSeasonId);
   const subscriptionId = useSelector(selectRewardsSubscriptionId);
   const dispatch = useDispatch();
-
+  const isLoadingRef = useRef(false);
   const fetchUnlockedRewards = useCallback(async (): Promise<void> => {
     // Don't fetch if no subscriptionId
     if (!subscriptionId || !seasonId) {
@@ -25,6 +26,11 @@ export const useUnlockedRewards = (): void => {
       dispatch(setUnlockedRewardLoading(false));
       return;
     }
+
+    if (isLoadingRef.current) {
+      return;
+    }
+    isLoadingRef.current = true;
 
     dispatch(setUnlockedRewardLoading(true));
 
@@ -40,14 +46,16 @@ export const useUnlockedRewards = (): void => {
       // Keep existing data on error to prevent UI flash
       dispatch(setUnlockedRewards([]));
     } finally {
+      isLoadingRef.current = false;
       dispatch(setUnlockedRewardLoading(false));
     }
   }, [dispatch, seasonId, subscriptionId]);
 
-  // Initial data fetch
-  useEffect(() => {
-    fetchUnlockedRewards();
-  }, [fetchUnlockedRewards]);
+  useFocusEffect(
+    useCallback(() => {
+      fetchUnlockedRewards();
+    }, [fetchUnlockedRewards]),
+  );
 
   // Listen for account linked events to trigger refetch
   useInvalidateByRewardEvents(

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -1373,6 +1373,13 @@ describe('RewardsController', () => {
         mockSubscriptionId,
       );
 
+      // Verify fresh fetch was logged
+      expect(mockLogger.log).toHaveBeenCalledWith(
+        'RewardsController: Fetching fresh season status data via API call for subscriptionId & seasonId',
+        mockSubscriptionId,
+        mockSeasonId,
+      );
+
       // Expect the result to be the converted state object, not the original DTO
       expect(result).toBeDefined();
       expect(result?.balance.total).toBe(1500);

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -784,6 +784,12 @@ export class RewardsController extends BaseController<
     }
 
     try {
+      Logger.log(
+        'RewardsController: Fetching fresh opt-in status for address count:',
+        {
+          addresses: params.addresses?.length,
+        },
+      );
       return await this.messagingSystem.call(
         'RewardsDataService:getOptInStatus',
         params,
@@ -822,6 +828,14 @@ export class RewardsController extends BaseController<
       return { has_more: false, cursor: null, total_results: 0, results: [] };
 
     try {
+      Logger.log(
+        'RewardsController: Fetching fresh points events data via API call for seasonId & subscriptionId & page cursor',
+        {
+          seasonId: params.seasonId,
+          subscriptionId: params.subscriptionId,
+          cursor: params.cursor,
+        },
+      );
       const pointsEvents = await this.messagingSystem.call(
         'RewardsDataService:getPointsEvents',
         params,
@@ -1579,10 +1593,6 @@ export class RewardsController extends BaseController<
         };
       });
 
-      Logger.log('RewardsController: Successfully cached active boosts data', {
-        boostCount: response.boosts.length,
-      });
-
       return response.boosts;
     } catch (error) {
       Logger.log(
@@ -1657,13 +1667,6 @@ export class RewardsController extends BaseController<
           lastFetched: Date.now(),
         };
       });
-
-      Logger.log(
-        'RewardsController: Successfully cached unlocked rewards data',
-        {
-          rewardCount: (response || []).length,
-        },
-      );
 
       return response || [];
     } catch (error) {

--- a/app/reducers/rewards/index.test.ts
+++ b/app/reducers/rewards/index.test.ts
@@ -520,7 +520,7 @@ describe('rewardsReducer', () => {
     });
 
     describe('setSeasonStatusLoading', () => {
-      it('should set season status loading to true', () => {
+      it('should set season status loading to true when no season data exists', () => {
         // Arrange
         const action = setSeasonStatusLoading(true);
 
@@ -529,6 +529,22 @@ describe('rewardsReducer', () => {
 
         // Assert
         expect(state.seasonStatusLoading).toBe(true);
+      });
+
+      it('should not set season status loading to true when season data already exists', () => {
+        // Arrange
+        const stateWithSeasonData = {
+          ...initialState,
+          seasonStartDate: new Date('2024-01-01'),
+          seasonStatusLoading: false,
+        };
+        const action = setSeasonStatusLoading(true);
+
+        // Act
+        const state = rewardsReducer(stateWithSeasonData, action);
+
+        // Assert
+        expect(state.seasonStatusLoading).toBe(false); // Should remain false due to guard clause
       });
 
       it('should set season status loading to false', () => {
@@ -542,10 +558,26 @@ describe('rewardsReducer', () => {
         // Assert
         expect(state.seasonStatusLoading).toBe(false);
       });
+
+      it('should set season status loading to false even when season data exists', () => {
+        // Arrange
+        const stateWithSeasonDataAndLoading = {
+          ...initialState,
+          seasonStartDate: new Date('2024-01-01'),
+          seasonStatusLoading: true,
+        };
+        const action = setSeasonStatusLoading(false);
+
+        // Act
+        const state = rewardsReducer(stateWithSeasonDataAndLoading, action);
+
+        // Assert
+        expect(state.seasonStatusLoading).toBe(false);
+      });
     });
 
     describe('setReferralDetailsLoading', () => {
-      it('should set referral details loading to true', () => {
+      it('should set referral details loading to true when no referral code exists', () => {
         // Arrange
         const action = setReferralDetailsLoading(true);
 
@@ -554,6 +586,22 @@ describe('rewardsReducer', () => {
 
         // Assert
         expect(state.referralDetailsLoading).toBe(true);
+      });
+
+      it('should not set referral details loading to true when referral code already exists', () => {
+        // Arrange
+        const stateWithReferralCode = {
+          ...initialState,
+          referralCode: 'EXISTING123',
+          referralDetailsLoading: false,
+        };
+        const action = setReferralDetailsLoading(true);
+
+        // Act
+        const state = rewardsReducer(stateWithReferralCode, action);
+
+        // Assert
+        expect(state.referralDetailsLoading).toBe(false); // Should remain false due to guard clause
       });
 
       it('should set referral details loading to false', () => {
@@ -566,6 +614,22 @@ describe('rewardsReducer', () => {
 
         // Act
         const state = rewardsReducer(stateWithLoading, action);
+
+        // Assert
+        expect(state.referralDetailsLoading).toBe(false);
+      });
+
+      it('should set referral details loading to false even when referral code exists', () => {
+        // Arrange
+        const stateWithReferralCodeAndLoading = {
+          ...initialState,
+          referralCode: 'EXISTING123',
+          referralDetailsLoading: true,
+        };
+        const action = setReferralDetailsLoading(false);
+
+        // Act
+        const state = rewardsReducer(stateWithReferralCodeAndLoading, action);
 
         // Assert
         expect(state.referralDetailsLoading).toBe(false);
@@ -1340,7 +1404,7 @@ describe('rewardsReducer', () => {
   });
 
   describe('setActiveBoostsLoading', () => {
-    it('should set activeBoostsLoading to true', () => {
+    it('should set activeBoostsLoading to true when no active boosts exist', () => {
       // Arrange
       const action = setActiveBoostsLoading(true);
 
@@ -1349,6 +1413,31 @@ describe('rewardsReducer', () => {
 
       // Assert
       expect(state.activeBoostsLoading).toBe(true);
+    });
+
+    it('should not set activeBoostsLoading to true when active boosts already exist', () => {
+      // Arrange
+      const stateWithBoosts = {
+        ...initialState,
+        activeBoosts: [
+          {
+            id: 'existing-boost',
+            name: 'Existing Boost',
+            icon: { lightModeUrl: 'test.png', darkModeUrl: 'test.png' },
+            boostBips: 1000,
+            seasonLong: true,
+            backgroundColor: '#FF0000',
+          },
+        ],
+        activeBoostsLoading: false,
+      };
+      const action = setActiveBoostsLoading(true);
+
+      // Act
+      const state = rewardsReducer(stateWithBoosts, action);
+
+      // Assert
+      expect(state.activeBoostsLoading).toBe(false); // Should remain false due to guard clause
     });
 
     it('should set activeBoostsLoading to false', () => {
@@ -1366,22 +1455,37 @@ describe('rewardsReducer', () => {
       expect(state.activeBoostsLoading).toBe(false);
     });
 
-    it('should not affect other state properties', () => {
+    it('should set activeBoostsLoading to false even when active boosts exist', () => {
       // Arrange
-      const stateWithData = {
+      const stateWithBoostsAndLoading = {
         ...initialState,
-        activeTab: 'activity' as const,
-        referralCode: 'TEST123',
         activeBoosts: [
           {
-            id: 'test-boost',
-            name: 'Test',
+            id: 'existing-boost',
+            name: 'Existing Boost',
             icon: { lightModeUrl: 'test.png', darkModeUrl: 'test.png' },
             boostBips: 1000,
             seasonLong: true,
             backgroundColor: '#FF0000',
           },
         ],
+        activeBoostsLoading: true,
+      };
+      const action = setActiveBoostsLoading(false);
+
+      // Act
+      const state = rewardsReducer(stateWithBoostsAndLoading, action);
+
+      // Assert
+      expect(state.activeBoostsLoading).toBe(false);
+    });
+
+    it('should not affect other state properties', () => {
+      // Arrange
+      const stateWithData = {
+        ...initialState,
+        activeTab: 'activity' as const,
+        referralCode: 'TEST123',
       };
       const action = setActiveBoostsLoading(true);
 
@@ -1392,7 +1496,7 @@ describe('rewardsReducer', () => {
       expect(state.activeBoostsLoading).toBe(true);
       expect(state.activeTab).toBe('activity');
       expect(state.referralCode).toBe('TEST123');
-      expect(state.activeBoosts).toEqual(stateWithData.activeBoosts);
+      expect(state.activeBoosts).toEqual([]);
     });
   });
 
@@ -1472,167 +1576,6 @@ describe('rewardsReducer', () => {
       action = setActiveBoostsError(true);
       currentState = rewardsReducer(currentState, action);
       expect(currentState.activeBoostsError).toBe(true);
-    });
-  });
-
-  describe('setActiveBoosts', () => {
-    it('should set active boosts array', () => {
-      // Arrange
-      const mockBoosts = [
-        {
-          id: 'boost-1',
-          name: 'Test Boost 1',
-          icon: {
-            lightModeUrl: 'light1.png',
-            darkModeUrl: 'dark1.png',
-          },
-          boostBips: 1000,
-          seasonLong: true,
-          backgroundColor: '#FF0000',
-        },
-        {
-          id: 'boost-2',
-          name: 'Test Boost 2',
-          icon: {
-            lightModeUrl: 'light2.png',
-            darkModeUrl: 'dark2.png',
-          },
-          boostBips: 500,
-          seasonLong: false,
-          startDate: '2024-01-01',
-          endDate: '2024-01-31',
-          backgroundColor: '#00FF00',
-        },
-      ];
-      const action = setActiveBoosts(mockBoosts);
-
-      // Act
-      const state = rewardsReducer(initialState, action);
-
-      // Assert
-      expect(state.activeBoosts).toEqual(mockBoosts);
-      expect(state.activeBoosts).toHaveLength(2);
-      expect(state.activeBoosts[0].id).toBe('boost-1');
-      expect(state.activeBoosts[1].seasonLong).toBe(false);
-    });
-
-    it('should replace existing active boosts', () => {
-      // Arrange
-      const existingBoosts = [
-        {
-          id: 'old-boost',
-          name: 'Old Boost',
-          icon: { lightModeUrl: 'old.png', darkModeUrl: 'old.png' },
-          boostBips: 100,
-          seasonLong: true,
-          backgroundColor: '#000000',
-        },
-      ];
-      const stateWithBoosts = {
-        ...initialState,
-        activeBoosts: existingBoosts,
-      };
-      const newBoosts = [
-        {
-          id: 'new-boost',
-          name: 'New Boost',
-          icon: { lightModeUrl: 'new.png', darkModeUrl: 'new.png' },
-          boostBips: 2000,
-          seasonLong: false,
-          backgroundColor: '#FFFFFF',
-        },
-      ];
-      const action = setActiveBoosts(newBoosts);
-
-      // Act
-      const state = rewardsReducer(stateWithBoosts, action);
-
-      // Assert
-      expect(state.activeBoosts).toEqual(newBoosts);
-      expect(state.activeBoosts).toHaveLength(1);
-      expect(state.activeBoosts[0].id).toBe('new-boost');
-    });
-
-    it('should set empty array when no boosts provided', () => {
-      // Arrange
-      const stateWithBoosts = {
-        ...initialState,
-        activeBoosts: [
-          {
-            id: 'existing-boost',
-            name: 'Existing',
-            icon: { lightModeUrl: 'test.png', darkModeUrl: 'test.png' },
-            boostBips: 500,
-            seasonLong: true,
-            backgroundColor: '#123456',
-          },
-        ],
-      };
-      const action = setActiveBoosts([]);
-
-      // Act
-      const state = rewardsReducer(stateWithBoosts, action);
-
-      // Assert
-      expect(state.activeBoosts).toEqual([]);
-      expect(state.activeBoosts).toHaveLength(0);
-    });
-  });
-
-  describe('setActiveBoostsLoading', () => {
-    it('should set activeBoostsLoading to true', () => {
-      // Arrange
-      const action = setActiveBoostsLoading(true);
-
-      // Act
-      const state = rewardsReducer(initialState, action);
-
-      // Assert
-      expect(state.activeBoostsLoading).toBe(true);
-    });
-
-    it('should set activeBoostsLoading to false', () => {
-      // Arrange
-      const stateWithLoading = {
-        ...initialState,
-        activeBoostsLoading: true,
-      };
-      const action = setActiveBoostsLoading(false);
-
-      // Act
-      const state = rewardsReducer(stateWithLoading, action);
-
-      // Assert
-      expect(state.activeBoostsLoading).toBe(false);
-    });
-
-    it('should not affect other state properties', () => {
-      // Arrange
-      const stateWithData = {
-        ...initialState,
-        activeTab: 'activity' as const,
-        referralCode: 'TEST123',
-        activeBoosts: [
-          {
-            id: 'test-boost',
-            name: 'Test',
-            icon: { lightModeUrl: 'test.png', darkModeUrl: 'test.png' },
-            boostBips: 1000,
-            seasonLong: true,
-            backgroundColor: '#FF0000',
-          },
-        ],
-      };
-      const action = setActiveBoostsLoading(true);
-
-      // Act
-      const state = rewardsReducer(stateWithData, action);
-
-      // Assert
-      expect(state.activeBoostsLoading).toBe(true);
-      expect(state.activeTab).toBe('activity');
-      expect(state.referralCode).toBe('TEST123');
-      expect(state.activeBoosts).toEqual(stateWithData.activeBoosts);
     });
   });
 
@@ -1755,7 +1698,7 @@ describe('rewardsReducer', () => {
   });
 
   describe('setUnlockedRewardLoading', () => {
-    it('should set unlocked reward loading to true', () => {
+    it('should set unlocked reward loading to true when no unlocked rewards exist', () => {
       // Arrange
       const action = setUnlockedRewardLoading(true);
 
@@ -1764,6 +1707,28 @@ describe('rewardsReducer', () => {
 
       // Assert
       expect(state.unlockedRewardLoading).toBe(true);
+    });
+
+    it('should not set unlocked reward loading to true when unlocked rewards already exist', () => {
+      // Arrange
+      const stateWithRewards = {
+        ...initialState,
+        unlockedRewards: [
+          {
+            id: 'existing-reward',
+            seasonRewardId: 'existing-season-reward',
+            claimStatus: RewardClaimStatus.CLAIMED,
+          },
+        ],
+        unlockedRewardLoading: false,
+      };
+      const action = setUnlockedRewardLoading(true);
+
+      // Act
+      const state = rewardsReducer(stateWithRewards, action);
+
+      // Assert
+      expect(state.unlockedRewardLoading).toBe(false); // Should remain false due to guard clause
     });
 
     it('should set unlocked reward loading to false', () => {
@@ -1781,12 +1746,35 @@ describe('rewardsReducer', () => {
       expect(state.unlockedRewardLoading).toBe(false);
     });
 
-    it('should toggle loading state correctly', () => {
-      // Arrange - Start with false
+    it('should set unlocked reward loading to false even when unlocked rewards exist', () => {
+      // Arrange
+      const stateWithRewardsAndLoading = {
+        ...initialState,
+        unlockedRewards: [
+          {
+            id: 'existing-reward',
+            seasonRewardId: 'existing-season-reward',
+            claimStatus: RewardClaimStatus.CLAIMED,
+          },
+        ],
+        unlockedRewardLoading: true,
+      };
+      const action = setUnlockedRewardLoading(false);
+
+      // Act
+      const state = rewardsReducer(stateWithRewardsAndLoading, action);
+
+      // Assert
+      expect(state.unlockedRewardLoading).toBe(false);
+    });
+
+    it('should toggle loading state correctly when no rewards exist', () => {
+      // Arrange - Start with false and no rewards
       let currentState = initialState;
       expect(currentState.unlockedRewardLoading).toBe(false);
+      expect(currentState.unlockedRewards).toHaveLength(0);
 
-      // Act - Set to true
+      // Act - Set to true (should work since no rewards exist)
       currentState = rewardsReducer(
         currentState,
         setUnlockedRewardLoading(true),
@@ -1807,13 +1795,6 @@ describe('rewardsReducer', () => {
         ...initialState,
         activeTab: 'activity' as const,
         referralCode: 'TEST456',
-        unlockedRewards: [
-          {
-            id: 'existing-reward',
-            seasonRewardId: 'existing-season-reward',
-            claimStatus: RewardClaimStatus.UNCLAIMED,
-          },
-        ],
         activeBoostsLoading: false,
       };
       const action = setUnlockedRewardLoading(true);
@@ -1825,7 +1806,7 @@ describe('rewardsReducer', () => {
       expect(state.unlockedRewardLoading).toBe(true);
       expect(state.activeTab).toBe('activity');
       expect(state.referralCode).toBe('TEST456');
-      expect(state.unlockedRewards).toHaveLength(1);
+      expect(state.unlockedRewards).toHaveLength(0);
       expect(state.activeBoostsLoading).toBe(false);
     });
   });

--- a/app/reducers/rewards/index.ts
+++ b/app/reducers/rewards/index.ts
@@ -166,10 +166,16 @@ const rewardsSlice = createSlice({
     },
 
     setReferralDetailsLoading: (state, action: PayloadAction<boolean>) => {
+      if (action.payload && state.referralCode) {
+        return;
+      }
       state.referralDetailsLoading = action.payload;
     },
 
     setSeasonStatusLoading: (state, action: PayloadAction<boolean>) => {
+      if (action.payload && state.seasonStartDate) {
+        return;
+      }
       state.seasonStatusLoading = action.payload;
     },
 
@@ -220,6 +226,9 @@ const rewardsSlice = createSlice({
       state.activeBoostsError = false; // Reset error when successful
     },
     setActiveBoostsLoading: (state, action: PayloadAction<boolean>) => {
+      if (action.payload && state.activeBoosts.length > 0) {
+        return;
+      }
       state.activeBoostsLoading = action.payload;
     },
     setActiveBoostsError: (state, action: PayloadAction<boolean>) => {
@@ -229,6 +238,9 @@ const rewardsSlice = createSlice({
       state.unlockedRewards = action.payload;
     },
     setUnlockedRewardLoading: (state, action: PayloadAction<boolean>) => {
+      if (action.payload && state.unlockedRewards.length > 0) {
+        return;
+      }
       state.unlockedRewardLoading = action.payload;
     },
   },


### PR DESCRIPTION
## **Description**

There's a bunch of things that we could be doing better to more accurately and be smarter about fetching data. Right now we sometimes are left with stale data on our views even if the user revisits them and the cache timeout has passed. Also we're fetching the same things x times when visiting a page. 

An example of a bug related to this is the linked accounts banner on the rewards dashboard; it's not being removed once a user has linked all their accounts.


## **Changelog**

CHANGELOG entry: null

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
