### PR TITLE
fix: prevent crash opening swaps for tokens with large balances

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -154,7 +154,6 @@ const BridgeView = () => {
     address: sourceToken?.address,
     decimals: sourceToken?.decimals,
     chainId: sourceToken?.chainId,
-    balance: sourceToken?.balance,
   });
 
   const {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
**Problem**
The `useLatestBalance` hook was receiving `sourceToken.balance` as a cached balance parameter, but this value is a display-formatted balance that can contain locale-specific separators (commas, periods). When the hook attempted to parse this display balance using `parseUnits`, it would fail because `parseUnits` expects a clean numeric string. This caused parsing errors when users had tokens with formatted balance displays.

**Solution**
Removed the `balance: sourceToken?.balance` parameter from the `useLatestBalance` hook call in `BridgeView`. The hook is designed to fetch fresh atomic balances from the blockchain anyway, so the cached display balance parameter is unnecessary. This eliminates the parsing error while ensuring the most up-to-date balance data is always used.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed bug that was causing swaps to crash when swapping assets with large balances

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3107

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: swaps asset with large balance
    Given user has asset with balance > 999 tokens

    When user opens swap page
    Then swap view does not crash
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the `balance` argument from `useLatestBalance` in `BridgeView` to avoid passing a formatted display balance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cad9e7741025e6a79448b52e35dbc0a37156d50c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->