### PR TITLE
fix: not being able to see the apply button in swaps source network picker

### DIFF
--- a/app/components/UI/Bridge/components/BridgeDestNetworkSelector/__snapshots__/BridgeDestNetworkSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeDestNetworkSelector/__snapshots__/BridgeDestNetworkSelector.test.tsx.snap
@@ -555,114 +555,125 @@ exports[`BridgeDestNetworkSelector renders with initial state and displays netwo
                                 ]
                               }
                             >
-                              <View
+                              <RCTScrollView
+                                showsVerticalScrollIndicator={false}
                                 style={
-                                  [
-                                    {},
-                                    {
-                                      "padding": 8,
-                                    },
-                                  ]
+                                  {
+                                    "flex": 1,
+                                  }
                                 }
                               >
-                                <TouchableOpacity
-                                  onPress={[Function]}
-                                >
+                                <View>
                                   <View
-                                    accessibilityRole="none"
-                                    accessible={true}
                                     style={
-                                      {
-                                        "padding": 16,
-                                      }
+                                      [
+                                        {},
+                                        {
+                                          "padding": 8,
+                                        },
+                                      ]
                                     }
                                   >
-                                    <View
-                                      style={
-                                        {
-                                          "alignItems": "center",
-                                          "flexDirection": "row",
-                                        }
-                                      }
+                                    <TouchableOpacity
+                                      onPress={[Function]}
                                     >
                                       <View
-                                        alignItems="center"
-                                        flexDirection="row"
+                                        accessibilityRole="none"
+                                        accessible={true}
                                         style={
-                                          [
-                                            {
-                                              "alignItems": "center",
-                                              "flexDirection": "row",
-                                            },
-                                            {
-                                              "flex": 1,
-                                            },
-                                          ]
+                                          {
+                                            "padding": 16,
+                                          }
                                         }
                                       >
                                         <View
-                                          alignItems="center"
-                                          flexDirection="row"
-                                          gap={8}
                                           style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "flexDirection": "row",
-                                                "gap": 8,
-                                              },
-                                              {
-                                                "flex": 1,
-                                              },
-                                            ]
+                                            {
+                                              "alignItems": "center",
+                                              "flexDirection": "row",
+                                            }
                                           }
                                         >
                                           <View
+                                            alignItems="center"
+                                            flexDirection="row"
                                             style={
-                                              {
-                                                "alignItems": "center",
-                                                "backgroundColor": "#ffffff",
-                                                "borderRadius": 8,
-                                                "height": 32,
-                                                "justifyContent": "center",
-                                                "overflow": "hidden",
-                                                "width": 32,
-                                              }
-                                            }
-                                          >
-                                            <Image
-                                              onError={[Function]}
-                                              resizeMode="contain"
-                                              source={1}
-                                              style={
+                                              [
                                                 {
-                                                  "height": 32,
-                                                  "width": 32,
-                                                }
-                                              }
-                                              testID="network-avatar-image"
-                                            />
-                                          </View>
-                                          <Text
-                                            accessibilityRole="text"
-                                            style={
-                                              {
-                                                "color": "#121314",
-                                                "fontFamily": "Geist Medium",
-                                                "fontSize": 18,
-                                                "letterSpacing": 0,
-                                                "lineHeight": 24,
-                                              }
+                                                  "alignItems": "center",
+                                                  "flexDirection": "row",
+                                                },
+                                                {
+                                                  "flex": 1,
+                                                },
+                                              ]
                                             }
                                           >
-                                            Optimism
-                                          </Text>
+                                            <View
+                                              alignItems="center"
+                                              flexDirection="row"
+                                              gap={8}
+                                              style={
+                                                [
+                                                  {
+                                                    "alignItems": "center",
+                                                    "flexDirection": "row",
+                                                    "gap": 8,
+                                                  },
+                                                  {
+                                                    "flex": 1,
+                                                  },
+                                                ]
+                                              }
+                                            >
+                                              <View
+                                                style={
+                                                  {
+                                                    "alignItems": "center",
+                                                    "backgroundColor": "#ffffff",
+                                                    "borderRadius": 8,
+                                                    "height": 32,
+                                                    "justifyContent": "center",
+                                                    "overflow": "hidden",
+                                                    "width": 32,
+                                                  }
+                                                }
+                                              >
+                                                <Image
+                                                  onError={[Function]}
+                                                  resizeMode="contain"
+                                                  source={1}
+                                                  style={
+                                                    {
+                                                      "height": 32,
+                                                      "width": 32,
+                                                    }
+                                                  }
+                                                  testID="network-avatar-image"
+                                                />
+                                              </View>
+                                              <Text
+                                                accessibilityRole="text"
+                                                style={
+                                                  {
+                                                    "color": "#121314",
+                                                    "fontFamily": "Geist Medium",
+                                                    "fontSize": 18,
+                                                    "letterSpacing": 0,
+                                                    "lineHeight": 24,
+                                                  }
+                                                }
+                                              >
+                                                Optimism
+                                              </Text>
+                                            </View>
+                                          </View>
                                         </View>
                                       </View>
-                                    </View>
+                                    </TouchableOpacity>
                                   </View>
-                                </TouchableOpacity>
-                              </View>
+                                </View>
+                              </RCTScrollView>
                             </View>
                           </View>
                         </View>

--- a/app/components/UI/Bridge/components/BridgeDestNetworkSelector/index.tsx
+++ b/app/components/UI/Bridge/components/BridgeDestNetworkSelector/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { StyleSheet, TouchableOpacity } from 'react-native';
+import { StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
 import { useSelector, useDispatch } from 'react-redux';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
 import { Box } from '../../../Box/Box';
@@ -24,6 +24,9 @@ export interface BridgeDestNetworkSelectorRouteParams {
 
 const createStyles = () =>
   StyleSheet.create({
+    scrollContainer: {
+      flex: 1,
+    },
     listContent: {
       padding: 8,
     },
@@ -80,7 +83,12 @@ export const BridgeDestNetworkSelector: React.FC = () => {
 
   return (
     <BridgeNetworkSelectorBase>
-      <Box style={styles.listContent}>{renderDestChains()}</Box>
+      <ScrollView
+        style={styles.scrollContainer}
+        showsVerticalScrollIndicator={false}
+      >
+        <Box style={styles.listContent}>{renderDestChains()}</Box>
+      </ScrollView>
     </BridgeNetworkSelectorBase>
   );
 };

--- a/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/__snapshots__/BridgeSourceNetworkSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/__snapshots__/BridgeSourceNetworkSelector.test.tsx.snap
@@ -601,385 +601,396 @@ exports[`BridgeSourceNetworkSelector renders with initial state and displays net
                                   </Text>
                                 </Text>
                               </View>
-                              <View
+                              <RCTScrollView
+                                showsVerticalScrollIndicator={false}
                                 style={
-                                  [
-                                    {},
-                                    {
-                                      "padding": 8,
-                                    },
-                                  ]
+                                  {
+                                    "flex": 1,
+                                  }
                                 }
                               >
-                                <TouchableOpacity
-                                  onPress={[Function]}
-                                  testID="chain-0x1"
-                                >
+                                <View>
                                   <View
-                                    accessibilityRole="none"
-                                    accessible={true}
                                     style={
-                                      {
-                                        "padding": 16,
-                                      }
+                                      [
+                                        {},
+                                        {
+                                          "padding": 8,
+                                        },
+                                      ]
                                     }
                                   >
-                                    <View
-                                      style={
-                                        {
-                                          "alignItems": "center",
-                                          "flexDirection": "row",
-                                        }
-                                      }
+                                    <TouchableOpacity
+                                      onPress={[Function]}
+                                      testID="chain-0x1"
                                     >
-                                      <TouchableOpacity
-                                        disabled={false}
-                                        onPress={[Function]}
+                                      <View
+                                        accessibilityRole="none"
+                                        accessible={true}
                                         style={
                                           {
-                                            "alignItems": "center",
-                                            "flexDirection": "row",
-                                            "height": 24,
-                                            "opacity": 1,
+                                            "padding": 16,
                                           }
                                         }
-                                        testID="checkbox-0x1"
                                       >
                                         <View
-                                          accessibilityRole="checkbox"
                                           style={
                                             {
                                               "alignItems": "center",
-                                              "backgroundColor": "#4459ff",
-                                              "borderColor": "#4459ff",
-                                              "borderRadius": 4,
-                                              "borderWidth": 2,
-                                              "height": 20,
-                                              "justifyContent": "center",
-                                              "width": 20,
+                                              "flexDirection": "row",
                                             }
                                           }
                                         >
-                                          <SvgMock
-                                            color="#ffffff"
-                                            fill="currentColor"
-                                            height={20}
-                                            name="CheckBold"
+                                          <TouchableOpacity
+                                            disabled={false}
                                             onPress={[Function]}
                                             style={
                                               {
-                                                "height": 20,
-                                                "width": 20,
+                                                "alignItems": "center",
+                                                "flexDirection": "row",
+                                                "height": 24,
+                                                "opacity": 1,
                                               }
                                             }
                                             testID="checkbox-0x1"
-                                            width={20}
+                                          >
+                                            <View
+                                              accessibilityRole="checkbox"
+                                              style={
+                                                {
+                                                  "alignItems": "center",
+                                                  "backgroundColor": "#4459ff",
+                                                  "borderColor": "#4459ff",
+                                                  "borderRadius": 4,
+                                                  "borderWidth": 2,
+                                                  "height": 20,
+                                                  "justifyContent": "center",
+                                                  "width": 20,
+                                                }
+                                              }
+                                            >
+                                              <SvgMock
+                                                color="#ffffff"
+                                                fill="currentColor"
+                                                height={20}
+                                                name="CheckBold"
+                                                onPress={[Function]}
+                                                style={
+                                                  {
+                                                    "height": 20,
+                                                    "width": 20,
+                                                  }
+                                                }
+                                                testID="checkbox-0x1"
+                                                width={20}
+                                              />
+                                            </View>
+                                          </TouchableOpacity>
+                                          <View
+                                            accessible={false}
+                                            style={
+                                              {
+                                                "width": 16,
+                                              }
+                                            }
+                                            testID="listitem-gap"
                                           />
+                                          <View
+                                            alignItems="center"
+                                            flexDirection="row"
+                                            style={
+                                              [
+                                                {
+                                                  "alignItems": "center",
+                                                  "flexDirection": "row",
+                                                },
+                                                {
+                                                  "flex": 1,
+                                                },
+                                              ]
+                                            }
+                                          >
+                                            <View
+                                              alignItems="center"
+                                              flexDirection="row"
+                                              gap={8}
+                                              style={
+                                                [
+                                                  {
+                                                    "alignItems": "center",
+                                                    "flexDirection": "row",
+                                                    "gap": 8,
+                                                  },
+                                                  {
+                                                    "flex": 1,
+                                                  },
+                                                ]
+                                              }
+                                            >
+                                              <View
+                                                style={
+                                                  {
+                                                    "alignItems": "center",
+                                                    "backgroundColor": "#ffffff",
+                                                    "borderRadius": 8,
+                                                    "height": 32,
+                                                    "justifyContent": "center",
+                                                    "overflow": "hidden",
+                                                    "width": 32,
+                                                  }
+                                                }
+                                              >
+                                                <Image
+                                                  onError={[Function]}
+                                                  resizeMode="contain"
+                                                  source={1}
+                                                  style={
+                                                    {
+                                                      "height": 32,
+                                                      "width": 32,
+                                                    }
+                                                  }
+                                                  testID="network-avatar-image"
+                                                />
+                                              </View>
+                                              <Text
+                                                accessibilityRole="text"
+                                                style={
+                                                  {
+                                                    "color": "#121314",
+                                                    "fontFamily": "Geist Medium",
+                                                    "fontSize": 18,
+                                                    "letterSpacing": 0,
+                                                    "lineHeight": 24,
+                                                  }
+                                                }
+                                              >
+                                                Ethereum Mainnet
+                                              </Text>
+                                            </View>
+                                            <View
+                                              alignItems="flex-end"
+                                              flexDirection="row"
+                                              style={
+                                                [
+                                                  {
+                                                    "alignItems": "flex-end",
+                                                    "flexDirection": "row",
+                                                  },
+                                                  {
+                                                    "flex": 1,
+                                                  },
+                                                ]
+                                              }
+                                            >
+                                              <Text
+                                                accessibilityRole="text"
+                                                style={
+                                                  {
+                                                    "color": "#121314",
+                                                    "flex": 1,
+                                                    "fontFamily": "Geist Medium",
+                                                    "fontSize": 18,
+                                                    "letterSpacing": 0,
+                                                    "lineHeight": 24,
+                                                    "textAlign": "right",
+                                                  }
+                                                }
+                                              >
+                                                $22600
+                                              </Text>
+                                            </View>
+                                          </View>
                                         </View>
-                                      </TouchableOpacity>
+                                      </View>
+                                    </TouchableOpacity>
+                                    <TouchableOpacity
+                                      onPress={[Function]}
+                                      testID="chain-0xa"
+                                    >
                                       <View
-                                        accessible={false}
+                                        accessibilityRole="none"
+                                        accessible={true}
                                         style={
                                           {
-                                            "width": 16,
+                                            "padding": 16,
                                           }
                                         }
-                                        testID="listitem-gap"
-                                      />
-                                      <View
-                                        alignItems="center"
-                                        flexDirection="row"
-                                        style={
-                                          [
+                                      >
+                                        <View
+                                          style={
                                             {
                                               "alignItems": "center",
                                               "flexDirection": "row",
-                                            },
-                                            {
-                                              "flex": 1,
-                                            },
-                                          ]
-                                        }
-                                      >
-                                        <View
-                                          alignItems="center"
-                                          flexDirection="row"
-                                          gap={8}
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "flexDirection": "row",
-                                                "gap": 8,
-                                              },
-                                              {
-                                                "flex": 1,
-                                              },
-                                            ]
-                                          }
-                                        >
-                                          <View
-                                            style={
-                                              {
-                                                "alignItems": "center",
-                                                "backgroundColor": "#ffffff",
-                                                "borderRadius": 8,
-                                                "height": 32,
-                                                "justifyContent": "center",
-                                                "overflow": "hidden",
-                                                "width": 32,
-                                              }
-                                            }
-                                          >
-                                            <Image
-                                              onError={[Function]}
-                                              resizeMode="contain"
-                                              source={1}
-                                              style={
-                                                {
-                                                  "height": 32,
-                                                  "width": 32,
-                                                }
-                                              }
-                                              testID="network-avatar-image"
-                                            />
-                                          </View>
-                                          <Text
-                                            accessibilityRole="text"
-                                            style={
-                                              {
-                                                "color": "#121314",
-                                                "fontFamily": "Geist Medium",
-                                                "fontSize": 18,
-                                                "letterSpacing": 0,
-                                                "lineHeight": 24,
-                                              }
-                                            }
-                                          >
-                                            Ethereum Mainnet
-                                          </Text>
-                                        </View>
-                                        <View
-                                          alignItems="flex-end"
-                                          flexDirection="row"
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "flex-end",
-                                                "flexDirection": "row",
-                                              },
-                                              {
-                                                "flex": 1,
-                                              },
-                                            ]
-                                          }
-                                        >
-                                          <Text
-                                            accessibilityRole="text"
-                                            style={
-                                              {
-                                                "color": "#121314",
-                                                "flex": 1,
-                                                "fontFamily": "Geist Medium",
-                                                "fontSize": 18,
-                                                "letterSpacing": 0,
-                                                "lineHeight": 24,
-                                                "textAlign": "right",
-                                              }
-                                            }
-                                          >
-                                            $22600
-                                          </Text>
-                                        </View>
-                                      </View>
-                                    </View>
-                                  </View>
-                                </TouchableOpacity>
-                                <TouchableOpacity
-                                  onPress={[Function]}
-                                  testID="chain-0xa"
-                                >
-                                  <View
-                                    accessibilityRole="none"
-                                    accessible={true}
-                                    style={
-                                      {
-                                        "padding": 16,
-                                      }
-                                    }
-                                  >
-                                    <View
-                                      style={
-                                        {
-                                          "alignItems": "center",
-                                          "flexDirection": "row",
-                                        }
-                                      }
-                                    >
-                                      <TouchableOpacity
-                                        disabled={false}
-                                        onPress={[Function]}
-                                        style={
-                                          {
-                                            "alignItems": "center",
-                                            "flexDirection": "row",
-                                            "height": 24,
-                                            "opacity": 1,
-                                          }
-                                        }
-                                        testID="checkbox-0xa"
-                                      >
-                                        <View
-                                          accessibilityRole="checkbox"
-                                          style={
-                                            {
-                                              "alignItems": "center",
-                                              "backgroundColor": "#4459ff",
-                                              "borderColor": "#4459ff",
-                                              "borderRadius": 4,
-                                              "borderWidth": 2,
-                                              "height": 20,
-                                              "justifyContent": "center",
-                                              "width": 20,
                                             }
                                           }
                                         >
-                                          <SvgMock
-                                            color="#ffffff"
-                                            fill="currentColor"
-                                            height={20}
-                                            name="CheckBold"
+                                          <TouchableOpacity
+                                            disabled={false}
                                             onPress={[Function]}
                                             style={
                                               {
-                                                "height": 20,
-                                                "width": 20,
+                                                "alignItems": "center",
+                                                "flexDirection": "row",
+                                                "height": 24,
+                                                "opacity": 1,
                                               }
                                             }
                                             testID="checkbox-0xa"
-                                            width={20}
-                                          />
-                                        </View>
-                                      </TouchableOpacity>
-                                      <View
-                                        accessible={false}
-                                        style={
-                                          {
-                                            "width": 16,
-                                          }
-                                        }
-                                        testID="listitem-gap"
-                                      />
-                                      <View
-                                        alignItems="center"
-                                        flexDirection="row"
-                                        style={
-                                          [
-                                            {
-                                              "alignItems": "center",
-                                              "flexDirection": "row",
-                                            },
-                                            {
-                                              "flex": 1,
-                                            },
-                                          ]
-                                        }
-                                      >
-                                        <View
-                                          alignItems="center"
-                                          flexDirection="row"
-                                          gap={8}
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "center",
-                                                "flexDirection": "row",
-                                                "gap": 8,
-                                              },
-                                              {
-                                                "flex": 1,
-                                              },
-                                            ]
-                                          }
-                                        >
-                                          <View
-                                            style={
-                                              {
-                                                "alignItems": "center",
-                                                "backgroundColor": "#ffffff",
-                                                "borderRadius": 8,
-                                                "height": 32,
-                                                "justifyContent": "center",
-                                                "overflow": "hidden",
-                                                "width": 32,
-                                              }
-                                            }
                                           >
-                                            <Image
-                                              onError={[Function]}
-                                              resizeMode="contain"
-                                              source={1}
+                                            <View
+                                              accessibilityRole="checkbox"
                                               style={
                                                 {
-                                                  "height": 32,
-                                                  "width": 32,
+                                                  "alignItems": "center",
+                                                  "backgroundColor": "#4459ff",
+                                                  "borderColor": "#4459ff",
+                                                  "borderRadius": 4,
+                                                  "borderWidth": 2,
+                                                  "height": 20,
+                                                  "justifyContent": "center",
+                                                  "width": 20,
                                                 }
                                               }
-                                              testID="network-avatar-image"
-                                            />
+                                            >
+                                              <SvgMock
+                                                color="#ffffff"
+                                                fill="currentColor"
+                                                height={20}
+                                                name="CheckBold"
+                                                onPress={[Function]}
+                                                style={
+                                                  {
+                                                    "height": 20,
+                                                    "width": 20,
+                                                  }
+                                                }
+                                                testID="checkbox-0xa"
+                                                width={20}
+                                              />
+                                            </View>
+                                          </TouchableOpacity>
+                                          <View
+                                            accessible={false}
+                                            style={
+                                              {
+                                                "width": 16,
+                                              }
+                                            }
+                                            testID="listitem-gap"
+                                          />
+                                          <View
+                                            alignItems="center"
+                                            flexDirection="row"
+                                            style={
+                                              [
+                                                {
+                                                  "alignItems": "center",
+                                                  "flexDirection": "row",
+                                                },
+                                                {
+                                                  "flex": 1,
+                                                },
+                                              ]
+                                            }
+                                          >
+                                            <View
+                                              alignItems="center"
+                                              flexDirection="row"
+                                              gap={8}
+                                              style={
+                                                [
+                                                  {
+                                                    "alignItems": "center",
+                                                    "flexDirection": "row",
+                                                    "gap": 8,
+                                                  },
+                                                  {
+                                                    "flex": 1,
+                                                  },
+                                                ]
+                                              }
+                                            >
+                                              <View
+                                                style={
+                                                  {
+                                                    "alignItems": "center",
+                                                    "backgroundColor": "#ffffff",
+                                                    "borderRadius": 8,
+                                                    "height": 32,
+                                                    "justifyContent": "center",
+                                                    "overflow": "hidden",
+                                                    "width": 32,
+                                                  }
+                                                }
+                                              >
+                                                <Image
+                                                  onError={[Function]}
+                                                  resizeMode="contain"
+                                                  source={1}
+                                                  style={
+                                                    {
+                                                      "height": 32,
+                                                      "width": 32,
+                                                    }
+                                                  }
+                                                  testID="network-avatar-image"
+                                                />
+                                              </View>
+                                              <Text
+                                                accessibilityRole="text"
+                                                style={
+                                                  {
+                                                    "color": "#121314",
+                                                    "fontFamily": "Geist Medium",
+                                                    "fontSize": 18,
+                                                    "letterSpacing": 0,
+                                                    "lineHeight": 24,
+                                                  }
+                                                }
+                                              >
+                                                Optimism
+                                              </Text>
+                                            </View>
+                                            <View
+                                              alignItems="flex-end"
+                                              flexDirection="row"
+                                              style={
+                                                [
+                                                  {
+                                                    "alignItems": "flex-end",
+                                                    "flexDirection": "row",
+                                                  },
+                                                  {
+                                                    "flex": 1,
+                                                  },
+                                                ]
+                                              }
+                                            >
+                                              <Text
+                                                accessibilityRole="text"
+                                                style={
+                                                  {
+                                                    "color": "#121314",
+                                                    "flex": 1,
+                                                    "fontFamily": "Geist Medium",
+                                                    "fontSize": 18,
+                                                    "letterSpacing": 0,
+                                                    "lineHeight": 24,
+                                                    "textAlign": "right",
+                                                  }
+                                                }
+                                              >
+                                                $12000
+                                              </Text>
+                                            </View>
                                           </View>
-                                          <Text
-                                            accessibilityRole="text"
-                                            style={
-                                              {
-                                                "color": "#121314",
-                                                "fontFamily": "Geist Medium",
-                                                "fontSize": 18,
-                                                "letterSpacing": 0,
-                                                "lineHeight": 24,
-                                              }
-                                            }
-                                          >
-                                            Optimism
-                                          </Text>
-                                        </View>
-                                        <View
-                                          alignItems="flex-end"
-                                          flexDirection="row"
-                                          style={
-                                            [
-                                              {
-                                                "alignItems": "flex-end",
-                                                "flexDirection": "row",
-                                              },
-                                              {
-                                                "flex": 1,
-                                              },
-                                            ]
-                                          }
-                                        >
-                                          <Text
-                                            accessibilityRole="text"
-                                            style={
-                                              {
-                                                "color": "#121314",
-                                                "flex": 1,
-                                                "fontFamily": "Geist Medium",
-                                                "fontSize": 18,
-                                                "letterSpacing": 0,
-                                                "lineHeight": 24,
-                                                "textAlign": "right",
-                                              }
-                                            }
-                                          >
-                                            $12000
-                                          </Text>
                                         </View>
                                       </View>
-                                    </View>
+                                    </TouchableOpacity>
                                   </View>
-                                </TouchableOpacity>
-                              </View>
+                                </View>
+                              </RCTScrollView>
                               <View
                                 style={
                                   [

--- a/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/index.tsx
+++ b/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import { StyleSheet, TouchableOpacity } from 'react-native';
+import { StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
 import { useSelector, useDispatch } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 import { Box } from '../../../Box/Box';
@@ -35,6 +35,9 @@ import { getNativeSourceToken } from '../../hooks/useInitialSourceToken';
 
 const createStyles = () =>
   StyleSheet.create({
+    scrollContainer: {
+      flex: 1,
+    },
     listContent: {
       padding: 8,
     },
@@ -264,7 +267,12 @@ export const BridgeSourceNetworkSelector: React.FC<
         />
       </Box>
 
-      <Box style={styles.listContent}>{renderSourceNetworks()}</Box>
+      <ScrollView
+        style={styles.scrollContainer}
+        showsVerticalScrollIndicator={false}
+      >
+        <Box style={styles.listContent}>{renderSourceNetworks()}</Box>
+      </ScrollView>
 
       <Box style={styles.applyButtonContainer}>
         <Button


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes an issue where the user could not see the Apply button in the Swaps source network picker if they had too many networks.

It also makes the destination network picker scrollable as well.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an issue where the user could not see the Apply button in the Swaps source network picker if they had too many networks.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-2876

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user wants to change their swaps source network
    Given user is in Swaps source network picker

    When user tries to apply their changes for source network
    Then they can see and click the apply button
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/f1e58753-e438-4524-909d-4eb7d41bcfa2



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wraps network lists in ScrollView for source and destination selectors so long lists scroll and the Apply button remains visible.
> 
> - **UI (Bridge)**:
>   - Wrap list content in `ScrollView` (hide vertical indicator, `flex: 1`) in `BridgeSourceNetworkSelector` and `BridgeDestNetworkSelector` to enable scrolling of long network lists.
>   - Add `scrollContainer` style and keep list padding via `listContent` `Box`.
> - **Tests**:
>   - Update snapshots for both selectors reflecting `ScrollView` structure and layout changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62125d3951f245372935832b2216a5eabaf5af7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->