### PR TITLE
fix: cp-7.56.2 remove unintended metrics from transaction finalised event

### DIFF
--- a/app/core/Engine/controllers/transaction-controller/utils.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/utils.test.ts
@@ -266,10 +266,7 @@ describe('generateDefaultTransactionMetrics', () => {
         transaction_type: 'simple_send',
       },
       sensitiveProperties: {
-        from_address: FROM_ADDRESS_MOCK,
         sensitive_data: 'sensitive_value',
-        to_address: undefined,
-        value: undefined,
       },
     });
   });
@@ -304,11 +301,6 @@ describe('generateDefaultTransactionMetrics', () => {
         transaction_envelope_type: undefined,
         transaction_internal_id: 'test-id-123',
         transaction_type: 'simple_send',
-      },
-      sensitiveProperties: {
-        from_address: FROM_ADDRESS_MOCK,
-        to_address: undefined,
-        value: undefined,
       },
     });
   });

--- a/app/core/Engine/controllers/transaction-controller/utils.ts
+++ b/app/core/Engine/controllers/transaction-controller/utils.ts
@@ -208,11 +208,6 @@ export async function generateDefaultTransactionMetrics(
         transaction_internal_id: id,
         transaction_type: getTransactionTypeValue(type),
       },
-      sensitiveProperties: {
-        from_address: transactionMeta.txParams.from,
-        to_address: transactionMeta.txParams.to,
-        value: transactionMeta.txParams.value,
-      },
     },
     getConfirmationMetricProperties(
       transactionEventHandlerRequest.getState,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to remove unintended metrics from transaction finalised event.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5934

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes from_address/to_address/value from the default transaction metrics payload and updates tests accordingly.
> 
> - **Analytics/Metrics**:
>   - `generateDefaultTransactionMetrics` (in `app/core/Engine/controllers/transaction-controller/utils.ts`): drops `sensitiveProperties` (`from_address`, `to_address`, `value`) from the default payload.
> - **Tests**:
>   - Update `utils.test.ts` expectations to no longer include the removed sensitive fields in generated metrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48d59f5a8f9cffbae9f72c05d52dae0c7bc74ca1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->