### PR TITLE
fix: handle transaction failures in confirmation

### DIFF
--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
@@ -299,6 +299,16 @@ describe('useTransactionConfirm', () => {
     });
   });
 
+  it('handles error during approval', async () => {
+    onApprovalConfirm.mockRejectedValueOnce(new Error('Test error'));
+
+    const { result } = renderHook();
+
+    await result.current.onConfirm();
+
+    expect(mockNavigate).toHaveBeenCalled();
+  });
+
   describe('navigates to', () => {
     it('perps market if perps deposit', async () => {
       useTransactionMetadataRequestMock.mockReturnValue({

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
@@ -20,8 +20,10 @@ import { useTransactionTotalFiat } from '../pay/useTransactionTotalFiat';
 import { isRemoveGlobalNetworkSelectorEnabled } from '../../../../../util/networks';
 import { useNetworkEnablement } from '../../../../hooks/useNetworkEnablement/useNetworkEnablement';
 import { TransactionBridgeQuote } from '../../utils/bridge';
-import { Hex } from '@metamask/utils';
+import { Hex, createProjectLogger } from '@metamask/utils';
 import { toHex } from '@metamask/controller-utils';
+
+const log = createProjectLogger('transaction-confirm');
 
 export function useTransactionConfirm() {
   const { onConfirm: onRequestConfirm } = useApprovalRequest();
@@ -77,14 +79,19 @@ export function useTransactionConfirm() {
       updatedMetadata.batchTransactionsOptions = {};
     }
 
-    await onRequestConfirm(
-      {
-        deleteAfterResult: true,
-        handleErrors: false,
-        waitForResult,
-      },
-      { txMeta: updatedMetadata },
-    );
+    try {
+      await onRequestConfirm(
+        {
+          deleteAfterResult: true,
+          // Intentionally not hiding errors so we can log
+          handleErrors: false,
+          waitForResult,
+        },
+        { txMeta: updatedMetadata },
+      );
+    } catch (error) {
+      log('Error confirming transaction', error);
+    }
 
     if (type === TransactionType.perpsDeposit) {
       navigation.navigate(Routes.PERPS.ROOT, {


### PR DESCRIPTION
## **Description**

Handle errors during approval in transaction confirmation by continuing to navigate away as usual.

## **Changelog**

CHANGELOG entry: Fixed bug causing infinite spinner after transaction error in confirmation

## **Related issues**

Fixes: #18725 

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
