### PR TITLE
fix: correct feature flag name in useAccountInfo test

### DIFF
--- a/app/components/Views/confirmations/hooks/useAccountInfo.test.ts
+++ b/app/components/Views/confirmations/hooks/useAccountInfo.test.ts
@@ -62,7 +62,7 @@ describe('useAccountInfo', () => {
         backgroundState: {
           RemoteFeatureFlagController: {
             remoteFeatureFlags: {
-              enableMultichainAccounts: {
+              enableMultichainAccountsState2: {
                 enabled: false,
                 featureVersion: null,
                 minimumVersion: null,
@@ -89,7 +89,7 @@ describe('useAccountInfo', () => {
         backgroundState: {
           RemoteFeatureFlagController: {
             remoteFeatureFlags: {
-              enableMultichainAccounts: {
+              enableMultichainAccountsState2: {
                 enabled: true,
                 featureVersion: '2',
                 minimumVersion: '0.0.0',
@@ -126,7 +126,7 @@ describe('useAccountInfo', () => {
         backgroundState: {
           RemoteFeatureFlagController: {
             remoteFeatureFlags: {
-              enableMultichainAccounts: {
+              enableMultichainAccountsState2: {
                 enabled: true,
                 featureVersion: '2',
                 minimumVersion: '0.0.0',
@@ -176,7 +176,7 @@ describe('useAccountInfo', () => {
         backgroundState: {
           RemoteFeatureFlagController: {
             remoteFeatureFlags: {
-              enableMultichainAccounts: {
+              enableMultichainAccountsState2: {
                 enabled: true,
                 featureVersion: '2',
                 minimumVersion: '0.0.0',
@@ -226,7 +226,7 @@ describe('useAccountInfo', () => {
         backgroundState: {
           RemoteFeatureFlagController: {
             remoteFeatureFlags: {
-              enableMultichainAccounts: {
+              enableMultichainAccountsState2: {
                 enabled: true,
                 featureVersion: '2',
                 minimumVersion: '0.0.0',
@@ -274,7 +274,7 @@ describe('useAccountInfo', () => {
         backgroundState: {
           RemoteFeatureFlagController: {
             remoteFeatureFlags: {
-              enableMultichainAccounts: {
+              enableMultichainAccountsState2: {
                 enabled: false,
                 featureVersion: null,
                 minimumVersion: null,
@@ -301,7 +301,7 @@ describe('useAccountInfo', () => {
         backgroundState: {
           RemoteFeatureFlagController: {
             remoteFeatureFlags: {
-              enableMultichainAccounts: {
+              enableMultichainAccountsState2: {
                 enabled: true,
                 featureVersion: '2',
                 minimumVersion: '0.0.0',
@@ -338,7 +338,7 @@ describe('useAccountInfo', () => {
         backgroundState: {
           RemoteFeatureFlagController: {
             remoteFeatureFlags: {
-              enableMultichainAccounts: {
+              enableMultichainAccountsState2: {
                 enabled: true,
                 featureVersion: '2',
                 minimumVersion: '0.0.0',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The `useAccountInfo` test "returns account group name when account is found in groups" was failing because it was using the wrong feature flag name.

### Root Cause
- Test was setting up `enableMultichainAccounts` feature flag
- But `useAccountInfo` hook uses `selectMultichainAccountsState2Enabled` selector
- This selector looks for `enableMultichainAccountsState2` feature flag
- Mismatch caused `isMultichainAccountsState2Enabled` to return `false`
- Hook's `accountGroupName` logic early-returned `undefined` instead of processing account groups

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
