### PR TITLE
refactor: Refactor subject metadata controller to use modular init pattern

### DIFF
--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -10,7 +10,6 @@ import {
 import {
   AccountTrackerController,
   AssetsContractController,
-  CodefiTokenPricesServiceV2,
   NftController,
   NftDetectionController,
   TokenBalancesController,
@@ -18,6 +17,7 @@ import {
   TokenListController,
   TokenRatesController,
   TokensController,
+  CodefiTokenPricesServiceV2,
   TokenSearchDiscoveryDataController,
 } from '@metamask/assets-controllers';
 import { AccountsController } from '@metamask/accounts-controller';
@@ -26,7 +26,9 @@ import { ComposableController } from '@metamask/composable-controller';
 import {
   KeyringController,
   KeyringControllerState,
+  ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
   KeyringTypes,
+  ///: END:ONLY_INCLUDE_IF
 } from '@metamask/keyring-controller';
 import {
   getDefaultNetworkControllerState,
@@ -47,7 +49,9 @@ import {
   type CaveatSpecificationConstraint,
   PermissionController,
   type PermissionSpecificationConstraint,
+  ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
   SubjectMetadataController,
+  ///: END:ONLY_INCLUDE_IF
 } from '@metamask/permission-controller';
 import SwapsController, { swapsUtils } from '@metamask/swaps-controller';
 import { PPOMController } from '@metamask/ppom-validator';
@@ -65,23 +69,23 @@ import {
 import { Encryptor, LEGACY_DERIVATION_OPTIONS, pbkdf2 } from '../Encryptor';
 import { getDecimalChainId, isTestNet } from '../../util/networks';
 import {
-  deprecatedGetNetworkId,
   fetchEstimatedMultiLayerL1Fee,
+  deprecatedGetNetworkId,
 } from '../../util/networks/engineNetworkUtils';
 import AppConstants from '../AppConstants';
 import { store } from '../../store';
 import {
-  balanceToFiatNumber,
-  hexToBN,
   renderFromTokenMinimalUnit,
-  renderFromWei,
-  toHexadecimal,
+  balanceToFiatNumber,
   weiToFiatNumber,
+  toHexadecimal,
+  hexToBN,
+  renderFromWei,
 } from '../../util/number';
 import NotificationManager from '../NotificationManager';
 import Logger from '../../util/Logger';
 import { isZero } from '../../util/lodash';
-import { MetaMetrics, MetaMetricsEvents } from '../Analytics';
+import { MetaMetricsEvents, MetaMetrics } from '../Analytics';
 
 ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
 import { calculateScryptKey } from './controllers/identity/calculate-scrypt-key';
@@ -110,7 +114,13 @@ import { selectBasicFunctionalityEnabled } from '../../selectors/settings';
 import { selectSwapsChainFeatureFlags } from '../../reducers/swaps';
 import { ClientId } from '@metamask/smart-transactions-controller/dist/types';
 import { zeroAddress } from 'ethereumjs-util';
-import { ChainId, toHex, type TraceCallback } from '@metamask/controller-utils';
+import {
+  ChainId,
+  type TraceCallback,
+  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+  toHex,
+  ///: END:ONLY_INCLUDE_IF
+} from '@metamask/controller-utils';
 import { ExtendedControllerMessenger } from '../ExtendedControllerMessenger';
 import {
   MetaMetricsEventCategory,
@@ -135,20 +145,20 @@ import { multichainAccountServiceInit } from './controllers/multichain-account-s
 import {
   cronjobControllerInit,
   executionServiceInit,
-  SnapControllerGetSnapAction,
-  SnapControllerHandleRequestAction,
   snapControllerInit,
-  SnapControllerIsMinimumPlatformVersionAction,
   snapInterfaceControllerInit,
   snapsRegistryInit,
+  SnapControllerGetSnapAction,
+  SnapControllerIsMinimumPlatformVersionAction,
+  SnapControllerHandleRequestAction,
 } from './controllers/snaps';
 import { RestrictedMethods } from '../Permissions/constants';
 ///: END:ONLY_INCLUDE_IF
 import { MetricsEventBuilder } from '../Analytics/MetricsEventBuilder';
 import {
   BaseControllerMessenger,
-  EngineContext,
   EngineState,
+  EngineContext,
   StatefulControllers,
 } from './types';
 import {
@@ -189,8 +199,8 @@ import { SECOND } from '../../constants/time';
 import { getIsQuicknodeEndpointUrl } from './controllers/network-controller/utils';
 import {
   MultichainRouter,
-  MultichainRouterArgs,
   MultichainRouterMessenger,
+  MultichainRouterArgs,
 } from '@metamask/snaps-controllers';
 import { ErrorReportingService } from '@metamask/error-reporting-service';
 import { captureException } from '@sentry/react-native';

--- a/app/core/Engine/controllers/subject-metadata-controller-init.test.ts
+++ b/app/core/Engine/controllers/subject-metadata-controller-init.test.ts
@@ -1,0 +1,43 @@
+import { buildControllerInitRequestMock } from '../utils/test-utils';
+import { ExtendedControllerMessenger } from '../../ExtendedControllerMessenger';
+import {
+  getSubjectMetadataControllerMessenger,
+  type SubjectMetadataControllerMessenger,
+} from '../messengers/subject-metadata-controller-messenger';
+import { ControllerInitRequest } from '../types';
+import { subjectMetadataControllerInit } from './subject-metadata-controller-init';
+import { SubjectMetadataController } from '@metamask/permission-controller';
+
+jest.mock('@metamask/permission-controller');
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<SubjectMetadataControllerMessenger>
+> {
+  const baseMessenger = new ExtendedControllerMessenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(baseMessenger),
+    controllerMessenger: getSubjectMetadataControllerMessenger(baseMessenger),
+    initMessenger: undefined,
+  };
+
+  return requestMock;
+}
+
+describe('SubjectMetadataControllerInit', () => {
+  it('initializes the controller', () => {
+    const { controller } = subjectMetadataControllerInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(SubjectMetadataController);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    subjectMetadataControllerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(SubjectMetadataController);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      state: {},
+      subjectCacheLimit: 100,
+    });
+  });
+});

--- a/app/core/Engine/controllers/subject-metadata-controller-init.ts
+++ b/app/core/Engine/controllers/subject-metadata-controller-init.ts
@@ -1,0 +1,26 @@
+import { ControllerInitFunction } from '../types';
+import { SubjectMetadataController } from '@metamask/permission-controller';
+import { SubjectMetadataControllerMessenger } from '../messengers/subject-metadata-controller-messenger';
+
+/**
+ * Initialize the subject metadata controller.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @param request.persistedState - The persisted state of the extension.
+ * @returns The initialized controller.
+ */
+export const subjectMetadataControllerInit: ControllerInitFunction<
+  SubjectMetadataController,
+  SubjectMetadataControllerMessenger
+> = ({ controllerMessenger, persistedState }) => {
+  const controller = new SubjectMetadataController({
+    messenger: controllerMessenger,
+    state: persistedState.SubjectMetadataController || {},
+    subjectCacheLimit: 100,
+  });
+
+  return {
+    controller,
+  };
+};

--- a/app/core/Engine/messengers/index.ts
+++ b/app/core/Engine/messengers/index.ts
@@ -49,6 +49,7 @@ import {
   getPermissionControllerInitMessenger,
   getPermissionControllerMessenger,
 } from './permission-controller-messenger';
+import { getSubjectMetadataControllerMessenger } from './subject-metadata-controller-messenger';
 
 /**
  * The messengers for the controllers that have been.
@@ -121,6 +122,10 @@ export const CONTROLLER_MESSENGERS = {
   },
   NotificationServicesPushController: {
     getMessenger: getNotificationServicesPushControllerMessenger,
+    getInitMessenger: noop,
+  },
+  SubjectMetadataController: {
+    getMessenger: getSubjectMetadataControllerMessenger,
     getInitMessenger: noop,
   },
   WebSocketService: {

--- a/app/core/Engine/messengers/subject-metadata-controller-messenger.test.ts
+++ b/app/core/Engine/messengers/subject-metadata-controller-messenger.test.ts
@@ -1,0 +1,14 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import { getSubjectMetadataControllerMessenger } from './subject-metadata-controller-messenger';
+
+describe('getSubjectMetadataControllerMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const subjectMetadataControllerMessenger =
+      getSubjectMetadataControllerMessenger(messenger);
+
+    expect(subjectMetadataControllerMessenger).toBeInstanceOf(
+      RestrictedMessenger,
+    );
+  });
+});

--- a/app/core/Engine/messengers/subject-metadata-controller-messenger.ts
+++ b/app/core/Engine/messengers/subject-metadata-controller-messenger.ts
@@ -1,0 +1,27 @@
+import { Messenger } from '@metamask/base-controller';
+import { HasPermissions } from '@metamask/permission-controller';
+
+type AllowedActions = HasPermissions;
+
+type AllowedEvents = never;
+
+export type SubjectMetadataControllerMessenger = ReturnType<
+  typeof getSubjectMetadataControllerMessenger
+>;
+
+/**
+ * Get a messenger restricted to the actions and events that the
+ * subject metadata controller is allowed to handle.
+ *
+ * @param messenger - The controller messenger to restrict.
+ * @returns The restricted controller messenger.
+ */
+export function getSubjectMetadataControllerMessenger(
+  messenger: Messenger<AllowedActions, AllowedEvents>,
+) {
+  return messenger.getRestricted({
+    name: 'SubjectMetadataController',
+    allowedActions: ['PermissionController:hasPermissions'],
+    allowedEvents: [],
+  });
+}

--- a/app/core/Engine/types.ts
+++ b/app/core/Engine/types.ts
@@ -680,6 +680,7 @@ export type ControllersToInitialize =
   | 'NotificationServicesController'
   | 'NotificationServicesPushController'
   | 'AppMetadataController'
+  | 'SubjectMetadataController'
   ///: END:ONLY_INCLUDE_IF
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   | 'MultichainAssetsController'

--- a/app/core/Engine/utils/utils.test.ts
+++ b/app/core/Engine/utils/utils.test.ts
@@ -77,7 +77,9 @@ import {
   CaveatSpecificationConstraint,
   PermissionController,
   PermissionSpecificationConstraint,
+  SubjectMetadataController,
 } from '@metamask/permission-controller';
+import { subjectMetadataControllerInit } from '../controllers/subject-metadata-controller-init';
 
 jest.mock('../controllers/accounts-controller');
 jest.mock('../controllers/rewards-controller');
@@ -123,6 +125,7 @@ jest.mock(
 );
 jest.mock('../controllers/selected-network-controller-init');
 jest.mock('../controllers/permission-controller-init');
+jest.mock('../controllers/subject-metadata-controller-init');
 
 describe('initModularizedControllers', () => {
   const mockAccountsControllerInit = jest.mocked(accountsControllerInit);
@@ -190,6 +193,9 @@ describe('initModularizedControllers', () => {
   const mockGatorPermissionsControllerInit = jest.mocked(
     GatorPermissionsControllerInit,
   );
+  const mockSubjectMetadataControllerInit = jest.mocked(
+    subjectMetadataControllerInit,
+  );
 
   function buildModularizedControllerRequest(
     overrides?: Record<string, unknown>,
@@ -235,6 +241,7 @@ describe('initModularizedControllers', () => {
           RewardsController: mockRewardsControllerInit,
           PredictController: mockPredictControllerInit,
           GatorPermissionsController: mockGatorPermissionsControllerInit,
+          SubjectMetadataController: mockSubjectMetadataControllerInit,
         },
         persistedState: {},
         baseControllerMessenger: new ExtendedControllerMessenger(),
@@ -334,6 +341,9 @@ describe('initModularizedControllers', () => {
     });
     mockGatorPermissionsControllerInit.mockReturnValue({
       controller: {} as unknown as GatorPermissionsController,
+    });
+    mockSubjectMetadataControllerInit.mockReturnValue({
+      controller: {} as unknown as SubjectMetadataController,
     });
   });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This refactors the subject metadata controller to use modular init.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors `SubjectMetadataController` to the modular init pattern with a dedicated messenger, types, and tests, and wires it into `Engine` under snaps-only flags.
> 
> - **Engine**:
>   - Replace inline `SubjectMetadataController` construction with modular init via `subjectMetadataControllerInit` (snaps-only).
>   - Register `SubjectMetadataController` in `initModularizedControllers` and assign `this.subjectMetadataController` from `controllersByName`.
> - **Controllers**:
>   - Add `controllers/subject-metadata-controller-init.ts` to create `SubjectMetadataController` with `state` and `subjectCacheLimit: 100`.
> - **Messengers**:
>   - Add `messengers/subject-metadata-controller-messenger.ts` exposing restricted action `PermissionController:hasPermissions`.
>   - Register in `messengers/index.ts`.
> - **Types**:
>   - Include `SubjectMetadataController` in `ControllersToInitialize` and related type unions.
> - **Tests**:
>   - Add unit tests for controller init and messenger.
>   - Update `utils.test.ts` to mock and validate modular initialization integration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1c549ca776cc2e9f4c77e3a037fcd68c1efb948. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->