### PR TITLE
fix: resolve prop override in PerpsEmptyState component

### DIFF
--- a/app/components/UI/Perps/Views/PerpsEmptyState/PerpsEmptyState.stories.tsx
+++ b/app/components/UI/Perps/Views/PerpsEmptyState/PerpsEmptyState.stories.tsx
@@ -7,4 +7,11 @@ const PerpsEmptyStateMeta = {
 
 export default PerpsEmptyStateMeta;
 
-export const Default = {};
+export const Default = {
+  args: {
+    onAction: () => {
+      // eslint-disable-next-line no-console
+      console.log('Start Trading pressed');
+    },
+  },
+};

--- a/app/components/UI/Perps/Views/PerpsEmptyState/PerpsEmptyState.stories.tsx
+++ b/app/components/UI/Perps/Views/PerpsEmptyState/PerpsEmptyState.stories.tsx
@@ -7,12 +7,4 @@ const PerpsEmptyStateMeta = {
 
 export default PerpsEmptyStateMeta;
 
-// Default story
-export const Default = {
-  args: {
-    onStartTrading: () => {
-      // eslint-disable-next-line no-console
-      console.log('Start Trading pressed');
-    },
-  },
-};
+export const Default = {};

--- a/app/components/UI/Perps/Views/PerpsEmptyState/PerpsEmptyState.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsEmptyState/PerpsEmptyState.test.tsx
@@ -4,7 +4,7 @@ import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { PerpsEmptyState } from './PerpsEmptyState';
 
 describe('PerpsEmptyState', () => {
-  const mockOnStartTrading = jest.fn();
+  const mockOnAction = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -12,7 +12,7 @@ describe('PerpsEmptyState', () => {
 
   it('should render correctly', () => {
     const { getByText } = renderWithProvider(
-      <PerpsEmptyState onStartTrading={mockOnStartTrading} />,
+      <PerpsEmptyState onAction={mockOnAction} />,
     );
 
     expect(
@@ -21,14 +21,14 @@ describe('PerpsEmptyState', () => {
     expect(getByText('Start trading')).toBeTruthy();
   });
 
-  it('should call onStartTrading when button is pressed', () => {
+  it('should call onAction when button is pressed', () => {
     const { getByText } = renderWithProvider(
-      <PerpsEmptyState onStartTrading={mockOnStartTrading} />,
+      <PerpsEmptyState onAction={mockOnAction} />,
     );
 
     const startTradingButton = getByText('Start trading');
     fireEvent.press(startTradingButton);
 
-    expect(mockOnStartTrading).toHaveBeenCalledTimes(1);
+    expect(mockOnAction).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/components/UI/Perps/Views/PerpsEmptyState/PerpsEmptyState.tsx
+++ b/app/components/UI/Perps/Views/PerpsEmptyState/PerpsEmptyState.tsx
@@ -11,12 +11,10 @@ import emptyStatePerpsLight from '../../../../../images/empty-state-perps-light.
 import emptyStatePerpsDark from '../../../../../images/empty-state-perps-dark.png';
 
 export interface PerpsEmptyStateProps extends TabEmptyStateProps {
-  onStartTrading: () => void;
   testID?: string;
 }
 
 export const PerpsEmptyState: React.FC<PerpsEmptyStateProps> = ({
-  onStartTrading,
   testID,
   ...props
 }) => {
@@ -36,7 +34,6 @@ export const PerpsEmptyState: React.FC<PerpsEmptyStateProps> = ({
       }
       description={strings('perps.position.list.first_time_description')}
       actionButtonText={strings('perps.position.list.start_trading')}
-      onAction={onStartTrading}
       testID={testID}
       {...props}
     />

--- a/app/components/UI/Perps/Views/PerpsPositionsView/PerpsPositionsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsPositionsView/PerpsPositionsView.tsx
@@ -24,6 +24,7 @@ import type { Position } from '../../controllers/types';
 import { usePerpsLivePositions, usePerpsTPSLUpdate } from '../../hooks';
 import { usePerpsLiveAccount } from '../../hooks/stream';
 import { formatPnl, formatPrice } from '../../utils/formatUtils';
+import { getPositionDirection } from '../../utils/positionCalculations';
 import { calculateTotalPnL } from '../../utils/pnlCalculations';
 import { createStyles } from './PerpsPositionsView.styles';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -125,14 +126,7 @@ const PerpsPositionsView: React.FC = () => {
           </Text>
         </View>
         {positions.map((position, index) => {
-          const sizeValue = parseFloat(position.size);
-          const directionSegment = Number.isFinite(sizeValue)
-            ? sizeValue > 0
-              ? 'long'
-              : sizeValue < 0
-              ? 'short'
-              : 'unknown'
-            : 'unknown';
+          const directionSegment = getPositionDirection(position.size);
           return (
             <View
               key={`${position.coin}-${index}`}

--- a/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.test.tsx
@@ -184,17 +184,17 @@ jest.mock('../../components/PerpsBottomSheetTooltip', () => ({
 // Mock PerpsEmptyState component to avoid Redux context issues while preserving testID
 jest.mock('../PerpsEmptyState', () => ({
   PerpsEmptyState: ({
-    onStartTrading,
+    onAction,
     testID,
   }: {
-    onStartTrading: () => void;
+    onAction?: () => void;
     testID?: string;
   }) => {
     const { TouchableOpacity, Text, View } = jest.requireActual('react-native');
     return (
       <View testID={testID}>
         <Text>Bet on price movements with up to 40x leverage.</Text>
-        <TouchableOpacity onPress={onStartTrading}>
+        <TouchableOpacity onPress={onAction}>
           <Text>Start trading</Text>
         </TouchableOpacity>
       </View>

--- a/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
@@ -246,7 +246,7 @@ const PerpsTabView: React.FC<PerpsTabViewProps> = () => {
           <View style={styles.contentContainer}>
             {!isInitialLoading && hasNoPositionsOrOrders ? (
               <PerpsEmptyState
-                onStartTrading={handleNewTrade}
+                onAction={handleNewTrade}
                 testID="perps-empty-state"
                 twClassName="mx-auto"
               />

--- a/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
@@ -95,17 +95,14 @@ const PerpsTabView: React.FC<PerpsTabViewProps> = () => {
 
       // Track homescreen tab viewed event with exact property names from requirements
       track(MetaMetricsEvents.PERPS_HOMESCREEN_TAB_VIEWED, {
-        [PerpsEventProperties.OPEN_POSITION]: positions.map((p) => {
-          const direction = getPositionDirection(p.size);
-          return {
-            [PerpsEventProperties.ASSET]: p.coin,
-            [PerpsEventProperties.LEVERAGE]: p.leverage.value,
-            [PerpsEventProperties.DIRECTION]:
-              direction === 'long'
-                ? PerpsEventValues.DIRECTION.LONG
-                : PerpsEventValues.DIRECTION.SHORT,
-          };
-        }),
+        [PerpsEventProperties.OPEN_POSITION]: positions.map((p) => ({
+          [PerpsEventProperties.ASSET]: p.coin,
+          [PerpsEventProperties.LEVERAGE]: p.leverage.value,
+          [PerpsEventProperties.DIRECTION]:
+            parseFloat(p.size) > 0
+              ? PerpsEventValues.DIRECTION.LONG
+              : PerpsEventValues.DIRECTION.SHORT,
+        })),
       });
 
       hasTrackedHomescreen.current = true;

--- a/app/components/UI/Perps/utils/positionCalculations.test.ts
+++ b/app/components/UI/Perps/utils/positionCalculations.test.ts
@@ -5,6 +5,7 @@ import {
   calculateCloseValue,
   calculatePercentageFromTokenAmount,
   calculatePercentageFromUSDAmount,
+  getPositionDirection,
 } from './positionCalculations';
 
 describe('Position Calculations Utils', () => {
@@ -191,6 +192,52 @@ describe('Position Calculations Utils', () => {
     it('returns 0 for invalid inputs', () => {
       const result = calculatePercentageFromUSDAmount(NaN, 500);
       expect(result).toBe(0);
+    });
+  });
+
+  describe('getPositionDirection', () => {
+    it('returns "long" for positive position sizes', () => {
+      expect(getPositionDirection('10.5')).toBe('long');
+      expect(getPositionDirection('0.01')).toBe('long');
+      expect(getPositionDirection('1000')).toBe('long');
+    });
+
+    it('returns "short" for negative position sizes', () => {
+      expect(getPositionDirection('-10.5')).toBe('short');
+      expect(getPositionDirection('-0.01')).toBe('short');
+      expect(getPositionDirection('-1000')).toBe('short');
+    });
+
+    it('returns "unknown" for zero position size', () => {
+      expect(getPositionDirection('0')).toBe('unknown');
+      expect(getPositionDirection('0.0')).toBe('unknown');
+      expect(getPositionDirection('-0')).toBe('unknown');
+    });
+
+    it('returns "unknown" for invalid strings', () => {
+      expect(getPositionDirection('abc')).toBe('unknown');
+      expect(getPositionDirection('not a number')).toBe('unknown');
+      expect(getPositionDirection('')).toBe('unknown');
+      expect(getPositionDirection(' ')).toBe('unknown');
+    });
+
+    it('returns "unknown" for non-finite values', () => {
+      expect(getPositionDirection('Infinity')).toBe('unknown');
+      expect(getPositionDirection('-Infinity')).toBe('unknown');
+      expect(getPositionDirection('NaN')).toBe('unknown');
+    });
+
+    it('handles edge cases correctly', () => {
+      expect(getPositionDirection('1e-10')).toBe('long'); // Very small positive
+      expect(getPositionDirection('-1e-10')).toBe('short'); // Very small negative
+      expect(getPositionDirection('1.23e15')).toBe('long'); // Large positive
+      expect(getPositionDirection('-1.23e15')).toBe('short'); // Large negative
+    });
+
+    it('handles strings with whitespace', () => {
+      expect(getPositionDirection(' 10.5 ')).toBe('long');
+      expect(getPositionDirection(' -10.5 ')).toBe('short');
+      expect(getPositionDirection('  0  ')).toBe('unknown');
     });
   });
 });

--- a/app/components/UI/Perps/utils/positionCalculations.ts
+++ b/app/components/UI/Perps/utils/positionCalculations.ts
@@ -175,3 +175,28 @@ export function calculatePercentageFromUSDAmount(
   const percentage = (usdAmount / totalPositionValue) * 100;
   return Math.max(0, Math.min(100, percentage));
 }
+
+/**
+ * Helper function to determine position direction based on size value
+ * @param sizeString - The position size as a string
+ * @returns 'long', 'short', or 'unknown'
+ */
+export function getPositionDirection(
+  sizeString: string,
+): 'long' | 'short' | 'unknown' {
+  const sizeValue = parseFloat(sizeString);
+
+  if (!Number.isFinite(sizeValue)) {
+    return 'unknown';
+  }
+
+  if (sizeValue > 0) {
+    return 'long';
+  }
+
+  if (sizeValue < 0) {
+    return 'short';
+  }
+
+  return 'unknown';
+}


### PR DESCRIPTION
## **Description**

Updated the PerpsEmptyState component to use the `onAction` prop from TabEmptyStateProps instead of a custom `onStartTrading` prop. This fixes a [prop spreading issue](https://github.com/MetaMask/metamask-mobile/pull/20483#discussion_r2383533046) where any `onAction` prop passed to PerpsEmptyState would override the explicitly set `onAction={onStartTrading}` due to the `{...props}` spread coming after the explicit assignment.

**What was the issue?**
The component had both a custom `onStartTrading` prop and inherited `onAction` from TabEmptyStateProps, causing conflicts when props were spread.

**What's the solution?**
Removed the redundant `onStartTrading` prop and updated all usages to use the inherited `onAction` prop, maintaining consistency with the parent TabEmptyState component.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: Internal code improvement to resolve prop override issue

## **Manual testing steps**

```gherkin
Feature: PerpsEmptyState component functionality

  Scenario: user interacts with empty state action button
    Given the app is running with no perp positions or orders
    And I navigate to the Perps tab
    When I see the empty state with "Start trading" button
    And I tap the "Start trading" button
    Then the onAction callback should be triggered correctly
    And I should navigate to the expected trading interface
```

## **Screenshots/Recordings**

### **Before**
No visual changes - this is an internal prop structure fix

### **After**
No visual changes - this is an internal prop structure fix. Smoke test to show button still works

https://github.com/user-attachments/assets/84fb0aa6-181f-461f-bee0-e15caba1ca87

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches PerpsEmptyState to use `onAction` and introduces `getPositionDirection`, updating usages, mocks, and tests.
> 
> - **Perps UI**:
>   - **PerpsEmptyState**: Remove custom `onStartTrading` prop; use inherited `onAction`. Update story, tests, and `PerpsTabView` to pass `onAction`.
> - **Refactor**:
>   - Add `getPositionDirection(sizeString)` in `utils/positionCalculations` and comprehensive unit tests.
>   - Replace inline direction parsing with `getPositionDirection` in `PerpsPositionsView` and `PerpsTabView` to build `testID`s.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0628e624e6f025855436a30093ca0299f6dff8eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->