### PR TITLE
fix: remove ">" on ways to earn and align fonts

### DIFF
--- a/app/components/UI/Rewards/components/Tabs/LevelsTab/RewardItem.tsx
+++ b/app/components/UI/Rewards/components/Tabs/LevelsTab/RewardItem.tsx
@@ -17,6 +17,7 @@ import {
   Button,
   ButtonVariant,
   ButtonSize,
+  FontWeight,
 } from '@metamask/design-system-react-native';
 import { selectRewardsActiveAccountAddress } from '../../../../../../selectors/rewards';
 import { useSelector } from 'react-redux';
@@ -60,7 +61,11 @@ const RewardItem: React.FC<RewardItemProps> = ({
   const shortDescription = useMemo(() => {
     if (isLocked) {
       return (
-        <Text variant={TextVariant.BodySm} twClassName="text-text-alternative">
+        <Text
+          variant={TextVariant.BodySm}
+          fontWeight={FontWeight.Medium}
+          twClassName="text-text-alternative"
+        >
           {seasonReward.shortDescription}
         </Text>
       );
@@ -78,6 +83,7 @@ const RewardItem: React.FC<RewardItemProps> = ({
             />
             <Text
               variant={TextVariant.BodySm}
+              fontWeight={FontWeight.Medium}
               twClassName="text-text-alternative"
             >
               {strings('rewards.unlocked_rewards.expired')}
@@ -96,9 +102,10 @@ const RewardItem: React.FC<RewardItemProps> = ({
             />
             <Text
               variant={TextVariant.BodySm}
+              fontWeight={FontWeight.Medium}
               twClassName="text-warning-default"
             >
-              {timeRemaining} left
+              {timeRemaining} {strings('rewards.unlocked_rewards.time_left')}
             </Text>
           </Box>
         );
@@ -117,6 +124,7 @@ const RewardItem: React.FC<RewardItemProps> = ({
             />
             <Text
               variant={TextVariant.BodySm}
+              fontWeight={FontWeight.Medium}
               twClassName="text-text-alternative"
             >
               {strings('rewards.unlocked_rewards.claimed_label')}
@@ -126,14 +134,22 @@ const RewardItem: React.FC<RewardItemProps> = ({
       }
       // Keep subtext for rewards that do not requires claim
       return (
-        <Text variant={TextVariant.BodySm} twClassName="text-text-alternative">
+        <Text
+          variant={TextVariant.BodySm}
+          fontWeight={FontWeight.Medium}
+          twClassName="text-text-alternative"
+        >
           {seasonReward.shortUnlockedDescription}
         </Text>
       );
     }
 
     return (
-      <Text variant={TextVariant.BodySm} twClassName="text-text-alternative">
+      <Text
+        variant={TextVariant.BodySm}
+        fontWeight={FontWeight.Medium}
+        twClassName="text-text-alternative"
+      >
         {seasonReward.shortUnlockedDescription}
       </Text>
     );
@@ -236,6 +252,7 @@ const RewardItem: React.FC<RewardItemProps> = ({
         <Box twClassName="flex-1">
           <Text
             variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Medium}
             twClassName="text-text-default mb-1"
             testID={REWARDS_VIEW_SELECTORS.TIER_REWARD_NAME}
           >

--- a/app/components/UI/Rewards/components/Tabs/LevelsTab/RewardsClaimBottomSheetModal.tsx
+++ b/app/components/UI/Rewards/components/Tabs/LevelsTab/RewardsClaimBottomSheetModal.tsx
@@ -19,6 +19,7 @@ import {
   Text,
   TextVariant,
   IconSize,
+  FontWeight,
 } from '@metamask/design-system-react-native';
 import BottomSheet, {
   BottomSheetRef,
@@ -193,7 +194,7 @@ const RewardsClaimBottomSheetModal = ({
 
   const renderTitle = () => (
     <Box twClassName="flex-row items-center justify-between w-full">
-      <Text variant={TextVariant.HeadingLg} twClassName="w-[80%]">
+      <Text variant={TextVariant.HeadingSm} twClassName="w-[80%]">
         {title}
       </Text>
       <Box
@@ -211,7 +212,11 @@ const RewardsClaimBottomSheetModal = ({
 
   const renderDescription = () => (
     <Box twClassName="my-4 w-full">
-      <Text variant={TextVariant.BodyMd} twClassName="text-text-alternative">
+      <Text
+        variant={TextVariant.BodyMd}
+        fontWeight={FontWeight.Medium}
+        twClassName="text-text-alternative"
+      >
         {description}
       </Text>
       {claimUrl && (
@@ -221,14 +226,15 @@ const RewardsClaimBottomSheetModal = ({
         >
           <Text
             variant={TextVariant.BodySm}
-            style={tw.style('text-primary-default underline mr-1')}
+            fontWeight={FontWeight.Medium}
+            twClassName="text-primary-default underline mr-1"
           >
             {formatUrl(claimUrl)}
           </Text>
           <Icon
             name={IconName.Export}
             size={IconSize.Sm}
-            style={tw.style('text-primary-default')}
+            twClassName="text-primary-default"
           />
         </TouchableOpacity>
       )}

--- a/app/components/UI/Rewards/components/Tabs/LevelsTab/UpcomingRewards.tsx
+++ b/app/components/UI/Rewards/components/Tabs/LevelsTab/UpcomingRewards.tsx
@@ -8,6 +8,7 @@ import {
   Icon,
   IconName,
   IconSize,
+  FontWeight,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { useTheme } from '../../../../../../util/theme';
@@ -101,6 +102,7 @@ const TierAccordion: React.FC<TierAccordionProps> = ({
         <Box twClassName="flex-1">
           <Text
             variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Medium}
             twClassName="text-text-default"
             testID={REWARDS_VIEW_SELECTORS.TIER_NAME}
           >
@@ -117,6 +119,7 @@ const TierAccordion: React.FC<TierAccordionProps> = ({
             />
             <Text
               variant={TextVariant.BodySm}
+              fontWeight={FontWeight.Medium}
               twClassName="text-text-alternative"
             >
               {strings('rewards.upcoming_rewards.points_needed', {

--- a/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.tsx
+++ b/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.tsx
@@ -267,8 +267,6 @@ export const WaysToEarn = () => {
                   </Text>
                 </Box>
               </Box>
-
-              <Icon name={IconName.ArrowRight} size={IconSize.Md} />
             </ButtonBase>
           )}
         />

--- a/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.tsx
+++ b/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.tsx
@@ -13,6 +13,7 @@ import {
   IconSize,
   IconColor,
   ButtonVariant,
+  FontWeight,
 } from '@metamask/design-system-react-native';
 import { useNavigation } from '@react-navigation/native';
 import { strings } from '../../../../../../../../locales/i18n';
@@ -251,11 +252,15 @@ export const WaysToEarn = () => {
                 </Box>
 
                 <Box>
-                  <Text variant={TextVariant.SectionHeading}>
+                  <Text
+                    variant={TextVariant.BodyMd}
+                    fontWeight={FontWeight.Medium}
+                  >
                     {wayToEarn.title}
                   </Text>
                   <Text
                     variant={TextVariant.BodySm}
+                    fontWeight={FontWeight.Medium}
                     color={TextColor.TextAlternative}
                   >
                     {wayToEarn.description}

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5979,7 +5979,7 @@
         "confirm": "Add account"
       },
       "multiple_unlinked_accounts": {
-        "title": "Start earning points", 
+        "title": "Start earning points",
         "description": "Add your accounts so you can track your rewards at a glance.",
         "confirm": "Add accounts"
       },
@@ -6056,6 +6056,7 @@
       "claim_label": "Claim",
       "claimed_label": "Claimed",
       "reward_claimed": "Reward claimed",
+      "time_left": "left",
       "expired": "Expired"
     }
   },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
- remove ">" on ways to earn
- align fonts between the overview and levels tabs

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/RWDS-490

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="1284" height="2778" alt="simulator_screenshot_A8E963B7-EDFF-47D4-A60E-FB32E1090498" src="https://github.com/user-attachments/assets/394823c8-5033-4fda-96a3-a4a06f97e2bb" />

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns font weights/variants across Rewards screens, removes the chevron in Ways to earn, and localizes the time-left label.
> 
> - **Rewards UI typography alignment**
>   - `LevelsTab/RewardItem.tsx`: Add `FontWeight.Medium` to multiple `Text` elements; localize time-remaining to use `strings('rewards.unlocked_rewards.time_left')`; set reward name to medium weight.
>   - `LevelsTab/UpcomingRewards.tsx`: Set tier name and points-needed texts to `FontWeight.Medium`.
>   - `LevelsTab/RewardsClaimBottomSheetModal.tsx`: Reduce title `Text` variant from `HeadingLg` to `HeadingSm`; apply medium weight to description/link text; switch link styles to `twClassName`.
> - **Overview UI adjustments**
>   - `OverviewTab/WaysToEarn/WaysToEarn.tsx`: Remove `ArrowRight` icon; change item title to `BodyMd` with `FontWeight.Medium`; apply medium weight to description.
> - **Localization**
>   - `locales/en.json`: Add `rewards.unlocked_rewards.time_left` key; minor whitespace cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0cb733142c85094b8b38eff548b220e42afdcd3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->