### PR TITLE
fix: view on blockexplorer links and names for supported networks

### DIFF
--- a/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.test.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.test.tsx
@@ -160,7 +160,7 @@ jest.mock('../../../../hooks/useBlockExplorer', () => ({
   __esModule: true,
   default: jest.fn().mockReturnValue({
     toBlockExplorer: jest.fn(),
-    blockExplorerName: 'Etherscan (Multichain)',
+    getBlockExplorerName: jest.fn().mockReturnValue('Etherscan (Multichain)'),
   }),
 }));
 
@@ -323,12 +323,15 @@ describe('ShareAddressQR', () => {
   it('navigates to block explorer when View on Etherscan button is pressed', () => {
     // Arrange
     const mockToBlockExplorer = jest.fn();
+    const mockGetBlockExplorerName = jest
+      .fn()
+      .mockReturnValue('Etherscan (Multichain)');
     const useBlockExplorer = jest.requireMock(
       '../../../../hooks/useBlockExplorer',
     ).default;
     useBlockExplorer.mockReturnValue({
       toBlockExplorer: mockToBlockExplorer,
-      blockExplorerName: 'Etherscan (Multichain)',
+      getBlockExplorerName: mockGetBlockExplorerName,
     });
 
     const { getByTestId } = render();

--- a/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/ShareAddressQR/ShareAddressQR.tsx
@@ -58,7 +58,7 @@ export const ShareAddressQR = () => {
   const accountGroupName = accountGroup?.metadata.name;
 
   const navigation = useNavigation();
-  const { toBlockExplorer } = useBlockExplorer();
+  const { toBlockExplorer, getBlockExplorerName } = useBlockExplorer(chainId);
   const networkImageSource = getNetworkImageSource({ chainId });
 
   const handleOnBack = useCallback(() => {
@@ -135,7 +135,7 @@ export const ShareAddressQR = () => {
           {strings(
             'multichain_accounts.share_address.view_on_explorer_button',
             {
-              explorer: 'Etherscan (Multichain)',
+              explorer: getBlockExplorerName(),
             },
           )}
         </Button>

--- a/app/components/hooks/useBlockExplorer.test.ts
+++ b/app/components/hooks/useBlockExplorer.test.ts
@@ -68,4 +68,65 @@ describe('useBlockExplorer', () => {
       },
     });
   });
+
+  describe('Popular networks support', () => {
+    const testCases = [
+      {
+        network: 'Polygon',
+        chainId: '0x89',
+        expectedUrl: 'https://polygonscan.com/address/0x1234567890abcdef',
+        expectedName: 'Polygonscan',
+      },
+      {
+        network: 'Arbitrum',
+        chainId: '0xa4b1',
+        expectedUrl: 'https://arbiscan.io/address/0x1234567890abcdef',
+        expectedName: 'Arbiscan',
+      },
+      {
+        network: 'BNB Chain',
+        chainId: '0x38',
+        expectedUrl: 'https://bscscan.com/address/0x1234567890abcdef',
+        expectedName: 'Bscscan',
+      },
+      {
+        network: 'Avalanche',
+        chainId: '0xa86a',
+        expectedUrl: 'https://snowtrace.io/address/0x1234567890abcdef',
+        expectedName: 'Snowtrace',
+      },
+      {
+        network: 'Optimism',
+        chainId: '0xa',
+        expectedUrl:
+          'https://optimistic.etherscan.io/address/0x1234567890abcdef',
+        expectedName: 'Optimistic',
+      },
+    ] as const;
+
+    it.each(testCases)(
+      'should return correct block explorer URL for $network',
+      ({ chainId, expectedUrl }) => {
+        const { result } = renderHookWithProvider(() => useBlockExplorer());
+        const { getBlockExplorerUrl } = result.current;
+        const address = '0x1234567890abcdef';
+
+        const url = getBlockExplorerUrl(address, chainId);
+
+        expect(url).toBe(expectedUrl);
+      },
+    );
+
+    it.each(testCases)(
+      'should return correct block explorer name for $network',
+      ({ chainId, expectedName }) => {
+        const { result } = renderHookWithProvider(() => useBlockExplorer());
+        const { getBlockExplorerName } = result.current;
+
+        const name = getBlockExplorerName(chainId);
+
+        expect(name).toBe(expectedName);
+      },
+    );
+  });
 });

--- a/app/components/hooks/useBlockExplorer.test.ts
+++ b/app/components/hooks/useBlockExplorer.test.ts
@@ -129,4 +129,98 @@ describe('useBlockExplorer', () => {
       },
     );
   });
+
+  describe('Non-EVM chains support', () => {
+    it('should return correct block explorer URL for Solana', () => {
+      const { result } = renderHookWithProvider(() => useBlockExplorer());
+      const { getBlockExplorerUrl } = result.current;
+      const address = '9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM';
+      const solanaChainId = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'; // Solana mainnet
+
+      const url = getBlockExplorerUrl(address, solanaChainId);
+      expect(url).toBe(
+        'https://solscan.io/account/9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM',
+      );
+    });
+
+    it('should return correct block explorer URL for Bitcoin', () => {
+      const { result } = renderHookWithProvider(() => useBlockExplorer());
+      const { getBlockExplorerUrl } = result.current;
+      const address = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+      const bitcoinChainId = 'bip122:000000000019d6689c085ae165831e93'; // Bitcoin mainnet
+
+      const url = getBlockExplorerUrl(address, bitcoinChainId);
+      expect(url).toBe(
+        'https://mempool.space/address/1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
+      );
+    });
+  });
+
+  describe('RPC networks with custom block explorers', () => {
+    it('should use custom RPC block explorer when available', () => {
+      // This test verifies the RPC fallback path is covered
+      // The actual implementation uses the mocked state from the main test setup
+      const { result } = renderHookWithProvider(() => useBlockExplorer());
+      const { getBlockExplorerUrl } = result.current;
+      const address = '0x1234567890abcdef';
+
+      // This should use the RPC fallback path from the mocked state
+      const url = getBlockExplorerUrl(address);
+      expect(url).toBeDefined();
+      expect(url).toContain('/address/');
+    });
+  });
+
+  describe('Fallback scenarios', () => {
+    it('should fallback to etherscan when no specific block explorer is found', () => {
+      const { result } = renderHookWithProvider(() => useBlockExplorer());
+      const { getBlockExplorerUrl } = result.current;
+      const address = '0x1234567890abcdef';
+      const unknownChainId = '0x9999'; // Unknown chain
+
+      const url = getBlockExplorerUrl(address, unknownChainId);
+      // Should fallback to etherscan or use the RPC fallback
+      expect(url).toBeDefined();
+      expect(url).toContain('/address/');
+    });
+
+    it('should return null when no block explorer is available', () => {
+      const { result } = renderHookWithProvider(() => useBlockExplorer());
+      const { getBlockExplorerUrl } = result.current;
+      const address = '0x1234567890abcdef';
+
+      // Test with no chainId and no provider config
+      const url = getBlockExplorerUrl(address);
+      expect(url).toBeDefined(); // Should fallback to etherscan
+    });
+
+    it('should handle missing address gracefully', () => {
+      const { result } = renderHookWithProvider(() => useBlockExplorer());
+      const { getBlockExplorerUrl } = result.current;
+      const polygonChainId = '0x89';
+
+      const url = getBlockExplorerUrl('', polygonChainId);
+      expect(url).toBe('https://polygonscan.com/address/');
+    });
+  });
+
+  describe('Block explorer names for edge cases', () => {
+    it('should return fallback name when no block explorer is found', () => {
+      const { result } = renderHookWithProvider(() => useBlockExplorer());
+      const { getBlockExplorerName } = result.current;
+      const unknownChainId = '0x9999';
+
+      const name = getBlockExplorerName(unknownChainId);
+      expect(name).toBeDefined();
+    });
+
+    it('should handle non-EVM chain names', () => {
+      const { result } = renderHookWithProvider(() => useBlockExplorer());
+      const { getBlockExplorerName } = result.current;
+      const solanaChainId = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+
+      const name = getBlockExplorerName(solanaChainId);
+      expect(name).toBe('Solscan');
+    });
+  });
 });

--- a/app/components/hooks/useBlockExplorer.ts
+++ b/app/components/hooks/useBlockExplorer.ts
@@ -1,6 +1,9 @@
 import { useCallback } from 'react';
-import { RPC, NO_RPC_BLOCK_EXPLORER } from '../../constants/network';
-import { findBlockExplorerForRpc } from '../../util/networks';
+import { RPC } from '../../constants/network';
+import {
+  findBlockExplorerForRpc,
+  getBlockExplorerName as getBlockExplorerNameFromUrl,
+} from '../../util/networks';
 import { getEtherscanAddressUrl } from '../../util/etherscan';
 import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
@@ -9,28 +12,122 @@ import {
   selectProviderConfig,
 } from '../../selectors/networkController';
 import Routes from '../../constants/navigation/Routes';
-import { selectIsEvmNetworkSelected } from '../../selectors/multichainNetworkController';
+import {
+  MAINNET_BLOCK_EXPLORER,
+  LINEA_MAINNET_BLOCK_EXPLORER,
+  LINEA_SEPOLIA_BLOCK_EXPLORER,
+  SEPOLIA_BLOCK_EXPLORER,
+  BASE_MAINNET_BLOCK_EXPLORER,
+} from '../../constants/urls';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import { formatBlockExplorerAddressUrl } from '../../core/Multichain/networks';
+import { MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP } from '../../core/Multichain/constants';
+import { isNonEvmChainId } from '../../core/Multichain/utils';
+import { parseCaipChainId, isCaipChainId } from '@metamask/utils';
+import { toHex } from '@metamask/controller-utils';
+import { PopularList } from '../../util/networks/customNetworks';
 
-const useBlockExplorer = () => {
+const useBlockExplorer = (chainId?: string) => {
   const navigation = useNavigation();
   const providerConfig = useSelector(selectProviderConfig);
   const networkConfigurations = useSelector(selectNetworkConfigurations);
-  const isEvmSelected = useSelector(selectIsEvmNetworkSelected);
+
+  // Helper function to convert CAIP chain ID to hex chain ID for EVM networks
+  const convertToHexChainId = useCallback((inputChainId: string): string => {
+    if (isCaipChainId(inputChainId)) {
+      const { namespace, reference } = parseCaipChainId(inputChainId);
+      if (namespace === 'eip155') {
+        return toHex(reference);
+      }
+      // For non-EVM chains, return as-is
+      return inputChainId;
+    }
+    // Already in hex format or other format
+    return inputChainId;
+  }, []);
+
+  // Helper function to get base block explorer URL for EVM chains
+  const getEvmBlockExplorerUrl = useCallback((targetChainId: string) => {
+    // First check the hardcoded constants for built-in networks
+    const builtInBlockExplorers = {
+      [CHAIN_IDS.MAINNET]: MAINNET_BLOCK_EXPLORER,
+      [CHAIN_IDS.LINEA_MAINNET]: LINEA_MAINNET_BLOCK_EXPLORER,
+      [CHAIN_IDS.LINEA_SEPOLIA]: LINEA_SEPOLIA_BLOCK_EXPLORER,
+      [CHAIN_IDS.SEPOLIA]: SEPOLIA_BLOCK_EXPLORER,
+      [CHAIN_IDS.BASE]: BASE_MAINNET_BLOCK_EXPLORER,
+    };
+
+    if (
+      builtInBlockExplorers[targetChainId as keyof typeof builtInBlockExplorers]
+    ) {
+      return builtInBlockExplorers[
+        targetChainId as keyof typeof builtInBlockExplorers
+      ];
+    }
+
+    // Then check the comprehensive PopularList for additional networks
+    const popularNetwork = PopularList.find(
+      (network) => network.chainId === targetChainId,
+    );
+    if (popularNetwork?.rpcPrefs?.blockExplorerUrl) {
+      return popularNetwork.rpcPrefs.blockExplorerUrl;
+    }
+
+    return null;
+  }, []);
+
+  const getBlockExplorerUrl = useCallback(
+    (address: string, targetChainId?: string) => {
+      const currentChainId = targetChainId || chainId;
+
+      // Handle non-EVM chains
+      if (currentChainId && isNonEvmChainId(currentChainId)) {
+        const blockExplorerUrls =
+          MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP[
+            currentChainId as keyof typeof MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP
+          ];
+        return blockExplorerUrls
+          ? formatBlockExplorerAddressUrl(blockExplorerUrls, address)
+          : null;
+      }
+
+      // For specific EVM chain block explorers
+      if (currentChainId) {
+        const hexChainId = convertToHexChainId(currentChainId);
+        const baseUrl = getEvmBlockExplorerUrl(hexChainId);
+        if (baseUrl) {
+          return `${baseUrl}/address/${address}`;
+        }
+      }
+
+      // For RPC networks, try to find custom block explorer
+      const { type, rpcUrl } = providerConfig;
+      if (type === RPC && rpcUrl) {
+        const blockExplorer = findBlockExplorerForRpc(
+          rpcUrl,
+          networkConfigurations,
+        );
+        return blockExplorer ? `${blockExplorer}/address/${address}` : null;
+      }
+
+      // Fallback to etherscan-based URL
+      return getEtherscanAddressUrl(type, address);
+    },
+    [
+      chainId,
+      providerConfig,
+      networkConfigurations,
+      getEvmBlockExplorerUrl,
+      convertToHexChainId,
+    ],
+  );
 
   const toBlockExplorer = useCallback(
-    (address: string) => {
-      // TODO: [SOLANA] to block explorer needs to be implemented
-      if (!isEvmSelected) return;
+    (address: string, targetChainId?: string) => {
+      const accountLink = getBlockExplorerUrl(address, targetChainId);
 
-      const { type, rpcUrl } = providerConfig;
-      let accountLink: string;
-      if (type === RPC && rpcUrl) {
-        const blockExplorer =
-          findBlockExplorerForRpc(rpcUrl, networkConfigurations) ||
-          NO_RPC_BLOCK_EXPLORER;
-        accountLink = `${blockExplorer}/address/${address}`;
-      } else {
-        accountLink = getEtherscanAddressUrl(type, address);
+      if (!accountLink) {
+        return;
       }
 
       navigation.navigate(Routes.WEBVIEW.MAIN, {
@@ -40,10 +137,61 @@ const useBlockExplorer = () => {
         },
       });
     },
-    [networkConfigurations, navigation, providerConfig, isEvmSelected],
+    [navigation, getBlockExplorerUrl],
   );
+
+  const getBlockExplorerName = useCallback(
+    (targetChainId?: string) => {
+      const currentChainId = targetChainId || chainId;
+
+      // Handle non-EVM chains
+      if (currentChainId && isNonEvmChainId(currentChainId)) {
+        const blockExplorerUrls =
+          MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP[
+            currentChainId as keyof typeof MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP
+          ];
+        return blockExplorerUrls
+          ? getBlockExplorerNameFromUrl(blockExplorerUrls.url)
+          : 'Block Explorer';
+      }
+
+      // For specific EVM chain block explorers
+      if (currentChainId) {
+        const hexChainId = convertToHexChainId(currentChainId);
+        const baseUrl = getEvmBlockExplorerUrl(hexChainId);
+        if (baseUrl) {
+          return getBlockExplorerNameFromUrl(baseUrl);
+        }
+      }
+
+      // For RPC networks, try to find custom block explorer
+      const { type, rpcUrl } = providerConfig;
+      if (type === RPC && rpcUrl) {
+        const blockExplorer = findBlockExplorerForRpc(
+          rpcUrl,
+          networkConfigurations,
+        );
+        return blockExplorer
+          ? getBlockExplorerNameFromUrl(blockExplorer)
+          : 'Block Explorer';
+      }
+
+      // Fallback to etherscan-based URL
+      return getBlockExplorerNameFromUrl(getEtherscanAddressUrl(type, ''));
+    },
+    [
+      chainId,
+      providerConfig,
+      networkConfigurations,
+      getEvmBlockExplorerUrl,
+      convertToHexChainId,
+    ],
+  );
+
   return {
     toBlockExplorer,
+    getBlockExplorerUrl,
+    getBlockExplorerName,
   };
 };
 

--- a/app/components/hooks/useBlockExplorer.ts
+++ b/app/components/hooks/useBlockExplorer.ts
@@ -7,6 +7,7 @@ import {
 import { getEtherscanAddressUrl } from '../../util/etherscan';
 import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
+import { strings } from '../../../locales/i18n';
 import {
   selectNetworkConfigurations,
   selectProviderConfig,
@@ -152,7 +153,7 @@ const useBlockExplorer = (chainId?: string) => {
           ];
         return blockExplorerUrls
           ? getBlockExplorerNameFromUrl(blockExplorerUrls.url)
-          : 'Block Explorer';
+          : strings('swaps.block_explorer');
       }
 
       // For specific EVM chain block explorers
@@ -173,7 +174,7 @@ const useBlockExplorer = (chainId?: string) => {
         );
         return blockExplorer
           ? getBlockExplorerNameFromUrl(blockExplorer)
-          : 'Block Explorer';
+          : strings('swaps.block_explorer');
       }
 
       // Fallback to etherscan-based URL


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR fixes `View on -blockExplorer-` button text and redirect URL for networks other than mainnet.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug that was causing View on -blockexplorer- button to always redirect to etherscan, regardless of network selected

## **Related issues**

Fixes:
Jira ticket: https://consensyssoftware.atlassian.net/browse/MUL-1044
## **Manual testing steps**

```gherkin
Feature: Redirect to blockexplorer

  Scenario: user checks currently used address
    Given multichain accounts feature is enabled

    When user opens networks list by clicking copy button on the main view
    Then clicks QR button icon next to any of the networks
    Then the correct blockexplorer name should appear on the "View on..." button and after clicking it, user should be redirected to that blockexplorer.
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/89b78d11-1ba8-4a28-857d-7cec4d1c3cb1


### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/5696b429-3a6d-4dfe-91b7-30af5f64281e


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolve correct block explorer URL and name per chain (EVM and non‑EVM) and update ShareAddressQR to use the new hook APIs.
> 
> - **Hooks (`useBlockExplorer`)**:
>   - Accepts optional `chainId`; adds `getBlockExplorerUrl` and `getBlockExplorerName`.
>   - Supports EVM (built-in constants, `PopularList`) and non‑EVM via `MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP`.
>   - Converts CAIP IDs, handles RPC custom explorers, and falls back to Etherscan; no‑op if URL unavailable.
>   - Removes `NO_RPC_BLOCK_EXPLORER` usage and `isEvmSelected` gate.
> - **UI (`ShareAddressQR`)**:
>   - Uses `useBlockExplorer(chainId)`; updates "View on..." button to display `getBlockExplorerName()` and navigate via `toBlockExplorer(address)`.
> - **Tests**:
>   - Add comprehensive tests for popular networks, non‑EVM chains, fallbacks, and navigation in `useBlockExplorer.test.ts`.
>   - Update `ShareAddressQR.test.tsx` to mock `getBlockExplorerName` and align with new hook behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41f87dfb6392f4534bb140e34cb72895115bc277. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->