### PR TITLE
chore: update tab empty state button to secondary variant

### DIFF
--- a/app/component-library/components-temp/TabEmptyState/TabEmptyState.tsx
+++ b/app/component-library/components-temp/TabEmptyState/TabEmptyState.tsx
@@ -49,7 +49,7 @@ export const TabEmptyState: React.FC<TabEmptyStateProps> = ({
 
     {actionButtonText && onAction && (
       <Button
-        variant={ButtonVariant.Tertiary}
+        variant={ButtonVariant.Secondary}
         onPress={onAction}
         {...actionButtonProps}
       >


### PR DESCRIPTION
## **Description**

Updated the button variant in `TabEmptyState` component from `ButtonVariant.Tertiary` to `ButtonVariant.Secondary` as requested by design team. This is a late design change to improve visual hierarchy and align with design system guidelines.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Tab Empty State Button Variant

  Scenario: User sees updated button variant in empty tab states
    Given the app is running
    And user navigates to any tab with empty state (e.g., Activity, NFTs)
    When the empty state is displayed
    Then the action button should use secondary variant styling
    And the button should have proper contrast and visual hierarchy
```

## **Screenshots/Recordings**

<!-- Design reference: https://www.figma.com/design/8u9mhomOTy9wsqvrT1aH1G/Homepage-Redesign?node-id=20-1935&m=dev -->

### **Before**

Button used tertiary variant with less visual prominence.

<img width="250" height="1600" alt="screenshot" src="https://github.com/user-attachments/assets/2e1dceac-da5d-48e3-b9a5-56b22f8cccd3" />


### **After**

Button now uses secondary variant with improved visual hierarchy.

<img width="250" height="1600" alt="screenshot" src="https://github.com/user-attachments/assets/da2caa3f-cf9c-4fde-8e0f-a9b99fdcca41" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.