### PR TITLE
fix: text for social login user and ios platform

### DIFF
--- a/app/components/Views/Login/index.tsx
+++ b/app/components/Views/Login/index.tsx
@@ -110,7 +110,10 @@ import {
   SeedlessOnboardingControllerError,
   SeedlessOnboardingControllerErrorType,
 } from '../../../core/Engine/controllers/seedless-onboarding-controller/error';
-import { selectIsSeedlessPasswordOutdated , selectSeedlessOnboardingLoginFlow } from '../../../selectors/seedlessOnboardingController';
+import {
+  selectIsSeedlessPasswordOutdated,
+  selectSeedlessOnboardingLoginFlow,
+} from '../../../selectors/seedlessOnboardingController';
 import FOX_LOGO from '../../../images/branding/fox.png';
 import { usePromptSeedlessRelogin } from '../../hooks/SeedlessHooks';
 import { useNetInfo } from '@react-native-community/netinfo';

--- a/app/components/Views/Login/index.tsx
+++ b/app/components/Views/Login/index.tsx
@@ -110,7 +110,7 @@ import {
   SeedlessOnboardingControllerError,
   SeedlessOnboardingControllerErrorType,
 } from '../../../core/Engine/controllers/seedless-onboarding-controller/error';
-import { selectIsSeedlessPasswordOutdated } from '../../../selectors/seedlessOnboardingController';
+import { selectIsSeedlessPasswordOutdated , selectSeedlessOnboardingLoginFlow } from '../../../selectors/seedlessOnboardingController';
 import FOX_LOGO from '../../../images/branding/fox.png';
 import { usePromptSeedlessRelogin } from '../../hooks/SeedlessHooks';
 import { useNetInfo } from '@react-native-community/netinfo';
@@ -176,9 +176,13 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
   const isSeedlessPasswordOutdated = useSelector(
     selectIsSeedlessPasswordOutdated,
   );
+  const isSocialLoginUser = useSelector(selectSeedlessOnboardingLoginFlow);
 
   const invalidCredentialsError = () => {
-    if (Platform.OS === 'ios' && isComingFromOauthOnboarding) {
+    if (
+      Platform.OS === 'ios' &&
+      (isComingFromOauthOnboarding || isSocialLoginUser)
+    ) {
       return strings('login.invalid_pin');
     }
     return strings('login.invalid_password');
@@ -800,7 +804,8 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
             </Text>
 
             <View style={styles.field}>
-              {(Platform.OS === 'android' || !isComingFromOauthOnboarding) && (
+              {(Platform.OS === 'android' ||
+                !(isComingFromOauthOnboarding || isSocialLoginUser)) && (
                 <Label
                   variant={TextVariant.BodyMDMedium}
                   color={TextColor.Default}
@@ -812,7 +817,8 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
               <TextField
                 size={TextFieldSize.Lg}
                 placeholder={
-                  Platform.OS === 'ios' && isComingFromOauthOnboarding
+                  Platform.OS === 'ios' &&
+                  (isComingFromOauthOnboarding || isSocialLoginUser)
                     ? strings('login.pin_placeholder')
                     : strings('login.password_placeholder')
                 }
@@ -882,7 +888,11 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
                   variant={ButtonVariants.Link}
                   onPress={toggleWarningModal}
                   testID={LoginViewSelectors.RESET_WALLET}
-                  label={strings('login.forgot_password')}
+                  label={
+                    Platform.OS === 'ios' && isSocialLoginUser
+                      ? strings('login.forgot_pin')
+                      : strings('login.forgot_password')
+                  }
                   isDisabled={finalLoading}
                   size={ButtonSize.Lg}
                 />

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -333,6 +333,7 @@
     "unlock_button": "Unlock",
     "go_back": "Wallet won't unlock? You can ERASE your current wallet and setup a new one",
     "forgot_password": "Forgot password?",
+    "forgot_pin": "Forgot PIN?",
     "cant_proceed": "You can’t proceed till you type the word ‘Delete’. With this action you are opting in to erase your current wallet.",
     "invalid_password": "Password is incorrect, try again.",
     "invalid_pin": "Password/PIN is incorrect. Try again.",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
1) Fix: text and button Placeholder for social login user and ios platform
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fix: text and button Placeholder for social login user and ios platform

## **Related issues**

Fixes:
Fix: text and button Placeholder for social login user and ios platform
## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
1) Create new wallet using social login in ios.
2) Close the app from background.
3) Reopen app. It show unlock screen.
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/ff8496b1-574a-4eb8-940b-a514c201425b


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Treat iOS social-login users like OAuth onboarding for login copy: show PIN wording, hide password label, and update reset button; add en string for “Forgot PIN?”.
> 
> - **Login screen (`app/components/Views/Login/index.tsx`)**:
>   - Add `selectSeedlessOnboardingLoginFlow` and derive `isSocialLoginUser`.
>   - iOS behavior for `(isComingFromOauthOnboarding || isSocialLoginUser)`:
>     - Use `login.invalid_pin` for invalid credentials.
>     - Hide `password` label; switch `TextField` placeholder to `login.pin_placeholder`.
>     - Change reset link label to `login.forgot_pin`.
> - **Localization (`locales/languages/en.json`)**:
>   - Add `login.forgot_pin` string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36bbdec9b937d747caa5903b84b8757c815e5d96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->