### PR TITLE
fix(perps): invalid candle interval button styles

### DIFF
--- a/app/components/UI/Perps/components/PerpsCandlePeriodBottomSheet/PerpsCandlePeriodBottomSheet.styles.ts
+++ b/app/components/UI/Perps/components/PerpsCandlePeriodBottomSheet/PerpsCandlePeriodBottomSheet.styles.ts
@@ -28,7 +28,7 @@ const styleSheet = (params: { theme: Theme }) => {
       backgroundColor: colors.background.muted,
     },
     periodOptionActive: {
-      backgroundColor: colors.primary.alternative,
+      backgroundColor: colors.background.alternative,
     },
     sectionTitle: {
       paddingVertical: 8,

--- a/app/components/UI/Perps/components/PerpsCandlePeriodBottomSheet/PerpsCandlePeriodBottomSheet.styles.ts
+++ b/app/components/UI/Perps/components/PerpsCandlePeriodBottomSheet/PerpsCandlePeriodBottomSheet.styles.ts
@@ -28,7 +28,9 @@ const styleSheet = (params: { theme: Theme }) => {
       backgroundColor: colors.background.muted,
     },
     periodOptionActive: {
-      backgroundColor: colors.background.alternative,
+      backgroundColor: colors.text.default,
+      borderWidth: 1,
+      borderColor: colors.text.default,
     },
     sectionTitle: {
       paddingVertical: 8,


### PR DESCRIPTION
## **Description**

Fixes candle interval button styling issue where buttons displayed in primary blue color instead of default styling in light mode.

**Root Cause:** The `periodOptionActive` style in `PerpsCandlePeriodBottomSheet` was using `colors.primary.alternative` which renders as blue in light mode, instead of following the standard pattern used across other Perps components.

## **Changelog**

CHANGELOG entry: Fixed candle interval button styling to use default colors instead of primary blue in light mode

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1687

## **Manual testing steps**

```gherkin
Feature: Candle interval button styling

  Scenario: candle interval buttons display correct styling in light mode
    Given user is on Perps trading screen in light mode

    When user taps candle intervals button to open bottom sheet
    Then active candle interval buttons should display with default background color
    And buttons should not appear in primary blue color

  Scenario: styling consistency with other Perps components
    Given user navigates through various Perps bottom sheets

    When user views different interactive elements
    Then all buttons should follow consistent styling patterns
    And background colors should match the design system
```

## **Screenshots/Recordings**

### **Before**
- Candle interval buttons appeared in primary blue color instead of default styling in light mode
- Inconsistent with other Perps component button styling
<img width="364" height="382" alt="image" src="https://github.com/user-attachments/assets/7606b017-15a8-41f1-80ed-5950bf27ffbf" />

### **After**
- Candle interval buttons now use proper default background color (`colors.background.alternative`)
- Consistent styling pattern with other Perps components
- Proper visual hierarchy maintained in light mode

darkmode:
<img width="416" height="828" alt="image" src="https://github.com/user-attachments/assets/b5302449-375f-46af-8082-3e85bd867100" />

ligthmode:
<img width="393" height="515" alt="image" src="https://github.com/user-attachments/assets/53291da1-6942-4739-8cef-08f0800a02bf" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.