### PR TITLE
fix: remove redundant marketing consent bottom sheet for social login user cp-7.56.0

### DIFF
--- a/app/components/Views/ChoosePassword/index.js
+++ b/app/components/Views/ChoosePassword/index.js
@@ -8,6 +8,7 @@ import {
   StyleSheet,
   TouchableOpacity,
   Platform,
+  Keyboard,
 } from 'react-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import { captureException } from '@sentry/react-native';
@@ -882,7 +883,7 @@ class ChoosePassword extends PureComponent {
                       ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID
                     }
                     autoComplete="new-password"
-                    onSubmitEditing={this.onPressCreate}
+                    onSubmitEditing={Keyboard.dismiss}
                     returnKeyType={'done'}
                     autoCapitalize="none"
                     keyboardAppearance={themeAppearance}

--- a/app/components/Views/ChoosePassword/index.test.tsx
+++ b/app/components/Views/ChoosePassword/index.test.tsx
@@ -22,11 +22,6 @@ import { EVENT_NAME } from '../../../core/Analytics';
 
 jest.mock('../../../util/metrics/TrackOnboarding/trackOnboarding');
 
-// Mock OAuthLoginService
-jest.mock('../../../core/OAuthService/OAuthService', () => ({
-  updateMarketingOptInStatus: jest.fn(),
-}));
-
 // Mock the entire trace module
 jest.mock('../../../util/trace', () => ({
   ...jest.requireActual('../../../util/trace'),
@@ -47,11 +42,6 @@ import OAuthLoginService from '../../../core/OAuthService/OAuthService';
 const mockTrackOnboarding = trackOnboarding as jest.MockedFunction<
   typeof trackOnboarding
 >;
-
-const mockUpdateMarketingOptInStatus =
-  OAuthLoginService.updateMarketingOptInStatus as jest.MockedFunction<
-    typeof OAuthLoginService.updateMarketingOptInStatus
-  >;
 
 jest.mock('../../../core/Engine', () => ({
   context: {
@@ -218,6 +208,12 @@ describe('ChoosePassword', () => {
   it('render loading state while creating password', async () => {
     jest.spyOn(Device, 'isIos').mockReturnValue(true);
     jest.spyOn(Device, 'isMediumDevice').mockReturnValue(true);
+    const spyUpdateMarketingOptInStatus = jest.spyOn(
+      OAuthLoginService,
+      'updateMarketingOptInStatus',
+    );
+
+    spyUpdateMarketingOptInStatus.mockResolvedValue(undefined);
 
     const component = renderWithProviders(<ChoosePassword {...defaultProps} />);
 
@@ -589,6 +585,9 @@ describe('ChoosePassword', () => {
       ChoosePasswordSelectorsIDs.I_UNDERSTAND_CHECKBOX_ID,
     );
 
+    const submitButton = component.getByTestId(
+      ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID,
+    );
     // Use short password that will fail passwordRequirementsMet
     await act(async () => {
       fireEvent.press(checkbox);
@@ -600,7 +599,7 @@ describe('ChoosePassword', () => {
     });
 
     await act(async () => {
-      fireEvent(confirmPasswordInput, 'submitEditing');
+      fireEvent(submitButton, 'press');
     });
 
     // Should not proceed with wallet creation
@@ -633,6 +632,9 @@ describe('ChoosePassword', () => {
     const checkbox = component.getByTestId(
       ChoosePasswordSelectorsIDs.I_UNDERSTAND_CHECKBOX_ID,
     );
+    const submitButton = component.getByTestId(
+      ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID,
+    );
 
     // Enter mismatched passwords
     await act(async () => {
@@ -645,7 +647,7 @@ describe('ChoosePassword', () => {
     });
 
     await act(async () => {
-      fireEvent(confirmPasswordInput, 'submitEditing');
+      fireEvent(submitButton, 'press');
     });
 
     // Should not proceed with wallet creation
@@ -698,6 +700,9 @@ describe('ChoosePassword', () => {
       ChoosePasswordSelectorsIDs.I_UNDERSTAND_CHECKBOX_ID,
     );
 
+    const submitButton = component.getByTestId(
+      ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID,
+    );
     await act(async () => {
       fireEvent.press(checkbox);
       fireEvent.changeText(passwordInput, 'StrongPassword123!');
@@ -708,7 +713,7 @@ describe('ChoosePassword', () => {
     });
 
     await act(async () => {
-      fireEvent(confirmPasswordInput, 'submitEditing');
+      fireEvent(submitButton, 'press');
     });
 
     // Should handle the rejection and create wallet with fallback method
@@ -744,6 +749,10 @@ describe('ChoosePassword', () => {
       ChoosePasswordSelectorsIDs.I_UNDERSTAND_CHECKBOX_ID,
     );
 
+    const submitButton = component.getByTestId(
+      ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID,
+    );
+
     await act(async () => {
       fireEvent.press(checkbox);
       fireEvent.changeText(passwordInput, 'StrongPassword123!');
@@ -754,7 +763,7 @@ describe('ChoosePassword', () => {
     });
 
     await act(async () => {
-      fireEvent(confirmPasswordInput, 'submitEditing');
+      fireEvent(submitButton, 'press');
     });
 
     await act(async () => {
@@ -777,10 +786,12 @@ describe('ChoosePassword', () => {
     );
     mockNewWalletAndKeychain.mockResolvedValue(undefined);
     mockMetricsIsEnabled.mockReturnValueOnce(true);
+    const spyUpdateMarketingOptInStatus = jest.spyOn(
+      OAuthLoginService,
+      'updateMarketingOptInStatus',
+    );
 
-    jest
-      .spyOn(OAuthLoginService, 'updateMarketingOptInStatus')
-      .mockResolvedValue(undefined);
+    spyUpdateMarketingOptInStatus.mockResolvedValue(undefined);
 
     const props: ChoosePasswordProps = {
       ...defaultProps,
@@ -805,7 +816,9 @@ describe('ChoosePassword', () => {
     const checkbox = component.getByTestId(
       ChoosePasswordSelectorsIDs.I_UNDERSTAND_CHECKBOX_ID,
     );
-
+    const submitButton = component.getByTestId(
+      ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID,
+    );
     await act(async () => {
       fireEvent.press(checkbox);
       fireEvent.changeText(passwordInput, 'StrongPassword123!');
@@ -816,7 +829,7 @@ describe('ChoosePassword', () => {
     });
 
     await act(async () => {
-      fireEvent(confirmPasswordInput, 'submitEditing');
+      fireEvent(submitButton, 'press');
     });
 
     await act(async () => {
@@ -871,6 +884,9 @@ describe('ChoosePassword', () => {
     const checkbox = component.getByTestId(
       ChoosePasswordSelectorsIDs.I_UNDERSTAND_CHECKBOX_ID,
     );
+    const submitButton = component.getByTestId(
+      ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID,
+    );
 
     await act(async () => {
       fireEvent.press(checkbox);
@@ -882,7 +898,7 @@ describe('ChoosePassword', () => {
     });
 
     await act(async () => {
-      fireEvent(confirmPasswordInput, 'submitEditing');
+      fireEvent(submitButton, 'press');
     });
 
     await act(async () => {
@@ -976,6 +992,9 @@ describe('ChoosePassword', () => {
       const checkbox = component.getByTestId(
         ChoosePasswordSelectorsIDs.I_UNDERSTAND_CHECKBOX_ID,
       );
+      const submitButton = component.getByTestId(
+        ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID,
+      );
 
       await act(async () => {
         fireEvent.press(checkbox);
@@ -985,7 +1004,7 @@ describe('ChoosePassword', () => {
         fireEvent.changeText(confirmPasswordInput, 'StrongPassword123!');
       });
       await act(async () => {
-        fireEvent(confirmPasswordInput, 'submitEditing');
+        fireEvent(submitButton, 'press');
       });
 
       await act(async () => {
@@ -1002,7 +1021,125 @@ describe('ChoosePassword', () => {
       mockNewWalletAndKeychain.mockRestore();
     });
   });
+  describe('Marketing API Integration', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
 
+    it('should call updateMarketingOptInStatus API when OAuth user creates password with marketing opt-in enabled', async () => {
+      const mockNewWalletAndKeychain = jest.spyOn(
+        Authentication,
+        'newWalletAndKeychain',
+      );
+      mockNewWalletAndKeychain.mockResolvedValue(undefined);
+
+      const props: ChoosePasswordProps = {
+        ...defaultProps,
+        route: {
+          ...defaultProps.route,
+          params: {
+            ...defaultProps.route.params,
+            [PREVIOUS_SCREEN]: ONBOARDING,
+            oauthLoginSuccess: true,
+          },
+        },
+      };
+      const spyUpdateMarketingOptInStatus = jest.spyOn(
+        OAuthLoginService,
+        'updateMarketingOptInStatus',
+      );
+
+      spyUpdateMarketingOptInStatus.mockResolvedValue(undefined);
+
+      const { getByTestId } = renderWithProviders(
+        <ChoosePassword {...props} />,
+      );
+      const passwordInput = getByTestId(
+        ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID,
+      );
+      const confirmPasswordInput = getByTestId(
+        ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
+      );
+      const createButton = getByTestId(
+        ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID,
+      );
+      const marketingCheckbox = getByTestId(
+        ChoosePasswordSelectorsIDs.I_UNDERSTAND_CHECKBOX_ID,
+      );
+
+      await act(async () => {
+        fireEvent.changeText(passwordInput, 'Test123456!');
+        fireEvent.changeText(confirmPasswordInput, 'Test123456!');
+      });
+      await act(async () => {
+        fireEvent.press(marketingCheckbox);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+      await act(async () => {
+        fireEvent(createButton, 'press');
+      });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      });
+
+      expect(mockNewWalletAndKeychain).toHaveBeenCalledTimes(1);
+      expect(spyUpdateMarketingOptInStatus).toHaveBeenCalledWith(true);
+    });
+
+    it('should call updateMarketingOptInStatus API when OAuth user creates password with marketing opt-in disabled', async () => {
+      const mockNewWalletAndKeychain = jest.spyOn(
+        Authentication,
+        'newWalletAndKeychain',
+      );
+      mockNewWalletAndKeychain.mockResolvedValue(undefined);
+
+      const props: ChoosePasswordProps = {
+        ...defaultProps,
+        route: {
+          ...defaultProps.route,
+          params: {
+            ...defaultProps.route.params,
+            [PREVIOUS_SCREEN]: ONBOARDING,
+            oauthLoginSuccess: true,
+          },
+        },
+      };
+      const spyUpdateMarketingOptInStatus = jest.spyOn(
+        OAuthLoginService,
+        'updateMarketingOptInStatus',
+      );
+
+      spyUpdateMarketingOptInStatus.mockResolvedValue(undefined);
+
+      const { getByTestId } = renderWithProviders(
+        <ChoosePassword {...props} />,
+      );
+      const passwordInput = getByTestId(
+        ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID,
+      );
+      const confirmPasswordInput = getByTestId(
+        ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
+      );
+      const createButton = getByTestId(
+        ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID,
+      );
+      await act(async () => {
+        fireEvent.changeText(passwordInput, 'Test123456!');
+        fireEvent.changeText(confirmPasswordInput, 'Test123456!');
+      });
+      await act(async () => {
+        fireEvent(createButton, 'press');
+      });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      });
+
+      expect(mockNewWalletAndKeychain).toHaveBeenCalledTimes(1);
+      expect(spyUpdateMarketingOptInStatus).toHaveBeenCalledWith(false);
+    });
+  });
   describe('Tracing functionality', () => {
     const mockTrace = trace as jest.MockedFunction<typeof trace>;
     const mockEndTrace = endTrace as jest.MockedFunction<typeof endTrace>;
@@ -1109,6 +1246,9 @@ describe('ChoosePassword', () => {
       const checkbox = component.getByTestId(
         ChoosePasswordSelectorsIDs.I_UNDERSTAND_CHECKBOX_ID,
       );
+      const submitButton = component.getByTestId(
+        ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID,
+      );
 
       await act(async () => {
         fireEvent.press(checkbox);
@@ -1120,7 +1260,7 @@ describe('ChoosePassword', () => {
       });
 
       await act(async () => {
-        fireEvent(confirmPasswordInput, 'submitEditing');
+        fireEvent(submitButton, 'press');
       });
 
       await act(async () => {
@@ -1409,117 +1549,6 @@ describe('ChoosePassword', () => {
 
         expect(submitButton.props.disabled).toBe(true);
       });
-    });
-  });
-
-  describe('Marketing API Integration', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-      mockUpdateMarketingOptInStatus.mockClear();
-    });
-
-    it('should call updateMarketingOptInStatus API when OAuth user creates password with marketing opt-in enabled', async () => {
-      const mockNewWalletAndKeychain = jest.spyOn(
-        Authentication,
-        'newWalletAndKeychain',
-      );
-      mockNewWalletAndKeychain.mockResolvedValue(undefined);
-
-      const props: ChoosePasswordProps = {
-        ...defaultProps,
-        route: {
-          ...defaultProps.route,
-          params: {
-            ...defaultProps.route.params,
-            [PREVIOUS_SCREEN]: ONBOARDING,
-            oauthLoginSuccess: true,
-          },
-        },
-      };
-
-      mockUpdateMarketingOptInStatus.mockResolvedValue(undefined);
-
-      const { getByTestId } = renderWithProviders(
-        <ChoosePassword {...props} />,
-      );
-      const passwordInput = getByTestId(
-        ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID,
-      );
-      const confirmPasswordInput = getByTestId(
-        ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
-      );
-      const createButton = getByTestId(
-        ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID,
-      );
-      const marketingCheckbox = getByTestId(
-        ChoosePasswordSelectorsIDs.I_UNDERSTAND_CHECKBOX_ID,
-      );
-
-      await act(async () => {
-        fireEvent.changeText(passwordInput, 'Test1234');
-        fireEvent.changeText(confirmPasswordInput, 'Test1234');
-        fireEvent.press(marketingCheckbox); // Enable marketing opt-in
-      });
-
-      await act(async () => {
-        fireEvent.press(createButton);
-      });
-
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      });
-
-      expect(mockUpdateMarketingOptInStatus).toHaveBeenCalledWith(true);
-    });
-
-    it('should call updateMarketingOptInStatus API when OAuth user creates password with marketing opt-in disabled', async () => {
-      const mockNewWalletAndKeychain = jest.spyOn(
-        Authentication,
-        'newWalletAndKeychain',
-      );
-      mockNewWalletAndKeychain.mockResolvedValue(undefined);
-
-      const props: ChoosePasswordProps = {
-        ...defaultProps,
-        route: {
-          ...defaultProps.route,
-          params: {
-            ...defaultProps.route.params,
-            [PREVIOUS_SCREEN]: ONBOARDING,
-            oauthLoginSuccess: true,
-          },
-        },
-      };
-
-      mockUpdateMarketingOptInStatus.mockResolvedValue(undefined);
-
-      const { getByTestId } = renderWithProviders(
-        <ChoosePassword {...props} />,
-      );
-      const passwordInput = getByTestId(
-        ChoosePasswordSelectorsIDs.NEW_PASSWORD_INPUT_ID,
-      );
-      const confirmPasswordInput = getByTestId(
-        ChoosePasswordSelectorsIDs.CONFIRM_PASSWORD_INPUT_ID,
-      );
-      const createButton = getByTestId(
-        ChoosePasswordSelectorsIDs.SUBMIT_BUTTON_ID,
-      );
-
-      await act(async () => {
-        fireEvent.changeText(passwordInput, 'Test1234');
-        fireEvent.changeText(confirmPasswordInput, 'Test1234');
-      });
-
-      await act(async () => {
-        fireEvent.press(createButton);
-      });
-
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      });
-
-      expect(mockUpdateMarketingOptInStatus).toHaveBeenCalledWith(false);
     });
   });
 });

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -24,7 +24,6 @@ import {
 } from '../../../component-library/components-temp/Tabs';
 import { CONSENSYS_PRIVACY_POLICY } from '../../../constants/urls';
 import {
-  isPastPrivacyPolicyDate,
   shouldShowNewPrivacyToastSelector,
   storePrivacyPolicyClickedOrClosed as storePrivacyPolicyClickedOrClosedAction,
   storePrivacyPolicyShownDate as storePrivacyPolicyShownDateAction,
@@ -631,9 +630,6 @@ const Wallet = ({
     selectSelectedInternalAccountFormattedAddress,
   );
 
-  const isDataCollectionForMarketingEnabled = useSelector(
-    (state: RootState) => state.security.dataCollectionForMarketing,
-  );
   /**
    * Is basic functionality enabled
    */
@@ -658,10 +654,6 @@ const Wallet = ({
     }
     return isEvmSelected;
   }, [isMultichainAccountsState2Enabled, isEvmSelected, allEnabledNetworks]);
-
-  const { isEnabled: getParticipationInMetaMetrics } = useMetrics();
-
-  const isParticipatingInMetaMetrics = getParticipationInMetaMetrics();
 
   const currentToast = toastRef?.current;
 
@@ -718,22 +710,6 @@ const Wallet = ({
   const { selectNetwork } = useNetworkSelection({
     networks: allNetworks,
   });
-
-  useEffect(() => {
-    if (
-      isDataCollectionForMarketingEnabled === null &&
-      isParticipatingInMetaMetrics &&
-      isPastPrivacyPolicyDate
-    ) {
-      navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
-        screen: Routes.SHEET.EXPERIENCE_ENHANCER,
-      });
-    }
-  }, [
-    isDataCollectionForMarketingEnabled,
-    isParticipatingInMetaMetrics,
-    navigate,
-  ]);
 
   const checkAndNavigateToPerpsGTM = useCallback(async () => {
     const hasSeenModal = await StorageWrapper.getItem(PERPS_GTM_MODAL_SHOWN);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

Resolves: https://github.com/MetaMask/metamask-mobile/issues/20376 and #20371 

## **Description**
Do not prompt enhance experience bottom sheet for social login flow

Pressing "Done" on the keyboard to dismisses it during confirm-password is pressed

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:
Removed `enhance user experience` bottom sheet prompting

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: remove enhance user experience bottom sheet

  Scenario: user create wallet with Metametrics consent but do not tick marketing data collection
    When user lock then unlock wallet
    Then user will not prompted enhance user experience bottomsheet 
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/9013a2fd-ba60-486f-b659-ec4e32fe1c30


### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/c272b0fb-1beb-4ff7-afab-ef0aa749f361


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
