### PR TITLE
feat: Add empty state to market list when no results found after search

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.styles.ts
@@ -164,6 +164,25 @@ const styleSheet = (params: { theme: Theme }) => {
       padding: 4,
       marginLeft: 8,
     },
+    emptyStateContainer: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      paddingHorizontal: 24,
+      paddingVertical: 48,
+      marginBottom: 120, // Account for tab bar height
+    },
+    emptyStateIcon: {
+      marginBottom: 16,
+    },
+    emptyStateTitle: {
+      textAlign: 'center',
+      marginBottom: 8,
+    },
+    emptyStateDescription: {
+      textAlign: 'center',
+      maxWidth: 280,
+    },
   });
 };
 

--- a/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.test.tsx
@@ -923,6 +923,41 @@ describe('PerpsMarketListView', () => {
       expect(screen.queryByTestId('market-row-SOL')).not.toBeOnTheScreen();
     });
 
+    it('shows empty state when search returns no results', () => {
+      renderWithProvider(<PerpsMarketListView />);
+
+      // First toggle search visibility
+      const searchButton = screen.getByTestId(
+        PerpsMarketListViewSelectorsIDs.SEARCH_TOGGLE_BUTTON,
+      );
+      act(() => {
+        fireEvent.press(searchButton);
+      });
+
+      const searchInput = screen.getByPlaceholderText('Search by token symbol');
+
+      act(() => {
+        fireEvent.changeText(searchInput, 'NONEXISTENT');
+      });
+
+      // Should show empty state message
+      expect(screen.getByText('No tokens found')).toBeOnTheScreen();
+      expect(
+        screen.getByText(
+          'We couldn\'t find any tokens with the name "NONEXISTENT". Try a different search.',
+        ),
+      ).toBeOnTheScreen();
+
+      // Should not show any market rows
+      expect(screen.queryByTestId('market-row-BTC')).not.toBeOnTheScreen();
+      expect(screen.queryByTestId('market-row-ETH')).not.toBeOnTheScreen();
+      expect(screen.queryByTestId('market-row-SOL')).not.toBeOnTheScreen();
+
+      // Should not show list header when empty state is shown
+      expect(screen.queryByText('Volume')).not.toBeOnTheScreen();
+      expect(screen.queryByText('Price / 24h change')).not.toBeOnTheScreen();
+    });
+
     it('handles search with whitespace', () => {
       renderWithProvider(<PerpsMarketListView />);
 

--- a/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
@@ -293,14 +293,14 @@ const PerpsMarketListView = ({
             color={TextColor.Default}
             style={styles.emptyStateTitle}
           >
-            No tokens found
+            {strings('perps.no_tokens_found')}
           </Text>
           <Text
             variant={TextVariant.BodyMD}
             color={TextColor.Alternative}
             style={styles.emptyStateDescription}
           >
-            {`We couldn't find any tokens with the name "${searchQuery}". Try a different search.`}
+            {strings('perps.no_tokens_found_description', { searchQuery })}
           </Text>
         </View>
       );

--- a/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
@@ -278,6 +278,34 @@ const PerpsMarketListView = ({
       );
     }
 
+    // Empty search results
+    if (searchQuery.trim() && filteredMarkets.length === 0) {
+      return (
+        <View style={styles.emptyStateContainer}>
+          <Icon
+            name={IconName.Search}
+            size={IconSize.Xl}
+            color={theme.colors.icon.muted}
+            style={styles.emptyStateIcon}
+          />
+          <Text
+            variant={TextVariant.HeadingSM}
+            color={TextColor.Default}
+            style={styles.emptyStateTitle}
+          >
+            No tokens found
+          </Text>
+          <Text
+            variant={TextVariant.BodyMD}
+            color={TextColor.Alternative}
+            style={styles.emptyStateDescription}
+          >
+            {`We couldn't find any tokens with the name "${searchQuery}". Try a different search.`}
+          </Text>
+        </View>
+      );
+    }
+
     return (
       <>
         <PerpsMarketListHeader />

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1459,6 +1459,8 @@
     "failed_to_load_market_data": "Failed to load market data",
     "tap_to_retry": "Tap to retry",
     "search_by_token_symbol": "Search by token symbol",
+    "no_tokens_found": "No tokens found",
+    "no_tokens_found_description": "We couldn't find any tokens with the name \"{{searchQuery}}\". Try a different search.",
     "testnet": "Testnet",
     "mainnet": "Mainnet",
     "developer_options": {


### PR DESCRIPTION
## **Description**

Adds empty state for when no tokens on Perps market list match search query

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<img width="437" height="891" alt="Screenshot 2025-09-30 at 1 49 59 PM" src="https://github.com/user-attachments/assets/46cfe0de-0ce0-46e9-8deb-58688020fe54" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shows an empty state with icon and explanatory text when Perps market search returns no matches, with new styles, i18n strings, and tests.
> 
> - **Perps Markets UI**:
>   - Empty search-results state in `PerpsMarketListView.tsx` when `searchQuery` is non-empty and `filteredMarkets.length === 0`; hides list header and rows.
>   - Adds styles for empty state (`emptyStateContainer`, `emptyStateIcon`, `emptyStateTitle`, `emptyStateDescription`) in `PerpsMarketListView.styles.ts`.
> - **Tests**:
>   - New test verifies empty state copy, absence of market rows, and header not rendered in `PerpsMarketListView.test.tsx`.
> - **Localization**:
>   - Adds `perps.no_tokens_found` and `perps.no_tokens_found_description` to `locales/languages/en.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6be57cd9879e0800cbf942f5196fd3bbf30a589. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->