### PR TITLE
chore: Make close position values reactive to price changes

### DIFF
--- a/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.test.tsx
@@ -452,14 +452,15 @@ describe('PerpsClosePositionView', () => {
         true,
       );
 
-      // Assert - receiveAmount = initialMargin - fees (P&L is shown separately in UI)
-      // receiveAmount = 1000 - 50 = 950
+      // Assert - receiveAmount = initialMargin + P&L - fees (P&L now included in calculation)
+      // P&L = (150 - 100) * 1 = 50
+      // receiveAmount = 1000 + 50 - 50 = 1000
       const receiveText = getByText(
         strings('perps.close_position.you_receive'),
       );
       expect(receiveText).toBeDefined();
-      // Look for 950 in the display (margin - fees, P&L shown separately)
-      expect(getByText('$950.00')).toBeDefined();
+      // Look for 1000 in the display (margin + P&L - fees)
+      expect(getByText('$1,000.00')).toBeDefined();
     });
 
     it('calculates receive amount correctly for partial close percentages', () => {
@@ -497,13 +498,14 @@ describe('PerpsClosePositionView', () => {
       );
 
       // For 100% close (default) with new calculation:
-      // receiveAmount = initialMargin - fees = 2000 - 25 = 1975
+      // P&L = (75 - 100) * 2 = -50 (loss)
+      // receiveAmount = 2000 + (-50) - 25 = 1925
       const receiveText = getByText(
         strings('perps.close_position.you_receive'),
       );
       expect(receiveText).toBeDefined();
-      // Look for 1975 in the display (initial margin - fees)
-      expect(getByText(/1,975/)).toBeDefined();
+      // Look for 1925 in the display (margin + P&L - fees)
+      expect(getByText(/1,925/)).toBeDefined();
     });
   });
 
@@ -1883,7 +1885,7 @@ describe('PerpsClosePositionView', () => {
         {
           totalFee: 45,
           marketPrice: 3000,
-          receivedAmount: 1405,
+          receivedAmount: 1555, // 1450 (margin) + 150 (P&L) - 45 (fees)
           realizedPnl: 150,
           metamaskFeeRate: 0,
           feeDiscountPercentage: undefined,

--- a/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
@@ -206,10 +206,13 @@ const PerpsClosePositionView: React.FC = () => {
     orderAmount: closingValueString,
   });
 
-  // Calculate what user will receive (initial margin - fees)
+  // Calculate what user will receive (initial margin + P&L - fees)
   // P&L is already shown separately in the margin section as "includes P&L"
-  const receiveAmount =
-    (closePercentage / 100) * initialMargin - feeResults.totalFee;
+  const receiveAmount = useMemo(() => {
+    const marginPortion = (closePercentage / 100) * initialMargin;
+    const pnlPortion = effectivePnL * (closePercentage / 100);
+    return marginPortion + pnlPortion - feeResults.totalFee;
+  }, [closePercentage, initialMargin, effectivePnL, feeResults.totalFee]);
 
   // Get minimum order amount for this asset
   const { minimumOrderAmount } = useMinimumOrderAmount({
@@ -499,9 +502,13 @@ const PerpsClosePositionView: React.FC = () => {
         </View>
         <View style={styles.summaryValue}>
           <Text variant={TextVariant.BodyMD}>
-            {formatPrice(initialMargin * (closePercentage / 100), {
-              maximumDecimals: 2,
-            })}
+            {formatPrice(
+              (closePercentage / 100) * initialMargin +
+                effectivePnL * (closePercentage / 100),
+              {
+                maximumDecimals: 2,
+              },
+            )}
           </Text>
           <View style={styles.inclusiveFeeRow}>
             <Text variant={TextVariant.BodySM} color={TextColor.Default}>


### PR DESCRIPTION
## **Description**

Make close position view values reactive to price change. Now, when price changes, P&L, Margin, and receiving values will update in real time as price values change.

## **Changelog**

CHANGELOG entry: Make close position price values reactive to live price updates

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1797

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/386e4138-3d8b-424d-b7c7-defb4d4de270

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Close-position receive amount now includes P&L at the effective price (proportional to close %) and UI reflects this; tests updated accordingly.
> 
> - **Perps Close Position**:
>   - **Calculation**: `receiveAmount` now computed as `(initialMargin * close%) + (effectivePnL * close%) - fees` using `useMemo`.
>   - **UI Summary**: `margin` display updated to show `initialMargin + P&L` (proportional) and continues to show P&L indicator.
>   - **Tests**: Adjust expected "You receive" values and confirmation payloads (e.g., `receivedAmount` from `1405` to `1555`) to match new formula; update partial-close scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc712c442224b119aa7f650549a093bf4089f213. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->