### PR TITLE
fix(multichain-accounts): use proper `selectedAccountGroup` (instead of `selectedInternalAccount`)

### DIFF
--- a/app/component-library/components-temp/MultichainAccounts/test-utils.ts
+++ b/app/component-library/components-temp/MultichainAccounts/test-utils.ts
@@ -146,6 +146,9 @@ export const createMockState = (
     return acc;
   }, {} as Record<string, AccountWalletObject>);
 
+  const firstWallet = wallets[0];
+  const firstGroupId = Object.keys(firstWallet?.groups ?? [])[0];
+
   return {
     engine: {
       backgroundState: {
@@ -153,6 +156,7 @@ export const createMockState = (
         AccountTreeController: {
           accountTree: {
             wallets: walletMap,
+            selectedAccountGroup: firstGroupId ?? '',
           },
         },
         AccountsController: {

--- a/app/components/UI/Ramp/Aggregator/Views/OrdersList/OrdersList.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/OrdersList/OrdersList.test.tsx
@@ -173,6 +173,7 @@ function render(Component: React.ReactElement, orders = testOrders) {
                   },
                 },
               },
+              selectedAccountGroup: 'keyring:test-wallet/ethereum',
             },
           },
           NetworkController: {

--- a/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/MultichainAccountsConnectedList.test.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/MultichainAccountsConnectedList.test.tsx
@@ -90,7 +90,7 @@ const DEFAULT_PROPS = {
 
 const mockStore = configureStore([]);
 const buildState = (groups: AccountGroupObject[]) => {
-  const wallet = createMockWallet('test-group', 'Test Wallet', groups);
+  const wallet = createMockWallet('keyring:test-group', 'Test Wallet', groups);
   const internalAccounts = createMockInternalAccountsFromGroups(groups);
   return createMockState([wallet], internalAccounts);
 };

--- a/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/__snapshots__/MultichainAccountsConnectedList.test.tsx.snap
+++ b/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/__snapshots__/MultichainAccountsConnectedList.test.tsx.snap
@@ -123,12 +123,12 @@ exports[`MultichainAccountsConnectedList renders component with different accoun
                     style={
                       {
                         "alignItems": "center",
-                        "borderColor": "#4459ff",
+                        "borderColor": "transparent",
                         "borderRadius": 8,
                         "borderWidth": 2,
-                        "height": 40,
+                        "height": 36,
                         "justifyContent": "center",
-                        "width": 40,
+                        "width": 36,
                       }
                     }
                   >
@@ -136,12 +136,12 @@ exports[`MultichainAccountsConnectedList renders component with different accoun
                       style={
                         {
                           "backgroundColor": "#3c4d9d0f",
-                          "borderColor": "#FFFFFF",
+                          "borderColor": "transparent",
                           "borderRadius": 6,
-                          "borderWidth": 2,
-                          "height": 36,
+                          "borderWidth": 0,
+                          "height": 32,
                           "overflow": "hidden",
-                          "width": 36,
+                          "width": 32,
                         }
                       }
                       testID="multichain-account-cell-avatar"
@@ -186,21 +186,6 @@ exports[`MultichainAccountsConnectedList renders component with different accoun
                     >
                       Account 1
                     </Text>
-                    <SvgMock
-                      color="#4459ff"
-                      fill="currentColor"
-                      height={20}
-                      name="CheckBold"
-                      style={
-                        {
-                          "height": 20,
-                          "marginLeft": 8,
-                          "width": 20,
-                        }
-                      }
-                      testID="multichain-account-cell-check-icon"
-                      width={20}
-                    />
                   </View>
                   <View
                     style={

--- a/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/__snapshots__/MultichainAccountsConnectedList.test.tsx.snap
+++ b/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/__snapshots__/MultichainAccountsConnectedList.test.tsx.snap
@@ -123,12 +123,12 @@ exports[`MultichainAccountsConnectedList renders component with different accoun
                     style={
                       {
                         "alignItems": "center",
-                        "borderColor": "transparent",
+                        "borderColor": "#4459ff",
                         "borderRadius": 8,
                         "borderWidth": 2,
-                        "height": 36,
+                        "height": 40,
                         "justifyContent": "center",
-                        "width": 36,
+                        "width": 40,
                       }
                     }
                   >
@@ -136,12 +136,12 @@ exports[`MultichainAccountsConnectedList renders component with different accoun
                       style={
                         {
                           "backgroundColor": "#3c4d9d0f",
-                          "borderColor": "transparent",
+                          "borderColor": "#FFFFFF",
                           "borderRadius": 6,
-                          "borderWidth": 0,
-                          "height": 32,
+                          "borderWidth": 2,
+                          "height": 36,
                           "overflow": "hidden",
-                          "width": 32,
+                          "width": 36,
                         }
                       }
                       testID="multichain-account-cell-avatar"
@@ -186,6 +186,21 @@ exports[`MultichainAccountsConnectedList renders component with different accoun
                     >
                       Account 1
                     </Text>
+                    <SvgMock
+                      color="#4459ff"
+                      fill="currentColor"
+                      height={20}
+                      name="CheckBold"
+                      style={
+                        {
+                          "height": 20,
+                          "marginLeft": 8,
+                          "width": 20,
+                        }
+                      }
+                      testID="multichain-account-cell-check-icon"
+                      width={20}
+                    />
                   </View>
                   <View
                     style={

--- a/app/reducers/fiatOrders/index.test.ts
+++ b/app/reducers/fiatOrders/index.test.ts
@@ -1101,6 +1101,7 @@ describe('selectors', () => {
                     },
                   },
                 },
+                selectedAccountGroup: 'keyring:test-wallet/ethereum',
               },
             },
             NetworkController: {
@@ -1200,6 +1201,7 @@ describe('selectors', () => {
                     },
                   },
                 },
+                selectedAccountGroup: 'keyring:test-wallet/ethereum',
               },
             },
             NetworkController: {
@@ -1431,6 +1433,7 @@ describe('selectors', () => {
                     },
                   },
                 },
+                selectedAccountGroup: 'keyring:test-wallet/ethereum',
               },
             },
             NetworkController: {
@@ -1532,6 +1535,7 @@ describe('selectors', () => {
                     },
                   },
                 },
+                selectedAccountGroup: 'keyring:test-wallet/ethereum',
               },
             },
             NetworkController: {
@@ -1895,6 +1899,7 @@ describe('selectors', () => {
                     },
                   },
                 },
+                selectedAccountGroup: 'keyring:test-wallet/ethereum',
               },
             },
             NetworkController: {
@@ -2104,6 +2109,7 @@ describe('selectors', () => {
                     },
                   },
                 },
+                selectedAccountGroup: 'keyring:test-wallet/ethereum',
               },
             },
             NetworkController: {
@@ -2203,6 +2209,7 @@ describe('selectors', () => {
                     },
                   },
                 },
+                selectedAccountGroup: 'keyring:test-wallet/ethereum',
               },
             },
             NetworkController: {


### PR DESCRIPTION
## **Description**

We were not properly using the `selectedAccountGroup` from the `AccountTreeController`, thus, resulting in some state inconsistencies.

This was discovered when using Swaps, for the following reason:
- Swaps are switching the active networks based on the assets being swapped
- This will automatically change the current `selectedInternalAccount` account (not group) with the last account compatible with that network (Solana here)
  * NOTE: Selecting an account will automatically select its group, [but we're not publishing `:selectedAccountChange` when we switch the network](https://github.com/MetaMask/core/blob/v589.0.0/packages/accounts-controller/src/AccountsController.ts#L1172-L1198))
- Since we no longer select Solana accounts with the new account group system (we only select the underlying EVM account for retro-compatibility)
  * This was automatically selecting the lastly select Solana (which was always defaulting to the first Solana account of the first wallet)
  * Thus, wrongly selecting the first account group ⚠️

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Account group selection

  Scenario: user starts a Swap from another account group
    Given the user had imported another wallet already

    When user starts a Swap, select the SOL asset, and close the Swap flow
    Then it should still use the lastly selected account group and not default to the first ever account group
```

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/447488f9-7642-49a8-9143-708c3f7c62a2

### **After**

https://github.com/user-attachments/assets/c05e6458-f717-4fb2-a253-4f7022e466ea

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors multichain account selectors to derive from `selectedAccountGroup` (not `selectedInternalAccount`) and updates tests/utilities to set and assert the proper group selection.
> 
> - **Selectors (multichain accounts)**:
>   - Introduce `getAccountGroupFrom` and use `parseAccountGroupId` to resolve groups by `groupId`.
>   - Change `selectSelectedAccountGroup` to read from `AccountTreeController.accountTree.selectedAccountGroup` via `selectSelectedAccountGroupId`.
>   - Keep `selectResolvedSelectedAccountGroup` but now prefer explicit `selectedAccountGroup` with robust group lookup.
>   - Update `selectAccountGroupById` to use parsed IDs; remove split-based logic.
> - **Tests**:
>   - Update selector tests to assert behavior when `selectedAccountGroup` is set; add cases using `toAccountGroupId`; remove malformed ID split test.
>   - Adjust expectations for selected group independent of `selectedInternalAccount`.
>   - Add `selectedAccountGroup` to Ramp `OrdersList` and `fiatOrders` tests' mock state.
> - **Test utilities**:
>   - Set default `selectedAccountGroup` to the first wallet group in `createMockState`.
>   - Normalize mock wallet IDs to include `keyring:` prefix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 556c9c5a067ca55f05ae94b608860b0f7aca118d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->