### PR TITLE
fix: restore unified activity footers

### DIFF
--- a/app/components/UI/Transactions/TransactionsFooter.test.tsx
+++ b/app/components/UI/Transactions/TransactionsFooter.test.tsx
@@ -110,6 +110,7 @@ describe('TransactionsFooter', () => {
         <TransactionsFooter
           chainId="0x1"
           providerType="mainnet"
+          rpcBlockExplorer="https://etherscan.io"
           onViewBlockExplorer={mockOnViewBlockExplorer}
         />,
       );
@@ -124,6 +125,7 @@ describe('TransactionsFooter', () => {
         <TransactionsFooter
           chainId="0x89"
           providerType="polygon"
+          rpcBlockExplorer="https://etherscan.io"
           onViewBlockExplorer={mockOnViewBlockExplorer}
         />,
       );
@@ -183,6 +185,7 @@ describe('TransactionsFooter', () => {
         <TransactionsFooter
           chainId="0x1"
           providerType="mainnet"
+          rpcBlockExplorer="https://etherscan.io"
           onViewBlockExplorer={mockOnViewBlockExplorer}
         />,
       );
@@ -316,6 +319,7 @@ describe('TransactionsFooter', () => {
         <TransactionsFooter
           chainId="0x1"
           providerType="mainnet"
+          rpcBlockExplorer="https://etherscan.io"
           onViewBlockExplorer={mockOnViewBlockExplorer}
           showDisclaimer
         />,
@@ -405,6 +409,7 @@ describe('TransactionsFooter', () => {
         <TransactionsFooter
           chainId="0x1"
           providerType="mainnet"
+          rpcBlockExplorer="https://etherscan.io"
           onViewBlockExplorer={mockOnViewBlockExplorer}
           showDisclaimer
         />,

--- a/app/components/UI/Transactions/TransactionsFooter.tsx
+++ b/app/components/UI/Transactions/TransactionsFooter.tsx
@@ -110,7 +110,7 @@ const TransactionsFooter = ({
 
   return (
     <View>
-      {blockExplorerText && (
+      {blockExplorerText && rpcBlockExplorer && (
         <View style={styles.viewMoreWrapper}>
           <Button
             variant={ButtonVariants.Link}

--- a/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.test.tsx
+++ b/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.test.tsx
@@ -177,7 +177,9 @@ jest.mock('../MultichainTransactionsView/MultichainTransactionsFooter', () => ({
   default: (props: unknown) => mockMultichainTransactionsFooter(props),
 }));
 
-const mockGetAddressUrl = jest.fn(() => 'https://solscan.io/account/0xabc');
+const mockGetAddressUrl = jest.fn(
+  (_address?: string, _chainId?: string) => 'https://solscan.io/account/0xabc',
+);
 
 jest.mock('../../../core/Multichain/utils', () => ({
   __esModule: true,
@@ -310,7 +312,7 @@ describe('UnifiedTransactionsView', () => {
     mockMultichainTransactionsFooter.mockClear();
     mockGetAddressUrl.mockClear();
     mockGetAddressUrl.mockImplementation(
-      (address: string) => `https://solscan.io/account/${address}`,
+      (address?: string) => `https://solscan.io/account/${address}`,
     );
     mockGetBlockExplorerAddressUrl.mockClear();
     mockGetBlockExplorerAddressUrl.mockImplementation(() => ({


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Restores the block explorer footer that regressed when the unified activity list landed. The unified view now renders the EVM or multichain footer only when the corresponding networks are enabled and uses the account-group’s EVM and Solana addresses for each explorer link. This ensures Solana users still see the Solscan CTA while EVM-only users get the standard footer.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/19233

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="593" height="1087" alt="Screenshot 2025-09-23 at 17 56 52" src="https://github.com/user-attachments/assets/4705d0f3-a02e-4eb2-827c-50e7754f3662" />
<img width="542" height="942" alt="Screenshot 2025-09-23 at 17 34 50" src="https://github.com/user-attachments/assets/4bee09c0-3a8e-42c4-be26-1d213482e4c9" />
<img width="516" height="919" alt="Screenshot 2025-09-23 at 17 34 33" src="https://github.com/user-attachments/assets/3e6485ba-5a39-4bb6-8d16-8f3f21d204c5" />


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
