### PR TITLE
refactor: Refactor permission controller to use modular init

### DIFF
--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -43,27 +43,18 @@ import {
   TransactionMeta,
 } from '@metamask/transaction-controller';
 import { GasFeeController } from '@metamask/gas-fee-controller';
-import {
-  AcceptOptions,
-  AddApprovalOptions,
-} from '@metamask/approval-controller';
+import { AcceptOptions } from '@metamask/approval-controller';
 import { HdKeyring } from '@metamask/eth-hd-keyring';
 import {
+  type CaveatSpecificationConstraint,
   PermissionController,
+  type PermissionSpecificationConstraint,
   ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
   SubjectMetadataController,
   ///: END:ONLY_INCLUDE_IF
 } from '@metamask/permission-controller';
 import SwapsController, { swapsUtils } from '@metamask/swaps-controller';
 import { PPOMController } from '@metamask/ppom-validator';
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
-import type { NotificationArgs } from '@metamask/snaps-rpc-methods/dist/restricted/notify.cjs';
-import {
-  buildSnapEndowmentSpecifications,
-  buildSnapRestrictedMethodSpecifications,
-} from '@metamask/snaps-rpc-methods';
-import type { EnumToUnion, DialogType } from '@metamask/snaps-sdk';
-///: END:ONLY_INCLUDE_IF
 import {
   QrKeyring,
   QrKeyringDeferredPromiseBridge,
@@ -97,7 +88,6 @@ import { isZero } from '../../util/lodash';
 import { MetaMetricsEvents, MetaMetrics } from '../Analytics';
 
 ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
-import { ExcludedSnapEndowments, ExcludedSnapPermissions } from '../Snaps';
 import { calculateScryptKey } from './controllers/identity/calculate-scrypt-key';
 import { notificationServicesControllerInit } from './controllers/notifications/notification-services-controller-init';
 import { notificationServicesPushControllerInit } from './controllers/notifications/notification-services-push-controller-init';
@@ -107,11 +97,6 @@ import { createAuthenticationController } from './controllers/identity/create-au
 import { getUserStorageControllerMessenger } from './messengers/identity/user-storage-controller-messenger';
 import { createUserStorageController } from './controllers/identity/create-user-storage-controller';
 ///: END:ONLY_INCLUDE_IF
-import {
-  getCaveatSpecifications,
-  getPermissionSpecifications,
-  unrestrictedMethods,
-} from '../Permissions/specifications.js';
 import { backupVault } from '../BackupVault';
 import { Hex, Json, KnownCaipNamespace } from '@metamask/utils';
 import { providerErrors } from '@metamask/rpc-errors';
@@ -148,7 +133,6 @@ import {
 ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import { snapKeyringBuilder } from '../SnapKeyring';
 import { removeAccountsFromPermissions } from '../Permissions';
-import { keyringSnapPermissionsBuilder } from '../SnapKeyring/keyringSnapsPermissions';
 import { multichainBalancesControllerInit } from './controllers/multichain-balances-controller/multichain-balances-controller-init';
 import { createMultichainRatesController } from './controllers/RatesController/utils';
 import { setupCurrencyRateSync } from './controllers/RatesController/subscriptions';
@@ -158,18 +142,13 @@ import { multichainTransactionsControllerInit } from './controllers/multichain-t
 import { multichainAccountServiceInit } from './controllers/multichain-account-service/multichain-account-service-init';
 ///: END:ONLY_INCLUDE_IF
 ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
-import { HandleSnapRequestArgs } from '../Snaps/types';
-import { handleSnapRequest } from '../Snaps/utils';
 import {
   cronjobControllerInit,
   executionServiceInit,
   snapControllerInit,
   snapInterfaceControllerInit,
   snapsRegistryInit,
-  SnapControllerClearSnapStateAction,
   SnapControllerGetSnapAction,
-  SnapControllerGetSnapStateAction,
-  SnapControllerUpdateSnapStateAction,
   SnapControllerIsMinimumPlatformVersionAction,
   SnapControllerHandleRequestAction,
 } from './controllers/snaps';
@@ -223,10 +202,6 @@ import {
   MultichainRouterMessenger,
   MultichainRouterArgs,
 } from '@metamask/snaps-controllers';
-import {
-  MultichainRouterGetSupportedAccountsEvent,
-  MultichainRouterIsSupportedScopeEvent,
-} from './controllers/multichain-router/constants';
 import { ErrorReportingService } from '@metamask/error-reporting-service';
 import { captureException } from '@sentry/react-native';
 import { WebSocketServiceInit } from './controllers/snaps/websocket-service-init';
@@ -243,6 +218,7 @@ import { RewardsDataService } from './controllers/rewards-controller/services/re
 import { selectAssetsAccountApiBalancesEnabled } from '../../selectors/featureFlagController/assetsAccountApiBalances';
 import type { GatorPermissionsController } from '@metamask/gator-permissions-controller';
 import { selectedNetworkControllerInit } from './controllers/selected-network-controller-init';
+import { permissionControllerInit } from './controllers/permission-controller-init';
 
 const NON_EMPTY = 'NON_EMPTY';
 
@@ -314,6 +290,11 @@ export class Engine {
   });
 
   rewardsDataService: RewardsDataService;
+
+  permissionController: PermissionController<
+    PermissionSpecificationConstraint,
+    CaveatSpecificationConstraint
+  >;
 
   /**
    * Creates a CoreController instance
@@ -675,240 +656,6 @@ export class Engine {
       cacheEncryptionKey: true,
     });
 
-    ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
-    /**
-     * Gets the mnemonic of the user's primary keyring.
-     */
-    const getPrimaryKeyringMnemonic = () => {
-      const [keyring] = this.keyringController.getKeyringsByType(
-        KeyringTypes.hd,
-      ) as HdKeyring[];
-
-      if (!keyring.mnemonic) {
-        throw new Error('Primary keyring mnemonic unavailable.');
-      }
-
-      return keyring.mnemonic;
-    };
-
-    const getPrimaryKeyringMnemonicSeed = () => {
-      const [keyring] = this.keyringController.getKeyringsByType(
-        KeyringTypes.hd,
-      ) as HdKeyring[];
-
-      if (!keyring.seed) {
-        throw new Error('Primary keyring mnemonic unavailable.');
-      }
-
-      return keyring.seed;
-    };
-
-    const getUnlockPromise = () => {
-      if (this.keyringController.isUnlocked()) {
-        return Promise.resolve();
-      }
-      return new Promise<void>((resolve) => {
-        this.controllerMessenger.subscribeOnceIf(
-          'KeyringController:unlock',
-          resolve,
-          () => true,
-        );
-      });
-    };
-
-    const snapRestrictedMethods = {
-      clearSnapState: this.controllerMessenger.call.bind(
-        this.controllerMessenger,
-        SnapControllerClearSnapStateAction,
-      ),
-      getMnemonic: async (source?: string) => {
-        if (!source) {
-          return getPrimaryKeyringMnemonic();
-        }
-
-        try {
-          const { type, mnemonic } = (await this.controllerMessenger.call(
-            'KeyringController:withKeyring',
-            {
-              id: source,
-            },
-            async ({ keyring }) => ({
-              type: keyring.type,
-              mnemonic: (keyring as unknown as HdKeyring).mnemonic,
-            }),
-          )) as { type: string; mnemonic?: Uint8Array };
-
-          if (type !== KeyringTypes.hd || !mnemonic) {
-            // The keyring isn't guaranteed to have a mnemonic (e.g.,
-            // hardware wallets, which can't be used as entropy sources),
-            // so we throw an error if it doesn't.
-            throw new Error(`Entropy source with ID "${source}" not found.`);
-          }
-
-          return mnemonic;
-        } catch {
-          throw new Error(`Entropy source with ID "${source}" not found.`);
-        }
-      },
-      getMnemonicSeed: async (source?: string) => {
-        if (!source) {
-          return getPrimaryKeyringMnemonicSeed();
-        }
-
-        try {
-          const { type, seed } = (await this.controllerMessenger.call(
-            'KeyringController:withKeyring',
-            {
-              id: source,
-            },
-            async ({ keyring }) => ({
-              type: keyring.type,
-              seed: (keyring as unknown as HdKeyring).seed,
-            }),
-          )) as { type: string; seed?: Uint8Array };
-
-          if (type !== KeyringTypes.hd || !seed) {
-            // The keyring isn't guaranteed to have a seed (e.g.,
-            // hardware wallets, which can't be used as entropy sources),
-            // so we throw an error if it doesn't.
-            throw new Error(`Entropy source with ID "${source}" not found.`);
-          }
-
-          return seed;
-        } catch {
-          throw new Error(`Entropy source with ID "${source}" not found.`);
-        }
-      },
-      getUnlockPromise: getUnlockPromise.bind(this),
-      getSnap: this.controllerMessenger.call.bind(
-        this.controllerMessenger,
-        SnapControllerGetSnapAction,
-      ),
-      handleSnapRpcRequest: async (args: HandleSnapRequestArgs) =>
-        await handleSnapRequest(this.controllerMessenger, args),
-      getSnapState: this.controllerMessenger.call.bind(
-        this.controllerMessenger,
-        SnapControllerGetSnapStateAction,
-      ),
-      updateSnapState: this.controllerMessenger.call.bind(
-        this.controllerMessenger,
-        SnapControllerUpdateSnapStateAction,
-      ),
-      maybeUpdatePhishingList: this.controllerMessenger.call.bind(
-        this.controllerMessenger,
-        'PhishingController:maybeUpdateState',
-      ),
-      isOnPhishingList: (origin: string) =>
-        this.controllerMessenger.call<'PhishingController:testOrigin'>(
-          'PhishingController:testOrigin',
-          origin,
-        ).result,
-      showDialog: (
-        origin: string,
-        type: EnumToUnion<DialogType>,
-        // TODO: Replace "any" with type
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        content: any, // should be Component from '@metamask/snaps-ui';
-        // TODO: Replace "any" with type
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        placeholder?: any,
-      ) =>
-        this.controllerMessenger.call<'ApprovalController:addRequest'>(
-          'ApprovalController:addRequest',
-          {
-            origin,
-            type,
-            requestData: { content, placeholder },
-          },
-          true,
-        ),
-      showInAppNotification: (origin: string, args: NotificationArgs) => {
-        Logger.log(
-          'Snaps/ showInAppNotification called with args: ',
-          args,
-          ' and origin: ',
-          origin,
-        );
-
-        return null;
-      },
-      createInterface: this.controllerMessenger.call.bind(
-        this.controllerMessenger,
-        'SnapInterfaceController:createInterface',
-      ),
-      getInterface: this.controllerMessenger.call.bind(
-        this.controllerMessenger,
-        'SnapInterfaceController:getInterface',
-      ),
-      updateInterface: this.controllerMessenger.call.bind(
-        this.controllerMessenger,
-        'SnapInterfaceController:updateInterface',
-      ),
-      requestUserApproval: (opts: AddApprovalOptions) =>
-        this.controllerMessenger.call<'ApprovalController:addRequest'>(
-          'ApprovalController:addRequest',
-          opts,
-          true,
-        ),
-      hasPermission: (origin: string, target: string) =>
-        this.controllerMessenger.call<'PermissionController:hasPermission'>(
-          'PermissionController:hasPermission',
-          origin,
-          target,
-        ),
-      getClientCryptography: () => ({ pbkdf2Sha512: pbkdf2 }),
-      getPreferences: () => {
-        const {
-          securityAlertsEnabled,
-          useTransactionSimulations,
-          useTokenDetection,
-          privacyMode,
-          useNftDetection,
-          displayNftMedia,
-          isMultiAccountBalancesEnabled,
-          showTestNetworks,
-        } = this.getPreferences();
-        const locale = I18n.locale;
-        return {
-          locale,
-          currency: this.context.CurrencyRateController.state.currentCurrency,
-          hideBalances: privacyMode,
-          useSecurityAlerts: securityAlertsEnabled,
-          simulateOnChainActions: useTransactionSimulations,
-          useTokenDetection,
-          batchCheckBalances: isMultiAccountBalancesEnabled,
-          displayNftMedia,
-          useNftDetection,
-          useExternalPricingData: true,
-          showTestnets: showTestNetworks,
-        };
-      },
-    };
-    ///: END:ONLY_INCLUDE_IF
-
-    ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-    const keyringSnapMethods = {
-      getAllowedKeyringMethods: (origin: string) =>
-        keyringSnapPermissionsBuilder(origin),
-      getSnapKeyring: this.getSnapKeyring.bind(this),
-    };
-    ///: END:ONLY_INCLUDE_IF
-
-    const getSnapPermissionSpecifications = () => ({
-      ...buildSnapEndowmentSpecifications(Object.keys(ExcludedSnapEndowments)),
-      ...buildSnapRestrictedMethodSpecifications(
-        Object.keys(ExcludedSnapPermissions),
-        {
-          ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
-          ...snapRestrictedMethods,
-          ///: END:ONLY_INCLUDE_IF
-          ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-          ...keyringSnapMethods,
-          ///: END:ONLY_INCLUDE_IF
-        },
-      ),
-    });
-
     const accountTrackerController = new AccountTrackerController({
       messenger: this.controllerMessenger.getRestricted({
         name: 'AccountTrackerController',
@@ -937,53 +684,12 @@ export class Engine {
       }) as `0x${string}`[],
       allowExternalServices: () => isBasicFunctionalityToggleEnabled(),
     });
-    const permissionController = new PermissionController({
-      messenger: this.controllerMessenger.getRestricted({
-        name: 'PermissionController',
-        allowedActions: [
-          `ApprovalController:addRequest`,
-          `ApprovalController:hasRequest`,
-          `ApprovalController:acceptRequest`,
-          `ApprovalController:rejectRequest`,
-          ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
-          `SnapController:getPermitted`,
-          `SnapController:install`,
-          `SubjectMetadataController:getSubjectMetadata`,
-          ///: END:ONLY_INCLUDE_IF
-        ],
-        allowedEvents: [],
-      }),
-      state: initialState.PermissionController,
-      caveatSpecifications: getCaveatSpecifications({
-        listAccounts: (...args) =>
-          this.accountsController.listAccounts(...args),
-        findNetworkClientIdByChainId:
-          networkController.findNetworkClientIdByChainId.bind(
-            networkController,
-          ),
-        isNonEvmScopeSupported: this.controllerMessenger.call.bind(
-          this.controllerMessenger,
-          MultichainRouterIsSupportedScopeEvent,
-        ),
-        getNonEvmAccountAddresses: this.controllerMessenger.call.bind(
-          this.controllerMessenger,
-          MultichainRouterGetSupportedAccountsEvent,
-        ),
-      }),
-      permissionSpecifications: {
-        ...getPermissionSpecifications(),
-        ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
-        ...getSnapPermissionSpecifications(),
-        ///: END:ONLY_INCLUDE_IF
-      },
-      unrestrictedMethods,
-    });
 
     ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
     this.subjectMetadataController = new SubjectMetadataController({
       messenger: this.controllerMessenger.getRestricted({
         name: 'SubjectMetadataController',
-        allowedActions: [`${permissionController.name}:hasPermissions`],
+        allowedActions: [`PermissionController:hasPermissions`],
         allowedEvents: [],
       }),
       state: initialState.SubjectMetadataController || {},
@@ -1142,6 +848,7 @@ export class Engine {
     const { controllersByName } = initModularizedControllers({
       controllerInitFunctions: {
         AccountsController: accountsControllerInit,
+        PermissionController: permissionControllerInit,
         AccountTreeController: accountTreeControllerInit,
         AppMetadataController: appMetadataControllerInit,
         SelectedNetworkController: selectedNetworkControllerInit,
@@ -1217,6 +924,7 @@ export class Engine {
     this.gasFeeController = gasFeeController;
     this.gatorPermissionsController = gatorPermissionsController;
     this.transactionController = transactionController;
+    this.permissionController = controllersByName.PermissionController;
 
     const multichainNetworkController =
       controllersByName.MultichainNetworkController;
@@ -1522,7 +1230,7 @@ export class Engine {
       GasFeeController: this.gasFeeController,
       GatorPermissionsController: gatorPermissionsController,
       ApprovalController: approvalController,
-      PermissionController: permissionController,
+      PermissionController: this.permissionController,
       RemoteFeatureFlagController: remoteFeatureFlagController,
       SelectedNetworkController: selectedNetworkController,
       SignatureController: signatureController,
@@ -1715,7 +1423,7 @@ export class Engine {
       allowedActions: [
         `SnapController:getAll`,
         `SnapController:handleRequest`,
-        `${permissionController.name}:getPermissions`,
+        `PermissionController:getPermissions`,
         `AccountsController:listMultichainAccounts`,
       ],
       allowedEvents: [],

--- a/app/core/Engine/controllers/permission-controller-init.test.ts
+++ b/app/core/Engine/controllers/permission-controller-init.test.ts
@@ -1,0 +1,67 @@
+import { buildControllerInitRequestMock } from '../utils/test-utils';
+import { ExtendedControllerMessenger } from '../../ExtendedControllerMessenger';
+import {
+  getPermissionControllerMessenger,
+  getPermissionControllerInitMessenger,
+  type PermissionControllerMessenger,
+  PermissionControllerInitMessenger,
+} from '../messengers/permission-controller-messenger';
+import { ControllerInitRequest } from '../types';
+import { permissionControllerInit } from './permission-controller-init';
+import { PermissionController } from '@metamask/permission-controller';
+
+jest.mock('@metamask/permission-controller');
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<
+    PermissionControllerMessenger,
+    PermissionControllerInitMessenger
+  >
+> {
+  const baseMessenger = new ExtendedControllerMessenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(baseMessenger),
+    controllerMessenger: getPermissionControllerMessenger(baseMessenger),
+    initMessenger: getPermissionControllerInitMessenger(baseMessenger),
+  };
+
+  // @ts-expect-error: Partial implementation.
+  requestMock.getController.mockImplementation((controllerName: string) => {
+    if (controllerName === 'ApprovalController') {
+      return {
+        addAndShowApprovalRequest: jest.fn(),
+      };
+    }
+
+    if (controllerName === 'KeyringController') {
+      return {
+        addNewKeyring: jest.fn(),
+      };
+    }
+
+    throw new Error(`Controller "${controllerName}" not found.`);
+  });
+
+  return requestMock;
+}
+
+describe('permissionControllerInit', () => {
+  it('initializes the controller', () => {
+    const { controller } = permissionControllerInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(PermissionController);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    permissionControllerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(PermissionController);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      state: undefined,
+      caveatSpecifications: expect.any(Object),
+      permissionSpecifications: expect.any(Object),
+      unrestrictedMethods: expect.any(Array),
+    });
+  });
+});

--- a/app/core/Engine/controllers/permission-controller-init.ts
+++ b/app/core/Engine/controllers/permission-controller-init.ts
@@ -13,7 +13,9 @@ import {
   getPermissionSpecifications,
   unrestrictedMethods,
 } from '../../Permissions/specifications';
+///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
 import { getSnapPermissionSpecifications } from '../../Snaps/permissions/specifications';
+///: END:ONLY_INCLUDE_IF
 import { CaipChainId } from '@metamask/utils';
 
 /**
@@ -31,7 +33,9 @@ export const permissionControllerInit: ControllerInitFunction<
   PermissionControllerMessenger,
   PermissionControllerInitMessenger
 > = ({ controllerMessenger, initMessenger, persistedState, getController }) => {
+  ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
   const keyringController = getController('KeyringController');
+  ///: END:ONLY_INCLUDE_IF
 
   const controller = new PermissionController({
     // @ts-expect-error: The permission controller needs certain actions that
@@ -60,7 +64,6 @@ export const permissionControllerInit: ControllerInitFunction<
     permissionSpecifications: {
       ...getPermissionSpecifications(),
       ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
-      // @ts-expect-error: Messenger type doesn't match.
       ...getSnapPermissionSpecifications(initMessenger, {
         addNewKeyring: keyringController.addNewKeyring.bind(keyringController),
       }),

--- a/app/core/Engine/controllers/permission-controller-init.ts
+++ b/app/core/Engine/controllers/permission-controller-init.ts
@@ -1,0 +1,75 @@
+import { ControllerInitFunction } from '../types';
+import {
+  PermissionController,
+  type PermissionSpecificationConstraint,
+  type CaveatSpecificationConstraint,
+} from '@metamask/permission-controller';
+import {
+  PermissionControllerInitMessenger,
+  PermissionControllerMessenger,
+} from '../messengers/permission-controller-messenger';
+import {
+  getCaveatSpecifications,
+  getPermissionSpecifications,
+  unrestrictedMethods,
+} from '../../Permissions/specifications';
+import { getSnapPermissionSpecifications } from '../../Snaps/permissions/specifications';
+import { CaipChainId } from '@metamask/utils';
+
+/**
+ * Initialize the permission controller.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @returns The initialized controller.
+ */
+export const permissionControllerInit: ControllerInitFunction<
+  PermissionController<
+    PermissionSpecificationConstraint,
+    CaveatSpecificationConstraint
+  >,
+  PermissionControllerMessenger,
+  PermissionControllerInitMessenger
+> = ({ controllerMessenger, initMessenger, persistedState, getController }) => {
+  const keyringController = getController('KeyringController');
+
+  const controller = new PermissionController({
+    // @ts-expect-error: The permission controller needs certain actions that
+    // are not declared in the messenger's type.
+    messenger: controllerMessenger,
+    state: persistedState.PermissionController,
+    caveatSpecifications: getCaveatSpecifications({
+      listAccounts: (...args) =>
+        initMessenger.call('AccountsController:listAccounts', ...args),
+      findNetworkClientIdByChainId: (...args) =>
+        initMessenger.call(
+          'NetworkController:findNetworkClientIdByChainId',
+          ...args,
+        ),
+      isNonEvmScopeSupported: (scope) =>
+        initMessenger.call(
+          'MultichainRouter:isSupportedScope',
+          scope as CaipChainId,
+        ),
+      getNonEvmAccountAddresses: (scope) =>
+        initMessenger.call(
+          'MultichainRouter:getSupportedAccounts',
+          scope as CaipChainId,
+        ),
+    }),
+    permissionSpecifications: {
+      ...getPermissionSpecifications(),
+      ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+      // @ts-expect-error: Messenger type doesn't match.
+      ...getSnapPermissionSpecifications(initMessenger, {
+        addNewKeyring: keyringController.addNewKeyring.bind(keyringController),
+      }),
+      ///: END:ONLY_INCLUDE_IF
+    },
+    unrestrictedMethods,
+  });
+
+  return {
+    controller,
+  };
+};

--- a/app/core/Engine/messengers/index.ts
+++ b/app/core/Engine/messengers/index.ts
@@ -45,6 +45,11 @@ import { getMultichainAccountServiceMessenger } from './multichain-account-servi
 import { getRewardsControllerMessenger } from './rewards-controller-messenger';
 import { getGatorPermissionsControllerMessenger } from './gator-permissions-controller-messenger';
 import { getSelectedNetworkControllerMessenger } from './selected-network-controller-messenger';
+import {
+  getPermissionControllerInitMessenger,
+  getPermissionControllerMessenger,
+} from './permission-controller-messenger';
+
 /**
  * The messengers for the controllers that have been.
  */
@@ -141,6 +146,10 @@ export const CONTROLLER_MESSENGERS = {
     getInitMessenger: noop,
   },
   ///: END:ONLY_INCLUDE_IF
+  PermissionController: {
+    getMessenger: getPermissionControllerMessenger,
+    getInitMessenger: getPermissionControllerInitMessenger,
+  },
   SeedlessOnboardingController: {
     getMessenger: getSeedlessOnboardingControllerMessenger,
     getInitMessenger: noop,

--- a/app/core/Engine/messengers/permission-controller-messenger.test.ts
+++ b/app/core/Engine/messengers/permission-controller-messenger.test.ts
@@ -1,0 +1,27 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import {
+  getPermissionControllerMessenger,
+  getPermissionControllerInitMessenger,
+} from './permission-controller-messenger';
+
+describe('getPermissionControllerMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const permissionControllerMessenger =
+      getPermissionControllerMessenger(messenger);
+
+    expect(permissionControllerMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});
+
+describe('getPermissionControllerInitMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const permissionControllerInitMessenger =
+      getPermissionControllerInitMessenger(messenger);
+
+    expect(permissionControllerInitMessenger).toBeInstanceOf(
+      RestrictedMessenger,
+    );
+  });
+});

--- a/app/core/Engine/messengers/permission-controller-messenger.ts
+++ b/app/core/Engine/messengers/permission-controller-messenger.ts
@@ -109,6 +109,7 @@ export function getPermissionControllerInitMessenger(
       'SnapController:updateSnapState',
       'SnapInterfaceController:createInterface',
       'SnapInterfaceController:getInterface',
+      'SnapInterfaceController:updateInterface',
     ],
     allowedEvents: ['KeyringController:unlock'],
   });

--- a/app/core/Engine/messengers/permission-controller-messenger.ts
+++ b/app/core/Engine/messengers/permission-controller-messenger.ts
@@ -1,0 +1,115 @@
+import { Messenger } from '@metamask/base-controller';
+import {
+  AcceptRequest,
+  AddApprovalRequest,
+  HasApprovalRequest,
+  RejectRequest,
+} from '@metamask/approval-controller';
+import {
+  GetPermittedSnaps,
+  InstallSnaps,
+  MultichainRouterGetSupportedAccountsAction,
+  MultichainRouterIsSupportedScopeAction,
+} from '@metamask/snaps-controllers';
+import { GetSubjectMetadata } from '@metamask/permission-controller';
+import { AccountsControllerListAccountsAction } from '@metamask/accounts-controller';
+import {
+  SnapPermissionSpecificationsActions,
+  SnapPermissionSpecificationsEvents,
+} from '../../Snaps/permissions/specifications.ts';
+import { NetworkControllerFindNetworkClientIdByChainIdAction } from '@metamask/network-controller';
+
+type AllowedActions =
+  | AddApprovalRequest
+  | HasApprovalRequest
+  | AcceptRequest
+  | RejectRequest
+  | GetPermittedSnaps
+  | InstallSnaps
+  | GetSubjectMetadata;
+
+export type PermissionControllerMessenger = ReturnType<
+  typeof getPermissionControllerMessenger
+>;
+
+/**
+ * Get a restricted messenger for the permission controller. This is scoped to the
+ * actions and events that the permission controller is allowed to handle.
+ *
+ * @param messenger - The messenger to restrict.
+ * @returns The restricted messenger.
+ */
+export function getPermissionControllerMessenger(
+  messenger: Messenger<AllowedActions, never>,
+) {
+  return messenger.getRestricted({
+    name: 'PermissionController',
+    allowedActions: [
+      'ApprovalController:addRequest',
+      'ApprovalController:hasRequest',
+      'ApprovalController:acceptRequest',
+      'ApprovalController:rejectRequest',
+      ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+      'SnapController:getPermitted',
+      'SnapController:install',
+      'SubjectMetadataController:getSubjectMetadata',
+      ///: END:ONLY_INCLUDE_IF
+    ],
+    allowedEvents: [],
+  });
+}
+
+type AllowedInitializationActions =
+  | AccountsControllerListAccountsAction
+  | MultichainRouterIsSupportedScopeAction
+  | MultichainRouterGetSupportedAccountsAction
+  | NetworkControllerFindNetworkClientIdByChainIdAction
+  | SnapPermissionSpecificationsActions;
+
+type AllowedInitializationEvents = SnapPermissionSpecificationsEvents;
+
+export type PermissionControllerInitMessenger = ReturnType<
+  typeof getPermissionControllerInitMessenger
+>;
+
+/**
+ * Get a restricted messenger for the permission controller. This is scoped to the
+ * actions and events that the permission controller is allowed to handle during
+ * initialization.
+ *
+ * @param messenger - The messenger to restrict.
+ * @returns The restricted messenger.
+ */
+export function getPermissionControllerInitMessenger(
+  messenger: Messenger<
+    AllowedInitializationActions,
+    AllowedInitializationEvents
+  >,
+) {
+  return messenger.getRestricted({
+    name: 'PermissionControllerInit',
+    allowedActions: [
+      'ApprovalController:addRequest',
+      'AccountsController:listAccounts',
+      'CurrencyRateController:getState',
+      'KeyringController:getKeyringsByType',
+      'KeyringController:getState',
+      'KeyringController:withKeyring',
+      'MultichainRouter:isSupportedScope',
+      'MultichainRouter:getSupportedAccounts',
+      'NetworkController:findNetworkClientIdByChainId',
+      'PermissionController:hasPermission',
+      'PhishingController:maybeUpdateState',
+      'PhishingController:testOrigin',
+      'PreferencesController:getState',
+      'SnapController:clearSnapState',
+      'SnapController:get',
+      'SnapController:getSnapState',
+      'SnapController:handleRequest',
+      'SnapController:updateSnapState',
+      'SnapInterfaceController:createInterface',
+      'SnapInterfaceController:getInterface',
+    ],
+    allowedEvents: ['KeyringController:unlock'],
+  });
+}

--- a/app/core/Engine/types.ts
+++ b/app/core/Engine/types.ts
@@ -131,10 +131,12 @@ import {
   SelectedNetworkControllerState,
 } from '@metamask/selected-network-controller';
 import {
+  type CaveatSpecificationConstraint,
   PermissionController,
   PermissionControllerActions,
   PermissionControllerEvents,
   PermissionControllerState,
+  type PermissionSpecificationConstraint,
   ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
   SubjectMetadataController,
   SubjectMetadataControllerActions,
@@ -517,10 +519,10 @@ export type Controllers = {
   NetworkEnablementController: NetworkEnablementController;
   NftController: NftController;
   NftDetectionController: NftDetectionController;
-  // TODO: Fix permission types
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  PermissionController: PermissionController<any, any>;
+  PermissionController: PermissionController<
+    PermissionSpecificationConstraint,
+    CaveatSpecificationConstraint
+  >;
   SelectedNetworkController: SelectedNetworkController;
   PhishingController: PhishingController;
   PreferencesController: PreferencesController;
@@ -698,6 +700,7 @@ export type ControllersToInitialize =
   | 'SignatureController'
   | 'SeedlessOnboardingController'
   | 'TransactionController'
+  | 'PermissionController'
   | 'PerpsController'
   | 'PredictController'
   | 'BridgeController'

--- a/app/core/Engine/types.ts
+++ b/app/core/Engine/types.ts
@@ -131,12 +131,10 @@ import {
   SelectedNetworkControllerState,
 } from '@metamask/selected-network-controller';
 import {
-  type CaveatSpecificationConstraint,
   PermissionController,
   PermissionControllerActions,
   PermissionControllerEvents,
   PermissionControllerState,
-  type PermissionSpecificationConstraint,
   ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
   SubjectMetadataController,
   SubjectMetadataControllerActions,
@@ -519,10 +517,10 @@ export type Controllers = {
   NetworkEnablementController: NetworkEnablementController;
   NftController: NftController;
   NftDetectionController: NftDetectionController;
-  PermissionController: PermissionController<
-    PermissionSpecificationConstraint,
-    CaveatSpecificationConstraint
-  >;
+  // TODO: Fix permission types
+  // TODO: Replace "any" with type
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  PermissionController: PermissionController<any, any>;
   SelectedNetworkController: SelectedNetworkController;
   PhishingController: PhishingController;
   PreferencesController: PreferencesController;

--- a/app/core/Engine/utils/utils.test.ts
+++ b/app/core/Engine/utils/utils.test.ts
@@ -72,6 +72,12 @@ import { PredictController } from '../../../components/UI/Predict/controllers/Pr
 import { GatorPermissionsController } from '@metamask/gator-permissions-controller';
 import { selectedNetworkControllerInit } from '../controllers/selected-network-controller-init';
 import { SelectedNetworkController } from '@metamask/selected-network-controller';
+import { permissionControllerInit } from '../controllers/permission-controller-init';
+import {
+  CaveatSpecificationConstraint,
+  PermissionController,
+  PermissionSpecificationConstraint,
+} from '@metamask/permission-controller';
 
 jest.mock('../controllers/accounts-controller');
 jest.mock('../controllers/rewards-controller');
@@ -116,10 +122,12 @@ jest.mock(
   '../controllers/gator-permissions-controller/gator-permissions-controller-init',
 );
 jest.mock('../controllers/selected-network-controller-init');
+jest.mock('../controllers/permission-controller-init');
 
 describe('initModularizedControllers', () => {
   const mockAccountsControllerInit = jest.mocked(accountsControllerInit);
   const mockApprovalControllerInit = jest.mocked(ApprovalControllerInit);
+  const mockPermissionControllerInit = jest.mocked(permissionControllerInit);
   const mockSelectedNetworkControllerInit = jest.mocked(
     selectedNetworkControllerInit,
   );
@@ -192,6 +200,7 @@ describe('initModularizedControllers', () => {
         controllerInitFunctions: {
           AccountsController: mockAccountsControllerInit,
           AccountTreeController: mockAccountTreeControllerInit,
+          PermissionController: mockPermissionControllerInit,
           SelectedNetworkController: mockSelectedNetworkControllerInit,
           ApprovalController: mockApprovalControllerInit,
           CurrencyRateController: mockCurrencyRateControllerInit,
@@ -244,6 +253,12 @@ describe('initModularizedControllers', () => {
     });
     mockApprovalControllerInit.mockReturnValue({
       controller: {} as unknown as ApprovalController,
+    });
+    mockPermissionControllerInit.mockReturnValue({
+      controller: {} as unknown as PermissionController<
+        PermissionSpecificationConstraint,
+        CaveatSpecificationConstraint
+      >,
     });
     mockSelectedNetworkControllerInit.mockReturnValue({
       controller: {} as unknown as SelectedNetworkController,

--- a/app/core/Snaps/permissions/specifications.ts
+++ b/app/core/Snaps/permissions/specifications.ts
@@ -1,0 +1,331 @@
+import {
+  buildSnapEndowmentSpecifications,
+  buildSnapRestrictedMethodSpecifications,
+} from '@metamask/snaps-rpc-methods';
+import { keyringSnapPermissionsBuilder } from '../../SnapKeyring/keyringSnapsPermissions';
+import {
+  ControllerGetStateAction,
+  RestrictedMessenger,
+} from '@metamask/base-controller';
+import {
+  ClearSnapState,
+  CreateInterface,
+  GetInterface,
+  GetSnap,
+  GetSnapState,
+  HandleSnapRequest,
+  UpdateInterface,
+  UpdateSnapState,
+} from '@metamask/snaps-controllers';
+import { CurrencyRateController } from '@metamask/assets-controllers';
+import {
+  KeyringControllerGetKeyringsByTypeAction,
+  KeyringControllerGetStateAction,
+  KeyringControllerUnlockEvent,
+  KeyringControllerWithKeyringAction,
+  KeyringMetadata,
+  KeyringTypes,
+} from '@metamask/keyring-controller';
+import { MaybeUpdateState, TestOrigin } from '@metamask/phishing-controller';
+import { PreferencesControllerGetStateAction } from '@metamask/preferences-controller';
+import { HdKeyring } from '@metamask/eth-hd-keyring';
+import { DialogType, EnumToUnion } from '@metamask/snaps-sdk';
+import {
+  AddApprovalOptions,
+  AddApprovalRequest,
+} from '@metamask/approval-controller';
+import Logger from '../../../util/Logger';
+import { HasPermission } from '@metamask/permission-controller';
+import { pbkdf2 } from '../../Encryptor';
+import I18n from '../../../../locales/i18n';
+import {
+  ExcludedSnapEndowments,
+  ExcludedSnapPermissions,
+} from './permissions.ts';
+
+export type SnapPermissionSpecificationsActions =
+  | AddApprovalRequest
+  | ClearSnapState
+  | ControllerGetStateAction<
+      'CurrencyRateController',
+      CurrencyRateController['state']
+    >
+  | CreateInterface
+  | GetInterface
+  | GetSnap
+  | GetSnapState
+  | HandleSnapRequest
+  | KeyringControllerGetKeyringsByTypeAction
+  | KeyringControllerWithKeyringAction
+  | MaybeUpdateState
+  | PreferencesControllerGetStateAction
+  | TestOrigin
+  | UpdateSnapState
+  | UpdateInterface
+  | KeyringControllerGetStateAction
+  | HasPermission;
+
+export type SnapPermissionSpecificationsEvents = KeyringControllerUnlockEvent;
+
+interface SnapPermissionSpecificationsHooks {
+  addAndShowApprovalRequest(request: unknown): Promise<unknown>;
+  addNewKeyring(
+    type: KeyringTypes | string,
+    opts?: unknown,
+  ): Promise<KeyringMetadata>;
+}
+
+export const getSnapPermissionSpecifications = (
+  messenger: RestrictedMessenger<
+    never,
+    SnapPermissionSpecificationsActions,
+    SnapPermissionSpecificationsEvents,
+    SnapPermissionSpecificationsActions['type'],
+    SnapPermissionSpecificationsEvents['type']
+  >,
+  { addNewKeyring }: SnapPermissionSpecificationsHooks,
+) => {
+  /**
+   * Gets the mnemonic of the user's primary keyring.
+   */
+  const getPrimaryKeyringMnemonic = () => {
+    const [keyring] = messenger.call(
+      'KeyringController:getKeyringsByType',
+      KeyringTypes.hd,
+    ) as HdKeyring[];
+
+    if (!keyring.mnemonic) {
+      throw new Error('Primary keyring mnemonic unavailable.');
+    }
+
+    return keyring.mnemonic;
+  };
+
+  const getPrimaryKeyringMnemonicSeed = () => {
+    const [keyring] = messenger.call(
+      'KeyringController:getKeyringsByType',
+      KeyringTypes.hd,
+    ) as HdKeyring[];
+
+    if (!keyring.seed) {
+      throw new Error('Primary keyring mnemonic unavailable.');
+    }
+
+    return keyring.seed;
+  };
+
+  const getUnlockPromise = () => {
+    if (messenger.call('KeyringController:getState').isUnlocked) {
+      return Promise.resolve();
+    }
+
+    return new Promise<void>((resolve) => {
+      const callback = () => {
+        messenger.unsubscribe('KeyringController:unlock', callback);
+        resolve();
+      };
+
+      messenger.subscribe('KeyringController:unlock', callback);
+    });
+  };
+
+  const snapRestrictedMethods = {
+    clearSnapState: messenger.call.bind(
+      messenger,
+      'SnapController:clearSnapState',
+    ),
+    getMnemonic: async (source?: string) => {
+      if (!source) {
+        return getPrimaryKeyringMnemonic();
+      }
+
+      try {
+        const { type, mnemonic } = (await messenger.call(
+          'KeyringController:withKeyring',
+          {
+            id: source,
+          },
+          async ({ keyring }) => ({
+            type: keyring.type,
+            mnemonic: (keyring as unknown as HdKeyring).mnemonic,
+          }),
+        )) as { type: string; mnemonic?: Uint8Array };
+
+        if (type !== KeyringTypes.hd || !mnemonic) {
+          // The keyring isn't guaranteed to have a mnemonic (e.g.,
+          // hardware wallets, which can't be used as entropy sources),
+          // so we throw an error if it doesn't.
+          throw new Error(`Entropy source with ID "${source}" not found.`);
+        }
+
+        return mnemonic;
+      } catch {
+        throw new Error(`Entropy source with ID "${source}" not found.`);
+      }
+    },
+    getMnemonicSeed: async (source?: string) => {
+      if (!source) {
+        return getPrimaryKeyringMnemonicSeed();
+      }
+
+      try {
+        const { type, seed } = (await messenger.call(
+          'KeyringController:withKeyring',
+          {
+            id: source,
+          },
+          async ({ keyring }) => ({
+            type: keyring.type,
+            seed: (keyring as unknown as HdKeyring).seed,
+          }),
+        )) as { type: string; seed?: Uint8Array };
+
+        if (type !== KeyringTypes.hd || !seed) {
+          // The keyring isn't guaranteed to have a seed (e.g.,
+          // hardware wallets, which can't be used as entropy sources),
+          // so we throw an error if it doesn't.
+          throw new Error(`Entropy source with ID "${source}" not found.`);
+        }
+
+        return seed;
+      } catch {
+        throw new Error(`Entropy source with ID "${source}" not found.`);
+      }
+    },
+    getUnlockPromise: getUnlockPromise.bind(this),
+    getSnap: messenger.call.bind(messenger, 'SnapController:get'),
+    handleSnapRpcRequest: messenger.call.bind(
+      messenger,
+      'SnapController:handleRequest',
+    ),
+    getSnapState: messenger.call.bind(messenger, 'SnapController:getSnapState'),
+    updateSnapState: messenger.call.bind(
+      messenger,
+      'SnapController:updateSnapState',
+    ),
+    maybeUpdatePhishingList: messenger.call.bind(
+      messenger,
+      'PhishingController:maybeUpdateState',
+    ),
+    isOnPhishingList: (origin: string) =>
+      messenger.call('PhishingController:testOrigin', origin).result,
+    showDialog: (
+      origin: string,
+      type: EnumToUnion<DialogType>,
+      // TODO: Replace "any" with type
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      content: any, // should be Component from '@metamask/snaps-ui';
+      // TODO: Replace "any" with type
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      placeholder?: any,
+    ) =>
+      messenger.call(
+        'ApprovalController:addRequest',
+        {
+          origin,
+          type,
+          requestData: { content, placeholder },
+        },
+        true,
+      ),
+    showInAppNotification: (origin: string, args: unknown) => {
+      Logger.log(
+        'Snaps/ showInAppNotification called with args: ',
+        args,
+        ' and origin: ',
+        origin,
+      );
+
+      return null;
+    },
+    createInterface: messenger.call.bind(
+      messenger,
+      'SnapInterfaceController:createInterface',
+    ),
+    getInterface: messenger.call.bind(
+      messenger,
+      'SnapInterfaceController:getInterface',
+    ),
+    updateInterface: messenger.call.bind(
+      messenger,
+      'SnapInterfaceController:updateInterface',
+    ),
+    requestUserApproval: (opts: AddApprovalOptions) =>
+      messenger.call('ApprovalController:addRequest', opts, true),
+    hasPermission: (origin: string, target: string) =>
+      messenger.call('PermissionController:hasPermission', origin, target),
+    getClientCryptography: () => ({ pbkdf2Sha512: pbkdf2 }),
+    getPreferences: () => {
+      const {
+        securityAlertsEnabled,
+        useTransactionSimulations,
+        useTokenDetection,
+        privacyMode,
+        useNftDetection,
+        displayNftMedia,
+        isMultiAccountBalancesEnabled,
+        showTestNetworks,
+      } = messenger.call('PreferencesController:getState');
+      const { currentCurrency } = messenger.call(
+        'CurrencyRateController:getState',
+      );
+
+      const locale = I18n.locale;
+      return {
+        locale,
+        currency: currentCurrency,
+        hideBalances: privacyMode,
+        useSecurityAlerts: securityAlertsEnabled,
+        simulateOnChainActions: useTransactionSimulations,
+        useTokenDetection,
+        batchCheckBalances: isMultiAccountBalancesEnabled,
+        displayNftMedia,
+        useNftDetection,
+        useExternalPricingData: true,
+        showTestnets: showTestNetworks,
+      };
+    },
+  };
+
+  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+  const getSnapKeyring = async () => {
+    // TODO: Replace `getKeyringsByType` with `withKeyring`
+    let [snapKeyring] = messenger.call(
+      'KeyringController:getKeyringsByType',
+      KeyringTypes.snap,
+    );
+
+    if (!snapKeyring) {
+      await addNewKeyring(KeyringTypes.snap);
+      // TODO: Replace `getKeyringsByType` with `withKeyring`
+      [snapKeyring] = messenger.call(
+        'KeyringController:getKeyringsByType',
+        KeyringTypes.snap,
+      );
+    }
+
+    return snapKeyring;
+  };
+
+  const keyringSnapMethods = {
+    getAllowedKeyringMethods: (origin: string) =>
+      keyringSnapPermissionsBuilder(origin),
+    getSnapKeyring,
+  };
+  ///: END:ONLY_INCLUDE_IF
+
+  return {
+    ...buildSnapEndowmentSpecifications(Object.keys(ExcludedSnapEndowments)),
+    ...buildSnapRestrictedMethodSpecifications(
+      Object.keys(ExcludedSnapPermissions),
+      {
+        ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+        ...snapRestrictedMethods,
+        ///: END:ONLY_INCLUDE_IF
+        ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+        ...keyringSnapMethods,
+        ///: END:ONLY_INCLUDE_IF
+      },
+    ),
+  };
+};

--- a/app/core/Snaps/permissions/specifications.ts
+++ b/app/core/Snaps/permissions/specifications.ts
@@ -68,7 +68,6 @@ export type SnapPermissionSpecificationsActions =
 export type SnapPermissionSpecificationsEvents = KeyringControllerUnlockEvent;
 
 interface SnapPermissionSpecificationsHooks {
-  addAndShowApprovalRequest(request: unknown): Promise<unknown>;
   addNewKeyring(
     type: KeyringTypes | string,
     opts?: unknown,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This refactors the permission controller to use the modular init pattern.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modularizes `PermissionController` via a dedicated init function and messengers, refactors Engine wiring, extracts Snaps permission specs, and adds tests.
> 
> - **Engine refactor**:
>   - Replace inline `PermissionController` construction with modular init `permissionControllerInit` and store on `this.permissionController`.
>   - Update usages to generic actions (`PermissionController:hasPermissions`, `PermissionController:getPermissions`).
>   - Clean up imports and types for permission constraints.
> - **New controller init + messengers**:
>   - Add `controllers/permission-controller-init.ts` and register in `initModularizedControllers`.
>   - Introduce `getPermissionControllerMessenger` and `getPermissionControllerInitMessenger`; wire into `messengers/index.ts`.
> - **Snaps permissions**:
>   - Extract Snaps permission specifications to `Snaps/permissions/specifications.ts` and integrate into permission init.
> - **Types and wiring**:
>   - Add `PermissionController` to `ControllerName`/`ControllersToInitialize` and related types.
>   - Adjust `Engine` context/state mappings to use modular `PermissionController`.
> - **Tests**:
>   - Add tests for permission controller init and messengers.
>   - Update utils tests to include `PermissionController` init mocking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85a30adc2d403c81988c3d1e5aac38eeafa6935f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->