### PR TITLE
fix: in recipient validations for internal accounts

### DIFF
--- a/app/components/Views/confirmations/hooks/send/evm/useEvmToAddressValidation.test.ts
+++ b/app/components/Views/confirmations/hooks/send/evm/useEvmToAddressValidation.test.ts
@@ -54,48 +54,6 @@ describe('shouldSkipValidation', () => {
       } as unknown as ShouldSkipValidationArgs),
     ).toStrictEqual(true);
   });
-  it('returns true if to address is present in address book', () => {
-    expect(
-      shouldSkipValidation({
-        toAddress: '0x935E73EDb9fF52E23BaC7F7e043A1ecD06d05477',
-        chainId: '0x1',
-        addressBook: {},
-        internalAccounts: [],
-      } as unknown as ShouldSkipValidationArgs),
-    ).toStrictEqual(false);
-    expect(
-      shouldSkipValidation({
-        toAddress: '0x935E73EDb9fF52E23BaC7F7e043A1ecD06d05477',
-        chainId: '0x1',
-        addressBook: {
-          '0x1': {
-            '0x935E73EDb9fF52E23BaC7F7e043A1ecD06d05477': {},
-          },
-        },
-        internalAccounts: [],
-      } as unknown as ShouldSkipValidationArgs),
-    ).toStrictEqual(true);
-  });
-  it('returns true if to address is an internal account', () => {
-    expect(
-      shouldSkipValidation({
-        toAddress: '0x935E73EDb9fF52E23BaC7F7e043A1ecD06d05477',
-        chainId: '0x1',
-        addressBook: {},
-        internalAccounts: [],
-      } as unknown as ShouldSkipValidationArgs),
-    ).toStrictEqual(false);
-    expect(
-      shouldSkipValidation({
-        toAddress: '0x935E73EDb9fF52E23BaC7F7e043A1ecD06d05477',
-        chainId: '0x1',
-        addressBook: {},
-        internalAccounts: [
-          { address: '0x935E73EDb9fF52E23BaC7F7e043A1ecD06d05477' },
-        ],
-      } as unknown as ShouldSkipValidationArgs),
-    ).toStrictEqual(true);
-  });
 });
 
 describe('validateToAddress', () => {

--- a/app/components/Views/confirmations/hooks/send/evm/useEvmToAddressValidation.ts
+++ b/app/components/Views/confirmations/hooks/send/evm/useEvmToAddressValidation.ts
@@ -46,7 +46,7 @@ export const shouldSkipValidation = ({
   const existingContact =
     address && chainId && addressBook[chainId as Hex]?.[address];
   if (existingContact) {
-    return true;
+    return false;
   }
 
   // sending to an internal account
@@ -54,7 +54,7 @@ export const shouldSkipValidation = ({
     areAddressesEqual(account.address, address),
   );
   if (internalAccount) {
-    return true;
+    return false;
   }
 
   return false;

--- a/app/components/Views/confirmations/hooks/send/non-evm/useNonEvmToAddressValidation.test.ts
+++ b/app/components/Views/confirmations/hooks/send/non-evm/useNonEvmToAddressValidation.test.ts
@@ -50,26 +50,6 @@ describe('shouldSkipValidation', () => {
       } as unknown as ShouldSkipValidationArgs),
     ).toStrictEqual(true);
   });
-  it('returns true if to address is an internal account', () => {
-    expect(
-      shouldSkipValidation({
-        toAddress: '0x935E73EDb9fF52E23BaC7F7e043A1ecD06d05477',
-        chainId: '0x1',
-        addressBook: {},
-        internalAccounts: [],
-      } as unknown as ShouldSkipValidationArgs),
-    ).toStrictEqual(false);
-    expect(
-      shouldSkipValidation({
-        toAddress: '0x935E73EDb9fF52E23BaC7F7e043A1ecD06d05477',
-        chainId: '0x1',
-        addressBook: {},
-        internalAccounts: [
-          { address: '0x935E73EDb9fF52E23BaC7F7e043A1ecD06d05477' },
-        ],
-      } as unknown as ShouldSkipValidationArgs),
-    ).toStrictEqual(true);
-  });
 });
 
 describe('validateToAddress', () => {

--- a/app/components/Views/confirmations/hooks/send/non-evm/useNonEvmToAddressValidation.ts
+++ b/app/components/Views/confirmations/hooks/send/non-evm/useNonEvmToAddressValidation.ts
@@ -30,7 +30,7 @@ export const shouldSkipValidation = ({
     areAddressesEqual(account.address, toAddress),
   );
   if (internalAccount) {
-    return true;
+    return false;
   }
 
   return false;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

fix: recipient validation for internal accounts

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Ref: https://github.com/MetaMask/MetaMask-planning/issues/5931

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**
TODO

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stop skipping to-address validation for internal-account and address-book recipients across EVM and non-EVM flows, and update tests accordingly.
> 
> - **Validation**:
>   - EVM: `shouldSkipValidation` no longer skips when `toAddress` is in the address book or matches an internal account (continues validation instead).
>   - Non-EVM: `shouldSkipValidation` no longer skips when `toAddress` matches an internal account.
> - **Tests**:
>   - Remove assertions expecting skip when `toAddress` is in address book or an internal account for both EVM and non-EVM hooks.
>   - Keep existing validation tests (burn address, contract address warning, ENS/confusables, Solana).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27fc32fedc73464020ffaa6bbbbd2dba8099ae09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->