### PR TITLE
fix: prevent duplicate switch requests in account network row modal

### DIFF
--- a/app/components/Views/confirmations/components/modals/switch-account-type-modal/account-network-row/account-network-row.test.tsx
+++ b/app/components/Views/confirmations/components/modals/switch-account-type-modal/account-network-row/account-network-row.test.tsx
@@ -283,5 +283,24 @@ describe('Account Network Row', () => {
         },
       });
     });
+
+    it('returns early when switchRequestSubmitted is true', async () => {
+      mockMultichainAccountsState1Enabled.mockReturnValueOnce(true);
+      const { getByTestId } = renderWithProvider(
+        <AccountNetworkRow address={MOCK_ADDRESS} network={MOCK_NETWORK} />,
+        { state: MOCK_STATE },
+      );
+
+      const switchComponent = getByTestId(SmartAccountIds.SMART_ACCOUNT_SWITCH);
+
+      // First click to trigger the switch and set switchRequestSubmitted to true
+      fireEvent(switchComponent, 'onValueChange', false);
+
+      // Second click while switchRequestSubmitted is true - should return early
+      fireEvent(switchComponent, 'onValueChange', true);
+
+      // Calls downgradeAccount once
+      expect(mockDowngradeAccount).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/app/components/Views/confirmations/components/modals/switch-account-type-modal/account-network-row/account-network-row.tsx
+++ b/app/components/Views/confirmations/components/modals/switch-account-type-modal/account-network-row/account-network-row.tsx
@@ -66,6 +66,7 @@ const AccountNetworkRow = ({
   );
 
   const onSwitch = useCallback(async () => {
+    if (switchRequestSubmitted) return;
     setSwitchRequestSubmitted(true);
     if (addressSupportSmartAccount) {
       await downgradeAccount(address);
@@ -94,6 +95,7 @@ const AccountNetworkRow = ({
     upgradeAccount,
     upgradeContractAddress,
     useMultichainAccountsDesign,
+    switchRequestSubmitted,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR prevents duplicate switch requests in account network row modal.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a but allowing to generate duplicate switch requests in account network row modal

## **Related issues**

Fixes:
Jira ticket: https://consensyssoftware.atlassian.net/browse/MUL-1108

## **Manual testing steps**

```gherkin
Feature: Toggle smart accounts

  Scenario: user toggles smart accounts
    Given user onboarded

    When user navigates to account details, then smart accounts then toggles one of the switches multiple times
    Then only one request will appear
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents duplicate account-type switch requests by guarding `onSwitch` when a request is in-flight and adds a unit test.
> 
> - **Confirmations UI**:
>   - `app/components/.../account-network-row.tsx`: Guard `onSwitch` with `switchRequestSubmitted` to avoid duplicate requests and add it to hook dependencies.
> - **Tests**:
>   - `app/components/.../account-network-row.test.tsx`: Add test ensuring subsequent toggles are ignored while `switchRequestSubmitted` is true.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab210e6ed5dec7b57dbbb9f75ff5a48cdf7f9757. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->