### PR TITLE
fix: App State Handling (SDKConnectV2) - Permission Revoke

### DIFF
--- a/app/core/SDKConnectV2/adapters/host-application-adapter.ts
+++ b/app/core/SDKConnectV2/adapters/host-application-adapter.ts
@@ -4,10 +4,9 @@ import { SDKSessions } from '../../../core/SDKConnect/SDKConnect';
 import { store } from '../../../store';
 import { setSdkV2Connections } from '../../../actions/sdk';
 import { ConnectionProps } from '../../../core/SDKConnect/Connection';
-import {
-  getPermittedAccounts,
-  removePermittedAccounts,
-} from '../../../core/Permissions';
+import { getPermittedAccounts } from '../../../core/Permissions';
+import Engine from '../../Engine';
+import { Caip25EndowmentPermissionName } from '@metamask/chain-agnostic-permission';
 
 export class HostApplicationAdapter implements IHostApplicationAdapter {
   showLoading(): void {
@@ -58,10 +57,17 @@ export class HostApplicationAdapter implements IHostApplicationAdapter {
     store.dispatch(setSdkV2Connections(v2Sessions));
   }
 
+  /**
+   * Revokes {@link Caip25EndowmentPermissionName} permission from a connection / origin.
+   * @param connectionId - The origin of the connection.
+   */
   revokePermissions(connectionId: string): void {
     const allAccountsForOrigin = getPermittedAccounts(connectionId);
     if (allAccountsForOrigin.length > 0) {
-      removePermittedAccounts(connectionId, allAccountsForOrigin);
+      Engine.context.PermissionController.revokePermission(
+        connectionId,
+        Caip25EndowmentPermissionName,
+      );
     }
   }
 }

--- a/app/core/SDKConnectV2/adapters/host-application-adapter.ts
+++ b/app/core/SDKConnectV2/adapters/host-application-adapter.ts
@@ -4,7 +4,6 @@ import { SDKSessions } from '../../../core/SDKConnect/SDKConnect';
 import { store } from '../../../store';
 import { setSdkV2Connections } from '../../../actions/sdk';
 import { ConnectionProps } from '../../../core/SDKConnect/Connection';
-import { getPermittedAccounts } from '../../../core/Permissions';
 import Engine from '../../Engine';
 import { Caip25EndowmentPermissionName } from '@metamask/chain-agnostic-permission';
 
@@ -62,11 +61,14 @@ export class HostApplicationAdapter implements IHostApplicationAdapter {
    * @param connectionId - The origin of the connection.
    */
   revokePermissions(connectionId: string): void {
-    const allAccountsForOrigin = getPermittedAccounts(connectionId);
-    if (allAccountsForOrigin.length > 0) {
+    try {
       Engine.context.PermissionController.revokePermission(
         connectionId,
         Caip25EndowmentPermissionName,
+      );
+    } catch {
+      console.warn(
+        `[SDKConnectV2] HostApplicationAdapter.revokePermissions called but no ${Caip25EndowmentPermissionName} permission for ${connectionId}.`,
       );
     }
   }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR addresses feedback left in https://github.com/MetaMask/metamask-mobile/pull/19505, namely [this specific comment](https://github.com/MetaMask/metamask-mobile/pull/19505#discussion_r2342070483). Minor refactor for calling `PermissionController.revokePermission` instead of removing accounts from permissions manually.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/pull/19505#discussion_r2342070483

## **Manual testing steps**

No manual testing steps are needed for this PR. The V2 connection code path is not fully integrated end-to-end, making these new lifecycle methods currently unreachable in a standard build. Comprehensive manual testing will be performed in subsequent PRs once the full connection flow is established.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches permission revocation to PermissionController.revokePermission for CAIP-25 and updates tests with error-tolerant handling.
> 
> - **SDKConnectV2 HostApplicationAdapter**:
>   - Replace `getPermittedAccounts`/`removePermittedAccounts` with `Engine.context.PermissionController.revokePermission` using `Caip25EndowmentPermissionName` in `revokePermissions`.
>   - Add try/catch to log a warning when the permission is absent.
> - **Tests** (`app/core/SDKConnectV2/adapters/host-application-adapter.test.ts`):
>   - Remove `Permissions` mocks; mock and assert `PermissionController.revokePermission` calls.
>   - Add test to ensure graceful handling and warning when permission does not exist.
>   - Keep `syncConnectionList` dispatch assertions unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce0c5c4f1e44130dc35bf2bedbd09694ed293569. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->