### PR TITLE
fix: Rewards activity tab timestamp truncated

### DIFF
--- a/app/components/UI/Rewards/components/Tabs/ActivityTab/ActivityEventRow.tsx
+++ b/app/components/UI/Rewards/components/Tabs/ActivityTab/ActivityEventRow.tsx
@@ -21,6 +21,7 @@ import Badge, {
   BadgeVariant,
 } from '../../../../../../component-library/components/Badges/Badge';
 import { AvatarSize } from '../../../../../../component-library/components/Avatars/Avatar';
+import Logger from '../../../../../../util/Logger';
 
 export const ActivityEventRow: React.FC<{
   event: PointsEventDto;
@@ -49,6 +50,10 @@ export const ActivityEventRow: React.FC<{
 
       return getNetworkImageSource({ chainId });
     } catch (error) {
+      Logger.error(
+        error as Error,
+        'ActivityEventRow: Failed to derive network image source from event payload',
+      );
       return;
     }
   }, [event]);

--- a/app/components/UI/Rewards/components/Tabs/ActivityTab/ActivityEventRow.tsx
+++ b/app/components/UI/Rewards/components/Tabs/ActivityTab/ActivityEventRow.tsx
@@ -118,17 +118,17 @@ export const ActivityEventRow: React.FC<{
           </Box>
         </Box>
 
-        <Box
-          flexDirection={BoxFlexDirection.Row}
-          justifyContent={BoxJustifyContent.Between}
-        >
+        <Box flexDirection={BoxFlexDirection.Row}>
           <Text
             variant={TextVariant.BodySm}
-            twClassName="text-alternative max-w-[60%]"
+            twClassName="text-alternative flex-1 max-w-[60%]"
           >
             {eventDetails.details}
           </Text>
-          <Text variant={TextVariant.BodySm} twClassName="text-alternative">
+          <Text
+            variant={TextVariant.BodySm}
+            twClassName="text-alternative flex-1 text-right"
+          >
             {formatRewardsDate(new Date(event.timestamp))}
           </Text>
         </Box>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
The timestamp was truncated in some rows. It seems to be related to space-between creating fractional widths, that React Native clips. Using flex-1 solved the issue

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/RWDS-521

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

### **Before**

<img width="1080" height="2400" alt="Screenshot_20250930_162518" src="https://github.com/user-attachments/assets/896b59e8-17f8-4e53-a9c9-d6828c3be9eb" />

### **After**

<img width="1080" height="2400" alt="Screenshot_20250930_165342" src="https://github.com/user-attachments/assets/bee73688-feec-4b69-8ad9-9b37d5028fc5" />

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents timestamp truncation in rewards activity rows and adds error logging for network icon derivation failures.
> 
> - **UI (Rewards Activity)**:
>   - In `ActivityEventRow.tsx`, adjust row layout to prevent timestamp truncation: remove `justifyContent=Between` on details row, give details `Text` `flex-1 max-w-[60%]`, and timestamp `Text` `flex-1 text-right`.
> - **Logging**:
>   - Add `Logger.error` when failing to derive network image source from event payload in `networkImageSource` memo.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30063d51559f77fbe8287d01bc688ce4bcf89dab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->