### PR TITLE
chore: error timeout feedback

### DIFF
--- a/app/actions/rewards/index.ts
+++ b/app/actions/rewards/index.ts
@@ -2,6 +2,7 @@ export {
   setActiveTab,
   setReferralDetails,
   setSeasonStatus,
+  setSeasonStatusError,
   resetRewardsState,
   resetOnboarding,
   setOnboardingActiveStep,

--- a/app/components/UI/Rewards/Views/RewardsSettingsView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsSettingsView.test.tsx
@@ -51,6 +51,8 @@ jest.mock('../../../../../locales/i18n', () => ({
       'rewards.optout.description':
         'Remove all accounts from the rewards program',
       'rewards.optout.confirm': 'Opt Out',
+      'rewards.settings.accounts_syncing':
+        'Your accounts are syncing. Please wait.',
     };
     return translations[key] || key;
   }),
@@ -95,15 +97,28 @@ jest.mock('../hooks/useOptout', () => ({
   useOptout: jest.fn(),
 }));
 
+// Mock useAccountsOperationsLoadingStates hook
+jest.mock(
+  '../../../../util/accounts/useAccountsOperationsLoadingStates',
+  () => ({
+    useAccountsOperationsLoadingStates: jest.fn(),
+  }),
+);
+
 // Import mocked selectors for setup
 import { selectRewardsActiveAccountHasOptedIn } from '../../../../selectors/rewards';
 import { useOptout } from '../hooks/useOptout';
+import { useAccountsOperationsLoadingStates } from '../../../../util/accounts/useAccountsOperationsLoadingStates';
 
 const mockSelectRewardsActiveAccountHasOptedIn =
   selectRewardsActiveAccountHasOptedIn as jest.MockedFunction<
     typeof selectRewardsActiveAccountHasOptedIn
   >;
 const mockUseOptout = useOptout as jest.MockedFunction<typeof useOptout>;
+const mockUseAccountsOperationsLoadingStates =
+  useAccountsOperationsLoadingStates as jest.MockedFunction<
+    typeof useAccountsOperationsLoadingStates
+  >;
 
 describe('RewardsSettingsView', () => {
   let store: ReturnType<typeof configureStore>;
@@ -152,6 +167,11 @@ describe('RewardsSettingsView', () => {
       optout: jest.fn(),
       isLoading: false,
       showOptoutBottomSheet: jest.fn(),
+    });
+    mockUseAccountsOperationsLoadingStates.mockReturnValue({
+      areAnyOperationsLoading: false,
+      isAccountSyncingInProgress: false,
+      loadingMessage: null,
     });
     mockUseRoute.mockReturnValue({
       params: {},
@@ -311,24 +331,6 @@ describe('RewardsSettingsView', () => {
     });
   });
 
-  describe('Hook integration', () => {
-    it('calls useOptout hook', () => {
-      // Act
-      renderWithNavigation(<RewardsSettingsView />);
-
-      // Assert
-      expect(mockUseOptout).toHaveBeenCalled();
-    });
-
-    it('uses selectRewardsActiveAccountHasOptedIn selector', () => {
-      // Act
-      renderWithNavigation(<RewardsSettingsView />);
-
-      // Assert
-      expect(mockSelectRewardsActiveAccountHasOptedIn).toHaveBeenCalled();
-    });
-  });
-
   describe('Component structure', () => {
     it('renders all main sections', () => {
       // Act
@@ -348,6 +350,132 @@ describe('RewardsSettingsView', () => {
 
       // Assert - Component should render without errors
       expect(component).toBeTruthy();
+    });
+  });
+
+  describe('Account syncing banner', () => {
+    it('shows syncing banner when isAccountSyncingInProgress is true', () => {
+      // Arrange
+      mockUseAccountsOperationsLoadingStates.mockReturnValue({
+        areAnyOperationsLoading: true,
+        isAccountSyncingInProgress: true,
+        loadingMessage: 'Syncing accounts...',
+      });
+
+      // Act
+      const { getByTestId, getByText } = renderWithNavigation(
+        <RewardsSettingsView />,
+      );
+
+      // Assert
+      expect(getByTestId('account-syncing-banner')).toBeOnTheScreen();
+      expect(getByText('Syncing accounts...')).toBeOnTheScreen();
+      expect(
+        getByText('Your accounts are syncing. Please wait.'),
+      ).toBeOnTheScreen();
+    });
+
+    it('does not show syncing banner when isAccountSyncingInProgress is false', () => {
+      // Arrange
+      mockUseAccountsOperationsLoadingStates.mockReturnValue({
+        areAnyOperationsLoading: false,
+        isAccountSyncingInProgress: false,
+        loadingMessage: null,
+      });
+
+      // Act
+      const { queryByTestId } = renderWithNavigation(<RewardsSettingsView />);
+
+      // Assert
+      expect(queryByTestId('account-syncing-banner')).toBeNull();
+    });
+
+    it('shows syncing banner with custom loading message', () => {
+      // Arrange
+      const customMessage = 'Importing accounts from backup...';
+      mockUseAccountsOperationsLoadingStates.mockReturnValue({
+        areAnyOperationsLoading: true,
+        isAccountSyncingInProgress: true,
+        loadingMessage: customMessage,
+      });
+
+      // Act
+      const { getByTestId, getByText } = renderWithNavigation(
+        <RewardsSettingsView />,
+      );
+
+      // Assert
+      expect(getByTestId('account-syncing-banner')).toBeOnTheScreen();
+      expect(getByText(customMessage)).toBeOnTheScreen();
+      expect(
+        getByText('Your accounts are syncing. Please wait.'),
+      ).toBeOnTheScreen();
+    });
+
+    it('shows syncing banner even when account is opted in', () => {
+      // Arrange - both syncing and opted in
+      mockSelectRewardsActiveAccountHasOptedIn.mockReturnValue(true);
+      mockUseAccountsOperationsLoadingStates.mockReturnValue({
+        areAnyOperationsLoading: true,
+        isAccountSyncingInProgress: true,
+        loadingMessage: 'Profile sync in progress...',
+      });
+
+      // Act
+      const { getByTestId, queryByText } = renderWithNavigation(
+        <RewardsSettingsView />,
+      );
+
+      // Assert
+      expect(getByTestId('account-syncing-banner')).toBeOnTheScreen();
+      // Should not show the unlinked account banner when opted in
+      expect(queryByText('Account Not Connected')).toBeNull();
+    });
+
+    it('shows both syncing and unlinked account banners when account is not opted in', () => {
+      // Arrange - both syncing and not opted in
+      mockSelectRewardsActiveAccountHasOptedIn.mockReturnValue(false);
+      mockUseAccountsOperationsLoadingStates.mockReturnValue({
+        areAnyOperationsLoading: true,
+        isAccountSyncingInProgress: true,
+        loadingMessage: 'Syncing profile data...',
+      });
+
+      // Act
+      const { getByTestId, getByText } = renderWithNavigation(
+        <RewardsSettingsView />,
+      );
+
+      // Assert
+      expect(getByTestId('account-syncing-banner')).toBeOnTheScreen();
+      expect(getByText('Syncing profile data...')).toBeOnTheScreen();
+      expect(getByText('Account Not Connected')).toBeOnTheScreen();
+    });
+  });
+
+  describe('Hook integration', () => {
+    it('calls useAccountsOperationsLoadingStates hook', () => {
+      // Act
+      renderWithNavigation(<RewardsSettingsView />);
+
+      // Assert
+      expect(mockUseAccountsOperationsLoadingStates).toHaveBeenCalled();
+    });
+
+    it('calls useOptout hook', () => {
+      // Act
+      renderWithNavigation(<RewardsSettingsView />);
+
+      // Assert
+      expect(mockUseOptout).toHaveBeenCalled();
+    });
+
+    it('uses selectRewardsActiveAccountHasOptedIn selector', () => {
+      // Act
+      renderWithNavigation(<RewardsSettingsView />);
+
+      // Assert
+      expect(mockSelectRewardsActiveAccountHasOptedIn).toHaveBeenCalled();
     });
   });
 
@@ -382,6 +510,21 @@ describe('RewardsSettingsView', () => {
         isLoading: false,
         showOptoutBottomSheet: jest.fn(),
       });
+    });
+
+    it('handles null loading message gracefully', () => {
+      // Arrange
+      mockUseAccountsOperationsLoadingStates.mockReturnValue({
+        areAnyOperationsLoading: true,
+        isAccountSyncingInProgress: true,
+        loadingMessage: null,
+      });
+
+      // Act
+      const { getByTestId } = renderWithNavigation(<RewardsSettingsView />);
+
+      // Assert - Should still render banner even with null message
+      expect(getByTestId('account-syncing-banner')).toBeOnTheScreen();
     });
   });
 });

--- a/app/components/UI/Rewards/Views/RewardsSettingsView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsSettingsView.tsx
@@ -21,6 +21,7 @@ import Routes from '../../../../constants/navigation/Routes';
 import RewardSettingsTabs from '../components/Settings/RewardSettingsTabs';
 import { selectRewardsActiveAccountHasOptedIn } from '../../../../selectors/rewards';
 import { useOptout } from '../hooks/useOptout';
+import { useAccountsOperationsLoadingStates } from '../../../../util/accounts/useAccountsOperationsLoadingStates';
 
 interface RewardsSettingsViewRouteParams {
   focusUnlinkedTab?: boolean;
@@ -37,6 +38,12 @@ const RewardsSettingsView: React.FC = () => {
   const hasAccountOptedIn = useSelector(selectRewardsActiveAccountHasOptedIn);
   const toastRef = useRef<ToastRef>(null);
   const { isLoading: isOptingOut, showOptoutBottomSheet } = useOptout();
+
+  // Check if any account operations are loading
+  const {
+    isAccountSyncingInProgress,
+    loadingMessage: accountSyncingLoadingMessage,
+  } = useAccountsOperationsLoadingStates();
 
   // Set navigation title with back button
   useEffect(() => {
@@ -85,6 +92,18 @@ const RewardsSettingsView: React.FC = () => {
               </Text>
             </Box>
           </Box>
+
+          {isAccountSyncingInProgress && (
+            <Box twClassName="-mx-4">
+              <Banner
+                variant={BannerVariant.Alert}
+                severity={BannerAlertSeverity.Info}
+                title={accountSyncingLoadingMessage}
+                description={strings('rewards.settings.accounts_syncing')}
+                testID="account-syncing-banner"
+              />
+            </Box>
+          )}
 
           {/* Current Account Not Opted In Banner */}
           {hasAccountOptedIn === false && (

--- a/app/components/UI/Rewards/components/Onboarding/OnboardingIntroStep.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/OnboardingIntroStep.tsx
@@ -17,8 +17,12 @@ import {
 } from '@metamask/design-system-react-native';
 
 import { Skeleton } from '../../../../../component-library/components/Skeleton';
+import { BannerAlertSeverity } from '../../../../../component-library/components/Banners/Banner/variants/BannerAlert/BannerAlert.types';
 
-import { setOnboardingActiveStep } from '../../../../../actions/rewards';
+import {
+  setOnboardingActiveStep,
+  setCandidateSubscriptionId,
+} from '../../../../../actions/rewards';
 import Routes from '../../../../../constants/navigation/Routes';
 import introBg from '../../../../../images/rewards/rewards-onboarding-intro-bg.png';
 import intro from '../../../../../images/rewards/rewards-onboarding-intro.png';
@@ -31,6 +35,7 @@ import {
 import { selectRewardsSubscriptionId } from '../../../../../selectors/rewards';
 import { strings } from '../../../../../../locales/i18n';
 import ButtonHero from '../../../../../component-library/components-temp/Buttons/ButtonHero';
+import BannerAlert from '../../../../../component-library/components/Banners/Banner/variants/BannerAlert';
 
 /**
  * OnboardingIntroStep Component
@@ -55,6 +60,7 @@ const OnboardingIntroStep: React.FC = () => {
   // Computed state
   const candidateSubscriptionIdLoading =
     !subscriptionId && candidateSubscriptionId === 'pending';
+  const candidateSubscriptionIdError = candidateSubscriptionId === 'error';
 
   /**
    * Shows error modal for unsupported scenarios
@@ -74,6 +80,21 @@ const OnboardingIntroStep: React.FC = () => {
     },
     [navigation],
   );
+
+  /**
+   * Handle retry action for candidateSubscriptionId errors
+   */
+  const handleRetry = useCallback(() => {
+    dispatch(setCandidateSubscriptionId('retry'));
+  }, [dispatch]);
+
+  /**
+   * Handle cancel action for candidateSubscriptionId errors
+   */
+  const handleCancel = useCallback(() => {
+    // Navigate back to wallet view
+    navigation.navigate(Routes.WALLET_VIEW);
+  }, [navigation]);
 
   /**
    * Handles the confirm/continue button press
@@ -195,6 +216,37 @@ const OnboardingIntroStep: React.FC = () => {
 
   if (candidateSubscriptionIdLoading || !!subscriptionId) {
     return <Skeleton width="100%" height="100%" />;
+  }
+
+  // Show error banner in center of skeleton when in error state
+  if (candidateSubscriptionIdError) {
+    return (
+      <Box twClassName="p-4 min-h-full justify-center items-center px-4">
+        <BannerAlert
+          severity={BannerAlertSeverity.Error}
+          title={strings('rewards.auth_fail_banner.title')}
+          description={strings('rewards.auth_fail_banner.description')}
+          style={tw.style('w-full')}
+        >
+          <Box flexDirection={BoxFlexDirection.Row} twClassName="mt-4 gap-2">
+            <Button
+              variant={ButtonVariant.Tertiary}
+              size={ButtonSize.Lg}
+              onPress={handleCancel}
+            >
+              <Text>{strings('rewards.auth_fail_banner.cta_cancel')}</Text>
+            </Button>
+            <Button
+              variant={ButtonVariant.Secondary}
+              size={ButtonSize.Lg}
+              onPress={handleRetry}
+            >
+              <Text>{strings('rewards.auth_fail_banner.cta_retry')}</Text>
+            </Button>
+          </Box>
+        </BannerAlert>
+      </Box>
+    );
   }
 
   return (

--- a/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingIntroStep.test.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingIntroStep.test.tsx
@@ -352,6 +352,240 @@ describe('OnboardingIntroStep', () => {
     });
   });
 
+  describe('candidateSubscriptionId states', () => {
+    it('should show skeleton when candidateSubscriptionId is pending', () => {
+      const mockSelectorWithPending = jest.fn((selector) => {
+        const state = {
+          rewards: {
+            optinAllowedForGeo: true,
+            optinAllowedForGeoLoading: false,
+            onboardingActiveStep: 'intro',
+            candidateSubscriptionId: 'pending',
+            rewardsControllerState: {
+              activeAccount: {
+                subscriptionId: null,
+                account: 'test-account',
+                hasOptedIn: false,
+              },
+            },
+          },
+          engine: {
+            backgroundState: {
+              AccountsController: {
+                internalAccounts: {
+                  selectedAccount: 'test-account',
+                  accounts: {
+                    'test-account': {
+                      type: 'eip155:eoa',
+                    },
+                  },
+                },
+              },
+              RewardsController: {
+                activeAccount: {
+                  subscriptionId: null,
+                  account: 'test-account',
+                  hasOptedIn: false,
+                },
+              },
+            },
+          },
+        };
+        return selector(state);
+      });
+
+      const mockUseSelectorPending = jest.requireMock('react-redux')
+        .useSelector as jest.Mock;
+      mockUseSelectorPending.mockImplementation(mockSelectorWithPending);
+
+      renderWithProviders(<OnboardingIntroStep />);
+
+      // Should not render the main container when loading
+      expect(screen.queryByTestId('onboarding-intro-container')).toBeNull();
+    });
+
+    it('should show error banner when candidateSubscriptionId is error', () => {
+      const mockSelectorWithError = jest.fn((selector) => {
+        const state = {
+          rewards: {
+            optinAllowedForGeo: true,
+            optinAllowedForGeoLoading: false,
+            onboardingActiveStep: 'intro',
+            candidateSubscriptionId: 'error',
+            rewardsControllerState: {
+              activeAccount: {
+                subscriptionId: null,
+                account: 'test-account',
+                hasOptedIn: false,
+              },
+            },
+          },
+          engine: {
+            backgroundState: {
+              AccountsController: {
+                internalAccounts: {
+                  selectedAccount: 'test-account',
+                  accounts: {
+                    'test-account': {
+                      type: 'eip155:eoa',
+                    },
+                  },
+                },
+              },
+              RewardsController: {
+                activeAccount: {
+                  subscriptionId: null,
+                  account: 'test-account',
+                  hasOptedIn: false,
+                },
+              },
+            },
+          },
+        };
+        return selector(state);
+      });
+
+      const mockUseSelectorError = jest.requireMock('react-redux')
+        .useSelector as jest.Mock;
+      mockUseSelectorError.mockImplementation(mockSelectorWithError);
+
+      renderWithProviders(<OnboardingIntroStep />);
+
+      // Should show error banner
+      expect(
+        screen.getByText('mocked_rewards.auth_fail_banner.title'),
+      ).toBeDefined();
+      expect(
+        screen.getByText('mocked_rewards.auth_fail_banner.description'),
+      ).toBeDefined();
+
+      // Should show retry and cancel buttons
+      expect(
+        screen.getByText('mocked_rewards.auth_fail_banner.cta_retry'),
+      ).toBeDefined();
+      expect(
+        screen.getByText('mocked_rewards.auth_fail_banner.cta_cancel'),
+      ).toBeDefined();
+    });
+
+    it('should dispatch setCandidateSubscriptionId with retry when retry button is pressed', () => {
+      const mockSelectorWithError = jest.fn((selector) => {
+        const state = {
+          rewards: {
+            optinAllowedForGeo: true,
+            optinAllowedForGeoLoading: false,
+            onboardingActiveStep: 'intro',
+            candidateSubscriptionId: 'error',
+            rewardsControllerState: {
+              activeAccount: {
+                subscriptionId: null,
+                account: 'test-account',
+                hasOptedIn: false,
+              },
+            },
+          },
+          engine: {
+            backgroundState: {
+              AccountsController: {
+                internalAccounts: {
+                  selectedAccount: 'test-account',
+                  accounts: {
+                    'test-account': {
+                      type: 'eip155:eoa',
+                    },
+                  },
+                },
+              },
+              RewardsController: {
+                activeAccount: {
+                  subscriptionId: null,
+                  account: 'test-account',
+                  hasOptedIn: false,
+                },
+              },
+            },
+          },
+        };
+        return selector(state);
+      });
+
+      const mockUseSelectorError = jest.requireMock('react-redux')
+        .useSelector as jest.Mock;
+      mockUseSelectorError.mockImplementation(mockSelectorWithError);
+
+      renderWithProviders(<OnboardingIntroStep />);
+
+      const retryButton = screen.getByText(
+        'mocked_rewards.auth_fail_banner.cta_retry',
+      );
+      fireEvent.press(retryButton);
+
+      // Should dispatch setCandidateSubscriptionId with 'retry'
+      expect(mockDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: expect.stringContaining('setCandidateSubscriptionId'),
+          payload: 'retry',
+        }),
+      );
+    });
+
+    it('should navigate to wallet view when cancel button is pressed', () => {
+      const mockSelectorWithError = jest.fn((selector) => {
+        const state = {
+          rewards: {
+            optinAllowedForGeo: true,
+            optinAllowedForGeoLoading: false,
+            onboardingActiveStep: 'intro',
+            candidateSubscriptionId: 'error',
+            rewardsControllerState: {
+              activeAccount: {
+                subscriptionId: null,
+                account: 'test-account',
+                hasOptedIn: false,
+              },
+            },
+          },
+          engine: {
+            backgroundState: {
+              AccountsController: {
+                internalAccounts: {
+                  selectedAccount: 'test-account',
+                  accounts: {
+                    'test-account': {
+                      type: 'eip155:eoa',
+                    },
+                  },
+                },
+              },
+              RewardsController: {
+                activeAccount: {
+                  subscriptionId: null,
+                  account: 'test-account',
+                  hasOptedIn: false,
+                },
+              },
+            },
+          },
+        };
+        return selector(state);
+      });
+
+      const mockUseSelectorError = jest.requireMock('react-redux')
+        .useSelector as jest.Mock;
+      mockUseSelectorError.mockImplementation(mockSelectorWithError);
+
+      renderWithProviders(<OnboardingIntroStep />);
+
+      const cancelButton = screen.getByText(
+        'mocked_rewards.auth_fail_banner.cta_cancel',
+      );
+      fireEvent.press(cancelButton);
+
+      // Should navigate to wallet view
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET_VIEW);
+    });
+  });
+
   describe('edge cases', () => {
     it('should handle missing account gracefully', () => {
       const mockSelectorWithNoAccount = jest.fn((selector) => {

--- a/app/components/UI/Rewards/components/SeasonStatus/SeasonStatus.test.tsx
+++ b/app/components/UI/Rewards/components/SeasonStatus/SeasonStatus.test.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import SeasonStatus from './SeasonStatus';
 
 // Mock react-redux
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
+  useDispatch: jest.fn(),
 }));
 
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+const mockUseDispatch = useDispatch as jest.MockedFunction<typeof useDispatch>;
 
 // Mock individual selectors
 jest.mock('../../../../../reducers/rewards/selectors', () => ({
@@ -33,6 +35,20 @@ import {
   selectCurrentTier,
   selectNextTier,
 } from '../../../../../reducers/rewards/selectors';
+
+// Mock rewards selectors
+jest.mock('../../../../../selectors/rewards', () => ({
+  selectSeasonStatusError: jest.fn(),
+}));
+
+import { selectSeasonStatusError } from '../../../../../selectors/rewards';
+
+// Mock useSeasonStatus hook
+jest.mock('../../hooks/useSeasonStatus', () => ({
+  useSeasonStatus: jest.fn(),
+}));
+
+import { useSeasonStatus } from '../../hooks/useSeasonStatus';
 
 const mockSelectSeasonStatusLoading =
   selectSeasonStatusLoading as jest.MockedFunction<
@@ -59,6 +75,13 @@ const mockSelectCurrentTier = selectCurrentTier as jest.MockedFunction<
 >;
 const mockSelectNextTier = selectNextTier as jest.MockedFunction<
   typeof selectNextTier
+>;
+const mockSelectSeasonStatusError =
+  selectSeasonStatusError as jest.MockedFunction<
+    typeof selectSeasonStatusError
+  >;
+const mockUseSeasonStatus = useSeasonStatus as jest.MockedFunction<
+  typeof useSeasonStatus
 >;
 
 // Mock date utility
@@ -154,6 +177,73 @@ jest.mock('../../../../../component-library/components/Skeleton', () => ({
   },
 }));
 
+// Mock Banner component
+jest.mock('../../../../../component-library/components/Banners/Banner', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Text, TouchableOpacity } = jest.requireActual('react-native');
+  return ReactActual.forwardRef(
+    (
+      {
+        title,
+        description,
+        onClose,
+        testID,
+        ...props
+      }: {
+        title?: string;
+        description?: string;
+        onClose?: () => void;
+        testID?: string;
+      },
+      ref: unknown,
+    ) =>
+      ReactActual.createElement(
+        View,
+        {
+          testID: testID || 'banner',
+          ref,
+          ...props,
+        },
+        [
+          ReactActual.createElement(Text, { key: 'title' }, title),
+          ReactActual.createElement(Text, { key: 'description' }, description),
+          onClose &&
+            ReactActual.createElement(
+              TouchableOpacity,
+              { key: 'close', onPress: onClose },
+              ReactActual.createElement(Text, {}, '×'),
+            ),
+        ],
+      ),
+  );
+});
+
+// Mock setSeasonStatusError action
+jest.mock('../../../../../actions/rewards', () => ({
+  setSeasonStatusError: jest.fn((payload) => ({
+    type: 'rewards/setSeasonStatusError',
+    payload,
+  })),
+}));
+
+// Mock SeasonTierImage
+jest.mock('../SeasonTierImage', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return ReactActual.forwardRef(
+    (
+      { tierOrder, testID, ...props }: { tierOrder?: number; testID?: string },
+      ref: unknown,
+    ) =>
+      ReactActual.createElement(View, {
+        testID: testID || 'season-tier-image',
+        ref,
+        'data-tier-order': tierOrder,
+        ...props,
+      }),
+  );
+});
+
 // Mock lodash capitalize but preserve the rest of lodash
 jest.mock('lodash', () => {
   const actual = jest.requireActual('lodash');
@@ -190,9 +280,12 @@ jest.mock('../ThemeImageComponent', () => {
 });
 
 describe('SeasonStatus', () => {
+  const mockDispatch = jest.fn();
+
   // Default mock values
   const defaultMockValues = {
     seasonStatusLoading: false,
+    seasonStatusError: null,
     seasonStartDate: new Date('2024-01-01T00:00:00Z'),
     seasonEndDate: new Date('2024-12-31T23:59:59Z'),
     balanceTotal: 1500,
@@ -265,8 +358,15 @@ describe('SeasonStatus', () => {
     );
 
     // Setup default mock returns
+    mockUseDispatch.mockReturnValue(mockDispatch);
+    mockUseSeasonStatus.mockImplementation(() => {
+      // Mock implementation
+    });
     mockSelectSeasonStatusLoading.mockReturnValue(
       defaultMockValues.seasonStatusLoading,
+    );
+    mockSelectSeasonStatusError.mockReturnValue(
+      defaultMockValues.seasonStatusError,
     );
     mockSelectSeasonStartDate.mockReturnValue(
       defaultMockValues.seasonStartDate,
@@ -658,6 +758,22 @@ describe('SeasonStatus', () => {
       // Then: new tier level and name are displayed
       expect(getByText('Level 3')).toBeTruthy();
       expect(getByText('Gold')).toBeTruthy();
+    });
+  });
+
+  describe('seasonStatusError states', () => {
+    it('should not show error banner when no seasonStatusError', () => {
+      // Given: no error state
+      mockSelectSeasonStatusError.mockReturnValue(null);
+
+      // When: component renders
+      const { queryByText, getByText } = render(<SeasonStatus />);
+
+      // Then: error banner should not be displayed, normal content should be shown
+      expect(
+        queryByText('rewards.season_status_error.error_fetching_title'),
+      ).toBeNull();
+      expect(getByText('Bronze')).toBeTruthy();
     });
   });
 });

--- a/app/components/UI/Rewards/components/SeasonStatus/SeasonStatus.test.tsx
+++ b/app/components/UI/Rewards/components/SeasonStatus/SeasonStatus.test.tsx
@@ -226,24 +226,6 @@ jest.mock('../../../../../actions/rewards', () => ({
   })),
 }));
 
-// Mock SeasonTierImage
-jest.mock('../SeasonTierImage', () => {
-  const ReactActual = jest.requireActual('react');
-  const { View } = jest.requireActual('react-native');
-  return ReactActual.forwardRef(
-    (
-      { tierOrder, testID, ...props }: { tierOrder?: number; testID?: string },
-      ref: unknown,
-    ) =>
-      ReactActual.createElement(View, {
-        testID: testID || 'season-tier-image',
-        ref,
-        'data-tier-order': tierOrder,
-        ...props,
-      }),
-  );
-});
-
 // Mock lodash capitalize but preserve the rest of lodash
 jest.mock('lodash', () => {
   const actual = jest.requireActual('lodash');

--- a/app/components/UI/Rewards/components/SeasonStatus/SeasonStatus.tsx
+++ b/app/components/UI/Rewards/components/SeasonStatus/SeasonStatus.tsx
@@ -13,7 +13,11 @@ import { useTheme } from '../../../../../util/theme';
 import MetamaskRewardsPointsImage from '../../../../../images/rewards/metamask-rewards-points.svg';
 import { Skeleton } from '../../../../../component-library/components/Skeleton';
 import { capitalize } from 'lodash';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
+import Banner, {
+  BannerVariant,
+} from '../../../../../component-library/components/Banners/Banner';
+import { BannerAlertSeverity } from '../../../../../component-library/components/Banners/Banner/variants/BannerAlert/BannerAlert.types';
 import {
   selectSeasonStatusLoading,
   selectSeasonTiers,
@@ -22,7 +26,10 @@ import {
   selectNextTierPointsNeeded,
   selectCurrentTier,
   selectNextTier,
+  selectSeasonStartDate,
 } from '../../../../../reducers/rewards/selectors';
+import { selectSeasonStatusError } from '../../../../../selectors/rewards';
+import { setSeasonStatusError } from '../../../../../actions/rewards';
 import { formatNumber, formatTimeRemaining } from '../../utils/formatUtils';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import RewardsThemeImageComponent from '../ThemeImageComponent';
@@ -37,8 +44,11 @@ const SeasonStatus: React.FC = () => {
   const tiers = useSelector(selectSeasonTiers);
   const balanceTotal = useSelector(selectBalanceTotal);
   const seasonStatusLoading = useSelector(selectSeasonStatusLoading);
+  const seasonStatusError = useSelector(selectSeasonStatusError);
+  const seasonStartDate = useSelector(selectSeasonStartDate);
   const seasonEndDate = useSelector(selectSeasonEndDate);
   const theme = useTheme();
+  const dispatch = useDispatch();
 
   const progress = React.useMemo(() => {
     if (!currentTier || !balanceTotal) {
@@ -79,6 +89,20 @@ const SeasonStatus: React.FC = () => {
 
   if (seasonStatusLoading || !currentTier) {
     return <Skeleton height={115} width="100%" />;
+  }
+
+  if (seasonStatusError && !seasonStartDate) {
+    return (
+      <Banner
+        variant={BannerVariant.Alert}
+        severity={BannerAlertSeverity.Error}
+        title={strings('rewards.season_status_error.error_fetching_title')}
+        description={strings(
+          'rewards.season_status_error.error_fetching_description',
+        )}
+        onClose={() => dispatch(setSeasonStatusError(null))}
+      />
+    );
   }
 
   return (

--- a/app/components/UI/Rewards/hooks/useCandidateSubscriptionId.test.ts
+++ b/app/components/UI/Rewards/hooks/useCandidateSubscriptionId.test.ts
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useCandidateSubscriptionId } from './useCandidateSubscriptionId';
 import Engine from '../../../../core/Engine';
 import { setCandidateSubscriptionId } from '../../../../actions/rewards';
-import Logger from '../../../../util/Logger';
+import { useFocusEffect } from '@react-navigation/native';
 
 // Mock dependencies
 jest.mock('react-redux', () => ({
@@ -14,6 +14,8 @@ jest.mock('react-redux', () => ({
 jest.mock('../../../../core/Engine', () => ({
   controllerMessenger: {
     call: jest.fn(),
+    subscribe: jest.fn(),
+    unsubscribe: jest.fn(),
   },
 }));
 
@@ -21,205 +23,160 @@ jest.mock('../../../../actions/rewards', () => ({
   setCandidateSubscriptionId: jest.fn(),
 }));
 
-jest.mock('../../../../util/Logger', () => ({
-  log: jest.fn(),
+// Mock React Navigation hooks
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: jest.fn(),
 }));
 
 describe('useCandidateSubscriptionId', () => {
   const mockDispatch = jest.fn();
+  const mockUseFocusEffect = useFocusEffect as jest.MockedFunction<
+    typeof useFocusEffect
+  >;
+  const mockUseDispatch = useDispatch as jest.MockedFunction<
+    typeof useDispatch
+  >;
   const mockUseSelector = useSelector as jest.MockedFunction<
     typeof useSelector
   >;
   const mockEngineCall = Engine.controllerMessenger.call as jest.MockedFunction<
     typeof Engine.controllerMessenger.call
   >;
-  const mockSetCandidateSubscriptionId =
-    setCandidateSubscriptionId as jest.MockedFunction<
-      typeof setCandidateSubscriptionId
-    >;
-  const mockLoggerLog = Logger.log as jest.MockedFunction<typeof Logger.log>;
-
-  const mockAccount = {
-    id: 'account-1',
-    address: '0x123456789abcdef',
-    metadata: {
-      name: 'Account 1',
-      keyring: {
-        type: 'HD Key Tree',
-      },
-    },
-    options: {},
-    methods: ['personal_sign', 'eth_signTransaction'],
-    type: 'eip155:eoa',
-    scopes: ['eip155:1'],
-  };
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (useDispatch as jest.MockedFunction<typeof useDispatch>).mockReturnValue(
-      mockDispatch,
+    mockUseDispatch.mockReturnValue(mockDispatch);
+    mockUseSelector.mockReturnValue(null); // Default return value for candidateSubscriptionId
+
+    // Reset the mocked hooks
+    mockUseFocusEffect.mockClear();
+  });
+
+  it('should register focus effect callback', () => {
+    renderHook(() => useCandidateSubscriptionId());
+
+    expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('should fetch candidate subscription ID successfully', async () => {
+    const mockCandidateId = 'candidate-123';
+    mockEngineCall.mockResolvedValueOnce(mockCandidateId);
+
+    renderHook(() => useCandidateSubscriptionId());
+
+    // Verify that the focus effect callback was registered
+    expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+
+    // Execute the focus effect callback to trigger the fetch logic
+    const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+    focusCallback();
+
+    // Wait for async operations
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(mockEngineCall).toHaveBeenCalledWith(
+      'RewardsController:getCandidateSubscriptionId',
     );
-    mockSetCandidateSubscriptionId.mockImplementation((id) => ({
-      type: 'rewards/setCandidateSubscriptionId',
-      payload: id,
-    }));
+    expect(mockDispatch).toHaveBeenCalledWith(
+      setCandidateSubscriptionId(mockCandidateId),
+    );
   });
 
-  describe('when account does not exist', () => {
-    it('should not fetch candidate subscription ID', () => {
-      // Arrange
-      mockUseSelector
-        .mockReturnValueOnce(null) // selectSelectedInternalAccount
-        .mockReturnValueOnce(false) // selectRewardsActiveAccountHasOptedIn
-        .mockReturnValueOnce(null); // selectRewardsSubscriptionId
+  it('should handle fetch errors gracefully', async () => {
+    const mockError = new Error('Fetch failed');
+    mockEngineCall.mockRejectedValueOnce(mockError);
 
-      // Act
+    renderHook(() => useCandidateSubscriptionId());
+
+    // Verify that the focus effect callback was registered
+    expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+
+    // Execute the focus effect callback to trigger the fetch logic
+    const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+    focusCallback();
+
+    // Wait for async operations
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(mockEngineCall).toHaveBeenCalledWith(
+      'RewardsController:getCandidateSubscriptionId',
+    );
+    expect(mockDispatch).toHaveBeenCalledWith(
+      setCandidateSubscriptionId('error'),
+    );
+  });
+
+  it('should retry fetching when candidateSubscriptionId is set to retry', async () => {
+    const mockCandidateId = 'retry-candidate-456';
+
+    // First render with null candidateSubscriptionId
+    const { rerender } = renderHook(() => useCandidateSubscriptionId());
+
+    // Simulate candidateSubscriptionId being set to 'retry'
+    mockUseSelector.mockReturnValue('retry');
+    mockEngineCall.mockResolvedValueOnce(mockCandidateId);
+
+    // Re-render the hook to trigger useEffect
+    rerender();
+
+    // Wait for async operations
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(mockEngineCall).toHaveBeenCalledWith(
+      'RewardsController:getCandidateSubscriptionId',
+    );
+    expect(mockDispatch).toHaveBeenCalledWith(
+      setCandidateSubscriptionId(mockCandidateId),
+    );
+  });
+
+  it('should handle retry errors gracefully', async () => {
+    const mockError = new Error('Retry failed');
+
+    // First render with null candidateSubscriptionId
+    const { rerender } = renderHook(() => useCandidateSubscriptionId());
+
+    // Simulate candidateSubscriptionId being set to 'retry'
+    mockUseSelector.mockReturnValue('retry');
+    mockEngineCall.mockRejectedValueOnce(mockError);
+
+    // Re-render the hook to trigger useEffect
+    rerender();
+
+    // Wait for async operations
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(mockEngineCall).toHaveBeenCalledWith(
+      'RewardsController:getCandidateSubscriptionId',
+    );
+    expect(mockDispatch).toHaveBeenCalledWith(
+      setCandidateSubscriptionId('error'),
+    );
+  });
+
+  it('should not fetch when candidateSubscriptionId is not retry', () => {
+    // Test with different states that should not trigger fetch
+    const nonRetryStates = [null, 'pending', 'error', 'some-id'];
+
+    nonRetryStates.forEach((state) => {
+      jest.clearAllMocks();
+      mockUseSelector.mockReturnValue(state);
+
       renderHook(() => useCandidateSubscriptionId());
 
-      // Assert
+      // Should only register focus effect, not call engine directly from useEffect
+      expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+
+      // Engine should not be called from useEffect for non-retry states
       expect(mockEngineCall).not.toHaveBeenCalled();
-      expect(mockDispatch).not.toHaveBeenCalled();
-      expect(mockLoggerLog).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('when account has opted in', () => {
-    it('should not fetch candidate subscription ID', () => {
-      // Arrange
-      mockUseSelector
-        .mockReturnValueOnce(mockAccount) // selectSelectedInternalAccount
-        .mockReturnValueOnce(true) // selectRewardsActiveAccountHasOptedIn
-        .mockReturnValueOnce(null); // selectRewardsSubscriptionId
-
-      // Act
-      renderHook(() => useCandidateSubscriptionId());
-
-      // Assert
-      expect(mockEngineCall).not.toHaveBeenCalled();
-      expect(mockDispatch).not.toHaveBeenCalled();
-      expect(mockLoggerLog).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('when subscription ID already exists', () => {
-    it('should not fetch candidate subscription ID', () => {
-      // Arrange
-      mockUseSelector
-        .mockReturnValueOnce(mockAccount) // selectSelectedInternalAccount
-        .mockReturnValueOnce(false) // selectRewardsActiveAccountHasOptedIn
-        .mockReturnValueOnce('existing-subscription-id'); // selectRewardsSubscriptionId
-
-      // Act
-      renderHook(() => useCandidateSubscriptionId());
-
-      // Assert
-      expect(mockEngineCall).not.toHaveBeenCalled();
-      expect(mockDispatch).not.toHaveBeenCalled();
-      expect(mockLoggerLog).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('when account exists and has not opted in', () => {
-    it('should fetch candidate subscription ID successfully when opt-in status is false', async () => {
-      // Arrange
-      const mockCandidateId = 'candidate-123';
-      mockUseSelector
-        .mockReturnValueOnce(mockAccount) // selectSelectedInternalAccount
-        .mockReturnValueOnce(false) // selectRewardsActiveAccountHasOptedIn
-        .mockReturnValueOnce(null); // selectRewardsSubscriptionId
-
-      mockEngineCall.mockResolvedValueOnce(mockCandidateId);
-
-      // Act
-      renderHook(() => useCandidateSubscriptionId());
-
-      // Assert
-      expect(mockLoggerLog).toHaveBeenCalledWith(
-        'useCandidateSubscriptionId: Getting candidate subscription ID',
-      );
-      expect(mockEngineCall).toHaveBeenCalledWith(
-        'RewardsController:getCandidateSubscriptionId',
-      );
-
-      // Wait for async operation to complete
-      await act(async () => {
-        await Promise.resolve();
-      });
-
-      expect(mockSetCandidateSubscriptionId).toHaveBeenCalledWith(
-        mockCandidateId,
-      );
-      expect(mockDispatch).toHaveBeenCalledWith({
-        type: 'rewards/setCandidateSubscriptionId',
-        payload: mockCandidateId,
-      });
-    });
-
-    it('should fetch candidate subscription ID successfully when opt-in status is null', async () => {
-      // Arrange
-      const mockCandidateId = 'candidate-456';
-      mockUseSelector
-        .mockReturnValueOnce(mockAccount) // selectSelectedInternalAccount
-        .mockReturnValueOnce(null) // selectRewardsActiveAccountHasOptedIn
-        .mockReturnValueOnce(null); // selectRewardsSubscriptionId
-
-      mockEngineCall.mockResolvedValueOnce(mockCandidateId);
-
-      // Act
-      renderHook(() => useCandidateSubscriptionId());
-
-      // Assert
-      expect(mockLoggerLog).toHaveBeenCalledWith(
-        'useCandidateSubscriptionId: Getting candidate subscription ID',
-      );
-      expect(mockEngineCall).toHaveBeenCalledWith(
-        'RewardsController:getCandidateSubscriptionId',
-      );
-
-      // Wait for async operation to complete
-      await act(async () => {
-        await Promise.resolve();
-      });
-
-      expect(mockSetCandidateSubscriptionId).toHaveBeenCalledWith(
-        mockCandidateId,
-      );
-      expect(mockDispatch).toHaveBeenCalledWith({
-        type: 'rewards/setCandidateSubscriptionId',
-        payload: mockCandidateId,
-      });
-    });
-
-    it('should handle errors when fetching candidate subscription ID fails', async () => {
-      // Arrange
-      mockUseSelector
-        .mockReturnValueOnce(mockAccount) // selectSelectedInternalAccount
-        .mockReturnValueOnce(false) // selectRewardsActiveAccountHasOptedIn
-        .mockReturnValueOnce(null); // selectRewardsSubscriptionId
-
-      mockEngineCall.mockRejectedValueOnce(new Error('Failed to fetch'));
-
-      // Act
-      renderHook(() => useCandidateSubscriptionId());
-
-      // Assert
-      expect(mockLoggerLog).toHaveBeenCalledWith(
-        'useCandidateSubscriptionId: Getting candidate subscription ID',
-      );
-      expect(mockEngineCall).toHaveBeenCalledWith(
-        'RewardsController:getCandidateSubscriptionId',
-      );
-
-      // Wait for async operation to complete
-      await act(async () => {
-        await Promise.resolve();
-      });
-
-      expect(mockSetCandidateSubscriptionId).toHaveBeenCalledWith('error');
-      expect(mockDispatch).toHaveBeenCalledWith({
-        type: 'rewards/setCandidateSubscriptionId',
-        payload: 'error',
-      });
     });
   });
 });

--- a/app/components/UI/Rewards/hooks/useRewardOptinSummary.test.ts
+++ b/app/components/UI/Rewards/hooks/useRewardOptinSummary.test.ts
@@ -6,6 +6,8 @@ import Logger from '../../../../util/Logger';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { OptInStatusDto } from '../../../../core/Engine/controllers/rewards-controller/types';
 import { useFocusEffect } from '@react-navigation/native';
+import { useDebouncedValue } from '../../../hooks/useDebouncedValue';
+import { useAccountsOperationsLoadingStates } from '../../../../util/accounts/useAccountsOperationsLoadingStates';
 
 // Mock dependencies
 jest.mock('react-redux', () => ({
@@ -15,6 +17,8 @@ jest.mock('react-redux', () => ({
 jest.mock('../../../../core/Engine', () => ({
   controllerMessenger: {
     call: jest.fn(),
+    subscribe: jest.fn(),
+    unsubscribe: jest.fn(),
   },
 }));
 
@@ -25,6 +29,19 @@ jest.mock('../../../../util/Logger', () => ({
 jest.mock('@react-navigation/native', () => ({
   useFocusEffect: jest.fn(),
 }));
+
+// Mock useDebouncedValue hook
+jest.mock('../../../hooks/useDebouncedValue', () => ({
+  useDebouncedValue: jest.fn(),
+}));
+
+// Mock useAccountsOperationsLoadingStates hook
+jest.mock(
+  '../../../../util/accounts/useAccountsOperationsLoadingStates',
+  () => ({
+    useAccountsOperationsLoadingStates: jest.fn(),
+  }),
+);
 
 describe('useRewardOptinSummary', () => {
   const mockUseSelector = useSelector as jest.MockedFunction<
@@ -37,6 +54,13 @@ describe('useRewardOptinSummary', () => {
   const mockUseFocusEffect = useFocusEffect as jest.MockedFunction<
     typeof useFocusEffect
   >;
+  const mockUseDebouncedValue = useDebouncedValue as jest.MockedFunction<
+    typeof useDebouncedValue
+  >;
+  const mockUseAccountsOperationsLoadingStates =
+    useAccountsOperationsLoadingStates as jest.MockedFunction<
+      typeof useAccountsOperationsLoadingStates
+    >;
 
   const mockAccount1: InternalAccount = {
     id: 'account-1',
@@ -93,6 +117,16 @@ describe('useRewardOptinSummary', () => {
     mockUseSelector
       .mockReturnValueOnce(mockAccounts) // selectInternalAccounts
       .mockReturnValueOnce(mockAccount1); // selectSelectedInternalAccount
+
+    // Mock useDebouncedValue to return accounts by default
+    mockUseDebouncedValue.mockReturnValue(mockAccounts);
+
+    // Mock useAccountsOperationsLoadingStates to return not syncing by default
+    mockUseAccountsOperationsLoadingStates.mockReturnValue({
+      areAnyOperationsLoading: false,
+      isAccountSyncingInProgress: false,
+      loadingMessage: null,
+    });
 
     // Reset the mocked hooks
     mockUseFocusEffect.mockClear();
@@ -394,6 +428,8 @@ describe('useRewardOptinSummary', () => {
         .mockReturnValueOnce([]) // selectInternalAccounts - empty
         .mockReturnValueOnce(null); // selectSelectedInternalAccount
 
+      mockUseDebouncedValue.mockReturnValue([]);
+
       const { result } = renderHook(() => useRewardOptinSummary());
 
       // Verify that the focus effect callback was registered
@@ -409,61 +445,6 @@ describe('useRewardOptinSummary', () => {
       expect(result.current.unlinkedAccounts).toEqual([]);
       expect(result.current.currentAccountOptedIn).toBeNull();
       expect(mockEngineCall).not.toHaveBeenCalled();
-    });
-
-    it('should handle null internal accounts selector', () => {
-      // Arrange
-      mockUseSelector
-        .mockReset()
-        .mockReturnValueOnce(null) // selectInternalAccounts - null
-        .mockReturnValueOnce(null); // selectSelectedInternalAccount
-
-      const { result } = renderHook(() => useRewardOptinSummary());
-
-      // Verify that the focus effect callback was registered
-      expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
-
-      // Execute the focus effect callback to trigger the fetch logic
-      const focusCallback = mockUseFocusEffect.mock.calls[0][0];
-      focusCallback();
-
-      // Assert
-      expect(result.current.isLoading).toBe(false);
-      expect(result.current.linkedAccounts).toEqual([]);
-      expect(result.current.unlinkedAccounts).toEqual([]);
-      expect(mockEngineCall).not.toHaveBeenCalled();
-    });
-
-    it('should handle single account', async () => {
-      // Arrange
-      const singleAccount = [mockAccount1];
-      mockUseSelector
-        .mockReset()
-        .mockReturnValueOnce(singleAccount) // selectInternalAccounts
-        .mockReturnValueOnce(mockAccount1); // selectSelectedInternalAccount
-
-      const mockResponse: OptInStatusDto = {
-        ois: [true],
-      };
-      mockEngineCall.mockResolvedValueOnce(mockResponse);
-
-      const { result, waitForNextUpdate } = renderHook(() =>
-        useRewardOptinSummary(),
-      );
-
-      // Verify that the focus effect callback was registered
-      expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
-
-      // Execute the focus effect callback to trigger the fetch logic
-      const focusCallback = mockUseFocusEffect.mock.calls[0][0];
-      focusCallback();
-
-      await waitForNextUpdate();
-
-      // Assert
-      expect(result.current.linkedAccounts).toHaveLength(1);
-      expect(result.current.unlinkedAccounts).toHaveLength(0);
-      expect(result.current.currentAccountOptedIn).toBe(true);
     });
 
     it('should handle no selected account', async () => {
@@ -493,6 +474,179 @@ describe('useRewardOptinSummary', () => {
 
       // Assert
       expect(result.current.currentAccountOptedIn).toBe(false); // Should default to false
+    });
+  });
+
+  describe('useDebouncedValue behavior', () => {
+    it('should use debounced value when account syncing is not in progress', () => {
+      // Arrange - not syncing
+      mockUseAccountsOperationsLoadingStates.mockReturnValue({
+        areAnyOperationsLoading: false,
+        isAccountSyncingInProgress: false,
+        loadingMessage: null,
+      });
+
+      // Act
+      renderHook(() => useRewardOptinSummary());
+
+      // Assert - should call useDebouncedValue with 0ms delay when not syncing
+      expect(mockUseDebouncedValue).toHaveBeenCalledWith(mockAccounts, 0);
+    });
+
+    it('should use debounced value with 10s delay when account syncing is in progress', () => {
+      // Arrange - syncing in progress
+      mockUseAccountsOperationsLoadingStates.mockReturnValue({
+        areAnyOperationsLoading: true,
+        isAccountSyncingInProgress: true,
+        loadingMessage: 'Syncing accounts...',
+      });
+
+      // Act
+      renderHook(() => useRewardOptinSummary());
+
+      // Assert - should call useDebouncedValue with 10000ms delay when syncing
+      expect(mockUseDebouncedValue).toHaveBeenCalledWith(mockAccounts, 10000);
+    });
+
+    it('should refetch when debounced accounts change', async () => {
+      // Arrange - initial accounts
+      const initialAccounts = [mockAccount1];
+      const updatedAccounts = [mockAccount1, mockAccount2];
+
+      mockUseDebouncedValue
+        .mockReturnValueOnce(initialAccounts)
+        .mockReturnValueOnce(updatedAccounts);
+
+      const mockResponse: OptInStatusDto = {
+        ois: [true],
+      };
+      mockEngineCall
+        .mockResolvedValueOnce(mockResponse)
+        .mockResolvedValueOnce({ ois: [true, false] });
+
+      // Act - first render
+      const { rerender, waitForNextUpdate } = renderHook(() =>
+        useRewardOptinSummary(),
+      );
+
+      // Trigger initial fetch
+      const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+      focusCallback();
+      await waitForNextUpdate();
+
+      // Clear previous calls
+      jest.clearAllMocks();
+      mockUseDebouncedValue.mockReturnValue(updatedAccounts);
+      mockEngineCall.mockResolvedValueOnce({ ois: [true, false] });
+
+      // Act - rerender with updated accounts
+      rerender();
+
+      // Trigger fetch again
+      const newFocusCallback = mockUseFocusEffect.mock.calls[0][0];
+      newFocusCallback();
+      await waitForNextUpdate();
+
+      // Assert - should call with updated accounts
+      expect(mockEngineCall).toHaveBeenCalledWith(
+        'RewardsController:getOptInStatus',
+        {
+          addresses: [mockAccount1.address, mockAccount2.address],
+        },
+      );
+    });
+
+    it('should not fetch when debounced accounts is empty', () => {
+      // Arrange - empty debounced accounts
+      mockUseDebouncedValue.mockReturnValue([]);
+
+      // Act
+      const { result } = renderHook(() => useRewardOptinSummary());
+
+      // Trigger fetch
+      const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+      focusCallback();
+
+      // Assert
+      expect(result.current.isLoading).toBe(false);
+      expect(mockEngineCall).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('refresh functionality', () => {
+    it('should prevent duplicate refresh calls when already loading', async () => {
+      // Arrange - setup to never resolve to simulate loading
+      mockEngineCall.mockImplementation(
+        () =>
+          new Promise(() => {
+            // Never resolves
+          }),
+      );
+
+      const { result } = renderHook(() => useRewardOptinSummary());
+
+      // Act - call refresh multiple times quickly
+      result.current.refresh();
+      result.current.refresh();
+      result.current.refresh();
+
+      // Assert - should only call once due to loading ref protection
+      expect(mockEngineCall).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('focus effect registration', () => {
+    it('should register focus effect callback', () => {
+      renderHook(() => useRewardOptinSummary());
+
+      expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    it('should register focus effect callback even when disabled', () => {
+      renderHook(() => useRewardOptinSummary({ enabled: false }));
+
+      expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+    });
+  });
+
+  describe('loading state management', () => {
+    it('should show loading false when accounts are already populated', async () => {
+      // Arrange - accounts already exist
+      const mockResponse: OptInStatusDto = {
+        ois: [true, false, true],
+      };
+      mockEngineCall.mockResolvedValueOnce(mockResponse);
+
+      const { result, waitForNextUpdate } = renderHook(() =>
+        useRewardOptinSummary(),
+      );
+
+      // Trigger fetch
+      const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+      focusCallback();
+      await waitForNextUpdate();
+
+      // Assert - loading should be false because optedInAccounts has data
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it('should show loading true when no accounts are populated yet', () => {
+      // Arrange - loading state with no resolved accounts
+      mockEngineCall.mockImplementation(
+        () =>
+          new Promise(() => {
+            // Never resolves
+          }),
+      );
+
+      const { result } = renderHook(() => useRewardOptinSummary());
+
+      // Trigger fetch
+      const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+      focusCallback();
+
+      // Assert - should show loading when no accounts populated
+      expect(result.current.isLoading).toBe(true);
     });
   });
 });

--- a/app/components/UI/Rewards/hooks/useRewardOptinSummary.ts
+++ b/app/components/UI/Rewards/hooks/useRewardOptinSummary.ts
@@ -4,11 +4,13 @@ import {
   selectInternalAccounts,
   selectSelectedInternalAccount,
 } from '../../../../selectors/accountsController';
+import { useDebouncedValue } from '../../../hooks/useDebouncedValue';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import Engine from '../../../../core/Engine';
 import { OptInStatusDto } from '../../../../core/Engine/controllers/rewards-controller/types';
 import Logger from '../../../../util/Logger';
 import { useFocusEffect } from '@react-navigation/native';
+import { useAccountsOperationsLoadingStates } from '../../../../util/accounts/useAccountsOperationsLoadingStates';
 
 interface AccountWithOptInStatus extends InternalAccount {
   hasOptedIn: boolean;
@@ -43,9 +45,14 @@ export const useRewardOptinSummary = (
     boolean | null
   >(null);
   const isLoadingRef = useRef(false);
+  // Check if any account operations are loading
+  const { isAccountSyncingInProgress } = useAccountsOperationsLoadingStates();
 
-  // Memoize accounts to avoid unnecessary re-renders
-  const accounts = useMemo(() => internalAccounts || [], [internalAccounts]);
+  // Debounce accounts for 30 seconds to avoid excessive re-renders (i.e. profile sync)
+  const accounts = useDebouncedValue(
+    internalAccounts,
+    isAccountSyncingInProgress ? 10000 : 0,
+  );
 
   // Fetch opt-in status for all accounts
   const fetchOptInStatus = useCallback(async (): Promise<void> => {

--- a/app/components/UI/Rewards/hooks/useRewardsToast.test.tsx
+++ b/app/components/UI/Rewards/hooks/useRewardsToast.test.tsx
@@ -83,8 +83,8 @@ describe('useRewardsToast', () => {
       expect(config).toMatchObject({
         variant: ToastVariants.Icon,
         iconName: IconName.Confirmation,
-        iconColor: '#4459ff', // primary.default
-        backgroundColor: '#4459ff1a', // primary.muted
+        iconColor: '#3c4d9d0f',
+        backgroundColor: '#4459ff',
         hapticsType: NotificationFeedbackType.Success,
         hasNoTimeout: false,
       });

--- a/app/components/UI/Rewards/hooks/useRewardsToast.tsx
+++ b/app/components/UI/Rewards/hooks/useRewardsToast.tsx
@@ -7,8 +7,6 @@ import {
 import { IconName } from '../../../../component-library/components/Icons/Icon';
 import { useAppThemeFromContext } from '../../../../util/theme';
 import { notificationAsync, NotificationFeedbackType } from 'expo-haptics';
-import { strings } from '../../../../../locales/i18n';
-import { ButtonVariants } from '../../../../component-library/components/Buttons/Button';
 
 export type RewardsToastOptions = ToastOptions & {
   hapticsType: NotificationFeedbackType;
@@ -68,45 +66,25 @@ const useRewardsToast = (): {
         ...(REWARDS_TOASTS_DEFAULT_OPTIONS as RewardsToastOptions),
         variant: ToastVariants.Icon,
         iconName: IconName.Confirmation,
-        iconColor: theme.colors.primary.default,
-        backgroundColor: theme.colors.primary.muted,
+        iconColor: theme.colors.background.muted,
+        backgroundColor: theme.colors.primary.default,
         hapticsType: NotificationFeedbackType.Success,
         labelOptions: getRewardsToastLabels(title, subtitle),
-        hasNoTimeout: false,
-        closeButtonOptions: {
-          variant: ButtonVariants.Primary,
-          endIconName: IconName.CircleX,
-          label: strings('rewards.toast_dismiss'),
-          onPress: () => {
-            toastRef?.current?.closeToast();
-          },
-        },
       }),
       error: (title: string, subtitle?: string) => ({
         ...(REWARDS_TOASTS_DEFAULT_OPTIONS as RewardsToastOptions),
         variant: ToastVariants.Icon,
         iconName: IconName.Error,
-        iconColor: theme.colors.error.default,
-        backgroundColor: theme.colors.error.muted,
+        iconColor: theme.colors.background.muted,
+        backgroundColor: theme.colors.error.default,
         hapticsType: NotificationFeedbackType.Error,
         labelOptions: getRewardsToastLabels(title, subtitle),
-        hasNoTimeout: false,
-        closeButtonOptions: {
-          variant: ButtonVariants.Primary,
-          endIconName: IconName.CircleX,
-          label: strings('rewards.toast_dismiss'),
-          onPress: () => {
-            toastRef?.current?.closeToast();
-          },
-        },
       }),
     }),
     [
+      theme.colors.background.muted,
       theme.colors.error.default,
-      theme.colors.error.muted,
       theme.colors.primary.default,
-      theme.colors.primary.muted,
-      toastRef,
     ],
   );
 

--- a/app/components/UI/Rewards/hooks/useSeasonStatus.test.ts
+++ b/app/components/UI/Rewards/hooks/useSeasonStatus.test.ts
@@ -1,11 +1,21 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { useSeasonStatus } from './useSeasonStatus';
 import Engine from '../../../../core/Engine';
-import { setSeasonStatus } from '../../../../actions/rewards';
+import {
+  setSeasonStatus,
+  setSeasonStatusError,
+} from '../../../../actions/rewards';
 import { setSeasonStatusLoading } from '../../../../reducers/rewards';
 import { useDispatch, useSelector } from 'react-redux';
 import { CURRENT_SEASON_ID } from '../../../../core/Engine/controllers/rewards-controller/types';
-import { useFocusEffect } from '@react-navigation/native';
+import {
+  ParamListBase,
+  NavigationProp,
+  useFocusEffect,
+  useNavigation,
+} from '@react-navigation/native';
+import { handleRewardsErrorMessage } from '../utils';
+import { strings } from '../../../../../locales/i18n';
 
 // Mock dependencies
 jest.mock('react-redux', () => ({
@@ -13,8 +23,11 @@ jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
 }));
 
+// Import the actual selectors for comparison in tests
+
 jest.mock('../../../../selectors/rewards', () => ({
   selectRewardsSubscriptionId: jest.fn(),
+  selectSeasonStatusError: jest.fn(),
 }));
 
 jest.mock('../../../../core/Engine', () => ({
@@ -27,6 +40,7 @@ jest.mock('../../../../core/Engine', () => ({
 
 jest.mock('../../../../actions/rewards', () => ({
   setSeasonStatus: jest.fn(),
+  setSeasonStatusError: jest.fn(),
 }));
 
 jest.mock('../../../../reducers/rewards', () => ({
@@ -40,14 +54,44 @@ jest.mock('./useInvalidateByRewardEvents', () => ({
 }));
 
 // Mock React Navigation hooks
+const mockNavigate = jest.fn();
+const mockGoBack = jest.fn();
 jest.mock('@react-navigation/native', () => ({
   useFocusEffect: jest.fn(),
+  useNavigation: jest.fn(),
+}));
+
+// Mock utility functions
+jest.mock('../utils', () => ({
+  handleRewardsErrorMessage: jest.fn(),
+}));
+
+// Mock constants
+jest.mock('../../../../constants/navigation/Routes', () => ({
+  MODAL: {
+    REWARDS_BOTTOM_SHEET_MODAL: 'RewardsBottomSheetModal',
+  },
+}));
+
+// Mock strings
+jest.mock('../../../../../locales/i18n', () => ({
+  strings: jest.fn(),
+}));
+
+// Mock design system
+jest.mock('@metamask/design-system-react-native', () => ({
+  ButtonVariant: {
+    Primary: 'Primary',
+  },
 }));
 
 describe('useSeasonStatus', () => {
   const mockDispatch = jest.fn();
   const mockUseFocusEffect = useFocusEffect as jest.MockedFunction<
     typeof useFocusEffect
+  >;
+  const mockUseNavigation = useNavigation as jest.MockedFunction<
+    typeof useNavigation
   >;
   const mockUseDispatch = useDispatch as jest.MockedFunction<
     typeof useDispatch
@@ -58,11 +102,32 @@ describe('useSeasonStatus', () => {
   const mockEngineCall = Engine.controllerMessenger.call as jest.MockedFunction<
     typeof Engine.controllerMessenger.call
   >;
+  const mockHandleRewardsErrorMessage =
+    handleRewardsErrorMessage as jest.MockedFunction<
+      typeof handleRewardsErrorMessage
+    >;
+  const mockStrings = strings as jest.MockedFunction<typeof strings>;
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseDispatch.mockReturnValue(mockDispatch);
-    mockUseSelector.mockReturnValue('test-subscription-id'); // selectRewardsSubscriptionId
+
+    // Default selector returns
+    mockUseSelector
+      .mockReturnValueOnce('test-subscription-id') // selectRewardsSubscriptionId
+      .mockReturnValueOnce(null); // selectSeasonStatusError
+
+    // Mock navigation
+    mockUseNavigation.mockReturnValue({
+      navigate: mockNavigate,
+      goBack: mockGoBack,
+    } as unknown as NavigationProp<ParamListBase>);
+
+    // Mock strings
+    mockStrings.mockImplementation((key: string) => `mocked_${key}`);
+
+    // Mock error message handler
+    mockHandleRewardsErrorMessage.mockReturnValue('Mocked error message');
 
     // Reset the mocked hooks
     mockUseFocusEffect.mockClear();
@@ -72,7 +137,11 @@ describe('useSeasonStatus', () => {
   });
 
   it('should skip fetch when subscriptionId is missing', () => {
-    mockUseSelector.mockReturnValue(null); // selectRewardsSubscriptionId - missing
+    // Reset to return null for subscriptionId
+    mockUseSelector
+      .mockReset()
+      .mockReturnValueOnce(null) // selectRewardsSubscriptionId - missing
+      .mockReturnValueOnce(null); // selectSeasonStatusError
 
     renderHook(() => useSeasonStatus());
 
@@ -150,6 +219,7 @@ describe('useSeasonStatus', () => {
       CURRENT_SEASON_ID,
     );
     expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatus(mockStatusData));
+    expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatusError(null));
     expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatusLoading(false));
   });
 
@@ -175,7 +245,10 @@ describe('useSeasonStatus', () => {
       'test-subscription-id',
       CURRENT_SEASON_ID,
     );
-    expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatus(null));
+    expect(mockHandleRewardsErrorMessage).toHaveBeenCalledWith(mockError);
+    expect(mockDispatch).toHaveBeenCalledWith(
+      setSeasonStatusError('Mocked error message'),
+    );
     expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatusLoading(false));
   });
 
@@ -206,5 +279,125 @@ describe('useSeasonStatus', () => {
 
     // Should only be called once despite multiple focus triggers
     expect(mockEngineCall).toHaveBeenCalledTimes(1);
+  });
+
+  describe('loading state management', () => {
+    it('should set loading to true at start of fetch', async () => {
+      const mockStatusData = { season: { id: 'test' } };
+      mockEngineCall.mockResolvedValueOnce(mockStatusData);
+
+      renderHook(() => useSeasonStatus());
+
+      // Trigger fetch
+      const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+      focusCallback();
+
+      // Assert - loading should be set to true immediately
+      expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatusLoading(true));
+    });
+
+    it('should set loading to false after successful fetch', async () => {
+      const mockStatusData = { season: { id: 'test' } };
+      mockEngineCall.mockResolvedValueOnce(mockStatusData);
+
+      renderHook(() => useSeasonStatus());
+
+      // Trigger fetch
+      const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+      focusCallback();
+
+      // Wait for async operations
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Assert - loading should be set to false after completion
+      expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatusLoading(false));
+    });
+
+    it('should set loading to false after failed fetch', async () => {
+      const mockError = new Error('Fetch failed');
+      mockEngineCall.mockRejectedValueOnce(mockError);
+
+      renderHook(() => useSeasonStatus());
+
+      // Trigger fetch
+      const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+      focusCallback();
+
+      // Wait for async operations
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Assert - loading should be set to false after error
+      expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatusLoading(false));
+    });
+  });
+
+  describe('subscription ID changes', () => {
+    it('should refetch when subscription ID changes from null to valid', async () => {
+      // Start with no subscription ID
+      mockUseSelector
+        .mockReset()
+        .mockReturnValueOnce(null) // selectRewardsSubscriptionId - initially null
+        .mockReturnValueOnce(null); // selectSeasonStatusError
+
+      const { rerender } = renderHook(() => useSeasonStatus());
+
+      // Clear previous calls
+      jest.clearAllMocks();
+
+      // Change to valid subscription ID
+      mockUseSelector
+        .mockReturnValueOnce('new-subscription-id') // selectRewardsSubscriptionId - now valid
+        .mockReturnValueOnce(null); // selectSeasonStatusError
+
+      const mockStatusData = { season: { id: 'test' } };
+      mockEngineCall.mockResolvedValueOnce(mockStatusData);
+
+      // Trigger rerender
+      rerender();
+
+      // Trigger focus effect
+      const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+      focusCallback();
+
+      // Wait for async operations
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // Assert - should fetch with new subscription ID
+      expect(mockEngineCall).toHaveBeenCalledWith(
+        'RewardsController:getSeasonStatus',
+        'new-subscription-id',
+        CURRENT_SEASON_ID,
+      );
+    });
+
+    it('should clear season status when subscription ID changes to null', () => {
+      // Start with valid subscription ID
+      mockUseSelector
+        .mockReset()
+        .mockReturnValueOnce('valid-subscription-id') // selectRewardsSubscriptionId
+        .mockReturnValueOnce(null); // selectSeasonStatusError
+
+      const { rerender } = renderHook(() => useSeasonStatus());
+
+      // Clear previous calls
+      jest.clearAllMocks();
+
+      // Change to null subscription ID
+      mockUseSelector
+        .mockReturnValueOnce(null) // selectRewardsSubscriptionId - now null
+        .mockReturnValueOnce(null); // selectSeasonStatusError
+
+      // Trigger rerender
+      rerender();
+
+      // Trigger focus effect
+      const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+      focusCallback();
+
+      // Assert - should clear season status
+      expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatus(null));
+      expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatusLoading(false));
+      expect(mockEngineCall).not.toHaveBeenCalled();
+    });
   });
 });

--- a/app/components/UI/Rewards/hooks/useSeasonStatus.ts
+++ b/app/components/UI/Rewards/hooks/useSeasonStatus.ts
@@ -63,7 +63,7 @@ export const useSeasonStatus = (): void => {
   }, [dispatch, subscriptionId]);
 
   useEffect(() => {
-    if (!seasonStatusError) return;
+    if (!seasonStatusError || !subscriptionId) return;
 
     // Show modal when no existing data
     navigation.navigate(Routes.MODAL.REWARDS_BOTTOM_SHEET_MODAL, {
@@ -84,7 +84,13 @@ export const useSeasonStatus = (): void => {
       showCancelButton: true,
       cancelLabel: strings('rewards.season_status_error.dismiss_button'),
     });
-  }, [seasonStatusError, fetchSeasonStatus, navigation, dispatch]);
+  }, [
+    seasonStatusError,
+    fetchSeasonStatus,
+    navigation,
+    dispatch,
+    subscriptionId,
+  ]);
 
   // Refresh data when screen comes into focus (each time page is visited)
   useFocusEffect(

--- a/app/components/UI/Rewards/hooks/useSeasonStatus.ts
+++ b/app/components/UI/Rewards/hooks/useSeasonStatus.ts
@@ -1,12 +1,23 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import Engine from '../../../../core/Engine';
-import { setSeasonStatus } from '../../../../actions/rewards';
+import {
+  setSeasonStatus,
+  setSeasonStatusError,
+} from '../../../../actions/rewards';
 import { useDispatch, useSelector } from 'react-redux';
 import { setSeasonStatusLoading } from '../../../../reducers/rewards';
 import { CURRENT_SEASON_ID } from '../../../../core/Engine/controllers/rewards-controller/types';
-import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
+import {
+  selectRewardsSubscriptionId,
+  selectSeasonStatusError,
+} from '../../../../selectors/rewards';
 import { useInvalidateByRewardEvents } from './useInvalidateByRewardEvents';
-import { useFocusEffect } from '@react-navigation/native';
+import { handleRewardsErrorMessage } from '../utils';
+import Routes from '../../../../constants/navigation/Routes';
+import { ModalType } from '../components/RewardsBottomSheetModal';
+import { strings } from '../../../../../locales/i18n';
+import { ButtonVariant } from '@metamask/design-system-react-native';
 
 /**
  * Custom hook to fetch and manage season status data from the rewards API
@@ -15,8 +26,9 @@ import { useFocusEffect } from '@react-navigation/native';
 export const useSeasonStatus = (): void => {
   const subscriptionId = useSelector(selectRewardsSubscriptionId);
   const dispatch = useDispatch();
+  const navigation = useNavigation();
   const isLoadingRef = useRef(false);
-
+  const seasonStatusError = useSelector(selectSeasonStatusError);
   const fetchSeasonStatus = useCallback(async (): Promise<void> => {
     // Don't fetch if no subscriptionId
     if (!subscriptionId) {
@@ -40,14 +52,39 @@ export const useSeasonStatus = (): void => {
       );
 
       dispatch(setSeasonStatus(statusData));
-    } catch {
-      // Keep existing data on error to prevent UI flash
-      dispatch(setSeasonStatus(null));
+      dispatch(setSeasonStatusError(null));
+    } catch (error) {
+      const errorMessage = handleRewardsErrorMessage(error);
+      dispatch(setSeasonStatusError(errorMessage));
     } finally {
       isLoadingRef.current = false;
       dispatch(setSeasonStatusLoading(false));
     }
   }, [dispatch, subscriptionId]);
+
+  useEffect(() => {
+    if (!seasonStatusError) return;
+
+    // Show modal when no existing data
+    navigation.navigate(Routes.MODAL.REWARDS_BOTTOM_SHEET_MODAL, {
+      title: strings('rewards.season_status_error.error_fetching_title'),
+      description: strings(
+        'rewards.season_status_error.error_fetching_description',
+      ),
+      type: ModalType.Danger,
+      confirmAction: {
+        label: strings('rewards.season_status_error.retry_button'),
+        onPress: () => {
+          navigation.goBack();
+          dispatch(setSeasonStatusError(null));
+          fetchSeasonStatus();
+        },
+        variant: ButtonVariant.Primary,
+      },
+      showCancelButton: true,
+      cancelLabel: strings('rewards.season_status_error.dismiss_button'),
+    });
+  }, [seasonStatusError, fetchSeasonStatus, navigation, dispatch]);
 
   // Refresh data when screen comes into focus (each time page is visited)
   useFocusEffect(

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -792,16 +792,115 @@ export class RewardsController extends BaseController<
     }
 
     try {
-      Logger.log(
-        'RewardsController: Fetching fresh opt-in status for address count:',
-        {
-          addresses: params.addresses?.length,
-        },
+      // Get all internal accounts to convert addresses to CAIP format
+      const allAccounts = this.messagingSystem.call(
+        'AccountsController:listMultichainAccounts',
       );
-      return await this.messagingSystem.call(
-        'RewardsDataService:getOptInStatus',
-        params,
-      );
+
+      // Create a map of address to internal account for quick lookup
+      const addressToAccountMap = new Map<string, InternalAccount>();
+      for (const account of allAccounts) {
+        addressToAccountMap.set(account.address.toLowerCase(), account);
+      }
+
+      // Arrays to track cached vs fresh data needed
+      const cachedResults: (boolean | null)[] = new Array(
+        params.addresses.length,
+      ).fill(null);
+      const addressesNeedingFresh: string[] = [];
+      const freshIndexMap: Map<string, number> = new Map();
+
+      // Check storage state for each address
+      for (let i = 0; i < params.addresses.length; i++) {
+        const address = params.addresses[i];
+        const internalAccount = addressToAccountMap.get(address.toLowerCase());
+
+        if (internalAccount) {
+          const caipAccount =
+            this.convertInternalAccountToCaipAccountId(internalAccount);
+          if (caipAccount) {
+            const accountState = this.#getAccountState(caipAccount);
+            if (accountState?.hasOptedIn !== undefined) {
+              // Use cached data
+              cachedResults[i] = accountState.hasOptedIn;
+              continue;
+            }
+          }
+        }
+
+        // No cached data found, need fresh API call
+        addressesNeedingFresh.push(address);
+        freshIndexMap.set(address, i);
+      }
+
+      // Make fresh API call only for addresses without cached data
+      let freshResults: boolean[] = [];
+      if (addressesNeedingFresh.length > 0) {
+        Logger.log(
+          'RewardsController: Making fresh opt-in status API call for addresses without cached data',
+          {
+            cachedCount: cachedResults.filter((result) => result !== null)
+              .length,
+            needFreshCount: addressesNeedingFresh.length,
+          },
+        );
+
+        const freshResponse = await this.messagingSystem.call(
+          'RewardsDataService:getOptInStatus',
+          { addresses: addressesNeedingFresh },
+        );
+        freshResults = freshResponse.ois;
+
+        // Update state with fresh results for future caching
+        for (let i = 0; i < addressesNeedingFresh.length; i++) {
+          const address = addressesNeedingFresh[i];
+          const hasOptedIn = freshResults[i];
+          const internalAccount = addressToAccountMap.get(
+            address.toLowerCase(),
+          );
+
+          if (internalAccount) {
+            const caipAccount =
+              this.convertInternalAccountToCaipAccountId(internalAccount);
+            if (caipAccount) {
+              this.update((state: RewardsControllerState) => {
+                // Update or create account state with fresh opt-in status
+                if (!state.accounts[caipAccount]) {
+                  state.accounts[caipAccount] = {
+                    account: caipAccount,
+                    hasOptedIn,
+                    subscriptionId: null,
+                    lastCheckedAuth: Date.now(),
+                    lastCheckedAuthError: false,
+                    perpsFeeDiscount: null,
+                    lastPerpsDiscountRateFetched: null,
+                  };
+                } else {
+                  state.accounts[caipAccount].hasOptedIn = hasOptedIn;
+                  state.accounts[caipAccount].lastCheckedAuth = Date.now();
+                }
+              });
+            }
+          }
+        }
+      }
+
+      // Combine cached and fresh results in the correct order
+      const finalResults: boolean[] = [];
+      let freshIndex = 0;
+
+      for (let i = 0; i < params.addresses.length; i++) {
+        if (cachedResults[i] !== null) {
+          // Use cached result
+          finalResults[i] = cachedResults[i] as boolean;
+        } else {
+          // Use fresh result
+          finalResults[i] = freshResults[freshIndex];
+          freshIndex++;
+        }
+      }
+
+      return { ois: finalResults };
     } catch (error) {
       Logger.log(
         'RewardsController: Failed to get opt-in status:',
@@ -1416,31 +1515,43 @@ export class RewardsController extends BaseController<
       );
 
       // Call opt-in status check
-      const optInStatusResponse = await this.messagingSystem.call(
-        'RewardsDataService:getOptInStatus',
-        { addresses },
-      );
-
-      const optedInAccounts =
-        optInStatusResponse?.ois?.filter((ois: boolean) => ois) ?? [];
+      const optInStatusResponse = await this.getOptInStatus({ addresses });
+      if (!optInStatusResponse?.ois?.filter((ois: boolean) => ois).length) {
+        Logger.log(
+          'RewardsController: No candidate subscription ID found. No opted in accounts found via opt-in status response.',
+        );
+        return null;
+      }
 
       Logger.log(
-        'RewardsController: Opted in accounts:',
-        optedInAccounts?.length ?? 0,
+        'RewardsController: Found opted in account via opt-in status response. Attempting silent auth to determine candidate subscription ID.',
       );
 
       // Loop through all accounts that have opted in (ois[i] === true)
       // Only process the first 10 accounts with a 500ms delay between each
-      const maxAccounts = Math.min(10, optedInAccounts.length);
-      for (let i = 0; i < maxAccounts; i++) {
+      const maxSilentAuthAttempts = Math.min(
+        10,
+        optInStatusResponse.ois.length,
+      );
+      let silentAuthAttempts = 0;
+      for (let i = 0; i < allAccounts.length; i++) {
+        if (silentAuthAttempts > maxSilentAuthAttempts) break;
         const account = allAccounts[i];
-        if (!account) continue;
+        if (!account || optInStatusResponse.ois[i] === false) continue;
         try {
+          silentAuthAttempts++;
           const subscriptionId = await this.#performSilentAuth(
             account,
             false, // shouldBecomeActiveAccount = false
           );
           if (subscriptionId) {
+            Logger.log(
+              'RewardsController: Found candidate subscription ID via opt-in status response.',
+              {
+                subscriptionId,
+              },
+            );
+
             return subscriptionId;
           }
         } catch (error) {
@@ -1451,11 +1562,6 @@ export class RewardsController extends BaseController<
             error instanceof Error ? error.message : String(error),
           );
         }
-
-        // Add 500ms delay between accounts (except for the last one)
-        if (i < maxAccounts - 1) {
-          await new Promise((resolve) => setTimeout(resolve, 500));
-        }
       }
     } catch (error) {
       Logger.log(
@@ -1464,7 +1570,9 @@ export class RewardsController extends BaseController<
       );
     }
 
-    return null;
+    throw new Error(
+      'No candidate subscription ID found after all silent auth attempts. There is an opted in account but we cannot use it to fetch the season status.',
+    );
   }
 
   /**

--- a/app/reducers/rewards/index.test.ts
+++ b/app/reducers/rewards/index.test.ts
@@ -4,6 +4,7 @@ import rewardsReducer, {
   setSeasonStatus,
   setReferralDetails,
   setSeasonStatusLoading,
+  setSeasonStatusError,
   setReferralDetailsLoading,
   resetRewardsState,
   setOnboardingActiveStep,
@@ -29,6 +30,7 @@ describe('rewardsReducer', () => {
   const initialState: RewardsState = {
     activeTab: 'overview',
     seasonStatusLoading: false,
+    seasonStatusError: null,
 
     seasonId: null,
     seasonName: null,
@@ -576,6 +578,98 @@ describe('rewardsReducer', () => {
       });
     });
 
+    describe('setSeasonStatusError', () => {
+      it('should set season status error to a string message', () => {
+        // Arrange
+        const errorMessage = 'Failed to fetch season status';
+        const action = setSeasonStatusError(errorMessage);
+
+        // Act
+        const state = rewardsReducer(initialState, action);
+
+        // Assert
+        expect(state.seasonStatusError).toBe(errorMessage);
+      });
+
+      it('should clear season status error when set to null', () => {
+        // Arrange
+        const stateWithError = {
+          ...initialState,
+          seasonStatusError: 'Previous error message',
+        };
+        const action = setSeasonStatusError(null);
+
+        // Act
+        const state = rewardsReducer(stateWithError, action);
+
+        // Assert
+        expect(state.seasonStatusError).toBe(null);
+      });
+
+      it('should replace existing error with new error message', () => {
+        // Arrange
+        const stateWithError = {
+          ...initialState,
+          seasonStatusError: 'Old error message',
+        };
+        const newErrorMessage = 'New error message';
+        const action = setSeasonStatusError(newErrorMessage);
+
+        // Act
+        const state = rewardsReducer(stateWithError, action);
+
+        // Assert
+        expect(state.seasonStatusError).toBe(newErrorMessage);
+      });
+
+      it('should handle network timeout error message', () => {
+        // Arrange
+        const timeoutError = 'Request timed out while fetching season status';
+        const action = setSeasonStatusError(timeoutError);
+
+        // Act
+        const state = rewardsReducer(initialState, action);
+
+        // Assert
+        expect(state.seasonStatusError).toBe(timeoutError);
+      });
+
+      it('should handle API error response message', () => {
+        // Arrange
+        const apiError = 'API returned 500: Internal server error';
+        const action = setSeasonStatusError(apiError);
+
+        // Act
+        const state = rewardsReducer(initialState, action);
+
+        // Assert
+        expect(state.seasonStatusError).toBe(apiError);
+      });
+
+      it('should not affect other state properties when setting error', () => {
+        // Arrange
+        const stateWithData = {
+          ...initialState,
+          seasonName: 'Test Season',
+          seasonId: 'season-123',
+          balanceTotal: 1000,
+          seasonStatusLoading: false,
+        };
+        const errorMessage = 'Something went wrong';
+        const action = setSeasonStatusError(errorMessage);
+
+        // Act
+        const state = rewardsReducer(stateWithData, action);
+
+        // Assert
+        expect(state.seasonStatusError).toBe(errorMessage);
+        expect(state.seasonName).toBe('Test Season');
+        expect(state.seasonId).toBe('season-123');
+        expect(state.balanceTotal).toBe(1000);
+        expect(state.seasonStatusLoading).toBe(false);
+      });
+    });
+
     describe('setReferralDetailsLoading', () => {
       it('should set referral details loading to true when no referral code exists', () => {
         // Arrange
@@ -974,6 +1068,7 @@ describe('rewardsReducer', () => {
             levelNumber: 'Level 10',
             rewards: [],
           },
+          seasonStatusError: null,
           nextTier: {
             id: 'tier-diamond',
             name: 'Diamond',
@@ -1128,6 +1223,7 @@ describe('rewardsReducer', () => {
               backgroundColor: '#FF0000',
             },
           ],
+          seasonStatusError: null,
           activeBoostsLoading: false,
           activeBoostsError: false,
           unlockedRewards: [],

--- a/app/reducers/rewards/index.ts
+++ b/app/reducers/rewards/index.ts
@@ -11,6 +11,7 @@ import { OnboardingStep } from './types';
 export interface RewardsState {
   activeTab: 'overview' | 'activity' | 'levels';
   seasonStatusLoading: boolean;
+  seasonStatusError: string | null;
 
   // Season state
   seasonId: string | null;
@@ -38,7 +39,7 @@ export interface RewardsState {
   onboardingActiveStep: OnboardingStep;
 
   // Candidate subscription state
-  candidateSubscriptionId: string | 'pending' | 'error' | null;
+  candidateSubscriptionId: string | 'pending' | 'error' | 'retry' | null;
 
   // Geolocation state
   geoLocation: string | null;
@@ -61,6 +62,7 @@ export interface RewardsState {
 export const initialState: RewardsState = {
   activeTab: 'overview',
   seasonStatusLoading: false,
+  seasonStatusError: null,
 
   seasonId: null,
   seasonName: null,
@@ -116,6 +118,9 @@ const rewardsSlice = createSlice({
       state,
       action: PayloadAction<SeasonStatusState | null>,
     ) => {
+      // Clear error on successful data fetch
+      state.seasonStatusError = null;
+
       // Season state
       state.seasonId = action.payload?.season.id || null;
       state.seasonName = action.payload?.season.name || null;
@@ -179,6 +184,10 @@ const rewardsSlice = createSlice({
       state.seasonStatusLoading = action.payload;
     },
 
+    setSeasonStatusError: (state, action: PayloadAction<string | null>) => {
+      state.seasonStatusError = action.payload;
+    },
+
     resetRewardsState: (state) => {
       Object.assign(state, initialState);
     },
@@ -193,7 +202,7 @@ const rewardsSlice = createSlice({
 
     setCandidateSubscriptionId: (
       state,
-      action: PayloadAction<string | 'pending' | 'error' | null>,
+      action: PayloadAction<string | 'pending' | 'error' | 'retry' | null>,
     ) => {
       state.candidateSubscriptionId = action.payload;
     },
@@ -265,6 +274,7 @@ export const {
   setSeasonStatus,
   setReferralDetails,
   setSeasonStatusLoading,
+  setSeasonStatusError,
   setReferralDetailsLoading,
   resetRewardsState,
   setOnboardingActiveStep,

--- a/app/reducers/rewards/selectors.test.ts
+++ b/app/reducers/rewards/selectors.test.ts
@@ -11,6 +11,7 @@ import {
   selectBalanceRefereePortion,
   selectBalanceUpdatedAt,
   selectSeasonStatusLoading,
+  selectSeasonStatusError,
   selectSeasonId,
   selectSeasonName,
   selectSeasonStartDate,
@@ -313,6 +314,60 @@ describe('Rewards selectors', () => {
         useSelector(selectSeasonStatusLoading),
       );
       expect(result.current).toBe(true);
+    });
+  });
+
+  describe('selectSeasonStatusError', () => {
+    it('returns null when no season status error is set', () => {
+      const mockState = { rewards: { seasonStatusError: null } };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result } = renderHook(() => useSelector(selectSeasonStatusError));
+      expect(result.current).toBeNull();
+    });
+
+    it('returns error message when season status error is set', () => {
+      const errorMessage = 'Failed to fetch season status';
+      const mockState = { rewards: { seasonStatusError: errorMessage } };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result } = renderHook(() => useSelector(selectSeasonStatusError));
+      expect(result.current).toBe(errorMessage);
+    });
+
+    it('returns timeout error message', () => {
+      const timeoutError = 'Request timed out while fetching season status';
+      const mockState = { rewards: { seasonStatusError: timeoutError } };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result } = renderHook(() => useSelector(selectSeasonStatusError));
+      expect(result.current).toBe(timeoutError);
+    });
+
+    it('returns API error message', () => {
+      const apiError = 'API returned 500: Internal server error';
+      const mockState = { rewards: { seasonStatusError: apiError } };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result } = renderHook(() => useSelector(selectSeasonStatusError));
+      expect(result.current).toBe(apiError);
+    });
+
+    it('returns network error message', () => {
+      const networkError = 'Network connection failed';
+      const mockState = { rewards: { seasonStatusError: networkError } };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result } = renderHook(() => useSelector(selectSeasonStatusError));
+      expect(result.current).toBe(networkError);
+    });
+
+    it('returns undefined when season status error is undefined', () => {
+      const mockState = { rewards: { seasonStatusError: undefined } };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result } = renderHook(() => useSelector(selectSeasonStatusError));
+      expect(result.current).toBeUndefined();
     });
   });
 

--- a/app/reducers/rewards/selectors.ts
+++ b/app/reducers/rewards/selectors.ts
@@ -30,6 +30,9 @@ export const selectBalanceUpdatedAt = (state: RootState) =>
 export const selectSeasonStatusLoading = (state: RootState) =>
   state.rewards.seasonStatusLoading;
 
+export const selectSeasonStatusError = (state: RootState) =>
+  state.rewards.seasonStatusError;
+
 export const selectSeasonId = (state: RootState) => state.rewards.seasonId;
 
 export const selectSeasonName = (state: RootState) => state.rewards.seasonName;

--- a/app/selectors/rewards/index.ts
+++ b/app/selectors/rewards/index.ts
@@ -27,7 +27,8 @@ export const selectRewardsSubscriptionId = createSelector(
     if (
       candidateSubscriptionId &&
       candidateSubscriptionId !== 'pending' &&
-      candidateSubscriptionId !== 'error'
+      candidateSubscriptionId !== 'error' &&
+      candidateSubscriptionId !== 'retry'
     ) {
       return candidateSubscriptionId;
     }
@@ -53,3 +54,6 @@ export const selectRewardsActiveAccountAddress = createSelector(
 
 export const selectHideUnlinkedAccountsBanner = (state: RootState): boolean =>
   state.rewards.hideUnlinkedAccountsBanner;
+
+export const selectSeasonStatusError = (state: RootState): string | null =>
+  state.rewards.seasonStatusError;

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5749,6 +5749,20 @@
     "not_implemented": "Coming soon",
     "not_implemented_season_summary": "Season Summary Coming Soon",
 
+    "auth_fail_banner": {
+      "title": "Authentication Failed",
+      "description": "Unable to authenticate with the rewards program. Please check your connection and try again.",
+      "cta_cancel": "Cancel",
+      "cta_retry": "Retry"
+    },
+
+    "season_status_error": {
+      "error_fetching_title": "Failed to fetch season balance",
+      "error_fetching_description": "We couldn't load your current season balance. Please check your connection and try again.",
+      "retry_button": "Retry",
+      "dismiss_button": "Dismiss"
+    },
+
     "referral_rewards_title": "Referrals",
     "points": "Points",
     "point": "Point",
@@ -5852,7 +5866,8 @@
       "all_accounts_linked_description": "You have added all your accounts to Rewards.",
       "link_account_success_title": "{{accountName}} successfully added",
       "link_account_error_title": "Failed to add account",
-      "link_account_button": "Add"
+      "link_account_button": "Add",
+      "accounts_syncing": "Your accounts are syncing. They will show up as they are discovered."
     },
 
     "optout": {


### PR DESCRIPTION
## **Description**

- When season status request fails via controller, the related hook will take notice and show an rewards error modal with the ability to refetch. Besides this, the related UI component will show an error banner so that users don't get confused.
- The getOptInStatus controller function is now checking the cached data first to see if it needs to do an actual API call to see if addresses are opted in or not.
- The getCandidateSubscriptionId controller function had a few minor bugs in it; it should now more accurately deduce the appropriate subscription id based on the getOptInStatus data.
- The useCandidateSubscriptionId hook is now rendered on focus and with less constraints. So each time we visit the rewards navigator, it will go to the controller and get a value for the UI state. This sounds excessive but since most things are cached it's actually more reliable. Previously there were cases where the candidate subscription id was null for some reason and that triggered onboarding even though users had already opted in with another account.
- In the rewards settings view, we are now showing whether or not profile sync is ongoing to prevent confusion around not visible accounts.
- In the useRewardOptInSUmmary hook we are keeping track of whether or not profile sync is ongoing + using a debounce mechanism to prevent spamming our UI for each newly discovered account. It will now do this if no new accounts have been discovered for 10 seconds. This benefits its usages like dashboard and settings views.

## **Changelog**

CHANGELOG entry: null`

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
