### PR TITLE
fix: wallet-connect qrcode redirect

### DIFF
--- a/app/core/WalletConnect/WalletConnect2Session.test.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.test.ts
@@ -596,8 +596,19 @@ describe('WalletConnect2Session', () => {
       expect(mockNavigation.navigate).not.toHaveBeenCalled();
     });
 
-    it('allows backward navigation for non-iOS devices', () => {
+    it('allows backward navigation for non-iOS devices when redirect metadata exists', () => {
       (Device.isIos as jest.Mock).mockReturnValue(false);
+      session.session = {
+        ...mockSession,
+        peer: {
+          metadata: {
+            ...mockSession.peer.metadata,
+            redirect: {
+              native: 'https://example.com',
+            },
+          },
+        },
+      } as any;
 
       session.redirect('test');
       jest.runAllTimers();
@@ -605,6 +616,31 @@ describe('WalletConnect2Session', () => {
       expect(Minimizer.goBack).toHaveBeenCalled();
       expect(Linking.openURL).not.toHaveBeenCalled();
       expect(mockNavigation.navigate).not.toHaveBeenCalled();
+    });
+
+    it('shows return notification when redirect metadata does not exist', () => {
+      (Device.isIos as jest.Mock).mockReturnValue(false);
+      session.session = {
+        ...mockSession,
+        peer: {
+          metadata: {
+            ...mockSession.peer.metadata,
+            redirect: undefined,
+          },
+        },
+      } as any;
+
+      session.redirect('test');
+      jest.runAllTimers();
+
+      expect(Minimizer.goBack).not.toHaveBeenCalled();
+      expect(Linking.openURL).not.toHaveBeenCalled();
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
+        Routes.MODAL.ROOT_MODAL_FLOW,
+        {
+          screen: Routes.SDK.RETURN_TO_DAPP_NOTIFCATION,
+        },
+      );
     });
 
     describe('iOS specific behavior', () => {
@@ -716,6 +752,17 @@ describe('WalletConnect2Session', () => {
 
       it('skips iOS specific logic for iOS versions below 17', () => {
         jest.spyOn(Platform, 'Version', 'get').mockReturnValue('16.0');
+        session.session = {
+          ...mockSession,
+          peer: {
+            metadata: {
+              ...mockSession.peer.metadata,
+              redirect: {
+                native: 'https://example.com',
+              },
+            },
+          },
+        } as any;
 
         session.redirect('test');
         jest.runAllTimers();

--- a/app/core/WalletConnect/WalletConnect2Session.test.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.test.ts
@@ -638,7 +638,7 @@ describe('WalletConnect2Session', () => {
       expect(mockNavigation.navigate).toHaveBeenCalledWith(
         Routes.MODAL.ROOT_MODAL_FLOW,
         {
-          screen: Routes.SDK.RETURN_TO_DAPP_NOTIFCATION,
+          screen: Routes.SDK.RETURN_TO_DAPP_TOAST,
         },
       );
     });

--- a/app/core/WalletConnect/WalletConnect2Session.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.ts
@@ -235,7 +235,7 @@ class WalletConnect2Session {
 
     const navigation = this.navigation;
 
-    const showReturnModal = () => {
+    const showReturnNotification = () => {
       navigation?.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
         screen: Routes.SDK.RETURN_TO_DAPP_TOAST,
       });
@@ -250,10 +250,10 @@ class WalletConnect2Session {
             DevLogger.log(
               `WC2::redirect error while opening ${peerLink} with error ${error}`,
             );
-            showReturnModal();
+            showReturnNotification();
           });
         } else {
-          showReturnModal();
+          showReturnNotification();
         }
       } else {
         Minimizer.goBack();

--- a/app/core/WalletConnect/WalletConnect2Session.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.ts
@@ -242,8 +242,9 @@ class WalletConnect2Session {
     };
 
     setTimeout(() => {
+      const redirect = this.session.peer.metadata.redirect;
+
       if (Device.isIos() && parseInt(Platform.Version as string) >= 17) {
-        const redirect = this.session.peer.metadata.redirect;
         const peerLink = redirect?.native || redirect?.universal;
         if (peerLink) {
           Linking.openURL(peerLink).catch((error) => {
@@ -252,12 +253,14 @@ class WalletConnect2Session {
             );
             showReturnNotification();
           });
-        } else {
-          showReturnNotification();
+          return;
         }
-      } else {
+      } else if (redirect) {
         Minimizer.goBack();
+        return;
       }
+
+      showReturnNotification();
     }, 100);
   };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**


The redirection test was based on the `deeplink` boolean [here](https://github.com/MetaMask/metamask-mobile/blob/4e8d8b29569168c976091aa6b653e47ee1392c41/app/core/WalletConnect/WalletConnect2Session.ts#L234).

It was set with this check: `const isDeepLink = origin === AppConstants.DEEPLINKS.ORIGIN_DEEPLINK;` [here](https://github.com/MetaMask/metamask-mobile/blob/4e8d8b29569168c976091aa6b653e47ee1392c41/app/core/WalletConnect/WalletConnectV2.ts#L652). Unlike the SDK, this boolean is provided by MetaMask Mobile. If you scan the QR code using MetaMask’s built-in scanner, the origin is set to qr-code [here](https://github.com/MetaMask/metamask-mobile/blob/4e8d8b29569168c976091aa6b653e47ee1392c41/app/components/Views/QRScanner/index.tsx#L238); otherwise it’s deeplink [here](https://github.com/MetaMask/metamask-mobile/blob/4e8d8b29569168c976091aa6b653e47ee1392c41/app/store/sagas/index.ts#L195).
 
However, when you scan with the phone’s camera, MetaMask can’t know the origin. It can’t tell whether the deeplink came from an app or from the camera scan, because the URL itself doesn’t include origin info—unlike the SDK.
 
Because of this, WalletConnect recommends that apps do not include redirect info when it’s a QR code. That prevents unwanted redirects. ([See recommended approach here](https://docs.walletconnect.network/wallet-sdk/react-native/mobile-linking#recommended-approach))

> **Recommended Approach**
> To avoid this behavior, wallets should:
> - **Restrict Redirect Metadata to Deep Link Use Cases**: Redirect metadata should only be used when the session proposal is initiated through a deep link. QR code scans should not trigger app redirects using session proposal metadata.
>
> The connection and sign request flows are similar across platforms.

 
I updated the redirection function accordingly, using the redirect metadata. I haven’t been able to test it yet, since I can’t scan anything with my Android simulator.





<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/WAPI-733

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Redirect now depends on peer `redirect` metadata; if absent, show `RETURN_TO_DAPP_TOAST` instead of navigating back/opening URL, with updated tests across iOS/Android and iOS <17.
> 
> - **WalletConnect redirect logic (`app/core/WalletConnect/WalletConnect2Session.ts`)**:
>   - Use peer `metadata.redirect` to decide behavior.
>   - iOS ≥17: try `redirect.native || redirect.universal`; on failure, show `RETURN_TO_DAPP_TOAST` and return.
>   - Non‑iOS / iOS <17: only `Minimizer.goBack()` when `redirect` exists; otherwise show `RETURN_TO_DAPP_TOAST`.
>   - Rename helper `showReturnModal` → `showReturnNotification` and centralize fallback to notification.
> - **Tests (`app/core/WalletConnect/WalletConnect2Session.test.ts`)**:
>   - Update non‑iOS test to require `redirect` metadata for backward navigation.
>   - Add test to show return notification when `redirect` is missing on non‑iOS.
>   - For iOS <17, ensure logic skips iOS‑specific flow but still respects `redirect` presence.
>   - Maintain iOS ≥17 cases: open peer link if available; fallback to notification on missing link or open failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b849c4b5e6cd8a0626af13389a46b28b0e66f1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->