### PR TITLE
fix: custom simulator name with space failing to start

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -416,19 +416,19 @@ buildAndroidFlaskLocal(){
 # Builds and installs the Main iOS app for local development
 buildIosMainLocal(){
 	prebuild_ios
-	yarn expo run:ios --no-install --configuration Debug --port $WATCHER_PORT --scheme "MetaMask" --device $IOS_SIMULATOR
+	yarn expo run:ios --no-install --configuration Debug --port $WATCHER_PORT --scheme "MetaMask" --device "$IOS_SIMULATOR"
 }
 
 # Builds and installs the Flask iOS app for local development
 buildIosFlaskLocal(){
 	prebuild_ios
-	yarn expo run:ios --no-install --configuration Debug --port $WATCHER_PORT --scheme "MetaMask-Flask" --device $IOS_SIMULATOR
+	yarn expo run:ios --no-install --configuration Debug --port $WATCHER_PORT --scheme "MetaMask-Flask" --device "$IOS_SIMULATOR"
 }
 
 # Builds and installs the QA iOS app for local development
 buildIosQALocal(){
   	prebuild_ios
-	yarn expo run:ios --no-install --configuration Debug --port $WATCHER_PORT --scheme "MetaMask-QA" --device $IOS_SIMULATOR
+	yarn expo run:ios --no-install --configuration Debug --port $WATCHER_PORT --scheme "MetaMask-QA" --device "$IOS_SIMULATOR"
 }
 
 buildIosSimulatorE2E(){
@@ -800,5 +800,3 @@ elif [ "$PLATFORM" == "android" ]; then
 elif [ "$PLATFORM" == "watcher" ]; then
 	startWatcher
 fi
-	
-


### PR DESCRIPTION
## **Description**

Fixed shell script to properly quote `$IOS_SIMULATOR` variable, allowing simulator names with spaces to work correctly during iOS builds.

## **Changelog**

CHANGELOG entry: Fixed iOS build script to support simulator names containing spaces

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: iOS build with custom simulator name

  Scenario: user starts iOS build with simulator name containing spaces
    Given IOS_SIMULATOR is set to a name with spaces (e.g., "iPhone 15 Pro")

    When user runs yarn start:ios
    Then build should complete successfully without shell parsing errors
```

## **Screenshots/Recordings**

N/A - Build script fix only

### **Before**

Build would fail with shell parsing errors when `IOS_SIMULATOR` contained spaces

### **After**

Build succeeds with quoted variable properly handling spaces in simulator names

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Quotes `$IOS_SIMULATOR` in iOS local build commands so simulator names with spaces work for Main, Flask, and QA schemes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab8dc24ae69a17ca80cb0a1bf6b2a3b0b841788c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->