### PR TITLE
fix: env vars reading utils

### DIFF
--- a/app/core/Engine/controllers/remote-feature-flag-controller/utils.ts
+++ b/app/core/Engine/controllers/remote-feature-flag-controller/utils.ts
@@ -13,8 +13,7 @@ import AppConstants from '../../../AppConstants';
 
 // Points to the LaunchDarkly environment based on the METAMASK_ENVIRONMENT environment variable
 export const getFeatureFlagAppEnvironment = () => {
-  // Spread process.env, which forces a fresh read when running unit tests
-  const env = { ...process.env }?.METAMASK_ENVIRONMENT;
+  const env = process.env.METAMASK_ENVIRONMENT;
 
   switch (env) {
     case 'production':
@@ -39,8 +38,7 @@ export const getFeatureFlagAppEnvironment = () => {
 };
 
 export const getFeatureFlagAppDistribution = () => {
-  // Spread process.env, which forces a fresh read when running unit tests
-  const dist = { ...process.env }?.METAMASK_BUILD_TYPE;
+  const dist = process.env.METAMASK_BUILD_TYPE;
 
   switch (dist) {
     case 'main':

--- a/babel.config.tests.js
+++ b/babel.config.tests.js
@@ -17,6 +17,8 @@ const newOverrides = [
       'app/core/Engine/controllers/network-controller/utils.test.ts',
       'app/core/Engine/controllers/gator-permissions-controller/gator-permissions-controller-init.ts',
       'app/core/Engine/controllers/gator-permissions-controller/gator-permissions-controller-init.test.ts',
+      'app/core/Engine/controllers/remote-feature-flag-controller/utils.ts',
+      'app/core/Engine/controllers/remote-feature-flag-controller/utils.test.ts',
       'app/components/UI/Ramp/Deposit/sdk/getSdkEnvironment.ts',
       'app/components/UI/Ramp/Deposit/sdk/getSdkEnvironment.test.ts',
       'app/components/UI/Ramp/Aggregator/sdk/getSdkEnvironment.ts',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This pull request updates the way environment variables are accessed in the feature flag utilities and adds test coverage for these changes. The most important changes include simplifying how environment variables are read in `utils.ts` and updating the test configuration to ensure these files are properly transpiled during testing.

**Environment variable access simplification:**

* Refactored `getFeatureFlagAppEnvironment` and `getFeatureFlagAppDistribution` in `app/core/Engine/controllers/remote-feature-flag-controller/utils.ts` to directly read from `process.env` instead of using object spreading, making the code simpler and more reliable. [[1]](diffhunk://#diff-c0bf8b8dee6c4fe9bd7f65f5a0eb652f89bfc4a0eff075dc77d31cbfa9f2d8aaL16-R16) [[2]](diffhunk://#diff-c0bf8b8dee6c4fe9bd7f65f5a0eb652f89bfc4a0eff075dc77d31cbfa9f2d8aaL42-R41)

**Test configuration updates:**

* Added `app/core/Engine/controllers/remote-feature-flag-controller/utils.ts` and its corresponding test file to the transpilation overrides in `babel.config.tests.js`, ensuring these files are correctly processed during unit tests.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fix the environment Build Type and MetaMask Environment utils.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Building

  Scenario: user builds different environments
    Given app can be prod/dev/etc..

    When user builds an specific environment
    Then the right environment is being used
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors feature flag utils to read env vars directly from process.env and updates test Babel overrides to handle these files correctly.
> 
> - **Feature Flags**:
>   - Simplify `getFeatureFlagAppEnvironment` and `getFeatureFlagAppDistribution` to read `process.env.METAMASK_ENVIRONMENT` and `process.env.METAMASK_BUILD_TYPE` directly in `app/core/Engine/controllers/remote-feature-flag-controller/utils.ts`.
> - **Tests/Config**:
>   - Add `app/core/Engine/controllers/remote-feature-flag-controller/utils.ts` and its test to `babel.config.tests.js` exclude list for inline env var transform.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 278a955e63c88c4bdd8f1500a25a014cb30b41a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->