### PR TITLE
[Ignore] Deeplink to Settings View working

### DIFF
--- a/app/components/UI/Tokens/TokenList/TokenListFooter/index.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListFooter/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import createStyles from '../../styles';
 import { useTheme } from '../../../../../util/theme';
-import { View } from 'react-native';
+import { Linking, View } from 'react-native';
 import TextComponent, {
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
@@ -22,6 +22,7 @@ import { selectChainId } from '../../../../../selectors/networkController';
 import { trace, TraceName } from '../../../../../util/trace';
 import { useSelectedAccountMultichainBalances } from '../../../../hooks/useMultichainBalances';
 import { createDepositNavigationDetails } from '../../../Ramp/Deposit/routes/utils';
+import { ACTIONS, PREFIXES } from '../../../../../constants/deeplinks';
 
 export const TokenListFooter = () => {
   const chainId = useSelector(selectChainId);
@@ -60,6 +61,8 @@ export const TokenListFooter = () => {
     });
   };
 
+  const path = `${PREFIXES.METAMASK}${ACTIONS.SETTINGS_VIEW}`;
+
   return (
     <>
       {/* render buy button */}
@@ -78,6 +81,14 @@ export const TokenListFooter = () => {
             style={styles.buyButton}
             onPress={goToDeposit}
             label={strings('wallet.add_funds')}
+          />
+          <Button
+            variant={ButtonVariants.Primary}
+            size={ButtonSize.Lg}
+            width={ButtonWidthTypes.Full}
+            style={styles.buyButton}
+            onPress={() => Linking.openURL(path)}
+            label={'Settings'}
           />
         </View>
       )}

--- a/app/constants/deeplinks.ts
+++ b/app/constants/deeplinks.ts
@@ -35,6 +35,7 @@ export enum ACTIONS {
   PERPS = 'perps',
   PERPS_MARKETS = 'perps-markets',
   PERPS_ASSET = 'perps-asset',
+  SETTINGS_VIEW = 'settings-view',
 }
 
 export const PREFIXES = {

--- a/app/core/DeeplinkManager/ParseManager/handleMetaMaskDeeplink.ts
+++ b/app/core/DeeplinkManager/ParseManager/handleMetaMaskDeeplink.ts
@@ -29,6 +29,11 @@ export function handleMetaMaskDeeplink({
 }) {
   handled();
 
+  // write it in here.
+  if (url.startsWith(`${PREFIXES.METAMASK}${ACTIONS.SETTINGS_VIEW}`)) {
+    SDKConnect.getInstance().state.navigation?.navigate(Routes.SETTINGS_VIEW);
+  }
+
   if (url.startsWith(`${PREFIXES.METAMASK}${ACTIONS.ANDROID_SDK}`)) {
     DevLogger.log(
       `DeeplinkManager:: metamask launched via android sdk deeplink`,


### PR DESCRIPTION
My first thought was to just ask AI how to do it before having to dive into such a large codebase, but I decided to do it the manual way because a lot of devs may not have access to powerful AI. **At multiple points I asked myself if there were any examples somewhere in the code base**. A Readme file or comments in the files may be helpful.

1. Search “deep” and find “app/core/DeeplinkManager   @MetaMask/mobile-platform” in the CODEOWNERS file
2. Go to app/core/DeeplinkManager, see “setDeepLink” which leads me nowhere, “addEventListener(‘url’)” doesn’t tell me much because “URL” is a common term so it’d be difficult to find where it is emitted. “handleDeeplink -> checkForDeepLink -> “CHECK_FOR_DEEPLINK” which leads to Sagas:
```
SharedDeeplinkManager.parse(deeplink, {
    origin: AppConstants.DEEPLINKS.ORIGIN_DEEPLINK,
});
```
Leads me to “parse” and then “parseDeepLink”

      `case PROTOCOLS.METAMASK which uses handleMetaMaskDeeplink`

3. Create conditional if LINK matches “SETTINGS” for example. Now we need to know how to do programmatically navigate the app. Maybe like this example from the `handleMetaMaskDeeplink` file?
```
      SDKConnect.getInstance().state.navigation?.navigate(
        Routes.MODAL.ROOT_MODAL_FLOW,
        {
          screen: Routes.SDK.RETURN_TO_DAPP_TOAST,
        },
      )
```

4. AI wants to help me code complete but I’ll resist for now. Is `SDKConnect.getInstance().state.navigation` really what we want to be using? Take a look at the “Routes” file and see one for settings. But what are the two parameters that “navigate” needs to take? They look similar in that example… both routes? Looks like first param is the route but why does the second variable have a “screen” field? I think that must be a misnomer for a stage of a modal process. I will remove the second parameter and use the Routes. I search in app for `Routes.SETTINGS_VIEW` to see if I need to pass a second param. Looks like this call should hopefully do the trick:
```
navigation.navigate(Routes.SETTINGS_VIEW, {
     screen: 'Settings',
});
```
5. Find deeplinks.ts file for the actual string route paths

6. Does React Native have link components? Documentation says no but we can create a button and use Linking.openURL(theUrl) 

7. Button link works!