### PR TITLE
fix(ramp): payment method selector height

### DIFF
--- a/app/components/UI/Ramp/Aggregator/components/PaymentMethodSelectorModal/PaymentMethodSelectorModal.styles.ts
+++ b/app/components/UI/Ramp/Aggregator/components/PaymentMethodSelectorModal/PaymentMethodSelectorModal.styles.ts
@@ -15,7 +15,7 @@ const styleSheet = (params: {
 
   return StyleSheet.create({
     scrollView: {
-      height: screenHeight * 0.8,
+      maxHeight: screenHeight * 0.8,
     },
     content: {
       paddingHorizontal: 16,

--- a/app/components/UI/Ramp/Aggregator/components/PaymentMethodSelectorModal/__snapshots__/PaymentMethodSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/PaymentMethodSelectorModal/__snapshots__/PaymentMethodSelectorModal.test.tsx.snap
@@ -525,7 +525,7 @@ exports[`PaymentMethodSelectorModal renders correctly 1`] = `
                           <RCTScrollView
                             style={
                               {
-                                "height": 1067.2,
+                                "maxHeight": 1067.2,
                               }
                             }
                           >
@@ -1671,7 +1671,7 @@ exports[`PaymentMethodSelectorModal renders for sell flow 1`] = `
                           <RCTScrollView
                             style={
                               {
-                                "height": 1067.2,
+                                "maxHeight": 1067.2,
                               }
                             }
                           >
@@ -2817,7 +2817,7 @@ exports[`PaymentMethodSelectorModal renders without disclaimer when selected pay
                           <RCTScrollView
                             style={
                               {
-                                "height": 1067.2,
+                                "maxHeight": 1067.2,
                               }
                             }
                           >


### PR DESCRIPTION
## **Description**

This pull request updates the `PaymentMethodSelectorModal` component to use `maxHeight` instead of `height` for its scroll view container. This change ensures that the scroll view will not exceed a certain height but can shrink if its content is smaller, improving layout flexibility and preventing overflow issues. Related snapshot tests have also been updated to reflect this change.

**UI improvements:**

* Changed the scroll view style property from `height` to `maxHeight` in `PaymentMethodSelectorModal.styles.ts` to allow the scrollable area to be flexible and not always occupy the screen height.

**Test updates:**

* Updated snapshot tests to use `maxHeight` instead of `height` for the scroll view style in `PaymentMethodSelectorModal.test.tsx.snap` for all relevant test cases. [[1]](diffhunk://#diff-eda23322f2162d1d166cd767cda7e0882ebf9f8d2132bac06f3b86ed1e226cb6L528-R528) [[2]](diffhunk://#diff-eda23322f2162d1d166cd767cda7e0882ebf9f8d2132bac06f3b86ed1e226cb6L1674-R1674) [[3]](diffhunk://#diff-eda23322f2162d1d166cd767cda7e0882ebf9f8d2132bac06f3b86ed1e226cb6L2820-R2820)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Buy/Sell payment method selector

  Scenario: user selects a payment method
    Given is in the buy or sell feature

    When user opens the selector by tapping on the payment method
    Then the modal does not use the full height if not needed
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**





https://github.com/user-attachments/assets/35757cff-be39-4ae8-9f9e-7024fbd24ec3


### **After**

https://github.com/user-attachments/assets/3046e380-58ab-43b7-b87d-f7dc23a16a0b


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `scrollView` style from fixed `height` to `maxHeight` in `PaymentMethodSelectorModal` and updates related snapshots.
> 
> - **UI/Styles**:
>   - `app/components/UI/Ramp/Aggregator/components/PaymentMethodSelectorModal/PaymentMethodSelectorModal.styles.ts`: Change `scrollView` style from `height: screenHeight * 0.8` to `maxHeight: screenHeight * 0.8`.
> - **Tests**:
>   - Update snapshots in `__snapshots__/PaymentMethodSelectorModal.test.tsx.snap` to reflect `maxHeight` instead of `height` for the scroll view.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d68fd07d1852389b29c05ecd805df45e7d950b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->