### PR TITLE
feat: update pk reveal with link to support page

### DIFF
--- a/app/components/Views/MultichainAccounts/PrivateKeyList/PrivateKeyList.tsx
+++ b/app/components/Views/MultichainAccounts/PrivateKeyList/PrivateKeyList.tsx
@@ -281,7 +281,9 @@ export const PrivateKeyList = () => {
   const privateKeyBannerDescription = useMemo(
     () => (
       <Text variant={TextVariant.BodyMD}>
-        {strings('multichain_accounts.private_key_list.warning_description')}{' '}
+        {`${strings(
+          'multichain_accounts.private_key_list.warning_description',
+        )} `}
         <Text
           color={TextColor.Primary}
           variant={TextVariant.BodyMDBold}

--- a/app/components/Views/MultichainAccounts/PrivateKeyList/PrivateKeyList.tsx
+++ b/app/components/Views/MultichainAccounts/PrivateKeyList/PrivateKeyList.tsx
@@ -5,7 +5,7 @@ import React, {
   useCallback,
   useRef,
 } from 'react';
-import { View, TextInput } from 'react-native';
+import { View, TextInput, Linking } from 'react-native';
 import { useSelector } from 'react-redux';
 import { FlashList } from '@shopify/flash-list';
 import { KeyringTypes } from '@metamask/keyring-controller';
@@ -44,6 +44,7 @@ import {
   createNavigationDetails,
 } from '../../../../util/navigation/navUtils';
 import Routes from '../../../../constants/navigation/Routes';
+import { PRIVATE_KEY_GUIDE_URL } from '../../../../constants/urls';
 import { PrivateKeyListIds } from '../../../../../e2e/selectors/MultichainAccounts/PrivateKeyList.selectors';
 
 import styleSheet from './styles';
@@ -287,6 +288,11 @@ export const PrivateKeyList = () => {
           description={`${strings(
             'multichain_accounts.private_key_list.warning_description',
           )}`}
+          actionButtonProps={{
+            variant: ButtonVariants.Link,
+            label: strings('reveal_credential.learn_more'),
+            onPress: () => Linking.openURL(PRIVATE_KEY_GUIDE_URL),
+          }}
           style={styles.banner}
           testID={PrivateKeyListIds.BANNER}
         />

--- a/app/components/Views/MultichainAccounts/PrivateKeyList/PrivateKeyList.tsx
+++ b/app/components/Views/MultichainAccounts/PrivateKeyList/PrivateKeyList.tsx
@@ -4,6 +4,7 @@ import React, {
   useEffect,
   useCallback,
   useRef,
+  useMemo,
 } from 'react';
 import { View, TextInput, Linking } from 'react-native';
 import { useSelector } from 'react-redux';
@@ -277,6 +278,22 @@ export const PrivateKeyList = () => {
     [filteredAccounts, renderAddressItem, styles.container],
   );
 
+  const privateKeyBannerDescription = useMemo(
+    () => (
+      <Text variant={TextVariant.BodyMD}>
+        {strings('multichain_accounts.private_key_list.warning_description')}{' '}
+        <Text
+          color={TextColor.Primary}
+          variant={TextVariant.BodyMDBold}
+          onPress={() => Linking.openURL(PRIVATE_KEY_GUIDE_URL)}
+        >
+          {strings('reveal_credential.learn_more')}
+        </Text>
+      </Text>
+    ),
+    [],
+  );
+
   return (
     <BottomSheet style={styles.bottomSheetContent} ref={sheetRef}>
       <Fragment>
@@ -285,14 +302,7 @@ export const PrivateKeyList = () => {
           variant={BannerVariant.Alert}
           severity={BannerAlertSeverity.Error}
           title={strings('multichain_accounts.private_key_list.warning_title')}
-          description={`${strings(
-            'multichain_accounts.private_key_list.warning_description',
-          )}`}
-          actionButtonProps={{
-            variant: ButtonVariants.Link,
-            label: strings('reveal_credential.learn_more'),
-            onPress: () => Linking.openURL(PRIVATE_KEY_GUIDE_URL),
-          }}
+          description={privateKeyBannerDescription}
           style={styles.banner}
           testID={PrivateKeyListIds.BANNER}
         />

--- a/app/components/Views/MultichainAccounts/PrivateKeyList/PrivateKeyList.tsx
+++ b/app/components/Views/MultichainAccounts/PrivateKeyList/PrivateKeyList.tsx
@@ -280,13 +280,12 @@ export const PrivateKeyList = () => {
 
   const privateKeyBannerDescription = useMemo(
     () => (
-      <Text variant={TextVariant.BodyMD}>
+      <Text>
         {`${strings(
           'multichain_accounts.private_key_list.warning_description',
         )} `}
         <Text
           color={TextColor.Primary}
-          variant={TextVariant.BodyMDBold}
           onPress={() => Linking.openURL(PRIVATE_KEY_GUIDE_URL)}
         >
           {strings('reveal_credential.learn_more')}

--- a/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
+++ b/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
@@ -37,7 +37,6 @@ import { WRONG_PASSWORD_ERROR } from '../../../constants/error';
 import {
   KEEP_SRP_SAFE_URL,
   NON_CUSTODIAL_WALLET_URL,
-  PRIVATE_KEY_GUIDE_URL,
   SRP_GUIDE_URL,
 } from '../../../constants/urls';
 import ClipboardManager from '../../../core/ClipboardManager';
@@ -607,12 +606,6 @@ const RevealPrivateCredential = ({
     </Text>
   );
 
-  const renderPrivateKeyBannerDescription = () => (
-    <Text variant={TextVariant.BodyMD}>
-      {strings('multichain_accounts.reveal_private_key.banner_description')}
-    </Text>
-  );
-
   const renderWarning = (privCredentialName: string) => (
     <View style={[styles.rowWrapper, styles.warningWrapper]}>
       <View style={[styles.warningRowWrapper]}>
@@ -683,12 +676,9 @@ const RevealPrivateCredential = ({
                   title={strings(
                     'multichain_accounts.reveal_private_key.banner_title',
                   )}
-                  description={renderPrivateKeyBannerDescription()}
-                  actionButtonProps={{
-                    variant: ButtonVariants.Link,
-                    label: strings('reveal_credential.learn_more'),
-                    onPress: () => Linking.openURL(PRIVATE_KEY_GUIDE_URL),
-                  }}
+                  description={strings(
+                    'multichain_accounts.reveal_private_key.banner_description',
+                  )}
                 />
               </>
             ) : (

--- a/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
+++ b/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
@@ -609,14 +609,7 @@ const RevealPrivateCredential = ({
 
   const renderPrivateKeyBannerDescription = () => (
     <Text variant={TextVariant.BodyMD}>
-      {strings('multichain_accounts.reveal_private_key.banner_description')}{' '}
-      <Text
-        color={colors.primary.default}
-        variant={TextVariant.BodyMDBold}
-        onPress={() => Linking.openURL(PRIVATE_KEY_GUIDE_URL)}
-      >
-        {strings('reveal_credential.learn_more')}
-      </Text>
+      {strings('multichain_accounts.reveal_private_key.banner_description')}
     </Text>
   );
 
@@ -691,6 +684,11 @@ const RevealPrivateCredential = ({
                     'multichain_accounts.reveal_private_key.banner_title',
                   )}
                   description={renderPrivateKeyBannerDescription()}
+                  actionButtonProps={{
+                    variant: ButtonVariants.Link,
+                    label: strings('reveal_credential.learn_more'),
+                    onPress: () => Linking.openURL(PRIVATE_KEY_GUIDE_URL),
+                  }}
                 />
               </>
             ) : (

--- a/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
+++ b/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
@@ -37,6 +37,7 @@ import { WRONG_PASSWORD_ERROR } from '../../../constants/error';
 import {
   KEEP_SRP_SAFE_URL,
   NON_CUSTODIAL_WALLET_URL,
+  PRIVATE_KEY_GUIDE_URL,
   SRP_GUIDE_URL,
 } from '../../../constants/urls';
 import ClipboardManager from '../../../core/ClipboardManager';
@@ -550,7 +551,13 @@ const RevealPrivateCredential = ({
             <Text
               color={colors.primary.default}
               variant={TextVariant.BodyMDBold}
-              onPress={() => Linking.openURL(KEEP_SRP_SAFE_URL)}
+              onPress={() =>
+                Linking.openURL(
+                  isPrivateKeyReveal
+                    ? PRIVATE_KEY_GUIDE_URL
+                    : KEEP_SRP_SAFE_URL,
+                )
+              }
             >
               {strings('reveal_credential.reveal_credential_modal')[4]}
             </Text>

--- a/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
+++ b/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
@@ -37,6 +37,7 @@ import { WRONG_PASSWORD_ERROR } from '../../../constants/error';
 import {
   KEEP_SRP_SAFE_URL,
   NON_CUSTODIAL_WALLET_URL,
+  PRIVATE_KEY_GUIDE_URL,
   SRP_GUIDE_URL,
 } from '../../../constants/urls';
 import ClipboardManager from '../../../core/ClipboardManager';
@@ -606,6 +607,19 @@ const RevealPrivateCredential = ({
     </Text>
   );
 
+  const renderPrivateKeyBannerDescription = () => (
+    <Text variant={TextVariant.BodyMD}>
+      {strings('multichain_accounts.reveal_private_key.banner_description')}{' '}
+      <Text
+        color={colors.primary.default}
+        variant={TextVariant.BodyMDBold}
+        onPress={() => Linking.openURL(PRIVATE_KEY_GUIDE_URL)}
+      >
+        {strings('reveal_credential.learn_more')}
+      </Text>
+    </Text>
+  );
+
   const renderWarning = (privCredentialName: string) => (
     <View style={[styles.rowWrapper, styles.warningWrapper]}>
       <View style={[styles.warningRowWrapper]}>
@@ -676,9 +690,7 @@ const RevealPrivateCredential = ({
                   title={strings(
                     'multichain_accounts.reveal_private_key.banner_title',
                   )}
-                  description={strings(
-                    'multichain_accounts.reveal_private_key.banner_description',
-                  )}
+                  description={renderPrivateKeyBannerDescription()}
                 />
               </>
             ) : (

--- a/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
+++ b/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
@@ -37,7 +37,6 @@ import { WRONG_PASSWORD_ERROR } from '../../../constants/error';
 import {
   KEEP_SRP_SAFE_URL,
   NON_CUSTODIAL_WALLET_URL,
-  PRIVATE_KEY_GUIDE_URL,
   SRP_GUIDE_URL,
 } from '../../../constants/urls';
 import ClipboardManager from '../../../core/ClipboardManager';
@@ -551,13 +550,7 @@ const RevealPrivateCredential = ({
             <Text
               color={colors.primary.default}
               variant={TextVariant.BodyMDBold}
-              onPress={() =>
-                Linking.openURL(
-                  isPrivateKeyReveal
-                    ? PRIVATE_KEY_GUIDE_URL
-                    : KEEP_SRP_SAFE_URL,
-                )
-              }
+              onPress={() => Linking.openURL(KEEP_SRP_SAFE_URL)}
             >
               {strings('reveal_credential.reveal_credential_modal')[4]}
             </Text>

--- a/app/constants/urls.ts
+++ b/app/constants/urls.ts
@@ -10,8 +10,6 @@ export const NON_CUSTODIAL_WALLET_URL =
   'https://support.metamask.io/getting-started/metamask-is-a-self-custodial-wallet/';
 export const KEEP_SRP_SAFE_URL =
   'https://support.metamask.io/privacy-and-security/staying-safe-in-web3/scammers-and-phishers-rugpulls-and-airdrop-scams/';
-export const PRIVATE_KEY_GUIDE_URL =
-  'https://support.metamask.io/start/user-guide-secret-recovery-phrase-password-and-private-keys/#private-keys';
 export const LEARN_MORE_URL =
   'https://support.metamask.io/privacy-and-security/basic-safety-and-security-tips-for-metamask/';
 export const WHY_TRANSACTION_TAKE_TIME_URL =

--- a/app/constants/urls.ts
+++ b/app/constants/urls.ts
@@ -10,6 +10,8 @@ export const NON_CUSTODIAL_WALLET_URL =
   'https://support.metamask.io/getting-started/metamask-is-a-self-custodial-wallet/';
 export const KEEP_SRP_SAFE_URL =
   'https://support.metamask.io/privacy-and-security/staying-safe-in-web3/scammers-and-phishers-rugpulls-and-airdrop-scams/';
+export const PRIVATE_KEY_GUIDE_URL =
+  'https://support.metamask.io/start/user-guide-secret-recovery-phrase-password-and-private-keys/#private-keys';
 export const LEARN_MORE_URL =
   'https://support.metamask.io/privacy-and-security/basic-safety-and-security-tips-for-metamask/';
 export const WHY_TRANSACTION_TAKE_TIME_URL =


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Added a "Learn More" hyperlink to the private key reveal warning banner that points to the specific private keys section of the MetaMask support documentation.

**What is the reason for the change?**
The private key reveal screen was missing a "Learn More" link in the warning banner, preventing users from accessing relevant guidance about private key security.

**What is the improvement/solution?**
- Added a new `PRIVATE_KEY_GUIDE_URL` constant pointing to the private keys section
- Updated the `PrivateKeyList` component to include an action button in the warning banner
- The "Learn More" link now appears as a clickable button below the banner description
- Links directly to [the dedicated support page](https://support.metamask.io/start/user-guide-secret-recovery-phrase-password-and-private-keys/#private-keys)

## **Changelog**

CHANGELOG entry: Added "Learn More" link to private key reveal warning banner

## **Related issues**

[MUL-709](https://consensyssoftware.atlassian.net/browse/MUL-709)

## **Manual testing steps**

```gherkin
Feature: Private Key List Learn More Link

  Scenario: user accesses private key list and clicks Learn More
    Given user is on account details page
    And user has clicked "Private keys" option
    And the private key list modal is displayed with warning banner

    When user clicks the "Learn More" link in the warning banner
    Then browser opens the private keys section of MetaMask support docs
    And URL contains "#private-keys" anchor

  Scenario: user can still enter password and reveal keys normally
    Given user is on the private key list screen
    And the warning banner with "Learn More" link is visible

    When user enters their password and clicks Continue
    Then private keys are revealed as expected
    And existing functionality remains unchanged
```

## **Screenshots/Recordings**

### **Before**

Private key list warning banner without "Learn More" link

### **After**

<img width="250" height="600" alt="Screenshot_20251002-151259 (1)" src="https://github.com/user-attachments/assets/72b68afa-1cca-4b75-ad74-b77d4d19410d" />

<img width="250" height="600" alt="Screenshot_20251002-151307 (1)" src="https://github.com/user-attachments/assets/9f1ec8b9-f25e-46e8-94b7-e6aa02145b08" />

Private key list warning banner now includes "Learn More" action button that provides users with relevant security guidance

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a memoized "Learn More" link in the private key reveal warning banner that opens the MetaMask private keys support page.
> 
> - **UI (Private Key Reveal)**:
>   - Update `PrivateKeyList.tsx` to render a memoized banner description with an inline "Learn More" link using `Linking.openURL(PRIVATE_KEY_GUIDE_URL)`.
>   - Replace string description with a formatted `Text` description for `Banner`.
> - **Constants**:
>   - Add `PRIVATE_KEY_GUIDE_URL` in `app/constants/urls.ts` pointing to the private keys support page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cac868509c583cbf98779eb2d8486a97569511b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[MUL-709]: https://consensyssoftware.atlassian.net/browse/MUL-709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ