### PR TITLE
chore: hide network selector in DeFi tab empty state

### DIFF
--- a/app/components/UI/DeFiPositions/DeFiPositionsList.test.tsx
+++ b/app/components/UI/DeFiPositions/DeFiPositionsList.test.tsx
@@ -214,6 +214,9 @@ describe('DeFiPositionsList', () => {
     expect(
       await findByTestId(WalletViewSelectorsIDs.DEFI_POSITIONS_CONTAINER),
     ).toBeOnTheScreen();
+    expect(
+      await findByTestId(WalletViewSelectorsIDs.DEFI_POSITIONS_NETWORK_FILTER),
+    ).toBeOnTheScreen();
     expect(await findByText('Protocol 1')).toBeOnTheScreen();
     expect(await findByText('$100.00')).toBeOnTheScreen();
 

--- a/app/components/UI/DeFiPositions/DeFiPositionsList.test.tsx
+++ b/app/components/UI/DeFiPositions/DeFiPositionsList.test.tsx
@@ -329,9 +329,6 @@ describe('DeFiPositionsList', () => {
       await findByTestId(WalletViewSelectorsIDs.DEFI_POSITIONS_CONTAINER),
     ).toBeOnTheScreen();
     expect(
-      await findByTestId(WalletViewSelectorsIDs.DEFI_POSITIONS_NETWORK_FILTER),
-    ).toBeOnTheScreen();
-    expect(
       await findByText(`Lend, borrow, and trade, right in your wallet.`),
     ).toBeOnTheScreen();
     expect(await findByText(`Explore DeFi`)).toBeOnTheScreen();
@@ -445,11 +442,6 @@ describe('DeFiPositionsList', () => {
 
       expect(
         await findByTestId(WalletViewSelectorsIDs.DEFI_POSITIONS_CONTAINER),
-      ).toBeOnTheScreen();
-      expect(
-        await findByTestId(
-          WalletViewSelectorsIDs.DEFI_POSITIONS_NETWORK_FILTER,
-        ),
       ).toBeOnTheScreen();
       expect(
         await findByText(`Lend, borrow, and trade, right in your wallet.`),

--- a/app/components/UI/DeFiPositions/DeFiPositionsList.tsx
+++ b/app/components/UI/DeFiPositions/DeFiPositionsList.tsx
@@ -2,7 +2,6 @@ import React, { useMemo } from 'react';
 import { View, FlatList } from 'react-native';
 import { strings } from '../../../../locales/i18n';
 import { useSelector } from 'react-redux';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   selectChainId,
   selectIsAllNetworks,
@@ -41,7 +40,6 @@ export interface DeFiPositionsListProps {
 
 const DeFiPositionsList: React.FC<DeFiPositionsListProps> = () => {
   const { styles } = useStyles(styleSheet, undefined);
-  const tw = useTailwind();
   const isAllNetworks = useSelector(selectIsAllNetworks);
   const currentChainId = useSelector(selectChainId) as Hex;
   const tokenSortConfig = useSelector(selectTokenSortConfig);
@@ -138,8 +136,7 @@ const DeFiPositionsList: React.FC<DeFiPositionsListProps> = () => {
     // No positions found for the current account
     return (
       <View testID={WalletViewSelectorsIDs.DEFI_POSITIONS_CONTAINER}>
-        <DeFiPositionsControlBar />
-        <DefiEmptyState style={tw.style('mx-auto')} />
+        <DefiEmptyState twClassName="mx-auto mt-4" />
       </View>
     );
   }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR hides the network selector (DeFiPositionsControlBar) when the DeFi tab is in its empty state (no DeFi positions available). 

**What is the reason for the change?**
The network selector provides no value when there are no DeFi positions to filter, creating unnecessary UI clutter in the empty state.

**What is the improvement/solution?**
- Removed the DeFiPositionsControlBar component from the empty state view
- Updated the DefiEmptyState component styling to be properly centered
- Updated unit tests to reflect the new behavior
- Cleaned up unused imports

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Hides network selector in empty state of the DeFi tab

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-228

## **Manual testing steps**

```gherkin
Feature: DeFi tab empty state display

  Scenario: user views DeFi tab with no positions
    Given the user has no DeFi positions on any network
    And the user is on the Wallet tab
    When user navigates to the DeFi tab
    Then the user should see the empty state message
    And the user should NOT see the network selector/filter
    And the empty state should be properly centered

  Scenario: user views DeFi tab with existing positions  
    Given the user has DeFi positions on one or more networks
    And the user is on the Wallet tab
    When user navigates to the DeFi tab
    Then the user should see their DeFi positions listed
    And the user should see the network selector/filter above the positions
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Network selector visible in empty state

https://github.com/user-attachments/assets/df8a04d3-0ce0-45ae-83d1-824812273e89

### **After**

Clean empty state without network selector

https://github.com/user-attachments/assets/b9d0eb5c-fdd3-4ce4-a398-0c572bd2d303

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>