### PR TITLE
chore: rwds-468 fix stale balance

### DIFF
--- a/app/components/UI/Rewards/hooks/useActivePointsBoosts.ts
+++ b/app/components/UI/Rewards/hooks/useActivePointsBoosts.ts
@@ -73,7 +73,11 @@ export const useActivePointsBoosts = (): void => {
 
   // Listen for events that should trigger a refetch of active boosts
   useInvalidateByRewardEvents(
-    ['RewardsController:accountLinked', 'RewardsController:rewardClaimed'],
+    [
+      'RewardsController:accountLinked',
+      'RewardsController:rewardClaimed',
+      'RewardsController:balanceUpdated',
+    ],
     fetchActivePointsBoosts,
   );
 };

--- a/app/components/UI/Rewards/hooks/useReferralDetails.test.ts
+++ b/app/components/UI/Rewards/hooks/useReferralDetails.test.ts
@@ -58,12 +58,6 @@ describe('useReferralDetails', () => {
     mockUseFocusEffect.mockClear();
   });
 
-  it('should return null', () => {
-    mockUseSelector.mockReturnValue(null);
-    const { result } = renderHook(() => useReferralDetails());
-    expect(result.current).toBeNull();
-  });
-
   it('should not fetch when subscriptionId is not available', () => {
     mockUseSelector.mockReturnValue(null);
 

--- a/app/components/UI/Rewards/hooks/useReferralDetails.ts
+++ b/app/components/UI/Rewards/hooks/useReferralDetails.ts
@@ -8,6 +8,7 @@ import {
 import Engine from '../../../../core/Engine';
 import type { SubscriptionReferralDetailsState } from '../../../../core/Engine/controllers/rewards-controller/types';
 import { useFocusEffect } from '@react-navigation/native';
+import { useInvalidateByRewardEvents } from './useInvalidateByRewardEvents';
 
 export const useReferralDetails = (): null => {
   const dispatch = useDispatch();
@@ -51,6 +52,16 @@ export const useReferralDetails = (): null => {
     useCallback(() => {
       fetchReferralDetails();
     }, [fetchReferralDetails]),
+  );
+
+  // Listen for events that should trigger a refetch of referral details
+  useInvalidateByRewardEvents(
+    [
+      'RewardsController:accountLinked',
+      'RewardsController:rewardClaimed',
+      'RewardsController:balanceUpdated',
+    ],
+    fetchReferralDetails,
   );
 
   return null;

--- a/app/components/UI/Rewards/hooks/useSeasonStatus.ts
+++ b/app/components/UI/Rewards/hooks/useSeasonStatus.ts
@@ -57,7 +57,11 @@ export const useSeasonStatus = (): void => {
   );
 
   useInvalidateByRewardEvents(
-    ['RewardsController:accountLinked', 'RewardsController:rewardClaimed'],
+    [
+      'RewardsController:accountLinked',
+      'RewardsController:rewardClaimed',
+      'RewardsController:balanceUpdated',
+    ],
     fetchSeasonStatus,
   );
 };

--- a/app/components/UI/Rewards/hooks/useUnlockedRewards.ts
+++ b/app/components/UI/Rewards/hooks/useUnlockedRewards.ts
@@ -59,7 +59,11 @@ export const useUnlockedRewards = (): void => {
 
   // Listen for account linked events to trigger refetch
   useInvalidateByRewardEvents(
-    ['RewardsController:accountLinked', 'RewardsController:rewardClaimed'],
+    [
+      'RewardsController:accountLinked',
+      'RewardsController:rewardClaimed',
+      'RewardsController:balanceUpdated',
+    ],
     fetchUnlockedRewards,
   );
 };

--- a/app/components/UI/Rewards/utils/formatUtils.test.ts
+++ b/app/components/UI/Rewards/utils/formatUtils.test.ts
@@ -103,6 +103,7 @@ describe('formatUtils', () => {
         value: 100,
         bonus: null,
         accountAddress: TEST_ADDRESS,
+        updatedAt: new Date('2024-01-15T14:30:00Z'),
       };
 
       switch (type) {

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -163,6 +163,16 @@ class TestableRewardsController extends RewardsController {
   }
 
   // Add other private methods as needed
+  public testGetSeasonStatus(
+    subscriptionId: string,
+    seasonId: string = CURRENT_SEASON_ID,
+  ): SeasonStatusState | null {
+    return this.state.seasonStatuses[`${subscriptionId}:${seasonId}`] || null;
+  }
+
+  public testUpdate(callback: (state: RewardsControllerState) => void) {
+    this.update(callback);
+  }
 
   public invalidateAccountsAndSubscriptions() {
     this.update((state: RewardsControllerState) => {
@@ -273,6 +283,58 @@ const createTestSeasonStatus = (
     currentTierId: overrides.currentTierId || 'silver',
   };
 };
+
+// Helper function to create test season status state (state format with proper structure)
+const createTestSeasonStatusState = (
+  overrides: Partial<{
+    balance: Partial<{
+      total: number;
+      refereePortion: number;
+      updatedAt: number;
+    }>;
+    lastFetched: number;
+  }> = {},
+): SeasonStatusState => ({
+  season: {
+    id: 'current',
+    name: 'Test Season',
+    startDate: Date.now() - 86400000,
+    endDate: Date.now() + 86400000,
+    tiers: [],
+  },
+  balance: {
+    total: 100,
+    refereePortion: 0,
+    updatedAt: Date.now(),
+    ...overrides.balance,
+  },
+  tier: {
+    currentTier: {
+      id: 'bronze',
+      name: 'Bronze',
+      pointsNeeded: 0,
+      image: {
+        lightModeUrl: 'bronze-light',
+        darkModeUrl: 'bronze-dark',
+      },
+      levelNumber: '1',
+      rewards: [],
+    },
+    nextTier: {
+      id: 'silver',
+      name: 'Silver',
+      pointsNeeded: 1000,
+      image: {
+        lightModeUrl: 'silver-light',
+        darkModeUrl: 'silver-dark',
+      },
+      levelNumber: '2',
+      rewards: [],
+    },
+    nextTierPointsNeeded: 1000,
+  },
+  lastFetched: overrides.lastFetched ?? Date.now(),
+});
 
 describe('RewardsController', () => {
   let mockMessenger: jest.Mocked<RewardsControllerMessenger>;
@@ -773,7 +835,7 @@ describe('RewardsController', () => {
         ],
       };
 
-      mockMessenger.call.mockResolvedValue(mockResponse);
+      mockMessenger.call.mockResolvedValue(mockResponse as any);
 
       const result = await controller.getPointsEvents(mockRequest);
 
@@ -808,7 +870,7 @@ describe('RewardsController', () => {
         ],
       };
 
-      mockMessenger.call.mockResolvedValue(mockResponse);
+      mockMessenger.call.mockResolvedValue(mockResponse as unknown as any);
 
       const result = await controller.getPointsEvents(mockRequest);
 
@@ -837,6 +899,712 @@ describe('RewardsController', () => {
         'RewardsController: Failed to get points events:',
         'API error',
       );
+    });
+
+    describe('balance updated event emission', () => {
+      let testableController: TestableRewardsController;
+
+      beforeEach(() => {
+        testableController = new TestableRewardsController({
+          messenger: mockMessenger,
+        });
+        // Clear any previous mock calls
+        mockMessenger.publish.mockClear();
+      });
+
+      it('should emit balance updated event when earliest event is newer than cached balance timestamp', async () => {
+        // Arrange
+        const mockRequest = {
+          seasonId: 'current',
+          subscriptionId: 'sub-123',
+          cursor: null,
+        };
+
+        const now = new Date();
+        const olderTimestamp = new Date(now.getTime() - 5000); // 5 seconds ago
+        const newerTimestamp = new Date(now.getTime() - 1000); // 1 second ago
+
+        // Set up cached season status with older balance timestamp
+        testableController.testUpdate((state) => {
+          state.seasonStatuses['current:sub-123'] = createTestSeasonStatusState(
+            {
+              balance: {
+                total: 100,
+                refereePortion: 0,
+                updatedAt: olderTimestamp.getTime(),
+              },
+              lastFetched: now.getTime(),
+            },
+          );
+        });
+
+        // Clear mock calls from state setup
+        mockMessenger.publish.mockClear();
+
+        const mockResponse = {
+          has_more: false,
+          cursor: null,
+          total_results: 1,
+          results: [
+            {
+              id: 'event-1',
+              type: 'SWAP' as const,
+              timestamp: newerTimestamp,
+              value: 50,
+              bonus: { bips: 0, bonuses: [] },
+              accountAddress: '0x123',
+              updatedAt: newerTimestamp, // Newer than cached balance
+              payload: null,
+            },
+          ],
+        };
+
+        mockMessenger.call.mockResolvedValue(mockResponse);
+
+        // Act
+        const result = await testableController.getPointsEvents(mockRequest);
+
+        // Assert
+        expect(result).toEqual(mockResponse);
+        expect(mockMessenger.publish).toHaveBeenCalledWith(
+          'RewardsController:balanceUpdated',
+          {
+            seasonId: 'current',
+            subscriptionId: 'sub-123',
+          },
+        );
+        expect(mockLogger.log).toHaveBeenCalledWith(
+          'RewardsController: Emitting balanceUpdated event due to newer points events',
+          expect.objectContaining({
+            seasonId: 'current',
+            subscriptionId: 'sub-123',
+          }),
+        );
+      });
+
+      it('should not emit balance updated event when cached balance and season status are newer than earliest event', async () => {
+        // Arrange
+        const mockRequest = {
+          seasonId: 'current',
+          subscriptionId: 'sub-123',
+          cursor: null,
+        };
+
+        const now = new Date();
+        const olderTimestamp = new Date(now.getTime() - 5000); // 5 seconds ago
+        const newerTimestamp = new Date(now.getTime() - 1000); // 1 second ago
+
+        // Set up cached season status with newer balance and season status timestamps
+        testableController.testUpdate((state) => {
+          state.seasonStatuses['current:sub-123'] = createTestSeasonStatusState(
+            {
+              balance: {
+                total: 100,
+                refereePortion: 0,
+                updatedAt: newerTimestamp.getTime(), // Newer than event
+              },
+              lastFetched: now.getTime(), // Also newer than event
+            },
+          );
+        });
+
+        // Clear mock calls from state setup
+        mockMessenger.publish.mockClear();
+
+        const mockResponse = {
+          has_more: false,
+          cursor: null,
+          total_results: 1,
+          results: [
+            {
+              id: 'event-1',
+              type: 'SWAP' as const,
+              timestamp: olderTimestamp,
+              value: 50,
+              bonus: { bips: 0, bonuses: [] },
+              accountAddress: '0x123',
+              updatedAt: olderTimestamp, // Older than cached balance
+              payload: null,
+            },
+          ],
+        };
+
+        mockMessenger.call.mockResolvedValue(mockResponse);
+
+        // Act
+        const result = await testableController.getPointsEvents(mockRequest);
+
+        // Assert
+        expect(result).toEqual(mockResponse);
+        // Should NOT emit because both balance and season status timestamps are newer than event
+        expect(mockMessenger.publish).not.toHaveBeenCalledWith(
+          'RewardsController:balanceUpdated',
+          expect.any(Object),
+        );
+      });
+
+      it('should not emit balance updated event when no cached season status exists', async () => {
+        // Arrange
+        const mockRequest = {
+          seasonId: 'current',
+          subscriptionId: 'sub-123',
+          cursor: null,
+        };
+
+        const mockResponse = {
+          has_more: false,
+          cursor: null,
+          total_results: 1,
+          results: [
+            {
+              id: 'event-1',
+              type: 'SWAP' as const,
+              timestamp: new Date(),
+              value: 50,
+              bonus: { bips: 0, bonuses: [] },
+              accountAddress: '0x123',
+              updatedAt: new Date(),
+              payload: null,
+            },
+          ],
+        };
+
+        mockMessenger.call.mockResolvedValue(mockResponse);
+
+        // Act
+        const result = await testableController.getPointsEvents(mockRequest);
+
+        // Assert
+        expect(result).toEqual(mockResponse);
+        expect(mockMessenger.publish).not.toHaveBeenCalledWith(
+          'RewardsController:balanceUpdated',
+          expect.any(Object),
+        );
+      });
+
+      it('should not emit balance updated event when points events result is empty', async () => {
+        // Arrange
+        const mockRequest = {
+          seasonId: 'current',
+          subscriptionId: 'sub-123',
+          cursor: null,
+        };
+
+        const mockResponse = {
+          has_more: false,
+          cursor: null,
+          total_results: 0,
+          results: [],
+        };
+
+        mockMessenger.call.mockResolvedValue(mockResponse);
+
+        // Act
+        const result = await testableController.getPointsEvents(mockRequest);
+
+        // Assert
+        expect(result).toEqual(mockResponse);
+        expect(mockMessenger.publish).not.toHaveBeenCalledWith(
+          'RewardsController:balanceUpdated',
+          expect.any(Object),
+        );
+      });
+
+      it('should find the earliest event from multiple points events with different timestamps', async () => {
+        // Arrange
+        const mockRequest = {
+          seasonId: 'current',
+          subscriptionId: 'sub-123',
+          cursor: null,
+        };
+
+        const now = new Date();
+        const earliestTimestamp = new Date(now.getTime() - 10000); // 10 seconds ago
+        const middleTimestamp = new Date(now.getTime() - 5000); // 5 seconds ago
+        const latestTimestamp = new Date(now.getTime() - 1000); // 1 second ago
+        const cachedTimestamp = new Date(now.getTime() - 15000); // 15 seconds ago
+
+        // Set up cached season status with very old balance timestamp
+        testableController.testUpdate((state) => {
+          state.seasonStatuses['current:sub-123'] = createTestSeasonStatusState(
+            {
+              balance: {
+                total: 100,
+                refereePortion: 0,
+                updatedAt: cachedTimestamp.getTime(),
+              },
+              lastFetched: now.getTime(),
+            },
+          );
+        });
+
+        // Clear mock calls from state setup
+        mockMessenger.publish.mockClear();
+
+        const mockResponse = {
+          has_more: false,
+          cursor: null,
+          total_results: 3,
+          results: [
+            {
+              id: 'event-1',
+              type: 'SWAP' as const,
+              timestamp: latestTimestamp,
+              value: 50,
+              bonus: { bips: 0, bonuses: [] },
+              accountAddress: '0x123',
+              updatedAt: latestTimestamp, // Latest
+              payload: null,
+            },
+            {
+              id: 'event-2',
+              type: 'PERPS' as const,
+              timestamp: earliestTimestamp,
+              value: 30,
+              bonus: { bips: 0, bonuses: [] },
+              accountAddress: '0x123',
+              updatedAt: earliestTimestamp, // Earliest - should be used for comparison
+              payload: null,
+            },
+            {
+              id: 'event-3',
+              type: 'SWAP' as const,
+              timestamp: middleTimestamp,
+              value: 25,
+              bonus: { bips: 0, bonuses: [] },
+              accountAddress: '0x123',
+              updatedAt: middleTimestamp, // Middle
+              payload: null,
+            },
+          ],
+        };
+
+        mockMessenger.call.mockResolvedValue(mockResponse);
+
+        // Act
+        const result = await testableController.getPointsEvents(mockRequest);
+
+        // Assert
+        expect(result).toEqual(mockResponse);
+        expect(mockMessenger.publish).toHaveBeenCalledWith(
+          'RewardsController:balanceUpdated',
+          {
+            seasonId: 'current',
+            subscriptionId: 'sub-123',
+          },
+        );
+        expect(mockLogger.log).toHaveBeenCalledWith(
+          'RewardsController: Comparing cache timestamps with earliest updatedAt',
+          expect.objectContaining({
+            earliestUpdatedAt: earliestTimestamp.getTime(),
+          }),
+        );
+      });
+
+      it('should handle Date vs string updatedAt timestamps in points events', async () => {
+        // Arrange
+        const mockRequest = {
+          seasonId: 'current',
+          subscriptionId: 'sub-123',
+          cursor: null,
+        };
+
+        const now = new Date();
+        const eventTimestamp = new Date(now.getTime() - 1000);
+        const cachedTimestamp = new Date(now.getTime() - 5000);
+
+        // Set up cached season status
+        testableController.testUpdate((state) => {
+          state.seasonStatuses['current:sub-123'] = createTestSeasonStatusState(
+            {
+              balance: {
+                total: 100,
+                refereePortion: 0,
+                updatedAt: cachedTimestamp.getTime(),
+              },
+              lastFetched: now.getTime(),
+            },
+          );
+        });
+
+        // Clear mock calls from state setup
+        mockMessenger.publish.mockClear();
+
+        const mockResponse = {
+          has_more: false,
+          cursor: null,
+          total_results: 1,
+          results: [
+            {
+              id: 'event-1',
+              type: 'SWAP' as const,
+              timestamp: eventTimestamp,
+              value: 50,
+              bonus: { bips: 0, bonuses: [] },
+              accountAddress: '0x123',
+              updatedAt: new Date(eventTimestamp.toISOString()), // Test Date parsing from string
+              payload: null,
+            },
+          ],
+        };
+
+        mockMessenger.call.mockResolvedValue(mockResponse);
+
+        // Act
+        const result = await testableController.getPointsEvents(mockRequest);
+
+        // Assert
+        expect(result).toEqual(mockResponse);
+        expect(mockMessenger.publish).toHaveBeenCalledWith(
+          'RewardsController:balanceUpdated',
+          {
+            seasonId: 'current',
+            subscriptionId: 'sub-123',
+          },
+        );
+      });
+
+      it('should add 300ms buffer to cached balance timestamp and include season status timestamp in comparison', async () => {
+        // Arrange
+        const mockRequest = {
+          seasonId: 'current',
+          subscriptionId: 'sub-123',
+          cursor: null,
+        };
+
+        const now = new Date();
+        const eventTimestamp = new Date(now.getTime() - 1000); // 1 second ago
+        const cachedTimestamp = new Date(now.getTime() - 1200); // 1.2 seconds ago
+
+        // Set up cached season status - without 300ms buffer, balance cache would be older
+        // With 300ms buffer: cachedTimestamp + 300ms = now - 900ms, which is newer than eventTimestamp
+        // Season status timestamp (now) is also newer than eventTimestamp
+        testableController.testUpdate((state) => {
+          state.seasonStatuses['current:sub-123'] = createTestSeasonStatusState(
+            {
+              balance: {
+                total: 100,
+                refereePortion: 0,
+                updatedAt: cachedTimestamp.getTime(),
+              },
+              lastFetched: now.getTime(),
+            },
+          );
+        });
+
+        // Clear mock calls from state setup
+        mockMessenger.publish.mockClear();
+
+        const mockResponse = {
+          has_more: false,
+          cursor: null,
+          total_results: 1,
+          results: [
+            {
+              id: 'event-1',
+              type: 'SWAP' as const,
+              timestamp: eventTimestamp,
+              value: 50,
+              bonus: { bips: 0, bonuses: [] },
+              accountAddress: '0x123',
+              updatedAt: eventTimestamp,
+              payload: null,
+            },
+          ],
+        };
+
+        mockMessenger.call.mockResolvedValue(mockResponse);
+
+        // Act
+        const result = await testableController.getPointsEvents(mockRequest);
+
+        // Assert
+        expect(result).toEqual(mockResponse);
+        // Should NOT emit because both balance (+ 300ms buffer) and season status are newer than event
+        expect(mockMessenger.publish).not.toHaveBeenCalledWith(
+          'RewardsController:balanceUpdated',
+          expect.any(Object),
+        );
+
+        // Verify the 300ms buffer was added in logging and season status timestamp is included
+        expect(mockLogger.log).toHaveBeenCalledWith(
+          'RewardsController: Comparing cache timestamps with earliest updatedAt',
+          expect.objectContaining({
+            cacheBalanceUpdatedAt: cachedTimestamp.getTime() + 300,
+            cacheSeasonStatusTimestamp: now.getTime(),
+            earliestUpdatedAt: eventTimestamp.getTime(),
+          }),
+        );
+      });
+
+      it('should emit balance updated event when earliest event is newer than cached season status timestamp', async () => {
+        // Arrange
+        const mockRequest = {
+          seasonId: 'current',
+          subscriptionId: 'sub-123',
+          cursor: null,
+        };
+
+        const now = new Date();
+        const olderSeasonStatusTimestamp = new Date(now.getTime() - 5000); // 5 seconds ago
+        const newerBalanceTimestamp = new Date(now.getTime() - 1000); // 1 second ago (newer than event)
+        const eventTimestamp = new Date(now.getTime() - 3000); // 3 seconds ago
+
+        // Set up cached season status where balance is newer but season status timestamp is older
+        testableController.testUpdate((state) => {
+          state.seasonStatuses['current:sub-123'] = createTestSeasonStatusState(
+            {
+              balance: {
+                total: 100,
+                refereePortion: 0,
+                updatedAt: newerBalanceTimestamp.getTime(), // Newer than event
+              },
+              lastFetched: olderSeasonStatusTimestamp.getTime(), // Older than event
+            },
+          );
+        });
+
+        // Clear mock calls from state setup
+        mockMessenger.publish.mockClear();
+
+        const mockResponse = {
+          has_more: false,
+          cursor: null,
+          total_results: 1,
+          results: [
+            {
+              id: 'event-1',
+              type: 'SWAP' as const,
+              timestamp: eventTimestamp,
+              value: 50,
+              bonus: { bips: 0, bonuses: [] },
+              accountAddress: '0x123',
+              updatedAt: eventTimestamp,
+              payload: null,
+            },
+          ],
+        };
+
+        mockMessenger.call.mockResolvedValue(mockResponse as any);
+
+        // Act
+        const result = await testableController.getPointsEvents(mockRequest);
+
+        // Assert
+        expect(result).toEqual(mockResponse);
+        // Should emit because event is newer than season status timestamp (even though balance is newer)
+        expect(mockMessenger.publish).toHaveBeenCalledWith(
+          'RewardsController:balanceUpdated',
+          {
+            seasonId: 'current',
+            subscriptionId: 'sub-123',
+          },
+        );
+      });
+
+      it('should not emit balance updated event when both cache timestamps are newer than earliest event', async () => {
+        // Arrange
+        const mockRequest = {
+          seasonId: 'current',
+          subscriptionId: 'sub-123',
+          cursor: null,
+        };
+
+        const now = new Date();
+        const eventTimestamp = new Date(now.getTime() - 5000); // 5 seconds ago (oldest)
+        const newerBalanceTimestamp = new Date(now.getTime() - 1000); // 1 second ago
+        const newerSeasonStatusTimestamp = new Date(now.getTime() - 2000); // 2 seconds ago
+
+        // Set up cached season status where both timestamps are newer than event
+        testableController.testUpdate((state) => {
+          state.seasonStatuses['current:sub-123'] = createTestSeasonStatusState(
+            {
+              balance: {
+                total: 100,
+                refereePortion: 0,
+                updatedAt: newerBalanceTimestamp.getTime(), // Newer than event
+              },
+              lastFetched: newerSeasonStatusTimestamp.getTime(), // Newer than event
+            },
+          );
+        });
+
+        // Clear mock calls from state setup
+        mockMessenger.publish.mockClear();
+
+        const mockResponse = {
+          has_more: false,
+          cursor: null,
+          total_results: 1,
+          results: [
+            {
+              id: 'event-1',
+              type: 'SWAP' as const,
+              timestamp: eventTimestamp,
+              value: 50,
+              bonus: { bips: 0, bonuses: [] },
+              accountAddress: '0x123',
+              updatedAt: eventTimestamp,
+              payload: null,
+            },
+          ],
+        };
+
+        mockMessenger.call.mockResolvedValue(mockResponse as any);
+
+        // Act
+        const result = await testableController.getPointsEvents(mockRequest);
+
+        // Assert
+        expect(result).toEqual(mockResponse);
+        // Should NOT emit because both cache timestamps are newer than event
+        expect(mockMessenger.publish).not.toHaveBeenCalledWith(
+          'RewardsController:balanceUpdated',
+          expect.any(Object),
+        );
+      });
+
+      it('should emit balance updated event when earliest event is newer than balance timestamp but season status is missing lastFetched', async () => {
+        // Arrange
+        const mockRequest = {
+          seasonId: 'current',
+          subscriptionId: 'sub-123',
+          cursor: null,
+        };
+
+        const now = new Date();
+        const olderBalanceTimestamp = new Date(now.getTime() - 5000); // 5 seconds ago
+        const eventTimestamp = new Date(now.getTime() - 3000); // 3 seconds ago
+
+        // Set up cached season status with missing lastFetched (defaults to 0)
+        testableController.testUpdate((state) => {
+          const seasonStatus = createTestSeasonStatusState({
+            balance: {
+              total: 100,
+              refereePortion: 0,
+              updatedAt: olderBalanceTimestamp.getTime(),
+            },
+          });
+          // Remove lastFetched to test fallback to 0
+          delete (seasonStatus as any).lastFetched;
+          state.seasonStatuses['current:sub-123'] = seasonStatus;
+        });
+
+        // Clear mock calls from state setup
+        mockMessenger.publish.mockClear();
+
+        const mockResponse = {
+          has_more: false,
+          cursor: null,
+          total_results: 1,
+          results: [
+            {
+              id: 'event-1',
+              type: 'SWAP' as const,
+              timestamp: eventTimestamp,
+              value: 50,
+              bonus: { bips: 0, bonuses: [] },
+              accountAddress: '0x123',
+              updatedAt: eventTimestamp,
+              payload: null,
+            },
+          ],
+        };
+
+        mockMessenger.call.mockResolvedValue(mockResponse as any);
+
+        // Act
+        const result = await testableController.getPointsEvents(mockRequest);
+
+        // Assert
+        expect(result).toEqual(mockResponse);
+        // Should emit because both balance and season status timestamps (0) are older than event
+        expect(mockMessenger.publish).toHaveBeenCalledWith(
+          'RewardsController:balanceUpdated',
+          {
+            seasonId: 'current',
+            subscriptionId: 'sub-123',
+          },
+        );
+
+        // Verify that cacheSeasonStatusTimestamp was 0 in the logs
+        expect(mockLogger.log).toHaveBeenCalledWith(
+          'RewardsController: Comparing cache timestamps with earliest updatedAt',
+          expect.objectContaining({
+            cacheSeasonStatusTimestamp: 0,
+            earliestUpdatedAt: eventTimestamp.getTime(),
+          }),
+        );
+      });
+
+      it('should invalidate subscription cache when balance updated event is emitted', async () => {
+        // Arrange
+        const mockRequest = {
+          seasonId: 'current',
+          subscriptionId: 'sub-123',
+          cursor: null,
+        };
+
+        const now = new Date();
+        const olderTimestamp = new Date(now.getTime() - 5000);
+        const newerTimestamp = new Date(now.getTime() - 1000);
+
+        // Set up cached season status with older balance timestamp
+        testableController.testUpdate((state) => {
+          state.seasonStatuses['current:sub-123'] = createTestSeasonStatusState(
+            {
+              balance: {
+                total: 100,
+                refereePortion: 0,
+                updatedAt: olderTimestamp.getTime(),
+              },
+              lastFetched: now.getTime(),
+            },
+          );
+        });
+
+        // Clear mock calls from state setup
+        mockMessenger.publish.mockClear();
+
+        const mockResponse = {
+          has_more: false,
+          cursor: null,
+          total_results: 1,
+          results: [
+            {
+              id: 'event-1',
+              type: 'SWAP' as const,
+              timestamp: newerTimestamp,
+              value: 50,
+              bonus: { bips: 0, bonuses: [] },
+              accountAddress: '0x123',
+              updatedAt: newerTimestamp,
+              payload: null,
+            },
+          ],
+        };
+
+        mockMessenger.call.mockResolvedValue(mockResponse);
+
+        // Act
+        await testableController.getPointsEvents(mockRequest);
+
+        // Assert
+        // Verify that the cache was invalidated (season status should be removed)
+        const cachedSeasonStatus = testableController.testGetSeasonStatus(
+          'sub-123',
+          'current',
+        );
+        expect(cachedSeasonStatus).toBeNull();
+
+        expect(mockMessenger.publish).toHaveBeenCalledWith(
+          'RewardsController:balanceUpdated',
+          {
+            seasonId: 'current',
+            subscriptionId: 'sub-123',
+          },
+        );
+      });
     });
   });
 

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -1110,7 +1110,7 @@ describe('RewardsController', () => {
         );
       });
 
-      it('should find the earliest event from multiple points events with different timestamps', async () => {
+      it('should find the latest event from multiple points events with different timestamps', async () => {
         // Arrange
         const mockRequest = {
           seasonId: 'current',
@@ -1153,7 +1153,7 @@ describe('RewardsController', () => {
               value: 50,
               bonus: { bips: 0, bonuses: [] },
               accountAddress: '0x123',
-              updatedAt: latestTimestamp, // Latest
+              updatedAt: latestTimestamp, // Latest - should be used for comparison
               payload: null,
             },
             {
@@ -1163,7 +1163,7 @@ describe('RewardsController', () => {
               value: 30,
               bonus: { bips: 0, bonuses: [] },
               accountAddress: '0x123',
-              updatedAt: earliestTimestamp, // Earliest - should be used for comparison
+              updatedAt: earliestTimestamp, // Earliest
               payload: null,
             },
             {
@@ -1194,9 +1194,9 @@ describe('RewardsController', () => {
           },
         );
         expect(mockLogger.log).toHaveBeenCalledWith(
-          'RewardsController: Comparing cache timestamps with earliest updatedAt',
+          'RewardsController: Comparing cache timestamps with latest updatedAt',
           expect.objectContaining({
-            earliestUpdatedAt: earliestTimestamp.getTime(),
+            latestUpdatedAt: latestTimestamp.getTime(),
           }),
         );
       });
@@ -1328,16 +1328,16 @@ describe('RewardsController', () => {
 
         // Verify the 300ms buffer was added in logging and season status timestamp is included
         expect(mockLogger.log).toHaveBeenCalledWith(
-          'RewardsController: Comparing cache timestamps with earliest updatedAt',
+          'RewardsController: Comparing cache timestamps with latest updatedAt',
           expect.objectContaining({
             cacheBalanceUpdatedAt: cachedTimestamp.getTime() + 300,
             cacheSeasonStatusTimestamp: now.getTime(),
-            earliestUpdatedAt: eventTimestamp.getTime(),
+            latestUpdatedAt: eventTimestamp.getTime(),
           }),
         );
       });
 
-      it('should emit balance updated event when earliest event is newer than cached season status timestamp', async () => {
+      it('should emit balance updated event when latest event is newer than cached season status timestamp', async () => {
         // Arrange
         const mockRequest = {
           seasonId: 'current',
@@ -1402,7 +1402,7 @@ describe('RewardsController', () => {
         );
       });
 
-      it('should not emit balance updated event when both cache timestamps are newer than earliest event', async () => {
+      it('should not emit balance updated event when both cache timestamps are newer than latest event', async () => {
         // Arrange
         const mockRequest = {
           seasonId: 'current',
@@ -1464,7 +1464,7 @@ describe('RewardsController', () => {
         );
       });
 
-      it('should emit balance updated event when earliest event is newer than balance timestamp but season status is missing lastFetched', async () => {
+      it('should emit balance updated event when latest event is newer than balance timestamp but season status is missing lastFetched', async () => {
         // Arrange
         const mockRequest = {
           seasonId: 'current',
@@ -1529,10 +1529,10 @@ describe('RewardsController', () => {
 
         // Verify that cacheSeasonStatusTimestamp was 0 in the logs
         expect(mockLogger.log).toHaveBeenCalledWith(
-          'RewardsController: Comparing cache timestamps with earliest updatedAt',
+          'RewardsController: Comparing cache timestamps with latest updatedAt',
           expect.objectContaining({
             cacheSeasonStatusTimestamp: 0,
-            earliestUpdatedAt: eventTimestamp.getTime(),
+            latestUpdatedAt: eventTimestamp.getTime(),
           }),
         );
       });

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -278,6 +278,12 @@ interface BasePointsEventDto {
    * @example '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6'
    */
   accountAddress: string | null;
+
+  /**
+   * Timestamp of the point earning activity
+   * @example '2021-01-01T00:00:00.000Z'
+   */
+  updatedAt: Date;
 }
 
 /**
@@ -597,6 +603,19 @@ export interface RewardsControllerRewardClaimedEvent {
 }
 
 /**
+ * Event emitted when balance data should be invalidated
+ */
+export interface RewardsControllerBalanceUpdatedEvent {
+  type: 'RewardsController:balanceUpdated';
+  payload: [
+    {
+      seasonId: string;
+      subscriptionId: string;
+    },
+  ];
+}
+
+/**
  * Events that can be emitted by the RewardsController
  */
 export type RewardsControllerEvents =
@@ -605,7 +624,8 @@ export type RewardsControllerEvents =
       payload: [RewardsControllerState, Patch[]];
     }
   | RewardsControllerAccountLinkedEvent
-  | RewardsControllerRewardClaimedEvent;
+  | RewardsControllerRewardClaimedEvent
+  | RewardsControllerBalanceUpdatedEvent;
 
 /**
  * Patch type for state changes


### PR DESCRIPTION
## **Description**

Balance via season status can get out of sync with point events seen in activity tab. So we have a mechanism now in the rewards controller that invalidates the necessary concepts (like season status) by emitting a balanceUpdated event. It does this by checking if the earliest points event it finds is after either the `season status cache.lastFetched `or `season status cache.balance.updatedAt `+ a small threshold (as point event & balance update happen almost at the same time but balance is often a bit sooner)

## **Changelog**

CHANGELOG entry: null


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
