### PR TITLE
fix: standardize button icon sizes to md (default) for bottomsheets, navigation and modals

### DIFF
--- a/app/component-library/components-temp/CellSelectWithMenu/__snapshots__/CellSelectWithMenu.test.tsx.snap
+++ b/app/component-library/components-temp/CellSelectWithMenu/__snapshots__/CellSelectWithMenu.test.tsx.snap
@@ -314,10 +314,10 @@ exports[`CellSelectWithMenu should render with default settings correctly 1`] = 
         {
           "alignItems": "center",
           "borderRadius": 8,
-          "height": 24,
+          "height": 28,
           "justifyContent": "center",
           "opacity": 1,
-          "width": 24,
+          "width": 28,
         }
       }
       testID="button-menu-select-test-id"
@@ -325,15 +325,15 @@ exports[`CellSelectWithMenu should render with default settings correctly 1`] = 
       <SvgMock
         color="#121314"
         fill="currentColor"
-        height={16}
+        height={20}
         name="MoreVertical"
         style={
           {
-            "height": 16,
-            "width": 16,
+            "height": 20,
+            "width": 20,
           }
         }
-        width={16}
+        width={20}
       />
     </TouchableOpacity>
   </View>

--- a/app/component-library/components-temp/ListItemMultiSelectButton/__snapshots__/ListItemMultiSelectButton.test.tsx.snap
+++ b/app/component-library/components-temp/ListItemMultiSelectButton/__snapshots__/ListItemMultiSelectButton.test.tsx.snap
@@ -68,10 +68,10 @@ exports[`ListItemMultiSelectButton should render correctly with default props 1`
         {
           "alignItems": "center",
           "borderRadius": 8,
-          "height": 24,
+          "height": 28,
           "justifyContent": "center",
           "opacity": 1,
-          "width": 24,
+          "width": 28,
         }
       }
       testID="button-menu-select-test-id"
@@ -79,15 +79,15 @@ exports[`ListItemMultiSelectButton should render correctly with default props 1`
       <SvgMock
         color="#121314"
         fill="currentColor"
-        height={16}
+        height={20}
         name="MoreVertical"
         style={
           {
-            "height": 16,
-            "width": 16,
+            "height": 20,
+            "width": 20,
           }
         }
-        width={16}
+        width={20}
       />
     </TouchableOpacity>
   </View>

--- a/app/component-library/components-temp/ListItemMultiSelectWithMenuButton/__snapshots__/ListItemMultiSelectWithMenuButton.test.tsx.snap
+++ b/app/component-library/components-temp/ListItemMultiSelectWithMenuButton/__snapshots__/ListItemMultiSelectWithMenuButton.test.tsx.snap
@@ -104,10 +104,10 @@ exports[`ListItemMultiSelectWithMenuButton should render correctly with default 
         {
           "alignItems": "center",
           "borderRadius": 8,
-          "height": 24,
+          "height": 28,
           "justifyContent": "center",
           "opacity": 1,
-          "width": 24,
+          "width": 28,
         }
       }
       testID="button-menu-select-with-menu-button-test-id"
@@ -115,15 +115,15 @@ exports[`ListItemMultiSelectWithMenuButton should render correctly with default 
       <SvgMock
         color="#121314"
         fill="currentColor"
-        height={16}
+        height={20}
         name="MoreVertical"
         style={
           {
-            "height": 16,
-            "width": 16,
+            "height": 20,
+            "width": 20,
           }
         }
-        width={16}
+        width={20}
       />
     </TouchableOpacity>
   </View>

--- a/app/component-library/components/Buttons/ButtonIcon/ButtonIcon.constants.ts
+++ b/app/component-library/components/Buttons/ButtonIcon/ButtonIcon.constants.ts
@@ -19,7 +19,7 @@ export const ICONSIZE_BY_BUTTONICONSIZE: IconSizeByButtonIconSize = {
 };
 
 // Defaults
-export const DEFAULT_BUTTONICON_SIZE = ButtonIconSizes.Sm;
+export const DEFAULT_BUTTONICON_SIZE = ButtonIconSizes.Md;
 export const DEFAULT_BUTTONICON_ICONNAME = IconName.Add;
 export const DEFAULT_BUTTONICON_ICONCOLOR = IconColor.Default;
 

--- a/app/component-library/components/Buttons/ButtonIcon/__snapshots__/ButtonIcon.test.tsx.snap
+++ b/app/component-library/components/Buttons/ButtonIcon/__snapshots__/ButtonIcon.test.tsx.snap
@@ -12,25 +12,25 @@ exports[`ButtonIcon should render correctly 1`] = `
     {
       "alignItems": "center",
       "borderRadius": 8,
-      "height": 24,
+      "height": 28,
       "justifyContent": "center",
       "opacity": 1,
-      "width": 24,
+      "width": 28,
     }
   }
 >
   <SvgMock
     color="#121314"
     fill="currentColor"
-    height={16}
+    height={20}
     name="Add"
     style={
       {
-        "height": 16,
-        "width": 16,
+        "height": 20,
+        "width": 20,
       }
     }
-    width={16}
+    width={20}
   />
 </TouchableOpacity>
 `;

--- a/app/component-library/components/Cells/Cell/__snapshots__/Cell.test.tsx.snap
+++ b/app/component-library/components/Cells/Cell/__snapshots__/Cell.test.tsx.snap
@@ -882,10 +882,10 @@ exports[`Cell should render CellMultiSelectWithMenu given the type MultiSelectWi
         {
           "alignItems": "center",
           "borderRadius": 8,
-          "height": 24,
+          "height": 28,
           "justifyContent": "center",
           "opacity": 1,
-          "width": 24,
+          "width": 28,
         }
       }
       testID="button-menu-select-with-menu-button-test-id"
@@ -893,15 +893,15 @@ exports[`Cell should render CellMultiSelectWithMenu given the type MultiSelectWi
       <SvgMock
         color="#121314"
         fill="currentColor"
-        height={16}
+        height={20}
         name="MoreVertical"
         style={
           {
-            "height": 16,
-            "width": 16,
+            "height": 20,
+            "width": 20,
           }
         }
-        width={16}
+        width={20}
       />
     </TouchableOpacity>
   </View>
@@ -1492,10 +1492,10 @@ exports[`Cell should render CellSelectWithMenu given the type SelectWithMenu 1`]
         {
           "alignItems": "center",
           "borderRadius": 8,
-          "height": 24,
+          "height": 28,
           "justifyContent": "center",
           "opacity": 1,
-          "width": 24,
+          "width": 28,
         }
       }
       testID="button-menu-select-test-id"
@@ -1503,15 +1503,15 @@ exports[`Cell should render CellSelectWithMenu given the type SelectWithMenu 1`]
       <SvgMock
         color="#121314"
         fill="currentColor"
-        height={16}
+        height={20}
         name="MoreVertical"
         style={
           {
-            "height": 16,
-            "width": 16,
+            "height": 20,
+            "width": 20,
           }
         }
-        width={16}
+        width={20}
       />
     </TouchableOpacity>
   </View>

--- a/app/components/Snaps/SnapUIAddressInput/__snapshots__/SnapUIAddressInput.test.tsx.snap
+++ b/app/components/Snaps/SnapUIAddressInput/__snapshots__/SnapUIAddressInput.test.tsx.snap
@@ -111,10 +111,10 @@ exports[`SnapUIAddressInput renders the matched address info in a disabled state
           "alignItems": "center",
           "borderRadius": 8,
           "flexShrink": 0,
-          "height": 24,
+          "height": 28,
           "justifyContent": "center",
           "opacity": 0.5,
-          "width": 24,
+          "width": 28,
         }
       }
       testID="snap-ui-address-input__clear-button"
@@ -122,15 +122,15 @@ exports[`SnapUIAddressInput renders the matched address info in a disabled state
       <SvgMock
         color="#4459ff"
         fill="currentColor"
-        height={16}
+        height={20}
         name="Close"
         style={
           {
-            "height": 16,
-            "width": 16,
+            "height": 20,
+            "width": 20,
           }
         }
-        width={16}
+        width={20}
       />
     </TouchableOpacity>
   </View>

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
@@ -965,25 +965,25 @@ exports[`SnapUIForm will render with fields 1`] = `
                                   {
                                     "alignItems": "center",
                                     "borderRadius": 8,
-                                    "height": 24,
+                                    "height": 28,
                                     "justifyContent": "center",
                                     "opacity": 1,
-                                    "width": 24,
+                                    "width": 28,
                                   }
                                 }
                               >
                                 <SvgMock
                                   color="#121314"
                                   fill="currentColor"
-                                  height={16}
+                                  height={20}
                                   name="ArrowLeft"
                                   style={
                                     {
-                                      "height": 16,
-                                      "width": 16,
+                                      "height": 20,
+                                      "width": 20,
                                     }
                                   }
-                                  width={16}
+                                  width={20}
                                 />
                               </TouchableOpacity>
                             </View>
@@ -1696,25 +1696,25 @@ exports[`SnapUIForm will render with fields 1`] = `
                                   {
                                     "alignItems": "center",
                                     "borderRadius": 8,
-                                    "height": 24,
+                                    "height": 28,
                                     "justifyContent": "center",
                                     "opacity": 1,
-                                    "width": 24,
+                                    "width": 28,
                                   }
                                 }
                               >
                                 <SvgMock
                                   color="#121314"
                                   fill="currentColor"
-                                  height={16}
+                                  height={20}
                                   name="ArrowLeft"
                                   style={
                                     {
-                                      "height": 16,
-                                      "width": 16,
+                                      "height": 20,
+                                      "width": 20,
                                     }
                                   }
-                                  width={16}
+                                  width={20}
                                 />
                               </TouchableOpacity>
                             </View>

--- a/app/components/UI/AddCustomToken/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/AddCustomToken/__snapshots__/index.test.tsx.snap
@@ -189,10 +189,10 @@ exports[`AddCustomToken render correctly 1`] = `
                 {
                   "alignItems": "center",
                   "borderRadius": 8,
-                  "height": 24,
+                  "height": 28,
                   "justifyContent": "center",
                   "opacity": 1,
-                  "width": 24,
+                  "width": 28,
                 }
               }
               testID="select-network-button"
@@ -200,15 +200,15 @@ exports[`AddCustomToken render correctly 1`] = `
               <SvgMock
                 color="#121314"
                 fill="currentColor"
-                height={16}
+                height={20}
                 name="ArrowDown"
                 style={
                   {
-                    "height": 16,
-                    "width": 16,
+                    "height": 20,
+                    "width": 20,
                   }
                 }
-                width={16}
+                width={20}
               />
             </TouchableOpacity>
           </View>

--- a/app/components/UI/Bridge/components/BridgeDestTokenSelector/__snapshots__/BridgeDestTokenSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeDestTokenSelector/__snapshots__/BridgeDestTokenSelector.test.tsx.snap
@@ -499,10 +499,10 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                   testID="bridge-token-selector-close-button"
@@ -510,15 +510,15 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Bridge/components/BridgeSourceTokenSelector/__snapshots__/BridgeSourceTokenSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeSourceTokenSelector/__snapshots__/BridgeSourceTokenSelector.test.tsx.snap
@@ -499,10 +499,10 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                   testID="bridge-token-selector-close-button"
@@ -510,15 +510,15 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Bridge/components/QuoteExpiredModal/__snapshots__/QuoteExpiredModal.test.tsx.snap
+++ b/app/components/UI/Bridge/components/QuoteExpiredModal/__snapshots__/QuoteExpiredModal.test.tsx.snap
@@ -198,25 +198,25 @@ exports[`QuoteExpiredModal renders correctly 1`] = `
                   {
                     "alignItems": "center",
                     "borderRadius": 8,
-                    "height": 24,
+                    "height": 28,
                     "justifyContent": "center",
                     "opacity": 1,
-                    "width": 24,
+                    "width": 28,
                   }
                 }
               >
                 <SvgMock
                   color="#121314"
                   fill="currentColor"
-                  height={16}
+                  height={20}
                   name="Close"
                   style={
                     {
-                      "height": 16,
-                      "width": 16,
+                      "height": 20,
+                      "width": 20,
                     }
                   }
-                  width={16}
+                  width={20}
                 />
               </TouchableOpacity>
             </View>

--- a/app/components/UI/Bridge/components/SlippageModal/__snapshots__/SlippageModal.test.tsx.snap
+++ b/app/components/UI/Bridge/components/SlippageModal/__snapshots__/SlippageModal.test.tsx.snap
@@ -198,25 +198,25 @@ exports[`SlippageModal renders all UI elements with the proper slippage options 
                   {
                     "alignItems": "center",
                     "borderRadius": 8,
-                    "height": 24,
+                    "height": 28,
                     "justifyContent": "center",
                     "opacity": 1,
-                    "width": 24,
+                    "width": 28,
                   }
                 }
               >
                 <SvgMock
                   color="#121314"
                   fill="currentColor"
-                  height={16}
+                  height={20}
                   name="Close"
                   style={
                     {
-                      "height": 16,
-                      "width": 16,
+                      "height": 20,
+                      "width": 20,
                     }
                   }
-                  width={16}
+                  width={20}
                 />
               </TouchableOpacity>
             </View>

--- a/app/components/UI/CaipAccountSelectorList/__snapshots__/CaipAccountSelectorList.test.tsx.snap
+++ b/app/components/UI/CaipAccountSelectorList/__snapshots__/CaipAccountSelectorList.test.tsx.snap
@@ -296,10 +296,10 @@ exports[`CaipAccountSelectorList renders all accounts with balances 1`] = `
               {
                 "alignItems": "center",
                 "borderRadius": 8,
-                "height": 24,
+                "height": 28,
                 "justifyContent": "center",
                 "opacity": 1,
-                "width": 24,
+                "width": 28,
               }
             }
             testID="main-wallet-account-actions"
@@ -307,15 +307,15 @@ exports[`CaipAccountSelectorList renders all accounts with balances 1`] = `
             <SvgMock
               color="#121314"
               fill="currentColor"
-              height={16}
+              height={20}
               name="MoreVertical"
               style={
                 {
-                  "height": 16,
-                  "width": 16,
+                  "height": 20,
+                  "width": 20,
                 }
               }
-              width={16}
+              width={20}
             />
           </TouchableOpacity>
         </View>
@@ -530,10 +530,10 @@ exports[`CaipAccountSelectorList renders all accounts with balances 1`] = `
               {
                 "alignItems": "center",
                 "borderRadius": 8,
-                "height": 24,
+                "height": 28,
                 "justifyContent": "center",
                 "opacity": 1,
-                "width": 24,
+                "width": 28,
               }
             }
             testID="main-wallet-account-actions"
@@ -541,15 +541,15 @@ exports[`CaipAccountSelectorList renders all accounts with balances 1`] = `
             <SvgMock
               color="#121314"
               fill="currentColor"
-              height={16}
+              height={20}
               name="MoreVertical"
               style={
                 {
-                  "height": 16,
-                  "width": 16,
+                  "height": 20,
+                  "width": 20,
                 }
               }
-              width={16}
+              width={20}
             />
           </TouchableOpacity>
         </View>
@@ -818,10 +818,10 @@ exports[`CaipAccountSelectorList renders all accounts with right accessory 1`] =
               {
                 "alignItems": "center",
                 "borderRadius": 8,
-                "height": 24,
+                "height": 28,
                 "justifyContent": "center",
                 "opacity": 1,
-                "width": 24,
+                "width": 28,
               }
             }
             testID="main-wallet-account-actions"
@@ -829,15 +829,15 @@ exports[`CaipAccountSelectorList renders all accounts with right accessory 1`] =
             <SvgMock
               color="#121314"
               fill="currentColor"
-              height={16}
+              height={20}
               name="MoreVertical"
               style={
                 {
-                  "height": 16,
-                  "width": 16,
+                  "height": 20,
+                  "width": 20,
                 }
               }
-              width={16}
+              width={20}
             />
           </TouchableOpacity>
         </View>
@@ -1015,10 +1015,10 @@ exports[`CaipAccountSelectorList renders all accounts with right accessory 1`] =
               {
                 "alignItems": "center",
                 "borderRadius": 8,
-                "height": 24,
+                "height": 28,
                 "justifyContent": "center",
                 "opacity": 1,
-                "width": 24,
+                "width": 28,
               }
             }
             testID="main-wallet-account-actions"
@@ -1026,15 +1026,15 @@ exports[`CaipAccountSelectorList renders all accounts with right accessory 1`] =
             <SvgMock
               color="#121314"
               fill="currentColor"
-              height={16}
+              height={20}
               name="MoreVertical"
               style={
                 {
-                  "height": 16,
-                  "width": 16,
+                  "height": 20,
+                  "width": 20,
                 }
               }
-              width={16}
+              width={20}
             />
           </TouchableOpacity>
         </View>
@@ -1340,10 +1340,10 @@ exports[`CaipAccountSelectorList renders correctly 1`] = `
               {
                 "alignItems": "center",
                 "borderRadius": 8,
-                "height": 24,
+                "height": 28,
                 "justifyContent": "center",
                 "opacity": 1,
-                "width": 24,
+                "width": 28,
               }
             }
             testID="main-wallet-account-actions"
@@ -1351,15 +1351,15 @@ exports[`CaipAccountSelectorList renders correctly 1`] = `
             <SvgMock
               color="#121314"
               fill="currentColor"
-              height={16}
+              height={20}
               name="MoreVertical"
               style={
                 {
-                  "height": 16,
-                  "width": 16,
+                  "height": 20,
+                  "width": 20,
                 }
               }
-              width={16}
+              width={20}
             />
           </TouchableOpacity>
         </View>
@@ -1574,10 +1574,10 @@ exports[`CaipAccountSelectorList renders correctly 1`] = `
               {
                 "alignItems": "center",
                 "borderRadius": 8,
-                "height": 24,
+                "height": 28,
                 "justifyContent": "center",
                 "opacity": 1,
-                "width": 24,
+                "width": 28,
               }
             }
             testID="main-wallet-account-actions"
@@ -1585,15 +1585,15 @@ exports[`CaipAccountSelectorList renders correctly 1`] = `
             <SvgMock
               color="#121314"
               fill="currentColor"
-              height={16}
+              height={20}
               name="MoreVertical"
               style={
                 {
-                  "height": 16,
-                  "width": 16,
+                  "height": 20,
+                  "width": 20,
                 }
               }
-              width={16}
+              width={20}
             />
           </TouchableOpacity>
         </View>
@@ -1899,10 +1899,10 @@ exports[`CaipAccountSelectorList renders network icons for accounts with transac
               {
                 "alignItems": "center",
                 "borderRadius": 8,
-                "height": 24,
+                "height": 28,
                 "justifyContent": "center",
                 "opacity": 1,
-                "width": 24,
+                "width": 28,
               }
             }
             testID="main-wallet-account-actions"
@@ -1910,15 +1910,15 @@ exports[`CaipAccountSelectorList renders network icons for accounts with transac
             <SvgMock
               color="#121314"
               fill="currentColor"
-              height={16}
+              height={20}
               name="MoreVertical"
               style={
                 {
-                  "height": 16,
-                  "width": 16,
+                  "height": 20,
+                  "width": 20,
                 }
               }
-              width={16}
+              width={20}
             />
           </TouchableOpacity>
         </View>
@@ -2133,10 +2133,10 @@ exports[`CaipAccountSelectorList renders network icons for accounts with transac
               {
                 "alignItems": "center",
                 "borderRadius": 8,
-                "height": 24,
+                "height": 28,
                 "justifyContent": "center",
                 "opacity": 1,
-                "width": 24,
+                "width": 28,
               }
             }
             testID="main-wallet-account-actions"
@@ -2144,15 +2144,15 @@ exports[`CaipAccountSelectorList renders network icons for accounts with transac
             <SvgMock
               color="#121314"
               fill="currentColor"
-              height={16}
+              height={20}
               name="MoreVertical"
               style={
                 {
-                  "height": 16,
-                  "width": 16,
+                  "height": 20,
+                  "width": 20,
                 }
               }
-              width={16}
+              width={20}
             />
           </TouchableOpacity>
         </View>

--- a/app/components/UI/Card/components/AddFundsBottomSheet/__snapshots__/AddFundsBottomSheet.test.tsx.snap
+++ b/app/components/UI/Card/components/AddFundsBottomSheet/__snapshots__/AddFundsBottomSheet.test.tsx.snap
@@ -499,25 +499,25 @@ exports[`AddFundsBottomSheet renders with both options enabled and matches snaps
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -1310,25 +1310,25 @@ exports[`AddFundsBottomSheet renders with no options when both are disabled and 
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -1905,25 +1905,25 @@ exports[`AddFundsBottomSheet renders with only deposit option when swaps are not
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -2608,25 +2608,25 @@ exports[`AddFundsBottomSheet renders with only swap option when deposit is disab
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Earn/LendingLearnMoreModal/__snapshots__/LendingLearnMoreModal.test.tsx.snap
+++ b/app/components/UI/Earn/LendingLearnMoreModal/__snapshots__/LendingLearnMoreModal.test.tsx.snap
@@ -178,25 +178,25 @@ exports[`LendingLearnMoreModal render lending history apy chart 1`] = `
                   {
                     "alignItems": "center",
                     "borderRadius": 8,
-                    "height": 24,
+                    "height": 28,
                     "justifyContent": "center",
                     "opacity": 1,
-                    "width": 24,
+                    "width": 28,
                   }
                 }
               >
                 <SvgMock
                   color="#121314"
                   fill="currentColor"
-                  height={16}
+                  height={20}
                   name="Close"
                   style={
                     {
-                      "height": 16,
-                      "width": 16,
+                      "height": 20,
+                      "width": 20,
                     }
                   }
-                  width={16}
+                  width={20}
                 />
               </TouchableOpacity>
             </View>

--- a/app/components/UI/Earn/components/MaxInputModal/__snapshots__/MaxInputModal.test.tsx.snap
+++ b/app/components/UI/Earn/components/MaxInputModal/__snapshots__/MaxInputModal.test.tsx.snap
@@ -505,25 +505,25 @@ exports[`MaxInputModal render matches snapshot 1`] = `
                                       {
                                         "alignItems": "center",
                                         "borderRadius": 8,
-                                        "height": 24,
+                                        "height": 28,
                                         "justifyContent": "center",
                                         "opacity": 1,
-                                        "width": 24,
+                                        "width": 28,
                                       }
                                     }
                                   >
                                     <SvgMock
                                       color="#121314"
                                       fill="currentColor"
-                                      height={16}
+                                      height={20}
                                       name="Close"
                                       style={
                                         {
-                                          "height": 16,
-                                          "width": 16,
+                                          "height": 20,
+                                          "width": 20,
                                         }
                                       }
-                                      width={16}
+                                      width={20}
                                     />
                                   </TouchableOpacity>
                                 </View>

--- a/app/components/UI/Earn/modals/LendingMaxWithdrawalModal/__snapshots__/LendingMaxWithdrawalModal.test.tsx.snap
+++ b/app/components/UI/Earn/modals/LendingMaxWithdrawalModal/__snapshots__/LendingMaxWithdrawalModal.test.tsx.snap
@@ -71,25 +71,25 @@ exports[`LendingMaxWithdrawalModal should render correctly 1`] = `
             {
               "alignItems": "center",
               "borderRadius": 8,
-              "height": 24,
+              "height": 28,
               "justifyContent": "center",
               "opacity": 1,
-              "width": 24,
+              "width": 28,
             }
           }
         >
           <SvgMock
             color="#121314"
             fill="currentColor"
-            height={16}
+            height={20}
             name="Close"
             style={
               {
-                "height": 16,
-                "width": 16,
+                "height": 20,
+                "width": 20,
               }
             }
-            width={16}
+            width={20}
           />
         </TouchableOpacity>
       </View>

--- a/app/components/UI/EvmAccountSelectorList/__snapshots__/EvmAccountSelectorList.test.tsx.snap
+++ b/app/components/UI/EvmAccountSelectorList/__snapshots__/EvmAccountSelectorList.test.tsx.snap
@@ -319,10 +319,10 @@ exports[`EvmAccountSelectorList renders all accounts with balances 1`] = `
                     {
                       "alignItems": "center",
                       "borderRadius": 8,
-                      "height": 24,
+                      "height": 28,
                       "justifyContent": "center",
                       "opacity": 1,
-                      "width": 24,
+                      "width": 28,
                     }
                   }
                   testID="main-wallet-account-actions"
@@ -330,15 +330,15 @@ exports[`EvmAccountSelectorList renders all accounts with balances 1`] = `
                   <SvgMock
                     color="#121314"
                     fill="currentColor"
-                    height={16}
+                    height={20}
                     name="MoreVertical"
                     style={
                       {
-                        "height": 16,
-                        "width": 16,
+                        "height": 20,
+                        "width": 20,
                       }
                     }
-                    width={16}
+                    width={20}
                   />
                 </TouchableOpacity>
               </View>
@@ -568,10 +568,10 @@ exports[`EvmAccountSelectorList renders all accounts with balances 1`] = `
                     {
                       "alignItems": "center",
                       "borderRadius": 8,
-                      "height": 24,
+                      "height": 28,
                       "justifyContent": "center",
                       "opacity": 1,
-                      "width": 24,
+                      "width": 28,
                     }
                   }
                   testID="main-wallet-account-actions"
@@ -579,15 +579,15 @@ exports[`EvmAccountSelectorList renders all accounts with balances 1`] = `
                   <SvgMock
                     color="#121314"
                     fill="currentColor"
-                    height={16}
+                    height={20}
                     name="MoreVertical"
                     style={
                       {
-                        "height": 16,
-                        "width": 16,
+                        "height": 20,
+                        "width": 20,
                       }
                     }
-                    width={16}
+                    width={20}
                   />
                 </TouchableOpacity>
               </View>
@@ -881,10 +881,10 @@ exports[`EvmAccountSelectorList renders all accounts with right accessory 1`] = 
                     {
                       "alignItems": "center",
                       "borderRadius": 8,
-                      "height": 24,
+                      "height": 28,
                       "justifyContent": "center",
                       "opacity": 1,
-                      "width": 24,
+                      "width": 28,
                     }
                   }
                   testID="main-wallet-account-actions"
@@ -892,15 +892,15 @@ exports[`EvmAccountSelectorList renders all accounts with right accessory 1`] = 
                   <SvgMock
                     color="#121314"
                     fill="currentColor"
-                    height={16}
+                    height={20}
                     name="MoreVertical"
                     style={
                       {
-                        "height": 16,
-                        "width": 16,
+                        "height": 20,
+                        "width": 20,
                       }
                     }
-                    width={16}
+                    width={20}
                   />
                 </TouchableOpacity>
               </View>
@@ -1092,10 +1092,10 @@ exports[`EvmAccountSelectorList renders all accounts with right accessory 1`] = 
                     {
                       "alignItems": "center",
                       "borderRadius": 8,
-                      "height": 24,
+                      "height": 28,
                       "justifyContent": "center",
                       "opacity": 1,
-                      "width": 24,
+                      "width": 28,
                     }
                   }
                   testID="main-wallet-account-actions"
@@ -1103,15 +1103,15 @@ exports[`EvmAccountSelectorList renders all accounts with right accessory 1`] = 
                   <SvgMock
                     color="#121314"
                     fill="currentColor"
-                    height={16}
+                    height={20}
                     name="MoreVertical"
                     style={
                       {
-                        "height": 16,
-                        "width": 16,
+                        "height": 20,
+                        "width": 20,
                       }
                     }
-                    width={16}
+                    width={20}
                   />
                 </TouchableOpacity>
               </View>
@@ -1443,10 +1443,10 @@ exports[`EvmAccountSelectorList renders correctly 1`] = `
                     {
                       "alignItems": "center",
                       "borderRadius": 8,
-                      "height": 24,
+                      "height": 28,
                       "justifyContent": "center",
                       "opacity": 1,
-                      "width": 24,
+                      "width": 28,
                     }
                   }
                   testID="main-wallet-account-actions"
@@ -1454,15 +1454,15 @@ exports[`EvmAccountSelectorList renders correctly 1`] = `
                   <SvgMock
                     color="#121314"
                     fill="currentColor"
-                    height={16}
+                    height={20}
                     name="MoreVertical"
                     style={
                       {
-                        "height": 16,
-                        "width": 16,
+                        "height": 20,
+                        "width": 20,
                       }
                     }
-                    width={16}
+                    width={20}
                   />
                 </TouchableOpacity>
               </View>
@@ -1692,10 +1692,10 @@ exports[`EvmAccountSelectorList renders correctly 1`] = `
                     {
                       "alignItems": "center",
                       "borderRadius": 8,
-                      "height": 24,
+                      "height": 28,
                       "justifyContent": "center",
                       "opacity": 1,
-                      "width": 24,
+                      "width": 28,
                     }
                   }
                   testID="main-wallet-account-actions"
@@ -1703,15 +1703,15 @@ exports[`EvmAccountSelectorList renders correctly 1`] = `
                   <SvgMock
                     color="#121314"
                     fill="currentColor"
-                    height={16}
+                    height={20}
                     name="MoreVertical"
                     style={
                       {
-                        "height": 16,
-                        "width": 16,
+                        "height": 20,
+                        "width": 20,
                       }
                     }
-                    width={16}
+                    width={20}
                   />
                 </TouchableOpacity>
               </View>
@@ -2043,10 +2043,10 @@ exports[`EvmAccountSelectorList renders network icons for accounts with transact
                     {
                       "alignItems": "center",
                       "borderRadius": 8,
-                      "height": 24,
+                      "height": 28,
                       "justifyContent": "center",
                       "opacity": 1,
-                      "width": 24,
+                      "width": 28,
                     }
                   }
                   testID="main-wallet-account-actions"
@@ -2054,15 +2054,15 @@ exports[`EvmAccountSelectorList renders network icons for accounts with transact
                   <SvgMock
                     color="#121314"
                     fill="currentColor"
-                    height={16}
+                    height={20}
                     name="MoreVertical"
                     style={
                       {
-                        "height": 16,
-                        "width": 16,
+                        "height": 20,
+                        "width": 20,
                       }
                     }
-                    width={16}
+                    width={20}
                   />
                 </TouchableOpacity>
               </View>
@@ -2292,10 +2292,10 @@ exports[`EvmAccountSelectorList renders network icons for accounts with transact
                     {
                       "alignItems": "center",
                       "borderRadius": 8,
-                      "height": 24,
+                      "height": 28,
                       "justifyContent": "center",
                       "opacity": 1,
-                      "width": 24,
+                      "width": 28,
                     }
                   }
                   testID="main-wallet-account-actions"
@@ -2303,15 +2303,15 @@ exports[`EvmAccountSelectorList renders network icons for accounts with transact
                   <SvgMock
                     color="#121314"
                     fill="currentColor"
-                    height={16}
+                    height={20}
                     name="MoreVertical"
                     style={
                       {
-                        "height": 16,
-                        "width": 16,
+                        "height": 20,
+                        "width": 20,
                       }
                     }
-                    width={16}
+                    width={20}
                   />
                 </TouchableOpacity>
               </View>

--- a/app/components/UI/HintModal/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/HintModal/__snapshots__/index.test.tsx.snap
@@ -61,7 +61,6 @@ exports[`HintModal should render correctly 1`] = `
         <ButtonIcon
           iconName="Close"
           onPress={[Function]}
-          size="24"
         />
       </View>
       <Text

--- a/app/components/UI/HintModal/index.js
+++ b/app/components/UI/HintModal/index.js
@@ -13,9 +13,7 @@ import Text, {
   TextVariant,
   TextColor,
 } from '../../../component-library/components/Texts/Text';
-import ButtonIcon, {
-  ButtonIconSizes,
-} from '../../../component-library/components/Buttons/ButtonIcon';
+import ButtonIcon from '../../../component-library/components/Buttons/ButtonIcon';
 import { IconName } from '../../../component-library/components/Icons/Icon';
 
 const createStyles = (colors) =>
@@ -82,11 +80,7 @@ const HintModal = ({
             <Text variant={TextVariant.HeadingMD} style={styles.recovery}>
               {strings('manual_backup_step_3.recovery_hint')}
             </Text>
-            <ButtonIcon
-              size={ButtonIconSizes.Sm}
-              iconName={IconName.Close}
-              onPress={onCancel}
-            />
+            <ButtonIcon iconName={IconName.Close} onPress={onCancel} />
           </View>
           <Text variant={TextVariant.BodyMD} style={styles.leaveHint}>
             {strings('manual_backup_step_3.leave_hint')}

--- a/app/components/UI/NetworkImages/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/NetworkImages/__snapshots__/index.test.tsx.snap
@@ -39,15 +39,15 @@ exports[`NetworkImageComponent should render correctly 1`] = `
     <SvgMock
       color="#121314"
       fill="currentColor"
-      height={16}
+      height={20}
       name="ArrowDown"
       style={
         {
-          "height": 16,
-          "width": 16,
+          "height": 20,
+          "width": 20,
         }
       }
-      width={16}
+      width={20}
     />
   </TouchableOpacity>
 </View>

--- a/app/components/UI/PermissionsSummary/PermissionsSummary.tsx
+++ b/app/components/UI/PermissionsSummary/PermissionsSummary.tsx
@@ -221,7 +221,6 @@ const PermissionsSummary = ({
           {onBack && !isNonDappNetworkSwitch && (
             <ButtonIcon
               testID={PermissionSummaryBottomSheetSelectorsIDs.BACK_BUTTON}
-              size={ButtonIconSizes.Sm}
               iconColor={IconColor.Default}
               onPress={onBack}
               iconName={IconName.ArrowLeft}

--- a/app/components/UI/Ramp/Aggregator/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
@@ -1113,25 +1113,25 @@ exports[`Quotes custom action renders correctly after animation with the recomme
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -3176,25 +3176,25 @@ exports[`Quotes renders correctly after animation with expanded quotes 2`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -4985,25 +4985,25 @@ exports[`Quotes renders correctly after animation with the recommended quote 1`]
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Aggregator/components/FiatSelectorModal/__snapshots__/FiatSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/FiatSelectorModal/__snapshots__/FiatSelectorModal.test.tsx.snap
@@ -498,25 +498,25 @@ exports[`FiatSelectorModal renders the modal with currency list 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -1435,25 +1435,25 @@ exports[`FiatSelectorModal search displays filtered currencies when search strin
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -2372,25 +2372,25 @@ exports[`FiatSelectorModal search displays filtered currencies when search strin
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -3309,25 +3309,25 @@ exports[`FiatSelectorModal search displays max 20 results 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Aggregator/components/IncompatibleAccountTokenModal/__snapshots__/IncompatibleAccountTokenModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/IncompatibleAccountTokenModal/__snapshots__/IncompatibleAccountTokenModal.test.tsx.snap
@@ -499,25 +499,25 @@ exports[`IncompatibleAccountTokenModal renders the modal with the correct title 
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Aggregator/components/PaymentMethodSelectorModal/__snapshots__/PaymentMethodSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/PaymentMethodSelectorModal/__snapshots__/PaymentMethodSelectorModal.test.tsx.snap
@@ -498,25 +498,25 @@ exports[`PaymentMethodSelectorModal renders correctly 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -1644,25 +1644,25 @@ exports[`PaymentMethodSelectorModal renders for sell flow 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -2790,25 +2790,25 @@ exports[`PaymentMethodSelectorModal renders without disclaimer when selected pay
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Aggregator/components/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
@@ -498,25 +498,25 @@ exports[`RegionSelectorModal clears search when clear button is pressed 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -1359,25 +1359,25 @@ exports[`RegionSelectorModal clears search when clear button is pressed 2`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -2558,25 +2558,25 @@ exports[`RegionSelectorModal filters regions based on search input 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -3419,25 +3419,25 @@ exports[`RegionSelectorModal handles empty regions list gracefully 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -4148,25 +4148,25 @@ exports[`RegionSelectorModal handles undefined regions gracefully 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -4843,10 +4843,10 @@ exports[`RegionSelectorModal navigates back to country view when back button is 
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                   testID="back-button"
@@ -4854,15 +4854,15 @@ exports[`RegionSelectorModal navigates back to country view when back button is 
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="ArrowLeft"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -4911,25 +4911,25 @@ exports[`RegionSelectorModal navigates back to country view when back button is 
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -5728,25 +5728,25 @@ exports[`RegionSelectorModal navigates back to country view when back button is 
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -6927,25 +6927,25 @@ exports[`RegionSelectorModal renders the modal with region list 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -8126,25 +8126,25 @@ exports[`RegionSelectorModal shows empty state when search returns no results 1`
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Aggregator/components/TokenSelectModal/__snapshots__/TokenSelectModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/TokenSelectModal/__snapshots__/TokenSelectModal.test.tsx.snap
@@ -498,25 +498,25 @@ exports[`TokenSelectModal renders the modal with token list 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Deposit/Views/Modals/IncompatibleAccountTokenModal/__snapshots__/IncompatibleAccountTokenModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/IncompatibleAccountTokenModal/__snapshots__/IncompatibleAccountTokenModal.test.tsx.snap
@@ -499,25 +499,25 @@ exports[`IncompatibleAccountTokenModal renders the modal with the correct title 
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Deposit/Views/Modals/PaymentMethodSelectorModal/__snapshots__/PaymentMethodSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/PaymentMethodSelectorModal/__snapshots__/PaymentMethodSelectorModal.test.tsx.snap
@@ -498,25 +498,25 @@ exports[`PaymentMethodSelectorModal Component renders correctly and matches snap
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Deposit/Views/Modals/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
@@ -498,25 +498,25 @@ exports[`RegionSelectorModal Component handles empty regions array from navigati
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -1204,25 +1204,25 @@ exports[`RegionSelectorModal Component receives and uses regions from navigation
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -2106,25 +2106,25 @@ exports[`RegionSelectorModal Component render matches snapshot 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -3252,25 +3252,25 @@ exports[`RegionSelectorModal Component render matches snapshot when search has n
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -3999,25 +3999,25 @@ exports[`RegionSelectorModal Component render matches snapshot when searching fo
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -4834,25 +4834,25 @@ exports[`RegionSelectorModal Component sorts recommended regions to the top when
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Deposit/Views/Modals/SsnInfoModal/__snapshots__/SsnInfoModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/SsnInfoModal/__snapshots__/SsnInfoModal.test.tsx.snap
@@ -499,25 +499,25 @@ exports[`SsnInfoModal Component renders correctly and matches snapshot 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Deposit/Views/Modals/StateSelectorModal/__snapshots__/StateSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/StateSelectorModal/__snapshots__/StateSelectorModal.test.tsx.snap
@@ -498,25 +498,25 @@ exports[`StateSelectorModal Component Snapshot Tests renders cleared search stat
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -1300,25 +1300,25 @@ exports[`StateSelectorModal Component Snapshot Tests renders empty state when no
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -2046,25 +2046,25 @@ exports[`StateSelectorModal Component Snapshot Tests renders filtered state when
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -2848,25 +2848,25 @@ exports[`StateSelectorModal Component Snapshot Tests renders filtered state when
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -3650,25 +3650,25 @@ exports[`StateSelectorModal Component Snapshot Tests renders initial state corre
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -4715,25 +4715,25 @@ exports[`StateSelectorModal Component Snapshot Tests renders partial search resu
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
@@ -498,25 +498,25 @@ exports[`TokenSelectorModal Component displays empty state when no tokens match 
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -1453,25 +1453,25 @@ exports[`TokenSelectorModal Component displays network filter selector when pres
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -2610,25 +2610,25 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedRegionModal/__snapshots__/UnsupportedRegionModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedRegionModal/__snapshots__/UnsupportedRegionModal.test.tsx.snap
@@ -478,25 +478,25 @@ exports[`UnsupportedRegionModal handles missing region gracefully 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -1151,25 +1151,25 @@ exports[`UnsupportedRegionModal render match snapshot 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedStateModal/__snapshots__/UnsupportedStateModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedStateModal/__snapshots__/UnsupportedStateModal.test.tsx.snap
@@ -478,25 +478,25 @@ exports[`UnsupportedStateModal render match snapshot 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/SearchTokenAutocomplete/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/SearchTokenAutocomplete/__snapshots__/index.test.tsx.snap
@@ -408,10 +408,10 @@ exports[`SearchTokenAutocomplete should render correctly 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                   testID="button-icon-test-id"
@@ -419,15 +419,15 @@ exports[`SearchTokenAutocomplete should render correctly 1`] = `
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="ArrowDown"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Stake/components/GasImpactModal/__snapshots__/GasImpactModal.test.tsx.snap
+++ b/app/components/UI/Stake/components/GasImpactModal/__snapshots__/GasImpactModal.test.tsx.snap
@@ -205,25 +205,25 @@ exports[`GasImpactModal render matches snapshot 1`] = `
                     {
                       "alignItems": "center",
                       "borderRadius": 8,
-                      "height": 24,
+                      "height": 28,
                       "justifyContent": "center",
                       "opacity": 1,
-                      "width": 24,
+                      "width": 28,
                     }
                   }
                 >
                   <SvgMock
                     color="#121314"
                     fill="currentColor"
-                    height={16}
+                    height={20}
                     name="Close"
                     style={
                       {
-                        "height": 16,
-                        "width": 16,
+                        "height": 20,
+                        "width": 20,
                       }
                     }
-                    width={16}
+                    width={20}
                   />
                 </TouchableOpacity>
               </View>

--- a/app/components/UI/Stake/components/PoolStakingLearnMoreModal/__snapshots__/PoolStakingLearnMoreModal.test.tsx.snap
+++ b/app/components/UI/Stake/components/PoolStakingLearnMoreModal/__snapshots__/PoolStakingLearnMoreModal.test.tsx.snap
@@ -182,25 +182,25 @@ exports[`PoolStakingLearnMoreModal render matches snapshot 1`] = `
                       {
                         "alignItems": "center",
                         "borderRadius": 8,
-                        "height": 24,
+                        "height": 28,
                         "justifyContent": "center",
                         "opacity": 1,
-                        "width": 24,
+                        "width": 28,
                       }
                     }
                   >
                     <SvgMock
                       color="#121314"
                       fill="currentColor"
-                      height={16}
+                      height={20}
                       name="Close"
                       style={
                         {
-                          "height": 16,
-                          "width": 16,
+                          "height": 20,
+                          "width": 20,
                         }
                       }
-                      width={16}
+                      width={20}
                     />
                   </TouchableOpacity>
                 </View>

--- a/app/components/UI/UpdateNeeded/__snapshots__/UpdateNeeded.test.tsx.snap
+++ b/app/components/UI/UpdateNeeded/__snapshots__/UpdateNeeded.test.tsx.snap
@@ -456,10 +456,10 @@ exports[`UpdateNeeded should render snapshot correctly 1`] = `
                                   {
                                     "alignItems": "center",
                                     "borderRadius": 8,
-                                    "height": 24,
+                                    "height": 28,
                                     "justifyContent": "center",
                                     "opacity": 1,
-                                    "width": 24,
+                                    "width": 28,
                                   }
                                 }
                                 testID="update-needed-modal-close-button"
@@ -467,15 +467,15 @@ exports[`UpdateNeeded should render snapshot correctly 1`] = `
                                 <SvgMock
                                   color="#121314"
                                   fill="currentColor"
-                                  height={16}
+                                  height={20}
                                   name="Close"
                                   style={
                                     {
-                                      "height": 16,
-                                      "width": 16,
+                                      "height": 20,
+                                      "width": 20,
                                     }
                                   }
-                                  width={16}
+                                  width={20}
                                 />
                               </TouchableOpacity>
                             </View>

--- a/app/components/Views/AccountConnect/AccountConnectMultiSelector/__snapshots__/AccountConnectMultiSelector.test.tsx.snap
+++ b/app/components/Views/AccountConnect/AccountConnectMultiSelector/__snapshots__/AccountConnectMultiSelector.test.tsx.snap
@@ -39,10 +39,10 @@ exports[`AccountConnectMultiSelector renders correctly 1`] = `
             {
               "alignItems": "center",
               "borderRadius": 8,
-              "height": 24,
+              "height": 28,
               "justifyContent": "center",
               "opacity": 1,
-              "width": 24,
+              "width": 28,
             }
           }
           testID="sheet-header-back-button"
@@ -50,15 +50,15 @@ exports[`AccountConnectMultiSelector renders correctly 1`] = `
           <SvgMock
             color="#121314"
             fill="currentColor"
-            height={16}
+            height={20}
             name="ArrowLeft"
             style={
               {
-                "height": 16,
-                "width": 16,
+                "height": 20,
+                "width": 20,
               }
             }
-            width={16}
+            width={20}
           />
         </TouchableOpacity>
       </View>

--- a/app/components/Views/AccountPermissions/__snapshots__/AccountPermissions.test.tsx.snap
+++ b/app/components/Views/AccountPermissions/__snapshots__/AccountPermissions.test.tsx.snap
@@ -557,10 +557,10 @@ exports[`AccountPermissions renders correctly 1`] = `
                     {
                       "alignItems": "center",
                       "borderRadius": 8,
-                      "height": 24,
+                      "height": 28,
                       "justifyContent": "center",
                       "opacity": 1,
-                      "width": 24,
+                      "width": 28,
                     }
                   }
                   testID="main-wallet-account-actions"
@@ -568,15 +568,15 @@ exports[`AccountPermissions renders correctly 1`] = `
                   <SvgMock
                     color="#121314"
                     fill="currentColor"
-                    height={16}
+                    height={20}
                     name="MoreVertical"
                     style={
                       {
-                        "height": 16,
-                        "width": 16,
+                        "height": 20,
+                        "width": 20,
                       }
                     }
-                    width={16}
+                    width={20}
                   />
                 </TouchableOpacity>
               </View>

--- a/app/components/Views/AccountSelector/__snapshots__/AccountSelector.test.tsx.snap
+++ b/app/components/Views/AccountSelector/__snapshots__/AccountSelector.test.tsx.snap
@@ -710,10 +710,10 @@ exports[`AccountSelector should render correctly 1`] = `
                                               {
                                                 "alignItems": "center",
                                                 "borderRadius": 8,
-                                                "height": 24,
+                                                "height": 28,
                                                 "justifyContent": "center",
                                                 "opacity": 1,
-                                                "width": 24,
+                                                "width": 28,
                                               }
                                             }
                                             testID="main-wallet-account-actions"
@@ -721,15 +721,15 @@ exports[`AccountSelector should render correctly 1`] = `
                                             <SvgMock
                                               color="#121314"
                                               fill="currentColor"
-                                              height={16}
+                                              height={20}
                                               name="MoreVertical"
                                               style={
                                                 {
-                                                  "height": 16,
-                                                  "width": 16,
+                                                  "height": 20,
+                                                  "width": 20,
                                                 }
                                               }
-                                              width={16}
+                                              width={20}
                                             />
                                           </TouchableOpacity>
                                         </View>
@@ -907,10 +907,10 @@ exports[`AccountSelector should render correctly 1`] = `
                                               {
                                                 "alignItems": "center",
                                                 "borderRadius": 8,
-                                                "height": 24,
+                                                "height": 28,
                                                 "justifyContent": "center",
                                                 "opacity": 1,
-                                                "width": 24,
+                                                "width": 28,
                                               }
                                             }
                                             testID="main-wallet-account-actions"
@@ -918,15 +918,15 @@ exports[`AccountSelector should render correctly 1`] = `
                                             <SvgMock
                                               color="#121314"
                                               fill="currentColor"
-                                              height={16}
+                                              height={20}
                                               name="MoreVertical"
                                               style={
                                                 {
-                                                  "height": 16,
-                                                  "width": 16,
+                                                  "height": 20,
+                                                  "width": 20,
                                                 }
                                               }
-                                              width={16}
+                                              width={20}
                                             />
                                           </TouchableOpacity>
                                         </View>

--- a/app/components/Views/AddAccountActions/__snapshots__/AddAccountActions.test.tsx.snap
+++ b/app/components/Views/AddAccountActions/__snapshots__/AddAccountActions.test.tsx.snap
@@ -343,10 +343,10 @@ exports[`AddAccountActions renders correctly 1`] = `
                               {
                                 "alignItems": "center",
                                 "borderRadius": 8,
-                                "height": 24,
+                                "height": 28,
                                 "justifyContent": "center",
                                 "opacity": 1,
-                                "width": 24,
+                                "width": 28,
                               }
                             }
                             testID="sheet-header-back-button"
@@ -354,15 +354,15 @@ exports[`AddAccountActions renders correctly 1`] = `
                             <SvgMock
                               color="#121314"
                               fill="currentColor"
-                              height={16}
+                              height={20}
                               name="ArrowLeft"
                               style={
                                 {
-                                  "height": 16,
-                                  "width": 16,
+                                  "height": 20,
+                                  "width": 20,
                                 }
                               }
-                              width={16}
+                              width={20}
                             />
                           </TouchableOpacity>
                         </View>

--- a/app/components/Views/AddAsset/__snapshots__/AddAsset.test.tsx.snap
+++ b/app/components/Views/AddAsset/__snapshots__/AddAsset.test.tsx.snap
@@ -215,11 +215,11 @@ exports[`AddAsset component renders collectible view correctly 1`] = `
                       {
                         "alignItems": "center",
                         "borderRadius": 8,
-                        "height": 24,
+                        "height": 28,
                         "justifyContent": "center",
                         "marginLeft": 16,
                         "opacity": 1,
-                        "width": 24,
+                        "width": 28,
                       }
                     }
                     testID="select-network-button"
@@ -227,15 +227,15 @@ exports[`AddAsset component renders collectible view correctly 1`] = `
                     <SvgMock
                       color="#121314"
                       fill="currentColor"
-                      height={16}
+                      height={20}
                       name="ArrowDown"
                       style={
                         {
-                          "height": 16,
-                          "width": 16,
+                          "height": 20,
+                          "width": 20,
                         }
                       }
-                      width={16}
+                      width={20}
                     />
                   </TouchableOpacity>
                 </View>
@@ -562,10 +562,10 @@ exports[`AddAsset component renders token view correctly 1`] = `
                     {
                       "alignItems": "center",
                       "borderRadius": 8,
-                      "height": 24,
+                      "height": 28,
                       "justifyContent": "center",
                       "opacity": 1,
-                      "width": 24,
+                      "width": 28,
                     }
                   }
                   testID="button-icon-test-id"
@@ -573,15 +573,15 @@ exports[`AddAsset component renders token view correctly 1`] = `
                   <SvgMock
                     color="#121314"
                     fill="currentColor"
-                    height={16}
+                    height={20}
                     name="ArrowDown"
                     style={
                       {
-                        "height": 16,
-                        "width": 16,
+                        "height": 20,
+                        "width": 20,
                       }
                     }
-                    width={16}
+                    width={20}
                   />
                 </TouchableOpacity>
               </View>
@@ -917,10 +917,10 @@ exports[`AddAsset component renders token view correctly 1`] = `
                     {
                       "alignItems": "center",
                       "borderRadius": 8,
-                      "height": 24,
+                      "height": 28,
                       "justifyContent": "center",
                       "opacity": 1,
-                      "width": 24,
+                      "width": 28,
                     }
                   }
                   testID="select-network-button"
@@ -928,15 +928,15 @@ exports[`AddAsset component renders token view correctly 1`] = `
                   <SvgMock
                     color="#121314"
                     fill="currentColor"
-                    height={16}
+                    height={20}
                     name="ArrowDown"
                     style={
                       {
-                        "height": 16,
-                        "width": 16,
+                        "height": 20,
+                        "width": 20,
                       }
                     }
-                    width={16}
+                    width={20}
                   />
                 </TouchableOpacity>
               </View>

--- a/app/components/Views/AddressSelector/__snapshots__/AddressSelector.test.tsx.snap
+++ b/app/components/Views/AddressSelector/__snapshots__/AddressSelector.test.tsx.snap
@@ -501,25 +501,25 @@ exports[`AccountSelector renders correctly and matches snapshot 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 24,
+                                      "height": 28,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 24,
+                                      "width": 28,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={16}
+                                    height={20}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 16,
-                                        "width": 16,
+                                        "height": 20,
+                                        "width": 20,
                                       }
                                     }
-                                    width={16}
+                                    width={20}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.tsx
@@ -231,7 +231,6 @@ const MultichainPermissionsSummary = ({
           {onBack && !isNonDappNetworkSwitch && (
             <ButtonIcon
               testID={PermissionSummaryBottomSheetSelectorsIDs.BACK_BUTTON}
-              size={ButtonIconSizes.Sm}
               iconColor={IconColor.Default}
               onPress={onBack}
               iconName={IconName.ArrowLeft}

--- a/app/components/Views/NetworkConnect/NetworkConnectMultiSelector/__snapshots__/NetworkConnectMultiSelector.test.tsx.snap
+++ b/app/components/Views/NetworkConnect/NetworkConnectMultiSelector/__snapshots__/NetworkConnectMultiSelector.test.tsx.snap
@@ -39,10 +39,10 @@ exports[`NetworkConnectMultiSelector renders correctly 1`] = `
             {
               "alignItems": "center",
               "borderRadius": 8,
-              "height": 24,
+              "height": 28,
               "justifyContent": "center",
               "opacity": 1,
-              "width": 24,
+              "width": 28,
             }
           }
           testID="sheet-header-back-button"
@@ -50,15 +50,15 @@ exports[`NetworkConnectMultiSelector renders correctly 1`] = `
           <SvgMock
             color="#121314"
             fill="currentColor"
-            height={16}
+            height={20}
             name="ArrowLeft"
             style={
               {
-                "height": 16,
-                "width": 16,
+                "height": 20,
+                "width": 20,
               }
             }
-            width={16}
+            width={20}
           />
         </TouchableOpacity>
       </View>

--- a/app/components/Views/NetworkSelector/__snapshots__/NetworkSelector.test.tsx.snap
+++ b/app/components/Views/NetworkSelector/__snapshots__/NetworkSelector.test.tsx.snap
@@ -2276,10 +2276,10 @@ exports[`Network Selector renders correctly when network UI redesign is enabled 
                                         {
                                           "alignItems": "center",
                                           "borderRadius": 8,
-                                          "height": 24,
+                                          "height": 28,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 24,
+                                          "width": 28,
                                         }
                                       }
                                       testID="button-menu-select-test-id"
@@ -2287,15 +2287,15 @@ exports[`Network Selector renders correctly when network UI redesign is enabled 
                                       <SvgMock
                                         color="#121314"
                                         fill="currentColor"
-                                        height={16}
+                                        height={20}
                                         name="MoreVertical"
                                         style={
                                           {
-                                            "height": 16,
-                                            "width": 16,
+                                            "height": 20,
+                                            "width": 20,
                                           }
                                         }
-                                        width={16}
+                                        width={20}
                                       />
                                     </TouchableOpacity>
                                   </View>
@@ -2494,10 +2494,10 @@ exports[`Network Selector renders correctly when network UI redesign is enabled 
                                         {
                                           "alignItems": "center",
                                           "borderRadius": 8,
-                                          "height": 24,
+                                          "height": 28,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 24,
+                                          "width": 28,
                                         }
                                       }
                                       testID="button-menu-select-test-id"
@@ -2505,15 +2505,15 @@ exports[`Network Selector renders correctly when network UI redesign is enabled 
                                       <SvgMock
                                         color="#121314"
                                         fill="currentColor"
-                                        height={16}
+                                        height={20}
                                         name="MoreVertical"
                                         style={
                                           {
-                                            "height": 16,
-                                            "width": 16,
+                                            "height": 20,
+                                            "width": 20,
                                           }
                                         }
-                                        width={16}
+                                        width={20}
                                       />
                                     </TouchableOpacity>
                                   </View>
@@ -2712,10 +2712,10 @@ exports[`Network Selector renders correctly when network UI redesign is enabled 
                                         {
                                           "alignItems": "center",
                                           "borderRadius": 8,
-                                          "height": 24,
+                                          "height": 28,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 24,
+                                          "width": 28,
                                         }
                                       }
                                       testID="button-menu-select-test-id"
@@ -2723,15 +2723,15 @@ exports[`Network Selector renders correctly when network UI redesign is enabled 
                                       <SvgMock
                                         color="#121314"
                                         fill="currentColor"
-                                        height={16}
+                                        height={20}
                                         name="MoreVertical"
                                         style={
                                           {
-                                            "height": 16,
-                                            "width": 16,
+                                            "height": 20,
+                                            "width": 20,
                                           }
                                         }
-                                        width={16}
+                                        width={20}
                                       />
                                     </TouchableOpacity>
                                   </View>
@@ -2930,10 +2930,10 @@ exports[`Network Selector renders correctly when network UI redesign is enabled 
                                         {
                                           "alignItems": "center",
                                           "borderRadius": 8,
-                                          "height": 24,
+                                          "height": 28,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 24,
+                                          "width": 28,
                                         }
                                       }
                                       testID="button-menu-select-test-id"
@@ -2941,15 +2941,15 @@ exports[`Network Selector renders correctly when network UI redesign is enabled 
                                       <SvgMock
                                         color="#121314"
                                         fill="currentColor"
-                                        height={16}
+                                        height={20}
                                         name="MoreVertical"
                                         style={
                                           {
-                                            "height": 16,
-                                            "width": 16,
+                                            "height": 20,
+                                            "width": 20,
                                           }
                                         }
-                                        width={16}
+                                        width={20}
                                       />
                                     </TouchableOpacity>
                                   </View>
@@ -3148,10 +3148,10 @@ exports[`Network Selector renders correctly when network UI redesign is enabled 
                                         {
                                           "alignItems": "center",
                                           "borderRadius": 8,
-                                          "height": 24,
+                                          "height": 28,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 24,
+                                          "width": 28,
                                         }
                                       }
                                       testID="button-menu-select-test-id"
@@ -3159,15 +3159,15 @@ exports[`Network Selector renders correctly when network UI redesign is enabled 
                                       <SvgMock
                                         color="#121314"
                                         fill="currentColor"
-                                        height={16}
+                                        height={20}
                                         name="MoreVertical"
                                         style={
                                           {
-                                            "height": 16,
-                                            "width": 16,
+                                            "height": 20,
+                                            "width": 20,
                                           }
                                         }
-                                        width={16}
+                                        width={20}
                                       />
                                     </TouchableOpacity>
                                   </View>
@@ -3369,10 +3369,10 @@ exports[`Network Selector renders correctly when network UI redesign is enabled 
                                         {
                                           "alignItems": "center",
                                           "borderRadius": 8,
-                                          "height": 24,
+                                          "height": 28,
                                           "justifyContent": "center",
                                           "opacity": 1,
-                                          "width": 24,
+                                          "width": 28,
                                         }
                                       }
                                       testID="button-menu-select-test-id"
@@ -3380,15 +3380,15 @@ exports[`Network Selector renders correctly when network UI redesign is enabled 
                                       <SvgMock
                                         color="#121314"
                                         fill="currentColor"
-                                        height={16}
+                                        height={20}
                                         name="MoreVertical"
                                         style={
                                           {
-                                            "height": 16,
-                                            "width": 16,
+                                            "height": 20,
+                                            "width": 20,
                                           }
                                         }
-                                        width={16}
+                                        width={20}
                                       />
                                     </TouchableOpacity>
                                   </View>

--- a/app/components/Views/confirmations/components/gas/gas-fee-token-modal/gas-fee-token-modal.tsx
+++ b/app/components/Views/confirmations/components/gas/gas-fee-token-modal/gas-fee-token-modal.tsx
@@ -11,9 +11,7 @@ import Text, {
   TextVariant,
 } from '../../../../../../component-library/components/Texts/Text';
 import { IconName } from '../../../../../../component-library/components/Icons/Icon';
-import ButtonIcon, {
-  ButtonIconSizes,
-} from '../../../../../../component-library/components/Buttons/ButtonIcon';
+import ButtonIcon from '../../../../../../component-library/components/Buttons/ButtonIcon';
 import styleSheet from './gas-fee-token-modal.styles';
 import { GasFeeTokenListItem } from '../gas-fee-token-list-item';
 import { Hex } from '@metamask/utils';
@@ -67,7 +65,6 @@ export function GasFeeTokenModal({ onClose }: { onClose?: () => void }) {
             <ButtonIcon
               iconName={IconName.ArrowLeft}
               onPress={onClose}
-              size={ButtonIconSizes.Sm}
               testID="back-button"
             />
           </View>

--- a/app/components/Views/confirmations/components/gas/gas-modal-header/gas-modal-header.tsx
+++ b/app/components/Views/confirmations/components/gas/gas-modal-header/gas-modal-header.tsx
@@ -3,9 +3,7 @@ import { View } from 'react-native';
 import { useStyles } from '../../../../../../component-library/hooks';
 import styleSheet from './gas-modal-header.styles';
 
-import ButtonIcon, {
-  ButtonIconSizes,
-} from '../../../../../../component-library/components/Buttons/ButtonIcon';
+import ButtonIcon from '../../../../../../component-library/components/Buttons/ButtonIcon';
 import { IconName } from '../../../../../../component-library/components/Icons/Icon';
 import Text, {
   TextVariant,
@@ -26,7 +24,6 @@ export const GasModalHeader = ({
         <ButtonIcon
           iconName={IconName.ArrowLeft}
           onPress={onBackButtonClick}
-          size={ButtonIconSizes.Sm}
           testID="back-button"
         />
       </View>

--- a/app/components/Views/confirmations/components/info/typed-sign-v3v4/simulation/components/native-value-display/native-value-display.tsx
+++ b/app/components/Views/confirmations/components/info/typed-sign-v3v4/simulation/components/native-value-display/native-value-display.tsx
@@ -9,7 +9,6 @@ import { selectConversionRateByChainId } from '../../../../../../../../../select
 import { useTheme } from '../../../../../../../../../util/theme';
 
 import ButtonPill from '../../../../../../../../../component-library/components-temp/Buttons/ButtonPill/ButtonPill';
-import { ButtonIconSizes } from '../../../../../../../../../component-library/components/Buttons/ButtonIcon/ButtonIcon.types';
 import ButtonIcon from '../../../../../../../../../component-library/components/Buttons/ButtonIcon/ButtonIcon';
 import {
   IconName,
@@ -141,7 +140,6 @@ const NativeValueDisplay: React.FC<PermitSimulationValueDisplayParams> = ({
               <View style={styles.valueModalHeader}>
                 <ButtonIcon
                   iconColor={IconColor.Default}
-                  size={ButtonIconSizes.Sm}
                   style={styles.valueModalHeaderIcon}
                   onPress={() => setHasValueModalOpen(false)}
                   iconName={IconName.ArrowLeft}

--- a/app/components/Views/confirmations/components/info/typed-sign-v3v4/simulation/components/value-display/value-display.tsx
+++ b/app/components/Views/confirmations/components/info/typed-sign-v3v4/simulation/components/value-display/value-display.tsx
@@ -6,7 +6,6 @@ import { Hex } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
 
 import ButtonPill from '../../../../../../../../../component-library/components-temp/Buttons/ButtonPill/ButtonPill';
-import { ButtonIconSizes } from '../../../../../../../../../component-library/components/Buttons/ButtonIcon/ButtonIcon.types';
 import ButtonIcon from '../../../../../../../../../component-library/components/Buttons/ButtonIcon/ButtonIcon';
 import {
   IconName,
@@ -249,7 +248,6 @@ const SimulationValueDisplay: React.FC<SimulationValueDisplayParams> = ({
               <View style={styles.valueModalHeader}>
                 <ButtonIcon
                   iconColor={IconColor.Default}
-                  size={ButtonIconSizes.Sm}
                   style={styles.valueModalHeaderIcon}
                   onPress={() => setHasValueModalOpen(false)}
                   iconName={IconName.ArrowLeft}


### PR DESCRIPTION
## **Description**

Updated button icon sizes to md (default) for bottomsheets, navigation and modals as part of design system standardization. Since md is the default size, this involved removing explicit md size specifications and cleaning up unused `ButtonIconSizes` imports.

**What is the reason for the change?**
Design system standardization requires consistent button icon sizes across bottomsheets, navigation and modals.

**What is the improvement/solution?**
- Standardized button icon sizes to md (default) across target components
- Removed explicit md size specifications since it's the default
- Cleaned up unused `ButtonIconSizes` imports that were no longer needed

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-226

**Reference:** https://consensys.slack.com/archives/C0354T27M5M/p1758912397636659

## **Manual testing steps**

```gherkin
Feature: Increase BottomSheet close and back button size increase

  Scenario: user navigates to bottom sheet component in storybook
    See larger button icon size for close and back
```

## **Screenshots/Recordings**

### **Before**

Button Icon size is set to small and hard to see

<img width="411" height="320" alt="Screenshot 2025-10-01 at 12 52 18 PM" src="https://github.com/user-attachments/assets/943c11c1-da9f-49b6-be89-72669c45865d" />


### **After**

Button Icon is now larger and more accessible

<img width="422" height="312" alt="Screenshot 2025-10-01 at 12 50 02 PM" src="https://github.com/user-attachments/assets/20f9382a-78c2-4bb4-b6a3-7745a2c94e28" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets `ButtonIcon` default to `md` and removes explicit size props, increasing touch targets/icons and updating snapshots across modals, sheets, and navigation.
> 
> - **Component Library**:
>   - **Default Size**: Change `DEFAULT_BUTTONICON_SIZE` to `ButtonIconSizes.Md` in `components/Buttons/ButtonIcon/ButtonIcon.constants.ts`.
> - **UI/Apps**:
>   - **Remove explicit size usage/imports**: Drop `ButtonIconSizes` imports and `size` prop from back/close buttons in `HintModal`, `PermissionsSummary`, `MultichainPermissionsSummary`, `gas-fee-token-modal`, `gas-modal-header`, typed-sign value display components, and various selectors/modals.
> - **Visual/Snapshots**:
>   - **Increased touch target and icon size**: Buttons `height/width` `24→28`; icons `16→20` across numerous snapshot files (bottom sheets, forms, selectors, modals, lists).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c73e7f1a5be184853fa1536a5adfa6a028f834ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->