### PR TITLE
fix: cp-7.56.0 Misc Fixes for Perps GTM fullscreen modal and Tutorial flow

### DIFF
--- a/app/components/UI/Perps/components/PerpsGTMModal/PerpsGTMModal.styles.ts
+++ b/app/components/UI/Perps/components/PerpsGTMModal/PerpsGTMModal.styles.ts
@@ -34,44 +34,54 @@ const scaleVertical = (size: number) => {
 
 const scaleHorizontal = (size: number) => Math.ceil(size * widthScale);
 
-const createStyles = (theme: Theme, isDarkMode: boolean) =>
+const createStyles = (
+  theme: Theme,
+  isDarkMode: boolean,
+  titleFontSize?: number | null,
+  subtitleFontSize?: number | null,
+) =>
   StyleSheet.create({
     pageContainer: {
       flex: 1,
       backgroundColor: theme.colors.background.default,
     },
-    contentContainer: {
+    headerContainer: {
       alignItems: 'center',
       paddingTop: scaleVertical(50),
-      flexGrow: 1,
+      paddingHorizontal: scaleHorizontal(16),
+      minHeight: '35%',
+      maxHeight: '40%',
+    },
+    contentImageContainer: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingHorizontal: scaleHorizontal(20),
+      paddingVertical: scaleVertical(10),
     },
     image: {
-      flexShrink: 1,
-      marginTop: scaleVertical(20),
       width: '100%',
+      height: '100%',
+      resizeMode: 'contain',
+      minWidth: '80%',
+      minHeight: '80%',
     },
     title: {
-      fontSize: scaleFont(47),
-      lineHeight: scaleFont(48),
+      fontSize: titleFontSize || scaleFont(47),
+      lineHeight: titleFontSize ? titleFontSize + 1 : scaleFont(48),
       textAlign: 'center',
       paddingTop: scaleVertical(12),
-      paddingHorizontal: scaleHorizontal(16),
       fontFamily: Platform.OS === 'ios' ? 'MM Poly' : 'MM Poly Regular',
       ...(Platform.OS === 'ios' ? { fontWeight: '900' } : {}),
     },
     titleDescription: {
       paddingTop: scaleVertical(10),
       paddingHorizontal: scaleHorizontal(8),
-      marginBottom: scaleVertical(16),
       textAlign: 'center',
-      fontSize: scaleFont(16),
+      fontSize: subtitleFontSize || scaleFont(16),
+      lineHeight: subtitleFontSize ? subtitleFontSize + 4 : scaleFont(20),
       fontFamily: 'Geist-Regular',
       fontWeight: '500',
-    },
-    ctas: {
-      flex: 1,
-      width: '100%',
-      paddingHorizontal: scaleHorizontal(30),
     },
     footerContainer: {
       display: 'flex',

--- a/app/components/UI/Perps/components/PerpsGTMModal/PerpsGTMModal.styles.ts
+++ b/app/components/UI/Perps/components/PerpsGTMModal/PerpsGTMModal.styles.ts
@@ -39,6 +39,7 @@ const createStyles = (
   isDarkMode: boolean,
   titleFontSize?: number | null,
   subtitleFontSize?: number | null,
+  useSystemFont?: boolean,
 ) =>
   StyleSheet.create({
     pageContainer: {
@@ -67,12 +68,24 @@ const createStyles = (
       minHeight: '80%',
     },
     title: {
-      fontSize: titleFontSize || scaleFont(47),
-      lineHeight: titleFontSize ? titleFontSize + 1 : scaleFont(48),
+      fontSize: titleFontSize || scaleFont(useSystemFont ? 44 : 47), // Slightly smaller base for system fonts
+      lineHeight: titleFontSize
+        ? titleFontSize + 1
+        : scaleFont(useSystemFont ? 46 : 48),
       textAlign: 'center',
       paddingTop: scaleVertical(12),
-      fontFamily: Platform.OS === 'ios' ? 'MM Poly' : 'MM Poly Regular',
-      ...(Platform.OS === 'ios' ? { fontWeight: '900' } : {}),
+      fontFamily: useSystemFont
+        ? Platform.OS === 'ios'
+          ? 'System'
+          : 'Roboto'
+        : Platform.OS === 'ios'
+        ? 'MM Poly'
+        : 'MM Poly Regular',
+      fontWeight: useSystemFont
+        ? '700'
+        : Platform.OS === 'ios'
+        ? '900'
+        : 'normal',
     },
     titleDescription: {
       paddingTop: scaleVertical(10),
@@ -80,7 +93,11 @@ const createStyles = (
       textAlign: 'center',
       fontSize: subtitleFontSize || scaleFont(16),
       lineHeight: subtitleFontSize ? subtitleFontSize + 4 : scaleFont(20),
-      fontFamily: 'Geist-Regular',
+      fontFamily: useSystemFont
+        ? Platform.OS === 'ios'
+          ? 'System'
+          : 'Roboto'
+        : 'Geist-Regular',
       fontWeight: '500',
     },
     footerContainer: {

--- a/app/components/UI/Perps/components/PerpsGTMModal/PerpsGTMModal.tsx
+++ b/app/components/UI/Perps/components/PerpsGTMModal/PerpsGTMModal.tsx
@@ -1,6 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
-import React from 'react';
-import { Image, View, useColorScheme } from 'react-native';
+import React, { useState } from 'react';
+import { Image, LayoutChangeEvent, View, useColorScheme } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { strings } from '../../../../../../locales/i18n';
 import ButtonBase from '../../../../../component-library/components/Buttons/Button/foundation/ButtonBase';
@@ -35,8 +35,41 @@ const PerpsGTMModal = () => {
   const theme = useTheme();
 
   const isDarkMode = useColorScheme() === 'dark';
+  const [titleFontSize, setTitleFontSize] = useState<number | null>(null);
+  const [subtitleFontSize, setSubtitleFontSize] = useState<number | null>(null);
 
-  const styles = createStyles(theme, isDarkMode);
+  const styles = createStyles(
+    theme,
+    isDarkMode,
+    titleFontSize,
+    subtitleFontSize,
+  );
+
+  const handleTitleLayout = (event: LayoutChangeEvent) => {
+    const { height } = event.nativeEvent.layout;
+    const maxTitleHeight = 120; // Approximate max height for title in header section
+
+    if (height > maxTitleHeight && titleFontSize === null) {
+      // Scale down font size proportionally
+      const currentFontSize = styles.title.fontSize;
+      const scaleFactor = maxTitleHeight / height;
+      const newFontSize = Math.max(currentFontSize * scaleFactor, 32); // Min font size of 32
+      setTitleFontSize(newFontSize);
+    }
+  };
+
+  const handleSubtitleLayout = (event: LayoutChangeEvent) => {
+    const { height } = event.nativeEvent.layout;
+    const maxSubtitleHeight = 80; // Approximate max height for subtitle in header section
+
+    if (height > maxSubtitleHeight && subtitleFontSize === null) {
+      // Scale down font size proportionally
+      const currentFontSize = styles.titleDescription.fontSize;
+      const scaleFactor = maxSubtitleHeight / height;
+      const newFontSize = Math.max(currentFontSize * scaleFactor, 14); // Min font size of 14
+      setSubtitleFontSize(newFontSize);
+    }
+  };
 
   const handleClose = async () => {
     await StorageWrapper.setItem(PERPS_GTM_MODAL_SHOWN, 'true');
@@ -81,20 +114,30 @@ const PerpsGTMModal = () => {
       style={styles.pageContainer}
       testID={PerpsGTMModalSelectorsIDs.PERPS_GTM_MODAL}
     >
-      {/* Content */}
-      <View style={styles.contentContainer}>
-        <Text style={styles.title} variant={TextVariant.HeadingLG}>
+      {/* Header Section */}
+      <View style={styles.headerContainer}>
+        <Text
+          style={styles.title}
+          variant={TextVariant.HeadingLG}
+          onLayout={handleTitleLayout}
+        >
           {strings('perps.gtm_content.title')}
         </Text>
-        <View style={styles.ctas}>
-          <Text variant={TextVariant.BodyMD} style={styles.titleDescription}>
-            {strings('perps.gtm_content.title_description')}
-          </Text>
-          <Image source={Character} style={styles.image} />
-        </View>
+        <Text
+          variant={TextVariant.BodyMD}
+          style={styles.titleDescription}
+          onLayout={handleSubtitleLayout}
+        >
+          {strings('perps.gtm_content.title_description')}
+        </Text>
       </View>
 
-      {/* Footer */}
+      {/* Content Section */}
+      <View style={styles.contentImageContainer}>
+        <Image source={Character} style={styles.image} />
+      </View>
+
+      {/* Footer Section */}
       <View style={styles.footerContainer}>
         <ButtonBase
           onPress={() => tryPerpsNow()}

--- a/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef } from 'react';
-import { Modal, Animated } from 'react-native';
+import { Modal, Animated, View } from 'react-native';
 import { useNavigation, type NavigationProp } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -267,16 +267,18 @@ const PerpsMarketBalanceActions: React.FC<
 
       {/* Eligibility Modal */}
       {isEligibilityModalVisible && (
-        <Modal visible transparent animationType="none" statusBarTranslucent>
-          <PerpsBottomSheetTooltip
-            isVisible
-            onClose={() => setIsEligibilityModalVisible(false)}
-            contentKey={'geo_block'}
-            testID={
-              PerpsMarketBalanceActionsSelectorsIDs.GEO_BLOCK_BOTTOM_SHEET_TOOLTIP
-            }
-          />
-        </Modal>
+        <View>
+          <Modal visible transparent animationType="none" statusBarTranslucent>
+            <PerpsBottomSheetTooltip
+              isVisible
+              onClose={() => setIsEligibilityModalVisible(false)}
+              contentKey={'geo_block'}
+              testID={
+                PerpsMarketBalanceActionsSelectorsIDs.GEO_BLOCK_BOTTOM_SHEET_TOOLTIP
+              }
+            />
+          </Modal>
+        </View>
       )}
     </>
   );

--- a/app/components/UI/Perps/components/PerpsTutorialCarousel/PerpsTutorialCarousel.styles.ts
+++ b/app/components/UI/Perps/components/PerpsTutorialCarousel/PerpsTutorialCarousel.styles.ts
@@ -24,6 +24,7 @@ const createStyles = (params: {
     },
     headerSection: {
       height: 160,
+      paddingHorizontal: 8,
       justifyContent: 'flex-start',
       alignItems: 'stretch',
     },
@@ -31,13 +32,13 @@ const createStyles = (params: {
       flex: 1,
     },
     animation: {
-      bottom: 50,
+      bottom: 60,
       flex: 1,
+      minHeight: 350,
     },
     title: {
       textAlign: 'left',
       marginBottom: 6,
-      fontSize: 26,
       lineHeight: 30,
     },
     description: {
@@ -70,7 +71,13 @@ const createStyles = (params: {
     },
     footer: {
       paddingHorizontal: 16,
-      marginVertical: 8,
+      marginTop: 16,
+    },
+    footerTextContainer: {
+      paddingHorizontal: 16,
+    },
+    footerText: {
+      textAlign: 'center',
     },
     fundsInfoText: {
       textAlign: 'center',

--- a/app/components/UI/Perps/components/PerpsTutorialCarousel/PerpsTutorialCarousel.styles.ts
+++ b/app/components/UI/Perps/components/PerpsTutorialCarousel/PerpsTutorialCarousel.styles.ts
@@ -3,7 +3,12 @@ import { Theme } from '../../../../../util/theme/models';
 
 const createStyles = (params: {
   theme: Theme;
-  vars: { shouldShowSkipButton: boolean };
+  vars: {
+    shouldShowSkipButton: boolean;
+    titleFontSize?: number | null;
+    descriptionFontSize?: number | null;
+    subtitleFontSize?: number | null;
+  };
 }) =>
   StyleSheet.create({
     container: {
@@ -39,16 +44,25 @@ const createStyles = (params: {
     title: {
       textAlign: 'left',
       marginBottom: 6,
-      lineHeight: 30,
+      fontSize: params.vars.titleFontSize || 24,
+      lineHeight: params.vars.titleFontSize
+        ? params.vars.titleFontSize + 6
+        : 30,
     },
     description: {
       textAlign: 'left',
-      lineHeight: 22,
+      fontSize: params.vars.descriptionFontSize || 16,
+      lineHeight: params.vars.descriptionFontSize
+        ? params.vars.descriptionFontSize + 6
+        : 22,
       marginBottom: 16,
     },
     subtitle: {
       textAlign: 'left',
-      lineHeight: 22,
+      fontSize: params.vars.subtitleFontSize || 16,
+      lineHeight: params.vars.subtitleFontSize
+        ? params.vars.subtitleFontSize + 6
+        : 22,
     },
     progressContainer: {
       flexDirection: 'row',

--- a/app/components/UI/Perps/components/PerpsTutorialCarousel/PerpsTutorialCarousel.tsx
+++ b/app/components/UI/Perps/components/PerpsTutorialCarousel/PerpsTutorialCarousel.tsx
@@ -44,6 +44,7 @@ import { PerpsTutorialSelectorsIDs } from '../../../../../../e2e/selectors/Perps
 import { useConfirmNavigation } from '../../../../Views/confirmations/hooks/useConfirmNavigation';
 import { selectPerpsEligibility } from '../../selectors/perpsController';
 import { useSelector } from 'react-redux';
+import { createFontScaleHandler } from '../../utils/textUtils';
 
 export enum PERPS_RIVE_ARTBOARD_NAMES {
   SHORT_LONG = '01_Short_Long',
@@ -132,6 +133,13 @@ const PerpsTutorialCarousel: React.FC = () => {
   const { ensureArbitrumNetworkExists } = usePerpsNetworkManagement();
   const [currentTab, setCurrentTab] = useState(0);
   const safeAreaInsets = useSafeAreaInsets();
+
+  // Font scaling state
+  const [titleFontSize, setTitleFontSize] = useState<number | null>(null);
+  const [descriptionFontSize, setDescriptionFontSize] = useState<number | null>(
+    null,
+  );
+  const [subtitleFontSize, setSubtitleFontSize] = useState<number | null>(null);
   const scrollableTabViewRef = useRef<
     typeof ScrollableTabView & { goToPage: (pageNumber: number) => void }
   >(null);
@@ -164,6 +172,34 @@ const PerpsTutorialCarousel: React.FC = () => {
 
   const { styles } = useStyles(createStyles, {
     shouldShowSkipButton,
+    titleFontSize,
+    descriptionFontSize,
+    subtitleFontSize,
+  });
+
+  // Create font scale handlers with height constraints for 160px headerSection
+  const handleTitleLayout = createFontScaleHandler({
+    maxHeight: 60,
+    currentFontSize: styles.title.fontSize || 24,
+    setter: setTitleFontSize,
+    minFontSize: 20,
+    currentValue: titleFontSize,
+  });
+
+  const handleDescriptionLayout = createFontScaleHandler({
+    maxHeight: 50,
+    currentFontSize: styles.description.fontSize || 16,
+    setter: setDescriptionFontSize,
+    minFontSize: 16,
+    currentValue: descriptionFontSize,
+  });
+
+  const handleSubtitleLayout = createFontScaleHandler({
+    maxHeight: 40,
+    currentFontSize: styles.subtitle.fontSize || 16,
+    setter: setSubtitleFontSize,
+    minFontSize: 16,
+    currentValue: subtitleFontSize,
   });
 
   const PerpsOnboardingAnimation = useMemo(
@@ -407,6 +443,7 @@ const PerpsTutorialCarousel: React.FC = () => {
                     variant={TextVariant.HeadingLG}
                     color={TextColor.Default}
                     style={styles.title}
+                    onLayout={handleTitleLayout}
                   >
                     {screen.title}
                   </Text>
@@ -414,6 +451,7 @@ const PerpsTutorialCarousel: React.FC = () => {
                     variant={TextVariant.BodyMD}
                     color={TextColor.Alternative}
                     style={styles.description}
+                    onLayout={handleDescriptionLayout}
                   >
                     {screen.description}
                   </Text>
@@ -422,6 +460,7 @@ const PerpsTutorialCarousel: React.FC = () => {
                       variant={TextVariant.BodyMD}
                       color={TextColor.Alternative}
                       style={styles.subtitle}
+                      onLayout={handleSubtitleLayout}
                     >
                       {screen.subtitle}
                     </Text>

--- a/app/components/UI/Perps/components/PerpsTutorialCarousel/PerpsTutorialCarousel.tsx
+++ b/app/components/UI/Perps/components/PerpsTutorialCarousel/PerpsTutorialCarousel.tsx
@@ -58,6 +58,7 @@ export interface TutorialScreen {
   title: string;
   description: string;
   subtitle?: string;
+  footerText?: string;
   content?: React.ReactNode;
   riveArtboardName?: PERPS_RIVE_ARTBOARD_NAMES;
 }
@@ -68,6 +69,7 @@ const getTutorialScreens = (isEligible: boolean): TutorialScreen[] => {
       id: 'what_are_perps',
       title: strings('perps.tutorial.what_are_perps.title'),
       description: strings('perps.tutorial.what_are_perps.description'),
+      subtitle: strings('perps.tutorial.what_are_perps.subtitle'),
       content: (
         <Image
           source={Character}
@@ -92,7 +94,6 @@ const getTutorialScreens = (isEligible: boolean): TutorialScreen[] => {
       id: 'choose_leverage',
       title: strings('perps.tutorial.choose_leverage.title'),
       description: strings('perps.tutorial.choose_leverage.description'),
-      subtitle: strings('perps.tutorial.choose_leverage.subtitle'),
       riveArtboardName: PERPS_RIVE_ARTBOARD_NAMES.LEVERAGE,
     },
     {
@@ -113,6 +114,7 @@ const getTutorialScreens = (isEligible: boolean): TutorialScreen[] => {
     id: 'ready_to_trade',
     title: strings('perps.tutorial.ready_to_trade.title'),
     description: strings('perps.tutorial.ready_to_trade.description'),
+    footerText: strings('perps.tutorial.ready_to_trade.footer_text'),
     riveArtboardName: PERPS_RIVE_ARTBOARD_NAMES.READY,
   };
 
@@ -397,50 +399,63 @@ const PerpsTutorialCarousel: React.FC = () => {
           initialPage={0}
         >
           {tutorialScreens.map((screen) => (
-            <View key={screen.id} style={styles.screenContainer}>
-              {/* Header Section - Fixed height for text content */}
-              <View style={styles.headerSection}>
-                <Text
-                  variant={TextVariant.HeadingMD}
-                  color={TextColor.Default}
-                  style={styles.title}
-                >
-                  {screen.title}
-                </Text>
-                <Text
-                  variant={TextVariant.BodyMD}
-                  color={TextColor.Alternative}
-                  style={styles.description}
-                >
-                  {screen.description}
-                </Text>
-                {screen.subtitle && (
+            <>
+              <View key={screen.id} style={styles.screenContainer}>
+                {/* Header Section - Fixed height for text content */}
+                <View style={styles.headerSection}>
+                  <Text
+                    variant={TextVariant.HeadingLG}
+                    color={TextColor.Default}
+                    style={styles.title}
+                  >
+                    {screen.title}
+                  </Text>
                   <Text
                     variant={TextVariant.BodyMD}
                     color={TextColor.Alternative}
-                    style={styles.subtitle}
+                    style={styles.description}
                   >
-                    {screen.subtitle}
+                    {screen.description}
+                  </Text>
+                  {screen.subtitle && (
+                    <Text
+                      variant={TextVariant.BodyMD}
+                      color={TextColor.Alternative}
+                      style={styles.subtitle}
+                    >
+                      {screen.subtitle}
+                    </Text>
+                  )}
+                </View>
+
+                {/* Content Section */}
+                <View style={styles.contentSection}>
+                  {screen?.content && screen.content}
+                  {screen?.riveArtboardName && (
+                    <Rive
+                      key={screen.id}
+                      style={styles.animation}
+                      artboardName={screen.riveArtboardName}
+                      source={PerpsOnboardingAnimation}
+                      fit={Fit.FitWidth}
+                      alignment={Alignment.Center}
+                      autoplay
+                    />
+                  )}
+                </View>
+              </View>
+              <View style={styles.footerTextContainer}>
+                {screen.footerText && (
+                  <Text
+                    variant={TextVariant.BodySM}
+                    color={TextColor.Alternative}
+                    style={styles.footerText}
+                  >
+                    {screen.footerText}
                   </Text>
                 )}
               </View>
-
-              {/* Content Section */}
-              <View style={styles.contentSection}>
-                {screen?.content && screen.content}
-                {screen?.riveArtboardName && (
-                  <Rive
-                    key={screen.id}
-                    style={styles.animation}
-                    artboardName={screen.riveArtboardName}
-                    source={PerpsOnboardingAnimation}
-                    fit={Fit.FitWidth}
-                    alignment={Alignment.Center}
-                    autoplay
-                  />
-                )}
-              </View>
-            </View>
+            </>
           ))}
         </ScrollableTabView>
       </View>

--- a/app/components/UI/Perps/components/RewardPointsDisplay/RewardPointsDisplay.tsx
+++ b/app/components/UI/Perps/components/RewardPointsDisplay/RewardPointsDisplay.tsx
@@ -107,7 +107,7 @@ const RewardPointsDisplay: React.FC<RewardPointsDisplayProps> = ({
   ) {
     displayContent = (
       <View style={styles.contentContainer}>
-        <Text variant={TextVariant.BodyMD} color={TextColor.Primary}>
+        <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
           {formattedEstimatedPoints}
         </Text>
         {bonusBips && bonusBips > 0 && typeof bonusBips === 'number' ? (

--- a/app/components/UI/Perps/utils/textUtils.test.ts
+++ b/app/components/UI/Perps/utils/textUtils.test.ts
@@ -91,6 +91,20 @@ describe('textUtils', () => {
           height,
         },
       },
+      currentTarget: null as never,
+      target: null as never,
+      bubbles: false,
+      cancelable: false,
+      defaultPrevented: false,
+      eventPhase: 0,
+      isTrusted: false,
+      preventDefault: jest.fn(),
+      isDefaultPrevented: jest.fn(() => false),
+      stopPropagation: jest.fn(),
+      isPropagationStopped: jest.fn(() => false),
+      persist: jest.fn(),
+      timeStamp: Date.now(),
+      type: 'layout',
     });
 
     beforeEach(() => {

--- a/app/components/UI/Perps/utils/textUtils.test.ts
+++ b/app/components/UI/Perps/utils/textUtils.test.ts
@@ -1,0 +1,208 @@
+import { LayoutChangeEvent } from 'react-native';
+import { hasNonLatinCharacters, createFontScaleHandler } from './textUtils';
+
+describe('textUtils', () => {
+  describe('hasNonLatinCharacters', () => {
+    describe('returns false for Latin-only text', () => {
+      it('returns false for English text', () => {
+        expect(hasNonLatinCharacters('Hello World')).toBe(false);
+      });
+
+      it('returns false for Spanish text', () => {
+        expect(hasNonLatinCharacters('Hola Mundo')).toBe(false);
+      });
+
+      it('returns false for text with accented Latin characters', () => {
+        expect(hasNonLatinCharacters('café résumé naïve')).toBe(false);
+      });
+
+      it('returns false for empty string', () => {
+        expect(hasNonLatinCharacters('')).toBe(false);
+      });
+
+      it('returns false for numbers and punctuation only', () => {
+        expect(hasNonLatinCharacters('123 !@# $%^ &*() .,?')).toBe(false);
+      });
+
+      it('returns false for mixed Latin, numbers, and punctuation', () => {
+        expect(hasNonLatinCharacters('PERPS Trading 2024!')).toBe(false);
+      });
+    });
+
+    describe('returns true for non-Latin text', () => {
+      it('returns true for Greek characters', () => {
+        expect(hasNonLatinCharacters('Αλφα Βητα Γάμμα')).toBe(true);
+      });
+
+      it('returns true for Cyrillic characters', () => {
+        expect(hasNonLatinCharacters('Привет мир')).toBe(true);
+      });
+
+      it('returns true for Hebrew characters', () => {
+        expect(hasNonLatinCharacters('שלום עולם')).toBe(true);
+      });
+
+      it('returns true for Arabic characters', () => {
+        expect(hasNonLatinCharacters('مرحبا بالعالم')).toBe(true);
+      });
+
+      it('returns true for Chinese characters', () => {
+        expect(hasNonLatinCharacters('你好世界')).toBe(true);
+      });
+
+      it('returns true for Japanese Hiragana', () => {
+        expect(hasNonLatinCharacters('こんにちは')).toBe(true);
+      });
+
+      it('returns true for Japanese Katakana', () => {
+        expect(hasNonLatinCharacters('コンニチハ')).toBe(true);
+      });
+
+      it('returns true for Korean Hangul', () => {
+        expect(hasNonLatinCharacters('안녕하세요')).toBe(true);
+      });
+
+      it('returns true for mixed Latin and non-Latin text', () => {
+        expect(hasNonLatinCharacters('Hello 안녕하세요')).toBe(true);
+      });
+
+      it('returns true for text with parentheses containing Latin text', () => {
+        expect(hasNonLatinCharacters('무기한 선물을 (PERPS)')).toBe(true);
+      });
+    });
+  });
+
+  describe('createFontScaleHandler', () => {
+    const mockSetter = jest.fn();
+    const mockConfig = {
+      maxHeight: 100,
+      currentFontSize: 48,
+      setter: mockSetter,
+      minFontSize: 24,
+      currentValue: null,
+    };
+
+    const createMockLayoutEvent = (height: number): LayoutChangeEvent => ({
+      nativeEvent: {
+        layout: {
+          x: 0,
+          y: 0,
+          width: 200,
+          height,
+        },
+      },
+    });
+
+    beforeEach(() => {
+      mockSetter.mockClear();
+    });
+
+    describe('function creation', () => {
+      it('returns a function when called with config', () => {
+        const handler = createFontScaleHandler(mockConfig);
+        expect(typeof handler).toBe('function');
+      });
+    });
+
+    describe('scaling logic', () => {
+      it('calls setter when height exceeds maxHeight and currentValue is null', () => {
+        const handler = createFontScaleHandler(mockConfig);
+        const event = createMockLayoutEvent(150); // Height > maxHeight (100)
+
+        handler(event);
+
+        expect(mockSetter).toHaveBeenCalledTimes(1);
+        // scaleFactor = 100 / 150 = 0.667
+        // newFontSize = 48 * 0.667 = 32
+        expect(mockSetter).toHaveBeenCalledWith(32);
+      });
+
+      it('does not call setter when height is within maxHeight', () => {
+        const handler = createFontScaleHandler(mockConfig);
+        const event = createMockLayoutEvent(80); // Height < maxHeight (100)
+
+        handler(event);
+
+        expect(mockSetter).not.toHaveBeenCalled();
+      });
+
+      it('does not call setter when currentValue is already set', () => {
+        const configWithValue = { ...mockConfig, currentValue: 36 };
+        const handler = createFontScaleHandler(configWithValue);
+        const event = createMockLayoutEvent(150); // Height > maxHeight
+
+        handler(event);
+
+        expect(mockSetter).not.toHaveBeenCalled();
+      });
+
+      it('respects minimum font size constraint', () => {
+        const handler = createFontScaleHandler(mockConfig);
+        const event = createMockLayoutEvent(400); // Very large height
+
+        handler(event);
+
+        expect(mockSetter).toHaveBeenCalledTimes(1);
+        // scaleFactor = 100 / 400 = 0.25
+        // calculated = 48 * 0.25 = 12, but minFontSize is 24
+        expect(mockSetter).toHaveBeenCalledWith(24);
+      });
+
+      it('calculates correct scaled font size for moderate overflow', () => {
+        const handler = createFontScaleHandler(mockConfig);
+        const event = createMockLayoutEvent(120);
+
+        handler(event);
+
+        expect(mockSetter).toHaveBeenCalledTimes(1);
+        // scaleFactor = 100 / 120 = 0.833
+        // newFontSize = 48 * 0.833 = 40
+        expect(mockSetter).toHaveBeenCalledWith(40);
+      });
+    });
+
+    describe('edge cases', () => {
+      it('handles zero maxHeight gracefully', () => {
+        const configWithZero = { ...mockConfig, maxHeight: 0 };
+        const handler = createFontScaleHandler(configWithZero);
+        const event = createMockLayoutEvent(50);
+
+        handler(event);
+
+        expect(mockSetter).toHaveBeenCalledWith(mockConfig.minFontSize);
+      });
+
+      it('handles minFontSize larger than currentFontSize', () => {
+        const configWithLargeMin = {
+          ...mockConfig,
+          currentFontSize: 20,
+          minFontSize: 30,
+        };
+        const handler = createFontScaleHandler(configWithLargeMin);
+        const event = createMockLayoutEvent(150);
+
+        handler(event);
+
+        expect(mockSetter).toHaveBeenCalledWith(30); // Should use minFontSize
+      });
+
+      it('handles very small scale factor', () => {
+        const handler = createFontScaleHandler(mockConfig);
+        const event = createMockLayoutEvent(1000); // Extremely large height
+
+        handler(event);
+
+        expect(mockSetter).toHaveBeenCalledWith(mockConfig.minFontSize);
+      });
+
+      it('handles height equal to maxHeight', () => {
+        const handler = createFontScaleHandler(mockConfig);
+        const event = createMockLayoutEvent(100); // Height = maxHeight
+
+        handler(event);
+
+        expect(mockSetter).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/app/components/UI/Perps/utils/textUtils.ts
+++ b/app/components/UI/Perps/utils/textUtils.ts
@@ -1,0 +1,39 @@
+import { LayoutChangeEvent } from 'react-native';
+
+// Detect if text contains non-Latin characters
+export const hasNonLatinCharacters = (text: string): boolean => {
+  // Check for common non-Latin Unicode ranges
+  const nonLatinRanges = [
+    /[\u0370-\u03FF]/, // Greek
+    /[\u0400-\u04FF]/, // Cyrillic
+    /[\u0590-\u05FF]/, // Hebrew
+    /[\u0600-\u06FF]/, // Arabic
+    /[\u4E00-\u9FFF]/, // CJK Ideographs (Chinese)
+    /[\u3040-\u309F]/, // Hiragana
+    /[\u30A0-\u30FF]/, // Katakana
+    /[\uAC00-\uD7AF]/, // Hangul (Korean)
+  ];
+
+  return nonLatinRanges.some((range) => range.test(text));
+};
+
+export const createFontScaleHandler =
+  (config: {
+    maxHeight: number;
+    currentFontSize: number;
+    setter: (size: number) => void;
+    minFontSize: number;
+    currentValue: number | null;
+  }) =>
+  (event: LayoutChangeEvent) => {
+    const { height } = event.nativeEvent.layout;
+
+    if (height > config.maxHeight && config.currentValue === null) {
+      const scaleFactor = config.maxHeight / height;
+      const newFontSize = Math.max(
+        config.currentFontSize * scaleFactor,
+        config.minFontSize,
+      );
+      config.setter(newFontSize);
+    }
+  };

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1485,29 +1485,30 @@
       "add_funds": "Add funds",
       "what_are_perps": {
         "title": "What are perps?",
-        "description": "MetaMask now supports perpetual futures—aka perps—letting you trade on a token's price movement without buying it. Here's how it works."
+        "description": "MetaMask now supports perpetual futures—aka perps—letting you trade on a token's price movement without buying it.",
+        "subtitle": "Here's how it works."
       },
       "go_long_or_short": {
-        "title": "Pick a token.\nGo long or short.",
-        "description": "Go long to profit if the price goes up. Go short to profit if the price goes down.",
-        "subtitle": "Set your margin: the amount you put into the trade."
+        "title": "Go long or short on a token",
+        "description": "Pick a token to long or short, then set your order size.",
+        "subtitle": "Go long to profit if the price goes up. Go short to profit if the price goes down."
       },
       "choose_leverage": {
-        "title": "Choose leverage",
-        "description": "Leverage amplifies both gains and losses.",
-        "subtitle": "With 10x leverage, a 1% price move = 10% gain or loss on your margin."
+        "title": "Choose your leverage",
+        "description": "Leverage amplifies both gains and losses. With 40x leverage, a 4% price move equals a 40% gain or loss on your margin."
       },
       "watch_liquidation": {
-        "title": "Watch your liquidation price",
+        "title": "Watch out for liquidation",
         "description": "You’ll lose your entire margin if the token hits your liquidation price. Higher leverage means less room to liquidation."
       },
       "close_anytime": {
         "title": "Close any time",
-        "description": "Exit whenever you want. You’ll get back your margin plus profits, or minus losses."
+        "description": "Exit whenever you want. You’ll get back your margin, plus profits or minus losses."
       },
       "ready_to_trade": {
         "title": "Ready to trade?",
-        "description": "Fund your perps account with any token and make your first trade in seconds."
+        "description": "Fund your perps account with any token and make your first trade in seconds.",
+        "footer_text": "MetaMask will swap your funds to USDC on Arbitrum, and deposit them onto HyperEVM for no added fee."
       },
       "got_it": "Got it"
     },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**
### Changes:
- Updated Perps tutorial carousel copy
- Updated Perps tutorial carousel UI element positioning for better scaling across device sizes
- Fixed app freeze when geo block modal is displayed by clicking on account balance card above market list
- Added font-scaling helpers to ensure the GTM and tutorial text fits for variety of languages
- Fixed font-scaling issues for non-latin character-based languages for Perps GTM fullscreen modal
- Fixed incorrect font color for rewards display. Was primary -> now alternative

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: misc fixes for perps gtm fullscreen modal and tutorial flow

## **Related issues**

Fixes:
- [TAT-1486: Update tutorial animations](https://consensys.atlassian.net/browse/TAT-1486)
- [TAT-1709: UI bug: Perps GTM full page modal has weird spacing](https://consensys.atlassian.net/browse/TAT-1709)
- [TAT-1790: font issues with rewards addition](https://consensys.atlassian.net/browse/TAT-1790)
- [TAT-1792: Implement font scaling for modal title](https://consensys.atlassian.net/browse/TAT-1792)
- [TAT-1795: Perps account card above market list freezes on Android when geo blocked](https://consensys.atlassian.net/browse/TAT-1795)


## **Manual testing steps**



## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **After**

<!-- [screenshots/recordings] -->
English (Using desired font)
<img width="222" height="480" alt="image" src="https://github.com/user-attachments/assets/f49bb2af-e596-4a3e-815f-71c2c868fa02" />

Spanish (Using desired font)
<img width="333" height="720" alt="image" src="https://github.com/user-attachments/assets/f19bb588-8b21-4408-bb90-2f987394ea31" />


Korean (Using system fallback font since characters aren't latin)
<img width="222" height="480" alt="image" src="https://github.com/user-attachments/assets/c5c62127-1907-45d7-a518-7a9704b5c5b4" />

Greek (Using system fallback font since characters aren't latin)
<img width="952" height="2026" alt="image" src="https://github.com/user-attachments/assets/074610db-473e-47a6-8b6a-5f95039584ea" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
