### PR TITLE
fix: browserstack build names for performance tests

### DIFF
--- a/.github/workflows/performance-test-runner.yml
+++ b/.github/workflows/performance-test-runner.yml
@@ -78,13 +78,9 @@ jobs:
           cache: 'yarn'
       
 
-      - name: Install dependencies with retry
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          retry_wait_seconds: 30
-          command: yarn setup:github-ci
+      - name: Install dependencies
+        run: yarn setup:github-ci
+        ## This will ensure that we install the patch for appwright
       
       - name: BrowserStack Env Setup
         uses: browserstack/github-actions/setup-env@4478e16186f38e5be07721931642e65a028713c3

--- a/.github/workflows/performance-test-runner.yml
+++ b/.github/workflows/performance-test-runner.yml
@@ -147,6 +147,7 @@ jobs:
           echo "Platform: ${{ inputs.platform }}"
           echo "BrowserStack App URL: ${{ inputs.browserstack_app_url }}"
           echo "QA App Version: ${{ inputs.app_version }}"
+          echo "BrowserStack Build Name: $BROWSERSTACK_BUILD_NAME"
           
           # Run the appropriate test command based on build_type flag
           if [ "${{ inputs.build_type }}" = "onboarding" ]; then

--- a/.github/workflows/performance-test-runner.yml
+++ b/.github/workflows/performance-test-runner.yml
@@ -79,7 +79,12 @@ jobs:
       
 
       - name: Install dependencies
-        run: yarn --immutable
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: yarn --immutable
         ## This installs dependencies and creates the node_modules state file
       
       - name: Setup project

--- a/.github/workflows/performance-test-runner.yml
+++ b/.github/workflows/performance-test-runner.yml
@@ -79,9 +79,13 @@ jobs:
       
 
       - name: Install dependencies
+        run: yarn --immutable
+        ## This installs dependencies and creates the node_modules state file
+      
+      - name: Setup project
         run: yarn setup:github-ci
-        ## This will ensure that we install the patch for appwright
         working-directory: '.'
+        ## This will apply the patches for appwright
       
       - name: BrowserStack Env Setup
         uses: browserstack/github-actions/setup-env@4478e16186f38e5be07721931642e65a028713c3

--- a/.github/workflows/performance-test-runner.yml
+++ b/.github/workflows/performance-test-runner.yml
@@ -84,7 +84,7 @@ jobs:
           timeout_minutes: 10
           max_attempts: 3
           retry_wait_seconds: 30
-          command: yarn --immutable
+          command: yarn setup:github-ci
       
       - name: BrowserStack Env Setup
         uses: browserstack/github-actions/setup-env@4478e16186f38e5be07721931642e65a028713c3

--- a/.github/workflows/performance-test-runner.yml
+++ b/.github/workflows/performance-test-runner.yml
@@ -139,6 +139,7 @@ jobs:
         env:
           BROWSERSTACK_LOCAL: true
           BROWSERSTACK_LOCAL_IDENTIFIER: ${{ github.run_id }}
+          BROWSERSTACK_BUILD_NAME: ${{ inputs.browserstack_build_name }}
         working-directory: '.'
         run: |
           echo "=== Running ${{ inputs.build_type }} Tests on ${{ matrix.device.name }} (${{ matrix.device.category }} Class) ==="

--- a/.github/workflows/performance-test-runner.yml
+++ b/.github/workflows/performance-test-runner.yml
@@ -81,6 +81,7 @@ jobs:
       - name: Install dependencies
         run: yarn setup:github-ci
         ## This will ensure that we install the patch for appwright
+        working-directory: '.'
       
       - name: BrowserStack Env Setup
         uses: browserstack/github-actions/setup-env@4478e16186f38e5be07721931642e65a028713c3

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -112,13 +112,11 @@ jobs:
       - name: Set unified build names
         id: set-builds
         run: |
-          # Use github.head_ref for workflow_dispatch, github.ref_name for other triggers
-          BRANCH_NAME="${{ github.head_ref || github.ref_name }}"
-          echo "android_build_name=Android-Performance-$BRANCH_NAME-Branch" >> "$GITHUB_OUTPUT"
-          echo "ios_build_name=iOS-Performance-$BRANCH_NAME-Branch" >> "$GITHUB_OUTPUT"
+          echo "android_build_name=Android-Performance-${{ github.ref_name }}-Branch" >> "$GITHUB_OUTPUT"
+          echo "ios_build_name=iOS-Performance-${{ github.ref_name }}-Branch" >> "$GITHUB_OUTPUT"
           echo "Set unified build names:"
-          echo "  Android: Android-Performance-$BRANCH_NAME-Branch"
-          echo "  iOS: iOS-Performance-$BRANCH_NAME-Branch"
+          echo "  Android: Android-Performance-${{ github.ref_name }}-Branch"
+          echo "  iOS: iOS-Performance-${{ github.ref_name }}-Branch"
 
   trigger-android-dual-versions:
     name: Trigger Android Dual Versions and Extract BrowserStack URLs

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -112,11 +112,13 @@ jobs:
       - name: Set unified build names
         id: set-builds
         run: |
-          echo "android_build_name=Android-Performance-${{ github.ref_name }}-Branch" >> "$GITHUB_OUTPUT"
-          echo "ios_build_name=iOS-Performance-${{ github.ref_name }}-Branch" >> "$GITHUB_OUTPUT"
+          # Use github.head_ref for workflow_dispatch, github.ref_name for other triggers
+          BRANCH_NAME="${{ github.head_ref || github.ref_name }}"
+          echo "android_build_name=Android-Performance-$BRANCH_NAME-Branch" >> "$GITHUB_OUTPUT"
+          echo "ios_build_name=iOS-Performance-$BRANCH_NAME-Branch" >> "$GITHUB_OUTPUT"
           echo "Set unified build names:"
-          echo "  Android: Android-Performance-${{ github.ref_name }}-Branch"
-          echo "  iOS: iOS-Performance-${{ github.ref_name }}-Branch"
+          echo "  Android: Android-Performance-$BRANCH_NAME-Branch"
+          echo "  iOS: iOS-Performance-$BRANCH_NAME-Branch"
 
   trigger-android-dual-versions:
     name: Trigger Android Dual Versions and Extract BrowserStack URLs


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The browserstack build name is unclear:
<img width="241" height="81" alt="image" src="https://github.com/user-attachments/assets/609ca46d-0c06-4022-997a-117ee8875f79" />

and the main reason for such is that currently on main, in the performance e2e workflow, whenever we install the dependencies we are not  applying the node patches as well. We have a patch in the appwright package that cleans up the build names in browserstack whenever we trigger the test. 

Now with this change:
![iOs-Performance-cifix-](https://github.com/user-attachments/assets/4184be0a-d544-4a1d-bf22-62c50687226a)


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
