### PR TITLE
refactor: Refactor keyring controller to use modular init pattern

### DIFF
--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -575,75 +575,6 @@ export class Engine {
       allowExternalServices: () => isBasicFunctionalityToggleEnabled(),
     });
 
-    ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
-    const authenticationControllerMessenger =
-      getAuthenticationControllerMessenger(this.controllerMessenger);
-    const authenticationController = createAuthenticationController({
-      messenger: authenticationControllerMessenger,
-      initialState: initialState.AuthenticationController,
-      metametrics: {
-        agent: Platform.MOBILE,
-        getMetaMetricsId: async () =>
-          (await MetaMetrics.getInstance().getMetaMetricsId()) || '',
-      },
-    });
-
-    const userStorageControllerMessenger = getUserStorageControllerMessenger(
-      this.controllerMessenger,
-    );
-    const userStorageController = createUserStorageController({
-      messenger: userStorageControllerMessenger,
-      initialState: initialState.UserStorageController,
-      nativeScryptCrypto: calculateScryptKey,
-      // @ts-expect-error Controller uses string for names rather than enum
-      trace,
-      config: {
-        contactSyncing: {
-          onContactUpdated: (profileId) => {
-            MetaMetrics.getInstance().trackEvent(
-              MetricsEventBuilder.createEventBuilder(
-                MetaMetricsEvents.PROFILE_ACTIVITY_UPDATED,
-              )
-                .addProperties({
-                  profile_id: profileId,
-                  feature_name: 'Contacts Sync',
-                  action: 'Contacts Sync Contact Updated',
-                })
-                .build(),
-            );
-          },
-          onContactDeleted: (profileId) => {
-            MetaMetrics.getInstance().trackEvent(
-              MetricsEventBuilder.createEventBuilder(
-                MetaMetricsEvents.PROFILE_ACTIVITY_UPDATED,
-              )
-                .addProperties({
-                  profile_id: profileId,
-                  feature_name: 'Contacts Sync',
-                  action: 'Contacts Sync Contact Deleted',
-                })
-                .build(),
-            );
-          },
-          onContactSyncErroneousSituation(profileId, situationMessage) {
-            MetaMetrics.getInstance().trackEvent(
-              MetricsEventBuilder.createEventBuilder(
-                MetaMetricsEvents.PROFILE_ACTIVITY_UPDATED,
-              )
-                .addProperties({
-                  profile_id: profileId,
-                  feature_name: 'Contacts Sync',
-                  action: 'Contacts Sync Erroneous Situation',
-                  additional_description: situationMessage,
-                })
-                .build(),
-            );
-          },
-        },
-      },
-    });
-    ///: END:ONLY_INCLUDE_IF
-
     const codefiTokenApiV2 = new CodefiTokenPricesServiceV2();
 
     const smartTransactionsControllerTrackMetaMetricsEvent = (
@@ -732,11 +663,11 @@ export class Engine {
       controllerInitFunctions: {
         PreferencesController: preferencesControllerInit,
         AccountsController: accountsControllerInit,
-        PermissionController: permissionControllerInit,
         ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
         SnapKeyringBuilder: snapKeyringBuilderInit,
         ///: END:ONLY_INCLUDE_IF
         KeyringController: keyringControllerInit,
+        PermissionController: permissionControllerInit,
         ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
         SubjectMetadataController: subjectMetadataControllerInit,
         ///: END:ONLY_INCLUDE_IF
@@ -855,6 +786,75 @@ export class Engine {
     const networkEnablementController =
       controllersByName.NetworkEnablementController;
     networkEnablementController.init();
+
+    ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+    const authenticationControllerMessenger =
+      getAuthenticationControllerMessenger(this.controllerMessenger);
+    const authenticationController = createAuthenticationController({
+      messenger: authenticationControllerMessenger,
+      initialState: initialState.AuthenticationController,
+      metametrics: {
+        agent: Platform.MOBILE,
+        getMetaMetricsId: async () =>
+          (await MetaMetrics.getInstance().getMetaMetricsId()) || '',
+      },
+    });
+
+    const userStorageControllerMessenger = getUserStorageControllerMessenger(
+      this.controllerMessenger,
+    );
+    const userStorageController = createUserStorageController({
+      messenger: userStorageControllerMessenger,
+      initialState: initialState.UserStorageController,
+      nativeScryptCrypto: calculateScryptKey,
+      // @ts-expect-error Controller uses string for names rather than enum
+      trace,
+      config: {
+        contactSyncing: {
+          onContactUpdated: (profileId) => {
+            MetaMetrics.getInstance().trackEvent(
+              MetricsEventBuilder.createEventBuilder(
+                MetaMetricsEvents.PROFILE_ACTIVITY_UPDATED,
+              )
+                .addProperties({
+                  profile_id: profileId,
+                  feature_name: 'Contacts Sync',
+                  action: 'Contacts Sync Contact Updated',
+                })
+                .build(),
+            );
+          },
+          onContactDeleted: (profileId) => {
+            MetaMetrics.getInstance().trackEvent(
+              MetricsEventBuilder.createEventBuilder(
+                MetaMetricsEvents.PROFILE_ACTIVITY_UPDATED,
+              )
+                .addProperties({
+                  profile_id: profileId,
+                  feature_name: 'Contacts Sync',
+                  action: 'Contacts Sync Contact Deleted',
+                })
+                .build(),
+            );
+          },
+          onContactSyncErroneousSituation(profileId, situationMessage) {
+            MetaMetrics.getInstance().trackEvent(
+              MetricsEventBuilder.createEventBuilder(
+                MetaMetricsEvents.PROFILE_ACTIVITY_UPDATED,
+              )
+                .addProperties({
+                  profile_id: profileId,
+                  feature_name: 'Contacts Sync',
+                  action: 'Contacts Sync Erroneous Situation',
+                  additional_description: situationMessage,
+                })
+                .build(),
+            );
+          },
+        },
+      },
+    });
+    ///: END:ONLY_INCLUDE_IF
 
     ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     const multichainRatesControllerMessenger =

--- a/app/core/Engine/controllers/keyring-controller-init.test.ts
+++ b/app/core/Engine/controllers/keyring-controller-init.test.ts
@@ -1,0 +1,60 @@
+import { buildControllerInitRequestMock } from '../utils/test-utils';
+import { ExtendedControllerMessenger } from '../../ExtendedControllerMessenger';
+import {
+  getKeyringControllerMessenger,
+  type KeyringControllerMessenger,
+} from '../messengers/keyring-controller-messenger';
+import { ControllerInitRequest } from '../types';
+import { keyringControllerInit } from './keyring-controller-init';
+import { KeyringController } from '@metamask/keyring-controller';
+import { Encryptor } from '../../Encryptor';
+
+jest.mock('@metamask/keyring-controller');
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<KeyringControllerMessenger>
+> {
+  const baseMessenger = new ExtendedControllerMessenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(baseMessenger),
+    controllerMessenger: getKeyringControllerMessenger(baseMessenger),
+    initMessenger: undefined,
+  };
+
+  // @ts-expect-error: Partial implementation.
+  requestMock.getController.mockImplementation((controllerName: string) => {
+    if (controllerName === 'SnapKeyringBuilder') {
+      return jest.fn();
+    }
+
+    if (controllerName === 'PreferencesController') {
+      return jest.fn();
+    }
+
+    throw new Error(`Controller "${controllerName}" not found.`);
+  });
+
+  return requestMock;
+}
+
+describe('keyringControllerInit', () => {
+  it('initializes the controller', () => {
+    const { controller } = keyringControllerInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(KeyringController);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    keyringControllerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(KeyringController);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      state: undefined,
+      cacheEncryptionKey: true,
+      encryptor: expect.any(Encryptor),
+      keyringBuilders: expect.any(Array),
+      removeIdentity: expect.any(Function),
+    });
+  });
+});

--- a/app/core/Engine/controllers/keyring-controller-init.ts
+++ b/app/core/Engine/controllers/keyring-controller-init.ts
@@ -15,7 +15,7 @@ const encryptor = new Encryptor({
 });
 
 /**
- * Initialize the subject metadata controller.
+ * Initialize the keyring controller.
  *
  * @param request - The request object.
  * @param request.controllerMessenger - The messenger to use for the controller.

--- a/app/core/Engine/controllers/keyring-controller-init.ts
+++ b/app/core/Engine/controllers/keyring-controller-init.ts
@@ -1,0 +1,85 @@
+import { ControllerInitFunction } from '../types';
+import { KeyringController } from '@metamask/keyring-controller';
+import { KeyringControllerMessenger } from '../messengers/keyring-controller-messenger';
+import { QrKeyring } from '@metamask/eth-qr-keyring';
+import {
+  LedgerKeyring,
+  LedgerMobileBridge,
+  LedgerTransportMiddleware,
+} from '@metamask/eth-ledger-bridge-keyring';
+import { HdKeyring } from '@metamask/eth-hd-keyring';
+import { Encryptor, LEGACY_DERIVATION_OPTIONS, pbkdf2 } from '../../Encryptor';
+
+const encryptor = new Encryptor({
+  keyDerivationOptions: LEGACY_DERIVATION_OPTIONS,
+});
+
+/**
+ * Initialize the subject metadata controller.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @param request.persistedState - The persisted state of the client.
+ * @returns The initialized controller.
+ */
+export const keyringControllerInit: ControllerInitFunction<
+  KeyringController,
+  KeyringControllerMessenger
+> = ({
+  controllerMessenger,
+  persistedState,
+  initialKeyringState,
+  qrKeyringScanner,
+  getController,
+}) => {
+  const additionalKeyrings = [];
+
+  const qrKeyringBuilder = () => {
+    const keyring = new QrKeyring({ bridge: qrKeyringScanner });
+    // To fix the bug in #9560, forgetDevice will reset all keyring properties
+    // to default.
+    keyring.forgetDevice();
+    return keyring;
+  };
+
+  qrKeyringBuilder.type = QrKeyring.type;
+
+  additionalKeyrings.push(qrKeyringBuilder);
+
+  const bridge = new LedgerMobileBridge(new LedgerTransportMiddleware());
+  const ledgerKeyringBuilder = () => new LedgerKeyring({ bridge });
+  ledgerKeyringBuilder.type = LedgerKeyring.type;
+
+  additionalKeyrings.push(ledgerKeyringBuilder);
+
+  const hdKeyringBuilder = () =>
+    new HdKeyring({
+      cryptographicFunctions: { pbkdf2Sha512: pbkdf2 },
+    });
+
+  hdKeyringBuilder.type = HdKeyring.type;
+  additionalKeyrings.push(hdKeyringBuilder);
+
+  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+  const snapKeyringBuilder = getController('SnapKeyringBuilder');
+  additionalKeyrings.push(snapKeyringBuilder);
+  ///: END:ONLY_INCLUDE_IF
+
+  const preferencesController = getController('PreferencesController');
+
+  const controller = new KeyringController({
+    removeIdentity: (address: string) =>
+      preferencesController.removeIdentity(address),
+    encryptor,
+    messenger: controllerMessenger,
+    state: initialKeyringState || persistedState.KeyringController,
+    // @ts-expect-error: TODO: Update the type of QRHardwareKeyring to
+    // `Keyring<Json>`.
+    keyringBuilders: additionalKeyrings,
+    cacheEncryptionKey: true,
+  });
+
+  return {
+    controller,
+  };
+};

--- a/app/core/Engine/controllers/snap-keyring-builder-init.test.ts
+++ b/app/core/Engine/controllers/snap-keyring-builder-init.test.ts
@@ -1,0 +1,34 @@
+import { buildControllerInitRequestMock } from '../utils/test-utils';
+import { ExtendedControllerMessenger } from '../../ExtendedControllerMessenger';
+import {
+  getSnapKeyringBuilderInitMessenger,
+  getSnapKeyringBuilderMessenger,
+  SnapKeyringBuilderInitMessenger,
+  type SnapKeyringBuilderMessenger,
+} from '../messengers/snap-keyring-builder-messenger';
+import { ControllerInitRequest } from '../types';
+import { snapKeyringBuilderInit } from './snap-keyring-builder-init';
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<
+    SnapKeyringBuilderMessenger,
+    SnapKeyringBuilderInitMessenger
+  >
+> {
+  const baseMessenger = new ExtendedControllerMessenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(baseMessenger),
+    controllerMessenger: getSnapKeyringBuilderMessenger(baseMessenger),
+    initMessenger: getSnapKeyringBuilderInitMessenger(baseMessenger),
+  };
+
+  return requestMock;
+}
+
+describe('snapKeyringBuilderInit', () => {
+  it('initializes the controller', () => {
+    const { controller } = snapKeyringBuilderInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(Function);
+  });
+});

--- a/app/core/Engine/controllers/snap-keyring-builder-init.ts
+++ b/app/core/Engine/controllers/snap-keyring-builder-init.ts
@@ -1,0 +1,37 @@
+import { ControllerInitFunction } from '../types';
+import {
+  SnapKeyringBuilderInitMessenger,
+  SnapKeyringBuilderMessenger,
+} from '../messengers/snap-keyring-builder-messenger';
+import {
+  snapKeyringBuilder,
+  SnapKeyringBuilder,
+} from '../../SnapKeyring/SnapKeyring';
+
+/**
+ * Initialize the Snap keyring builder.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @returns The initialized controller.
+ */
+export const snapKeyringBuilderInit: ControllerInitFunction<
+  SnapKeyringBuilder,
+  SnapKeyringBuilderMessenger,
+  SnapKeyringBuilderInitMessenger
+> = ({ controllerMessenger, initMessenger, removeAccount }) => {
+  const controller = snapKeyringBuilder(controllerMessenger, {
+    persistKeyringHelper: async () => {
+      // Necessary to only persist the keyrings, the `AccountsController` will
+      // automatically react to `KeyringController:stateChange`.
+      await initMessenger.call('KeyringController:persistAllKeyrings');
+    },
+    removeAccountHelper: (address) => removeAccount(address),
+  });
+
+  return {
+    persistedStateKey: null,
+    memStateKey: null,
+    controller,
+  };
+};

--- a/app/core/Engine/messengers/index.ts
+++ b/app/core/Engine/messengers/index.ts
@@ -51,6 +51,11 @@ import {
 } from './permission-controller-messenger';
 import { getSubjectMetadataControllerMessenger } from './subject-metadata-controller-messenger';
 import { getPreferencesControllerMessenger } from './preferences-controller-messenger';
+import {
+  getSnapKeyringBuilderInitMessenger,
+  getSnapKeyringBuilderMessenger,
+} from './snap-keyring-builder-messenger';
+import { getKeyringControllerMessenger } from './keyring-controller-messenger';
 
 /**
  * The messengers for the controllers that have been.
@@ -82,6 +87,10 @@ export const CONTROLLER_MESSENGERS = {
   },
   GasFeeController: {
     getMessenger: getGasFeeControllerMessenger,
+    getInitMessenger: noop,
+  },
+  KeyringController: {
+    getMessenger: getKeyringControllerMessenger,
     getInitMessenger: noop,
   },
   AppMetadataController: {
@@ -154,6 +163,10 @@ export const CONTROLLER_MESSENGERS = {
   MultichainTransactionsController: {
     getMessenger: getMultichainTransactionsControllerMessenger,
     getInitMessenger: noop,
+  },
+  SnapKeyringBuilder: {
+    getMessenger: getSnapKeyringBuilderMessenger,
+    getInitMessenger: getSnapKeyringBuilderInitMessenger,
   },
   ///: END:ONLY_INCLUDE_IF
   PermissionController: {

--- a/app/core/Engine/messengers/keyring-controller-messenger.test.ts
+++ b/app/core/Engine/messengers/keyring-controller-messenger.test.ts
@@ -1,0 +1,11 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import { getKeyringControllerMessenger } from './keyring-controller-messenger';
+
+describe('getKeyringControllerMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const keyringControllerMessenger = getKeyringControllerMessenger(messenger);
+
+    expect(keyringControllerMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});

--- a/app/core/Engine/messengers/keyring-controller-messenger.ts
+++ b/app/core/Engine/messengers/keyring-controller-messenger.ts
@@ -1,0 +1,26 @@
+import { Messenger } from '@metamask/base-controller';
+
+type AllowedActions = never;
+
+type AllowedEvents = never;
+
+export type KeyringControllerMessenger = ReturnType<
+  typeof getKeyringControllerMessenger
+>;
+
+/**
+ * Get a messenger restricted to the actions and events that the
+ * keyring controller is allowed to handle.
+ *
+ * @param messenger - The controller messenger to restrict.
+ * @returns The restricted controller messenger.
+ */
+export function getKeyringControllerMessenger(
+  messenger: Messenger<AllowedActions, AllowedEvents>,
+) {
+  return messenger.getRestricted({
+    name: 'KeyringController',
+    allowedActions: [],
+    allowedEvents: [],
+  });
+}

--- a/app/core/Engine/messengers/snap-keyring-builder-messenger.test.ts
+++ b/app/core/Engine/messengers/snap-keyring-builder-messenger.test.ts
@@ -1,0 +1,25 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import {
+  getSnapKeyringBuilderMessenger,
+  getSnapKeyringBuilderInitMessenger,
+} from './snap-keyring-builder-messenger';
+
+describe('getSnapKeyringBuilderMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const snapKeyringBuilderMessenger =
+      getSnapKeyringBuilderMessenger(messenger);
+
+    expect(snapKeyringBuilderMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});
+
+describe('getSnapKeyringBuilderInitMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const snapKeyringBuilderInitMessenger =
+      getSnapKeyringBuilderInitMessenger(messenger);
+
+    expect(snapKeyringBuilderInitMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});

--- a/app/core/Engine/messengers/snap-keyring-builder-messenger.ts
+++ b/app/core/Engine/messengers/snap-keyring-builder-messenger.ts
@@ -1,0 +1,115 @@
+import { Messenger } from '@metamask/base-controller';
+import {
+  AcceptRequest,
+  AddApprovalRequest,
+  EndFlow,
+  RejectRequest,
+  ShowError,
+  ShowSuccess,
+  StartFlow,
+} from '@metamask/approval-controller';
+import { MaybeUpdateState, TestOrigin } from '@metamask/phishing-controller';
+import {
+  KeyringControllerGetAccountsAction,
+  KeyringControllerPersistAllKeyringsAction,
+} from '@metamask/keyring-controller';
+import {
+  AccountsControllerGetAccountByAddressAction,
+  AccountsControllerGetSelectedAccountAction,
+  AccountsControllerListMultichainAccountsAction,
+  AccountsControllerSetAccountNameAction,
+  AccountsControllerSetAccountNameAndSelectAccountAction,
+  AccountsControllerSetSelectedAccountAction,
+} from '@metamask/accounts-controller';
+import {
+  GetSnap,
+  HandleSnapRequest,
+  IsMinimumPlatformVersion,
+} from '@metamask/snaps-controllers';
+
+type AllowedActions =
+  | AcceptRequest
+  | AccountsControllerGetSelectedAccountAction
+  | AccountsControllerGetAccountByAddressAction
+  | AccountsControllerSetAccountNameAction
+  | AccountsControllerSetAccountNameAndSelectAccountAction
+  | AccountsControllerSetSelectedAccountAction
+  | AccountsControllerListMultichainAccountsAction
+  | AddApprovalRequest
+  | EndFlow
+  | GetSnap
+  | HandleSnapRequest
+  | IsMinimumPlatformVersion
+  | KeyringControllerGetAccountsAction
+  | MaybeUpdateState
+  | RejectRequest
+  | StartFlow
+  | ShowSuccess
+  | ShowError
+  | TestOrigin;
+
+type AllowedEvents = never;
+
+export type SnapKeyringBuilderMessenger = ReturnType<
+  typeof getSnapKeyringBuilderMessenger
+>;
+
+/**
+ * Get a messenger restricted to the actions and events that the
+ * Snap keyring builder is allowed to handle.
+ *
+ * @param messenger - The controller messenger to restrict.
+ * @returns The restricted controller messenger.
+ */
+export function getSnapKeyringBuilderMessenger(
+  messenger: Messenger<AllowedActions, AllowedEvents>,
+) {
+  return messenger.getRestricted({
+    name: 'SnapKeyringBuilder',
+    allowedActions: [
+      'AccountsController:getAccountByAddress',
+      'AccountsController:listMultichainAccounts',
+      'AccountsController:setAccountName',
+      'AccountsController:setAccountNameAndSelectAccount',
+      'AccountsController:setSelectedAccount',
+      'ApprovalController:acceptRequest',
+      'ApprovalController:addRequest',
+      'ApprovalController:endFlow',
+      'ApprovalController:rejectRequest',
+      'ApprovalController:showError',
+      'ApprovalController:showSuccess',
+      'ApprovalController:startFlow',
+      'KeyringController:getAccounts',
+      'PhishingController:maybeUpdateState',
+      'PhishingController:testOrigin',
+      'SnapController:get',
+      'SnapController:handleRequest',
+      'SnapController:isMinimumPlatformVersion',
+    ],
+    allowedEvents: [],
+  });
+}
+
+export type AllowedInitializationActions =
+  KeyringControllerPersistAllKeyringsAction;
+
+export type SnapKeyringBuilderInitMessenger = ReturnType<
+  typeof getSnapKeyringBuilderInitMessenger
+>;
+
+/**
+ * Get a messenger restricted to the actions and events that the
+ * Snap keyring builder needs during initialization.
+ *
+ * @param messenger - The controller messenger to restrict.
+ * @returns The restricted controller messenger.
+ */
+export function getSnapKeyringBuilderInitMessenger(
+  messenger: Messenger<AllowedInitializationActions, never>,
+) {
+  return messenger.getRestricted({
+    name: 'SnapKeyringBuilderInit',
+    allowedActions: ['KeyringController:persistAllKeyrings'],
+    allowedEvents: [],
+  });
+}

--- a/app/core/Engine/types.ts
+++ b/app/core/Engine/types.ts
@@ -324,13 +324,15 @@ import {
   GatorPermissionsController,
   GatorPermissionsControllerState,
 } from '@metamask/gator-permissions-controller';
+import { SnapKeyringBuilder } from '../SnapKeyring/SnapKeyring';
+import { QrKeyringDeferredPromiseBridge } from '@metamask/eth-qr-keyring';
 
 /**
  * Controllers that area always instantiated
  */
 type RequiredControllers = Omit<
   Controllers,
-  'PPOMController' | 'RewardsDataService'
+  'PPOMController' | 'RewardsDataService' | 'SnapKeyringBuilder'
 >;
 
 /**
@@ -338,7 +340,7 @@ type RequiredControllers = Omit<
  */
 type OptionalControllers = Pick<
   Controllers,
-  'PPOMController' | 'RewardsDataService'
+  'PPOMController' | 'RewardsDataService' | 'SnapKeyringBuilder'
 >;
 
 /**
@@ -557,6 +559,7 @@ export type Controllers = {
   MultichainAssetsController: MultichainAssetsController;
   MultichainTransactionsController: MultichainTransactionsController;
   MultichainAccountService: MultichainAccountService;
+  SnapKeyringBuilder: SnapKeyringBuilder;
   ///: END:ONLY_INCLUDE_IF
   TokenSearchDiscoveryDataController: TokenSearchDiscoveryDataController;
   MultichainNetworkController: MultichainNetworkController;
@@ -688,6 +691,7 @@ export type ControllersToInitialize =
   | 'MultichainBalancesController'
   | 'MultichainTransactionsController'
   | 'MultichainAccountService'
+  | 'SnapKeyringBuilder'
   ///: END:ONLY_INCLUDE_IF
   | 'AccountTreeController'
   | 'AccountsController'
@@ -695,6 +699,7 @@ export type ControllersToInitialize =
   | 'CurrencyRateController'
   | 'DeFiPositionsController'
   | 'GasFeeController'
+  | 'KeyringController'
   | 'MultichainNetworkController'
   | 'SignatureController'
   | 'SeedlessOnboardingController'
@@ -772,6 +777,25 @@ export type ControllerInitRequest<
    */
   getState: () => RootState;
 
+  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+  /**
+   * Remove an account from all controllers that manage accounts.
+   *
+   * @param address - The address of the account to remove.
+   */
+  removeAccount(address: string): Promise<void>;
+  ///: END:ONLY_INCLUDE_IF
+
+  /**
+   * The initial state of the keyring controller, if applicable.
+   */
+  initialKeyringState?: KeyringControllerState | null;
+
+  /**
+   * QR keyring scanner bridge.
+   */
+  qrKeyringScanner: QrKeyringDeferredPromiseBridge;
+
   /**
    * Required initialization messenger instance.
    * Generated using the callback specified in `getInitMessenger`.
@@ -810,16 +834,25 @@ export type ControllerInitFunctionByControllerName = {
   >;
 };
 
-/**
- * Function to initialize the controllers in the engine.
- */
-export type InitModularizedControllersFunction = (request: {
+export interface InitModularizedControllersFunctionRequest {
   baseControllerMessenger: BaseControllerMessenger;
   controllerInitFunctions: ControllerInitFunctionByControllerName;
   existingControllersByName?: Partial<ControllerByName>;
   getGlobalChainId: () => Hex;
   getState: () => RootState;
+  initialKeyringState?: KeyringControllerState | null;
+  qrKeyringScanner: QrKeyringDeferredPromiseBridge;
+  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+  removeAccount: (address: string) => Promise<void>;
+  ///: END:ONLY_INCLUDE_IF
   persistedState: ControllerPersistedState;
-}) => {
+}
+
+/**
+ * Function to initialize the controllers in the engine.
+ */
+export type InitModularizedControllersFunction = (
+  request: InitModularizedControllersFunctionRequest,
+) => {
   controllersByName: ControllerByName;
 };

--- a/app/core/Engine/utils/test-utils.ts
+++ b/app/core/Engine/utils/test-utils.ts
@@ -6,6 +6,7 @@ import {
   ControllerName,
   ControllerInitRequest,
 } from '../types';
+import { QrKeyringDeferredPromiseBridge } from '@metamask/eth-qr-keyring';
 
 /**
  * Build a mock for the ControllerInitRequest.
@@ -22,6 +23,8 @@ export function buildControllerInitRequestMock(
     getGlobalChainId: jest.fn(),
     getState: jest.fn(),
     initMessenger: jest.fn() as unknown as void,
+    qrKeyringScanner: jest.fn() as unknown as QrKeyringDeferredPromiseBridge,
+    removeAccount: jest.fn(),
     persistedState: {},
   };
 }

--- a/app/core/Engine/utils/utils.test.ts
+++ b/app/core/Engine/utils/utils.test.ts
@@ -82,6 +82,12 @@ import {
 import { subjectMetadataControllerInit } from '../controllers/subject-metadata-controller-init';
 import { preferencesControllerInit } from '../controllers/preferences-controller-init';
 import { PreferencesController } from '@metamask/preferences-controller';
+import { keyringControllerInit } from '../controllers/keyring-controller-init';
+import { snapKeyringBuilderInit } from '../controllers/snap-keyring-builder-init';
+import { KeyringController } from '@metamask/keyring-controller';
+import { SnapKeyringBuilder } from '../../SnapKeyring/SnapKeyring';
+import { InitModularizedControllersFunctionRequest } from '../types';
+import { QrKeyringDeferredPromiseBridge } from '@metamask/eth-qr-keyring';
 
 jest.mock('../controllers/accounts-controller');
 jest.mock('../controllers/rewards-controller');
@@ -129,6 +135,8 @@ jest.mock('../controllers/selected-network-controller-init');
 jest.mock('../controllers/permission-controller-init');
 jest.mock('../controllers/subject-metadata-controller-init');
 jest.mock('../controllers/preferences-controller-init');
+jest.mock('../controllers/keyring-controller-init');
+jest.mock('../controllers/snap-keyring-builder-init');
 
 describe('initModularizedControllers', () => {
   const mockAccountsControllerInit = jest.mocked(accountsControllerInit);
@@ -200,10 +208,12 @@ describe('initModularizedControllers', () => {
     subjectMetadataControllerInit,
   );
   const mockPreferencesControllerInit = jest.mocked(preferencesControllerInit);
+  const mockKeyringControllerInit = jest.mocked(keyringControllerInit);
+  const mockSnapKeyringBuilderInit = jest.mocked(snapKeyringBuilderInit);
 
   function buildModularizedControllerRequest(
     overrides?: Record<string, unknown>,
-  ) {
+  ): InitModularizedControllersFunctionRequest {
     return merge(
       {
         existingControllersByName: {},
@@ -247,11 +257,17 @@ describe('initModularizedControllers', () => {
           GatorPermissionsController: mockGatorPermissionsControllerInit,
           SubjectMetadataController: mockSubjectMetadataControllerInit,
           PreferencesController: mockPreferencesControllerInit,
+          KeyringController: mockKeyringControllerInit,
+          SnapKeyringBuilder: mockSnapKeyringBuilderInit,
         },
         persistedState: {},
         baseControllerMessenger: new ExtendedControllerMessenger(),
         getGlobalChainId: jest.fn(),
         getState: jest.fn(),
+        removeAccount: jest.fn(),
+        qrKeyringScanner:
+          jest.fn() as unknown as QrKeyringDeferredPromiseBridge,
+        initialKeyringState: null,
       },
       overrides,
     );
@@ -352,6 +368,12 @@ describe('initModularizedControllers', () => {
     });
     mockPreferencesControllerInit.mockReturnValue({
       controller: {} as unknown as PreferencesController,
+    });
+    mockKeyringControllerInit.mockReturnValue({
+      controller: {} as unknown as KeyringController,
+    });
+    mockSnapKeyringBuilderInit.mockReturnValue({
+      controller: {} as unknown as SnapKeyringBuilder,
     });
   });
 

--- a/app/core/SnapKeyring/SnapKeyring.ts
+++ b/app/core/SnapKeyring/SnapKeyring.ts
@@ -23,6 +23,9 @@ import { areAddressesEqual } from '../../util/address';
  * Builder type for the Snap keyring.
  */
 export interface SnapKeyringBuilder {
+  name: 'SnapKeyringBuilder';
+  state: null;
+
   (): SnapKeyring;
   type: typeof SnapKeyring.type;
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This refactors the keyring controller to use modular init.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves keyring setup from Engine into modular init functions with dedicated messengers, updates Engine to use them, and adds supporting types and tests.
> 
> - **Engine**:
>   - Refactors keyring setup to use modular controllers. Removes inlined `HdKeyring`/`LedgerKeyring`/`QrKeyring` builders and direct `KeyringController` construction and encryptor wiring.
>   - Passes `initialKeyringState`, `qrKeyringScanner`, and (keyring-snaps) `removeAccount` into `initModularizedControllers` and retrieves `KeyringController` from `controllersByName`.
>   - Adjusts snaps auth/user-storage init placement; minor import cleanups.
> - **Controllers**:
>   - Adds `keyring-controller-init` to construct `KeyringController` (configures `Encryptor`, `HdKeyring`, `LedgerKeyring`, `QrKeyring`, and (keyring-snaps) `SnapKeyringBuilder`).
>   - Adds `snap-keyring-builder-init` to create `SnapKeyring` builder; persists keyrings via init messenger and uses `removeAccount` helper.
> - **Messengers**:
>   - Adds `keyring-controller-messenger` and `snap-keyring-builder-messenger` (plus init messenger) and registers them in `messengers/index`.
> - **Types/Utils**:
>   - Extends engine `types` and init request to include `initialKeyringState`, `qrKeyringScanner`, and (keyring-snaps) `removeAccount`; adds `KeyringController` and `SnapKeyringBuilder` to controller maps.
>   - Updates test utils to provide new init request fields.
>   - Enhances `SnapKeyringBuilder` interface (name/state metadata).
> - **Tests**:
>   - Adds unit tests for keyring init and messengers; updates modular init tests to include new controllers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47db4a345acc293cd1bb94b2abf60ba0b59fec8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->