### PR TITLE
fix: use rewards toast

### DIFF
--- a/app/components/UI/Rewards/Views/RewardsSettingsView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsSettingsView.tsx
@@ -36,7 +36,7 @@ const RewardsSettingsView: React.FC = () => {
   const { colors } = useTheme();
   const hasAccountOptedIn = useSelector(selectRewardsActiveAccountHasOptedIn);
   const toastRef = useRef<ToastRef>(null);
-  const { isLoading: isOptingOut, showOptoutBottomSheet } = useOptout(toastRef);
+  const { isLoading: isOptingOut, showOptoutBottomSheet } = useOptout();
 
   // Set navigation title with back button
   useEffect(() => {

--- a/app/components/UI/Rewards/components/Settings/RewardSettingsTabs.test.tsx
+++ b/app/components/UI/Rewards/components/Settings/RewardSettingsTabs.test.tsx
@@ -61,6 +61,11 @@ jest.mock('@metamask/design-system-twrnc-preset', () => ({
       }
       return styles || {};
     }),
+    color: jest.fn(
+      () =>
+        // Return a default color value for testing
+        '#037DD6',
+    ),
   })),
 }));
 

--- a/app/components/UI/Rewards/components/Settings/RewardSettingsTabs.tsx
+++ b/app/components/UI/Rewards/components/Settings/RewardSettingsTabs.tsx
@@ -1,17 +1,20 @@
 import React, { useCallback, useState, useMemo } from 'react';
-import { FlatList, ListRenderItem, View, Pressable } from 'react-native';
+import {
+  FlatList,
+  ListRenderItem,
+  View,
+  Pressable,
+  ActivityIndicator,
+} from 'react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
   Text,
   TextVariant,
   FontWeight,
-  Icon,
-  IconName,
   BoxFlexDirection,
   BoxAlignItems,
   BoxJustifyContent,
-  IconSize,
 } from '@metamask/design-system-react-native';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { strings } from '../../../../../../locales/i18n';
@@ -130,19 +133,23 @@ const RewardSettingsTabs: React.FC<RewardSettingsTabsProps> = ({
               flexDirection={BoxFlexDirection.Row}
               alignItems={BoxAlignItems.Center}
             >
-              <Text
-                variant={TextVariant.BodyMd}
-                fontWeight={FontWeight.Medium}
-                twClassName="text-primary"
-              >
-                {strings('rewards.settings.link_account_button')}
-              </Text>
+              {linkingAccount === account ? (
+                <ActivityIndicator size="small" color={tw.color('primary')} />
+              ) : (
+                <Text
+                  variant={TextVariant.BodyMd}
+                  fontWeight={FontWeight.Medium}
+                  twClassName="text-primary"
+                >
+                  {strings('rewards.settings.link_account_button')}
+                </Text>
+              )}
             </Box>
           </Pressable>
         )}
       </Box>
     ),
-    [isLinkingAccount, handleLinkAccountPress, tw],
+    [isLinkingAccount, linkingAccount, tw, handleLinkAccountPress],
   );
 
   // Render individual account item for linked accounts
@@ -254,30 +261,6 @@ const RewardSettingsTabs: React.FC<RewardSettingsTabsProps> = ({
               showsVerticalScrollIndicator={false}
               contentContainerStyle={tw.style('gap-3 pt-4')}
             />
-
-            {/* Linking Account Overlay */}
-            {linkingAccount && (
-              <Box
-                twClassName="absolute inset-0 w-full h-full bg-pressed opacity-80 justify-center items-center"
-                style={tw.style('z-50')}
-              >
-                <Box
-                  twClassName="items-center gap-4"
-                  alignItems={BoxAlignItems.Center}
-                >
-                  <Icon name={IconName.Loading} size={IconSize.Md} />
-                  <Text
-                    variant={TextVariant.BodyMd}
-                    fontWeight={FontWeight.Medium}
-                    twClassName="text-primary text-center"
-                  >
-                    {strings('rewards.linking_account', {
-                      accountName: linkingAccount.address,
-                    })}
-                  </Text>
-                </Box>
-              </Box>
-            )}
           </Box>
         ) : (
           <Box twClassName="py-8">

--- a/app/components/UI/Rewards/hooks/useLinkAccount.test.ts
+++ b/app/components/UI/Rewards/hooks/useLinkAccount.test.ts
@@ -3,10 +3,6 @@ import { useContext } from 'react';
 import { useLinkAccount } from './useLinkAccount';
 import Engine from '../../../../core/Engine';
 import Logger from '../../../../util/Logger';
-import { ToastVariants } from '../../../../component-library/components/Toast/Toast.types';
-import { IconName } from '../../../../component-library/components/Icons/Icon';
-import { IconColor } from '../../../../component-library/components/Icons/Icon/Icon.types';
-import { ButtonVariants } from '../../../../component-library/components/Buttons/Button/Button.types';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 
 // Mock dependencies
@@ -25,6 +21,22 @@ jest.mock('../../../../util/Logger', () => ({
   log: jest.fn(),
 }));
 
+// Mock useRewardsToast
+const mockShowToast = jest.fn();
+const mockSuccessToast = jest.fn();
+const mockErrorToast = jest.fn();
+
+jest.mock('./useRewardsToast', () => ({
+  __esModule: true,
+  default: () => ({
+    showToast: mockShowToast,
+    RewardsToastOptions: {
+      success: mockSuccessToast,
+      error: mockErrorToast,
+    },
+  }),
+}));
+
 jest.mock('../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string, params?: Record<string, unknown>) => {
     const mockStrings: Record<string, string> = {
@@ -37,54 +49,58 @@ jest.mock('../../../../../locales/i18n', () => ({
 }));
 
 describe('useLinkAccount', () => {
-  const mockShowToast = jest.fn();
+  // Set up mocks for the old toast system (for backward compatibility in tests)
   const mockCloseToast = jest.fn();
   const mockToastRef = {
     current: {
-      showToast: mockShowToast,
+      showToast: jest.fn(),
       closeToast: mockCloseToast,
     },
   };
 
+  // Get references to the mocked functions
   const mockEngineCall = Engine.controllerMessenger.call as jest.MockedFunction<
     typeof Engine.controllerMessenger.call
   >;
   const mockLoggerLog = Logger.log as jest.MockedFunction<typeof Logger.log>;
+  const mockUseContext = useContext as jest.MockedFunction<typeof useContext>;
 
+  // Mock account data
   const mockAccount: InternalAccount = {
-    id: 'account-1',
+    id: 'test-account-id',
     address: '0x123456789abcdef',
     metadata: {
       name: 'Test Account',
-      importTime: Date.now(),
       keyring: {
         type: 'HD Key Tree',
       },
+      importTime: Date.now(),
     },
-    options: {},
-    methods: ['personal_sign', 'eth_signTransaction'],
     type: 'eip155:eoa',
-    scopes: ['eip155:1'],
-  } as InternalAccount;
+    options: {},
+    scopes: [],
+    methods: [],
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (useContext as jest.Mock).mockReturnValue({ toastRef: mockToastRef });
+    mockUseContext.mockReturnValue(mockToastRef);
+    mockEngineCall.mockResolvedValue(true);
   });
 
-  describe('initial state', () => {
-    it('should initialize with correct default values', () => {
-      const { result } = renderHook(() => useLinkAccount());
+  it('should initialize with default values', () => {
+    // Act
+    const { result } = renderHook(() => useLinkAccount());
 
-      expect(result.current.isLoading).toBe(false);
-      expect(result.current.isError).toBe(false);
-      expect(result.current.error).toBeNull();
-      expect(typeof result.current.linkAccount).toBe('function');
-    });
+    // Assert
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isError).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(typeof result.current.linkAccount).toBe('function');
   });
 
-  describe('successful account linking', () => {
-    it('should handle successful account linking and show success toast', async () => {
+  describe('linkAccount', () => {
+    it('should link account successfully', async () => {
       // Arrange
       mockEngineCall.mockResolvedValueOnce(true);
 
@@ -107,52 +123,14 @@ describe('useLinkAccount', () => {
         mockAccount,
       );
 
-      expect(mockShowToast).toHaveBeenCalledWith({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Check,
-        iconColor: IconColor.Success,
-        labelOptions: [
-          {
-            label: 'Test Account linked successfully',
-          },
-        ],
-        hasNoTimeout: false,
-        closeButtonOptions: {
-          variant: ButtonVariants.Primary,
-          endIconName: IconName.CircleX,
-          label: 'Dismiss',
-          onPress: expect.any(Function),
-        },
-      });
+      // Verify success toast was shown
+      expect(mockSuccessToast).toHaveBeenCalledWith(
+        'Test Account linked successfully',
+      );
+      expect(mockShowToast).toHaveBeenCalled();
     });
 
-    it('should call closeToast when success toast close button is pressed', async () => {
-      // Arrange
-      mockEngineCall.mockResolvedValueOnce(true);
-
-      const { result } = renderHook(() => useLinkAccount());
-
-      // Act
-      await act(async () => {
-        await result.current.linkAccount(mockAccount);
-      });
-
-      // Get the onPress function from the close button
-      const closeButtonOnPress =
-        mockShowToast.mock.calls[0][0].closeButtonOptions.onPress;
-
-      // Act - press close button
-      act(() => {
-        closeButtonOnPress();
-      });
-
-      // Assert
-      expect(mockCloseToast).toHaveBeenCalled();
-    });
-  });
-
-  describe('failed account linking (API returns false)', () => {
-    it('should handle API returning false and show error toast', async () => {
+    it('should handle linking failure from controller', async () => {
       // Arrange
       mockEngineCall.mockResolvedValueOnce(false);
 
@@ -175,51 +153,17 @@ describe('useLinkAccount', () => {
         mockAccount,
       );
 
-      expect(mockShowToast).toHaveBeenCalledWith({
-        variant: ToastVariants.Icon,
-        iconName: IconName.CircleX,
-        iconColor: IconColor.Error,
-        labelOptions: [{ label: 'Failed to link account' }],
-        hasNoTimeout: false,
-        closeButtonOptions: {
-          variant: ButtonVariants.Primary,
-          endIconName: IconName.CircleX,
-          label: 'Dismiss',
-          onPress: expect.any(Function),
-        },
-      });
-    });
-
-    it('should call closeToast when error toast close button is pressed', async () => {
-      // Arrange
-      mockEngineCall.mockResolvedValueOnce(false);
-
-      const { result } = renderHook(() => useLinkAccount());
-
-      // Act
-      await act(async () => {
-        await result.current.linkAccount(mockAccount);
-      });
-
-      // Get the onPress function from the close button
-      const closeButtonOnPress =
-        mockShowToast.mock.calls[0][0].closeButtonOptions.onPress;
-
-      // Act - press close button
-      act(() => {
-        closeButtonOnPress();
-      });
-
-      // Assert
-      expect(mockCloseToast).toHaveBeenCalled();
+      // Verify error toast was shown
+      expect(mockErrorToast).toHaveBeenCalledWith('Failed to link account');
+      expect(mockShowToast).toHaveBeenCalled();
     });
   });
 
   describe('exception handling', () => {
-    it('should handle Error instance and show error toast with error message', async () => {
+    it('should handle exceptions and show error toast', async () => {
       // Arrange
-      const mockError = new Error('Network connection failed');
-      mockEngineCall.mockRejectedValueOnce(mockError);
+      const testError = new Error('Test error message');
+      mockEngineCall.mockRejectedValueOnce(testError);
 
       const { result } = renderHook(() => useLinkAccount());
 
@@ -233,427 +177,21 @@ describe('useLinkAccount', () => {
       expect(linkResult).toBe(false);
       expect(result.current.isLoading).toBe(false);
       expect(result.current.isError).toBe(true);
-      expect(result.current.error).toBe('Network connection failed');
+      expect(result.current.error).toBe('Test error message');
+
+      expect(mockEngineCall).toHaveBeenCalledWith(
+        'RewardsController:linkAccountToSubscriptionCandidate',
+        mockAccount,
+      );
 
       expect(mockLoggerLog).toHaveBeenCalledWith(
         'useLinkAccount: Failed to link account',
-        mockError,
+        testError,
       );
 
-      expect(mockShowToast).toHaveBeenCalledWith({
-        variant: ToastVariants.Icon,
-        iconName: IconName.CircleX,
-        iconColor: IconColor.Error,
-        labelOptions: [{ label: 'Failed to link account' }],
-        hasNoTimeout: false,
-        closeButtonOptions: {
-          variant: ButtonVariants.Primary,
-          endIconName: IconName.CircleX,
-          label: 'Dismiss',
-          onPress: expect.any(Function),
-        },
-      });
-    });
-
-    it('should handle non-Error exception and show error toast with generic message', async () => {
-      // Arrange
-      const mockError = 'String error';
-      mockEngineCall.mockRejectedValueOnce(mockError);
-
-      const { result } = renderHook(() => useLinkAccount());
-
-      // Act
-      let linkResult: boolean | undefined;
-      await act(async () => {
-        linkResult = await result.current.linkAccount(mockAccount);
-      });
-
-      // Assert
-      expect(linkResult).toBe(false);
-      expect(result.current.isLoading).toBe(false);
-      expect(result.current.isError).toBe(true);
-      expect(result.current.error).toBe('Unknown error occurred');
-
-      expect(mockLoggerLog).toHaveBeenCalledWith(
-        'useLinkAccount: Failed to link account',
-        mockError,
-      );
-    });
-
-    it('should call closeToast when exception error toast close button is pressed', async () => {
-      // Arrange
-      const mockError = new Error('Test error');
-      mockEngineCall.mockRejectedValueOnce(mockError);
-
-      const { result } = renderHook(() => useLinkAccount());
-
-      // Act
-      await act(async () => {
-        await result.current.linkAccount(mockAccount);
-      });
-
-      // Get the onPress function from the close button
-      const closeButtonOnPress =
-        mockShowToast.mock.calls[0][0].closeButtonOptions.onPress;
-
-      // Act - press close button
-      act(() => {
-        closeButtonOnPress();
-      });
-
-      // Assert
-      expect(mockCloseToast).toHaveBeenCalled();
-    });
-  });
-
-  describe('loading state management', () => {
-    it('should set loading to true during API call and false after success', async () => {
-      // Arrange
-      let resolveApiCall: (value: boolean) => void;
-      const apiCallPromise = new Promise<boolean>((resolve) => {
-        resolveApiCall = resolve;
-      });
-      mockEngineCall.mockReturnValueOnce(apiCallPromise);
-
-      const { result } = renderHook(() => useLinkAccount());
-
-      // Act - start linking
-      const linkPromise = act(async () => {
-        await result.current.linkAccount(mockAccount);
-      });
-
-      // Assert - loading should be true
-      expect(result.current.isLoading).toBe(true);
-
-      // Act - resolve API call
-      act(() => {
-        resolveApiCall(true);
-      });
-
-      // Wait for the promise to resolve
-      await linkPromise;
-
-      // Assert - loading should be false
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    it('should set loading to true during API call and false after failure', async () => {
-      // Arrange
-      let resolveApiCall: (value: boolean) => void;
-      const apiCallPromise = new Promise<boolean>((resolve) => {
-        resolveApiCall = resolve;
-      });
-      mockEngineCall.mockReturnValueOnce(apiCallPromise);
-
-      const { result } = renderHook(() => useLinkAccount());
-
-      // Act - start linking
-      const linkPromise = act(async () => {
-        await result.current.linkAccount(mockAccount);
-      });
-
-      // Assert - loading should be true
-      expect(result.current.isLoading).toBe(true);
-
-      // Act - resolve API call with failure
-      act(() => {
-        resolveApiCall(false);
-      });
-
-      // Wait for the promise to resolve
-      await linkPromise;
-
-      // Assert - loading should be false
-      expect(result.current.isLoading).toBe(false);
-    });
-
-    it('should set loading to true during API call and false after exception', async () => {
-      // Arrange
-      let rejectApiCall: (error: Error) => void;
-      const apiCallPromise = new Promise<boolean>((_, reject) => {
-        rejectApiCall = reject;
-      });
-      mockEngineCall.mockReturnValueOnce(apiCallPromise);
-
-      const { result } = renderHook(() => useLinkAccount());
-
-      // Act - start linking
-      const linkPromise = act(async () => {
-        await result.current.linkAccount(mockAccount);
-      });
-
-      // Assert - loading should be true
-      expect(result.current.isLoading).toBe(true);
-
-      // Act - reject API call
-      act(() => {
-        rejectApiCall(new Error('Test error'));
-      });
-
-      // Wait for the promise to resolve
-      await linkPromise;
-
-      // Assert - loading should be false
-      expect(result.current.isLoading).toBe(false);
-    });
-  });
-
-  describe('state reset behavior', () => {
-    it('should reset error state when starting a new link operation', async () => {
-      // Arrange - first call that fails
-      mockEngineCall.mockRejectedValueOnce(new Error('First error'));
-
-      const { result } = renderHook(() => useLinkAccount());
-
-      // Act - first failed attempt
-      await act(async () => {
-        await result.current.linkAccount(mockAccount);
-      });
-
-      // Assert - should have error state
-      expect(result.current.isError).toBe(true);
-      expect(result.current.error).toBe('First error');
-
-      // Arrange - second call that succeeds
-      mockEngineCall.mockResolvedValueOnce(true);
-
-      // Act - second successful attempt
-      await act(async () => {
-        await result.current.linkAccount(mockAccount);
-      });
-
-      // Assert - error state should be reset
-      expect(result.current.isError).toBe(false);
-      expect(result.current.error).toBeNull();
-    });
-
-    it('should reset error state even if subsequent call also fails', async () => {
-      // Arrange - first call that fails
-      mockEngineCall.mockRejectedValueOnce(new Error('First error'));
-
-      const { result } = renderHook(() => useLinkAccount());
-
-      // Act - first failed attempt
-      await act(async () => {
-        await result.current.linkAccount(mockAccount);
-      });
-
-      // Assert - should have first error
-      expect(result.current.error).toBe('First error');
-
-      // Arrange - second call that also fails
-      mockEngineCall.mockRejectedValueOnce(new Error('Second error'));
-
-      // Act - second failed attempt
-      await act(async () => {
-        await result.current.linkAccount(mockAccount);
-      });
-
-      // Assert - should have second error (state was reset)
-      expect(result.current.error).toBe('Second error');
-    });
-  });
-
-  describe('toastRef context variations', () => {
-    it('should handle missing toastRef gracefully on success', async () => {
-      // Arrange
-      (useContext as jest.Mock).mockReturnValue({ toastRef: null });
-      mockEngineCall.mockResolvedValueOnce(true);
-
-      const { result } = renderHook(() => useLinkAccount());
-
-      // Act
-      let linkResult: boolean | undefined;
-      await act(async () => {
-        linkResult = await result.current.linkAccount(mockAccount);
-      });
-
-      // Assert
-      expect(linkResult).toBe(true);
-      expect(result.current.isError).toBe(false);
-      expect(mockShowToast).not.toHaveBeenCalled();
-    });
-
-    it('should handle missing toastRef gracefully on API failure', async () => {
-      // Arrange
-      (useContext as jest.Mock).mockReturnValue({ toastRef: null });
-      mockEngineCall.mockResolvedValueOnce(false);
-
-      const { result } = renderHook(() => useLinkAccount());
-
-      // Act
-      let linkResult: boolean | undefined;
-      await act(async () => {
-        linkResult = await result.current.linkAccount(mockAccount);
-      });
-
-      // Assert
-      expect(linkResult).toBe(false);
-      expect(result.current.isError).toBe(true);
-      expect(result.current.error).toBe('Failed to link account');
-      expect(mockShowToast).not.toHaveBeenCalled();
-    });
-
-    it('should handle missing toastRef gracefully on exception', async () => {
-      // Arrange
-      (useContext as jest.Mock).mockReturnValue({ toastRef: null });
-      const mockError = new Error('Test error');
-      mockEngineCall.mockRejectedValueOnce(mockError);
-
-      const { result } = renderHook(() => useLinkAccount());
-
-      // Act
-      let linkResult: boolean | undefined;
-      await act(async () => {
-        linkResult = await result.current.linkAccount(mockAccount);
-      });
-
-      // Assert
-      expect(linkResult).toBe(false);
-      expect(result.current.isError).toBe(true);
-      expect(result.current.error).toBe('Test error');
-      expect(mockShowToast).not.toHaveBeenCalled();
-      expect(mockLoggerLog).toHaveBeenCalledWith(
-        'useLinkAccount: Failed to link account',
-        mockError,
-      );
-    });
-
-    it('should handle missing toastRef.current gracefully', async () => {
-      // Arrange
-      (useContext as jest.Mock).mockReturnValue({
-        toastRef: { current: null },
-      });
-      mockEngineCall.mockResolvedValueOnce(true);
-
-      const { result } = renderHook(() => useLinkAccount());
-
-      // Act
-      let linkResult: boolean | undefined;
-      await act(async () => {
-        linkResult = await result.current.linkAccount(mockAccount);
-      });
-
-      // Assert
-      expect(linkResult).toBe(true);
-      expect(mockShowToast).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('useCallback dependency', () => {
-    it('should maintain stable function reference when toastRef is stable', () => {
-      const { result, rerender } = renderHook(() => useLinkAccount());
-
-      const firstLinkAccount = result.current.linkAccount;
-
-      // Rerender without changing toastRef
-      rerender();
-
-      const secondLinkAccount = result.current.linkAccount;
-
-      expect(firstLinkAccount).toBe(secondLinkAccount);
-    });
-
-    it('should update function reference when toastRef changes', () => {
-      const { result, rerender } = renderHook(() => useLinkAccount());
-
-      const firstLinkAccount = result.current.linkAccount;
-
-      // Change toastRef
-      const newToastRef = {
-        current: {
-          showToast: jest.fn(),
-          closeToast: jest.fn(),
-        },
-      };
-      (useContext as jest.Mock).mockReturnValue({ toastRef: newToastRef });
-
-      rerender();
-
-      const secondLinkAccount = result.current.linkAccount;
-
-      expect(firstLinkAccount).not.toBe(secondLinkAccount);
-    });
-  });
-
-  describe('edge cases', () => {
-    it('should handle account with special characters in name', async () => {
-      // Arrange
-      const specialAccount = {
-        ...mockAccount,
-        metadata: {
-          ...mockAccount.metadata,
-          name: 'Account with "quotes" & symbols',
-        },
-      };
-      mockEngineCall.mockResolvedValueOnce(true);
-
-      const { result } = renderHook(() => useLinkAccount());
-
-      // Act
-      await act(async () => {
-        await result.current.linkAccount(specialAccount);
-      });
-
-      // Assert
-      expect(mockShowToast).toHaveBeenCalledWith(
-        expect.objectContaining({
-          labelOptions: [
-            {
-              label: 'Account with "quotes" & symbols linked successfully',
-            },
-          ],
-        }),
-      );
-    });
-
-    it('should handle multiple simultaneous calls correctly', async () => {
-      // Arrange
-      let resolveFirst: (value: boolean) => void;
-      let resolveSecond: (value: boolean) => void;
-
-      const firstPromise = new Promise<boolean>((resolve) => {
-        resolveFirst = resolve;
-      });
-      const secondPromise = new Promise<boolean>((resolve) => {
-        resolveSecond = resolve;
-      });
-
-      mockEngineCall
-        .mockReturnValueOnce(firstPromise)
-        .mockReturnValueOnce(secondPromise);
-
-      const { result } = renderHook(() => useLinkAccount());
-
-      // Act - start both calls
-      let firstResult: boolean | undefined;
-      let secondResult: boolean | undefined;
-
-      const firstCallPromise = act(async () => {
-        firstResult = await result.current.linkAccount(mockAccount);
-      });
-
-      const secondCallPromise = act(async () => {
-        secondResult = await result.current.linkAccount(mockAccount);
-      });
-
-      // Assert - should be loading
-      expect(result.current.isLoading).toBe(true);
-
-      // Act - resolve both
-      act(() => {
-        resolveFirst(true);
-        resolveSecond(false);
-      });
-
-      // Wait for both to complete
-      await Promise.all([firstCallPromise, secondCallPromise]);
-
-      // Assert
-      expect(firstResult).toBe(true);
-      expect(secondResult).toBe(false);
-      expect(result.current.isLoading).toBe(false);
-      expect(result.current.isError).toBe(true); // Last call determines final state
+      // Verify error toast was shown
+      expect(mockErrorToast).toHaveBeenCalledWith('Failed to link account');
+      expect(mockShowToast).toHaveBeenCalled();
     });
   });
 });

--- a/app/components/UI/Rewards/hooks/useLinkAccount.ts
+++ b/app/components/UI/Rewards/hooks/useLinkAccount.ts
@@ -1,13 +1,9 @@
-import { useCallback, useState, useContext } from 'react';
+import { useCallback, useState } from 'react';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import Engine from '../../../../core/Engine';
 import Logger from '../../../../util/Logger';
-import { ToastVariants } from '../../../../component-library/components/Toast/Toast.types';
 import { strings } from '../../../../../locales/i18n';
-import { ToastContext } from '../../../../component-library/components/Toast/Toast.context';
-import { IconColor } from '../../../../component-library/components/Icons/Icon/Icon.types';
-import { IconName } from '../../../../component-library/components/Icons/Icon';
-import { ButtonVariants } from '../../../../component-library/components/Buttons/Button/Button.types';
+import useRewardsToast from './useRewardsToast';
 
 interface UseLinkAccountResult {
   linkAccount: (account: InternalAccount) => Promise<boolean>;
@@ -20,7 +16,7 @@ export const useLinkAccount = (): UseLinkAccountResult => {
   const [isLoading, setIsLoading] = useState(false);
   const [isError, setIsError] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const { toastRef } = useContext(ToastContext);
+  const { showToast, RewardsToastOptions } = useRewardsToast();
 
   const linkAccount = useCallback(
     async (account: InternalAccount): Promise<boolean> => {
@@ -35,78 +31,31 @@ export const useLinkAccount = (): UseLinkAccountResult => {
         );
 
         if (success) {
-          if (toastRef?.current) {
-            toastRef.current.showToast({
-              variant: ToastVariants.Icon,
-              iconName: IconName.Check,
-              iconColor: IconColor.Success,
-              labelOptions: [
-                {
-                  label: strings(
-                    'rewards.settings.link_account_success_title',
-                    {
-                      accountName: account.metadata.name,
-                    },
-                  ),
-                },
-              ],
-              hasNoTimeout: false,
-              closeButtonOptions: {
-                variant: ButtonVariants.Primary,
-                endIconName: IconName.CircleX,
-                label: strings('rewards.toast_dismiss'),
-                onPress: () => {
-                  toastRef.current?.closeToast();
-                },
-              },
-            });
-          }
+          showToast(
+            RewardsToastOptions.success(
+              strings('rewards.settings.link_account_success_title', {
+                accountName: account.metadata.name,
+              }),
+            ),
+          );
           return true;
         }
 
-        if (toastRef?.current) {
-          toastRef.current.showToast({
-            variant: ToastVariants.Icon,
-            iconName: IconName.CircleX,
-            iconColor: IconColor.Error,
-            labelOptions: [
-              { label: strings('rewards.settings.link_account_error_title') },
-            ],
-            hasNoTimeout: false,
-            closeButtonOptions: {
-              variant: ButtonVariants.Primary,
-              endIconName: IconName.CircleX,
-              label: strings('rewards.toast_dismiss'),
-              onPress: () => {
-                toastRef.current?.closeToast();
-              },
-            },
-          });
-        }
+        showToast(
+          RewardsToastOptions.error(
+            strings('rewards.settings.link_account_error_title'),
+          ),
+        );
 
         setIsError(true);
         setError('Failed to link account');
         return false;
       } catch (err) {
-        if (toastRef?.current) {
-          toastRef.current.showToast({
-            variant: ToastVariants.Icon,
-            iconName: IconName.CircleX,
-            iconColor: IconColor.Error,
-            labelOptions: [
-              { label: strings('rewards.settings.link_account_error_title') },
-            ],
-            hasNoTimeout: false,
-            closeButtonOptions: {
-              variant: ButtonVariants.Primary,
-              endIconName: IconName.CircleX,
-              label: strings('rewards.toast_dismiss'),
-              onPress: () => {
-                toastRef.current?.closeToast();
-              },
-            },
-          });
-        }
+        showToast(
+          RewardsToastOptions.error(
+            strings('rewards.settings.link_account_error_title'),
+          ),
+        );
 
         Logger.log('useLinkAccount: Failed to link account', err);
         setIsError(true);
@@ -116,7 +65,7 @@ export const useLinkAccount = (): UseLinkAccountResult => {
         setIsLoading(false);
       }
     },
-    [toastRef],
+    [RewardsToastOptions, showToast],
   );
 
   return {

--- a/app/components/UI/Rewards/hooks/useOptout.ts
+++ b/app/components/UI/Rewards/hooks/useOptout.ts
@@ -6,13 +6,10 @@ import Engine from '../../../../core/Engine';
 import Logger from '../../../../util/Logger';
 import { resetRewardsState } from '../../../../reducers/rewards';
 import { strings } from '../../../../../locales/i18n';
-import {
-  ToastRef,
-  ToastVariants,
-} from '../../../../component-library/components/Toast/Toast.types';
 import { ModalType } from '../components/RewardsBottomSheetModal';
 import Routes from '../../../../constants/navigation/Routes';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
+import useRewardsToast from './useRewardsToast';
 
 interface UseOptoutResult {
   optout: () => Promise<void>;
@@ -20,13 +17,12 @@ interface UseOptoutResult {
   showOptoutBottomSheet: (dismissRoute?: string) => void;
 }
 
-export const useOptout = (
-  toastRef?: React.RefObject<ToastRef>,
-): UseOptoutResult => {
+export const useOptout = (): UseOptoutResult => {
   const [isLoading, setIsLoading] = useState(false);
   const dispatch = useDispatch();
   const navigation = useNavigation();
   const subscriptionId = useSelector(selectRewardsSubscriptionId);
+  const { showToast, RewardsToastOptions } = useRewardsToast();
 
   const optout = useCallback(async () => {
     if (isLoading || !subscriptionId) return;
@@ -55,35 +51,32 @@ export const useOptout = (
         Logger.log('useOptout: Opt-out failed - controller returned false');
 
         // Show error toast
-        toastRef?.current?.showToast({
-          variant: ToastVariants.Plain,
-          labelOptions: [
-            {
-              label: strings('rewards.optout.modal.error_message'),
-              isBold: true,
-            },
-          ],
-          hasNoTimeout: false,
-        });
+        showToast(
+          RewardsToastOptions.error(
+            strings('rewards.optout.modal.error_message'),
+          ),
+        );
       }
     } catch (error) {
       Logger.log('useOptout: Opt-out failed with exception:', error);
 
       // Show error toast
-      toastRef?.current?.showToast({
-        variant: ToastVariants.Plain,
-        labelOptions: [
-          {
-            label: strings('rewards.optout.error_message'),
-            isBold: true,
-          },
-        ],
-        hasNoTimeout: false,
-      });
+      showToast(
+        RewardsToastOptions.error(
+          strings('rewards.optout.modal.error_message'),
+        ),
+      );
     } finally {
       setIsLoading(false);
     }
-  }, [isLoading, dispatch, navigation, toastRef, subscriptionId]);
+  }, [
+    isLoading,
+    subscriptionId,
+    dispatch,
+    navigation,
+    showToast,
+    RewardsToastOptions,
+  ]);
 
   const showOptoutBottomSheet = useCallback(
     (dismissRoute?: string) => {

--- a/app/components/UI/Rewards/hooks/useRewardsToast.tsx
+++ b/app/components/UI/Rewards/hooks/useRewardsToast.tsx
@@ -7,6 +7,8 @@ import {
 import { IconName } from '../../../../component-library/components/Icons/Icon';
 import { useAppThemeFromContext } from '../../../../util/theme';
 import { notificationAsync, NotificationFeedbackType } from 'expo-haptics';
+import { strings } from '../../../../../locales/i18n';
+import { ButtonVariants } from '../../../../component-library/components/Buttons/Button';
 
 export type RewardsToastOptions = ToastOptions & {
   hapticsType: NotificationFeedbackType;
@@ -14,6 +16,7 @@ export type RewardsToastOptions = ToastOptions & {
 
 export interface RewardsToastConfig {
   success: (title: string, subtitle?: string) => RewardsToastOptions;
+  error: (title: string, subtitle?: string) => RewardsToastOptions;
 }
 
 const getRewardsToastLabels = (title: string, subtitle?: string) => {
@@ -69,9 +72,42 @@ const useRewardsToast = (): {
         backgroundColor: theme.colors.primary.muted,
         hapticsType: NotificationFeedbackType.Success,
         labelOptions: getRewardsToastLabels(title, subtitle),
+        hasNoTimeout: false,
+        closeButtonOptions: {
+          variant: ButtonVariants.Primary,
+          endIconName: IconName.CircleX,
+          label: strings('rewards.toast_dismiss'),
+          onPress: () => {
+            toastRef?.current?.closeToast();
+          },
+        },
+      }),
+      error: (title: string, subtitle?: string) => ({
+        ...(REWARDS_TOASTS_DEFAULT_OPTIONS as RewardsToastOptions),
+        variant: ToastVariants.Icon,
+        iconName: IconName.Error,
+        iconColor: theme.colors.error.default,
+        backgroundColor: theme.colors.error.muted,
+        hapticsType: NotificationFeedbackType.Error,
+        labelOptions: getRewardsToastLabels(title, subtitle),
+        hasNoTimeout: false,
+        closeButtonOptions: {
+          variant: ButtonVariants.Primary,
+          endIconName: IconName.CircleX,
+          label: strings('rewards.toast_dismiss'),
+          onPress: () => {
+            toastRef?.current?.closeToast();
+          },
+        },
       }),
     }),
-    [theme],
+    [
+      theme.colors.error.default,
+      theme.colors.error.muted,
+      theme.colors.primary.default,
+      theme.colors.primary.muted,
+      toastRef,
+    ],
   );
 
   return {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
- Removed overlaying 'Linking...' text and replace with ActivityIndicator when loading
- use standard useRewardsToast for showing toast

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/9609a7a5-97b1-4281-83fc-6578ea7186f5


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
