### PR TITLE
fix: change styles for error and loading defi status

### DIFF
--- a/app/components/UI/DeFiPositions/DeFiPositionsList.styles.ts
+++ b/app/components/UI/DeFiPositions/DeFiPositionsList.styles.ts
@@ -9,8 +9,7 @@ const styleSheet = () =>
   StyleSheet.create({
     emptyView: {
       alignItems: 'center',
-      height: '100%',
-      justifyContent: 'center',
+      marginVertical: 8,
     },
     wrapper: {
       flex: 1,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Height of the list seems to now be variable even with no items, which renders the previous solution ineffective, as it some times renders the message out of the view port.

This PR moves the remaining DeFi loading and error messages to the top.

DO NOT MERGE FOR NOW

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug in which DeFi messages loaded out of view

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/20501

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 Pro - 2025-09-29 at 14 35 26" src="https://github.com/user-attachments/assets/e06ff5a4-1732-4e10-8258-3bc36eee6d54" />
<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 Pro - 2025-09-29 at 14 35 43" src="https://github.com/user-attachments/assets/58044f38-d41f-423a-9f8e-fc3165e07455" />

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tweaks `DeFiPositionsList.styles` by removing `height: '100%'` and `justifyContent: 'center'` from `emptyView` and adding `marginVertical: 8`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a7e5451eb757b92ac063d8239589d1034ea9ca1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->