### PR TITLE
feat: cp-7.56.0 bump solana snap

### DIFF
--- a/package.json
+++ b/package.json
@@ -303,7 +303,7 @@
     "@metamask/snaps-rpc-methods": "^13.5.0",
     "@metamask/snaps-sdk": "^9.3.0",
     "@metamask/snaps-utils": "^11.5.0",
-    "@metamask/solana-wallet-snap": "^2.3.10",
+    "@metamask/solana-wallet-snap": "^2.3.11",
     "@metamask/solana-wallet-standard": "^0.5.1",
     "@metamask/stake-sdk": "^3.2.0",
     "@metamask/swappable-obj-proxy": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6234,10 +6234,10 @@
     ses "^1.14.0"
     validate-npm-package-name "^5.0.0"
 
-"@metamask/solana-wallet-snap@^2.3.10":
-  version "2.3.10"
-  resolved "https://registry.yarnpkg.com/@metamask/solana-wallet-snap/-/solana-wallet-snap-2.3.10.tgz#62865af0512b8e6456253ee367bd0e6260fb93c4"
-  integrity sha512-k5yHFqVhKsZcDwlcpTQC8XmonEbsTjrSiXQDvnxyil+fnbhWEEuJeGezlTiFGf4CK1eHi/ML3JlEWkDwfZGSyg==
+"@metamask/solana-wallet-snap@^2.3.11":
+  version "2.3.11"
+  resolved "https://registry.yarnpkg.com/@metamask/solana-wallet-snap/-/solana-wallet-snap-2.3.11.tgz#f60e5b821f05fc9d26d82a2a34f0b09de705678d"
+  integrity sha512-1xXnq/9FbrvFMdXtPKta31VrMQAYsD4FKDnxDL7gVNffpOUWSO4nX+k/pYgGj+94GNqiHdQTvkpP2+OQN0Pz8Q==
 
 "@metamask/solana-wallet-standard@^0.5.1":
   version "0.5.1"


### PR DESCRIPTION
## **Description**

This PR bumps the Solana snap to version `2.3.11`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/36251?quickstart=1)

## **Changelog**

CHANGELOG entry: Added support for signing transactions where the fee payer differs from the user's account ([#535](https://github.com/MetaMask/snap-solana-wallet/pull/535))
CHANGELOG entry: Offline fee calculation with support to secp256k1 and secp256r1 signatures ([#527](https://github.com/MetaMask/snap-solana-wallet/pull/527))

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
