### PR TITLE
test: fix numberKey.waitFor is not a function

### DIFF
--- a/wdio/screen-objects/AmountScreen.js
+++ b/wdio/screen-objects/AmountScreen.js
@@ -2,7 +2,7 @@ import AppwrightSelectors from '../../e2e/framework/AppwrightSelectors';
 import AppwrightGestures from '../../e2e/framework/AppwrightGestures';
 import Gestures from '../helpers/Gestures';
 import Selectors from '../helpers/Selectors';
-import { expect } from 'appwright';
+import { expect as appwrightExpect } from 'appwright';
 import {
   AMOUNT_ERROR,
   AMOUNT_SCREEN,
@@ -67,14 +67,14 @@ class AmountScreen {
     console.log('Amount digits:', digits);
     for (const digit of digits) {
       if (AppwrightSelectors.isAndroid(this._device)) {
-        const numberKey = AppwrightSelectors.getElementByXpath(this._device, `//android.widget.Button[@content-desc='${digit}']`)
-        await numberKey.waitFor('visible',{ timeout: 30000 });
+        const numberKey = await AppwrightSelectors.getElementByXpath(this._device, `//android.widget.Button[@content-desc='${digit}']`)
+        await appwrightExpect(numberKey).toBeVisible({ timeout: 30000 });
         await AppwrightGestures.tap(numberKey);
       }
       else {
-        const numberKey = AppwrightSelectors.getElementByXpath(this._device, `//XCUIElementTypeButton[@name="${digit}"]`);
-        await numberKey.waitFor('visible', { timeout: 30000 });
-        await AppwrightGestures.tap(numberKey); 
+        const numberKey = await AppwrightSelectors.getElementByXpath(this._device, `//XCUIElementTypeButton[@name="${digit}"]`);
+        await appwrightExpect(numberKey).toBeVisible({ timeout: 30000 });
+        await AppwrightGestures.tap(numberKey);
       }
     }
     }
@@ -95,7 +95,7 @@ class AmountScreen {
   }
 
   async tapOnNextButton() {
-    await AppwrightGestures.tap(this.nextButton);
+    await AppwrightGestures.tap(this.nextButton, );
   }
 
   async isVisible() {
@@ -104,7 +104,7 @@ class AmountScreen {
       await element.waitForDisplayed();
     } else {
       const element = await AppwrightSelectors.getElementByCatchAll(this._device, '25%');
-      await expect(element).toBeVisible();
+      await appwrightExpect(element).toBeVisible();
     }
   }
 }

--- a/wdio/screen-objects/BridgeScreen.js
+++ b/wdio/screen-objects/BridgeScreen.js
@@ -72,19 +72,19 @@ class BridgeScreen {
     for (const digit of digits) {
       if (AppwrightSelectors.isAndroid(this._device)) {
         if (digit != '.') {
-          const numberKey = AppwrightSelectors.getElementByXpath(this._device, `//android.widget.Button[@content-desc='${digit}']`)
-          await numberKey.waitFor('visible',{ timeout: 30000 });
+          const numberKey = await AppwrightSelectors.getElementByXpath(this._device, `//android.widget.Button[@content-desc='${digit}']`)
+          await appwrightExpect(numberKey).toBeVisible({ timeout: 30000 });
           await AppwrightGestures.tap(numberKey);
         }
         else {
-          const numberKey = AppwrightSelectors.getElementByXpath(this._device, `//android.view.View[@text="."]`);
-          await numberKey.waitFor('visible',{ timeout: 30000 });
+          const numberKey = await AppwrightSelectors.getElementByXpath(this._device, `//android.view.View[@text="."]`);
+          await appwrightExpect(numberKey).toBeVisible({ timeout: 30000 });
           await AppwrightGestures.tap(numberKey);
         }
       }
       else {
-        const numberKey = AppwrightSelectors.getElementByXpath(this._device, `//XCUIElementTypeButton[@name="${digit}"]`);
-        await numberKey.waitFor('visible', { timeout: 30000 });
+        const numberKey = await AppwrightSelectors.getElementByXpath(this._device, `//XCUIElementTypeButton[@name="${digit}"]`);
+        await appwrightExpect(numberKey).toBeVisible({ timeout: 30000 });
         await AppwrightGestures.tap(numberKey);
       }
     }
@@ -123,7 +123,7 @@ class BridgeScreen {
           console.log('Found token button by ID');
         }
       }
-      await tokenButton.waitFor('visible',{ timeout: 10000 });
+      await appwrightExpect(tokenButton).toBeVisible({ timeout: 10000 });
       console.log('Token button found and visible');
       
       console.log('About to hide keyboard...');
@@ -156,7 +156,7 @@ class BridgeScreen {
       // Check if number input field is available
       try {
         const testNumberButton = AppwrightSelectors.isIOS(this._device) ? await AppwrightSelectors.getElementByXpath(this._device, `//XCUIElementTypeButton[@name="1"]`) : await AppwrightSelectors.getElementByXpath(this._device, `//android.widget.Button[@content-desc='1']`);
-        await testNumberButton.waitFor('visible', { timeout: 5000 });
+        await appwrightExpect(testNumberButton).toBeVisible({ timeout: 5000 });
         console.log('Number input field is visible - token tap worked');
       } catch (error) {
         console.log('Number input field not visible - token tap may not have worked, trying alternative tap method...');

--- a/wdio/screen-objects/WalletMainScreen.js
+++ b/wdio/screen-objects/WalletMainScreen.js
@@ -232,8 +232,7 @@ class WalletMainScreen {
       await this.walletButton.waitForDisplayed();
     } else {
       const element = await this.walletButton;
-      await element.waitFor('visible',{ timeout: 10000 });
-      await appwrightExpect(element).toBeVisible();
+      await appwrightExpect(element).toBeVisible({ timeout: 10000 });
     }
   }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR addresses an error we saw with the performance e2e: numberKey.waitFor is not a function

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces `waitFor('visible')` with `appwrightExpect(...).toBeVisible()` and awaits selector retrieval in `AmountScreen`, `BridgeScreen`, and `WalletMainScreen`.
> 
> - **E2E Screen Objects**:
>   - `wdio/screen-objects/AmountScreen.js`:
>     - Use `appwrightExpect(...).toBeVisible()` instead of `waitFor('visible')` and alias `expect` import.
>     - Await xpath selector retrieval before interactions; update `isVisible()` to use appwright expect.
>   - `wdio/screen-objects/BridgeScreen.js`:
>     - Replace multiple `waitFor('visible')` checks with `appwrightExpect(...).toBeVisible()` for numeric keypad and token elements.
>     - Await selector lookups; maintain platform-specific paths; add visibility check after token tap via appwright expect.
>   - `wdio/screen-objects/WalletMainScreen.js`:
>     - Simplify `isMainWalletViewVisible()` to `appwrightExpect(element).toBeVisible({ timeout: 10000 })`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e63443258cbe2bf709fb3c577b1af66026cbfa4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->