### PR TITLE
refactor: tab empty state cleanup

### DIFF
--- a/app/components/UI/CollectibleContracts/index.js
+++ b/app/components/UI/CollectibleContracts/index.js
@@ -28,7 +28,6 @@ import {
   multichainCollectiblesByEnabledNetworksSelector,
 } from '../../../reducers/collectibles';
 import { removeFavoriteCollectible } from '../../../actions/collectibles';
-import AppConstants from '../../../core/AppConstants';
 import { areAddressesEqual } from '../../../util/address';
 import { compareTokenIds } from '../../../util/tokens';
 import CollectibleDetectionModal from '../CollectibleDetectionModal';
@@ -562,7 +561,7 @@ const CollectibleContracts = ({
     ],
   );
 
-  // TODO: Placeholder variable for now until we update the network enablement controller
+  // Placeholder variable for now until we update the network enablement controller
   const firstEnabledChainId = enabledNetworks[0]?.chainId || '';
   const networkImageSource = getNetworkImageSource({
     chainId: firstEnabledChainId,

--- a/app/components/UI/CollectibleContracts/index.js
+++ b/app/components/UI/CollectibleContracts/index.js
@@ -12,7 +12,7 @@ import {
   RefreshControl,
   ActivityIndicator,
 } from 'react-native';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
+
 import { FlashList } from '@shopify/flash-list';
 import { connect, useSelector } from 'react-redux';
 import { fontStyles } from '../../../styles/common';
@@ -176,7 +176,6 @@ const CollectibleContracts = ({
 }) => {
   // Start tracing component loading
   const isFirstRender = useRef(true);
-  const tw = useTailwind();
   if (isFirstRender.current) {
     trace({ name: TraceName.CollectibleContractsComponent });
   }
@@ -500,16 +499,21 @@ const CollectibleContracts = ({
 
   const renderEmpty = useCallback(
     () => (
-      <CollectiblesEmptyState
-        onDiscoverCollectibles={goToAddCollectible}
-        actionButtonProps={{
-          testID: WalletViewSelectorsIDs.IMPORT_NFT_BUTTON,
-          isDisabled: !isAddNFTEnabled,
-        }}
-        style={tw.style('mx-auto')}
-      />
+      <>
+        {!isNftFetchingProgress && (
+          <CollectiblesEmptyState
+            onAction={goToAddCollectible}
+            actionButtonProps={{
+              testID: WalletViewSelectorsIDs.IMPORT_NFT_BUTTON,
+              isDisabled: !isAddNFTEnabled,
+            }}
+            twClassName="mx-auto mt-4"
+            testID="collectibles-empty-state"
+          />
+        )}
+      </>
     ),
-    [goToAddCollectible, tw, isAddNFTEnabled],
+    [goToAddCollectible, isAddNFTEnabled, isNftFetchingProgress],
   );
 
   const renderList = useCallback(

--- a/app/components/UI/CollectiblesEmptyState/CollectiblesEmptyState.stories.tsx
+++ b/app/components/UI/CollectiblesEmptyState/CollectiblesEmptyState.stories.tsx
@@ -4,7 +4,7 @@ const CollectiblesEmptyStateMeta = {
   title: 'Components / UI / CollectiblesEmptyState',
   component: CollectiblesEmptyStateComponent,
   argTypes: {
-    onDiscoverCollectibles: { action: 'onDiscoverCollectibles' },
+    onAction: { action: 'onAction' },
   },
 };
 
@@ -12,9 +12,9 @@ export default CollectiblesEmptyStateMeta;
 
 export const Default = {
   args: {
-    onDiscoverCollectibles: () => {
+    onAcion: () => {
       // eslint-disable-next-line no-console
-      console.log('onDiscoverCollectibles');
+      console.log('onAction');
     },
   },
 };

--- a/app/components/UI/CollectiblesEmptyState/CollectiblesEmptyState.stories.tsx
+++ b/app/components/UI/CollectiblesEmptyState/CollectiblesEmptyState.stories.tsx
@@ -10,9 +10,9 @@ const CollectiblesEmptyStateMeta = {
 
 export default CollectiblesEmptyStateMeta;
 
-export const Default = {
+export const DefaultStory = {
   args: {
-    onAcion: () => {
+    onAction: () => {
       // eslint-disable-next-line no-console
       console.log('onAction');
     },

--- a/app/components/UI/CollectiblesEmptyState/CollectiblesEmptyState.test.tsx
+++ b/app/components/UI/CollectiblesEmptyState/CollectiblesEmptyState.test.tsx
@@ -24,15 +24,13 @@ describe('CollectiblesEmptyState', () => {
     // Button should not render when no onAction is provided
   });
 
-  it('calls onDiscoverCollectibles when action button is pressed', () => {
-    const mockOnDiscoverCollectibles = jest.fn();
+  it('calls onAction when action button is pressed', () => {
+    const mockOnAction = jest.fn();
     const { getByText } = renderWithProvider(
-      <CollectiblesEmptyState
-        onDiscoverCollectibles={mockOnDiscoverCollectibles}
-      />,
+      <CollectiblesEmptyState onAction={mockOnAction} />,
     );
 
     fireEvent.press(getByText('Import NFTs'));
-    expect(mockOnDiscoverCollectibles).toHaveBeenCalledTimes(1);
+    expect(mockOnAction).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/components/UI/CollectiblesEmptyState/CollectiblesEmptyState.tsx
+++ b/app/components/UI/CollectiblesEmptyState/CollectiblesEmptyState.tsx
@@ -10,12 +10,9 @@ import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import emptyStateNftsLight from '../../../images/empty-state-nfts-light.png';
 import emptyStateNftsDark from '../../../images/empty-state-nfts-dark.png';
 
-interface CollectiblesEmptyStateProps extends TabEmptyStateProps {
-  onDiscoverCollectibles?: () => void;
-}
+interface CollectiblesEmptyStateProps extends TabEmptyStateProps {}
 
 export const CollectiblesEmptyState: React.FC<CollectiblesEmptyStateProps> = ({
-  onDiscoverCollectibles,
   ...props
 }) => {
   const collectiblesImage = useAssetFromTheme(
@@ -34,7 +31,6 @@ export const CollectiblesEmptyState: React.FC<CollectiblesEmptyStateProps> = ({
       }
       description={strings('wallet.nft_empty_description')}
       actionButtonText={strings('wallet.discover_nfts')}
-      onAction={onDiscoverCollectibles}
       {...props}
     />
   );

--- a/app/components/UI/DeFiPositions/DeFiPositionsList.tsx
+++ b/app/components/UI/DeFiPositions/DeFiPositionsList.tsx
@@ -136,6 +136,7 @@ const DeFiPositionsList: React.FC<DeFiPositionsListProps> = () => {
     // No positions found for the current account
     return (
       <View testID={WalletViewSelectorsIDs.DEFI_POSITIONS_CONTAINER}>
+        <DeFiPositionsControlBar />
         <DefiEmptyState twClassName="mx-auto mt-4" />
       </View>
     );

--- a/app/components/UI/DeFiPositions/DeFiPositionsList.tsx
+++ b/app/components/UI/DeFiPositions/DeFiPositionsList.tsx
@@ -2,7 +2,6 @@ import React, { useMemo } from 'react';
 import { View, FlatList } from 'react-native';
 import { strings } from '../../../../locales/i18n';
 import { useSelector } from 'react-redux';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   selectChainId,
   selectIsAllNetworks,
@@ -41,7 +40,6 @@ export interface DeFiPositionsListProps {
 
 const DeFiPositionsList: React.FC<DeFiPositionsListProps> = () => {
   const { styles } = useStyles(styleSheet, undefined);
-  const tw = useTailwind();
   const isAllNetworks = useSelector(selectIsAllNetworks);
   const currentChainId = useSelector(selectChainId) as Hex;
   const tokenSortConfig = useSelector(selectTokenSortConfig);
@@ -138,8 +136,7 @@ const DeFiPositionsList: React.FC<DeFiPositionsListProps> = () => {
     // No positions found for the current account
     return (
       <View testID={WalletViewSelectorsIDs.DEFI_POSITIONS_CONTAINER}>
-        <DeFiPositionsControlBar />
-        <DefiEmptyState style={tw.style('mx-auto')} />
+        <DefiEmptyState twClassName="mx-auto mt-4" />
       </View>
     );
   }

--- a/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.styles.ts
@@ -9,12 +9,6 @@ const styleSheet = (params: { theme: Theme }) => {
     tradeInfoContainer: {
       paddingBottom: 12,
     },
-    firstTimeIcon: {
-      width: 48,
-      height: 48,
-      marginTop: 16,
-      marginBottom: 8,
-    },
     wrapper: {
       flex: 1,
       backgroundColor: colors.background.default,
@@ -25,7 +19,6 @@ const styleSheet = (params: { theme: Theme }) => {
     contentContainer: {
       flexGrow: 1,
     },
-    section: {},
     sectionHeader: {
       flexDirection: 'row',
       justifyContent: 'space-between',

--- a/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
@@ -254,8 +254,8 @@ const PerpsTabView: React.FC<PerpsTabViewProps> = () => {
               />
             ) : (
               <View style={styles.tradeInfoContainer}>
-                <View style={styles.section}>{renderPositionsSection()}</View>
-                <View style={styles.section}>{renderOrdersSection()}</View>
+                <View>{renderPositionsSection()}</View>
+                <View>{renderOrdersSection()}</View>
               </View>
             )}
           </View>

--- a/app/components/UI/Perps/components/PerpsLoadingSkeleton/PerpsLoadingSkeleton.tsx
+++ b/app/components/UI/Perps/components/PerpsLoadingSkeleton/PerpsLoadingSkeleton.tsx
@@ -55,6 +55,7 @@ const PerpsLoadingSkeleton: React.FC<PerpsLoadingSkeletonProps> = ({
     } catch (error) {
       // Error is handled by connection manager
       // The loading skeleton will either disappear (on success) or timeout will restart
+      console.warn('PerpsLoadingSkeleton: Reconnection failed:', error);
     }
   };
 

--- a/app/components/UI/Perps/components/PerpsLoadingSkeleton/PerpsLoadingSkeleton.tsx
+++ b/app/components/UI/Perps/components/PerpsLoadingSkeleton/PerpsLoadingSkeleton.tsx
@@ -7,9 +7,9 @@ import {
   BoxAlignItems,
   BoxJustifyContent,
   TextColor,
-  Button,
-  ButtonSize,
   ButtonVariant,
+  ButtonSize,
+  Button,
 } from '@metamask/design-system-react-native';
 import { useTheme } from '../../../../../util/theme';
 import { strings } from '../../../../../../locales/i18n';
@@ -91,8 +91,8 @@ const PerpsLoadingSkeleton: React.FC<PerpsLoadingSkeletonProps> = ({
           </Text>
           {/* Retry Button */}
           <Button
-            variant={ButtonVariant.Primary}
-            size={ButtonSize.Md}
+            variant={ButtonVariant.Secondary}
+            size={ButtonSize.Lg}
             onPress={handleRetry}
             testID={`${testID}-retry-button`}
           >


### PR DESCRIPTION
## **Description**

Some refactoring clean up to the empty state of tabs.

### Key Changes:
1. **Standardized CollectiblesEmptyState API** - Changed from custom `onDiscoverCollectibles` prop to standard `onAction` prop to match `TabEmptyState` interface
2. **Styling pattern cleanup** - Removed uncessary `useTailwind` imports in favor of `twClassName` props  
3. **Improved conditional rendering NFT tab** - Enhanced empty state rendering logic with loading state considerations

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A
## **Manual testing steps**

```gherkin
Feature: Empty state component standardization

  Scenario: user views NFT tab with no collectibles
    Given the user is on the NFT tab
    And there are no NFTs in the wallet
    When the page loads
    Then the empty state should display with "Import NFTs" button
    And the button should be functional

  Scenario: user views DeFi tab with no positions  
    Given the user is on the DeFi tab
    And there are no DeFi positions
    When the page loads
    Then the empty state should display without network selector
    And the proper spacing should be applied
```

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/4bbb84f2-a3be-4bc9-8dfd-1d3eafe0dded

### **After**

Some very small visual changes for edge cases that are better seen in code comments

https://github.com/user-attachments/assets/0153a417-3623-46db-951b-c5f3cf0318de

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes empty state APIs and styling, refines NFT/DeFi/Perps empty-state rendering, and tweaks Perps loading retry behavior.
> 
> - **UI Empty States**
>   - **API Standardization**: Replace `onDiscoverCollectibles` with `onAction` across `CollectiblesEmptyState` usage; update stories/tests accordingly.
>   - **Styling Cleanup**: Remove `useTailwind` usage in screens; switch component styling to `twClassName` props (e.g., `CollectiblesEmptyState`, `DefiEmptyState`).
> - **NFT Tab (`app/components/UI/CollectibleContracts/index.js`)**
>   - Render `CollectiblesEmptyState` only when `!isNftFetchingProgress`.
>   - Update empty state props: `onAction`, `twClassName`, add `testID`.
>   - Minor comment cleanup and dependency removals.
> - **DeFi Tab (`DeFiPositionsList.tsx`)**
>   - Replace inline Tailwind styles with `twClassName` on `DefiEmptyState`.
> - **Perps**
>   - Remove unused styles and simplify section wrappers in `PerpsTabView` and styles.
>   - `PerpsLoadingSkeleton`: change retry button to `variant=Secondary`, `size=Lg` and add reconnection failure warning log.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8103427d05b40c90da509bb00080feeca82da9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->