### PR TITLE
fix: Update styling of tag component for Bitcoin support

### DIFF
--- a/app/component-library/components-temp/CellSelectWithMenu/__snapshots__/CellSelectWithMenu.test.tsx.snap
+++ b/app/component-library/components-temp/CellSelectWithMenu/__snapshots__/CellSelectWithMenu.test.tsx.snap
@@ -266,14 +266,12 @@ exports[`CellSelectWithMenu should render with default settings correctly 1`] = 
             <View
               style={
                 {
-                  "backgroundColor": "#ffffff",
-                  "borderColor": "#b7bbc8",
-                  "borderRadius": 10,
-                  "borderWidth": 1,
+                  "backgroundColor": "#f3f5f9",
+                  "borderRadius": 4,
                   "height": 24,
                   "justifyContent": "center",
                   "marginTop": 4,
-                  "paddingHorizontal": 4,
+                  "paddingHorizontal": 8,
                 }
               }
               testID="celltag-label"
@@ -282,7 +280,7 @@ exports[`CellSelectWithMenu should render with default settings correctly 1`] = 
                 accessibilityRole="text"
                 style={
                   {
-                    "color": "#121314",
+                    "color": "#686e7d",
                     "fontFamily": "Geist Regular",
                     "fontSize": 16,
                     "letterSpacing": 0,

--- a/app/component-library/components/Cells/Cell/__snapshots__/Cell.test.tsx.snap
+++ b/app/component-library/components/Cells/Cell/__snapshots__/Cell.test.tsx.snap
@@ -232,14 +232,12 @@ exports[`Cell should render CellDisplay given the type Display 1`] = `
       <View
         style={
           {
-            "backgroundColor": "#ffffff",
-            "borderColor": "#b7bbc8",
-            "borderRadius": 10,
-            "borderWidth": 1,
+            "backgroundColor": "#f3f5f9",
+            "borderRadius": 4,
             "height": 24,
             "justifyContent": "center",
             "marginTop": 4,
-            "paddingHorizontal": 4,
+            "paddingHorizontal": 8,
           }
         }
       >
@@ -247,7 +245,7 @@ exports[`Cell should render CellDisplay given the type Display 1`] = `
           accessibilityRole="text"
           style={
             {
-              "color": "#121314",
+              "color": "#686e7d",
               "fontFamily": "Geist Regular",
               "fontSize": 16,
               "letterSpacing": 0,
@@ -545,14 +543,12 @@ exports[`Cell should render CellMultiSelect given the type MultiSelect 1`] = `
           <View
             style={
               {
-                "backgroundColor": "#ffffff",
-                "borderColor": "#b7bbc8",
-                "borderRadius": 10,
-                "borderWidth": 1,
+                "backgroundColor": "#f3f5f9",
+                "borderRadius": 4,
                 "height": 24,
                 "justifyContent": "center",
                 "marginTop": 4,
-                "paddingHorizontal": 4,
+                "paddingHorizontal": 8,
               }
             }
           >
@@ -560,7 +556,7 @@ exports[`Cell should render CellMultiSelect given the type MultiSelect 1`] = `
               accessibilityRole="text"
               style={
                 {
-                  "color": "#121314",
+                  "color": "#686e7d",
                   "fontFamily": "Geist Regular",
                   "fontSize": 16,
                   "letterSpacing": 0,
@@ -838,14 +834,12 @@ exports[`Cell should render CellMultiSelectWithMenu given the type MultiSelectWi
             <View
               style={
                 {
-                  "backgroundColor": "#ffffff",
-                  "borderColor": "#b7bbc8",
-                  "borderRadius": 10,
-                  "borderWidth": 1,
+                  "backgroundColor": "#f3f5f9",
+                  "borderRadius": 4,
                   "height": 24,
                   "justifyContent": "center",
                   "marginTop": 4,
-                  "paddingHorizontal": 4,
+                  "paddingHorizontal": 8,
                 }
               }
               testID="celltag-label"
@@ -854,7 +848,7 @@ exports[`Cell should render CellMultiSelectWithMenu given the type MultiSelectWi
                 accessibilityRole="text"
                 style={
                   {
-                    "color": "#121314",
+                    "color": "#686e7d",
                     "fontFamily": "Geist Regular",
                     "fontSize": 16,
                     "letterSpacing": 0,
@@ -1153,14 +1147,12 @@ exports[`Cell should render CellSelect given the type Select 1`] = `
           <View
             style={
               {
-                "backgroundColor": "#ffffff",
-                "borderColor": "#b7bbc8",
-                "borderRadius": 10,
-                "borderWidth": 1,
+                "backgroundColor": "#f3f5f9",
+                "borderRadius": 4,
                 "height": 24,
                 "justifyContent": "center",
                 "marginTop": 4,
-                "paddingHorizontal": 4,
+                "paddingHorizontal": 8,
               }
             }
           >
@@ -1168,7 +1160,7 @@ exports[`Cell should render CellSelect given the type Select 1`] = `
               accessibilityRole="text"
               style={
                 {
-                  "color": "#121314",
+                  "color": "#686e7d",
                   "fontFamily": "Geist Regular",
                   "fontSize": 16,
                   "letterSpacing": 0,
@@ -1452,14 +1444,12 @@ exports[`Cell should render CellSelectWithMenu given the type SelectWithMenu 1`]
             <View
               style={
                 {
-                  "backgroundColor": "#ffffff",
-                  "borderColor": "#b7bbc8",
-                  "borderRadius": 10,
-                  "borderWidth": 1,
+                  "backgroundColor": "#f3f5f9",
+                  "borderRadius": 4,
                   "height": 24,
                   "justifyContent": "center",
                   "marginTop": 4,
-                  "paddingHorizontal": 4,
+                  "paddingHorizontal": 8,
                 }
               }
               testID="celltag-label"
@@ -1468,7 +1458,7 @@ exports[`Cell should render CellSelectWithMenu given the type SelectWithMenu 1`]
                 accessibilityRole="text"
                 style={
                   {
-                    "color": "#121314",
+                    "color": "#686e7d",
                     "fontFamily": "Geist Regular",
                     "fontSize": 16,
                     "letterSpacing": 0,

--- a/app/component-library/components/Cells/Cell/foundation/CellBase/__snapshots__/CellBase.test.tsx.snap
+++ b/app/component-library/components/Cells/Cell/foundation/CellBase/__snapshots__/CellBase.test.tsx.snap
@@ -209,14 +209,12 @@ exports[`CellBase should render default settings correctly 1`] = `
     <View
       style={
         {
-          "backgroundColor": "#ffffff",
-          "borderColor": "#b7bbc8",
-          "borderRadius": 10,
-          "borderWidth": 1,
+          "backgroundColor": "#f3f5f9",
+          "borderRadius": 4,
           "height": 24,
           "justifyContent": "center",
           "marginTop": 4,
-          "paddingHorizontal": 4,
+          "paddingHorizontal": 8,
         }
       }
     >
@@ -224,7 +222,7 @@ exports[`CellBase should render default settings correctly 1`] = `
         accessibilityRole="text"
         style={
           {
-            "color": "#121314",
+            "color": "#686e7d",
             "fontFamily": "Geist Regular",
             "fontSize": 16,
             "letterSpacing": 0,

--- a/app/component-library/components/Cells/Cell/variants/CellDisplay/__snapshots__/CellDisplay.test.tsx.snap
+++ b/app/component-library/components/Cells/Cell/variants/CellDisplay/__snapshots__/CellDisplay.test.tsx.snap
@@ -232,14 +232,12 @@ exports[`CellDisplay should render default settings correctly 1`] = `
       <View
         style={
           {
-            "backgroundColor": "#ffffff",
-            "borderColor": "#b7bbc8",
-            "borderRadius": 10,
-            "borderWidth": 1,
+            "backgroundColor": "#f3f5f9",
+            "borderRadius": 4,
             "height": 24,
             "justifyContent": "center",
             "marginTop": 4,
-            "paddingHorizontal": 4,
+            "paddingHorizontal": 8,
           }
         }
       >
@@ -247,7 +245,7 @@ exports[`CellDisplay should render default settings correctly 1`] = `
           accessibilityRole="text"
           style={
             {
-              "color": "#121314",
+              "color": "#686e7d",
               "fontFamily": "Geist Regular",
               "fontSize": 16,
               "letterSpacing": 0,

--- a/app/component-library/components/Cells/Cell/variants/CellMultiSelect/__snapshots__/CellMultiSelect.test.tsx.snap
+++ b/app/component-library/components/Cells/Cell/variants/CellMultiSelect/__snapshots__/CellMultiSelect.test.tsx.snap
@@ -282,14 +282,12 @@ exports[`CellMultiSelect should render default settings correctly 1`] = `
           <View
             style={
               {
-                "backgroundColor": "#ffffff",
-                "borderColor": "#b7bbc8",
-                "borderRadius": 10,
-                "borderWidth": 1,
+                "backgroundColor": "#f3f5f9",
+                "borderRadius": 4,
                 "height": 24,
                 "justifyContent": "center",
                 "marginTop": 4,
-                "paddingHorizontal": 4,
+                "paddingHorizontal": 8,
               }
             }
           >
@@ -297,7 +295,7 @@ exports[`CellMultiSelect should render default settings correctly 1`] = `
               accessibilityRole="text"
               style={
                 {
-                  "color": "#121314",
+                  "color": "#686e7d",
                   "fontFamily": "Geist Regular",
                   "fontSize": 16,
                   "letterSpacing": 0,

--- a/app/component-library/components/Cells/Cell/variants/CellSelect/__snapshots__/CellSelect.test.tsx.snap
+++ b/app/component-library/components/Cells/Cell/variants/CellSelect/__snapshots__/CellSelect.test.tsx.snap
@@ -239,14 +239,12 @@ exports[`CellSelect should render default settings correctly 1`] = `
           <View
             style={
               {
-                "backgroundColor": "#ffffff",
-                "borderColor": "#b7bbc8",
-                "borderRadius": 10,
-                "borderWidth": 1,
+                "backgroundColor": "#f3f5f9",
+                "borderRadius": 4,
                 "height": 24,
                 "justifyContent": "center",
                 "marginTop": 4,
-                "paddingHorizontal": 4,
+                "paddingHorizontal": 8,
               }
             }
           >
@@ -254,7 +252,7 @@ exports[`CellSelect should render default settings correctly 1`] = `
               accessibilityRole="text"
               style={
                 {
-                  "color": "#121314",
+                  "color": "#686e7d",
                   "fontFamily": "Geist Regular",
                   "fontSize": 16,
                   "letterSpacing": 0,

--- a/app/component-library/components/Tags/Tag/Tag.styles.ts
+++ b/app/component-library/components/Tags/Tag/Tag.styles.ts
@@ -21,12 +21,10 @@ const styleSheet = (params: { theme: Theme; vars: TagStyleSheetVars }) => {
   return StyleSheet.create({
     base: Object.assign(
       {
-        backgroundColor: theme.colors.background.default,
-        borderColor: theme.colors.border.default,
-        borderWidth: 1,
-        borderRadius: 10,
+        backgroundColor: theme.colors.background.section,
+        borderRadius: 4,
         height: 24,
-        paddingHorizontal: 4,
+        paddingHorizontal: 8,
         justifyContent: 'center',
       } as ViewStyle,
       style,

--- a/app/component-library/components/Tags/Tag/Tag.tsx
+++ b/app/component-library/components/Tags/Tag/Tag.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { View } from 'react-native';
 
 // External dependencies.
-import Text, { TextVariant } from '../../Texts/Text';
+import Text, { TextVariant, TextColor } from '../../Texts/Text';
 import { useStyles } from '../../../hooks';
 
 // Internal dependencies.
@@ -17,7 +17,7 @@ const Tag = ({ label, style, ...props }: TagProps) => {
 
   return (
     <View style={styles.base} {...props}>
-      <Text variant={TextVariant.BodyMD}>{label}</Text>
+      <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>{label}</Text>
     </View>
   );
 };

--- a/app/component-library/components/Tags/Tag/__snapshots__/Tag.test.tsx.snap
+++ b/app/component-library/components/Tags/Tag/__snapshots__/Tag.test.tsx.snap
@@ -4,13 +4,11 @@ exports[`Tag should render correctly 1`] = `
 <View
   style={
     {
-      "backgroundColor": "#ffffff",
-      "borderColor": "#b7bbc8",
-      "borderRadius": 10,
-      "borderWidth": 1,
+      "backgroundColor": "#f3f5f9",
+      "borderRadius": 4,
       "height": 24,
       "justifyContent": "center",
-      "paddingHorizontal": 4,
+      "paddingHorizontal": 8,
     }
   }
 >
@@ -18,7 +16,7 @@ exports[`Tag should render correctly 1`] = `
     accessibilityRole="text"
     style={
       {
-        "color": "#121314",
+        "color": "#686e7d",
         "fontFamily": "Geist Regular",
         "fontSize": 16,
         "letterSpacing": 0,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR updates the tag component to match the [design specs](https://www.figma.com/design/9e6RSJCvezaLqDQ3mtE5wB/Home-Page?node-id=6183-23097&t=wKdMTXeiddFvKaNE-4). It is a dependency for adding Bitcoin labels. 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/pull/36437/files

## **Manual testing steps**

```gherkin
Users should see an updated tag component
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

### **After**

<img width="1041" height="462" alt="Screenshot 2025-10-01 at 3 07 29 AM" src="https://github.com/user-attachments/assets/d9bb9f1a-2616-47ae-a7c4-fa305a48d35a" />

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restyles the Tag component (bg, radius, padding, text color) and updates cell snapshots to match the new tag appearance.
> 
> - **UI**
>   - **`Tag` component**:
>     - Background: `theme.colors.background.section` (was `background.default`)
>     - Removed border; set `borderRadius: 4`; `paddingHorizontal: 8`
>     - Text now uses `TextColor.Alternative`
> - **Tests**
>   - Updated snapshots in `Cells/Cell*` and `CellSelectWithMenu` to reflect new tag styling (`backgroundColor: #f3f5f9`, no border, smaller radius, increased padding, alternative text color).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe84d1e9aaedc6b45ec1887874c5d6cf195a1ea4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->