### PR TITLE
INFRA-2999-Fixes for create release workflows

### DIFF
--- a/.github/workflows/auto-create-release-pr.yml
+++ b/.github/workflows/auto-create-release-pr.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     uses: ./.github/workflows/create-release-pr.yml
     secrets:
       github-token: ${{ secrets.PR_TOKEN }}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Tested1: https://github.com/consensys-test/metamask-extension-test-workflow2/actions/runs/18100340079
Tested2: https://github.com/consensys-test/metamask-mobile-test-workflow/actions/runs/18165051064/job/51705108936 (failed before change) -> https://github.com/consensys-test/metamask-extension-test-workflow2/actions/runs/18100340079/job/51501418704 (passed after change)


Changed .github/scripts/resolve-previous-ref.sh
Before: Listed all release/* branches via paginated API calls; failed with “Exceeded maximum pagination limit (100 pages)” when too many branches existed.
After:
Tries the immediate previous minor branch directly (e.g., release/X.(Y-1).0) via a single branch check.
If not found, queries only the previous major’s release/<prev_major>.* branches and picks the highest non‑hotfix (patch == 0).
Hotfix behavior unchanged (patch > 0 → previous_ref='null').
Impact: Eliminates pagination failure, speeds up resolution, preserves expected previous_ref output.
Changed .github/workflows/auto-create-release-pr.yml
Before: The call-create-release-pr job failed validation because the nested reusable workflow requested id-token: write, but the caller only provided id-token: none.
After: Added id-token: write to the job’s permissions, allowing the nested workflow to obtain an OIDC token.
Impact: Fixes workflow validation error; the reusable workflow can run end‑to‑end.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolve previous release ref via direct previous-minor branch check with previous-major fallback; add id-token: write permission to the reusable workflow.
> 
> - **Scripts**:
>   - `./.github/scripts/resolve-previous-ref.sh`:
>     - Non-hotfix: check `release/<major>.<minor-1>.0` directly; if missing, query `release/<prev_major>.*`, keep patch `== 0`, pick highest.
>     - Keeps hotfix behavior (`previous_ref='null'`).
>     - Narrows API queries to specific prefixes and updates selection/logging.
> - **Workflows**:
>   - `./.github/workflows/auto-create-release-pr.yml`: add `id-token: write` to `call-create-release-pr` permissions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ba6d00797cf942fa510f15e1a97edfaa4ad5d8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->