### PR TITLE
fix(card): card home viewed metric returning NaN error

### DIFF
--- a/app/components/UI/Card/Views/CardHome/CardHome.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.tsx
@@ -160,8 +160,14 @@ const CardHome = () => {
         createEventBuilder(MetaMetricsEvents.CARD_HOME_VIEWED)
           .addProperties({
             token_symbol_priority: priorityToken?.symbol,
-            token_raw_balance_priority: rawTokenBalance,
-            token_fiat_balance_priority: rawFiatNumber,
+            token_raw_balance_priority:
+              rawTokenBalance !== undefined && isNaN(rawTokenBalance)
+                ? 0
+                : rawTokenBalance,
+            token_fiat_balance_priority:
+              rawFiatNumber !== undefined && isNaN(rawFiatNumber)
+                ? 0
+                : rawFiatNumber,
           })
           .build(),
       );

--- a/app/components/UI/Card/hooks/useAssetBalance.tsx
+++ b/app/components/UI/Card/hooks/useAssetBalance.tsx
@@ -165,12 +165,8 @@ export const useAssetBalance = (
                   { minimumFractionDigits: 0, maximumFractionDigits: 5 },
                 )
               : zeroBalanceFormatted,
-          rawTokenBalance: isNaN(parsedBalance)
-            ? undefined
-            : parseFloat(String(parsedBalance).replace(/[^0-9.]/g, '')),
-          rawFiatNumber: isNaN(parsedFiat)
-            ? undefined
-            : parseFloat(String(parsedFiat).replace(/[^0-9.]/g, '')),
+          rawTokenBalance: isNaN(parsedBalance) ? undefined : parsedBalance,
+          rawFiatNumber: isNaN(parsedFiat) ? undefined : parsedFiat,
         };
       }
 
@@ -187,11 +183,7 @@ export const useAssetBalance = (
           rawTokenBalance: derived.balance
             ? parseFloat(String(derived.balance).replace(/[^0-9.]/g, ''))
             : undefined,
-          rawFiatNumber: derived.balanceFiatCalculation
-            ? parseFloat(
-                String(derived.balanceFiatCalculation).replace(/[^0-9.]/g, ''),
-              )
-            : undefined,
+          rawFiatNumber: derived.balanceFiatCalculation,
         };
       }
 

--- a/app/components/UI/Card/hooks/useAssetBalance.tsx
+++ b/app/components/UI/Card/hooks/useAssetBalance.tsx
@@ -165,8 +165,12 @@ export const useAssetBalance = (
                   { minimumFractionDigits: 0, maximumFractionDigits: 5 },
                 )
               : zeroBalanceFormatted,
-          rawTokenBalance: isNaN(parsedBalance) ? undefined : parsedBalance,
-          rawFiatNumber: isNaN(parsedFiat) ? undefined : parsedFiat,
+          rawTokenBalance: isNaN(parsedBalance)
+            ? undefined
+            : parseFloat(String(parsedBalance).replace(/[^0-9.]/g, '')),
+          rawFiatNumber: isNaN(parsedFiat)
+            ? undefined
+            : parseFloat(String(parsedFiat).replace(/[^0-9.]/g, '')),
         };
       }
 
@@ -181,9 +185,13 @@ export const useAssetBalance = (
         return {
           ...derived,
           rawTokenBalance: derived.balance
-            ? parseFloat(derived.balance)
+            ? parseFloat(String(derived.balance).replace(/[^0-9.]/g, ''))
             : undefined,
-          rawFiatNumber: derived.balanceFiatCalculation,
+          rawFiatNumber: derived.balanceFiatCalculation
+            ? parseFloat(
+                String(derived.balanceFiatCalculation).replace(/[^0-9.]/g, ''),
+              )
+            : undefined,
         };
       }
 
@@ -204,7 +212,9 @@ export const useAssetBalance = (
               { minimumFractionDigits: 0, maximumFractionDigits: 5 },
             )
           : TOKEN_BALANCE_LOADING,
-        rawTokenBalance: asset?.balance ? parseFloat(asset.balance) : undefined,
+        rawTokenBalance: asset?.balance
+          ? parseFloat(String(asset.balance).replace(/[^0-9.]/g, ''))
+          : undefined,
         rawFiatNumber: asset?.balanceFiat
           ? parseFloat(String(asset.balanceFiat).replace(/[^0-9.]/g, ''))
           : undefined,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The Card Home Viewed metric was registering some events with `NaN`. This PR adds a string sanitization step to remove invalid characters and a specific check for `NaN` on Card Home, where the event is being tracked.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sanitizes balance parsing and converts NaN to 0 in Card Home tracking properties, adding tests to ensure NaN is avoided and undefined is preserved.
> 
> - **Metrics/Tracking**:
>   - In `CardHome.tsx`, ensure `token_raw_balance_priority` and `token_fiat_balance_priority` convert `NaN` to `0` while preserving `undefined`.
> - **Balance Parsing**:
>   - In `hooks/useAssetBalance.tsx`, sanitize numeric parsing for `rawTokenBalance` and `rawFiatNumber` by stripping non-numeric characters before `parseFloat` in both derived and fallback paths.
> - **Tests**:
>   - In `CardHome.test.tsx`, add cases verifying `NaN` raw values are converted to `0` in events and `undefined` remains `undefined`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 990a49cea81b3d83692c4fc98dd1dac37c9dda8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->