### PR TITLE
fix: fixed minus symbol position in fiat formatting

### DIFF
--- a/app/components/UI/Assets/components/BalanceChange/AccountGroupBalanceChange.test.tsx
+++ b/app/components/UI/Assets/components/BalanceChange/AccountGroupBalanceChange.test.tsx
@@ -86,7 +86,7 @@ describe('AccountGroupBalanceChange', () => {
       const value = getByTestId(FORMATTED_VALUE_PRICE_TEST_ID);
       const percent = getByTestId(FORMATTED_PERCENTAGE_TEST_ID);
       expect(String(percent.props.children)).toMatch(/^\(-/);
-      expect(String(value.props.children)).toContain('-');
+      expect(String(value.props.children)).toContain('-$1.23');
     });
 
     it('renders large negative values correctly', () => {
@@ -101,7 +101,7 @@ describe('AccountGroupBalanceChange', () => {
 
       const value = getByTestId(FORMATTED_VALUE_PRICE_TEST_ID);
       const percent = getByTestId(FORMATTED_PERCENTAGE_TEST_ID);
-      expect(String(value.props.children)).toContain('-');
+      expect(String(value.props.children)).toContain('-$5678.9');
       expect(String(percent.props.children)).toMatch(/^\(-/);
     });
 
@@ -117,7 +117,7 @@ describe('AccountGroupBalanceChange', () => {
 
       const value = getByTestId(FORMATTED_VALUE_PRICE_TEST_ID);
       const percent = getByTestId(FORMATTED_PERCENTAGE_TEST_ID);
-      expect(String(value.props.children)).toContain('-');
+      expect(String(value.props.children)).toContain('-$0.05');
       expect(String(percent.props.children)).toMatch(/^\(-/);
     });
   });

--- a/app/util/number/index.js
+++ b/app/util/number/index.js
@@ -716,7 +716,10 @@ export function renderFiat(value, currencyCode, decimalsToShow = 5) {
   let fiatFixed = parseFloat(Math.round(value * base) / base);
   fiatFixed = isNaN(fiatFixed) ? 0.0 : fiatFixed;
   if (currencySymbols[currencyCode]) {
-    return `${currencySymbols[currencyCode]}${fiatFixed}`;
+    const isNegative = fiatFixed < 0;
+    const absValue = Math.abs(fiatFixed);
+    const sign = isNegative ? '-' : '';
+    return `${sign}${currencySymbols[currencyCode]}${absValue}`;
   }
   return `${fiatFixed} ${currencyCode.toUpperCase()}`;
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR changes the way fiat value is formatted, to place minus sign before the currency sign for negative numbers.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug that was causing minus sign being placed after the currency sign

## **Related issues**

Fixes:
Jira ticket: https://consensyssoftware.atlassian.net/browse/MUL-1104

## **Manual testing steps**

```gherkin
Feature: Display currency on main view

  Scenario: user unlocks application
    Given performance of main balance is negative

    When user navigates to main wallet view
    Then the minus sign should be placed before the currency sign on the main balance view
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="375" height="100" alt="Screenshot 2025-09-29 at 14 32 09" src="https://github.com/user-attachments/assets/a9423ded-82ae-4bab-896f-5eaf04465f4e" />

<!-- [screenshots/recordings] -->

### **After**
<img width="369" height="94" alt="Screenshot 2025-09-29 at 14 25 19" src="https://github.com/user-attachments/assets/0898b003-fe4f-4e0c-a8ef-49b2521fb3a9" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjust fiat rendering to show the negative sign before the currency symbol and update tests to assert explicit prefixed amounts.
> 
> - **Utilities**:
>   - `app/util/number/index.js`: Update `renderFiat` to prefix the minus sign before the currency symbol by separating sign and absolute value.
> - **Tests**:
>   - `AccountGroupBalanceChange.test.tsx`: Update negative value expectations to assert formatted amounts like `-$1.23`, `-$5678.9`, and `-$0.05`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c33e81f3c056795a849f021bd558e2b03c0030c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->