### PR TITLE
fix: cp-7.57.0 MM Poly font on iOS & onboarding title cropped

### DIFF
--- a/app/components/UI/Rewards/components/Onboarding/OnboardingIntroStep.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/OnboardingIntroStep.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef } from 'react';
-import { Image, ImageBackground, Text as RNText } from 'react-native';
+import { Image, ImageBackground, Platform, Text as RNText } from 'react-native';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -270,9 +270,11 @@ const OnboardingIntroStep: React.FC<{
       <Box twClassName="justify-center items-center">
         <RNText
           style={[
-            tw.style('text-center text-white text-12 leading-1'),
+            tw.style('text-center text-white text-12 leading-1 pt-1'),
             // eslint-disable-next-line react-native/no-inline-styles
-            { fontFamily: 'MM Poly Regular', fontWeight: '500' },
+            {
+              fontFamily: Platform.OS === 'ios' ? 'MM Poly' : 'MM Poly Regular',
+            },
           ]}
         >
           {title}
@@ -348,7 +350,7 @@ const OnboardingIntroStep: React.FC<{
         resizeMode="cover"
       >
         {/* Spacer */}
-        <Box twClassName="flex-basis-[10%]" />
+        <Box twClassName="flex-basis-[6%]" />
 
         {/* Title Section */}
         {renderTitle()}

--- a/app/components/UI/Rewards/components/Onboarding/OnboardingStep1.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/OnboardingStep1.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { Image } from 'react-native';
+import { Image, useWindowDimensions } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useDispatch } from 'react-redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -18,6 +18,7 @@ const OnboardingStep1: React.FC = () => {
   const dispatch = useDispatch();
   const tw = useTailwind();
   const { colors } = useTheme();
+  const { width: screenWidth, height: screenHeight } = useWindowDimensions();
 
   const handleNext = useCallback(() => {
     dispatch(setOnboardingActiveStep(OnboardingStep.STEP_2));
@@ -34,7 +35,9 @@ const OnboardingStep1: React.FC = () => {
       <Step1BgImg
         name="rewards-onboarding-step1-bg"
         fill={colors.background.muted}
-        style={tw.style('absolute w-full h-full')}
+        style={tw.style('absolute')}
+        width={screenWidth}
+        height={screenHeight}
       />
 
       <Image

--- a/app/components/UI/Rewards/components/Onboarding/OnboardingStep2.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/OnboardingStep2.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { Image } from 'react-native';
+import { Image, useWindowDimensions } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useDispatch } from 'react-redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -18,6 +18,7 @@ const OnboardingStep2: React.FC = () => {
   const dispatch = useDispatch();
   const tw = useTailwind();
   const { colors } = useTheme();
+  const { width: screenWidth, height: screenHeight } = useWindowDimensions();
 
   const handleNext = useCallback(() => {
     dispatch(setOnboardingActiveStep(OnboardingStep.STEP_3));
@@ -35,6 +36,8 @@ const OnboardingStep2: React.FC = () => {
         name="rewards-onboarding-step2-bg"
         fill={colors.background.muted}
         style={tw.style('absolute flex-1 w-full h-full')}
+        width={screenWidth}
+        height={screenHeight}
       />
 
       <Image

--- a/app/components/UI/Rewards/components/Onboarding/OnboardingStep3.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/OnboardingStep3.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { Image } from 'react-native';
+import { Image, useWindowDimensions } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { useDispatch } from 'react-redux';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -20,6 +20,7 @@ const OnboardingStep3: React.FC = () => {
   const tw = useTailwind();
   const { colors } = useTheme();
   const { trackEvent, createEventBuilder } = useMetrics();
+  const { width: screenWidth, height: screenHeight } = useWindowDimensions();
 
   const handleNext = useCallback(async () => {
     dispatch(setOnboardingActiveStep(OnboardingStep.STEP_4));
@@ -42,6 +43,8 @@ const OnboardingStep3: React.FC = () => {
         name="rewards-onboarding-step3-bg"
         fill={colors.background.muted}
         style={tw.style('absolute w-full h-full')}
+        width={screenWidth}
+        height={screenHeight}
       />
 
       <Image


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
- Adapt MM Poly font to each OS to prevent displaying normal font in some cases
- Fix cropped Rewards onboarding title

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/RWDS-319
Fixes: https://consensyssoftware.atlassian.net/browse/RWDS-563
Fixes: https://consensyssoftware.atlassian.net/browse/RWDS-544
Fixes: https://consensyssoftware.atlassian.net/browse/RWDS-549

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/d90e1995-be75-4de0-8b52-71e624021091" />

### **After**

<!-- [screenshots/recordings] -->
![simulator_screenshot_D2C64A2E-EFB9-4E63-AF52-0B4CF3ABBA5E](https://github.com/user-attachments/assets/30385893-fa4e-4d83-a2e3-5900f33d86c7)

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use platform-specific MM Poly font and small padding for intro title; size onboarding step background SVGs via window dimensions and slightly adjust layout spacing.
> 
> - **Rewards Onboarding UI**:
>   - **Intro step (`OnboardingIntroStep.tsx`)**:
>     - Use platform-specific `fontFamily` for `MM Poly` (`ios: 'MM Poly'`, others: `'MM Poly Regular'`).
>     - Add small padding to title (`pt-1`) and reduce top spacer from `10%` to `6%`.
>   - **Steps 1–3 (`OnboardingStep1/2/3.tsx`)**:
>     - Size background SVGs (`StepXBgImg`) using `useWindowDimensions()` to set `width`/`height` to the screen.
>     - Minor style tweaks to background container; step images unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05550ca071775b8b896dfad69e00ab76075052a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->