### PR TITLE
fix: cp-7.56.1 recipient validation for internal accounts

### DIFF
--- a/app/components/Views/confirmations/hooks/send/useToAddressValidation.ts
+++ b/app/components/Views/confirmations/hooks/send/useToAddressValidation.ts
@@ -20,7 +20,7 @@ interface ValidationResult {
 }
 
 export const useToAddressValidation = () => {
-  const { chainId, to } = useSendContext();
+  const { asset, chainId, to } = useSendContext();
   const { isEvmSendType, isSolanaSendType } = useSendType();
   const { validateName } = useNameValidation();
   const [result, setResult] = useState<ValidationResult>({});
@@ -45,7 +45,11 @@ export const useToAddressValidation = () => {
         isEvmSendType &&
         isValidHexAddress(toAddress, { mixedCaseUseChecksum: true })
       ) {
-        return await validateHexAddress(toAddress, chainId as Hex);
+        return await validateHexAddress(
+          toAddress,
+          chainId as Hex,
+          asset?.address,
+        );
       }
 
       if (isSolanaSendType && isSolanaAddress(toAddress)) {
@@ -60,7 +64,7 @@ export const useToAddressValidation = () => {
         error: strings('send.invalid_address'),
       };
     },
-    [chainId, isEvmSendType, isSolanaSendType, validateName],
+    [asset, chainId, isEvmSendType, isSolanaSendType, validateName],
   );
 
   useEffect(() => {

--- a/app/components/Views/confirmations/hooks/send/useToAddressValidation.ts
+++ b/app/components/Views/confirmations/hooks/send/useToAddressValidation.ts
@@ -1,14 +1,10 @@
 import { Hex } from '@metamask/utils';
 import { isAddress as isSolanaAddress } from '@solana/addresses';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useSelector } from 'react-redux';
 
 import { strings } from '../../../../../../locales/i18n';
 import { isENS, isValidHexAddress } from '../../../../../util/address';
-import { selectAddressBook } from '../../../../../selectors/addressBookController';
-import { selectInternalAccounts } from '../../../../../selectors/accountsController';
 import {
-  shouldSkipValidation,
   validateHexAddress,
   validateSolanaAddress,
 } from '../../utils/send-address-validations';
@@ -24,8 +20,6 @@ interface ValidationResult {
 }
 
 export const useToAddressValidation = () => {
-  const internalAccounts = useSelector(selectInternalAccounts);
-  const addressBook = useSelector(selectAddressBook);
   const { chainId, to } = useSendContext();
   const { isEvmSendType, isSolanaSendType } = useSendType();
   const { validateName } = useNameValidation();
@@ -34,22 +28,16 @@ export const useToAddressValidation = () => {
   const prevAddressValidated = useRef<string>();
   const unmountedRef = useRef(false);
 
-  useEffect(() => () => {
+  useEffect(
+    () => () => {
       unmountedRef.current = true;
-    }, []);
+    },
+    [],
+  );
 
   const validateToAddress = useCallback(
     async (toAddress?: string) => {
-      if (
-        !toAddress ||
-        !chainId ||
-        shouldSkipValidation({
-          toAddress,
-          chainId,
-          addressBook,
-          internalAccounts,
-        })
-      ) {
+      if (!toAddress || !chainId) {
         return {};
       }
 
@@ -72,14 +60,7 @@ export const useToAddressValidation = () => {
         error: strings('send.invalid_address'),
       };
     },
-    [
-      addressBook,
-      chainId,
-      internalAccounts,
-      isEvmSendType,
-      isSolanaSendType,
-      validateName,
-    ],
+    [chainId, isEvmSendType, isSolanaSendType, validateName],
   );
 
   useEffect(() => {

--- a/app/components/Views/confirmations/utils/send-address-validations.test.ts
+++ b/app/components/Views/confirmations/utils/send-address-validations.test.ts
@@ -1,12 +1,8 @@
-import { AddressBookControllerState } from '@metamask/address-book-controller';
-import { InternalAccount } from '@metamask/keyring-internal-api';
-
 import Engine from '../../../../core/Engine';
 // eslint-disable-next-line import/no-namespace
 import * as ConfusablesUtils from '../../../../util/confusables';
 import {
   getConfusableCharacterInfo,
-  shouldSkipValidation,
   validateHexAddress,
   validateSolanaAddress,
 } from './send-address-validations';
@@ -21,75 +17,6 @@ jest.mock('../../../../core/Engine', () => ({
     },
   },
 }));
-
-interface ShouldSkipValidationArgs {
-  toAddress?: string;
-  chainId?: string;
-  addressBook: AddressBookControllerState['addressBook'];
-  internalAccounts: InternalAccount[];
-}
-
-describe('shouldSkipValidation', () => {
-  it('returns true if to address is not defined', () => {
-    expect(
-      shouldSkipValidation({
-        toAddress: undefined,
-      } as unknown as ShouldSkipValidationArgs),
-    ).toStrictEqual(true);
-    expect(
-      shouldSkipValidation({
-        toAddress: null,
-      } as unknown as ShouldSkipValidationArgs),
-    ).toStrictEqual(true);
-    expect(
-      shouldSkipValidation({
-        toAddress: '',
-      } as unknown as ShouldSkipValidationArgs),
-    ).toStrictEqual(true);
-  });
-  it('returns true if to address is present in address book', () => {
-    expect(
-      shouldSkipValidation({
-        toAddress: '0x935E73EDb9fF52E23BaC7F7e043A1ecD06d05477',
-        chainId: '0x1',
-        addressBook: {},
-        internalAccounts: [],
-      } as unknown as ShouldSkipValidationArgs),
-    ).toStrictEqual(false);
-    expect(
-      shouldSkipValidation({
-        toAddress: '0x935E73EDb9fF52E23BaC7F7e043A1ecD06d05477',
-        chainId: '0x1',
-        addressBook: {
-          '0x1': {
-            '0x935E73EDb9fF52E23BaC7F7e043A1ecD06d05477': {},
-          },
-        },
-        internalAccounts: [],
-      } as unknown as ShouldSkipValidationArgs),
-    ).toStrictEqual(true);
-  });
-  it('returns true if to address is an internal account', () => {
-    expect(
-      shouldSkipValidation({
-        toAddress: '0x935E73EDb9fF52E23BaC7F7e043A1ecD06d05477',
-        chainId: '0x1',
-        addressBook: {},
-        internalAccounts: [],
-      } as unknown as ShouldSkipValidationArgs),
-    ).toStrictEqual(false);
-    expect(
-      shouldSkipValidation({
-        toAddress: '0x935E73EDb9fF52E23BaC7F7e043A1ecD06d05477',
-        chainId: '0x1',
-        addressBook: {},
-        internalAccounts: [
-          { address: '0x935E73EDb9fF52E23BaC7F7e043A1ecD06d05477' },
-        ],
-      } as unknown as ShouldSkipValidationArgs),
-    ).toStrictEqual(true);
-  });
-});
 
 describe('validateHexAddress', () => {
   it('returns error if address is burn address', async () => {

--- a/app/components/Views/confirmations/utils/send-address-validations.test.ts
+++ b/app/components/Views/confirmations/utils/send-address-validations.test.ts
@@ -72,7 +72,7 @@ describe('validateHexAddress', () => {
         '0x1',
       ),
     ).toStrictEqual({
-      warning:
+      error:
         'This address is a token contract address. If you send tokens to this address, you will lose them.',
     });
   });

--- a/app/components/Views/confirmations/utils/send-address-validations.test.ts
+++ b/app/components/Views/confirmations/utils/send-address-validations.test.ts
@@ -57,7 +57,10 @@ describe('validateHexAddress', () => {
         '0x1',
         '0xdB055877e6c13b6A6B25aBcAA29B393777dD0a73',
       ),
-    ).toStrictEqual({ error: 'send.contractAddressError' });
+    ).toStrictEqual({
+      error:
+        "You are sending tokens to the token's contract address. This may result in the loss of these tokens.",
+    });
   });
   it('returns warning if address is contract address', async () => {
     mockMemoizedGetTokenStandardAndDetails.mockResolvedValue({

--- a/app/components/Views/confirmations/utils/send-address-validations.ts
+++ b/app/components/Views/confirmations/utils/send-address-validations.ts
@@ -55,7 +55,7 @@ export const validateHexAddress = async (
           warning: strings('send.token_contract_warning'),
         };
       }
-    } catch (e) {
+    } catch {
       // Not a token address
     }
   }

--- a/app/components/Views/confirmations/utils/send-address-validations.ts
+++ b/app/components/Views/confirmations/utils/send-address-validations.ts
@@ -32,7 +32,7 @@ export const validateHexAddress = async (
 
   if (toAddress?.toLowerCase() === assetAddress?.toLowerCase()) {
     return {
-      error: 'send.contractAddressError',
+      error: strings('send.contractAddressError'),
     };
   }
 

--- a/app/components/Views/confirmations/utils/send-address-validations.ts
+++ b/app/components/Views/confirmations/utils/send-address-validations.ts
@@ -52,7 +52,7 @@ export const validateHexAddress = async (
       });
       if (token?.standard) {
         return {
-          warning: strings('send.token_contract_warning'),
+          error: strings('send.token_contract_warning'),
         };
       }
     } catch {

--- a/app/components/Views/confirmations/utils/send-address-validations.ts
+++ b/app/components/Views/confirmations/utils/send-address-validations.ts
@@ -1,57 +1,14 @@
-import { AddressBookControllerState } from '@metamask/address-book-controller';
 import { Hex } from '@metamask/utils';
-import { InternalAccount } from '@metamask/keyring-internal-api';
 import { isAddress as isSolanaAddress } from '@solana/addresses';
 
 import { strings } from '../../../../../locales/i18n';
 import Engine from '../../../../core/Engine';
-import {
-  areAddressesEqual,
-  isValidHexAddress,
-  toChecksumAddress,
-} from '../../../../util/address';
+import { toChecksumAddress } from '../../../../util/address';
 import {
   collectConfusables,
   getConfusablesExplanations,
   hasZeroWidthPoints,
 } from '../../../../util/confusables';
-
-export const shouldSkipValidation = ({
-  toAddress,
-  chainId,
-  addressBook,
-  internalAccounts,
-}: {
-  toAddress?: string;
-  chainId?: string;
-  addressBook: AddressBookControllerState['addressBook'];
-  internalAccounts: InternalAccount[];
-}): boolean => {
-  if (!toAddress || !chainId) {
-    return true;
-  }
-  const address = isValidHexAddress(toAddress, { mixedCaseUseChecksum: true })
-    ? toChecksumAddress(toAddress)
-    : toAddress;
-
-  // address is present in address book
-  // address book is supported for Evm accounts only
-  const existingContact =
-    address && chainId && addressBook[chainId as Hex]?.[address];
-  if (existingContact) {
-    return true;
-  }
-
-  // sending to an internal account
-  const internalAccount = internalAccounts.find((account) =>
-    areAddressesEqual(account.address, address),
-  );
-  if (internalAccount) {
-    return true;
-  }
-
-  return false;
-};
 
 const LOWER_CASED_BURN_ADDRESSES = [
   '0x0000000000000000000000000000000000000000',

--- a/app/util/test/utils.js
+++ b/app/util/test/utils.js
@@ -26,8 +26,8 @@ export const isTest =
   process.env.METAMASK_ENVIRONMENT !== 'beta' &&
   process.env.METAMASK_ENVIRONMENT !== 'rc' &&
   process.env.METAMASK_ENVIRONMENT !== 'exp';
-export const isE2E =
-  process.env.IS_TEST === 'true' || process.env.METAMASK_ENVIRONMENT === 'e2e';
+export const isE2E = true;
+// process.env.IS_TEST === 'true' || process.env.METAMASK_ENVIRONMENT === 'e2e';
 export const enableApiCallLogs = process.env.LOG_API_CALLS === 'true';
 export const getFixturesServerPortInApp = () =>
   testConfig.fixtureServerPort ?? FIXTURE_SERVER_PORT;

--- a/app/util/test/utils.js
+++ b/app/util/test/utils.js
@@ -26,8 +26,8 @@ export const isTest =
   process.env.METAMASK_ENVIRONMENT !== 'beta' &&
   process.env.METAMASK_ENVIRONMENT !== 'rc' &&
   process.env.METAMASK_ENVIRONMENT !== 'exp';
-export const isE2E = true;
-// process.env.IS_TEST === 'true' || process.env.METAMASK_ENVIRONMENT === 'e2e';
+export const isE2E =
+  process.env.IS_TEST === 'true' || process.env.METAMASK_ENVIRONMENT === 'e2e';
 export const enableApiCallLogs = process.env.LOG_API_CALLS === 'true';
 export const getFixturesServerPortInApp = () =>
   testConfig.fixtureServerPort ?? FIXTURE_SERVER_PORT;

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -575,7 +575,8 @@
     "token_contract_warning": "This address is a token contract address. If you send tokens to this address, you will lose them.",
     "invisible_character_error": "We detected an invisible character in the ENS name. Check the ENS name to avoid a potential scam.",
     "could_not_resolve_name": "Couldn't resolve name",
-    "invalid_address": "Invalid address"
+    "invalid_address": "Invalid address",
+    "contractAddressError": "You are sending tokens to the token's contract address. This may result in the loss of these tokens."
   },
   "deposit": {
     "title": "Deposit",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

fix: recipient validation for internal accounts

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5931

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**
TODO

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens send recipient validation by removing skip logic, passing asset to EVM checks, and blocking token/asset contract addresses; updates tests and locales.
> 
> - **Send validation**:
>   - Update `useToAddressValidation` to stop using `shouldSkipValidation`, remove address book/internal account shortcuts, and read `asset` from context; pass `asset?.address` to `validateHexAddress`.
>   - Clean up effects/deps; only early-return on missing `toAddress`/`chainId`.
> - **Address checks** (`app/components/Views/confirmations/utils/send-address-validations.ts`):
>   - Remove `shouldSkipValidation` and related imports.
>   - Extend `validateHexAddress(toAddress, chainId, assetAddress?)`:
>     - Error if `toAddress` equals `assetAddress` via `send.contractAddressError`.
>     - Detect contract addresses via `memoizedGetTokenStandardAndDetails`; return `send.token_contract_warning` as an error (not warning).
> - **Tests** (`send-address-validations.test.ts`):
>   - Remove `shouldSkipValidation` tests; mock `./token`.
>   - Add test for asset contract address error and update contract address check to expect an error.
> - **Locales** (`locales/languages/en.json`):
>   - Add `send.contractAddressError` string; minor JSON comma fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d61eb599f29d37231e556ef3ee74a7bb228f7fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->