### PR TITLE
Rewards rwds 495 hardware wallet settings exclusion v2

### DIFF
--- a/app/components/UI/Rewards/Views/RewardsDashboard.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsDashboard.test.tsx
@@ -3,7 +3,11 @@ import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import { useDispatch, useSelector } from 'react-redux';
 import { Alert } from 'react-native';
 import RewardsDashboard from './RewardsDashboard';
-import { setActiveTab } from '../../../../actions/rewards';
+import {
+  setActiveTab,
+  setHideUnlinkedAccountsBanner,
+} from '../../../../actions/rewards';
+import { setHideCurrentAccountNotOptedInBanner } from '../../../../reducers/rewards';
 import Routes from '../../../../constants/navigation/Routes';
 import { REWARDS_VIEW_SELECTORS } from './RewardsView.constants';
 
@@ -35,17 +39,30 @@ jest.mock('@react-navigation/native', () => ({
 jest.mock('../../../../reducers/rewards/selectors', () => ({
   selectActiveTab: jest.fn(),
   selectSeasonId: jest.fn(),
+  selectHideCurrentAccountNotOptedInBannerArray: jest.fn(),
 }));
 
 jest.mock('../../../../selectors/rewards', () => ({
   selectRewardsSubscriptionId: jest.fn(),
+  selectRewardsActiveAccountHasOptedIn: jest.fn(),
+  selectHideUnlinkedAccountsBanner: jest.fn(),
+}));
+
+jest.mock('../../../../selectors/accountsController', () => ({
+  selectSelectedInternalAccount: jest.fn(),
 }));
 
 import {
   selectActiveTab,
   selectSeasonId,
+  selectHideCurrentAccountNotOptedInBannerArray,
 } from '../../../../reducers/rewards/selectors';
-import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
+import {
+  selectRewardsSubscriptionId,
+  selectRewardsActiveAccountHasOptedIn,
+  selectHideUnlinkedAccountsBanner,
+} from '../../../../selectors/rewards';
+import { selectSelectedInternalAccount } from '../../../../selectors/accountsController';
 import { CURRENT_SEASON_ID } from '../../../../core/Engine/controllers/rewards-controller/types';
 
 const mockSelectActiveTab = selectActiveTab as jest.MockedFunction<
@@ -58,6 +75,22 @@ const mockSelectRewardsSubscriptionId =
 const mockSelectSeasonId = selectSeasonId as jest.MockedFunction<
   typeof selectSeasonId
 >;
+const mockSelectRewardsActiveAccountHasOptedIn =
+  selectRewardsActiveAccountHasOptedIn as jest.MockedFunction<
+    typeof selectRewardsActiveAccountHasOptedIn
+  >;
+const mockSelectHideUnlinkedAccountsBanner =
+  selectHideUnlinkedAccountsBanner as jest.MockedFunction<
+    typeof selectHideUnlinkedAccountsBanner
+  >;
+const mockSelectHideCurrentAccountNotOptedInBannerArray =
+  selectHideCurrentAccountNotOptedInBannerArray as jest.MockedFunction<
+    typeof selectHideCurrentAccountNotOptedInBannerArray
+  >;
+const mockSelectSelectedInternalAccount =
+  selectSelectedInternalAccount as jest.MockedFunction<
+    typeof selectSelectedInternalAccount
+  >;
 
 // Mock theme
 jest.mock('../../../../util/theme', () => ({
@@ -155,6 +188,102 @@ jest.mock('../components/Tabs/RewardsActivity', () => ({
       ReactActual.createElement(Text, null, tabLabel || 'Activity'),
     );
   },
+}));
+
+// Mock RewardsInfoBanner
+jest.mock('../components/RewardsInfoBanner', () => ({
+  __esModule: true,
+  default: function MockRewardsInfoBanner({
+    title,
+    description,
+    onConfirm,
+    onDismiss,
+    confirmButtonLabel,
+    onConfirmLoading,
+    testID,
+  }: {
+    title: string | React.ReactNode;
+    description: string;
+    onConfirm?: () => void;
+    onDismiss?: () => void;
+    confirmButtonLabel?: string;
+    onConfirmLoading?: boolean;
+    testID?: string;
+  }) {
+    const ReactActual = jest.requireActual('react');
+    const { View, Text, TouchableOpacity } = jest.requireActual('react-native');
+
+    return ReactActual.createElement(
+      View,
+      { testID: testID || 'rewards-info-banner' },
+      ReactActual.createElement(
+        Text,
+        { testID: 'banner-title' },
+        typeof title === 'string' ? title : 'Custom Title',
+      ),
+      ReactActual.createElement(
+        Text,
+        { testID: 'banner-description' },
+        description,
+      ),
+      onConfirm &&
+        ReactActual.createElement(
+          TouchableOpacity,
+          {
+            testID: 'banner-confirm-button',
+            onPress: onConfirm,
+            disabled: onConfirmLoading,
+          },
+          ReactActual.createElement(
+            Text,
+            null,
+            onConfirmLoading ? 'Loading...' : confirmButtonLabel || 'Confirm',
+          ),
+        ),
+      onDismiss &&
+        ReactActual.createElement(
+          TouchableOpacity,
+          { testID: 'banner-dismiss-button', onPress: onDismiss },
+          ReactActual.createElement(Text, null, 'Dismiss'),
+        ),
+    );
+  },
+}));
+
+// Mock AccountDisplayItem
+jest.mock('../components/AccountDisplayItem/AccountDisplayItem', () => ({
+  __esModule: true,
+  default: function MockAccountDisplayItem({
+    account,
+  }: {
+    account: InternalAccount;
+  }) {
+    const ReactActual = jest.requireActual('react');
+    const { View, Text } = jest.requireActual('react-native');
+
+    return ReactActual.createElement(
+      View,
+      { testID: 'account-display-item' },
+      ReactActual.createElement(
+        Text,
+        null,
+        account?.metadata?.name || 'Account',
+      ),
+    );
+  },
+}));
+
+// Mock hooks
+jest.mock('../hooks/useRewardOptinSummary', () => ({
+  useRewardOptinSummary: jest.fn(),
+}));
+
+jest.mock('../hooks/useLinkAccount', () => ({
+  useLinkAccount: jest.fn(),
+}));
+
+jest.mock('../utils', () => ({
+  convertInternalAccountToCaipAccountId: jest.fn(),
 }));
 
 // Mock TabsList
@@ -309,18 +438,73 @@ jest.mock('@metamask/design-system-react-native', () => {
 const mockAlert = jest.fn();
 jest.spyOn(Alert, 'alert').mockImplementation(mockAlert);
 
+// Import mocked hooks
+import { useRewardOptinSummary } from '../hooks/useRewardOptinSummary';
+import { useLinkAccount } from '../hooks/useLinkAccount';
+import { convertInternalAccountToCaipAccountId } from '../utils';
+import { InternalAccount } from '@metamask/keyring-internal-api';
+
+const mockUseRewardOptinSummary = useRewardOptinSummary as jest.MockedFunction<
+  typeof useRewardOptinSummary
+>;
+const mockUseLinkAccount = useLinkAccount as jest.MockedFunction<
+  typeof useLinkAccount
+>;
+const mockConvertInternalAccountToCaipAccountId =
+  convertInternalAccountToCaipAccountId as jest.MockedFunction<
+    typeof convertInternalAccountToCaipAccountId
+  >;
+
 describe('RewardsDashboard', () => {
   const mockDispatch = jest.fn();
+  const mockLinkAccount = jest.fn();
+
+  const mockSelectedAccount = {
+    id: 'account-1',
+    address: '0x123',
+    type: 'eip155:eoa' as const,
+    options: {},
+    metadata: {
+      name: 'Account 1',
+      importTime: Date.now(),
+      keyring: { type: 'HD Key Tree' },
+    },
+    scopes: ['eip155:1'] as `${string}:${string}`[],
+    methods: ['eth_sendTransaction'],
+  };
 
   const defaultSelectorValues = {
     activeTab: 'overview' as const,
     subscriptionId: 'test-subscription-id',
     seasonId: CURRENT_SEASON_ID,
+    hasAccountedOptedIn: true,
+    hideUnlinkedAccountsBanner: false,
+    hideCurrentAccountNotOptedInBannerArray: [],
+    selectedAccount: mockSelectedAccount,
+  };
+
+  const defaultHookValues = {
+    useRewardOptinSummary: {
+      linkedAccounts: [],
+      unlinkedAccounts: [],
+      currentAccountSupported: true,
+      currentAccountOptedIn: null,
+      isLoading: false,
+      hasError: false,
+      refresh: jest.fn(),
+    },
+    useLinkAccount: {
+      linkAccount: mockLinkAccount,
+      isLoading: false,
+      isError: false,
+      error: null,
+    },
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockAlert.mockClear();
+    mockLinkAccount.mockClear();
 
     mockUseDispatch.mockReturnValue(mockDispatch);
 
@@ -330,12 +514,39 @@ describe('RewardsDashboard', () => {
       defaultSelectorValues.subscriptionId,
     );
     mockSelectSeasonId.mockReturnValue(defaultSelectorValues.seasonId);
+    mockSelectRewardsActiveAccountHasOptedIn.mockReturnValue(
+      defaultSelectorValues.hasAccountedOptedIn,
+    );
+    mockSelectHideUnlinkedAccountsBanner.mockReturnValue(
+      defaultSelectorValues.hideUnlinkedAccountsBanner,
+    );
+    mockSelectHideCurrentAccountNotOptedInBannerArray.mockReturnValue(
+      defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray,
+    );
+    mockSelectSelectedInternalAccount.mockReturnValue(
+      defaultSelectorValues.selectedAccount,
+    );
+
+    // Setup hook mocks
+    mockUseRewardOptinSummary.mockReturnValue(
+      defaultHookValues.useRewardOptinSummary,
+    );
+    mockUseLinkAccount.mockReturnValue(defaultHookValues.useLinkAccount);
+    mockConvertInternalAccountToCaipAccountId.mockReturnValue('eip155:1:0x123');
 
     mockUseSelector.mockImplementation((selector) => {
       if (selector === selectActiveTab) return defaultSelectorValues.activeTab;
       if (selector === selectRewardsSubscriptionId)
         return defaultSelectorValues.subscriptionId;
       if (selector === selectSeasonId) return defaultSelectorValues.seasonId;
+      if (selector === selectRewardsActiveAccountHasOptedIn)
+        return defaultSelectorValues.hasAccountedOptedIn;
+      if (selector === selectHideUnlinkedAccountsBanner)
+        return defaultSelectorValues.hideUnlinkedAccountsBanner;
+      if (selector === selectHideCurrentAccountNotOptedInBannerArray)
+        return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
+      if (selector === selectSelectedInternalAccount)
+        return defaultSelectorValues.selectedAccount;
       return undefined;
     });
   });
@@ -543,6 +754,405 @@ describe('RewardsDashboard', () => {
 
       // Act & Assert
       expect(() => render(<RewardsDashboard />)).not.toThrow();
+    });
+  });
+
+  describe('current account not opted in banner', () => {
+    it('should show banner when account has not opted in', () => {
+      // Arrange
+      mockSelectRewardsActiveAccountHasOptedIn.mockReturnValue(false);
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectActiveTab)
+          return defaultSelectorValues.activeTab;
+        if (selector === selectRewardsSubscriptionId)
+          return defaultSelectorValues.subscriptionId;
+        if (selector === selectSeasonId) return defaultSelectorValues.seasonId;
+        if (selector === selectRewardsActiveAccountHasOptedIn) return false;
+        if (selector === selectHideUnlinkedAccountsBanner)
+          return defaultSelectorValues.hideUnlinkedAccountsBanner;
+        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
+          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
+        if (selector === selectSelectedInternalAccount)
+          return defaultSelectorValues.selectedAccount;
+        return undefined;
+      });
+
+      // Act
+      const { getByTestId } = render(<RewardsDashboard />);
+
+      // Assert
+      expect(getByTestId('rewards-info-banner')).toBeTruthy();
+      expect(getByTestId('banner-confirm-button')).toBeTruthy();
+      expect(getByTestId('banner-dismiss-button')).toBeTruthy();
+    });
+
+    it('should show banner when account is not supported', () => {
+      // Arrange
+      mockUseRewardOptinSummary.mockReturnValue({
+        ...defaultHookValues.useRewardOptinSummary,
+        currentAccountSupported: false,
+      });
+
+      // Act
+      const { getByTestId } = render(<RewardsDashboard />);
+
+      // Assert
+      expect(getByTestId('rewards-info-banner')).toBeTruthy();
+      expect(getByTestId('banner-dismiss-button')).toBeTruthy();
+      // Should not show confirm button for unsupported accounts
+      expect(() => getByTestId('banner-confirm-button')).toThrow();
+    });
+
+    it('should hide banner when banner is dismissed via state', () => {
+      // Arrange
+      mockSelectRewardsActiveAccountHasOptedIn.mockReturnValue(false);
+      mockSelectHideCurrentAccountNotOptedInBannerArray.mockReturnValue([
+        { caipAccountId: 'eip155:1:0x123', hide: true },
+      ]);
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectActiveTab)
+          return defaultSelectorValues.activeTab;
+        if (selector === selectRewardsSubscriptionId)
+          return defaultSelectorValues.subscriptionId;
+        if (selector === selectSeasonId) return defaultSelectorValues.seasonId;
+        if (selector === selectRewardsActiveAccountHasOptedIn) return false;
+        if (selector === selectHideUnlinkedAccountsBanner)
+          return defaultSelectorValues.hideUnlinkedAccountsBanner;
+        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
+          return [{ caipAccountId: 'eip155:1:0x123', hide: true }];
+        if (selector === selectSelectedInternalAccount)
+          return defaultSelectorValues.selectedAccount;
+        return undefined;
+      });
+
+      // Act
+      const { queryByTestId } = render(<RewardsDashboard />);
+
+      // Assert
+      expect(queryByTestId('rewards-info-banner')).toBeNull();
+    });
+
+    it('should call dismiss action when dismiss button is pressed', () => {
+      // Arrange
+      mockSelectRewardsActiveAccountHasOptedIn.mockReturnValue(false);
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectActiveTab)
+          return defaultSelectorValues.activeTab;
+        if (selector === selectRewardsSubscriptionId)
+          return defaultSelectorValues.subscriptionId;
+        if (selector === selectSeasonId) return defaultSelectorValues.seasonId;
+        if (selector === selectRewardsActiveAccountHasOptedIn) return false;
+        if (selector === selectHideUnlinkedAccountsBanner)
+          return defaultSelectorValues.hideUnlinkedAccountsBanner;
+        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
+          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
+        if (selector === selectSelectedInternalAccount)
+          return defaultSelectorValues.selectedAccount;
+        return undefined;
+      });
+
+      // Act
+      const { getByTestId } = render(<RewardsDashboard />);
+      const dismissButton = getByTestId('banner-dismiss-button');
+      fireEvent.press(dismissButton);
+
+      // Assert
+      expect(mockDispatch).toHaveBeenCalledWith(
+        setHideCurrentAccountNotOptedInBanner({
+          accountId: 'eip155:1:0x123',
+          hide: true,
+        }),
+      );
+    });
+
+    it('should call link account when confirm button is pressed', async () => {
+      // Arrange
+      mockSelectRewardsActiveAccountHasOptedIn.mockReturnValue(false);
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectActiveTab)
+          return defaultSelectorValues.activeTab;
+        if (selector === selectRewardsSubscriptionId)
+          return defaultSelectorValues.subscriptionId;
+        if (selector === selectSeasonId) return defaultSelectorValues.seasonId;
+        if (selector === selectRewardsActiveAccountHasOptedIn) return false;
+        if (selector === selectHideUnlinkedAccountsBanner)
+          return defaultSelectorValues.hideUnlinkedAccountsBanner;
+        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
+          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
+        if (selector === selectSelectedInternalAccount)
+          return defaultSelectorValues.selectedAccount;
+        return undefined;
+      });
+
+      // Act
+      const { getByTestId } = render(<RewardsDashboard />);
+      const confirmButton = getByTestId('banner-confirm-button');
+      fireEvent.press(confirmButton);
+
+      // Assert
+      await waitFor(() => {
+        expect(mockLinkAccount).toHaveBeenCalledWith(mockSelectedAccount);
+      });
+    });
+  });
+
+  describe('unlinked accounts banner', () => {
+    beforeEach(() => {
+      // Set up default state for unlinked accounts banner tests
+      mockSelectRewardsActiveAccountHasOptedIn.mockReturnValue(true);
+      mockUseRewardOptinSummary.mockReturnValue({
+        ...defaultHookValues.useRewardOptinSummary,
+        unlinkedAccounts: [
+          {
+            id: 'account-2',
+            address: '0x456',
+            type: 'eip155:eoa' as const,
+            options: {},
+            metadata: {
+              name: 'Account 2',
+              importTime: Date.now(),
+              keyring: { type: 'HD Key Tree' },
+            },
+            scopes: ['eip155:1'] as `${string}:${string}`[],
+            methods: ['eth_sendTransaction'],
+            hasOptedIn: false,
+          },
+        ],
+      });
+    });
+
+    it('should show unlinked accounts banner when there are unlinked accounts', () => {
+      // Act
+      const { getAllByTestId } = render(<RewardsDashboard />);
+      const banners = getAllByTestId('rewards-info-banner');
+
+      // Assert - Should have unlinked accounts banner
+      expect(banners.length).toBeGreaterThan(0);
+    });
+
+    it('should navigate to settings when confirm button is pressed', () => {
+      // Act
+      const { getAllByTestId } = render(<RewardsDashboard />);
+      const confirmButtons = getAllByTestId('banner-confirm-button');
+
+      // Press the confirm button (should be the unlinked accounts banner)
+      fireEvent.press(confirmButtons[confirmButtons.length - 1]);
+
+      // Assert
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_SETTINGS_VIEW, {
+        focusUnlinkedTab: true,
+      });
+    });
+
+    it('should dispatch hide action when dismiss button is pressed', () => {
+      // Act
+      const { getAllByTestId } = render(<RewardsDashboard />);
+      const dismissButtons = getAllByTestId('banner-dismiss-button');
+
+      // Press the dismiss button (should be the unlinked accounts banner)
+      fireEvent.press(dismissButtons[dismissButtons.length - 1]);
+
+      // Assert
+      expect(mockDispatch).toHaveBeenCalledWith(
+        setHideUnlinkedAccountsBanner(true),
+      );
+    });
+
+    it('should hide banner when hideUnlinkedAccountsBanner is true', () => {
+      // Arrange
+      mockSelectHideUnlinkedAccountsBanner.mockReturnValue(true);
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectActiveTab)
+          return defaultSelectorValues.activeTab;
+        if (selector === selectRewardsSubscriptionId)
+          return defaultSelectorValues.subscriptionId;
+        if (selector === selectSeasonId) return defaultSelectorValues.seasonId;
+        if (selector === selectRewardsActiveAccountHasOptedIn) return true;
+        if (selector === selectHideUnlinkedAccountsBanner) return true;
+        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
+          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
+        if (selector === selectSelectedInternalAccount)
+          return defaultSelectorValues.selectedAccount;
+        return undefined;
+      });
+
+      // Act
+      const { queryByTestId } = render(<RewardsDashboard />);
+
+      // Assert - Should not show unlinked accounts banner
+      expect(queryByTestId('rewards-info-banner')).toBeNull();
+    });
+
+    it('should hide banner when user is not opted in', () => {
+      // Arrange
+      mockSelectRewardsActiveAccountHasOptedIn.mockReturnValue(false);
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectActiveTab)
+          return defaultSelectorValues.activeTab;
+        if (selector === selectRewardsSubscriptionId)
+          return defaultSelectorValues.subscriptionId;
+        if (selector === selectSeasonId) return defaultSelectorValues.seasonId;
+        if (selector === selectRewardsActiveAccountHasOptedIn) return false;
+        if (selector === selectHideUnlinkedAccountsBanner)
+          return defaultSelectorValues.hideUnlinkedAccountsBanner;
+        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
+          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
+        if (selector === selectSelectedInternalAccount)
+          return defaultSelectorValues.selectedAccount;
+        return undefined;
+      });
+
+      // Act
+      const { getAllByTestId } = render(<RewardsDashboard />);
+      const banners = getAllByTestId('rewards-info-banner');
+
+      // Assert - Should only show current account banner, not unlinked accounts banner
+      expect(banners.length).toBe(1);
+    });
+  });
+
+  describe('banner prioritization', () => {
+    it('should show current account banner when account not opted in and has unlinked accounts', () => {
+      // Arrange
+      mockSelectRewardsActiveAccountHasOptedIn.mockReturnValue(false);
+      mockUseRewardOptinSummary.mockReturnValue({
+        ...defaultHookValues.useRewardOptinSummary,
+        unlinkedAccounts: [
+          {
+            id: 'account-2',
+            address: '0x456',
+            type: 'eip155:eoa' as const,
+            options: {},
+            metadata: {
+              name: 'Account 2',
+              importTime: Date.now(),
+              keyring: { type: 'HD Key Tree' },
+            },
+            scopes: ['eip155:1'] as `${string}:${string}`[],
+            methods: ['eth_sendTransaction'],
+            hasOptedIn: false,
+          },
+        ],
+      });
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectActiveTab)
+          return defaultSelectorValues.activeTab;
+        if (selector === selectRewardsSubscriptionId)
+          return defaultSelectorValues.subscriptionId;
+        if (selector === selectSeasonId) return defaultSelectorValues.seasonId;
+        if (selector === selectRewardsActiveAccountHasOptedIn) return false;
+        if (selector === selectHideUnlinkedAccountsBanner)
+          return defaultSelectorValues.hideUnlinkedAccountsBanner;
+        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
+          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
+        if (selector === selectSelectedInternalAccount)
+          return defaultSelectorValues.selectedAccount;
+        return undefined;
+      });
+
+      // Act
+      const { getAllByTestId } = render(<RewardsDashboard />);
+      const banners = getAllByTestId('rewards-info-banner');
+
+      // Assert - Should only show current account banner
+      expect(banners.length).toBe(1);
+    });
+
+    it('should show unlinked accounts banner when current account dismissed and opted in', () => {
+      // Arrange
+      mockSelectRewardsActiveAccountHasOptedIn.mockReturnValue(true);
+      mockSelectHideCurrentAccountNotOptedInBannerArray.mockReturnValue([
+        { caipAccountId: 'eip155:1:0x123', hide: true },
+      ]);
+      mockUseRewardOptinSummary.mockReturnValue({
+        ...defaultHookValues.useRewardOptinSummary,
+        unlinkedAccounts: [
+          {
+            id: 'account-2',
+            address: '0x456',
+            type: 'eip155:eoa' as const,
+            options: {},
+            metadata: {
+              name: 'Account 2',
+              importTime: Date.now(),
+              keyring: { type: 'HD Key Tree' },
+            },
+            scopes: ['eip155:1'] as `${string}:${string}`[],
+            methods: ['eth_sendTransaction'],
+            hasOptedIn: false,
+          },
+        ],
+      });
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectActiveTab)
+          return defaultSelectorValues.activeTab;
+        if (selector === selectRewardsSubscriptionId)
+          return defaultSelectorValues.subscriptionId;
+        if (selector === selectSeasonId) return defaultSelectorValues.seasonId;
+        if (selector === selectRewardsActiveAccountHasOptedIn) return true;
+        if (selector === selectHideUnlinkedAccountsBanner)
+          return defaultSelectorValues.hideUnlinkedAccountsBanner;
+        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
+          return [{ caipAccountId: 'eip155:1:0x123', hide: true }];
+        if (selector === selectSelectedInternalAccount)
+          return defaultSelectorValues.selectedAccount;
+        return undefined;
+      });
+
+      // Act
+      const { getAllByTestId } = render(<RewardsDashboard />);
+      const banners = getAllByTestId('rewards-info-banner');
+
+      // Assert - Should show unlinked accounts banner
+      expect(banners.length).toBe(1);
+    });
+  });
+
+  describe('hook integration', () => {
+    it('should call useRewardOptinSummary with correct parameters', () => {
+      // Act
+      render(<RewardsDashboard />);
+
+      // Assert
+      expect(mockUseRewardOptinSummary).toHaveBeenCalledWith({
+        enabled: !defaultSelectorValues.hideUnlinkedAccountsBanner,
+      });
+    });
+
+    it('should call useLinkAccount hook', () => {
+      // Act
+      render(<RewardsDashboard />);
+
+      // Assert
+      expect(mockUseLinkAccount).toHaveBeenCalled();
+    });
+
+    it('should call convertInternalAccountToCaipAccountId when needed', () => {
+      // Arrange
+      mockSelectRewardsActiveAccountHasOptedIn.mockReturnValue(false);
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectActiveTab)
+          return defaultSelectorValues.activeTab;
+        if (selector === selectRewardsSubscriptionId)
+          return defaultSelectorValues.subscriptionId;
+        if (selector === selectSeasonId) return defaultSelectorValues.seasonId;
+        if (selector === selectRewardsActiveAccountHasOptedIn) return false;
+        if (selector === selectHideUnlinkedAccountsBanner)
+          return defaultSelectorValues.hideUnlinkedAccountsBanner;
+        if (selector === selectHideCurrentAccountNotOptedInBannerArray)
+          return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
+        if (selector === selectSelectedInternalAccount)
+          return defaultSelectorValues.selectedAccount;
+        return undefined;
+      });
+
+      // Act
+      render(<RewardsDashboard />);
+
+      // Assert
+      expect(mockConvertInternalAccountToCaipAccountId).toHaveBeenCalledWith(
+        mockSelectedAccount,
+      );
     });
   });
 

--- a/app/components/UI/Rewards/Views/RewardsSettingsView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsSettingsView.tsx
@@ -11,10 +11,7 @@ import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
 import Button, {
   ButtonVariants,
 } from '../../../../component-library/components/Buttons/Button';
-import Banner, {
-  BannerVariant,
-} from '../../../../component-library/components/Banners/Banner';
-import { BannerAlertSeverity } from '../../../../component-library/components/Banners/Banner/variants/BannerAlert/BannerAlert.types';
+import RewardsInfoBanner from '../components/RewardsInfoBanner';
 import Toast from '../../../../component-library/components/Toast';
 import { ToastRef } from '../../../../component-library/components/Toast/Toast.types';
 import Routes from '../../../../constants/navigation/Routes';
@@ -97,29 +94,11 @@ const RewardsSettingsView: React.FC = () => {
           </Box>
 
           {isAccountSyncingInProgress && (
-            <Box twClassName="-mx-4">
-              <Banner
-                variant={BannerVariant.Alert}
-                severity={BannerAlertSeverity.Info}
-                title={accountSyncingLoadingMessage}
-                description={strings('rewards.settings.accounts_syncing')}
-                testID="account-syncing-banner"
-              />
-            </Box>
-          )}
-
-          {/* Current Account Not Opted In Banner */}
-          {hasAccountOptedIn === false && (
-            <Box twClassName="-mx-4">
-              <Banner
-                variant={BannerVariant.Alert}
-                severity={BannerAlertSeverity.Info}
-                title={strings('rewards.unlinked_account_info.title')}
-                description={strings(
-                  'rewards.unlinked_account_info.description',
-                )}
-              />
-            </Box>
+            <RewardsInfoBanner
+              title={accountSyncingLoadingMessage}
+              description={strings('rewards.settings.accounts_syncing')}
+              testID="account-syncing-banner"
+            />
           )}
 
           {/* Section 2: Account Tabs */}

--- a/app/components/UI/Rewards/components/Onboarding/OnboardingIntroStep.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/OnboardingIntroStep.tsx
@@ -38,6 +38,7 @@ import ButtonHero from '../../../../../component-library/components-temp/Buttons
 import { useGeoRewardsMetadata } from '../../hooks/useGeoRewardsMetadata';
 import { selectSelectedInternalAccount } from '../../../../../selectors/accountsController';
 import { isHardwareAccount } from '../../../../../util/address';
+import Engine from '../../../../../core/Engine';
 
 /**
  * OnboardingIntroStep Component
@@ -156,6 +157,21 @@ const OnboardingIntroStep: React.FC = () => {
       showErrorModal(
         'rewards.onboarding.not_supported_hardware_account_title',
         'rewards.onboarding.not_supported_hardware_account_description',
+      );
+      return;
+    }
+
+    // Check if account type is supported for opt-in
+    if (
+      internalAccount &&
+      !Engine.controllerMessenger.call(
+        'RewardsController:isOptInSupported',
+        internalAccount,
+      )
+    ) {
+      showErrorModal(
+        'rewards.onboarding.not_supported_account_type_title',
+        'rewards.onboarding.not_supported_account_type_description',
       );
       return;
     }

--- a/app/components/UI/Rewards/components/RewardsInfoBanner.test.tsx
+++ b/app/components/UI/Rewards/components/RewardsInfoBanner.test.tsx
@@ -1,0 +1,450 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { Text } from '@metamask/design-system-react-native';
+import RewardsInfoBanner from './RewardsInfoBanner';
+
+describe('RewardsInfoBanner', () => {
+  const defaultProps = {
+    title: 'Info Title',
+    description: 'Information description message',
+  };
+
+  describe('basic rendering', () => {
+    it('renders title and description', () => {
+      // Arrange & Act
+      const { getByText } = render(<RewardsInfoBanner {...defaultProps} />);
+
+      // Assert
+      expect(getByText('Info Title')).toBeOnTheScreen();
+      expect(getByText('Information description message')).toBeOnTheScreen();
+    });
+
+    it('renders with custom testID', () => {
+      // Arrange & Act
+      const { getByTestId } = render(
+        <RewardsInfoBanner {...defaultProps} testID="custom-banner" />,
+      );
+
+      // Assert
+      expect(getByTestId('custom-banner')).toBeOnTheScreen();
+    });
+
+    it('renders title as React node when provided', () => {
+      // Arrange
+      const customTitleNode = (
+        <Text testID="custom-title-node">Custom Title Node</Text>
+      );
+
+      // Act
+      const { getByTestId, queryByText } = render(
+        <RewardsInfoBanner {...defaultProps} title={customTitleNode} />,
+      );
+
+      // Assert
+      expect(getByTestId('custom-title-node')).toBeOnTheScreen();
+      expect(queryByText('Info Title')).toBeNull();
+    });
+
+    it('renders title as string when provided as string', () => {
+      // Arrange & Act
+      const { getByText } = render(
+        <RewardsInfoBanner {...defaultProps} title="String Title" />,
+      );
+
+      // Assert
+      expect(getByText('String Title')).toBeOnTheScreen();
+    });
+  });
+
+  describe('button rendering', () => {
+    it('does not render buttons when no callbacks provided', () => {
+      // Arrange & Act
+      const { queryByText } = render(<RewardsInfoBanner {...defaultProps} />);
+
+      // Assert
+      expect(queryByText('Dismiss')).toBeNull();
+      expect(queryByText('Confirm')).toBeNull();
+    });
+
+    it('renders dismiss button when onDismiss callback provided', () => {
+      // Arrange
+      const onDismiss = jest.fn();
+
+      // Act
+      const { getByText, queryByText } = render(
+        <RewardsInfoBanner {...defaultProps} onDismiss={onDismiss} />,
+      );
+
+      // Assert
+      expect(getByText('Dismiss')).toBeOnTheScreen();
+      expect(queryByText('Confirm')).toBeNull();
+    });
+
+    it('renders confirm button when onConfirm callback provided', () => {
+      // Arrange
+      const onConfirm = jest.fn();
+
+      // Act
+      const { getByText, queryByText } = render(
+        <RewardsInfoBanner {...defaultProps} onConfirm={onConfirm} />,
+      );
+
+      // Assert
+      expect(getByText('Confirm')).toBeOnTheScreen();
+      expect(queryByText('Dismiss')).toBeNull();
+    });
+
+    it('renders both buttons when both callbacks provided', () => {
+      // Arrange
+      const onDismiss = jest.fn();
+      const onConfirm = jest.fn();
+
+      // Act
+      const { getByText } = render(
+        <RewardsInfoBanner
+          {...defaultProps}
+          onDismiss={onDismiss}
+          onConfirm={onConfirm}
+        />,
+      );
+
+      // Assert
+      expect(getByText('Dismiss')).toBeOnTheScreen();
+      expect(getByText('Confirm')).toBeOnTheScreen();
+    });
+  });
+
+  describe('button interactions', () => {
+    it('calls onDismiss when dismiss button pressed', () => {
+      // Arrange
+      const onDismiss = jest.fn();
+      const { getByText } = render(
+        <RewardsInfoBanner {...defaultProps} onDismiss={onDismiss} />,
+      );
+
+      // Act
+      fireEvent.press(getByText('Dismiss'));
+
+      // Assert
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onConfirm when confirm button pressed', () => {
+      // Arrange
+      const onConfirm = jest.fn();
+      const { getByText } = render(
+        <RewardsInfoBanner {...defaultProps} onConfirm={onConfirm} />,
+      );
+
+      // Act
+      fireEvent.press(getByText('Confirm'));
+
+      // Assert
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls respective callbacks when both buttons pressed', () => {
+      // Arrange
+      const onDismiss = jest.fn();
+      const onConfirm = jest.fn();
+      const { getByText } = render(
+        <RewardsInfoBanner
+          {...defaultProps}
+          onDismiss={onDismiss}
+          onConfirm={onConfirm}
+        />,
+      );
+
+      // Act
+      fireEvent.press(getByText('Dismiss'));
+      fireEvent.press(getByText('Confirm'));
+
+      // Assert
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not throw error when buttons pressed multiple times', () => {
+      // Arrange
+      const onDismiss = jest.fn();
+      const onConfirm = jest.fn();
+      const { getByText } = render(
+        <RewardsInfoBanner
+          {...defaultProps}
+          onDismiss={onDismiss}
+          onConfirm={onConfirm}
+        />,
+      );
+
+      // Act & Assert - Should not throw
+      expect(() => {
+        fireEvent.press(getByText('Dismiss'));
+        fireEvent.press(getByText('Dismiss'));
+        fireEvent.press(getByText('Confirm'));
+        fireEvent.press(getByText('Confirm'));
+      }).not.toThrow();
+
+      expect(onDismiss).toHaveBeenCalledTimes(2);
+      expect(onConfirm).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('custom confirm button label', () => {
+    it('renders default "Confirm" label when no custom label provided', () => {
+      // Arrange
+      const onConfirm = jest.fn();
+
+      // Act
+      const { getByText } = render(
+        <RewardsInfoBanner {...defaultProps} onConfirm={onConfirm} />,
+      );
+
+      // Assert
+      expect(getByText('Confirm')).toBeOnTheScreen();
+    });
+
+    it('renders custom confirm button label when provided', () => {
+      // Arrange
+      const onConfirm = jest.fn();
+      const customLabel = 'Get Started';
+
+      // Act
+      const { getByText, queryByText } = render(
+        <RewardsInfoBanner
+          {...defaultProps}
+          onConfirm={onConfirm}
+          confirmButtonLabel={customLabel}
+        />,
+      );
+
+      // Assert
+      expect(getByText('Get Started')).toBeOnTheScreen();
+      expect(queryByText('Confirm')).toBeNull();
+    });
+
+    it('calls onConfirm when custom labeled button pressed', () => {
+      // Arrange
+      const onConfirm = jest.fn();
+      const customLabel = 'Continue';
+      const { getByText } = render(
+        <RewardsInfoBanner
+          {...defaultProps}
+          onConfirm={onConfirm}
+          confirmButtonLabel={customLabel}
+        />,
+      );
+
+      // Act
+      fireEvent.press(getByText('Continue'));
+
+      // Assert
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles empty confirm button label gracefully', () => {
+      // Arrange
+      const onConfirm = jest.fn();
+
+      // Act
+      const { getByText } = render(
+        <RewardsInfoBanner
+          {...defaultProps}
+          onConfirm={onConfirm}
+          confirmButtonLabel=""
+        />,
+      );
+
+      // Assert - Should fall back to default "Confirm" label
+      expect(getByText('Confirm')).toBeOnTheScreen();
+    });
+  });
+
+  describe('confirm button loading state', () => {
+    it('shows loading state when onConfirmLoading is true', () => {
+      // Arrange
+      const onConfirm = jest.fn();
+
+      // Act
+      const { getByText } = render(
+        <RewardsInfoBanner
+          {...defaultProps}
+          onConfirm={onConfirm}
+          onConfirmLoading
+        />,
+      );
+
+      // Assert
+      const confirmButton = getByText('Confirm');
+      expect(confirmButton).toBeOnTheScreen();
+      // The button should be in loading state (this depends on Button component implementation)
+    });
+
+    it('does not show loading state when onConfirmLoading is false', () => {
+      // Arrange
+      const onConfirm = jest.fn();
+
+      // Act
+      const { getByText } = render(
+        <RewardsInfoBanner {...defaultProps} onConfirm={onConfirm} />,
+      );
+
+      // Assert
+      const confirmButton = getByText('Confirm');
+      expect(confirmButton).toBeOnTheScreen();
+    });
+
+    it('shows loading state with custom button label', () => {
+      // Arrange
+      const onConfirm = jest.fn();
+      const customLabel = 'Processing';
+
+      // Act
+      const { getByText } = render(
+        <RewardsInfoBanner
+          {...defaultProps}
+          onConfirm={onConfirm}
+          confirmButtonLabel={customLabel}
+          onConfirmLoading
+        />,
+      );
+
+      // Assert
+      const confirmButton = getByText('Processing');
+      expect(confirmButton).toBeOnTheScreen();
+    });
+
+    it('cannot call onConfirm when loading', () => {
+      // Arrange
+      const onConfirm = jest.fn();
+      const { getByText } = render(
+        <RewardsInfoBanner
+          {...defaultProps}
+          onConfirm={onConfirm}
+          onConfirmLoading
+        />,
+      );
+
+      // Act
+      fireEvent.press(getByText('Confirm'));
+
+      // Assert
+      expect(onConfirm).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('layout and structure', () => {
+    it('maintains proper layout with both buttons and custom labels', () => {
+      // Arrange
+      const onDismiss = jest.fn();
+      const onConfirm = jest.fn();
+
+      // Act
+      const { getByText } = render(
+        <RewardsInfoBanner
+          {...defaultProps}
+          onDismiss={onDismiss}
+          onConfirm={onConfirm}
+          confirmButtonLabel="Custom Confirm"
+        />,
+      );
+
+      // Assert - Check that all elements are present and accessible
+      expect(getByText('Info Title')).toBeOnTheScreen();
+      expect(getByText('Information description message')).toBeOnTheScreen();
+      expect(getByText('Dismiss')).toBeOnTheScreen();
+      expect(getByText('Custom Confirm')).toBeOnTheScreen();
+    });
+
+    it('renders with title as React node and buttons', () => {
+      // Arrange
+      const customTitleNode = (
+        <Text testID="custom-title">Custom React Title</Text>
+      );
+      const onDismiss = jest.fn();
+      const onConfirm = jest.fn();
+
+      // Act
+      const { getByTestId, getByText } = render(
+        <RewardsInfoBanner
+          title={customTitleNode}
+          description="Test description"
+          onDismiss={onDismiss}
+          onConfirm={onConfirm}
+        />,
+      );
+
+      // Assert
+      expect(getByTestId('custom-title')).toBeOnTheScreen();
+      expect(getByText('Test description')).toBeOnTheScreen();
+      expect(getByText('Dismiss')).toBeOnTheScreen();
+      expect(getByText('Confirm')).toBeOnTheScreen();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('renders with empty title and description', () => {
+      // Arrange & Act
+      const renderResult = render(
+        <RewardsInfoBanner title="" description="" />,
+      );
+
+      // Assert - Should render without errors
+      expect(renderResult).toBeTruthy();
+    });
+
+    it('renders with very long title and description', () => {
+      // Arrange
+      const longTitle = 'A'.repeat(100);
+      const longDescription = 'B'.repeat(500);
+
+      // Act
+      const { getByText } = render(
+        <RewardsInfoBanner title={longTitle} description={longDescription} />,
+      );
+
+      // Assert
+      expect(getByText(longTitle)).toBeOnTheScreen();
+      expect(getByText(longDescription)).toBeOnTheScreen();
+    });
+
+    it('renders with all optional props', () => {
+      // Arrange
+      const onDismiss = jest.fn();
+      const onConfirm = jest.fn();
+      const customTitleNode = (
+        <Text testID="full-custom-title">Full Custom Title</Text>
+      );
+
+      // Act
+      const { getByTestId, getByText } = render(
+        <RewardsInfoBanner
+          title={customTitleNode}
+          description="Full feature description"
+          onDismiss={onDismiss}
+          onConfirm={onConfirm}
+          confirmButtonLabel="Custom Action"
+          onConfirmLoading={false}
+          testID="full-banner"
+          showInfoIcon
+        />,
+      );
+
+      // Assert
+      expect(getByTestId('full-banner')).toBeOnTheScreen();
+      expect(getByTestId('full-custom-title')).toBeOnTheScreen();
+      expect(getByText('Full feature description')).toBeOnTheScreen();
+      expect(getByText('Dismiss')).toBeOnTheScreen();
+      expect(getByText('Custom Action')).toBeOnTheScreen();
+    });
+
+    it('renders without icon when showInfoIcon is false', () => {
+      // Arrange & Act
+      const renderResult = render(
+        <RewardsInfoBanner {...defaultProps} showInfoIcon={false} />,
+      );
+
+      // Assert - Should render without errors
+      expect(renderResult).toBeTruthy();
+    });
+  });
+});

--- a/app/components/UI/Rewards/components/RewardsInfoBanner.tsx
+++ b/app/components/UI/Rewards/components/RewardsInfoBanner.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import {
+  Box,
+  Text,
+  Button,
+  Icon,
+  TextVariant,
+  BoxFlexDirection,
+  BoxAlignItems,
+  ButtonVariant,
+  ButtonSize,
+  IconName,
+  IconSize,
+  FontWeight,
+} from '@metamask/design-system-react-native';
+
+interface RewardsInfoBannerProps {
+  title: string | React.ReactNode;
+  description: string;
+  onDismiss?: () => void;
+  onConfirm?: () => void;
+  confirmButtonLabel?: string;
+  onConfirmLoading?: boolean;
+  testID?: string;
+  showInfoIcon?: boolean;
+}
+
+const RewardsInfoBanner: React.FC<RewardsInfoBannerProps> = ({
+  title,
+  description,
+  onDismiss,
+  onConfirm,
+  confirmButtonLabel,
+  onConfirmLoading,
+  testID,
+  showInfoIcon = true,
+}) => (
+  <Box
+    flexDirection={BoxFlexDirection.Row}
+    alignItems={BoxAlignItems.Start}
+    twClassName="bg-info-muted rounded-2xl p-4 gap-4 w-full"
+    testID={testID}
+  >
+    {/* Column 1: Info Icon */}
+    {showInfoIcon && (
+      <Icon
+        name={IconName.Info}
+        size={IconSize.Xl}
+        twClassName="text-info-default"
+      />
+    )}
+
+    {/* Column 2: Content */}
+    <Box twClassName="flex-1 gap-4">
+      <Box twClassName="gap-1">
+        {typeof title === 'string' ? (
+          <Text
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Bold}
+            twClassName="text-default"
+          >
+            {title}
+          </Text>
+        ) : (
+          title
+        )}
+
+        {/* Description */}
+        <Text variant={TextVariant.BodyMd} twClassName="text-default">
+          {description}
+        </Text>
+      </Box>
+
+      {/* Button Section */}
+      {(onDismiss || onConfirm) && (
+        <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-3">
+          {onDismiss && (
+            <Button
+              variant={ButtonVariant.Secondary}
+              size={ButtonSize.Md}
+              onPress={onDismiss}
+            >
+              Dismiss
+            </Button>
+          )}
+          {onConfirm && (
+            <Button
+              variant={ButtonVariant.Primary}
+              size={ButtonSize.Md}
+              onPress={onConfirm}
+              isLoading={onConfirmLoading}
+            >
+              {confirmButtonLabel || 'Confirm'}
+            </Button>
+          )}
+        </Box>
+      )}
+    </Box>
+  </Box>
+);
+
+export default RewardsInfoBanner;

--- a/app/components/UI/Rewards/components/Settings/RewardSettingsTabs.test.tsx
+++ b/app/components/UI/Rewards/components/Settings/RewardSettingsTabs.test.tsx
@@ -227,50 +227,64 @@ jest.mock(
     },
 );
 
-// Mock Banner
-jest.mock('../../../../../component-library/components/Banners/Banner', () => {
+// Mock RewardsInfoBanner
+jest.mock('../RewardsInfoBanner', () => {
   const ReactForBanner = jest.requireActual('react');
   const { View, Text, TouchableOpacity } = jest.requireActual('react-native');
 
-  const Banner = ({
-    title,
-    description,
-    actionButtonProps,
-  }: {
-    title: string;
-    description: string;
-    actionButtonProps?: { label: string; onPress: () => void };
-  }) =>
-    ReactForBanner.createElement(
-      View,
-      { testID: 'banner' },
-      ReactForBanner.createElement(Text, { testID: 'banner-title' }, title),
-      ReactForBanner.createElement(
-        Text,
-        { testID: 'banner-description' },
-        description,
-      ),
-      actionButtonProps &&
-        ReactForBanner.createElement(
-          TouchableOpacity,
-          {
-            onPress: actionButtonProps.onPress,
-            testID: 'banner-action-button',
-          },
-          ReactForBanner.createElement(Text, {}, actionButtonProps.label),
-        ),
-    );
-
   return {
     __esModule: true,
-    default: Banner,
-    BannerVariant: {
-      Alert: 'Alert',
-    },
-    BannerAlertSeverity: {
-      Error: 'Error',
-      Info: 'Info',
-    },
+    default: ({
+      title,
+      description,
+      onDismiss,
+      onConfirm,
+      confirmButtonLabel,
+      onConfirmLoading,
+      testID,
+    }: {
+      title: string | React.ReactNode;
+      description: string;
+      onDismiss?: () => void;
+      onConfirm?: () => void;
+      confirmButtonLabel?: string;
+      onConfirmLoading?: boolean;
+      testID?: string;
+    }) =>
+      ReactForBanner.createElement(
+        View,
+        { testID: testID || 'rewards-info-banner' },
+        ReactForBanner.createElement(
+          Text,
+          { testID: 'info-banner-title' },
+          typeof title === 'string' ? title : 'Complex Title',
+        ),
+        ReactForBanner.createElement(
+          Text,
+          { testID: 'info-banner-description' },
+          description,
+        ),
+        onDismiss &&
+          ReactForBanner.createElement(
+            TouchableOpacity,
+            { testID: 'info-banner-dismiss-button', onPress: onDismiss },
+            ReactForBanner.createElement(Text, {}, 'Dismiss'),
+          ),
+        onConfirm &&
+          ReactForBanner.createElement(
+            TouchableOpacity,
+            {
+              testID: 'info-banner-confirm-button',
+              onPress: onConfirm,
+              disabled: onConfirmLoading,
+            },
+            ReactForBanner.createElement(
+              Text,
+              {},
+              confirmButtonLabel || 'Confirm',
+            ),
+          ),
+      ),
   };
 });
 

--- a/app/components/UI/Rewards/components/Settings/RewardSettingsTabs.tsx
+++ b/app/components/UI/Rewards/components/Settings/RewardSettingsTabs.tsx
@@ -20,10 +20,7 @@ import { InternalAccount } from '@metamask/keyring-internal-api';
 import { strings } from '../../../../../../locales/i18n';
 import { TabsList } from '../../../../../component-library/components-temp/Tabs';
 import AccountDisplayItem from '../AccountDisplayItem/AccountDisplayItem';
-import Banner, {
-  BannerVariant,
-  BannerAlertSeverity,
-} from '../../../../../component-library/components/Banners/Banner';
+import RewardsInfoBanner from '../RewardsInfoBanner';
 import RewardsErrorBanner from '../RewardsErrorBanner';
 import { TabViewProps } from '../../../Perps/components/PerpsMarketTabs/PerpsMarketTabs.types';
 import { Skeleton } from '../../../../../component-library/components/Skeleton';
@@ -269,9 +266,7 @@ const RewardSettingsTabs: React.FC<RewardSettingsTabsProps> = ({
           </Box>
         ) : (
           <Box twClassName="py-8">
-            <Banner
-              variant={BannerVariant.Alert}
-              severity={BannerAlertSeverity.Info}
+            <RewardsInfoBanner
               title={strings('rewards.settings.all_accounts_linked_title')}
               description={strings(
                 'rewards.settings.all_accounts_linked_description',

--- a/app/components/UI/Rewards/hooks/useRewardOptinSummary.test.ts
+++ b/app/components/UI/Rewards/hooks/useRewardOptinSummary.test.ts
@@ -128,6 +128,17 @@ describe('useRewardOptinSummary', () => {
       loadingMessage: null,
     });
 
+    // Mock RewardsController:isOptInSupported to return true for all accounts by default
+    mockEngineCall.mockImplementation((method: string, ..._args) => {
+      if (method === 'RewardsController:isOptInSupported') {
+        return true; // Default: all accounts are supported
+      }
+      if (method === 'RewardsController:getOptInStatus') {
+        return Promise.resolve({ ois: [true, false, true] }); // Default response
+      }
+      return Promise.resolve();
+    });
+
     // Reset the mocked hooks
     mockUseFocusEffect.mockClear();
   });
@@ -157,6 +168,7 @@ describe('useRewardOptinSummary', () => {
       expect(result.current.isLoading).toBe(true);
       expect(result.current.hasError).toBe(false);
       expect(result.current.currentAccountOptedIn).toBeNull();
+      expect(result.current.currentAccountSupported).toBeNull();
       expect(typeof result.current.refresh).toBe('function');
     });
 
@@ -174,7 +186,16 @@ describe('useRewardOptinSummary', () => {
       const mockResponse: OptInStatusDto = {
         ois: [true, false, true], // Account1: true, Account2: false, Account3: true
       };
-      mockEngineCall.mockResolvedValueOnce(mockResponse);
+
+      mockEngineCall.mockImplementation((method: string, ..._args) => {
+        if (method === 'RewardsController:isOptInSupported') {
+          return true; // All accounts are supported
+        }
+        if (method === 'RewardsController:getOptInStatus') {
+          return Promise.resolve(mockResponse);
+        }
+        return Promise.resolve();
+      });
 
       const { result, waitForNextUpdate } = renderHook(() =>
         useRewardOptinSummary(),
@@ -194,6 +215,7 @@ describe('useRewardOptinSummary', () => {
       expect(result.current.isLoading).toBe(false);
       expect(result.current.hasError).toBe(false);
       expect(result.current.currentAccountOptedIn).toBe(true); // Account1 is selected and opted in
+      expect(result.current.currentAccountSupported).toBe(true); // Account1 is supported
 
       // Check linked accounts (opted in)
       expect(result.current.linkedAccounts).toHaveLength(2);
@@ -213,6 +235,20 @@ describe('useRewardOptinSummary', () => {
         hasOptedIn: false,
       });
 
+      // Verify that isOptInSupported was called for each account
+      expect(mockEngineCall).toHaveBeenCalledWith(
+        'RewardsController:isOptInSupported',
+        mockAccount1,
+      );
+      expect(mockEngineCall).toHaveBeenCalledWith(
+        'RewardsController:isOptInSupported',
+        mockAccount2,
+      );
+      expect(mockEngineCall).toHaveBeenCalledWith(
+        'RewardsController:isOptInSupported',
+        mockAccount3,
+      );
+
       expect(mockEngineCall).toHaveBeenCalledWith(
         'RewardsController:getOptInStatus',
         {
@@ -230,7 +266,16 @@ describe('useRewardOptinSummary', () => {
       const mockResponse: OptInStatusDto = {
         ois: [false, false, false],
       };
-      mockEngineCall.mockResolvedValueOnce(mockResponse);
+
+      mockEngineCall.mockImplementation((method: string, ..._args) => {
+        if (method === 'RewardsController:isOptInSupported') {
+          return true; // All accounts are supported
+        }
+        if (method === 'RewardsController:getOptInStatus') {
+          return Promise.resolve(mockResponse);
+        }
+        return Promise.resolve();
+      });
 
       const { result, waitForNextUpdate } = renderHook(() =>
         useRewardOptinSummary(),
@@ -249,6 +294,7 @@ describe('useRewardOptinSummary', () => {
       expect(result.current.linkedAccounts).toHaveLength(0);
       expect(result.current.unlinkedAccounts).toHaveLength(3);
       expect(result.current.currentAccountOptedIn).toBe(false);
+      expect(result.current.currentAccountSupported).toBe(true);
     });
 
     it('should handle all accounts opted in', async () => {
@@ -256,7 +302,16 @@ describe('useRewardOptinSummary', () => {
       const mockResponse: OptInStatusDto = {
         ois: [true, true, true],
       };
-      mockEngineCall.mockResolvedValueOnce(mockResponse);
+
+      mockEngineCall.mockImplementation((method: string, ..._args) => {
+        if (method === 'RewardsController:isOptInSupported') {
+          return true; // All accounts are supported
+        }
+        if (method === 'RewardsController:getOptInStatus') {
+          return Promise.resolve(mockResponse);
+        }
+        return Promise.resolve();
+      });
 
       const { result, waitForNextUpdate } = renderHook(() =>
         useRewardOptinSummary(),
@@ -275,6 +330,7 @@ describe('useRewardOptinSummary', () => {
       expect(result.current.linkedAccounts).toHaveLength(3);
       expect(result.current.unlinkedAccounts).toHaveLength(0);
       expect(result.current.currentAccountOptedIn).toBe(true);
+      expect(result.current.currentAccountSupported).toBe(true);
     });
 
     it('should handle selected account not in accounts list', async () => {
@@ -293,7 +349,16 @@ describe('useRewardOptinSummary', () => {
       const mockResponse: OptInStatusDto = {
         ois: [true, false, true],
       };
-      mockEngineCall.mockResolvedValueOnce(mockResponse);
+
+      mockEngineCall.mockImplementation((method: string, ..._args) => {
+        if (method === 'RewardsController:isOptInSupported') {
+          return true; // All accounts are supported
+        }
+        if (method === 'RewardsController:getOptInStatus') {
+          return Promise.resolve(mockResponse);
+        }
+        return Promise.resolve();
+      });
 
       const { result, waitForNextUpdate } = renderHook(() =>
         useRewardOptinSummary(),
@@ -310,6 +375,7 @@ describe('useRewardOptinSummary', () => {
 
       // Assert
       expect(result.current.currentAccountOptedIn).toBe(false); // Should default to false
+      expect(result.current.currentAccountSupported).toBe(false); // Different account not in supported list
     });
   });
 
@@ -317,7 +383,16 @@ describe('useRewardOptinSummary', () => {
     it('should handle API errors and set error state', async () => {
       // Arrange
       const mockError = new Error('Network error');
-      mockEngineCall.mockRejectedValueOnce(mockError);
+
+      mockEngineCall.mockImplementation((method: string, ..._args) => {
+        if (method === 'RewardsController:isOptInSupported') {
+          return true; // All accounts are supported
+        }
+        if (method === 'RewardsController:getOptInStatus') {
+          return Promise.reject(mockError);
+        }
+        return Promise.resolve();
+      });
 
       const { result, waitForNextUpdate } = renderHook(() =>
         useRewardOptinSummary(),
@@ -338,6 +413,7 @@ describe('useRewardOptinSummary', () => {
       expect(result.current.linkedAccounts).toEqual([]);
       expect(result.current.unlinkedAccounts).toEqual([]);
       expect(result.current.currentAccountOptedIn).toBeNull();
+      expect(result.current.currentAccountSupported).toBeNull();
 
       expect(mockLoggerLog).toHaveBeenCalledWith(
         'useRewardOptinSummary: Failed to fetch opt-in status',
@@ -348,7 +424,16 @@ describe('useRewardOptinSummary', () => {
     it('should set loading to true at start and false after error', async () => {
       // Arrange
       const mockError = new Error('Network error');
-      mockEngineCall.mockRejectedValueOnce(mockError);
+
+      mockEngineCall.mockImplementation((method: string, ..._args) => {
+        if (method === 'RewardsController:isOptInSupported') {
+          return true; // All accounts are supported
+        }
+        if (method === 'RewardsController:getOptInStatus') {
+          return Promise.reject(mockError);
+        }
+        return Promise.resolve();
+      });
 
       const { result, waitForNextUpdate } = renderHook(() =>
         useRewardOptinSummary(),
@@ -381,39 +466,6 @@ describe('useRewardOptinSummary', () => {
       focusCallback();
 
       expect(mockEngineCall).not.toHaveBeenCalled();
-    });
-
-    it('should not refetch when enabled changes from true to false', async () => {
-      // Arrange
-      const mockResponse: OptInStatusDto = {
-        ois: [true, false, true],
-      };
-      mockEngineCall.mockResolvedValueOnce(mockResponse);
-
-      const { rerender, waitForNextUpdate } = renderHook(
-        ({ enabled }) => useRewardOptinSummary({ enabled }),
-        {
-          initialProps: { enabled: true },
-        },
-      );
-
-      // Verify that the focus effect callback was registered
-      expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
-
-      // Execute the focus effect callback to trigger the fetch logic
-      const focusCallback = mockUseFocusEffect.mock.calls[0][0];
-      focusCallback();
-
-      await waitForNextUpdate();
-
-      // Assert initial call
-      expect(mockEngineCall).toHaveBeenCalledTimes(1);
-
-      // Act - disable
-      rerender({ enabled: false });
-
-      // Assert - no additional calls
-      expect(mockEngineCall).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -461,7 +513,16 @@ describe('useRewardOptinSummary', () => {
       const mockResponse: OptInStatusDto = {
         ois: [true, false, true],
       };
-      mockEngineCall.mockResolvedValueOnce(mockResponse);
+
+      mockEngineCall.mockImplementation((method: string, ..._args) => {
+        if (method === 'RewardsController:isOptInSupported') {
+          return true; // All accounts are supported
+        }
+        if (method === 'RewardsController:getOptInStatus') {
+          return Promise.resolve(mockResponse);
+        }
+        return Promise.resolve();
+      });
 
       const { result, waitForNextUpdate } = renderHook(() =>
         useRewardOptinSummary(),
@@ -478,6 +539,127 @@ describe('useRewardOptinSummary', () => {
 
       // Assert
       expect(result.current.currentAccountOptedIn).toBe(false); // Should default to false
+      expect(result.current.currentAccountSupported).toBe(false); // No selected account
+    });
+  });
+
+  describe('account support filtering', () => {
+    it('should only fetch opt-in status for supported accounts', async () => {
+      // Arrange - Only account1 and account3 are supported
+      const mockResponse: OptInStatusDto = {
+        ois: [true, false], // Only 2 accounts supported: account1 (true), account3 (false)
+      };
+
+      mockEngineCall.mockImplementation((method: string, ...args) => {
+        if (method === 'RewardsController:isOptInSupported') {
+          const [account] = args as [InternalAccount];
+          // Only account1 and account3 are supported
+          return (
+            account.address === mockAccount1.address ||
+            account.address === mockAccount3.address
+          );
+        }
+        if (method === 'RewardsController:getOptInStatus') {
+          return Promise.resolve(mockResponse);
+        }
+        return Promise.resolve();
+      });
+
+      const { result, waitForNextUpdate } = renderHook(() =>
+        useRewardOptinSummary(),
+      );
+
+      // Execute the focus effect callback to trigger the fetch logic
+      const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+      focusCallback();
+
+      await waitForNextUpdate();
+
+      // Assert
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.hasError).toBe(false);
+      expect(result.current.currentAccountOptedIn).toBe(true); // Account1 is selected and opted in
+      expect(result.current.currentAccountSupported).toBe(true); // Account1 is supported
+
+      // Should only have 2 accounts total (account2 was filtered out)
+      expect(result.current.linkedAccounts).toHaveLength(1); // Only account1 opted in
+      expect(result.current.unlinkedAccounts).toHaveLength(1); // Only account3 not opted in
+
+      expect(result.current.linkedAccounts[0]).toMatchObject({
+        ...mockAccount1,
+        hasOptedIn: true,
+      });
+      expect(result.current.unlinkedAccounts[0]).toMatchObject({
+        ...mockAccount3,
+        hasOptedIn: false,
+      });
+
+      // Verify that getOptInStatus was called with only supported account addresses
+      expect(mockEngineCall).toHaveBeenCalledWith(
+        'RewardsController:getOptInStatus',
+        {
+          addresses: [mockAccount1.address, mockAccount3.address],
+        },
+      );
+    });
+
+    it('should handle when selected account is unsupported but others are supported', async () => {
+      // Arrange - Account1 (selected) is unsupported, but account2 and account3 are supported
+      const mockResponse: OptInStatusDto = {
+        ois: [true, false], // account2 (true), account3 (false)
+      };
+
+      mockEngineCall.mockImplementation((method: string, ...args) => {
+        if (method === 'RewardsController:isOptInSupported') {
+          const [account] = args as [InternalAccount];
+          // Only account2 and account3 are supported (not account1)
+          return (
+            account.address === mockAccount2.address ||
+            account.address === mockAccount3.address
+          );
+        }
+        if (method === 'RewardsController:getOptInStatus') {
+          return Promise.resolve(mockResponse);
+        }
+        return Promise.resolve();
+      });
+
+      const { result, waitForNextUpdate } = renderHook(() =>
+        useRewardOptinSummary(),
+      );
+
+      // Execute the focus effect callback to trigger the fetch logic
+      const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+      focusCallback();
+
+      await waitForNextUpdate();
+
+      // Assert
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.hasError).toBe(false);
+      expect(result.current.currentAccountOptedIn).toBe(false); // Account1 is selected but unsupported
+      expect(result.current.currentAccountSupported).toBe(false); // Account1 is not supported
+
+      // Should have data for the 2 supported accounts
+      expect(result.current.linkedAccounts).toHaveLength(1); // account2 opted in
+      expect(result.current.unlinkedAccounts).toHaveLength(1); // account3 not opted in
+
+      expect(result.current.linkedAccounts[0]).toMatchObject({
+        ...mockAccount2,
+        hasOptedIn: true,
+      });
+      expect(result.current.unlinkedAccounts[0]).toMatchObject({
+        ...mockAccount3,
+        hasOptedIn: false,
+      });
+
+      // Verify that getOptInStatus was called with only supported account addresses
+      expect(mockEngineCall).toHaveBeenCalledWith(
+        'RewardsController:getOptInStatus',
+        {
+          addresses: [mockAccount2.address, mockAccount3.address],
+        },
+      );
     });
   });
 
@@ -558,28 +740,6 @@ describe('useRewardOptinSummary', () => {
           addresses: [mockAccount1.address, mockAccount2.address],
         },
       );
-    });
-  });
-
-  describe('refresh functionality', () => {
-    it('should prevent duplicate refresh calls when already loading', async () => {
-      // Arrange - setup to never resolve to simulate loading
-      mockEngineCall.mockImplementation(
-        () =>
-          new Promise(() => {
-            // Never resolves
-          }),
-      );
-
-      const { result } = renderHook(() => useRewardOptinSummary());
-
-      // Act - call refresh multiple times quickly
-      result.current.refresh();
-      result.current.refresh();
-      result.current.refresh();
-
-      // Assert - should only call once due to loading ref protection
-      expect(mockEngineCall).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/app/components/UI/Rewards/utils.test.ts
+++ b/app/components/UI/Rewards/utils.test.ts
@@ -1,9 +1,194 @@
 import {
   handleRewardsErrorMessage,
   SOLANA_SIGNUP_NOT_SUPPORTED,
+  convertInternalAccountToCaipAccountId,
 } from './utils';
+import { parseCaipChainId, toCaipAccountId } from '@metamask/utils';
+import Logger from '../../../util/Logger';
+import { InternalAccount } from '@metamask/keyring-internal-api';
+
+// Mock external dependencies
+jest.mock('@metamask/utils', () => ({
+  parseCaipChainId: jest.fn(),
+  toCaipAccountId: jest.fn(),
+}));
+
+jest.mock('../../../util/Logger', () => ({
+  log: jest.fn(),
+}));
+
+const mockParseCaipChainId = parseCaipChainId as jest.MockedFunction<
+  typeof parseCaipChainId
+>;
+const mockToCaipAccountId = toCaipAccountId as jest.MockedFunction<
+  typeof toCaipAccountId
+>;
+const mockLogger = Logger as jest.Mocked<typeof Logger>;
 
 describe('Rewards Utils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('convertInternalAccountToCaipAccountId', () => {
+    const mockAccount: InternalAccount = {
+      id: 'test-account-id',
+      address: '0x1234567890123456789012345678901234567890',
+      scopes: ['eip155:1'],
+      type: 'eip155:eoa',
+      options: {},
+      methods: [],
+      metadata: {
+        name: 'Test Account',
+        keyring: { type: 'HD Key Tree' },
+        importTime: Date.now(),
+      },
+    };
+
+    describe('successful conversion', () => {
+      it('should convert Ethereum account to CAIP account ID successfully', () => {
+        // Arrange
+        const expectedNamespace = 'eip155';
+        const expectedReference = '1';
+        const expectedCaipAccountId =
+          'eip155:1:0x1234567890123456789012345678901234567890';
+
+        mockParseCaipChainId.mockReturnValue({
+          namespace: expectedNamespace,
+          reference: expectedReference,
+        });
+        mockToCaipAccountId.mockReturnValue(expectedCaipAccountId);
+
+        // Act
+        const result = convertInternalAccountToCaipAccountId(mockAccount);
+
+        // Assert
+        expect(mockParseCaipChainId).toHaveBeenCalledWith('eip155:1');
+        expect(mockToCaipAccountId).toHaveBeenCalledWith(
+          expectedNamespace,
+          expectedReference,
+          mockAccount.address,
+        );
+        expect(result).toBe(expectedCaipAccountId);
+        expect(mockLogger.log).not.toHaveBeenCalled();
+      });
+
+      it('should convert Solana account to CAIP account ID successfully', () => {
+        // Arrange
+        const solanaAccount: InternalAccount = {
+          ...mockAccount,
+          address: '11111111111111111111111111111112',
+          scopes: ['solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'],
+        };
+        const expectedNamespace = 'solana';
+        const expectedReference = '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+        const expectedCaipAccountId =
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:11111111111111111111111111111112';
+
+        mockParseCaipChainId.mockReturnValue({
+          namespace: expectedNamespace,
+          reference: expectedReference,
+        });
+        mockToCaipAccountId.mockReturnValue(expectedCaipAccountId);
+
+        // Act
+        const result = convertInternalAccountToCaipAccountId(solanaAccount);
+
+        // Assert
+        expect(mockParseCaipChainId).toHaveBeenCalledWith(
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        );
+        expect(mockToCaipAccountId).toHaveBeenCalledWith(
+          expectedNamespace,
+          expectedReference,
+          solanaAccount.address,
+        );
+        expect(result).toBe(expectedCaipAccountId);
+        expect(mockLogger.log).not.toHaveBeenCalled();
+      });
+
+      it('should use the first scope when account has multiple scopes', () => {
+        // Arrange
+        const multiScopeAccount: InternalAccount = {
+          ...mockAccount,
+          scopes: ['eip155:1', 'eip155:137', 'eip155:56'],
+        };
+        const expectedNamespace = 'eip155';
+        const expectedReference = '1';
+        const expectedCaipAccountId =
+          'eip155:1:0x1234567890123456789012345678901234567890';
+
+        mockParseCaipChainId.mockReturnValue({
+          namespace: expectedNamespace,
+          reference: expectedReference,
+        });
+        mockToCaipAccountId.mockReturnValue(expectedCaipAccountId);
+
+        // Act
+        const result = convertInternalAccountToCaipAccountId(multiScopeAccount);
+
+        // Assert
+        expect(mockParseCaipChainId).toHaveBeenCalledWith('eip155:1');
+        expect(mockToCaipAccountId).toHaveBeenCalledWith(
+          expectedNamespace,
+          expectedReference,
+          multiScopeAccount.address,
+        );
+        expect(result).toBe(expectedCaipAccountId);
+      });
+    });
+
+    describe('error handling', () => {
+      it('should return null and log error when parseCaipChainId throws', () => {
+        // Arrange
+        const parseError = new Error('Invalid CAIP chain ID format');
+        mockParseCaipChainId.mockImplementation(() => {
+          throw parseError;
+        });
+
+        // Act
+        const result = convertInternalAccountToCaipAccountId(mockAccount);
+
+        // Assert
+        expect(result).toBeNull();
+        expect(mockLogger.log).toHaveBeenCalledWith(
+          'RewardsUtils: Failed to convert address to CAIP-10 format:',
+          parseError,
+        );
+        expect(mockParseCaipChainId).toHaveBeenCalledWith('eip155:1');
+        expect(mockToCaipAccountId).not.toHaveBeenCalled();
+      });
+
+      it('should return null and log error when toCaipAccountId throws', () => {
+        // Arrange
+        const convertError = new Error('Invalid account address format');
+        mockParseCaipChainId.mockReturnValue({
+          namespace: 'eip155',
+          reference: '1',
+        });
+        mockToCaipAccountId.mockImplementation(() => {
+          throw convertError;
+        });
+
+        // Act
+        const result = convertInternalAccountToCaipAccountId(mockAccount);
+
+        // Assert
+        expect(result).toBeNull();
+        expect(mockLogger.log).toHaveBeenCalledWith(
+          'RewardsUtils: Failed to convert address to CAIP-10 format:',
+          convertError,
+        );
+        expect(mockParseCaipChainId).toHaveBeenCalledWith('eip155:1');
+        expect(mockToCaipAccountId).toHaveBeenCalledWith(
+          'eip155',
+          '1',
+          mockAccount.address,
+        );
+      });
+    });
+  });
+
   describe('SOLANA_SIGNUP_NOT_SUPPORTED constant', () => {
     it('should export the correct message for Solana signup not supported', () => {
       // Arrange & Act & Assert

--- a/app/components/UI/Rewards/utils.ts
+++ b/app/components/UI/Rewards/utils.ts
@@ -1,5 +1,12 @@
+import {
+  CaipAccountId,
+  parseCaipChainId,
+  toCaipAccountId,
+} from '@metamask/utils';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
+import { InternalAccount } from '@metamask/keyring-internal-api';
+import Logger from '../../../util/Logger';
 
 // Initialize dayjs with relativeTime plugin
 dayjs.extend(relativeTime);
@@ -40,4 +47,20 @@ export const handleRewardsErrorMessage = (error: unknown) => {
     return 'Service is not available at the moment. Please try again shortly.';
   }
   return message;
+};
+
+export const convertInternalAccountToCaipAccountId = (
+  account: InternalAccount,
+): CaipAccountId | null => {
+  try {
+    const [scope] = account.scopes;
+    const { namespace, reference } = parseCaipChainId(scope);
+    return toCaipAccountId(namespace, reference, account.address);
+  } catch (error) {
+    Logger.log(
+      'RewardsUtils: Failed to convert address to CAIP-10 format:',
+      error,
+    );
+    return null;
+  }
 };

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -329,6 +329,10 @@ export class RewardsController extends BaseController<
       'RewardsController:claimReward',
       this.claimReward.bind(this),
     );
+    this.messagingSystem.registerActionHandler(
+      'RewardsController:isOptInSupported',
+      this.isOptInSupported.bind(this),
+    );
   }
 
   /**
@@ -503,9 +507,12 @@ export class RewardsController extends BaseController<
   /**
    * Check if silent authentication should be skipped
    */
-  #shouldSkipSilentAuth(account: CaipAccountId, address: string): boolean {
-    // Skip for hardware
-    if (isHardwareAccount(address)) return true;
+  #shouldSkipSilentAuth(
+    account: CaipAccountId,
+    internalAccount: InternalAccount,
+  ): boolean {
+    // Skip if opt-in is not supported (e.g., hardware wallets, unsupported account types)
+    if (!this.isOptInSupported(internalAccount)) return true;
 
     const now = Date.now();
 
@@ -518,6 +525,43 @@ export class RewardsController extends BaseController<
     }
 
     return false;
+  }
+
+  /**
+   * Check if an internal account supports opt-in for rewards
+   * @param account - The internal account to check
+   * @returns boolean - True if the account supports opt-in, false otherwise
+   */
+  isOptInSupported(account: InternalAccount): boolean {
+    try {
+      // Try to check if it's a hardware wallet
+      const isHardware = isHardwareAccount(account.address);
+      // If it's a hardware wallet, opt-in is not supported
+      if (isHardware) {
+        return false;
+      }
+
+      // Check if it's an EVM address (not non-EVM)
+      if (!isNonEvmAddress(account.address)) {
+        return true;
+      }
+
+      // Check if it's a Solana address
+      if (isSolanaAddress(account.address)) {
+        return true;
+      }
+
+      // If it's neither Solana nor EVM, opt-in is not supported
+      return false;
+    } catch (error) {
+      // If there's an exception (e.g., checking hardware wallet status fails),
+      // assume opt-in is not supported
+      Logger.log(
+        'RewardsController: Exception checking opt-in support, assuming not supported:',
+        error,
+      );
+      return false;
+    }
   }
 
   convertInternalAccountToCaipAccountId(
@@ -556,7 +600,7 @@ export class RewardsController extends BaseController<
       this.convertInternalAccountToCaipAccountId(internalAccount);
 
     const shouldSkip = account
-      ? this.#shouldSkipSilentAuth(account, internalAccount.address)
+      ? this.#shouldSkipSilentAuth(account, internalAccount)
       : false;
 
     if (shouldSkip) {
@@ -1503,12 +1547,16 @@ export class RewardsController extends BaseController<
         'AccountsController:listMultichainAccounts',
       );
 
-      if (!allAccounts || allAccounts.length === 0) {
+      // Extract addresses from internal accounts using isOptInSupported
+      const supportedAccounts: InternalAccount[] =
+        allAccounts?.filter((account: InternalAccount) =>
+          this.isOptInSupported(account),
+        ) || [];
+      if (!supportedAccounts || supportedAccounts.length === 0) {
         return null;
       }
 
-      // Extract addresses from internal accounts
-      const addresses = allAccounts.map(
+      const addresses = supportedAccounts.map(
         (account: InternalAccount) => account.address,
       );
 
@@ -1532,9 +1580,9 @@ export class RewardsController extends BaseController<
         optInStatusResponse.ois.length,
       );
       let silentAuthAttempts = 0;
-      for (let i = 0; i < allAccounts.length; i++) {
+      for (let i = 0; i < supportedAccounts.length; i++) {
         if (silentAuthAttempts > maxSilentAuthAttempts) break;
-        const account = allAccounts[i];
+        const account = supportedAccounts[i];
         if (!account || optInStatusResponse.ois[i] === false) continue;
         try {
           silentAuthAttempts++;

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -781,6 +781,14 @@ export interface RewardsControllerValidateReferralCodeAction {
 }
 
 /**
+ * Action for checking if an account supports opt-in
+ */
+export interface RewardsControllerIsOptInSupportedAction {
+  type: 'RewardsController:isOptInSupported';
+  handler: (account: InternalAccount) => boolean;
+}
+
+/**
  * Action for linking an account to a subscription
  */
 export interface RewardsControllerLinkAccountToSubscriptionAction {
@@ -852,6 +860,7 @@ export type RewardsControllerActions =
   | RewardsControllerLogoutAction
   | RewardsControllerGetGeoRewardsMetadataAction
   | RewardsControllerValidateReferralCodeAction
+  | RewardsControllerIsOptInSupportedAction
   | RewardsControllerLinkAccountToSubscriptionAction
   | RewardsControllerGetCandidateSubscriptionIdAction
   | RewardsControllerOptOutAction

--- a/app/reducers/rewards/index.test.ts
+++ b/app/reducers/rewards/index.test.ts
@@ -6,13 +6,16 @@ import rewardsReducer, {
   setSeasonStatusLoading,
   setSeasonStatusError,
   setReferralDetailsLoading,
+  setReferralDetailsError,
   resetRewardsState,
   setOnboardingActiveStep,
   resetOnboarding,
   setCandidateSubscriptionId,
   setGeoRewardsMetadata,
   setGeoRewardsMetadataLoading,
+  setGeoRewardsMetadataError,
   setHideUnlinkedAccountsBanner,
+  setHideCurrentAccountNotOptedInBanner,
   setActiveBoosts,
   setActiveBoostsLoading,
   setActiveBoostsError,
@@ -26,6 +29,7 @@ import {
   SeasonStatusState,
   RewardClaimStatus,
 } from '../../core/Engine/controllers/rewards-controller/types';
+import { CaipAccountId } from '@metamask/utils';
 
 describe('rewardsReducer', () => {
   const initialState: RewardsState = {
@@ -59,6 +63,7 @@ describe('rewardsReducer', () => {
     optinAllowedForGeoLoading: false,
     optinAllowedForGeoError: false,
     hideUnlinkedAccountsBanner: false,
+    hideCurrentAccountNotOptedInBanner: [],
 
     activeBoosts: null,
     activeBoostsLoading: false,
@@ -498,6 +503,54 @@ describe('rewardsReducer', () => {
       });
     });
 
+    describe('setReferralDetailsError', () => {
+      it('should set referral details error to true', () => {
+        // Arrange
+        const action = setReferralDetailsError(true);
+
+        // Act
+        const state = rewardsReducer(initialState, action);
+
+        // Assert
+        expect(state.referralDetailsError).toBe(true);
+      });
+
+      it('should set referral details error to false', () => {
+        // Arrange
+        const stateWithError = {
+          ...initialState,
+          referralDetailsError: true,
+        };
+        const action = setReferralDetailsError(false);
+
+        // Act
+        const state = rewardsReducer(stateWithError, action);
+
+        // Assert
+        expect(state.referralDetailsError).toBe(false);
+      });
+
+      it('should not affect other state properties', () => {
+        // Arrange
+        const stateWithData = {
+          ...initialState,
+          referralCode: 'TEST123',
+          refereeCount: 5,
+          referralDetailsLoading: true,
+        };
+        const action = setReferralDetailsError(true);
+
+        // Act
+        const state = rewardsReducer(stateWithData, action);
+
+        // Assert
+        expect(state.referralDetailsError).toBe(true);
+        expect(state.referralCode).toBe('TEST123');
+        expect(state.refereeCount).toBe(5);
+        expect(state.referralDetailsLoading).toBe(true);
+      });
+    });
+
     describe('setSeasonStatusLoading', () => {
       it('should set season status loading to true when no season data exists', () => {
         // Arrange
@@ -904,6 +957,54 @@ describe('rewardsReducer', () => {
       });
     });
 
+    describe('setGeoRewardsMetadataError', () => {
+      it('should set geo rewards metadata error to true', () => {
+        // Arrange
+        const action = setGeoRewardsMetadataError(true);
+
+        // Act
+        const state = rewardsReducer(initialState, action);
+
+        // Assert
+        expect(state.optinAllowedForGeoError).toBe(true);
+      });
+
+      it('should set geo rewards metadata error to false', () => {
+        // Arrange
+        const stateWithError = {
+          ...initialState,
+          optinAllowedForGeoError: true,
+        };
+        const action = setGeoRewardsMetadataError(false);
+
+        // Act
+        const state = rewardsReducer(stateWithError, action);
+
+        // Assert
+        expect(state.optinAllowedForGeoError).toBe(false);
+      });
+
+      it('should not affect other geo metadata properties', () => {
+        // Arrange
+        const stateWithGeoData = {
+          ...initialState,
+          geoLocation: 'US',
+          optinAllowedForGeo: true,
+          optinAllowedForGeoLoading: true,
+        };
+        const action = setGeoRewardsMetadataError(true);
+
+        // Act
+        const state = rewardsReducer(stateWithGeoData, action);
+
+        // Assert
+        expect(state.optinAllowedForGeoError).toBe(true);
+        expect(state.geoLocation).toBe('US');
+        expect(state.optinAllowedForGeo).toBe(true);
+        expect(state.optinAllowedForGeoLoading).toBe(true);
+      });
+    });
+
     describe('setCandidateSubscriptionId', () => {
       it('should set candidate subscription ID to a string value', () => {
         // Arrange
@@ -1024,6 +1125,158 @@ describe('rewardsReducer', () => {
       });
     });
 
+    describe('setHideCurrentAccountNotOptedInBanner', () => {
+      it('should add new account banner entry when it does not exist', () => {
+        // Arrange
+        const accountId: CaipAccountId =
+          'eip155:1:0x1234567890123456789012345678901234567890';
+        const action = setHideCurrentAccountNotOptedInBanner({
+          accountId,
+          hide: true,
+        });
+
+        // Act
+        const state = rewardsReducer(initialState, action);
+
+        // Assert
+        expect(state.hideCurrentAccountNotOptedInBanner).toHaveLength(1);
+        expect(state.hideCurrentAccountNotOptedInBanner[0]).toEqual({
+          caipAccountId: accountId,
+          hide: true,
+        });
+      });
+
+      it('should update existing account banner entry', () => {
+        // Arrange
+        const accountId: CaipAccountId =
+          'eip155:1:0x1234567890123456789012345678901234567890';
+        const stateWithExistingEntry = {
+          ...initialState,
+          hideCurrentAccountNotOptedInBanner: [
+            {
+              caipAccountId: accountId,
+              hide: false,
+            },
+          ],
+        };
+        const action = setHideCurrentAccountNotOptedInBanner({
+          accountId,
+          hide: true,
+        });
+
+        // Act
+        const state = rewardsReducer(stateWithExistingEntry, action);
+
+        // Assert
+        expect(state.hideCurrentAccountNotOptedInBanner).toHaveLength(1);
+        expect(state.hideCurrentAccountNotOptedInBanner[0]).toEqual({
+          caipAccountId: accountId,
+          hide: true,
+        });
+      });
+
+      it('should add multiple different account entries', () => {
+        // Arrange
+        const accountId1: CaipAccountId =
+          'eip155:1:0x1111111111111111111111111111111111111111';
+        const accountId2: CaipAccountId =
+          'eip155:1:0x2222222222222222222222222222222222222222';
+
+        let currentState = initialState;
+
+        // Add first account
+        const action1 = setHideCurrentAccountNotOptedInBanner({
+          accountId: accountId1,
+          hide: true,
+        });
+        currentState = rewardsReducer(currentState, action1);
+
+        // Add second account
+        const action2 = setHideCurrentAccountNotOptedInBanner({
+          accountId: accountId2,
+          hide: false,
+        });
+
+        // Act
+        const state = rewardsReducer(currentState, action2);
+
+        // Assert
+        expect(state.hideCurrentAccountNotOptedInBanner).toHaveLength(2);
+        expect(state.hideCurrentAccountNotOptedInBanner[0]).toEqual({
+          caipAccountId: accountId1,
+          hide: true,
+        });
+        expect(state.hideCurrentAccountNotOptedInBanner[1]).toEqual({
+          caipAccountId: accountId2,
+          hide: false,
+        });
+      });
+
+      it('should update specific account without affecting others', () => {
+        // Arrange
+        const accountId1: CaipAccountId =
+          'eip155:1:0x1111111111111111111111111111111111111111';
+        const accountId2: CaipAccountId =
+          'eip155:1:0x2222222222222222222222222222222222222222';
+        const stateWithMultipleEntries = {
+          ...initialState,
+          hideCurrentAccountNotOptedInBanner: [
+            {
+              caipAccountId: accountId1,
+              hide: true,
+            },
+            {
+              caipAccountId: accountId2,
+              hide: false,
+            },
+          ],
+        };
+        const action = setHideCurrentAccountNotOptedInBanner({
+          accountId: accountId1,
+          hide: false,
+        });
+
+        // Act
+        const state = rewardsReducer(stateWithMultipleEntries, action);
+
+        // Assert
+        expect(state.hideCurrentAccountNotOptedInBanner).toHaveLength(2);
+        expect(state.hideCurrentAccountNotOptedInBanner[0]).toEqual({
+          caipAccountId: accountId1,
+          hide: false, // Updated
+        });
+        expect(state.hideCurrentAccountNotOptedInBanner[1]).toEqual({
+          caipAccountId: accountId2,
+          hide: false, // Unchanged
+        });
+      });
+
+      it('should not affect other state properties', () => {
+        // Arrange
+        const stateWithData = {
+          ...initialState,
+          activeTab: 'activity' as const,
+          referralCode: 'TEST123',
+          hideUnlinkedAccountsBanner: true,
+        };
+        const accountId: CaipAccountId =
+          'eip155:1:0x1234567890123456789012345678901234567890';
+        const action = setHideCurrentAccountNotOptedInBanner({
+          accountId,
+          hide: true,
+        });
+
+        // Act
+        const state = rewardsReducer(stateWithData, action);
+
+        // Assert
+        expect(state.hideCurrentAccountNotOptedInBanner).toHaveLength(1);
+        expect(state.activeTab).toBe('activity');
+        expect(state.referralCode).toBe('TEST123');
+        expect(state.hideUnlinkedAccountsBanner).toBe(true);
+      });
+    });
+
     describe('resetRewardsState', () => {
       it('should reset all state to initial values', () => {
         // Arrange
@@ -1083,6 +1336,13 @@ describe('rewardsReducer', () => {
           optinAllowedForGeo: true,
           optinAllowedForGeoLoading: false,
           hideUnlinkedAccountsBanner: true,
+          hideCurrentAccountNotOptedInBanner: [
+            {
+              caipAccountId:
+                'eip155:1:0x1234567890123456789012345678901234567890' as CaipAccountId,
+              hide: true,
+            },
+          ],
           activeBoosts: [
             {
               id: 'boost-1',
@@ -1115,7 +1375,7 @@ describe('rewardsReducer', () => {
     });
 
     describe('persist/REHYDRATE', () => {
-      it('should reset all state to initial values and only restore hideUnlinkedAccountsBanner', () => {
+      it('should reset all state to initial values including banner preferences', () => {
         // Arrange
         const persistedRewardsState: RewardsState = {
           activeTab: 'activity',
@@ -1161,7 +1421,14 @@ describe('rewardsReducer', () => {
           geoLocation: 'CA',
           optinAllowedForGeo: true,
           optinAllowedForGeoLoading: false,
-          hideUnlinkedAccountsBanner: true, // This should be preserved
+          hideUnlinkedAccountsBanner: true, // This will be reset
+          hideCurrentAccountNotOptedInBanner: [
+            {
+              caipAccountId:
+                'eip155:1:0x1234567890123456789012345678901234567890' as CaipAccountId,
+              hide: true,
+            },
+          ], // This will be reset
           activeBoosts: [
             {
               id: 'boost-1',
@@ -1194,20 +1461,28 @@ describe('rewardsReducer', () => {
         // Act
         const state = rewardsReducer(initialState, rehydrateAction);
 
-        // Assert - All state should be reset to initial except hideUnlinkedAccountsBanner
+        // Assert - All state should be reset to initial values
         const expectedState = {
           ...initialState,
-          hideUnlinkedAccountsBanner: true, // Only this should be preserved
+          hideUnlinkedAccountsBanner: false,
+          hideCurrentAccountNotOptedInBanner: [],
         };
         expect(state).toEqual(expectedState);
       });
 
-      it('should handle rehydration with hideUnlinkedAccountsBanner false', () => {
+      it('should reset banner preferences regardless of persisted values', () => {
         // Arrange
         const persistedRewardsState: RewardsState = {
           ...initialState,
           referralCode: 'SOME_CODE', // This will be reset
-          hideUnlinkedAccountsBanner: false, // This should be preserved
+          hideUnlinkedAccountsBanner: true, // This will be reset to false
+          hideCurrentAccountNotOptedInBanner: [
+            {
+              caipAccountId:
+                'eip155:1:0x1234567890123456789012345678901234567890' as CaipAccountId,
+              hide: true,
+            },
+          ], // This will be reset to empty array
         };
         const rehydrateAction = {
           type: 'persist/REHYDRATE',
@@ -1221,6 +1496,7 @@ describe('rewardsReducer', () => {
 
         // Assert
         expect(state.hideUnlinkedAccountsBanner).toBe(false);
+        expect(state.hideCurrentAccountNotOptedInBanner).toEqual([]);
         expect(state.referralCode).toBe(null); // Should be reset
       });
 

--- a/app/reducers/rewards/index.test.ts
+++ b/app/reducers/rewards/index.test.ts
@@ -1461,11 +1461,13 @@ describe('rewardsReducer', () => {
         // Act
         const state = rewardsReducer(initialState, rehydrateAction);
 
-        // Assert - All state should be reset to initial values
+        // Assert - State should be reset to initial values but preserve banner preferences
         const expectedState = {
           ...initialState,
-          hideUnlinkedAccountsBanner: false,
-          hideCurrentAccountNotOptedInBanner: [],
+          hideUnlinkedAccountsBanner:
+            persistedRewardsState.hideUnlinkedAccountsBanner,
+          hideCurrentAccountNotOptedInBanner:
+            persistedRewardsState.hideCurrentAccountNotOptedInBanner,
         };
         expect(state).toEqual(expectedState);
       });
@@ -1495,8 +1497,12 @@ describe('rewardsReducer', () => {
         const state = rewardsReducer(initialState, rehydrateAction);
 
         // Assert
-        expect(state.hideUnlinkedAccountsBanner).toBe(false);
-        expect(state.hideCurrentAccountNotOptedInBanner).toEqual([]);
+        expect(state.hideUnlinkedAccountsBanner).toBe(
+          persistedRewardsState.hideUnlinkedAccountsBanner,
+        );
+        expect(state.hideCurrentAccountNotOptedInBanner).toEqual(
+          persistedRewardsState.hideCurrentAccountNotOptedInBanner,
+        );
         expect(state.referralCode).toBe(null); // Should be reset
       });
 

--- a/app/reducers/rewards/index.ts
+++ b/app/reducers/rewards/index.ts
@@ -7,6 +7,12 @@ import {
   RewardDto,
 } from '../../core/Engine/controllers/rewards-controller/types';
 import { OnboardingStep } from './types';
+import { CaipAccountId } from '@metamask/utils';
+
+export interface AccountOptInBannerInfoStatus {
+  caipAccountId: CaipAccountId;
+  hide: boolean;
+}
 
 export interface RewardsState {
   activeTab: 'overview' | 'activity' | 'levels';
@@ -49,6 +55,7 @@ export interface RewardsState {
   optinAllowedForGeoError: boolean;
 
   // UI preferences
+  hideCurrentAccountNotOptedInBanner: AccountOptInBannerInfoStatus[];
   hideUnlinkedAccountsBanner: boolean;
 
   // Points Boost state
@@ -93,6 +100,7 @@ export const initialState: RewardsState = {
   optinAllowedForGeoLoading: false,
   optinAllowedForGeoError: false,
   hideUnlinkedAccountsBanner: false,
+  hideCurrentAccountNotOptedInBanner: [],
 
   activeBoosts: null,
   activeBoostsLoading: false,
@@ -244,6 +252,27 @@ const rewardsSlice = createSlice({
       state.hideUnlinkedAccountsBanner = action.payload;
     },
 
+    setHideCurrentAccountNotOptedInBanner: (
+      state,
+      action: PayloadAction<{ accountId: CaipAccountId; hide: boolean }>,
+    ) => {
+      const existingIndex = state.hideCurrentAccountNotOptedInBanner.findIndex(
+        (item) => item.caipAccountId === action.payload.accountId,
+      );
+
+      if (existingIndex !== -1) {
+        // Update existing entry
+        state.hideCurrentAccountNotOptedInBanner[existingIndex].hide =
+          action.payload.hide;
+      } else {
+        // Add new entry
+        state.hideCurrentAccountNotOptedInBanner.push({
+          caipAccountId: action.payload.accountId,
+          hide: action.payload.hide,
+        });
+      }
+    },
+
     setActiveBoosts: (
       state,
       action: PayloadAction<PointsBoostDto[] | null>,
@@ -283,6 +312,8 @@ const rewardsSlice = createSlice({
           // Restore only a few persistent state
           hideUnlinkedAccountsBanner:
             action.payload.rewards.hideUnlinkedAccountsBanner,
+          hideCurrentAccountNotOptedInBanner:
+            action.payload.rewards.hideCurrentAccountNotOptedInBanner,
         };
       }
       return state;
@@ -306,6 +337,7 @@ export const {
   setGeoRewardsMetadataLoading,
   setGeoRewardsMetadataError,
   setHideUnlinkedAccountsBanner,
+  setHideCurrentAccountNotOptedInBanner,
   setActiveBoosts,
   setActiveBoostsLoading,
   setActiveBoostsError,

--- a/app/reducers/rewards/selectors.test.ts
+++ b/app/reducers/rewards/selectors.test.ts
@@ -24,6 +24,7 @@ import {
   selectReferralDetailsLoading,
   selectCandidateSubscriptionId,
   selectHideUnlinkedAccountsBanner,
+  selectHideCurrentAccountNotOptedInBannerArray,
   selectActiveBoosts,
   selectActiveBoostsLoading,
   selectActiveBoostsError,
@@ -38,7 +39,7 @@ import {
   SeasonTierDto,
 } from '../../core/Engine/controllers/rewards-controller/types';
 import { RootState } from '..';
-import { RewardsState } from '.';
+import { RewardsState, AccountOptInBannerInfoStatus } from '.';
 
 // Mock react-redux
 jest.mock('react-redux', () => ({
@@ -725,6 +726,198 @@ describe('Rewards selectors', () => {
     });
   });
 
+  describe('selectHideCurrentAccountNotOptedInBannerArray', () => {
+    it('returns empty array when no accounts are configured', () => {
+      const mockState = { rewards: { hideCurrentAccountNotOptedInBanner: [] } };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result } = renderHook(() =>
+        useSelector(selectHideCurrentAccountNotOptedInBannerArray),
+      );
+      expect(result.current).toEqual([]);
+      expect(result.current).toHaveLength(0);
+    });
+
+    it('returns single account configuration when set', () => {
+      const mockAccountConfig: AccountOptInBannerInfoStatus = {
+        caipAccountId: 'eip155:1:0x123456789abcdef',
+        hide: true,
+      };
+      const mockState = {
+        rewards: { hideCurrentAccountNotOptedInBanner: [mockAccountConfig] },
+      };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result } = renderHook(() =>
+        useSelector(selectHideCurrentAccountNotOptedInBannerArray),
+      );
+      expect(result.current).toEqual([mockAccountConfig]);
+      expect(result.current).toHaveLength(1);
+      expect(result.current?.[0]?.caipAccountId).toBe(
+        'eip155:1:0x123456789abcdef',
+      );
+      expect(result.current?.[0]?.hide).toBe(true);
+    });
+
+    it('returns multiple account configurations when set', () => {
+      const mockAccountConfigs: AccountOptInBannerInfoStatus[] = [
+        {
+          caipAccountId: 'eip155:1:0x123456789abcdef',
+          hide: true,
+        },
+        {
+          caipAccountId: 'eip155:1:0xabcdef123456789',
+          hide: false,
+        },
+        {
+          caipAccountId: 'eip155:137:0x987654321fedcba',
+          hide: true,
+        },
+      ];
+      const mockState = {
+        rewards: { hideCurrentAccountNotOptedInBanner: mockAccountConfigs },
+      };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result } = renderHook(() =>
+        useSelector(selectHideCurrentAccountNotOptedInBannerArray),
+      );
+      expect(result.current).toEqual(mockAccountConfigs);
+      expect(result.current).toHaveLength(3);
+      expect(result.current?.[0]?.hide).toBe(true);
+      expect(result.current?.[1]?.hide).toBe(false);
+      expect(result.current?.[2]?.hide).toBe(true);
+    });
+
+    it('handles mixed hide states correctly', () => {
+      const mockAccountConfigs: AccountOptInBannerInfoStatus[] = [
+        {
+          caipAccountId: 'eip155:1:0x111111111111111',
+          hide: false,
+        },
+        {
+          caipAccountId: 'eip155:1:0x222222222222222',
+          hide: true,
+        },
+        {
+          caipAccountId: 'eip155:1:0x333333333333333',
+          hide: false,
+        },
+      ];
+      const mockState = {
+        rewards: { hideCurrentAccountNotOptedInBanner: mockAccountConfigs },
+      };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result } = renderHook(() =>
+        useSelector(selectHideCurrentAccountNotOptedInBannerArray),
+      );
+      expect(result.current).toEqual(mockAccountConfigs);
+      expect(result.current?.filter((config) => config.hide)).toHaveLength(1);
+      expect(result.current?.filter((config) => !config.hide)).toHaveLength(2);
+    });
+
+    it('handles state changes correctly', () => {
+      let mockState = {
+        rewards: {
+          hideCurrentAccountNotOptedInBanner:
+            [] as AccountOptInBannerInfoStatus[],
+        },
+      };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result, rerender } = renderHook(() =>
+        useSelector(selectHideCurrentAccountNotOptedInBannerArray),
+      );
+      expect(result.current).toEqual([]);
+
+      // Change state to have account configs
+      const newAccountConfigs: AccountOptInBannerInfoStatus[] = [
+        {
+          caipAccountId: 'eip155:1:0x444444444444444',
+          hide: true,
+        },
+      ];
+      mockState = {
+        rewards: { hideCurrentAccountNotOptedInBanner: newAccountConfigs },
+      };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+      rerender();
+      expect(result.current).toEqual(newAccountConfigs);
+      expect(result.current).toHaveLength(1);
+    });
+
+    it('preserves account configuration order', () => {
+      const orderedConfigs: AccountOptInBannerInfoStatus[] = [
+        {
+          caipAccountId: 'eip155:1:0xaaa',
+          hide: true,
+        },
+        {
+          caipAccountId: 'eip155:1:0xbbb',
+          hide: false,
+        },
+        {
+          caipAccountId: 'eip155:1:0xccc',
+          hide: true,
+        },
+        {
+          caipAccountId: 'eip155:1:0xddd',
+          hide: false,
+        },
+      ];
+      const mockState = {
+        rewards: { hideCurrentAccountNotOptedInBanner: orderedConfigs },
+      };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result } = renderHook(() =>
+        useSelector(selectHideCurrentAccountNotOptedInBannerArray),
+      );
+      expect(result.current).toEqual(orderedConfigs);
+      expect(result.current?.[0]?.caipAccountId).toBe('eip155:1:0xaaa');
+      expect(result.current?.[1]?.caipAccountId).toBe('eip155:1:0xbbb');
+      expect(result.current?.[2]?.caipAccountId).toBe('eip155:1:0xccc');
+      expect(result.current?.[3]?.caipAccountId).toBe('eip155:1:0xddd');
+    });
+
+    it('handles different CAIP account ID formats correctly', () => {
+      const differentFormatConfigs: AccountOptInBannerInfoStatus[] = [
+        {
+          caipAccountId: 'eip155:1:0x123456789abcdef', // Ethereum mainnet
+          hide: true,
+        },
+        {
+          caipAccountId: 'eip155:137:0xabcdef123456789', // Polygon
+          hide: false,
+        },
+        {
+          caipAccountId: 'eip155:56:0x987654321fedcba', // BSC
+          hide: true,
+        },
+        {
+          caipAccountId: 'eip155:42161:0x555666777888999', // Arbitrum
+          hide: false,
+        },
+      ];
+      const mockState = {
+        rewards: { hideCurrentAccountNotOptedInBanner: differentFormatConfigs },
+      };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result } = renderHook(() =>
+        useSelector(selectHideCurrentAccountNotOptedInBannerArray),
+      );
+      expect(result.current).toEqual(differentFormatConfigs);
+      expect(result.current).toHaveLength(4);
+      expect(
+        result.current?.every((config) =>
+          config.caipAccountId.startsWith('eip155:'),
+        ),
+      ).toBe(true);
+    });
+  });
+
   describe('selectCurrentSeasonId', () => {
     it('returns null when season ID is null', () => {
       const mockState = { rewards: { seasonId: null } };
@@ -1040,6 +1233,74 @@ describe('Rewards selectors', () => {
       it('returns true when error occurs', () => {
         const state = createMockRootState({ activeBoostsError: true });
         expect(selectActiveBoostsError(state)).toBe(true);
+      });
+    });
+
+    describe('selectHideCurrentAccountNotOptedInBannerArray direct calls', () => {
+      it('returns empty array when no accounts configured', () => {
+        const state = createMockRootState({
+          hideCurrentAccountNotOptedInBanner: [],
+        });
+        expect(selectHideCurrentAccountNotOptedInBannerArray(state)).toEqual(
+          [],
+        );
+      });
+
+      it('returns account configurations when set', () => {
+        const accountConfigs: AccountOptInBannerInfoStatus[] = [
+          {
+            caipAccountId: 'eip155:1:0x123456789abcdef',
+            hide: true,
+          },
+          {
+            caipAccountId: 'eip155:1:0xabcdef123456789',
+            hide: false,
+          },
+        ];
+        const state = createMockRootState({
+          hideCurrentAccountNotOptedInBanner: accountConfigs,
+        });
+        expect(selectHideCurrentAccountNotOptedInBannerArray(state)).toEqual(
+          accountConfigs,
+        );
+        expect(
+          selectHideCurrentAccountNotOptedInBannerArray(state),
+        ).toHaveLength(2);
+      });
+
+      it('preserves account configuration references', () => {
+        const accountConfig: AccountOptInBannerInfoStatus = {
+          caipAccountId: 'eip155:1:0x987654321fedcba',
+          hide: true,
+        };
+        const state = createMockRootState({
+          hideCurrentAccountNotOptedInBanner: [accountConfig],
+        });
+
+        const result1 = selectHideCurrentAccountNotOptedInBannerArray(state);
+        const result2 = selectHideCurrentAccountNotOptedInBannerArray(state);
+
+        expect(result1).toBe(result2); // Same reference
+        expect(result1).toEqual(result2); // Same value
+        expect(result1[0]).toBe(accountConfig); // Original reference preserved
+      });
+
+      it('handles large arrays correctly', () => {
+        const largeAccountConfigs: AccountOptInBannerInfoStatus[] = Array.from(
+          { length: 50 },
+          (_, i) => ({
+            caipAccountId: `eip155:1:0x${i.toString().padStart(40, '0')}`,
+            hide: i % 2 === 0,
+          }),
+        );
+        const state = createMockRootState({
+          hideCurrentAccountNotOptedInBanner: largeAccountConfigs,
+        });
+
+        const result = selectHideCurrentAccountNotOptedInBannerArray(state);
+        expect(result).toHaveLength(50);
+        expect(result.filter((config) => config.hide)).toHaveLength(25);
+        expect(result.filter((config) => !config.hide)).toHaveLength(25);
       });
     });
   });
@@ -1362,6 +1623,16 @@ describe('Rewards selectors', () => {
         optinAllowedForGeo: true,
         optinAllowedForGeoLoading: false,
         hideUnlinkedAccountsBanner: true,
+        hideCurrentAccountNotOptedInBanner: [
+          {
+            caipAccountId: 'eip155:1:0x123456789abcdef',
+            hide: true,
+          },
+          {
+            caipAccountId: 'eip155:137:0xabcdef123456789',
+            hide: false,
+          },
+        ],
         activeBoosts: [],
         activeBoostsLoading: false,
         activeBoostsError: false,
@@ -1403,6 +1674,25 @@ describe('Rewards selectors', () => {
         expect(selectOptinAllowedForGeo(comprehensiveState)).toBe(true);
         expect(selectOptinAllowedForGeoLoading(comprehensiveState)).toBe(false);
         expect(selectHideUnlinkedAccountsBanner(comprehensiveState)).toBe(true);
+        expect(
+          selectHideCurrentAccountNotOptedInBannerArray(comprehensiveState),
+        ).toHaveLength(2);
+        expect(
+          selectHideCurrentAccountNotOptedInBannerArray(comprehensiveState)[0]
+            .caipAccountId,
+        ).toBe('eip155:1:0x123456789abcdef');
+        expect(
+          selectHideCurrentAccountNotOptedInBannerArray(comprehensiveState)[0]
+            .hide,
+        ).toBe(true);
+        expect(
+          selectHideCurrentAccountNotOptedInBannerArray(comprehensiveState)[1]
+            .caipAccountId,
+        ).toBe('eip155:137:0xabcdef123456789');
+        expect(
+          selectHideCurrentAccountNotOptedInBannerArray(comprehensiveState)[1]
+            .hide,
+        ).toBe(false);
         expect(selectActiveBoosts(comprehensiveState)).toEqual([]);
         expect(selectActiveBoostsLoading(comprehensiveState)).toBe(false);
         expect(selectActiveBoostsError(comprehensiveState)).toBe(false);

--- a/app/reducers/rewards/selectors.ts
+++ b/app/reducers/rewards/selectors.ts
@@ -73,6 +73,10 @@ export const selectCandidateSubscriptionId = (state: RootState) =>
 export const selectHideUnlinkedAccountsBanner = (state: RootState) =>
   state.rewards.hideUnlinkedAccountsBanner;
 
+export const selectHideCurrentAccountNotOptedInBannerArray = (
+  state: RootState,
+) => state.rewards.hideCurrentAccountNotOptedInBanner;
+
 export const selectActiveBoosts = (state: RootState) =>
   state.rewards.activeBoosts;
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5971,7 +5971,7 @@
       "title": "Account not earning points",
       "title_optin_not_supported": "Account not supported",
       "description": "This account's activity is not being tracked for this season.",
-      "description_optin_not_supported": "Currently only internal Ethereum and Solana accounts can be opted into the Rewards program."
+      "description_optin_not_supported": "Currently only non-hardware internal Ethereum and Solana accounts can be opted into the Rewards program."
     },
 
     "link_account": "Add account",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5884,6 +5884,8 @@
       "not_supported_region_description": "Rewards are not supported in your region yet. We are working on expanding access, so check back later.",
       "not_supported_hardware_account_title": "Account not supported",
       "not_supported_hardware_account_description": "Hardware wallet accounts are not eligible to receive rewards yet. Please switch to a different account to proceed.",
+      "not_supported_account_type_title": "Account type not supported",
+      "not_supported_account_type_description": "Currently only internal Ethereum and Solana accounts can be opted into the Rewards program. Please switch to a different account to proceed.",
       "not_supported_confirm_go_back": "Go back",
       "not_supported_confirm_retry": "Retry",
       "auth_fail_title": "Authentication Failed",
@@ -5967,7 +5969,9 @@
 
     "unlinked_account_info": {
       "title": "Account not earning points",
-      "description": "This account's activity is not being tracked for this season."
+      "title_optin_not_supported": "Account not supported",
+      "description": "This account's activity is not being tracked for this season.",
+      "description_optin_not_supported": "Currently only internal Ethereum and Solana accounts can be opted into the Rewards program."
     },
 
     "link_account": "Add account",


### PR DESCRIPTION
## **Description**

This will add the concept of supported/unsupported accounts for opt-in. This concept is then used in various places, such as:

- Onboarding intro
- getCandidateSubscriptionId
- useRewardOptInSummary

Visually, we also filter out these accounts on the settings page. On the dashboard page, if the current account is such an unsupported account we show an appropriate message.

## **Changelog**

CHANGELOG entry: null

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
