### PR TITLE
fix: recalculate trade button cutout on font scale change

### DIFF
--- a/app/component-library/components/Navigation/TradeTabBarItem/TradeTabBarItem.tsx
+++ b/app/component-library/components/Navigation/TradeTabBarItem/TradeTabBarItem.tsx
@@ -1,5 +1,10 @@
 import React, { useCallback, useState } from 'react';
-import { LayoutRectangle, Pressable, PressableProps } from 'react-native';
+import {
+  LayoutRectangle,
+  Pressable,
+  PressableProps,
+  useWindowDimensions,
+} from 'react-native';
 import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
 import Icon, { IconColor, IconName, IconSize } from '../../Icons/Icon';
 import { useTheme } from '../../../../util/theme';
@@ -32,6 +37,7 @@ function TradeTabBarItem({ label, ...props }: TradeTabBarItemProps) {
   const tw = useTailwind(); // Gets theme from ThemeProvider context
   const navigation = useNavigation();
   const [buttonLayout, setButtonLayout] = useState<LayoutRectangle>();
+  const fontScale = useWindowDimensions().fontScale;
 
   const { trackEvent, createEventBuilder } = useMetrics();
 
@@ -89,6 +95,7 @@ function TradeTabBarItem({ label, ...props }: TradeTabBarItemProps) {
       onPress={handleOnPress}
     >
       <Animated.View
+        key={fontScale}
         style={[
           tw.style('items-center justify-center', {
             width: TRADE_BUTTON_SIZE,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes a bug when the user changed the font size the cut out of the trade button did not update, causing a misplacement when opening the trade menu.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: trade wallet actions

  Scenario: user opens the trade wallet actions
    Given the app is in the home state

    When user taps on the + trade button
    Then the screen cutout renders correctly on the button
```

## **Screenshots/Recordings**


### **Before**


https://github.com/user-attachments/assets/e9b9d136-d44e-4786-b3b4-e445ed98b031


### **After**


https://github.com/user-attachments/assets/4945e7b3-ba7b-4dd7-a428-eaef85d1f397




## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
