### PR TITLE
feat: PerpsTransactionsSkeleton

### DIFF
--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx
@@ -23,6 +23,7 @@ import { PerpsNavigationParamList } from '../../types/navigation';
 
 // Import PerpsController hooks
 import PerpsTransactionItem from '../../components/PerpsTransactionItem';
+import PerpsTransactionsSkeleton from '../../components/PerpsTransactionsSkeleton';
 import { PERPS_TRANSACTIONS_HISTORY_CONSTANTS } from '../../constants/transactionsHistoryConfig';
 import {
   usePerpsConnection,
@@ -66,14 +67,22 @@ const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = () => {
     dependencies: [flatListData.length > 0],
   });
 
-  const { isConnected } = usePerpsConnection();
+  const { isConnected, isConnecting } = usePerpsConnection();
 
   // Use new hooks for data fetching
-  const { orderFills: fillsData, refresh: refreshFills } = usePerpsOrderFills({
+  const {
+    orderFills: fillsData,
+    isLoading: fillsLoading,
+    refresh: refreshFills,
+  } = usePerpsOrderFills({
     skipInitialFetch: !isConnected,
   });
 
-  const { orders: ordersData, refresh: refreshOrders } = usePerpsOrders({
+  const {
+    orders: ordersData,
+    isLoading: ordersLoading,
+    refresh: refreshOrders,
+  } = usePerpsOrders({
     skipInitialFetch: !isConnected,
   });
 
@@ -85,7 +94,11 @@ const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = () => {
     [], // Empty dependency array since we want this to be stable
   );
 
-  const { funding: fundingData, refresh: refreshFunding } = usePerpsFunding({
+  const {
+    funding: fundingData,
+    isLoading: fundingLoading,
+    refresh: refreshFunding,
+  } = usePerpsFunding({
     params: fundingParams,
     skipInitialFetch: !isConnected,
   });
@@ -369,6 +382,48 @@ const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = () => {
     return null;
   }, [activeFilter]);
 
+  // Determine if we should show loading skeleton
+  const isInitialLoading = useMemo(() =>
+    // Show loading if we're connecting or if any data sources are loading
+     isConnecting || fillsLoading || ordersLoading || fundingLoading
+  , [isConnecting, fillsLoading, ordersLoading, fundingLoading]);
+
+  // Determine if we should show empty state (only after loading is complete and no data)
+  const shouldShowEmptyState = useMemo(() => {
+    if (isInitialLoading) return false;
+    if (!isConnected) return false;
+
+    // Show empty state only if loading is complete and we have no data
+    return flatListData.length === 0;
+  }, [isInitialLoading, isConnected, flatListData.length]);
+
+  // Show loading skeleton during initial load
+  if (isInitialLoading) {
+    return (
+      <View style={styles.container}>
+        <View style={styles.filterContainer} pointerEvents="box-none">
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            style={styles.filterScrollView}
+            pointerEvents="auto"
+            scrollEnabled={false}
+          >
+            {filterTabs.map(renderFilterTab)}
+          </ScrollView>
+        </View>
+
+        {filterTabDescription && (
+          <View style={styles.tabDescription}>
+            <Text variant={TextVariant.BodySM}>{filterTabDescription}</Text>
+          </View>
+        )}
+
+        <PerpsTransactionsSkeleton testID="perps-transactions-loading-skeleton" />
+      </View>
+    );
+  }
+
   return (
     <View style={styles.container}>
       <View style={styles.filterContainer} pointerEvents="box-none">
@@ -397,7 +452,7 @@ const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = () => {
         getItemType={(item) =>
           item.type === 'header' ? 'header' : 'transaction'
         }
-        ListEmptyComponent={renderEmptyState}
+        ListEmptyComponent={shouldShowEmptyState ? renderEmptyState : null}
         refreshControl={
           <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
         }

--- a/app/components/UI/Perps/components/PerpsTransactionsSkeleton/PerpsTransactionsSkeleton.styles.ts
+++ b/app/components/UI/Perps/components/PerpsTransactionsSkeleton/PerpsTransactionsSkeleton.styles.ts
@@ -1,0 +1,55 @@
+import { StyleSheet } from 'react-native';
+import type { Theme } from '../../../../../util/theme/models';
+
+const styleSheet = (params: { theme: Theme }) => {
+  const { theme } = params;
+  const { colors } = theme;
+
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      paddingHorizontal: 16,
+    },
+    sectionHeader: {
+      paddingVertical: 12,
+      paddingHorizontal: 0,
+    },
+    sectionHeaderSkeleton: {
+      borderRadius: 4,
+    },
+    transactionItem: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: 12,
+      paddingHorizontal: 0,
+      borderBottomWidth: 1,
+      borderBottomColor: colors.border.muted,
+    },
+    tokenIconContainer: {
+      marginRight: 12,
+    },
+    tokenIcon: {
+      borderRadius: 18,
+    },
+    transactionContent: {
+      flex: 1,
+      justifyContent: 'center',
+    },
+    transactionTitle: {
+      marginBottom: 4,
+      borderRadius: 4,
+    },
+    transactionSubtitle: {
+      borderRadius: 4,
+    },
+    rightContent: {
+      alignItems: 'flex-end',
+      justifyContent: 'center',
+    },
+    rightContentSkeleton: {
+      borderRadius: 4,
+    },
+  });
+};
+
+export default styleSheet;

--- a/app/components/UI/Perps/components/PerpsTransactionsSkeleton/PerpsTransactionsSkeleton.test.tsx
+++ b/app/components/UI/Perps/components/PerpsTransactionsSkeleton/PerpsTransactionsSkeleton.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import PerpsTransactionsSkeleton from './PerpsTransactionsSkeleton';
+
+// Mock the useStyles hook
+jest.mock('../../../../../component-library/hooks', () => ({
+  useStyles: jest.fn(() => ({
+    styles: {
+      container: {},
+      sectionHeader: {},
+      sectionHeaderSkeleton: {},
+      transactionItem: {},
+      tokenIconContainer: {},
+      tokenIcon: {},
+      transactionContent: {},
+      transactionTitle: {},
+      transactionSubtitle: {},
+      rightContent: {},
+      rightContentSkeleton: {},
+    },
+  })),
+}));
+
+// Mock the Skeleton component
+jest.mock(
+  '../../../../../component-library/components/Skeleton/Skeleton',
+  () =>
+    function MockSkeleton({
+      testID,
+      ...props
+    }: {
+      testID?: string;
+      [key: string]: unknown;
+    }) {
+      return <div data-testid={testID} {...props} />;
+    },
+);
+
+describe('PerpsTransactionsSkeleton', () => {
+  it('renders loading skeleton with correct structure', () => {
+    render(<PerpsTransactionsSkeleton />);
+
+    // Should render the main container
+    expect(screen.getByTestId('perps-transactions-skeleton')).toBeOnTheScreen();
+  });
+
+  it('renders with custom testID', () => {
+    const customTestID = 'custom-skeleton-test-id';
+    render(<PerpsTransactionsSkeleton testID={customTestID} />);
+
+    expect(screen.getByTestId(customTestID)).toBeOnTheScreen();
+  });
+
+  it('renders multiple skeleton sections and transaction items', () => {
+    render(<PerpsTransactionsSkeleton />);
+
+    // Should render skeleton elements (mocked as div elements)
+    // The actual structure includes 2 sections with 3 transaction items each
+    const skeletonElements = screen.getAllByTestId(/skeleton/i);
+    expect(skeletonElements.length).toBeGreaterThan(0);
+  });
+});

--- a/app/components/UI/Perps/components/PerpsTransactionsSkeleton/PerpsTransactionsSkeleton.tsx
+++ b/app/components/UI/Perps/components/PerpsTransactionsSkeleton/PerpsTransactionsSkeleton.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { View } from 'react-native';
+import Skeleton from '../../../../../component-library/components/Skeleton/Skeleton';
+import { useStyles } from '../../../../../component-library/hooks';
+import styleSheet from './PerpsTransactionsSkeleton.styles';
+
+interface PerpsTransactionsSkeletonProps {
+  testID?: string;
+}
+
+/**
+ * PerpsTransactionsSkeleton - Loading skeleton for Perps transactions list
+ *
+ * Mimics the structure of the actual transaction list with:
+ * - Section headers
+ * - Transaction items with token logo, content, and right side content
+ */
+const PerpsTransactionsSkeleton: React.FC<PerpsTransactionsSkeletonProps> = ({
+  testID = 'perps-transactions-skeleton',
+}) => {
+  const { styles } = useStyles(styleSheet, {});
+
+  const renderSkeletonTransactionItem = () => (
+    <View style={styles.transactionItem} key="skeleton-transaction">
+      {/* Token logo skeleton */}
+      <View style={styles.tokenIconContainer}>
+        <Skeleton width={36} height={36} style={styles.tokenIcon} />
+      </View>
+
+      {/* Transaction content skeleton */}
+      <View style={styles.transactionContent}>
+        <Skeleton width={120} height={16} style={styles.transactionTitle} />
+        <Skeleton width={80} height={12} style={styles.transactionSubtitle} />
+      </View>
+
+      {/* Right content skeleton */}
+      <View style={styles.rightContent}>
+        <Skeleton width={60} height={14} style={styles.rightContentSkeleton} />
+      </View>
+    </View>
+  );
+
+  const renderSkeletonSection = (sectionIndex: number) => (
+    <View key={`skeleton-section-${sectionIndex}`}>
+      {/* Section header skeleton */}
+      <View style={styles.sectionHeader}>
+        <Skeleton
+          width={100}
+          height={16}
+          style={styles.sectionHeaderSkeleton}
+        />
+      </View>
+
+      {/* Transaction items skeleton */}
+      {Array.from({ length: 3 }, () => renderSkeletonTransactionItem())}
+    </View>
+  );
+
+  return (
+    <View style={styles.container} testID={testID}>
+      {/* Render 2 skeleton sections to mimic typical transaction list */}
+      {Array.from({ length: 2 }, (_, sectionIndex) =>
+        renderSkeletonSection(sectionIndex),
+      )}
+    </View>
+  );
+};
+
+export default PerpsTransactionsSkeleton;

--- a/app/components/UI/Perps/components/PerpsTransactionsSkeleton/index.ts
+++ b/app/components/UI/Perps/components/PerpsTransactionsSkeleton/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PerpsTransactionsSkeleton';


### PR DESCRIPTION
## **Description**

Adds a skeleton loader for when perps activity list is first loading. Only show empty state after activity is loaded, and there is no activity to show.

## **Changelog**

CHANGELOG entry: Add skeleton loader to perps activity screen

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1476

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

Filled state:

https://github.com/user-attachments/assets/ecd59c00-b0cc-4794-ae43-01752f02957a

Empty state:

https://github.com/user-attachments/assets/7de6e60b-60e6-4275-9676-dd0b80807a9d

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a loading skeleton to the perps transactions view and only shows the empty state after data finishes loading.
> 
> - **UI/Perps**:
>   - **Transactions View (`app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx`)**:
>     - Integrates loading state via `isConnecting`, `fillsLoading`, `ordersLoading`, `fundingLoading` to compute `isInitialLoading`.
>     - Renders `PerpsTransactionsSkeleton` during initial load; defers empty state using `shouldShowEmptyState` and conditional `ListEmptyComponent`.
>     - Keeps filter tabs and description visible while loading.
>   - **New Component**:
>     - `components/PerpsTransactionsSkeleton` (styles, index, tests) providing skeleton UI for section headers and transaction rows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdee6c7c15f4ff2ae49b5d1ce19f24c747182b54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->