### PR TITLE
fix(account-tree-controller): re-use computed names for groups

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "@lavamoat/react-native-lockdown": "^0.0.2",
     "@ledgerhq/react-native-hw-transport-ble": "^6.34.1",
     "@metamask/account-api": "^0.12.0",
-    "@metamask/account-tree-controller": "^1.3.0",
+    "@metamask/account-tree-controller": "^1.4.0",
     "@metamask/accounts-controller": "^33.1.0",
     "@metamask/address-book-controller": "^6.1.0",
     "@metamask/app-metadata-controller": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6660,15 +6660,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/account-tree-controller@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "@metamask/account-tree-controller@npm:1.3.0"
+"@metamask/account-tree-controller@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "@metamask/account-tree-controller@npm:1.4.0"
   dependencies:
     "@metamask/base-controller": ^8.4.0
     "@metamask/snaps-sdk": ^9.0.0
     "@metamask/snaps-utils": ^11.0.0
     "@metamask/superstruct": ^3.1.0
-    "@metamask/utils": ^11.8.0
+    "@metamask/utils": ^11.8.1
     fast-deep-equal: ^3.1.3
     lodash: ^4.17.21
   peerDependencies:
@@ -6680,7 +6680,7 @@ __metadata:
     "@metamask/providers": ^22.0.0
     "@metamask/snaps-controllers": ^14.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: db9c6bf0c91d3afbcfecb41759066cac4ab527101c1a9698a0c5fef4c96fd3ed33e3481e17543e64de40ae9a817f97c5081ab5b19b53e543d3e26eaad0ccfd9c
+  checksum: d9dcf5a210445efa19550e1f3df69aeb9a6980c640864f3439d89b0d6ca1efddb0fda9dd37293a6b319887500b213cad9fd51531fcfc69d15cffe06f799384af
   languageName: node
   linkType: hard
 
@@ -33734,7 +33734,7 @@ __metadata:
     "@ledgerhq/react-native-hw-transport-ble": ^6.34.1
     "@metamask/abi-utils": ^3.0.0
     "@metamask/account-api": ^0.12.0
-    "@metamask/account-tree-controller": ^1.3.0
+    "@metamask/account-tree-controller": ^1.4.0
     "@metamask/accounts-controller": ^33.1.0
     "@metamask/address-book-controller": ^6.1.0
     "@metamask/app-metadata-controller": ^1.0.0


### PR DESCRIPTION
## **Description**

Re-introducing computed names for account groups. (migrating from older account names).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

```gherkin
Feature: Re-use older account names when upgrading to BIP-44 update

  Scenario: user upgrades from an older version
    Given its accounts had different names (e.g "My EVM Account", "EVM account 1", etc..) and that "Backup & sync" feature is disabled

    When user upgrades to the new BIP-44 update
    Then all its new account groups should inherit from its older EVM account names (or use default naming like "Account N" for all others)
```

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates dependency `@metamask/account-tree-controller` from `^1.3.0` to `^1.4.0` with corresponding `yarn.lock` changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34e649a2f22df317076355000d1a5b22bb31c066. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->