### PR TITLE
test: skip dorny on scheduled runs

### DIFF
--- a/.github/workflows/needs-e2e-build.yml
+++ b/.github/workflows/needs-e2e-build.yml
@@ -68,6 +68,7 @@ jobs:
 
       - name: Paths filter (Android/iOS impact)
         id: filter
+        if: github.event_name != 'schedule'
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         with:
           filters: |
@@ -126,6 +127,6 @@ jobs:
           ANDROID="${{ steps.filter.outputs.android }}" \
           IOS="${{ steps.filter.outputs.ios }}" \
           SHARED="${{ steps.filter.outputs.shared }}" \
-          IGNORE_FILES="${{ steps.filter.outputs.ignore_files }}" \
-          CATCH_ALL_FILES="${{ steps.filter.outputs.catch_all_files }}" \
+          IGNORE_FILES="${{ github.event_name == 'schedule' && '' || steps.filter.outputs.ignore_files }}" \
+          CATCH_ALL_FILES="${{ github.event_name == 'schedule' && '' || steps.filter.outputs.catch_all_files }}" \
           node .github/scripts/needs-e2e-builds.mjs

--- a/.github/workflows/needs-e2e-build.yml
+++ b/.github/workflows/needs-e2e-build.yml
@@ -121,11 +121,28 @@ jobs:
         id: set-outputs
         run: |
           # Compute outputs using Node script
-          GITHUB_EVENT_NAME="${{ github.event_name }}" \
-          SHOULD_SKIP_E2E="${{ steps.skip-tag.outputs.SKIP == 'true' || steps.skip-label.outputs.SKIP == 'true' }}" \
-          ANDROID="${{ github.event_name == 'schedule' && '' || steps.filter.outputs.android }}" \
-          IOS="${{ github.event_name == 'schedule' && '' || steps.filter.outputs.ios }}" \
-          SHARED="${{ github.event_name == 'schedule' && '' || steps.filter.outputs.shared }}" \
-          IGNORE_FILES="${{ github.event_name == 'schedule' && '' || steps.filter.outputs.ignore_files }}" \
-          CATCH_ALL_FILES="${{ github.event_name == 'schedule' && '' || steps.filter.outputs.catch_all_files }}" \
+          GITHUB_EVENT_NAME="${{ github.event_name }}"
+          SHOULD_SKIP_E2E="${{ steps.skip-tag.outputs.SKIP == 'true' || steps.skip-label.outputs.SKIP == 'true' }}"
+
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            ANDROID=""
+            IOS=""
+            SHARED=""
+            IGNORE_FILES=""
+            CATCH_ALL_FILES=""
+          else
+            ANDROID="${{ steps.filter.outputs.android }}"
+            IOS="${{ steps.filter.outputs.ios }}"
+            SHARED="${{ steps.filter.outputs.shared }}"
+            IGNORE_FILES="${{ steps.filter.outputs.ignore_files }}"
+            CATCH_ALL_FILES="${{ steps.filter.outputs.catch_all_files }}"
+          fi
+
+          GITHUB_EVENT_NAME="$GITHUB_EVENT_NAME" \
+          SHOULD_SKIP_E2E="$SHOULD_SKIP_E2E" \
+          ANDROID="$ANDROID" \
+          IOS="$IOS" \
+          SHARED="$SHARED" \
+          IGNORE_FILES="$IGNORE_FILES" \
+          CATCH_ALL_FILES="$CATCH_ALL_FILES" \
           node .github/scripts/needs-e2e-builds.mjs

--- a/.github/workflows/needs-e2e-build.yml
+++ b/.github/workflows/needs-e2e-build.yml
@@ -68,7 +68,6 @@ jobs:
 
       - name: Paths filter (Android/iOS impact)
         id: filter
-        if: github.event_name != 'schedule'
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         with:
           filters: |
@@ -124,9 +123,9 @@ jobs:
           # Compute outputs using Node script
           GITHUB_EVENT_NAME="${{ github.event_name }}" \
           SHOULD_SKIP_E2E="${{ steps.skip-tag.outputs.SKIP == 'true' || steps.skip-label.outputs.SKIP == 'true' }}" \
-          ANDROID="${{ steps.filter.outputs.android }}" \
-          IOS="${{ steps.filter.outputs.ios }}" \
-          SHARED="${{ steps.filter.outputs.shared }}" \
+          ANDROID="${{ github.event_name == 'schedule' && '' || steps.filter.outputs.android }}" \
+          IOS="${{ github.event_name == 'schedule' && '' || steps.filter.outputs.ios }}" \
+          SHARED="${{ github.event_name == 'schedule' && '' || steps.filter.outputs.shared }}" \
           IGNORE_FILES="${{ github.event_name == 'schedule' && '' || steps.filter.outputs.ignore_files }}" \
           CATCH_ALL_FILES="${{ github.event_name == 'schedule' && '' || steps.filter.outputs.catch_all_files }}" \
           node .github/scripts/needs-e2e-builds.mjs


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Disable dorny path filtering on scheduled runs and pass empty IGNORE_FILES/CATCH_ALL_FILES to the Node script when github.event_name == 'schedule'. This prevents “Argument list too long” errors and removes misleading dorny warnings during schedules, while keeping the script’s behavior to emit no builds/changed files on schedules. Behavior for PRs and pushes is unchanged.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> For scheduled runs, skip dorny outputs and pass empty file lists to the Node script, avoiding long-arg issues while keeping PR/push behavior unchanged.
> 
> - **GitHub Actions**:
>   - **` .github/workflows/needs-e2e-build.yml`**:
>     - In `Set final outputs`, add conditional handling for `schedule` events:
>       - Set `ANDROID`, `IOS`, `SHARED`, `IGNORE_FILES`, `CATCH_ALL_FILES` to empty when `github.event_name == 'schedule'`; otherwise use `dorny/paths-filter` outputs.
>       - Compute and pass `GITHUB_EVENT_NAME` and `SHOULD_SKIP_E2E` along with the (possibly empty) vars to `node .github/scripts/needs-e2e-builds.mjs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59d96794d8081c1ff95085279d6c44aefdc6ab89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->