### PR TITLE
fix(conf): Migrate to react-native-safearea-context for android 35

### DIFF
--- a/app/components/Views/confirmations/components/send/recipient/recipient.tsx
+++ b/app/components/Views/confirmations/components/send/recipient/recipient.tsx
@@ -6,12 +6,8 @@ import {
 } from '@metamask/design-system-react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import React, { useCallback, useEffect, useState } from 'react';
-import {
-  KeyboardAvoidingView,
-  Platform,
-  SafeAreaView,
-  ScrollView,
-} from 'react-native';
+import { KeyboardAvoidingView, Platform, ScrollView } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { strings } from '../../../../../../../locales/i18n';
 import Banner, {
   BannerAlertSeverity,
@@ -156,7 +152,7 @@ export const Recipient = () => {
   useRecipientPageReset(resetStateOnInput);
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView edges={['left', 'right', 'bottom']} style={styles.container}>
       <KeyboardAvoidingView
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
         style={styles.container}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes an upcoming issue in send flow will be introduced with Android 35 update [here](https://github.com/MetaMask/metamask-mobile/pull/20461). As suggested we are now using `react-native-safearea-context` for `SafeAreaView` now.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

![2025-10-01 11 55 45](https://github.com/user-attachments/assets/74e01f35-a8ea-490f-820e-e90232b05ce6)


### **After**

![2025-10-01 13 38 21](https://github.com/user-attachments/assets/d7e6364f-e612-463a-898e-78adff1b4aa6)


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces SafeAreaView with react-native-safe-area-context across key screens, adjusts safe-area edges/paddings, and refactors SimpleWebview to functional TSX with hook-based navbar/share.
> 
> - **UI/Layout**:
>   - Switches to `react-native-safe-area-context` `SafeAreaView` across views (`Settings`, `AdvancedSettings`, `Contacts`, `NetworksSettings`, `OnboardingSuccess`, `Recipient`, `SimpleWebView`, etc.) with `edges={{ bottom: 'additive' }}` and related tweaks.
>   - Normalizes spacing: multiple screens reduce padding (e.g., `24` → `16`), add bottom padding via safe area insets, and minor flex fixes (`flexGrow` → `flex`).
>   - `NetworksSettings`: restructures layout with `SafeAreaView`, separates `searchWrapper`, adds `ScrollView` `contentContainerStyle` padding, adjusts margins for controls and CTA.
>   - `RevealPrivateCredential`: adds bottom padding; snapshots updated.
> - **Send Flow**:
>   - `Asset`: adds `contentContainerStyle` bottom inset using `useSafeAreaInsets`.
>   - `Recipient`: wraps in `SafeAreaView` with specific `edges` and keeps keyboard handling.
> - **Webview**:
>   - Refactors `SimpleWebview` from class JS to functional TSX using hooks; sets navbar via `getWebviewNavbar`, adds share handler, wraps in `SafeAreaView`, updates tests/snapshots.
> - **Tests/Snapshots**:
>   - Updates snapshots to reflect safe area components, padding changes, and layout adjustments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98e448ab1e6144e2da7d3e0d34a578670fbf2bf6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->