### PR TITLE
fix: cp-7.56.0 generate metrics for failed transactions on startup

### DIFF
--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
@@ -300,7 +300,7 @@ describe('useTransactionConfirm', () => {
   });
 
   describe('navigates to', () => {
-    it('wallet view if perps deposit', async () => {
+    it('perps market if perps deposit', async () => {
       useTransactionMetadataRequestMock.mockReturnValue({
         id: transactionIdMock,
         type: TransactionType.perpsDeposit,
@@ -310,7 +310,9 @@ describe('useTransactionConfirm', () => {
 
       await result.current.onConfirm();
 
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET_VIEW);
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PERPS.ROOT, {
+        screen: Routes.PERPS.MARKETS,
+      });
     });
 
     it('transactions if full screen', async () => {

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
@@ -87,7 +87,9 @@ export function useTransactionConfirm() {
     );
 
     if (type === TransactionType.perpsDeposit) {
-      navigation.navigate(Routes.WALLET_VIEW);
+      navigation.navigate(Routes.PERPS.ROOT, {
+        screen: Routes.PERPS.MARKETS,
+      });
     } else if (isFullScreenConfirmation) {
       navigation.navigate(Routes.TRANSACTIONS_VIEW);
     } else {

--- a/app/core/Engine/controllers/transaction-controller/event-handlers/metrics.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/event-handlers/metrics.test.ts
@@ -18,7 +18,6 @@ import {
   enabledSmartTransactionsState,
 } from '../data-helpers';
 import { selectShouldUseSmartTransaction } from '../../../../../selectors/smartTransactionsController';
-import Engine from '../../../Engine';
 
 jest.mock('../../../../../util/smart-transactions', () => {
   const actual = jest.requireActual('../../../../../util/smart-transactions');

--- a/app/core/Engine/controllers/transaction-controller/event-handlers/metrics.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/event-handlers/metrics.test.ts
@@ -18,6 +18,7 @@ import {
   enabledSmartTransactionsState,
 } from '../data-helpers';
 import { selectShouldUseSmartTransaction } from '../../../../../selectors/smartTransactionsController';
+import Engine from '../../../Engine';
 
 jest.mock('../../../../../util/smart-transactions', () => {
   const actual = jest.requireActual('../../../../../util/smart-transactions');
@@ -42,6 +43,10 @@ jest.mock('../../../../Analytics/MetricsEventBuilder', () => ({
   MetricsEventBuilder: {
     createEventBuilder: jest.fn(),
   },
+}));
+
+jest.mock('../../../Engine', () => ({
+  context: {},
 }));
 
 describe('Transaction Metric Event Handlers', () => {

--- a/app/core/Engine/controllers/transaction-controller/transaction-controller-init.ts
+++ b/app/core/Engine/controllers/transaction-controller/transaction-controller-init.ts
@@ -58,6 +58,12 @@ export const TransactionControllerInit: ControllerInitFunction<
     smartTransactionsController,
   } = getControllers(request);
 
+  addTransactionControllerListeners({
+    initMessenger,
+    getState,
+    smartTransactionsController,
+  });
+
   try {
     const transactionController: TransactionController =
       new TransactionController({
@@ -121,12 +127,6 @@ export const TransactionControllerInit: ControllerInitFunction<
         state: persistedState.TransactionController,
         publicKeyEIP7702: AppConstants.EIP_7702_PUBLIC_KEY as Hex | undefined,
       });
-
-    addTransactionControllerListeners({
-      initMessenger,
-      getState,
-      smartTransactionsController,
-    });
 
     return { controller: transactionController };
   } catch (error) {

--- a/app/core/Engine/controllers/transaction-controller/utils.ts
+++ b/app/core/Engine/controllers/transaction-controller/utils.ts
@@ -175,9 +175,16 @@ export async function generateDefaultTransactionMetrics(
 
   const { from } = txParams || {};
 
-  const accountType = isValidHexAddress(from)
-    ? getAddressAccountType(from)
-    : 'unknown';
+  let accountType = 'unknown';
+
+  // Fails if wallet locked
+  try {
+    accountType = isValidHexAddress(from)
+      ? getAddressAccountType(from)
+      : accountType;
+  } catch {
+    // Intentionally empty
+  }
 
   const batchProperties = await getBatchProperties(transactionMeta);
   const gasFeeProperties = getGasMetricProperties(transactionMeta);


### PR DESCRIPTION
## **Description**

Generate metrics for incomplete transactions on startup.

Redirect to Perps market view after Perps deposit.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#5862](https://github.com/MetaMask/MetaMask-planning/issues/5862)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
