### PR TITLE
chore: Prioritize target and environment values from js env for build.sh

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -31,8 +31,8 @@ loadJSEnv
 
 # Enable Sentry to auto upload source maps and debug symbols
 export SENTRY_DISABLE_AUTO_UPLOAD=${SENTRY_DISABLE_AUTO_UPLOAD:-"true"}
-export METAMASK_BUILD_TYPE=${MODE:-"$METAMASK_BUILD_TYPE"}
-export METAMASK_ENVIRONMENT=${ENVIRONMENT:-"$METAMASK_ENVIRONMENT"}
+export METAMASK_BUILD_TYPE=${METAMASK_BUILD_TYPE:-"$MODE"}
+export METAMASK_ENVIRONMENT=${METAMASK_ENVIRONMENT:-"$ENVIRONMENT"}
 export EXPO_NO_TYPESCRIPT_SETUP=1
 
 echo "PLATFORM = $PLATFORM"
@@ -72,7 +72,7 @@ printTitle(){
 	echo ''
 	echo '-------------------------------------------'
 	echo ''
-	echo "  🚀 BUILDING $PLATFORM for $MODE target with $ENVIRONMENT environment" | tr [a-z] [A-Z]
+	echo "  🚀 BUILDING $PLATFORM for $METAMASK_BUILD_TYPE target with $METAMASK_ENVIRONMENT environment" | tr [a-z] [A-Z]
 	echo ''
 	echo '-------------------------------------------'
 	echo ''
@@ -576,7 +576,7 @@ buildAndroidReleaseE2E(){
 }
 
 buildAndroid() {
-	if [ "$MODE" == "release" ] || [ "$MODE" == "main" ] ; then
+	if [ "$METAMASK_BUILD_TYPE" == "release" ] || [ "$METAMASK_BUILD_TYPE" == "main" ] ; then
 		if [ "$IS_LOCAL" = true ] ; then
 			buildAndroidMainLocal
 		elif [ "$METAMASK_ENVIRONMENT" == "dev" ] ; then
@@ -584,7 +584,7 @@ buildAndroid() {
 		else
 			buildAndroidMainProduction
 		fi
-	elif [ "$MODE" == "flask" ] ; then
+	elif [ "$METAMASK_BUILD_TYPE" == "flask" ] ; then
 		if [ "$IS_LOCAL" = true ] ; then
 			buildAndroidFlaskLocal
 		elif [ "$METAMASK_ENVIRONMENT" == "dev" ] ; then
@@ -592,7 +592,7 @@ buildAndroid() {
 		else
 			buildAndroidFlaskProduction
 		fi
-	elif [ "$MODE" == "QA" ] || [ "$MODE" == "qa" ] ; then
+	elif [ "$METAMASK_BUILD_TYPE" == "QA" ] || [ "$METAMASK_BUILD_TYPE" == "qa" ] ; then
 		if [ "$IS_LOCAL" = true ] ; then
 			buildAndroidQALocal
 		elif [ "$METAMASK_ENVIRONMENT" == "dev" ] ; then
@@ -600,9 +600,9 @@ buildAndroid() {
 		else
 			buildAndroidQaProduction
 		fi
-	elif [ "$MODE" == "releaseE2E" ] ; then
+	elif [ "$METAMASK_BUILD_TYPE" == "releaseE2E" ] ; then
 		buildAndroidReleaseE2E
-  	elif [ "$MODE" == "debugE2E" ] ; then
+  	elif [ "$METAMASK_BUILD_TYPE" == "debugE2E" ] ; then
 		buildAndroidRunE2E
 	else
 		printError "METAMASK_ENVIRONMENT '${METAMASK_ENVIRONMENT}' is not recognized."
@@ -621,8 +621,8 @@ buildAndroidRunE2E(){
 }
 
 buildIos() {
-	echo "Build iOS $MODE started..."
-	if [ "$MODE" == "release" ] || [ "$MODE" == "main" ] ; then
+	echo "Build iOS $METAMASK_BUILD_TYPE started..."
+	if [ "$METAMASK_BUILD_TYPE" == "release" ] || [ "$METAMASK_BUILD_TYPE" == "main" ] ; then
 		if [ "$IS_LOCAL" = true ] ; then
 			buildIosMainLocal
 		else
@@ -633,7 +633,7 @@ buildIos() {
 			# Generate iOS binary
 			generateIosBinary "MetaMask"
 		fi
-	elif [ "$MODE" == "flask" ] ; then
+	elif [ "$METAMASK_BUILD_TYPE" == "flask" ] ; then
 		if [ "$IS_LOCAL" = true ] ; then
 			buildIosFlaskLocal
 		else
@@ -644,7 +644,7 @@ buildIos() {
 			# Generate iOS binary
 			generateIosBinary "MetaMask-Flask"
 		fi
-	elif [ "$MODE" == "QA" ] || [ "$MODE" == "qa" ] ; then
+	elif [ "$METAMASK_BUILD_TYPE" == "QA" ] || [ "$METAMASK_BUILD_TYPE" == "qa" ] ; then
 		if [ "$IS_LOCAL" = true ] ; then
 			buildIosQALocal
 		else
@@ -655,13 +655,13 @@ buildIos() {
 			# Generate iOS binary
 			generateIosBinary "MetaMask-QA"
 		fi
-	elif [ "$MODE" == "releaseE2E" ] ; then
+	elif [ "$METAMASK_BUILD_TYPE" == "releaseE2E" ] ; then
 		buildIosReleaseE2E
-	elif [ "$MODE" == "debugE2E" ] ; then
+	elif [ "$METAMASK_BUILD_TYPE" == "debugE2E" ] ; then
 			buildIosSimulatorE2E
-	elif [ "$MODE" == "qadebugE2E" ] ; then
+	elif [ "$METAMASK_BUILD_TYPE" == "qadebugE2E" ] ; then
 			buildIosQASimulatorE2E
-	elif [ "$MODE" == "flaskDebugE2E" ] ; then
+	elif [ "$METAMASK_BUILD_TYPE" == "flaskDebugE2E" ] ; then
 			buildIosFlaskSimulatorE2E
 	else
 		printError "METAMASK_ENVIRONMENT '${METAMASK_ENVIRONMENT}' is not recognized"
@@ -690,7 +690,7 @@ checkAuthToken() {
 	if [ -n "${MM_SENTRY_AUTH_TOKEN}" ]; then
 		sed -i'' -e "s/auth.token.*/auth.token=${MM_SENTRY_AUTH_TOKEN}/" "./${propertiesFileName}";
 	elif ! grep -qE '^auth.token=[[:alnum:]]+$' "./${propertiesFileName}"; then
-		if [ "$ENVIRONMENT" == "production" ]; then
+		if [ "$METAMASK_ENVIRONMENT" == "production" ]; then
 			printError "Missing auth token in '${propertiesFileName}'; add the token, or set it as MM_SENTRY_AUTH_TOKEN"
 			exit 1
 		else
@@ -703,7 +703,7 @@ checkAuthToken() {
 			cp "./${propertiesFileName}.example" "./${propertiesFileName}"
 			sed -i'' -e "s/auth.token.*/auth.token=${MM_SENTRY_AUTH_TOKEN}/" "./${propertiesFileName}";
 		else
-			if [ "$ENVIRONMENT" == "production" ]; then
+			if [ "$METAMASK_ENVIRONMENT" == "production" ]; then
 				printError "Missing '${propertiesFileName}' file (see '${propertiesFileName}.example' or set MM_SENTRY_AUTH_TOKEN to generate)"
 				exit 1
 			else
@@ -720,50 +720,50 @@ printTitle
 
 # Map environment variables based on mode.
 # TODO: MODE should be renamed to TARGET
-if [ "$MODE" == "main" ]; then
+if [ "$METAMASK_BUILD_TYPE" == "main" ]; then
 	export GENERATE_BUNDLE=true # Used only for Android
 	export PRE_RELEASE=true # Used mostly for iOS, for Android only deletes old APK and installs new one
-	if [ "$ENVIRONMENT" == "production" ]; then
+	if [ "$METAMASK_ENVIRONMENT" == "production" ]; then
 		remapMainProdEnvVariables
-	elif [ "$ENVIRONMENT" == "beta" ]; then
+	elif [ "$METAMASK_ENVIRONMENT" == "beta" ]; then
 		remapMainBetaEnvVariables
-	elif [ "$ENVIRONMENT" == "rc" ]; then
+	elif [ "$METAMASK_ENVIRONMENT" == "rc" ]; then
 		remapMainReleaseCandidateEnvVariables
-	elif [ "$ENVIRONMENT" == "exp" ]; then
+	elif [ "$METAMASK_ENVIRONMENT" == "exp" ]; then
 		remapMainExperimentalEnvVariables
-	elif [ "$ENVIRONMENT" == "test" ]; then
+	elif [ "$METAMASK_ENVIRONMENT" == "test" ]; then
 		remapMainTestEnvVariables
-	elif [ "$ENVIRONMENT" == "e2e" ]; then
+	elif [ "$METAMASK_ENVIRONMENT" == "e2e" ]; then
 		remapMainE2EEnvVariables
-	elif [ "$ENVIRONMENT" == "dev" ]; then
+	elif [ "$METAMASK_ENVIRONMENT" == "dev" ]; then
 		remapMainDevEnvVariables
 	fi
-elif [ "$MODE" == "flask" ]; then
+elif [ "$METAMASK_BUILD_TYPE" == "flask" ]; then
 	# TODO: Map environment variables based on environment
-	if [ "$ENVIRONMENT" == "production" ]; then
+	if [ "$METAMASK_ENVIRONMENT" == "production" ]; then
 		remapFlaskProdEnvVariables
-	elif [ "$ENVIRONMENT" == "test" ]; then
+	elif [ "$METAMASK_ENVIRONMENT" == "test" ]; then
 		remapFlaskTestEnvVariables
-	elif [ "$ENVIRONMENT" == "e2e" ]; then
+	elif [ "$METAMASK_ENVIRONMENT" == "e2e" ]; then
 		remapFlaskE2EEnvVariables
 	fi
-elif [ "$MODE" == "qa" ] || [ "$MODE" == "QA" ]; then
+elif [ "$METAMASK_BUILD_TYPE" == "qa" ] || [ "$METAMASK_BUILD_TYPE" == "QA" ]; then
 	# TODO: Map environment variables based on environment
 	remapEnvVariableQA
 fi
 
-if [ "$ENVIRONMENT" == "e2e" ]; then
+if [ "$METAMASK_ENVIRONMENT" == "e2e" ]; then
 	# Build for simulator
 	export IS_SIM_BUILD="true"
 	# Ignore Boxlogs for E2E builds
 	export IGNORE_BOXLOGS_DEVELOPMENT="true"
 fi
 
-if [ "$MODE" == "releaseE2E" ] || [ "$MODE" == "QA" ]; then
+if [ "$METAMASK_BUILD_TYPE" == "releaseE2E" ] || [ "$METAMASK_BUILD_TYPE" == "QA" ]; then
 	echo "DEBUG SENTRY PROPS"
 	checkAuthToken 'sentry.debug.properties'
 	export SENTRY_PROPERTIES="${REPO_ROOT_DIR}/sentry.debug.properties"
-elif [ "$MODE" == "release" ] || [ "$MODE" == "flask" ] || [ "$MODE" == "main" ]; then
+elif [ "$METAMASK_BUILD_TYPE" == "release" ] || [ "$METAMASK_BUILD_TYPE" == "flask" ] || [ "$METAMASK_BUILD_TYPE" == "main" ]; then
 	echo "RELEASE SENTRY PROPS"
 	checkAuthToken 'sentry.release.properties'
 	export SENTRY_PROPERTIES="${REPO_ROOT_DIR}/sentry.release.properties"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This change prioritizes the `METAMASK_ENVIRONMENT` and `METAMASK_BUILD_TYPE` values from `.js.env` over the inputs that are specified in package.json scripts. This will enable developers to easily switch between build types and environments using the watcher.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

Env vars not specified, using inputs from script (defaults to `main` type `dev` environment)
<img width="970" height="319" alt="image" src="https://github.com/user-attachments/assets/e00974b8-f309-4948-969d-27d77d186e76" />

Env vars specified, which are used in the build.sh
<img width="836" height="345" alt="image" src="https://github.com/user-attachments/assets/8cae2257-6685-4681-8e01-3575820828f9" />


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make build.sh prefer METAMASK_BUILD_TYPE and METAMASK_ENVIRONMENT from .js.env (fallback to args) and update build conditionals, logs, and Sentry checks to use them.
> 
> - **Build scripts (`scripts/build.sh`)**:
>   - **Env precedence**: Export `METAMASK_BUILD_TYPE` and `METAMASK_ENVIRONMENT` to prefer existing values (from `.js.env`) with fallback to `MODE`/`ENVIRONMENT`.
>   - **Refactors**:
>     - Replace checks and logs using `MODE`/`ENVIRONMENT` with `METAMASK_BUILD_TYPE`/`METAMASK_ENVIRONMENT` across Android and iOS build paths (dev/prod/QA/Flask/E2E).
>     - Update title output and iOS/Android branching to use new vars.
>     - Use `METAMASK_ENVIRONMENT` in Sentry auth token validation and in selecting debug/release Sentry properties.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b17b72a66cc69f1d781e8a08a1f21dded6759567. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->