### PR TITLE
feat: New Multichain Account Selected Styles

### DIFF
--- a/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.stories.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.stories.tsx
@@ -161,7 +161,6 @@ export const MultichainAddressSelectedRow = {
     <AccountCell
       accountGroup={args.accountGroup}
       avatarAccountType={args.avatarAccountType}
-      isSelected
     />
   ),
 };
@@ -171,7 +170,6 @@ export const MultichainAddressRow = {
     <AccountCell
       accountGroup={args.accountGroup}
       avatarAccountType={args.avatarAccountType}
-      isSelected={args.isSelected}
     />
   ),
 };

--- a/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.styles.ts
+++ b/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.styles.ts
@@ -8,6 +8,8 @@ const styleSheet = (params: { theme: Theme }) => {
   return StyleSheet.create({
     container: {
       gap: 16,
+      paddingTop: 2,
+      paddingBottom: 2,
     },
     accountName: {
       display: 'flex',

--- a/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.styles.ts
+++ b/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.styles.ts
@@ -1,37 +1,13 @@
 import { StyleSheet } from 'react-native';
 import { Theme } from '../../../../util/theme/models';
-import { colors as staticColors } from '../../../../styles/common';
 
-const styleSheet = (params: {
-  theme: Theme;
-  vars: { isSelected: boolean };
-}) => {
-  const { theme, vars } = params;
-  const { isSelected } = vars;
+const styleSheet = (params: { theme: Theme }) => {
+  const { theme } = params;
   const { colors } = theme;
 
   return StyleSheet.create({
     container: {
       gap: 16,
-      paddingTop: 16,
-      paddingBottom: 16,
-    },
-    avatarWrapper: {
-      borderRadius: 8,
-      width: isSelected ? 40 : 36, // 36 (avatar size) + 2*2 (border width) when selected, 32 + 2*2 when not
-      height: isSelected ? 40 : 36, // 36 (avatar size) + 2*2 (border width) when selected, 32 + 2*2 when not
-      borderWidth: 2,
-      borderColor: isSelected ? colors.info.default : staticColors.transparent,
-      justifyContent: 'center',
-      alignItems: 'center',
-    },
-    avatar: {
-      borderRadius: 6, // Slightly smaller to account for wrapper border
-      width: isSelected ? 36 : 32, // Increase size to maintain 32x32 content area with 2px border
-      height: isSelected ? 36 : 32, // Increase size to maintain 32x32 content area with 2px border
-      backgroundColor: colors.background.muted,
-      borderWidth: isSelected ? 2 : 0,
-      borderColor: isSelected ? staticColors.white : staticColors.transparent,
     },
     accountName: {
       display: 'flex',

--- a/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.tsx
@@ -79,15 +79,12 @@ const AccountCell = ({
       testID={AccountCellIds.CONTAINER}
     >
       {startAccessory}
-      <View style={styles.avatarWrapper}>
-        <AvatarAccount
-          accountAddress={evmAddress}
-          type={avatarAccountType}
-          size={AvatarSize.Md}
-          style={styles.avatar}
-          testID={AccountCellIds.AVATAR}
-        />
-      </View>
+      <AvatarAccount
+        accountAddress={evmAddress}
+        type={avatarAccountType}
+        size={AvatarSize.Md}
+        testID={AccountCellIds.AVATAR}
+      />
       <View style={styles.accountName}>
         <Text
           variant={TextVariant.BodyMDMedium}

--- a/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.tsx
@@ -29,7 +29,6 @@ interface AccountCellProps {
   avatarAccountType: AvatarAccountType;
   isSelected: boolean;
   hideMenu?: boolean;
-  startAccessory?: React.ReactNode;
 }
 
 const AccountCell = ({
@@ -37,7 +36,6 @@ const AccountCell = ({
   avatarAccountType,
   isSelected,
   hideMenu = false,
-  startAccessory,
 }: AccountCellProps) => {
   const { styles } = useStyles(styleSheet, { isSelected });
   const { navigate } = useNavigation();
@@ -78,7 +76,6 @@ const AccountCell = ({
       alignItems={AlignItems.center}
       testID={AccountCellIds.CONTAINER}
     >
-      {startAccessory}
       <AvatarAccount
         accountAddress={evmAddress}
         type={avatarAccountType}

--- a/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.tsx
@@ -27,17 +27,15 @@ import { createAccountGroupDetailsNavigationDetails } from '../../../../componen
 interface AccountCellProps {
   accountGroup: AccountGroupObject;
   avatarAccountType: AvatarAccountType;
-  isSelected: boolean;
   hideMenu?: boolean;
 }
 
 const AccountCell = ({
   accountGroup,
   avatarAccountType,
-  isSelected,
   hideMenu = false,
 }: AccountCellProps) => {
-  const { styles } = useStyles(styleSheet, { isSelected });
+  const { styles } = useStyles(styleSheet, {});
   const { navigate } = useNavigation();
 
   const handleMenuPress = useCallback(() => {

--- a/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.tsx
@@ -98,15 +98,6 @@ const AccountCell = ({
         >
           {accountGroup.metadata.name}
         </Text>
-        {!startAccessory && isSelected && (
-          <Icon
-            name={IconName.CheckBold}
-            size={IconSize.Md}
-            style={styles.checkIcon}
-            color={TextColor.Primary}
-            testID={AccountCellIds.CHECK_ICON}
-          />
-        )}
       </View>
       <View style={styles.endContainer}>
         <Text

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListCell/AccountListCell.test.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListCell/AccountListCell.test.tsx
@@ -101,7 +101,7 @@ describe('AccountListCell', () => {
 
     it('shows checkbox when showCheckbox prop is true', () => {
       const mockOnSelectAccount = jest.fn();
-      const { getByTestId } = renderWithProvider(
+      const { getAllByTestId } = renderWithProvider(
         <AccountListCell
           accountGroup={mockAccountGroup}
           isSelected={false}
@@ -112,14 +112,12 @@ describe('AccountListCell', () => {
         { state: baseState },
       );
 
-      expect(
-        getByTestId(`account-list-cell-checkbox-${mockAccountGroup.id}`),
-      ).toBeTruthy();
+      expect(getAllByTestId('list-item-select').length).toBeGreaterThan(0);
     });
 
     it('hides checkbox when showCheckbox prop is false', () => {
       const mockOnSelectAccount = jest.fn();
-      const { queryByTestId } = renderWithProvider(
+      const { queryAllByRole } = renderWithProvider(
         <AccountListCell
           accountGroup={mockAccountGroup}
           isSelected={false}
@@ -130,14 +128,12 @@ describe('AccountListCell', () => {
         { state: baseState },
       );
 
-      expect(
-        queryByTestId(`account-list-cell-checkbox-${mockAccountGroup.id}`),
-      ).toBeFalsy();
+      expect(queryAllByRole('checkbox').length).toBe(0);
     });
 
     it('hides checkbox by default when showCheckbox prop is not provided', () => {
       const mockOnSelectAccount = jest.fn();
-      const { queryByTestId } = renderWithProvider(
+      const { queryAllByRole } = renderWithProvider(
         <AccountListCell
           accountGroup={mockAccountGroup}
           isSelected={false}
@@ -147,9 +143,7 @@ describe('AccountListCell', () => {
         { state: baseState },
       );
 
-      expect(
-        queryByTestId(`account-list-cell-checkbox-${mockAccountGroup.id}`),
-      ).toBeFalsy();
+      expect(queryAllByRole('checkbox').length).toBe(0);
     });
 
     it('renders checked checkbox when isSelected is true', () => {
@@ -165,15 +159,12 @@ describe('AccountListCell', () => {
         { state: baseState },
       );
 
-      expect(
-        getByTestId(`account-list-cell-checkbox-${mockAccountGroup.id}`),
-      ).toBeTruthy();
       expect(getByTestId('checkbox-icon-component')).toBeTruthy();
     });
 
     it('renders unchecked checkbox when isSelected is false', () => {
       const mockOnSelectAccount = jest.fn();
-      const { getByTestId, queryByTestId } = renderWithProvider(
+      const { queryByTestId } = renderWithProvider(
         <AccountListCell
           accountGroup={mockAccountGroup}
           isSelected={false}
@@ -183,10 +174,6 @@ describe('AccountListCell', () => {
         />,
         { state: baseState },
       );
-
-      expect(
-        getByTestId(`account-list-cell-checkbox-${mockAccountGroup.id}`),
-      ).toBeTruthy();
       expect(queryByTestId('checkbox-icon-component')).toBeFalsy();
     });
 
@@ -203,10 +190,8 @@ describe('AccountListCell', () => {
         { state: baseState },
       );
 
-      const checkboxElement = getByTestId(
-        `account-list-cell-checkbox-${mockAccountGroup.id}`,
-      );
-      fireEvent.press(checkboxElement);
+      const wrapper = getByTestId('list-item-select');
+      fireEvent.press(wrapper);
 
       expect(mockOnSelectAccount).toHaveBeenCalledWith(mockAccountGroup);
     });
@@ -242,9 +227,6 @@ describe('AccountListCell', () => {
         { state: baseState },
       );
 
-      expect(
-        getByTestId(`account-list-cell-checkbox-${mockAccountGroup.id}`),
-      ).toBeTruthy();
       expect(getByTestId('checkbox-icon-component')).toBeTruthy();
       expect(getByText('Test Account')).toBeTruthy();
     });

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListCell/AccountListCell.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListCell/AccountListCell.tsx
@@ -31,12 +31,11 @@ const AccountListCell = memo(
         style={styles.accountItem}
         onPress={handlePress}
         activeOpacity={0.7}
-        testID="list-item-select"
+        testID={`account-list-cell-${accountGroup.id}`}
       >
         <AccountCell
           accountGroup={accountGroup}
           avatarAccountType={avatarAccountType}
-          isSelected={isSelected}
         />
       </WrapperComponent>
     );

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListCell/AccountListCell.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListCell/AccountListCell.tsx
@@ -31,6 +31,7 @@ const AccountListCell = memo(
         style={styles.accountItem}
         onPress={handlePress}
         activeOpacity={0.7}
+        testID="list-item-select"
       >
         <AccountCell
           accountGroup={accountGroup}

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListCell/AccountListCell.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListCell/AccountListCell.tsx
@@ -1,11 +1,12 @@
 import React, { memo, useCallback } from 'react';
-import { TouchableOpacity, View } from 'react-native';
+import { View } from 'react-native';
 
 import { useStyles } from '../../../../hooks';
 import AccountCell from '../../AccountCell';
 import createStyles from '../MultichainAccountSelectorList.styles';
 import { AccountListCellProps } from './AccountListCell.types';
 import Checkbox from '../../../../components/Checkbox';
+import ListItemSelect from '../../../../components/List/ListItemSelect';
 
 const AccountListCell = memo(
   ({
@@ -22,7 +23,8 @@ const AccountListCell = memo(
     }, [accountGroup, onSelectAccount]);
 
     return (
-      <TouchableOpacity
+      <ListItemSelect
+        isSelected={isSelected}
         style={styles.accountItem}
         onPress={handlePress}
         activeOpacity={0.7}
@@ -39,7 +41,7 @@ const AccountListCell = memo(
           avatarAccountType={avatarAccountType}
           isSelected={isSelected}
         />
-      </TouchableOpacity>
+      </ListItemSelect>
     );
   },
 );

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListCell/AccountListCell.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListCell/AccountListCell.tsx
@@ -1,12 +1,11 @@
 import React, { memo, useCallback } from 'react';
-import { View } from 'react-native';
 
 import { useStyles } from '../../../../hooks';
 import AccountCell from '../../AccountCell';
 import createStyles from '../MultichainAccountSelectorList.styles';
 import { AccountListCellProps } from './AccountListCell.types';
-import Checkbox from '../../../../components/Checkbox';
 import ListItemSelect from '../../../../components/List/ListItemSelect';
+import ListItemMultiSelect from '../../../../components/List/ListItemMultiSelect';
 
 const AccountListCell = memo(
   ({
@@ -22,30 +21,27 @@ const AccountListCell = memo(
       onSelectAccount(accountGroup);
     }, [accountGroup, onSelectAccount]);
 
+    const WrapperComponent = showCheckbox
+      ? ListItemMultiSelect
+      : ListItemSelect;
+
     return (
-      <ListItemSelect
+      <WrapperComponent
         isSelected={isSelected}
         style={styles.accountItem}
         onPress={handlePress}
         activeOpacity={0.7}
       >
         <AccountCell
-          startAccessory={
-            showCheckbox ? (
-              <View testID={`account-list-cell-checkbox-${accountGroup.id}`}>
-                <Checkbox isChecked={isSelected} onPress={handlePress} />
-              </View>
-            ) : undefined
-          }
           accountGroup={accountGroup}
           avatarAccountType={avatarAccountType}
           isSelected={isSelected}
         />
-      </ListItemSelect>
+      </WrapperComponent>
     );
   },
 );
 
 AccountListCell.displayName = 'AccountListCell';
 
-export default AccountListCell;
+export default React.memo(AccountListCell);

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/MultichainAccountSelectorList.styles.ts
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/MultichainAccountSelectorList.styles.ts
@@ -44,7 +44,6 @@ const createStyles = ({ theme }: { theme: Theme }) =>
       color: theme.colors.text.alternative,
     },
     accountItem: {
-      paddingHorizontal: 16,
       width: '100%',
     },
     emptyState: {

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/MultichainAccountSelectorList.test.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/MultichainAccountSelectorList.test.tsx
@@ -937,7 +937,7 @@ describe('MultichainAccountSelectorList', () => {
       const internalAccounts = createMockInternalAccountsFromGroups([account1]);
       const mockState = createMockState([wallet1], internalAccounts);
 
-      const { getByTestId } = renderWithProvider(
+      const { getAllByTestId } = renderWithProvider(
         <MultichainAccountSelectorList
           onSelectAccount={mockOnSelectAccount}
           selectedAccountGroups={[]}
@@ -946,9 +946,9 @@ describe('MultichainAccountSelectorList', () => {
         { state: mockState },
       );
 
-      expect(
-        getByTestId(`account-list-cell-checkbox-${account1.id}`),
-      ).toBeTruthy();
+      // Ensure wrapper exists with expected testID (from ListItemSelect)
+      const wrappers = getAllByTestId('list-item-select');
+      expect(wrappers.length).toBeGreaterThan(0);
     });
 
     it('hides checkboxes when showCheckbox prop is false', () => {
@@ -996,7 +996,7 @@ describe('MultichainAccountSelectorList', () => {
       ]);
       const mockState = createMockState([wallet1], internalAccounts);
 
-      const { getAllByTestId } = renderWithProvider(
+      const { getByTestId } = renderWithProvider(
         <MultichainAccountSelectorList
           onSelectAccount={mockOnSelectAccount}
           selectedAccountGroups={[account1]}
@@ -1005,24 +1005,8 @@ describe('MultichainAccountSelectorList', () => {
         { state: mockState },
       );
 
-      // Check that checkboxes exist for both accounts
-      const account1Checkboxes = getAllByTestId(
-        `account-list-cell-checkbox-${account1.id}`,
-      );
-      const account2Checkboxes = getAllByTestId(
-        `account-list-cell-checkbox-${account2.id}`,
-      );
-      expect(account1Checkboxes.length).toEqual(1); // Only container should have the testID (selected account)
-      expect(account2Checkboxes.length).toEqual(1); // Only container should have the testID (unselected account)
-
-      // Check that there is at least 1 checked checkbox icon (for the selected account)
-      // The checkbox icon uses the testID from the Checkbox component, which is overridden by the custom testID
-      // So we need to look for the actual checkbox elements with the custom testID
-      const selectedAccount = account1; // account1 is selected
-      const checkboxElements = getAllByTestId(
-        `account-list-cell-checkbox-${selectedAccount.id}`,
-      );
-      expect(checkboxElements.length).toEqual(1); // Only container should have the testID (selected account)
+      // The Checkbox component renders an icon when checked
+      expect(getByTestId('checkbox-icon-component')).toBeTruthy();
     });
 
     it('displays unchecked checkbox for unselected accounts', () => {
@@ -1046,7 +1030,7 @@ describe('MultichainAccountSelectorList', () => {
       ]);
       const mockState = createMockState([wallet1], internalAccounts);
 
-      const { getAllByTestId, queryByTestId } = renderWithProvider(
+      const { queryByTestId } = renderWithProvider(
         <MultichainAccountSelectorList
           onSelectAccount={mockOnSelectAccount}
           selectedAccountGroups={[]}
@@ -1054,16 +1038,6 @@ describe('MultichainAccountSelectorList', () => {
         />,
         { state: mockState },
       );
-
-      // Check that checkboxes exist for both accounts
-      const account1Checkboxes = getAllByTestId(
-        `account-list-cell-checkbox-${account1.id}`,
-      );
-      const account2Checkboxes = getAllByTestId(
-        `account-list-cell-checkbox-${account2.id}`,
-      );
-      expect(account1Checkboxes.length).toEqual(1); // Only container (unselected account, no icon rendered)
-      expect(account2Checkboxes.length).toEqual(1); // Only container (unselected account, no icon rendered)
 
       // Check that there are no checked checkbox icons (since none are selected)
       expect(queryByTestId('checkbox-icon-component')).toBeFalsy();
@@ -1088,10 +1062,9 @@ describe('MultichainAccountSelectorList', () => {
         { state: mockState },
       );
 
-      const checkboxElements = getAllByTestId(
-        `account-list-cell-checkbox-${account1.id}`,
-      );
-      fireEvent.press(checkboxElements[0]);
+      // Press the list item wrapper (acts as the selection control)
+      const wrappers = getAllByTestId('list-item-select');
+      fireEvent.press(wrappers[0]);
 
       expect(mockOnSelectAccount).toHaveBeenCalledWith(account1);
     });
@@ -1133,33 +1106,9 @@ describe('MultichainAccountSelectorList', () => {
         { state: mockState },
       );
 
-      // Check that all 3 checkboxes exist
-      const account1Checkboxes = getAllByTestId(
-        `account-list-cell-checkbox-${account1.id}`,
-      );
-      const account2Checkboxes = getAllByTestId(
-        `account-list-cell-checkbox-${account2.id}`,
-      );
-      const account3Checkboxes = getAllByTestId(
-        `account-list-cell-checkbox-${account3.id}`,
-      );
-      expect(account1Checkboxes.length).toEqual(1); // Only container should have the testID (selected account)
-      expect(account2Checkboxes.length).toEqual(1); // Only container should have the testID (unselected account)
-      expect(account3Checkboxes.length).toEqual(1); // Only container should have the testID (selected account)
-
       // Check that there are checked checkbox icons (for the 2 selected accounts)
-      // The checkbox icon uses the testID from the Checkbox component, which is overridden by the custom testID
-      // So we need to look for the actual checkbox elements with their custom testIDs
-      const selectedAccount1 = account1; // account1 is selected
-      const selectedAccount3 = account3; // account3 is selected
-      const checkboxElements1 = getAllByTestId(
-        `account-list-cell-checkbox-${selectedAccount1.id}`,
-      );
-      const checkboxElements3 = getAllByTestId(
-        `account-list-cell-checkbox-${selectedAccount3.id}`,
-      );
-      expect(checkboxElements1.length).toEqual(1); // Only container should have the testID (selected account)
-      expect(checkboxElements3.length).toEqual(1); // Only container should have the testID (selected account)
+      const checkedIcons = getAllByTestId('checkbox-icon-component');
+      expect(checkedIcons.length).toEqual(2);
     });
   });
 });

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/MultichainAccountSelectorList.test.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/MultichainAccountSelectorList.test.tsx
@@ -593,7 +593,7 @@ describe('MultichainAccountSelectorList', () => {
           expect(queryByText('My Account')).toBeFalsy();
           expect(queryByText('Test Account')).toBeTruthy();
         },
-        { timeout: 500 },
+        { timeout: 1200 },
       );
 
       // Clear search

--- a/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/MultichainAccountsConnectedList.test.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/MultichainAccountsConnectedList.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
-import { render, fireEvent } from '@testing-library/react-native';
+import { render, fireEvent, within } from '@testing-library/react-native';
 import { AccountGroupObject } from '@metamask/account-tree-controller';
 
 import { ConnectedAccountsSelectorsIDs } from '../../../../../e2e/selectors/Browser/ConnectedAccountModal.selectors';
@@ -336,7 +336,7 @@ describe('MultichainAccountsConnectedList', () => {
   });
 
   describe('Selected Account Visual Indicator', () => {
-    it('displays checkmark icon for the selected account', () => {
+    it('displays selected underlay for the selected account', () => {
       // Given a list of connected accounts with the first account selected
       const selectedAccountGroupId = MOCK_ACCOUNT_GROUP_1.id;
       const groups = [MOCK_ACCOUNT_GROUP_1, MOCK_ACCOUNT_GROUP_2];
@@ -350,7 +350,7 @@ describe('MultichainAccountsConnectedList', () => {
 
       const store = mockStore(state as unknown as Record<string, unknown>);
 
-      const { getByText, getByTestId } = render(
+      const { getByText, getAllByTestId, getAllByRole } = render(
         <Provider store={store}>
           <MultichainAccountsConnectedList {...DEFAULT_PROPS} />
         </Provider>,
@@ -361,8 +361,13 @@ describe('MultichainAccountsConnectedList', () => {
       expect(getByText('Account 1')).toBeTruthy();
       expect(getByText('Account 2')).toBeTruthy();
 
-      // Assert that the checkmark icon is present for the selected account
-      expect(getByTestId(AccountCellIds.CHECK_ICON)).toBeTruthy();
+      const cells = getAllByTestId(AccountCellIds.CONTAINER);
+      const selectedCell = cells.find((cell) =>
+        within(cell).queryByText('Account 1'),
+      );
+      expect(selectedCell).toBeTruthy();
+      const checkboxes = getAllByRole('checkbox');
+      expect(checkboxes.length).toBe(1);
     });
   });
 });

--- a/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/__snapshots__/MultichainAccountsConnectedList.test.tsx.snap
+++ b/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/__snapshots__/MultichainAccountsConnectedList.test.tsx.snap
@@ -102,6 +102,7 @@ exports[`MultichainAccountsConnectedList renders component with different accoun
                     "width": "100%",
                   }
                 }
+                testID="list-item-select"
               >
                 <View
                   accessibilityRole="none"
@@ -311,6 +312,7 @@ exports[`MultichainAccountsConnectedList renders component with different accoun
                     "width": "100%",
                   }
                 }
+                testID="list-item-select"
               >
                 <View
                   accessibilityRole="none"

--- a/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/__snapshots__/MultichainAccountsConnectedList.test.tsx.snap
+++ b/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/__snapshots__/MultichainAccountsConnectedList.test.tsx.snap
@@ -134,6 +134,8 @@ exports[`MultichainAccountsConnectedList renders component with different accoun
                           },
                           {
                             "gap": 16,
+                            "paddingBottom": 2,
+                            "paddingTop": 2,
                           },
                         ]
                       }
@@ -344,6 +346,8 @@ exports[`MultichainAccountsConnectedList renders component with different accoun
                           },
                           {
                             "gap": 16,
+                            "paddingBottom": 2,
+                            "paddingTop": 2,
                           },
                         ]
                       }

--- a/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/__snapshots__/MultichainAccountsConnectedList.test.tsx.snap
+++ b/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/__snapshots__/MultichainAccountsConnectedList.test.tsx.snap
@@ -91,175 +91,192 @@ exports[`MultichainAccountsConnectedList renders component with different accoun
             >
               <TouchableOpacity
                 activeOpacity={0.7}
+                disabled={false}
                 onPress={[Function]}
                 style={
                   {
-                    "paddingHorizontal": 16,
+                    "backgroundColor": "#ffffff",
+                    "borderRadius": 4,
+                    "opacity": 1,
+                    "position": "relative",
                     "width": "100%",
                   }
                 }
               >
                 <View
-                  alignItems="center"
-                  flexDirection="row"
-                  justifyContent="flex-start"
+                  accessibilityRole="none"
+                  accessible={true}
                   style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "flexDirection": "row",
-                        "justifyContent": "flex-start",
-                      },
-                      {
-                        "gap": 16,
-                        "paddingBottom": 16,
-                        "paddingTop": 16,
-                      },
-                    ]
+                    {
+                      "padding": 16,
+                    }
                   }
-                  testID="multichain-account-cell-container"
                 >
                   <View
                     style={
                       {
                         "alignItems": "center",
-                        "borderColor": "#4459ff",
-                        "borderRadius": 8,
-                        "borderWidth": 2,
-                        "height": 40,
-                        "justifyContent": "center",
-                        "width": 40,
+                        "flexDirection": "row",
                       }
                     }
                   >
                     <View
+                      alignItems="center"
+                      flexDirection="row"
+                      justifyContent="flex-start"
                       style={
-                        {
-                          "backgroundColor": "#3c4d9d0f",
-                          "borderColor": "#FFFFFF",
-                          "borderRadius": 6,
-                          "borderWidth": 2,
-                          "height": 36,
-                          "overflow": "hidden",
-                          "width": 36,
-                        }
+                        [
+                          {
+                            "alignItems": "center",
+                            "flexDirection": "row",
+                            "justifyContent": "flex-start",
+                          },
+                          {
+                            "gap": 16,
+                          },
+                        ]
                       }
-                      testID="multichain-account-cell-avatar"
+                      testID="multichain-account-cell-container"
                     >
                       <View
                         style={
                           {
+                            "backgroundColor": "#ffffff",
+                            "borderRadius": 8,
                             "height": 32,
+                            "overflow": "hidden",
                             "width": 32,
                           }
                         }
-                      />
-                    </View>
-                  </View>
-                  <View
-                    style={
-                      {
-                        "alignItems": "center",
-                        "display": "flex",
-                        "flex": 1,
-                        "flexDirection": "row",
-                        "justifyContent": "flex-start",
-                        "minWidth": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityRole="text"
-                      numberOfLines={1}
-                      style={
-                        {
-                          "color": "#121314",
-                          "flex": 1,
-                          "fontFamily": "Geist Medium",
-                          "fontSize": 16,
-                          "letterSpacing": 0,
-                          "lineHeight": 24,
-                          "minWidth": 0,
-                        }
-                      }
-                      testID="multichain-account-cell-address"
-                    >
-                      Account 1
-                    </Text>
-                    <SvgMock
-                      color="#4459ff"
-                      fill="currentColor"
-                      height={20}
-                      name="CheckBold"
-                      style={
-                        {
-                          "height": 20,
-                          "marginLeft": 8,
-                          "width": 20,
-                        }
-                      }
-                      testID="multichain-account-cell-check-icon"
-                      width={20}
-                    />
-                  </View>
-                  <View
-                    style={
-                      {
-                        "alignItems": "center",
-                        "display": "flex",
-                        "flexDirection": "row",
-                        "flexShrink": 0,
-                        "gap": 8,
-                        "justifyContent": "flex-end",
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityRole="text"
-                      style={
-                        {
-                          "color": "#121314",
-                          "fontFamily": "Geist Medium",
-                          "fontSize": 16,
-                          "letterSpacing": 0,
-                          "lineHeight": 24,
-                        }
-                      }
-                      testID="multichain-account-cell-balance"
-                    >
-                      $0.00
-                    </Text>
-                    <TouchableOpacity
-                      onPress={[Function]}
-                      style={
-                        {
-                          "alignItems": "center",
-                          "backgroundColor": "#3c4d9d0f",
-                          "borderRadius": 8,
-                          "display": "flex",
-                          "flexDirection": "row",
-                          "height": 28,
-                          "justifyContent": "center",
-                          "width": 28,
-                        }
-                      }
-                      testID="multichain-account-cell-menu"
-                    >
-                      <SvgMock
-                        color="#686e7d"
-                        fill="currentColor"
-                        height={20}
-                        name="MoreVertical"
+                        testID="multichain-account-cell-avatar"
+                      >
+                        <View
+                          style={
+                            {
+                              "height": 32,
+                              "width": 32,
+                            }
+                          }
+                        />
+                      </View>
+                      <View
                         style={
                           {
-                            "height": 20,
-                            "width": 20,
+                            "alignItems": "center",
+                            "display": "flex",
+                            "flex": 1,
+                            "flexDirection": "row",
+                            "justifyContent": "flex-start",
+                            "minWidth": 0,
                           }
                         }
-                        width={20}
-                      />
-                    </TouchableOpacity>
+                      >
+                        <Text
+                          accessibilityRole="text"
+                          numberOfLines={1}
+                          style={
+                            {
+                              "color": "#121314",
+                              "flex": 1,
+                              "fontFamily": "Geist Medium",
+                              "fontSize": 16,
+                              "letterSpacing": 0,
+                              "lineHeight": 24,
+                              "minWidth": 0,
+                            }
+                          }
+                          testID="multichain-account-cell-address"
+                        >
+                          Account 1
+                        </Text>
+                      </View>
+                      <View
+                        style={
+                          {
+                            "alignItems": "center",
+                            "display": "flex",
+                            "flexDirection": "row",
+                            "flexShrink": 0,
+                            "gap": 8,
+                            "justifyContent": "flex-end",
+                          }
+                        }
+                      >
+                        <Text
+                          accessibilityRole="text"
+                          style={
+                            {
+                              "color": "#121314",
+                              "fontFamily": "Geist Medium",
+                              "fontSize": 16,
+                              "letterSpacing": 0,
+                              "lineHeight": 24,
+                            }
+                          }
+                          testID="multichain-account-cell-balance"
+                        >
+                          $0.00
+                        </Text>
+                        <TouchableOpacity
+                          onPress={[Function]}
+                          style={
+                            {
+                              "alignItems": "center",
+                              "backgroundColor": "#3c4d9d0f",
+                              "borderRadius": 8,
+                              "display": "flex",
+                              "flexDirection": "row",
+                              "height": 28,
+                              "justifyContent": "center",
+                              "width": 28,
+                            }
+                          }
+                          testID="multichain-account-cell-menu"
+                        >
+                          <SvgMock
+                            color="#686e7d"
+                            fill="currentColor"
+                            height={20}
+                            name="MoreVertical"
+                            style={
+                              {
+                                "height": 20,
+                                "width": 20,
+                              }
+                            }
+                            width={20}
+                          />
+                        </TouchableOpacity>
+                      </View>
+                    </View>
                   </View>
+                </View>
+                <View
+                  accessibilityRole="checkbox"
+                  accessible={true}
+                  style={
+                    {
+                      "backgroundColor": "#4459ff1a",
+                      "bottom": 0,
+                      "flexDirection": "row",
+                      "left": 0,
+                      "position": "absolute",
+                      "right": 0,
+                      "top": 0,
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "backgroundColor": "#4459ff",
+                        "borderRadius": 2,
+                        "marginLeft": 4,
+                        "marginVertical": 4,
+                        "width": 4,
+                      }
+                    }
+                  />
                 </View>
               </TouchableOpacity>
             </View>
@@ -283,159 +300,164 @@ exports[`MultichainAccountsConnectedList renders component with different accoun
             >
               <TouchableOpacity
                 activeOpacity={0.7}
+                disabled={false}
                 onPress={[Function]}
                 style={
                   {
-                    "paddingHorizontal": 16,
+                    "backgroundColor": "#ffffff",
+                    "borderRadius": 4,
+                    "opacity": 1,
+                    "position": "relative",
                     "width": "100%",
                   }
                 }
               >
                 <View
-                  alignItems="center"
-                  flexDirection="row"
-                  justifyContent="flex-start"
+                  accessibilityRole="none"
+                  accessible={true}
                   style={
-                    [
-                      {
-                        "alignItems": "center",
-                        "flexDirection": "row",
-                        "justifyContent": "flex-start",
-                      },
-                      {
-                        "gap": 16,
-                        "paddingBottom": 16,
-                        "paddingTop": 16,
-                      },
-                    ]
+                    {
+                      "padding": 16,
+                    }
                   }
-                  testID="multichain-account-cell-container"
                 >
                   <View
                     style={
                       {
                         "alignItems": "center",
-                        "borderColor": "transparent",
-                        "borderRadius": 8,
-                        "borderWidth": 2,
-                        "height": 36,
-                        "justifyContent": "center",
-                        "width": 36,
+                        "flexDirection": "row",
                       }
                     }
                   >
                     <View
+                      alignItems="center"
+                      flexDirection="row"
+                      justifyContent="flex-start"
                       style={
-                        {
-                          "backgroundColor": "#3c4d9d0f",
-                          "borderColor": "transparent",
-                          "borderRadius": 6,
-                          "borderWidth": 0,
-                          "height": 32,
-                          "overflow": "hidden",
-                          "width": 32,
-                        }
+                        [
+                          {
+                            "alignItems": "center",
+                            "flexDirection": "row",
+                            "justifyContent": "flex-start",
+                          },
+                          {
+                            "gap": 16,
+                          },
+                        ]
                       }
-                      testID="multichain-account-cell-avatar"
+                      testID="multichain-account-cell-container"
                     >
                       <View
                         style={
                           {
+                            "backgroundColor": "#ffffff",
+                            "borderRadius": 8,
                             "height": 32,
+                            "overflow": "hidden",
                             "width": 32,
                           }
                         }
-                      />
-                    </View>
-                  </View>
-                  <View
-                    style={
-                      {
-                        "alignItems": "center",
-                        "display": "flex",
-                        "flex": 1,
-                        "flexDirection": "row",
-                        "justifyContent": "flex-start",
-                        "minWidth": 0,
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityRole="text"
-                      numberOfLines={1}
-                      style={
-                        {
-                          "color": "#121314",
-                          "flex": 1,
-                          "fontFamily": "Geist Medium",
-                          "fontSize": 16,
-                          "letterSpacing": 0,
-                          "lineHeight": 24,
-                          "minWidth": 0,
-                        }
-                      }
-                      testID="multichain-account-cell-address"
-                    >
-                      Account 2
-                    </Text>
-                  </View>
-                  <View
-                    style={
-                      {
-                        "alignItems": "center",
-                        "display": "flex",
-                        "flexDirection": "row",
-                        "flexShrink": 0,
-                        "gap": 8,
-                        "justifyContent": "flex-end",
-                      }
-                    }
-                  >
-                    <Text
-                      accessibilityRole="text"
-                      style={
-                        {
-                          "color": "#121314",
-                          "fontFamily": "Geist Medium",
-                          "fontSize": 16,
-                          "letterSpacing": 0,
-                          "lineHeight": 24,
-                        }
-                      }
-                      testID="multichain-account-cell-balance"
-                    >
-                      $0.00
-                    </Text>
-                    <TouchableOpacity
-                      onPress={[Function]}
-                      style={
-                        {
-                          "alignItems": "center",
-                          "backgroundColor": "#3c4d9d0f",
-                          "borderRadius": 8,
-                          "display": "flex",
-                          "flexDirection": "row",
-                          "height": 28,
-                          "justifyContent": "center",
-                          "width": 28,
-                        }
-                      }
-                      testID="multichain-account-cell-menu"
-                    >
-                      <SvgMock
-                        color="#686e7d"
-                        fill="currentColor"
-                        height={20}
-                        name="MoreVertical"
+                        testID="multichain-account-cell-avatar"
+                      >
+                        <View
+                          style={
+                            {
+                              "height": 32,
+                              "width": 32,
+                            }
+                          }
+                        />
+                      </View>
+                      <View
                         style={
                           {
-                            "height": 20,
-                            "width": 20,
+                            "alignItems": "center",
+                            "display": "flex",
+                            "flex": 1,
+                            "flexDirection": "row",
+                            "justifyContent": "flex-start",
+                            "minWidth": 0,
                           }
                         }
-                        width={20}
-                      />
-                    </TouchableOpacity>
+                      >
+                        <Text
+                          accessibilityRole="text"
+                          numberOfLines={1}
+                          style={
+                            {
+                              "color": "#121314",
+                              "flex": 1,
+                              "fontFamily": "Geist Medium",
+                              "fontSize": 16,
+                              "letterSpacing": 0,
+                              "lineHeight": 24,
+                              "minWidth": 0,
+                            }
+                          }
+                          testID="multichain-account-cell-address"
+                        >
+                          Account 2
+                        </Text>
+                      </View>
+                      <View
+                        style={
+                          {
+                            "alignItems": "center",
+                            "display": "flex",
+                            "flexDirection": "row",
+                            "flexShrink": 0,
+                            "gap": 8,
+                            "justifyContent": "flex-end",
+                          }
+                        }
+                      >
+                        <Text
+                          accessibilityRole="text"
+                          style={
+                            {
+                              "color": "#121314",
+                              "fontFamily": "Geist Medium",
+                              "fontSize": 16,
+                              "letterSpacing": 0,
+                              "lineHeight": 24,
+                            }
+                          }
+                          testID="multichain-account-cell-balance"
+                        >
+                          $0.00
+                        </Text>
+                        <TouchableOpacity
+                          onPress={[Function]}
+                          style={
+                            {
+                              "alignItems": "center",
+                              "backgroundColor": "#3c4d9d0f",
+                              "borderRadius": 8,
+                              "display": "flex",
+                              "flexDirection": "row",
+                              "height": 28,
+                              "justifyContent": "center",
+                              "width": 28,
+                            }
+                          }
+                          testID="multichain-account-cell-menu"
+                        >
+                          <SvgMock
+                            color="#686e7d"
+                            fill="currentColor"
+                            height={20}
+                            name="MoreVertical"
+                            style={
+                              {
+                                "height": 20,
+                                "width": 20,
+                              }
+                            }
+                            width={20}
+                          />
+                        </TouchableOpacity>
+                      </View>
+                    </View>
                   </View>
                 </View>
               </TouchableOpacity>

--- a/app/components/Views/MultichainAccounts/WalletDetails/BaseWalletDetails/index.tsx
+++ b/app/components/Views/MultichainAccounts/WalletDetails/BaseWalletDetails/index.tsx
@@ -203,7 +203,6 @@ export const BaseWalletDetails = ({
         <AccountCell
           accountGroup={accountGroup}
           avatarAccountType={avatarAccountType}
-          isSelected={false}
           hideMenu
         />
       </View>

--- a/e2e/selectors/MultichainAccounts/AccountCell.selectors.ts
+++ b/e2e/selectors/MultichainAccounts/AccountCell.selectors.ts
@@ -5,5 +5,4 @@ export const AccountCellIds = {
   COPY_ADDRESS: 'multichain-account-cell-copy-address',
   BALANCE: 'multichain-account-cell-balance',
   MENU: 'multichain-account-cell-menu',
-  CHECK_ICON: 'multichain-account-cell-check-icon',
 };


### PR DESCRIPTION
## **Description**

1. What is the reason for the change?
- we want to reverse the selected account styling to what we had before. 
- removes the checkmark in favour of a blue highlight to show the connected status
2. What is the improvement/solution?
- wrap the component the AccountListCell in ListItemMultiSelect or ListItemSelect


Designs: https://www.figma.com/design/tIC9CbWA9QS7tju1VjIkov/BIP-44-Mobile?node-id=3977-62017&t=7JMn0cGCGkSwWVE4-0

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1090


## **Manual testing steps**
- open the account list and click around
- open the dapp connection accounts permissions and click around 

## **Screenshots/Recordings**



### **Before**

<img width="250" height="600" alt="Simulator Screenshot - iPhone 16 Plus - 2025-09-26 at 14 46 49" src="https://github.com/user-attachments/assets/0a3b6277-f5f3-4b1d-9384-6f3d3295f6a2" />

<img width="250" height="600" alt="Simulator Screenshot - iPhone 16 Plus - 2025-09-26 at 14 46 39" src="https://github.com/user-attachments/assets/a7058171-7630-4285-938d-f3730d281617" />

<img width="250" height="600" alt="Simulator Screenshot - iPhone 16 Plus - 2025-09-26 at 14 48 57" src="https://github.com/user-attachments/assets/0419487a-79d4-4475-a789-a1af89bea758" />


https://github.com/user-attachments/assets/5f7bbf19-5782-457a-8175-dd4a48cc47ce



### **After**

<img width="250" height="600" alt="Simulator Screenshot - iPhone 16 Plus - 2025-09-26 at 15 30 40" src="https://github.com/user-attachments/assets/7f5df2fa-1136-4d64-b7b7-5b7030ee2bd4" />

<img width="250" height="600" alt="Simulator Screenshot - iPhone 16 Plus - 2025-09-26 at 15 30 50" src="https://github.com/user-attachments/assets/30c900e5-be2a-4e39-8106-cacc3e07bc41" />

<img width="250" height="600" alt="Simulator Screenshot - iPhone 16 Plus - 2025-09-26 at 15 30 58" src="https://github.com/user-attachments/assets/469749fb-dc5e-40f2-b35f-4f2fb568302a" />

<img width="250" height="600" alt="Simulator Screenshot - iPhone 16 Plus - 2025-09-26 at 14 53 41" src="https://github.com/user-attachments/assets/15af5c51-d485-4146-aa89-052487faa205" />


https://github.com/user-attachments/assets/14b353d1-9701-42de-bcc2-f3040cbcfc05



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces in-cell checkmark selection with ListItemSelect/MultiSelect wrappers and blue highlight, removes AccountCell isSelected/startAccessory, and updates styles/tests accordingly.
> 
> - **UI/Components**:
>   - Replace `TouchableOpacity` + `Checkbox` with `ListItemSelect`/`ListItemMultiSelect` in `AccountListCell`; pass `isSelected` to wrapper and add `testID="list-item-select"`.
>   - Simplify `AccountCell`: remove `isSelected` and `startAccessory` props, delete checkmark icon and avatar wrapper/borders; use plain `AvatarAccount`; adjust container padding (now 2px vertical) and remove extra padding from list item styles.
>   - Update `BaseWalletDetails` to use `AccountCell` without `isSelected`.
> - **Tests**:
>   - Refactor tests to assert wrapper-based selection (role `checkbox`, `list-item-select`) and checkbox icon presence via new wrappers; remove reliance on `CHECK_ICON` and old checkbox container testIDs; tweak timeouts and queries.
>   - Snapshot updates reflecting new wrappers and selected underlay.
> - **E2E**:
>   - Remove `CHECK_ICON` from `AccountCellIds`.
> - **Stories**:
>   - Remove `isSelected` usage in `AccountCell` stories.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21c22d37226c8700c1b186fb63cc65878c313dd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->