### PR TITLE
fix: missing transactions in activity after perps deposit

### DIFF
--- a/app/util/activity/index.test.ts
+++ b/app/util/activity/index.test.ts
@@ -456,6 +456,40 @@ describe('Activity utils :: filterByAddressAndNetwork', () => {
 
     expect(result).toEqual(false);
   });
+
+  it('returns true if no batch id and perps deposit', () => {
+    const transaction = {
+      id: '123',
+      chainId: '0x1',
+      status: TX_SUBMITTED,
+      txParams: {
+        from: TEST_ADDRESS_ONE,
+        to: TEST_ADDRESS_TWO,
+      },
+      isTransfer: false,
+      transferInformation: undefined,
+    } as Partial<TransactionMeta> as TransactionMeta;
+
+    const allTransactions = [
+      {
+        id: '789',
+        chainId: '0x1',
+        type: TransactionType.perpsDeposit,
+      },
+    ] as Partial<TransactionMeta>[] as TransactionMeta[];
+
+    const tokens = [] as Token[];
+
+    const result = filterByAddressAndNetwork(
+      transaction,
+      tokens,
+      TEST_ADDRESS_ONE,
+      { '0x1': true },
+      allTransactions,
+    );
+
+    expect(result).toEqual(true);
+  });
 });
 
 describe('Activity utils :: filterByAddress', () => {
@@ -634,5 +668,38 @@ describe('Activity utils :: filterByAddress', () => {
     );
 
     expect(result).toEqual(false);
+  });
+
+  it('returns true if no batch id and perps deposit', () => {
+    const transaction = {
+      id: '123',
+      chainId: '0x1',
+      status: TX_SUBMITTED,
+      txParams: {
+        from: TEST_ADDRESS_ONE,
+        to: TEST_ADDRESS_TWO,
+      },
+      isTransfer: false,
+      transferInformation: undefined,
+    } as Partial<TransactionMeta> as TransactionMeta;
+
+    const allTransactions = [
+      {
+        id: '789',
+        chainId: '0x1',
+        type: TransactionType.perpsDeposit,
+      },
+    ] as Partial<TransactionMeta>[] as TransactionMeta[];
+
+    const tokens = [] as Token[];
+
+    const result = filterByAddress(
+      transaction,
+      tokens,
+      TEST_ADDRESS_ONE,
+      allTransactions,
+    );
+
+    expect(result).toEqual(true);
   });
 });

--- a/app/util/activity/index.ts
+++ b/app/util/activity/index.ts
@@ -115,7 +115,10 @@ export const filterByAddressAndNetwork = (
   const isInBatchWithPerpsDeposit =
     type !== TransactionType.perpsDeposit &&
     allTransactions?.some(
-      (t) => t.batchId === batchId && t.type === TransactionType.perpsDeposit,
+      (t) =>
+        batchId &&
+        t.batchId === batchId &&
+        t.type === TransactionType.perpsDeposit,
     );
 
   if (isInBatchWithPerpsDeposit) {
@@ -184,7 +187,10 @@ export const filterByAddress = (
   const isInBatchWithPerpsDeposit =
     type !== TransactionType.perpsDeposit &&
     allTransactions?.some(
-      (t) => t.batchId === batchId && t.type === TransactionType.perpsDeposit,
+      (t) =>
+        batchId &&
+        t.batchId === batchId &&
+        t.type === TransactionType.perpsDeposit,
     );
 
   if (isInBatchWithPerpsDeposit) {


### PR DESCRIPTION
## **Description**

Prevent missing transactions in activity after Perps deposit.

## **Changelog**

CHANGELOG entry: Fixed bug causing missing transactions in activity after Perps deposit

## **Related issues**

Fixes: #20498 

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjust activity filters to require matching batchId before excluding transactions due to a perps deposit, and add tests for no-batch scenarios.
> 
> - **Activity utils**:
>   - **Filtering logic**: In `filterByAddressAndNetwork` and `filterByAddress`, add a `batchId` check before treating a transaction as in a batch with a `perpsDeposit` (`batchId && t.batchId === batchId`).
> - **Tests**:
>   - Add unit tests in `app/util/activity/index.test.ts` verifying transactions without `batchId` are not excluded when a `perpsDeposit` exists elsewhere.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f95738435757c3d45609b36a80ccd9328b3647b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->