### PR TITLE
feat: use `wallet.status`

### DIFF
--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListFooter/AccountListFooter.test.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListFooter/AccountListFooter.test.tsx
@@ -36,6 +36,13 @@ jest.mock('../../../../../components/UI/AnimatedSpinner', () => ({
   },
 }));
 
+jest.mock(
+  '../../../../../util/accounts/useAccountWalletOperationsLoadingStates',
+  () => ({
+    useAccountWalletOperationsLoadingStates: jest.fn(),
+  }),
+);
+
 // Mock InteractionManager
 const { InteractionManager } = jest.requireActual('react-native');
 InteractionManager.runAfterInteractions = jest.fn();

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListFooter/AccountListFooter.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListFooter/AccountListFooter.tsx
@@ -28,7 +28,7 @@ import {
   endTrace,
   trace,
 } from '../../../../../util/trace';
-import { useAccountsOperationsLoadingStates } from '../../../../../util/accounts/useAccountsOperationsLoadingStates';
+import { useAccountWalletOperationsLoadingStates } from '../../../../../util/accounts/useAccountWalletOperationsLoadingStates';
 
 interface AccountListFooterProps {
   walletId: AccountWalletId;
@@ -40,14 +40,14 @@ const AccountListFooter = memo(
     const [isLoading, setIsLoading] = useState(false);
     const { styles } = useStyles(createStyles, {});
     const {
-      isAccountSyncingInProgress,
+      areAnyOperationsLoading,
       loadingMessage: accountOperationLoadingMessage,
-    } = useAccountsOperationsLoadingStates();
+    } = useAccountWalletOperationsLoadingStates(walletId);
 
-    const isLoadingState = isLoading || isAccountSyncingInProgress;
+    const isLoadingState = areAnyOperationsLoading;
 
     const actionLabel = useMemo(() => {
-      if (isAccountSyncingInProgress) {
+      if (areAnyOperationsLoading) {
         return accountOperationLoadingMessage;
       }
 
@@ -58,8 +58,8 @@ const AccountListFooter = memo(
       return strings('multichain_accounts.wallet_details.create_account');
     }, [
       isLoadingState,
+      areAnyOperationsLoading,
       accountOperationLoadingMessage,
-      isAccountSyncingInProgress,
     ]);
 
     // Get wallet information to find the keyringId

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListFooter/AccountListFooter.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListFooter/AccountListFooter.tsx
@@ -44,7 +44,7 @@ const AccountListFooter = memo(
       loadingMessage: accountOperationLoadingMessage,
     } = useAccountWalletOperationsLoadingStates(walletId);
 
-    const isLoadingState = areAnyOperationsLoading;
+    const isLoadingState = isLoading || areAnyOperationsLoading;
 
     const actionLabel = useMemo(() => {
       if (areAnyOperationsLoading) {

--- a/app/selectors/multichainAccounts/accountTreeController.ts
+++ b/app/selectors/multichainAccounts/accountTreeController.ts
@@ -261,7 +261,7 @@ export const selectWalletStatus = createSelector(
     (walletId: AccountWalletId): AccountWalletObject['status'] | null => {
       if (!wallets) return null;
 
-      return wallets[walletId].status ?? null;
+      return wallets[walletId]?.status ?? null;
     },
 );
 

--- a/app/selectors/multichainAccounts/accountTreeController.ts
+++ b/app/selectors/multichainAccounts/accountTreeController.ts
@@ -250,6 +250,22 @@ export const selectWalletByAccount = createSelector(
 );
 
 /**
+ * Get a wallet status.
+ *
+ * @param walletId - The wallet ID.
+ * @returns The wallet status is wallet has been found, null otherwise.
+ */
+export const selectWalletStatus = createSelector(
+  [selectWalletsMap],
+  (wallets) =>
+    (walletId: AccountWalletId): AccountWalletObject['status'] | null => {
+      if (!wallets) return null;
+
+      return wallets[walletId].status ?? null;
+    },
+);
+
+/**
  * Resolves the selected account group preferring the controller's explicit selection,
  * and falling back to deriving from the selected internal account.
  */

--- a/app/util/accounts/useAccountWalletOperationsLoadingStates/index.test.tsx
+++ b/app/util/accounts/useAccountWalletOperationsLoadingStates/index.test.tsx
@@ -1,0 +1,63 @@
+import { useAccountWalletOperationsLoadingStates } from './index';
+import { renderHookWithProvider } from '../../test/renderWithProvider';
+import { strings } from '../../../../locales/i18n';
+import { AccountWalletObject } from '@metamask/account-tree-controller';
+
+const mockWalletId = 'entropy:test';
+
+describe('useAccountWalletOperationsLoadingStates', () => {
+  const getState = (status: AccountWalletObject['status']) => ({
+    engine: {
+      backgroundState: {
+        AccountTreeController: {
+          accountTree: {
+            wallets: {
+              [mockWalletId]: {
+                status,
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  it.each([
+    [
+      'in-progress:alignment',
+      'multichain_accounts.wallet_details.discovering_accounts',
+    ],
+    [
+      'in-progress:discovery',
+      'multichain_accounts.wallet_details.discovering_accounts',
+    ],
+    [
+      'in-progress:create-accounts',
+      'multichain_accounts.wallet_details.creating_account',
+    ],
+  ] as const)(
+    'returns loading state and message when a wallet operation is in progress: "%s"',
+    (
+      status: AccountWalletObject['status'],
+      expectedLoadingMessageKey: string,
+    ) => {
+      const { result } = renderHookWithProvider(
+        () => useAccountWalletOperationsLoadingStates(mockWalletId),
+        { state: getState(status) },
+      );
+      expect(result.current.areAnyOperationsLoading).toBe(true);
+      expect(result.current.loadingMessage).toBe(
+        strings(expectedLoadingMessageKey),
+      );
+    },
+  );
+
+  it('returns no loading state and undefined message when no wallet operation is in progress', () => {
+    const { result } = renderHookWithProvider(
+      () => useAccountWalletOperationsLoadingStates(mockWalletId),
+      { state: getState('ready') },
+    );
+    expect(result.current.areAnyOperationsLoading).toBe(false);
+    expect(result.current.loadingMessage).toBeUndefined();
+  });
+});

--- a/app/util/accounts/useAccountWalletOperationsLoadingStates/index.ts
+++ b/app/util/accounts/useAccountWalletOperationsLoadingStates/index.ts
@@ -2,6 +2,7 @@ import { useSelector } from 'react-redux';
 import { useMemo } from 'react';
 import { useAccountsOperationsLoadingStates } from '../useAccountsOperationsLoadingStates';
 import { AccountWalletId } from '@metamask/account-api';
+import { strings } from '../../../../locales/i18n';
 import { selectWalletStatus } from '../../../selectors/multichainAccounts/accountTreeController';
 
 export const useAccountWalletOperationsLoadingStates = (
@@ -25,11 +26,17 @@ export const useAccountWalletOperationsLoadingStates = (
     if (walletStatus !== null) {
       switch (walletStatus) {
         case 'in-progress:alignment':
-          return 'Alignment in progress...';
+          // We use the same copy as discovery for this one, mainly cause alignment is
+          // an internal and technical operation.
+          return strings(
+            'multichain_accounts.wallet_details.discovering_accounts',
+          );
         case 'in-progress:discovery':
-          return 'Discovery in progress...';
+          return strings(
+            'multichain_accounts.wallet_details.discovering_accounts',
+          );
         case 'in-progress:create-accounts':
-          return 'Creating accounts...';
+          return strings('multichain_accounts.wallet_details.creating_account');
         default:
           return undefined;
       }
@@ -42,10 +49,13 @@ export const useAccountWalletOperationsLoadingStates = (
     walletStatus,
   ]);
 
+  // If we have any valid message, then the wallet is busy with an operation.
+  const isWalletOperationLoading = loadingMessage?.length > 0;
+
   // If there's any valid loading message, then an operation is on-going.
   const areAnyOperationsLoading = useMemo(
-    () => areAnyAccountsOperationsLoading || loadingMessage,
-    [areAnyAccountsOperationsLoading, loadingMessage],
+    () => areAnyAccountsOperationsLoading || isWalletOperationLoading,
+    [areAnyAccountsOperationsLoading, isWalletOperationLoading],
   );
 
   return {

--- a/app/util/accounts/useAccountWalletOperationsLoadingStates/index.ts
+++ b/app/util/accounts/useAccountWalletOperationsLoadingStates/index.ts
@@ -1,0 +1,55 @@
+import { useSelector } from 'react-redux';
+import { useMemo } from 'react';
+import { useAccountsOperationsLoadingStates } from '../useAccountsOperationsLoadingStates';
+import { AccountWalletId } from '@metamask/account-api';
+import { selectWalletStatus } from '../../../selectors/multichainAccounts/accountTreeController';
+
+export const useAccountWalletOperationsLoadingStates = (
+  walletId: AccountWalletId,
+) => {
+  const {
+    isAccountSyncingInProgress,
+    areAnyOperationsLoading: areAnyAccountsOperationsLoading,
+    loadingMessage: accountsOperationsLoadingMessage,
+  } = useAccountsOperationsLoadingStates();
+
+  const walletStatus = useSelector(selectWalletStatus)(walletId);
+
+  // We order by priority, the first one that matches will be shown
+  const loadingMessage = useMemo(() => {
+    // Any global operations on accounts take precedence over the wallet status.
+    if (isAccountSyncingInProgress) {
+      return accountsOperationsLoadingMessage;
+    }
+
+    if (walletStatus !== null) {
+      switch (walletStatus) {
+        case 'in-progress:alignment':
+          return 'Alignment in progress...';
+        case 'in-progress:discovery':
+          return 'Discovery in progress...';
+        case 'in-progress:create-accounts':
+          return 'Creating accounts...';
+        default:
+          return undefined;
+      }
+    }
+
+    return undefined;
+  }, [
+    isAccountSyncingInProgress,
+    accountsOperationsLoadingMessage,
+    walletStatus,
+  ]);
+
+  // If there's any valid loading message, then an operation is on-going.
+  const areAnyOperationsLoading = useMemo(
+    () => areAnyAccountsOperationsLoading || loadingMessage,
+    [areAnyAccountsOperationsLoading, loadingMessage],
+  );
+
+  return {
+    areAnyOperationsLoading,
+    loadingMessage,
+  };
+};

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5655,6 +5655,7 @@
       "balance": "Balance",
       "create_account": "Create account",
       "creating_account": "Creating account...",
+      "discovering_accounts": "Discovering accounts...",
       "back_up": "Back up",
       "reveal_recovery_phrase_with_index": "Reveal Recovery Phrase {{index}}"
     },


### PR DESCRIPTION
## **Description**

Using the new `wallet.status` to report wallet on-going operation.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

```gherkin
Feature: Wallet status
  Scenario: user onboarding with wallet status
    Given "Backup & Sync" setting is OFF

    When user onboards and click on the account list
    Then it should display the wallet status instead of "+ Create account"
```

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/c40e8621-b100-43c1-921c-7c9ec960d5d6

### **After**

https://github.com/user-attachments/assets/ad659519-d1f0-4eb0-96a9-026b15d2e3c8

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Scopes AccountListFooter loading/messaging by wallet-specific `wallet.status` using a new hook and selector, with tests and i18n updates.
> 
> - **Multichain Accounts UI**
>   - `AccountListFooter.tsx`: Replace global syncing checks with wallet-scoped `useAccountWalletOperationsLoadingStates(walletId)`; derive `isLoadingState` and button label from `wallet.status` and hook outputs.
> - **State/Selectors**
>   - Add `selectWalletStatus` to get a wallet’s `status` from `AccountTreeController`.
> - **Hooks**
>   - New `useAccountWalletOperationsLoadingStates(walletId)`: Combines global account ops state with per-wallet `status` to return `areAnyOperationsLoading` and contextual `loadingMessage`.
> - **Tests**
>   - Update `AccountListFooter.test.tsx` to mock `useAccountWalletOperationsLoadingStates` and add loading transition test.
>   - Add tests for the new hook (`useAccountWalletOperationsLoadingStates/index.test.tsx`).
> - **i18n**
>   - Add `multichain_accounts.wallet_details.discovering_accounts` copy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1e381bdeeb2160f2787c3c1e3cd3b6d950fd39a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->