### PR TITLE
fix: add a loading state when loading prices instead of 0 00 incl in perp asset page

### DIFF
--- a/app/components/UI/Perps/components/LivePriceDisplay/LivePriceHeader.test.tsx
+++ b/app/components/UI/Perps/components/LivePriceDisplay/LivePriceHeader.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
 import LivePriceHeader from './LivePriceHeader';
-import { usePerpsLivePrices } from '../../hooks/stream';
+import { PriceUpdate, usePerpsLivePrices } from '../../hooks/stream';
 
 // Mock dependencies
 jest.mock('../../hooks/stream', () => ({
@@ -43,7 +43,7 @@ describe('LivePriceHeader', () => {
 
   it('should show placeholders when price data is undefined', () => {
     mockUsePerpsLivePrices.mockReturnValue({
-      ETH: undefined,
+      ETH: undefined as unknown as PriceUpdate,
     });
     const { getByText } = render(<LivePriceHeader symbol="ETH" />);
     expect(getByText('$---')).toBeTruthy();

--- a/app/components/UI/Perps/components/LivePriceDisplay/LivePriceHeader.test.tsx
+++ b/app/components/UI/Perps/components/LivePriceDisplay/LivePriceHeader.test.tsx
@@ -2,473 +2,191 @@ import React from 'react';
 import { render } from '@testing-library/react-native';
 import LivePriceHeader from './LivePriceHeader';
 import { usePerpsLivePrices } from '../../hooks/stream';
-import {
-  formatPerpsFiat,
-  formatPercentage,
-  formatPnl,
-  PRICE_RANGES_DETAILED_VIEW,
-} from '../../utils/formatUtils';
-import { useStyles } from '../../../../../component-library/hooks';
 
 // Mock dependencies
-jest.mock('../../hooks/stream');
-jest.mock('../../utils/formatUtils', () => ({
-  formatPerpsFiat: jest.fn(),
-  formatPercentage: jest.fn(),
-  formatPnl: jest.fn(),
-  PRICE_RANGES_DETAILED_VIEW: [
-    {
-      condition: (v: number) => v >= 1,
-      minimumDecimals: 2,
-      maximumDecimals: 2,
-      threshold: 1,
-    },
-    {
-      condition: (v: number) => v < 1,
-      minimumDecimals: 2,
-      maximumDecimals: 7,
-      significantDigits: 3,
-      threshold: 0.0000001,
-    },
-  ],
+jest.mock('../../hooks/stream', () => ({
+  usePerpsLivePrices: jest.fn(),
 }));
-jest.mock('../../../../../component-library/hooks');
-jest.mock('../../constants/perpsConfig', () => ({
-  PERPS_CONSTANTS: {
-    FALLBACK_PRICE_DISPLAY: '$---',
-    FALLBACK_DATA_DISPLAY: '--',
-  },
-  PERFORMANCE_CONFIG: {
-    MARKET_DATA_CACHE_DURATION_MS: 5 * 60 * 1000,
-  },
+
+jest.mock('../../../../../component-library/hooks', () => ({
+  useStyles: jest.fn(() => ({
+    styles: {
+      container: { flexDirection: 'row', alignItems: 'baseline', gap: 6 },
+      positionValue: { fontWeight: '700' },
+      priceChange24h: { fontSize: 12 },
+    },
+    theme: {},
+  })),
 }));
+
+const mockUsePerpsLivePrices = usePerpsLivePrices as jest.MockedFunction<
+  typeof usePerpsLivePrices
+>;
 
 describe('LivePriceHeader', () => {
-  const mockUsePerpsLivePrices = usePerpsLivePrices as jest.MockedFunction<
-    typeof usePerpsLivePrices
-  >;
-  const mockFormatPerpsFiat = formatPerpsFiat as jest.MockedFunction<
-    typeof formatPerpsFiat
-  >;
-  const mockFormatPercentage = formatPercentage as jest.MockedFunction<
-    typeof formatPercentage
-  >;
-  const mockFormatPnl = formatPnl as jest.MockedFunction<typeof formatPnl>;
-  const mockUseStyles = useStyles as jest.MockedFunction<typeof useStyles>;
-
   beforeEach(() => {
     jest.clearAllMocks();
-    mockFormatPerpsFiat.mockImplementation((price) => {
-      const num = typeof price === 'string' ? parseFloat(price) : price;
-      return `$${num.toFixed(2)}`;
-    });
-    mockFormatPercentage.mockImplementation((pct) => `${pct}%`);
-    mockFormatPnl.mockImplementation((amount) => {
-      const num = typeof amount === 'string' ? parseFloat(amount) : amount;
-      return num >= 0
-        ? `+$${Math.abs(num).toFixed(2)}`
-        : `-$${Math.abs(num).toFixed(2)}`;
-    });
-    mockUseStyles.mockReturnValue({
-      styles: {
-        container: { flexDirection: 'row', alignItems: 'baseline', gap: 6 },
-        positionValue: { fontWeight: '700' },
-        priceChange24h: { fontSize: 12 },
-      },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      theme: {} as any,
-    });
-
-    // Mock PRICE_RANGES_DETAILED_VIEW
-    (PRICE_RANGES_DETAILED_VIEW as typeof PRICE_RANGES_DETAILED_VIEW) =
-      mockPriceRangesDetailedView;
   });
 
-  it('should render with live price data', () => {
+  it('should render without crashing', () => {
+    mockUsePerpsLivePrices.mockReturnValue({});
+    const component = render(<LivePriceHeader symbol="ETH" />);
+    expect(component).toBeDefined();
+  });
+
+  it('should show placeholders when no price data available', () => {
+    mockUsePerpsLivePrices.mockReturnValue({});
+    const { getByText } = render(<LivePriceHeader symbol="ETH" />);
+    expect(getByText('$---')).toBeTruthy();
+    expect(getByText('--%')).toBeTruthy();
+  });
+
+  it('should show placeholders when price data is undefined', () => {
     mockUsePerpsLivePrices.mockReturnValue({
-      BTC: {
-        coin: 'BTC',
-        price: '50000',
+      ETH: undefined,
+    });
+    const { getByText } = render(<LivePriceHeader symbol="ETH" />);
+    expect(getByText('$---')).toBeTruthy();
+    expect(getByText('--%')).toBeTruthy();
+  });
+
+  it('should show placeholders when price is invalid (zero)', () => {
+    mockUsePerpsLivePrices.mockReturnValue({
+      ETH: {
+        coin: 'ETH',
+        price: '0',
+        percentChange24h: '5',
+        timestamp: Date.now(),
+      },
+    });
+    const { getByText } = render(<LivePriceHeader symbol="ETH" />);
+    expect(getByText('$---')).toBeTruthy();
+    expect(getByText('--%')).toBeTruthy();
+  });
+
+  it('should show placeholders when price is invalid (negative)', () => {
+    mockUsePerpsLivePrices.mockReturnValue({
+      ETH: {
+        coin: 'ETH',
+        price: '-100',
+        percentChange24h: '5',
+        timestamp: Date.now(),
+      },
+    });
+    const { getByText } = render(<LivePriceHeader symbol="ETH" />);
+    expect(getByText('$---')).toBeTruthy();
+    expect(getByText('--%')).toBeTruthy();
+  });
+
+  it('should show placeholders when price is invalid (NaN)', () => {
+    mockUsePerpsLivePrices.mockReturnValue({
+      ETH: {
+        coin: 'ETH',
+        price: 'invalid',
+        percentChange24h: '5',
+        timestamp: Date.now(),
+      },
+    });
+    const { getByText } = render(<LivePriceHeader symbol="ETH" />);
+    expect(getByText('$---')).toBeTruthy();
+    expect(getByText('--%')).toBeTruthy();
+  });
+
+  it('should render valid price and positive change', () => {
+    mockUsePerpsLivePrices.mockReturnValue({
+      ETH: {
+        coin: 'ETH',
+        price: '3000',
         percentChange24h: '5.5',
         timestamp: Date.now(),
       },
     });
-
-    const { getByText } = render(<LivePriceHeader symbol="BTC" />);
-
-    expect(getByText('$50000.00')).toBeTruthy();
-    // 5.5% of 50000 = 2750
-    expect(getByText('5.5%')).toBeTruthy();
+    const { getByText } = render(<LivePriceHeader symbol="ETH" />);
+    expect(getByText('$3,000.00')).toBeTruthy();
+    expect(getByText('+5.50%')).toBeTruthy();
   });
 
-  it('should use fallback values when no live data', () => {
-    mockUsePerpsLivePrices.mockReturnValue({});
-
-    const { getByText } = render(
-      <LivePriceHeader
-        symbol="ETH"
-        fallbackPrice="3000"
-        fallbackChange="2.5"
-      />,
-    );
-
-    expect(getByText('$3000.00')).toBeTruthy();
-    // 2.5% of 3000 = 75
-    expect(getByText('2.5%')).toBeTruthy();
+  it('should render valid price and negative change', () => {
+    mockUsePerpsLivePrices.mockReturnValue({
+      ETH: {
+        coin: 'ETH',
+        price: '2500',
+        percentChange24h: '-3.2',
+        timestamp: Date.now(),
+      },
+    });
+    const { getByText } = render(<LivePriceHeader symbol="ETH" />);
+    expect(getByText('$2,500.00')).toBeTruthy();
+    expect(getByText('-3.20%')).toBeTruthy();
   });
 
-  it('should handle negative price change', () => {
+  it('should render valid price and zero change', () => {
+    mockUsePerpsLivePrices.mockReturnValue({
+      ETH: {
+        coin: 'ETH',
+        price: '2000',
+        percentChange24h: '0',
+        timestamp: Date.now(),
+      },
+    });
+    const { getByText } = render(<LivePriceHeader symbol="ETH" />);
+    expect(getByText('$2,000.00')).toBeTruthy();
+    expect(getByText('+0.00%')).toBeTruthy();
+  });
+
+  it('should handle different symbols', () => {
     mockUsePerpsLivePrices.mockReturnValue({
       SOL: {
         coin: 'SOL',
         price: '100',
-        percentChange24h: '-10',
+        percentChange24h: '2.1',
         timestamp: Date.now(),
       },
     });
-
     const { getByText } = render(<LivePriceHeader symbol="SOL" />);
-
     expect(getByText('$100.00')).toBeTruthy();
-    // -10% of 100 = -10
-    expect(getByText('-10%')).toBeTruthy();
+    expect(getByText('+2.10%')).toBeTruthy();
   });
 
-  it('should handle positive price change color', () => {
-    mockUsePerpsLivePrices.mockReturnValue({
-      AVAX: {
-        coin: 'AVAX',
-        price: '25',
-        percentChange24h: '8',
-        timestamp: Date.now(),
-      },
-    });
-
-    const { getByText } = render(<LivePriceHeader symbol="AVAX" />);
-
-    expect(getByText('8%')).toBeTruthy();
-  });
-
-  it('should handle zero price change', () => {
-    mockUsePerpsLivePrices.mockReturnValue({
-      MATIC: {
-        coin: 'MATIC',
-        price: '1',
-        percentChange24h: '0',
-        timestamp: Date.now(),
-      },
-    });
-
-    const { getByText } = render(<LivePriceHeader symbol="MATIC" />);
-
-    expect(getByText('$1.00')).toBeTruthy();
-    expect(getByText('0%')).toBeTruthy();
-  });
-
-  it('should use custom throttle value', () => {
-    mockUsePerpsLivePrices.mockReturnValue({
-      DOGE: {
-        coin: 'DOGE',
-        price: '0.1',
-        percentChange24h: '0',
-        timestamp: Date.now(),
-      },
-    });
-
-    render(<LivePriceHeader symbol="DOGE" throttleMs={2000} />);
-
-    expect(mockUsePerpsLivePrices).toHaveBeenCalledWith({
-      symbols: ['DOGE'],
-      throttleMs: 2000,
-    });
-  });
-
-  it('should use default throttle value of 1000ms', () => {
-    mockUsePerpsLivePrices.mockReturnValue({
-      UNI: {
-        coin: 'UNI',
-        price: '10',
-        percentChange24h: '0',
-        timestamp: Date.now(),
-      },
-    });
-
-    render(<LivePriceHeader symbol="UNI" />);
-
-    expect(mockUsePerpsLivePrices).toHaveBeenCalledWith({
-      symbols: ['UNI'],
-      throttleMs: 1000,
-    });
-  });
-
-  it('should apply test IDs correctly', () => {
-    mockUsePerpsLivePrices.mockReturnValue({
-      LINK: {
-        coin: 'LINK',
-        price: '15',
-        percentChange24h: '3',
-        timestamp: Date.now(),
-      },
-    });
-
-    const { getByTestId } = render(
+  it('should use fallback values when no live data', () => {
+    mockUsePerpsLivePrices.mockReturnValue({});
+    const { getByText } = render(
       <LivePriceHeader
-        symbol="LINK"
-        testIDPrice="price-test"
-        testIDChange="change-test"
+        symbol="ETH"
+        fallbackPrice="1500"
+        fallbackChange="1.5"
       />,
     );
-
-    expect(getByTestId('price-test')).toBeTruthy();
-    expect(getByTestId('change-test')).toBeTruthy();
+    expect(getByText('$1,500.00')).toBeTruthy();
+    expect(getByText('+1.50%')).toBeTruthy();
   });
 
-  it('should handle missing percentChange24h', () => {
-    mockUsePerpsLivePrices.mockReturnValue({
-      DOT: {
-        coin: 'DOT',
-        price: '5',
-        timestamp: Date.now(),
-        // percentChange24h is missing
-      },
-    });
-
-    const { getByText } = render(<LivePriceHeader symbol="DOT" />);
-
-    expect(getByText('$5.00')).toBeTruthy();
-    expect(getByText('0%')).toBeTruthy(); // Defaults to 0
-  });
-
-  it('should calculate change amount correctly', () => {
-    mockUsePerpsLivePrices.mockReturnValue({
-      ADA: {
-        coin: 'ADA',
-        price: '0.5',
-        percentChange24h: '20',
-        timestamp: Date.now(),
-      },
-    });
-
-    const { getByText } = render(<LivePriceHeader symbol="ADA" />);
-
-    expect(getByText('$0.50')).toBeTruthy();
-    // 20% of 0.5 = 0.1
-    expect(getByText('20%')).toBeTruthy();
-  });
-
-  it('should use fallback values as defaults', () => {
+  it('should show placeholders when fallback price is invalid', () => {
     mockUsePerpsLivePrices.mockReturnValue({});
-
     const { getByText } = render(
-      <LivePriceHeader symbol="XRP" fallbackPrice="0.6" fallbackChange="-5" />,
+      <LivePriceHeader symbol="ETH" fallbackPrice="0" fallbackChange="1.5" />,
     );
-
-    expect(getByText('$0.60')).toBeTruthy();
-    // -5% of 0.6 = -0.03
-    expect(getByText('-5%')).toBeTruthy();
+    expect(getByText('$---')).toBeTruthy();
+    expect(getByText('--%')).toBeTruthy();
   });
 
   it('should prefer live data over fallback', () => {
     mockUsePerpsLivePrices.mockReturnValue({
-      ALGO: {
-        coin: 'ALGO',
-        price: '0.2',
-        percentChange24h: '15',
+      BTC: {
+        coin: 'BTC',
+        price: '50000',
+        percentChange24h: '3.0',
         timestamp: Date.now(),
       },
     });
-
     const { getByText } = render(
-      <LivePriceHeader symbol="ALGO" fallbackPrice="0.3" fallbackChange="10" />,
+      <LivePriceHeader
+        symbol="BTC"
+        fallbackPrice="45000"
+        fallbackChange="2.0"
+      />,
     );
-
-    // Should use live data, not fallback
-    expect(getByText('$0.20')).toBeTruthy();
-    // 15% of 0.2 = 0.03
-    expect(getByText('15%')).toBeTruthy();
-  });
-
-  // New tests for edge case handling and error handling
-  describe('Edge case handling', () => {
-    it('should display fallback when price is zero', () => {
-      mockUsePerpsLivePrices.mockReturnValue({
-        ZERO: {
-          coin: 'ZERO',
-          price: '0',
-          percentChange24h: '5',
-          timestamp: Date.now(),
-        },
-      });
-
-      const { getByText } = render(<LivePriceHeader symbol="ZERO" />);
-
-      expect(getByText('$---')).toBeTruthy();
-      expect(getByText('5%')).toBeTruthy();
-    });
-
-    it('should display fallback when price is negative', () => {
-      mockUsePerpsLivePrices.mockReturnValue({
-        NEG: {
-          coin: 'NEG',
-          price: '-100',
-          percentChange24h: '2',
-          timestamp: Date.now(),
-        },
-      });
-
-      const { getByText } = render(<LivePriceHeader symbol="NEG" />);
-
-      expect(getByText('$---')).toBeTruthy();
-      expect(getByText('2%')).toBeTruthy();
-    });
-
-    it('should display fallback when price is NaN', () => {
-      mockUsePerpsLivePrices.mockReturnValue({
-        NAN: {
-          coin: 'NAN',
-          price: 'invalid',
-          percentChange24h: '1',
-          timestamp: Date.now(),
-        },
-      });
-
-      const { getByText } = render(<LivePriceHeader symbol="NAN" />);
-
-      expect(getByText('$---')).toBeTruthy();
-      expect(getByText('1%')).toBeTruthy();
-    });
-
-    it('should display fallback when price is Infinity', () => {
-      mockUsePerpsLivePrices.mockReturnValue({
-        INF: {
-          coin: 'INF',
-          price: 'Infinity',
-          percentChange24h: '3',
-          timestamp: Date.now(),
-        },
-      });
-
-      const { getByText } = render(<LivePriceHeader symbol="INF" />);
-
-      expect(getByText('$---')).toBeTruthy();
-      expect(getByText('3%')).toBeTruthy();
-    });
-
-    it('should display fallback when fallback price is invalid', () => {
-      mockUsePerpsLivePrices.mockReturnValue({});
-
-      const { getByText } = render(
-        <LivePriceHeader
-          symbol="INVALID"
-          fallbackPrice="invalid"
-          fallbackChange="2"
-        />,
-      );
-
-      expect(getByText('$---')).toBeTruthy();
-      expect(getByText('2%')).toBeTruthy();
-    });
-
-    it('should display fallback when fallback price is zero', () => {
-      mockUsePerpsLivePrices.mockReturnValue({});
-
-      const { getByText } = render(
-        <LivePriceHeader
-          symbol="ZERO_FALLBACK"
-          fallbackPrice="0"
-          fallbackChange="4"
-        />,
-      );
-
-      expect(getByText('$---')).toBeTruthy();
-      expect(getByText('4%')).toBeTruthy();
-    });
-  });
-
-  describe('Format error handling', () => {
-    it('should display fallback when formatPerpsFiat throws an error', () => {
-      mockUsePerpsLivePrices.mockReturnValue({
-        ERROR: {
-          coin: 'ERROR',
-          price: '100',
-          percentChange24h: '5',
-          timestamp: Date.now(),
-        },
-      });
-
-      // Mock formatPerpsFiat to throw an error
-      mockFormatPerpsFiat.mockImplementation(() => {
-        throw new Error('Formatting error');
-      });
-
-      const { getByText } = render(<LivePriceHeader symbol="ERROR" />);
-
-      expect(getByText('$---')).toBeTruthy();
-      expect(getByText('5%')).toBeTruthy();
-    });
-
-    it('should call formatPerpsFiat with PRICE_RANGES_DETAILED_VIEW', () => {
-      mockUsePerpsLivePrices.mockReturnValue({
-        RANGES: {
-          coin: 'RANGES',
-          price: '50',
-          percentChange24h: '2',
-          timestamp: Date.now(),
-        },
-      });
-
-      render(<LivePriceHeader symbol="RANGES" />);
-
-      expect(mockFormatPerpsFiat).toHaveBeenCalledWith(50, {
-        ranges: PRICE_RANGES_DETAILED_VIEW,
-      });
-    });
-
-    it('should handle formatPerpsFiat success with detailed view ranges', () => {
-      mockUsePerpsLivePrices.mockReturnValue({
-        SUCCESS: {
-          coin: 'SUCCESS',
-          price: '123.456',
-          percentChange24h: '7',
-          timestamp: Date.now(),
-        },
-      });
-
-      // Mock successful formatting with detailed ranges
-      mockFormatPerpsFiat.mockReturnValue('$123.46');
-
-      const { getByText } = render(<LivePriceHeader symbol="SUCCESS" />);
-
-      expect(getByText('$123.46')).toBeTruthy();
-      expect(getByText('7%')).toBeTruthy();
-      expect(mockFormatPerpsFiat).toHaveBeenCalledWith(123.456, {
-        ranges: PRICE_RANGES_DETAILED_VIEW,
-      });
-    });
-  });
-
-  describe('Memoization behavior', () => {
-    it('should memoize price formatting based on displayPrice', () => {
-      const { rerender } = render(<LivePriceHeader symbol="MEMO" />);
-
-      // First render
-      expect(mockFormatPerpsFiat).toHaveBeenCalledTimes(1);
-
-      // Re-render with same price - should not call formatPerpsFiat again
-      rerender(<LivePriceHeader symbol="MEMO" />);
-      expect(mockFormatPerpsFiat).toHaveBeenCalledTimes(1);
-
-      // Re-render with different price - should call formatPerpsFiat again
-      mockUsePerpsLivePrices.mockReturnValue({
-        MEMO: {
-          coin: 'MEMO',
-          price: '200',
-          percentChange24h: '1',
-          timestamp: Date.now(),
-        },
-      });
-      rerender(<LivePriceHeader symbol="MEMO" />);
-      expect(mockFormatPerpsFiat).toHaveBeenCalledTimes(2);
-    });
+    expect(getByText('$50,000.00')).toBeTruthy();
+    expect(getByText('+3.00%')).toBeTruthy();
   });
 });

--- a/app/components/UI/Perps/components/LivePriceDisplay/LivePriceHeader.tsx
+++ b/app/components/UI/Perps/components/LivePriceDisplay/LivePriceHeader.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React, { memo, useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
 import Text, {
   TextVariant,
@@ -11,6 +11,7 @@ import {
   formatPercentage,
 } from '../../utils/formatUtils';
 import { useStyles } from '../../../../../component-library/hooks';
+import { PERPS_CONSTANTS } from '../../constants/perpsConfig';
 
 interface LivePriceHeaderProps {
   symbol: string;
@@ -61,6 +62,23 @@ const LivePriceHeader: React.FC<LivePriceHeaderProps> = ({
   const isPositiveChange = displayChange >= 0;
   const changeColor = isPositiveChange ? TextColor.Success : TextColor.Error;
 
+  // Format price display with edge case handling
+  const formattedPrice = useMemo(() => {
+    // Handle invalid or edge case values
+    if (!displayPrice || displayPrice <= 0 || !Number.isFinite(displayPrice)) {
+      return PERPS_CONSTANTS.FALLBACK_PRICE_DISPLAY;
+    }
+
+    try {
+      return formatPerpsFiat(displayPrice, {
+        ranges: PRICE_RANGES_DETAILED_VIEW,
+      });
+    } catch {
+      // Fallback if formatPrice throws
+      return PERPS_CONSTANTS.FALLBACK_PRICE_DISPLAY;
+    }
+  }, [displayPrice]);
+
   return (
     <View style={styles.container}>
       <Text
@@ -68,7 +86,7 @@ const LivePriceHeader: React.FC<LivePriceHeaderProps> = ({
         color={TextColor.Default}
         testID={testIDPrice}
       >
-        {formatPerpsFiat(displayPrice, { ranges: PRICE_RANGES_DETAILED_VIEW })}
+        {formattedPrice}
       </Text>
       <Text
         variant={TextVariant.BodyMD}

--- a/app/components/UI/Perps/components/LivePriceDisplay/LivePriceHeader.tsx
+++ b/app/components/UI/Perps/components/LivePriceDisplay/LivePriceHeader.tsx
@@ -79,6 +79,18 @@ const LivePriceHeader: React.FC<LivePriceHeaderProps> = ({
     }
   }, [displayPrice]);
 
+  const formattedChange = useMemo(() => {
+    if (!displayPrice || displayPrice <= 0 || !Number.isFinite(displayPrice)) {
+      return PERPS_CONSTANTS.FALLBACK_PERCENTAGE_DISPLAY;
+    }
+
+    try {
+      return formatPercentage(displayChange.toString());
+    } catch {
+      return PERPS_CONSTANTS.FALLBACK_PERCENTAGE_DISPLAY;
+    }
+  }, [displayPrice, displayChange]);
+
   return (
     <View style={styles.container}>
       <Text
@@ -93,7 +105,7 @@ const LivePriceHeader: React.FC<LivePriceHeaderProps> = ({
         color={changeColor}
         testID={testIDChange}
       >
-        {formatPercentage(displayChange.toString())}
+        {formattedChange}
       </Text>
     </View>
   );

--- a/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.test.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.test.tsx
@@ -22,9 +22,16 @@ jest.mock('../../../../../util/theme', () => ({
 
 jest.mock('../../../Swaps/components/TokenIcon', () => 'TokenIcon');
 
-jest.mock('../../utils/formatUtils', () => ({
-  formatPrice: jest.fn((price) => `$${price.toFixed(2)}`),
-  formatPercentage: jest.fn((percentage) => `${percentage.toFixed(2)}%`),
+jest.mock('../../../../../../locales/i18n', () => ({
+  strings: jest.fn((key) => {
+    const translations = {
+      'perps.market.long': 'Long',
+      'perps.market.short': 'Short',
+      'perps.order.market': 'Market',
+      'perps.order.limit': 'Limit',
+    };
+    return translations[key as keyof typeof translations] || key;
+  }),
 }));
 
 // Mock ButtonIcon to make it easier to test
@@ -84,8 +91,105 @@ describe('PerpsOrderHeader', () => {
     expect(mockGoBack).not.toHaveBeenCalled();
   });
 
-  it('should render with invalid price', () => {
-    const component = render(<PerpsOrderHeader {...defaultProps} price={0} />);
-    expect(component).toBeDefined();
+  it('should render with valid price and change', () => {
+    const { getByText } = render(<PerpsOrderHeader {...defaultProps} />);
+    expect(getByText('$3,000.00')).toBeTruthy();
+    expect(getByText('+2.50%')).toBeTruthy();
+  });
+
+  it('should show placeholders when price is undefined', () => {
+    const { getByText, queryByText } = render(
+      <PerpsOrderHeader
+        asset="ETH"
+        price={undefined as unknown as number}
+        priceChange={2.5}
+        orderType="market"
+        onOrderTypePress={mockOnOrderTypePress}
+      />,
+    );
+    expect(getByText('$---')).toBeTruthy();
+    // When price is invalid, percentage change is not rendered at all
+    expect(queryByText('--%')).toBeNull();
+    expect(queryByText('2.50%')).toBeNull();
+  });
+
+  it('should show placeholders when price is zero', () => {
+    const { getByText, queryByText } = render(
+      <PerpsOrderHeader {...defaultProps} price={0} />,
+    );
+    expect(getByText('$---')).toBeTruthy();
+    // When price is invalid, percentage change is not rendered at all
+    expect(queryByText('--%')).toBeNull();
+    expect(queryByText('2.50%')).toBeNull();
+  });
+
+  it('should show placeholders when price is negative', () => {
+    const { getByText, queryByText } = render(
+      <PerpsOrderHeader {...defaultProps} price={-100} />,
+    );
+    expect(getByText('$---')).toBeTruthy();
+    // When price is invalid, percentage change is not rendered at all
+    expect(queryByText('--%')).toBeNull();
+    expect(queryByText('2.50%')).toBeNull();
+  });
+
+  it('should render long direction by default', () => {
+    const { getByText } = render(<PerpsOrderHeader {...defaultProps} />);
+    expect(getByText('Long ETH')).toBeTruthy();
+  });
+
+  it('should render short direction when specified', () => {
+    const { getByText } = render(
+      <PerpsOrderHeader {...defaultProps} direction="short" />,
+    );
+    expect(getByText('Short ETH')).toBeTruthy();
+  });
+
+  it('should render custom title when provided', () => {
+    const { getByText } = render(
+      <PerpsOrderHeader {...defaultProps} title="Custom Title" />,
+    );
+    expect(getByText('Custom Title')).toBeTruthy();
+  });
+
+  it('should render order type button', () => {
+    const { getByTestId } = render(<PerpsOrderHeader {...defaultProps} />);
+    expect(getByTestId('perps-order-header-order-type-button')).toBeTruthy();
+  });
+
+  it('should handle order type press', () => {
+    const { getByTestId } = render(<PerpsOrderHeader {...defaultProps} />);
+    const orderTypeButton = getByTestId('perps-order-header-order-type-button');
+    fireEvent.press(orderTypeButton);
+    expect(mockOnOrderTypePress).toHaveBeenCalled();
+  });
+
+  it('should not render order type button when orderType is not provided', () => {
+    const { queryByTestId } = render(
+      <PerpsOrderHeader asset="ETH" price={3000} priceChange={2.5} />,
+    );
+    expect(queryByTestId('perps-order-header-order-type-button')).toBeNull();
+  });
+
+  it('should render Market order type', () => {
+    const { getByText } = render(
+      <PerpsOrderHeader {...defaultProps} orderType="market" />,
+    );
+    expect(getByText('Market')).toBeTruthy();
+  });
+
+  it('should render Limit order type', () => {
+    const { getByText } = render(
+      <PerpsOrderHeader {...defaultProps} orderType="limit" />,
+    );
+    expect(getByText('Limit')).toBeTruthy();
+  });
+
+  it('should disable order type button when loading', () => {
+    const { getByTestId } = render(
+      <PerpsOrderHeader {...defaultProps} isLoading />,
+    );
+    const orderTypeButton = getByTestId('perps-order-header-order-type-button');
+    expect(orderTypeButton.props.disabled).toBe(true);
   });
 });

--- a/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderHeader/PerpsOrderHeader.tsx
@@ -78,6 +78,17 @@ const PerpsOrderHeader: React.FC<PerpsOrderHeaderProps> = ({
     }
   }, [price]);
 
+  const formattedChange = useMemo(() => {
+    if (!price || price <= 0 || !Number.isFinite(price)) {
+      return PERPS_CONSTANTS.FALLBACK_PERCENTAGE_DISPLAY;
+    }
+    try {
+      return formatPercentage(priceChange.toString());
+    } catch {
+      return PERPS_CONSTANTS.FALLBACK_PERCENTAGE_DISPLAY;
+    }
+  }, [priceChange, price]);
+
   return (
     <View style={styles.header} testID={PerpsOrderHeaderSelectorsIDs.HEADER}>
       <ButtonIcon
@@ -108,7 +119,7 @@ const PerpsOrderHeader: React.FC<PerpsOrderHeaderProps> = ({
               variant={TextVariant.BodyMD}
               color={priceChange >= 0 ? TextColor.Success : TextColor.Error}
             >
-              {formatPercentage(priceChange)}
+              {formattedChange}
             </Text>
           )}
         </View>

--- a/app/components/UI/Perps/constants/perpsConfig.ts
+++ b/app/components/UI/Perps/constants/perpsConfig.ts
@@ -21,6 +21,7 @@ export const PERPS_CONSTANTS = {
   DEFAULT_ASSET_PREVIEW_LIMIT: 5,
   DEFAULT_MAX_LEVERAGE: 3 as number, // Default fallback max leverage when market data is unavailable - conservative default
   FALLBACK_PRICE_DISPLAY: '$---', // Display when price data is unavailable
+  FALLBACK_PERCENTAGE_DISPLAY: '--%', // Display when change data is unavailable
   FALLBACK_DATA_DISPLAY: '--', // Display when non-price data is unavailable
 } as const;
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
1. What is the reason for the change?
There is no loading state for the market details live header page 
2. What is the improvement/solution?
Add the default loading state text for the price if not available
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1610

## **Manual testing steps**

```gherkin
Feature: fix loading state for live price header

  Scenario: user enters market page for asset
    Given they look at the top price header while there is no available price

    When user sees the price

   Then there is a default loading text state $---
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="500" alt="Simulator Screenshot - iPhone 15 Pro - 2025-10-02 at 16 41 54" src="https://github.com/user-attachments/assets/df51f57b-d4c8-484f-94ef-910dc46adcca" />
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask
-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Show $---/--% placeholders and guard formatting for missing or invalid perps prices, updating headers and tests accordingly.
> 
> - **Perps UI**:
>   - **LivePriceHeader (`LivePriceHeader.tsx`)**: Guard price/change formatting with `useMemo`; display `PERPS_CONSTANTS.FALLBACK_PRICE_DISPLAY` and `PERPS_CONSTANTS.FALLBACK_PERCENTAGE_DISPLAY` when price is missing/invalid; continue colorizing change by sign.
>   - **PerpsOrderHeader (`PerpsOrderHeader.tsx`)**: Add guarded `formattedChange`; show `$---` when price invalid and hide percentage; keep back handling and order type button (disable via `isLoading`).
> - **Constants**:
>   - Add `PERPS_CONSTANTS.FALLBACK_PERCENTAGE_DISPLAY` to `perpsConfig.ts`.
> - **Tests**:
>   - Rewrite/expand `LivePriceHeader.test.tsx` to assert placeholders, valid/invalid inputs, fallback preference, symbol handling.
>   - Expand `PerpsOrderHeader.test.tsx` with i18n mocks; assert placeholders, direction/title text, order type button presence/disabled state, and interaction.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e3925e76af5d0fd9d218664937b3fc7a0027a3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->