### PR TITLE
refactor: Refactor network controller to use messenger and init pattern

### DIFF
--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -30,12 +30,7 @@ import {
   KeyringTypes,
   ///: END:ONLY_INCLUDE_IF
 } from '@metamask/keyring-controller';
-import {
-  getDefaultNetworkControllerState,
-  NetworkController,
-  NetworkState,
-  NetworkStatus,
-} from '@metamask/network-controller';
+import { NetworkState, NetworkStatus } from '@metamask/network-controller';
 import { PhishingController } from '@metamask/phishing-controller';
 import {
   TransactionController,
@@ -104,7 +99,6 @@ import { selectSwapsChainFeatureFlags } from '../../reducers/swaps';
 import { ClientId } from '@metamask/smart-transactions-controller/dist/types';
 import { zeroAddress } from 'ethereumjs-util';
 import {
-  ChainId,
   type TraceCallback,
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   toHex,
@@ -174,14 +168,6 @@ import { isProductSafetyDappScanningEnabled } from '../../util/phishingDetection
 import { appMetadataControllerInit } from './controllers/app-metadata-controller';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { toFormattedAddress } from '../../util/address';
-import { getFailoverUrlsForInfuraNetwork } from '../../util/networks/customNetworks';
-import {
-  onRpcEndpointDegraded,
-  onRpcEndpointUnavailable,
-} from './controllers/network-controller/messenger-action-handlers';
-import { INFURA_PROJECT_ID } from '../../constants/network';
-import { SECOND } from '../../constants/time';
-import { getIsQuicknodeEndpointUrl } from './controllers/network-controller/utils';
 import {
   MultichainRouter,
   MultichainRouterMessenger,
@@ -212,9 +198,8 @@ import { preferencesControllerInit } from './controllers/preferences-controller-
 import { snapKeyringBuilderInit } from './controllers/snap-keyring-builder-init';
 ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import { keyringControllerInit } from './controllers/keyring-controller-init';
+import { networkControllerInit } from './controllers/network-controller-init';
 ///: END:ONLY_INCLUDE_IF
-
-const NON_EMPTY = 'NON_EMPTY';
 
 // TODO: Replace "any" with type
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -318,135 +303,218 @@ export class Engine {
       captureException,
     });
 
-    const networkControllerMessenger = this.controllerMessenger.getRestricted({
-      name: 'NetworkController',
-      allowedEvents: [],
-      allowedActions: ['ErrorReportingService:captureException'],
+    const codefiTokenApiV2 = new CodefiTokenPricesServiceV2();
+
+    const smartTransactionsControllerTrackMetaMetricsEvent = (
+      params: {
+        event: MetaMetricsEventName;
+        category: MetaMetricsEventCategory;
+        properties?: ReturnType<
+          typeof getSmartTransactionMetricsPropertiesType
+        >;
+        sensitiveProperties?: ReturnType<
+          typeof getSmartTransactionMetricsSensitivePropertiesType
+        >;
+      },
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      options?: {
+        metaMetricsId?: string;
+      },
+    ) => {
+      MetaMetrics.getInstance().trackEvent(
+        MetricsEventBuilder.createEventBuilder({
+          category: params.event,
+        })
+          .addProperties(params.properties || {})
+          .addSensitiveProperties(params.sensitiveProperties || {})
+          .build(),
+      );
+    };
+
+    this.smartTransactionsController = new SmartTransactionsController({
+      // @ts-expect-error TODO: resolve types
+      supportedChainIds: getAllowedSmartTransactionsChainIds(),
+      clientId: ClientId.Mobile,
+      getNonceLock: (...args) =>
+        this.transactionController.getNonceLock(...args),
+      confirmExternalTransaction: (...args) =>
+        this.transactionController.confirmExternalTransaction(...args),
+      trackMetaMetricsEvent: smartTransactionsControllerTrackMetaMetricsEvent,
+      state: initialState.SmartTransactionsController,
+      // @ts-expect-error TODO: Resolve mismatch between base-controller versions.
+      messenger: this.controllerMessenger.getRestricted({
+        name: 'SmartTransactionsController',
+        allowedActions: [
+          'NetworkController:getNetworkClientById',
+          'NetworkController:getState',
+        ],
+        allowedEvents: ['NetworkController:stateChange'],
+      }),
+      getTransactions: (...args) =>
+        this.transactionController.getTransactions(...args),
+      updateTransaction: (...args) =>
+        this.transactionController.updateTransaction(...args),
+      getFeatureFlags: () => selectSwapsChainFeatureFlags(store.getState()),
+      getMetaMetricsProps: () => Promise.resolve({}), // Return MetaMetrics props once we enable HW wallets for smart transactions.
+      trace: trace as TraceCallback,
     });
 
-    const additionalDefaultNetworks = [
-      ChainId['megaeth-testnet'],
-      ChainId['monad-testnet'],
-    ];
+    const tokenSearchDiscoveryDataController =
+      new TokenSearchDiscoveryDataController({
+        tokenPricesService: codefiTokenApiV2,
+        swapsSupportedChainIds,
+        fetchSwapsTokensThresholdMs: AppConstants.SWAPS.CACHE_TOKENS_THRESHOLD,
+        fetchTokens: swapsUtils.fetchTokens,
+        messenger: this.controllerMessenger.getRestricted({
+          name: 'TokenSearchDiscoveryDataController',
+          allowedActions: ['CurrencyRateController:getState'],
+          allowedEvents: [],
+        }),
+      });
 
-    let initialNetworkControllerState = initialState.NetworkController;
-    if (!initialNetworkControllerState) {
-      initialNetworkControllerState = getDefaultNetworkControllerState(
-        additionalDefaultNetworks,
-      );
-
-      // Add failovers for default Infura RPC endpoints
-      initialNetworkControllerState.networkConfigurationsByChainId[
-        ChainId.mainnet
-      ].rpcEndpoints[0].failoverUrls =
-        getFailoverUrlsForInfuraNetwork('ethereum-mainnet');
-      initialNetworkControllerState.networkConfigurationsByChainId[
-        ChainId['linea-mainnet']
-      ].rpcEndpoints[0].failoverUrls =
-        getFailoverUrlsForInfuraNetwork('linea-mainnet');
-      initialNetworkControllerState.networkConfigurationsByChainId[
-        ChainId['base-mainnet']
-      ].rpcEndpoints[0].failoverUrls =
-        getFailoverUrlsForInfuraNetwork('base-mainnet');
-
-      // Update default popular network names
-      initialNetworkControllerState.networkConfigurationsByChainId[
-        ChainId.mainnet
-      ].name = 'Ethereum';
-      initialNetworkControllerState.networkConfigurationsByChainId[
-        ChainId['linea-mainnet']
-      ].name = 'Linea';
-      initialNetworkControllerState.networkConfigurationsByChainId[
-        ChainId['base-mainnet']
-      ].name = 'Base';
-    }
-
-    const infuraProjectId = INFURA_PROJECT_ID || NON_EMPTY;
-    const networkControllerOptions = {
-      infuraProjectId,
-      state: initialNetworkControllerState,
-      messenger: networkControllerMessenger,
-      getBlockTrackerOptions: () =>
-        process.env.IN_TEST
-          ? {}
-          : {
-              pollingInterval: 20 * SECOND,
-              // The retry timeout is pretty short by default, and if the endpoint is
-              // down, it will end up exhausting the max number of consecutive
-              // failures quickly.
-              retryTimeout: 20 * SECOND,
-            },
-      getRpcServiceOptions: (rpcEndpointUrl: string) => {
-        const maxRetries = 4;
-        const commonOptions = {
-          fetch: globalThis.fetch.bind(globalThis),
-          btoa: globalThis.btoa.bind(globalThis),
-        };
-
-        if (getIsQuicknodeEndpointUrl(rpcEndpointUrl)) {
-          return {
-            ...commonOptions,
-            policyOptions: {
-              maxRetries,
-              // When we fail over to Quicknode, we expect it to be down at
-              // first while it is being automatically activated. If an endpoint
-              // is down, the failover logic enters a "cooldown period" of 30
-              // minutes. We'd really rather not enter that for Quicknode, so
-              // keep retrying longer.
-              maxConsecutiveFailures: (maxRetries + 1) * 14,
-            },
-          };
-        }
-
-        return {
-          ...commonOptions,
-          policyOptions: {
-            maxRetries,
-            // Ensure that the circuit does not break too quickly.
-            maxConsecutiveFailures: (maxRetries + 1) * 7,
-          },
-        };
-      },
-      additionalDefaultNetworks,
+    const existingControllersByName = {
+      SmartTransactionsController: this.smartTransactionsController,
     };
-    const networkController = new NetworkController(networkControllerOptions);
-    networkControllerMessenger.subscribe(
-      'NetworkController:rpcEndpointUnavailable',
-      async ({ chainId, endpointUrl, error }) => {
-        onRpcEndpointUnavailable({
-          chainId,
-          endpointUrl,
-          infuraProjectId,
-          error,
-          trackEvent: ({ event, properties }) => {
-            const metricsEvent = MetricsEventBuilder.createEventBuilder(event)
-              .addProperties(properties)
-              .build();
-            MetaMetrics.getInstance().trackEvent(metricsEvent);
-          },
-          metaMetricsId: await MetaMetrics.getInstance().getMetaMetricsId(),
-        });
+
+    const initRequest = {
+      getState: () => store.getState(),
+      getGlobalChainId: () => currentChainId,
+      ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+      removeAccount: this.removeAccount.bind(this),
+      ///: END:ONLY_INCLUDE_IF
+      initialKeyringState,
+      qrKeyringScanner: this.qrKeyringScanner,
+    };
+
+    const { controllersByName } = initModularizedControllers({
+      controllerInitFunctions: {
+        PreferencesController: preferencesControllerInit,
+        NetworkController: networkControllerInit,
+        AccountsController: accountsControllerInit,
+        ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+        SnapKeyringBuilder: snapKeyringBuilderInit,
+        ///: END:ONLY_INCLUDE_IF
+        KeyringController: keyringControllerInit,
+        PermissionController: permissionControllerInit,
+        ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+        SubjectMetadataController: subjectMetadataControllerInit,
+        ///: END:ONLY_INCLUDE_IF
+        AccountTreeController: accountTreeControllerInit,
+        AppMetadataController: appMetadataControllerInit,
+        SelectedNetworkController: selectedNetworkControllerInit,
+        ApprovalController: ApprovalControllerInit,
+        GasFeeController: GasFeeControllerInit,
+        GatorPermissionsController: GatorPermissionsControllerInit,
+        TransactionController: TransactionControllerInit,
+        SignatureController: SignatureControllerInit,
+        CurrencyRateController: currencyRateControllerInit,
+        MultichainNetworkController: multichainNetworkControllerInit,
+        DeFiPositionsController: defiPositionsControllerInit,
+        BridgeController: bridgeControllerInit,
+        BridgeStatusController: bridgeStatusControllerInit,
+        ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+        ExecutionService: executionServiceInit,
+        CronjobController: cronjobControllerInit,
+        SnapController: snapControllerInit,
+        SnapInterfaceController: snapInterfaceControllerInit,
+        SnapsRegistry: snapsRegistryInit,
+        NotificationServicesController: notificationServicesControllerInit,
+        NotificationServicesPushController:
+          notificationServicesPushControllerInit,
+        WebSocketService: WebSocketServiceInit,
+        ///: END:ONLY_INCLUDE_IF
+        ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+        MultichainAssetsController: multichainAssetsControllerInit,
+        MultichainAssetsRatesController: multichainAssetsRatesControllerInit,
+        MultichainBalancesController: multichainBalancesControllerInit,
+        MultichainTransactionsController: multichainTransactionsControllerInit,
+        MultichainAccountService: multichainAccountServiceInit,
+        ///: END:ONLY_INCLUDE_IF
+        SeedlessOnboardingController: seedlessOnboardingControllerInit,
+        NetworkEnablementController: networkEnablementControllerInit,
+        PerpsController: perpsControllerInit,
+        PredictController: predictControllerInit,
+        RewardsController: rewardsControllerInit,
       },
-    );
-    networkControllerMessenger.subscribe(
-      'NetworkController:rpcEndpointDegraded',
-      async ({ chainId, endpointUrl, error }) => {
-        onRpcEndpointDegraded({
-          chainId,
-          endpointUrl,
-          error,
-          infuraProjectId,
-          trackEvent: ({ event, properties }) => {
-            const metricsEvent = MetricsEventBuilder.createEventBuilder(event)
-              .addProperties(properties)
-              .build();
-            MetaMetrics.getInstance().trackEvent(metricsEvent);
-          },
-          metaMetricsId: await MetaMetrics.getInstance().getMetaMetricsId(),
-        });
-      },
-    );
-    networkController.initializeProvider();
+      persistedState: initialState as EngineState,
+      existingControllersByName,
+      baseControllerMessenger: this.controllerMessenger,
+      ...initRequest,
+    });
+
+    const accountsController = controllersByName.AccountsController;
+    const accountTreeController = controllersByName.AccountTreeController;
+    const approvalController = controllersByName.ApprovalController;
+    const gasFeeController = controllersByName.GasFeeController;
+    const signatureController = controllersByName.SignatureController;
+    const transactionController = controllersByName.TransactionController;
+    const seedlessOnboardingController =
+      controllersByName.SeedlessOnboardingController;
+    const perpsController = controllersByName.PerpsController;
+    const predictController = controllersByName.PredictController;
+    const rewardsController = controllersByName.RewardsController;
+    const gatorPermissionsController =
+      controllersByName.GatorPermissionsController;
+    const selectedNetworkController =
+      controllersByName.SelectedNetworkController;
+    const preferencesController = controllersByName.PreferencesController;
+
+    // Initialize and store RewardsDataService
+    this.rewardsDataService = new RewardsDataService({
+      messenger: this.controllerMessenger.getRestricted({
+        name: 'RewardsDataService',
+        allowedActions: [],
+        allowedEvents: [],
+      }),
+      fetch,
+      locale: I18n.locale,
+    });
+
+    // Backwards compatibility for existing references
+    this.accountsController = accountsController;
+    this.gasFeeController = gasFeeController;
+    this.gatorPermissionsController = gatorPermissionsController;
+    this.transactionController = transactionController;
+    this.permissionController = controllersByName.PermissionController;
+    this.preferencesController = preferencesController;
+    this.keyringController = controllersByName.KeyringController;
+
+    const multichainNetworkController =
+      controllersByName.MultichainNetworkController;
+    const currencyRateController = controllersByName.CurrencyRateController;
+    const bridgeController = controllersByName.BridgeController;
+    const networkController = controllersByName.NetworkController;
+
+    ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+    const cronjobController = controllersByName.CronjobController;
+    const executionService = controllersByName.ExecutionService;
+    const snapController = controllersByName.SnapController;
+    const snapInterfaceController = controllersByName.SnapInterfaceController;
+    const snapsRegistry = controllersByName.SnapsRegistry;
+    const webSocketService = controllersByName.WebSocketService;
+    const notificationServicesController =
+      controllersByName.NotificationServicesController;
+    const notificationServicesPushController =
+      controllersByName.NotificationServicesPushController;
+    this.subjectMetadataController =
+      controllersByName.SubjectMetadataController;
+    ///: END:ONLY_INCLUDE_IF
+
+    ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+    const multichainAssetsController =
+      controllersByName.MultichainAssetsController;
+    const multichainAssetsRatesController =
+      controllersByName.MultichainAssetsRatesController;
+    const multichainBalancesController =
+      controllersByName.MultichainBalancesController;
+    const multichainTransactionsController =
+      controllersByName.MultichainTransactionsController;
+    const multichainAccountService = controllersByName.MultichainAccountService;
+    ///: END:ONLY_INCLUDE_IF
+
+    const networkEnablementController =
+      controllersByName.NetworkEnablementController;
+    networkEnablementController.init();
 
     const assetsContractController = new AssetsContractController({
       messenger: this.controllerMessenger.getRestricted({
@@ -574,218 +642,6 @@ export class Engine {
       }) as `0x${string}`[],
       allowExternalServices: () => isBasicFunctionalityToggleEnabled(),
     });
-
-    const codefiTokenApiV2 = new CodefiTokenPricesServiceV2();
-
-    const smartTransactionsControllerTrackMetaMetricsEvent = (
-      params: {
-        event: MetaMetricsEventName;
-        category: MetaMetricsEventCategory;
-        properties?: ReturnType<
-          typeof getSmartTransactionMetricsPropertiesType
-        >;
-        sensitiveProperties?: ReturnType<
-          typeof getSmartTransactionMetricsSensitivePropertiesType
-        >;
-      },
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      options?: {
-        metaMetricsId?: string;
-      },
-    ) => {
-      MetaMetrics.getInstance().trackEvent(
-        MetricsEventBuilder.createEventBuilder({
-          category: params.event,
-        })
-          .addProperties(params.properties || {})
-          .addSensitiveProperties(params.sensitiveProperties || {})
-          .build(),
-      );
-    };
-
-    this.smartTransactionsController = new SmartTransactionsController({
-      // @ts-expect-error TODO: resolve types
-      supportedChainIds: getAllowedSmartTransactionsChainIds(),
-      clientId: ClientId.Mobile,
-      getNonceLock: (...args) =>
-        this.transactionController.getNonceLock(...args),
-      confirmExternalTransaction: (...args) =>
-        this.transactionController.confirmExternalTransaction(...args),
-      trackMetaMetricsEvent: smartTransactionsControllerTrackMetaMetricsEvent,
-      state: initialState.SmartTransactionsController,
-      // @ts-expect-error TODO: Resolve mismatch between base-controller versions.
-      messenger: this.controllerMessenger.getRestricted({
-        name: 'SmartTransactionsController',
-        allowedActions: [
-          'NetworkController:getNetworkClientById',
-          'NetworkController:getState',
-        ],
-        allowedEvents: ['NetworkController:stateChange'],
-      }),
-      getTransactions: (...args) =>
-        this.transactionController.getTransactions(...args),
-      updateTransaction: (...args) =>
-        this.transactionController.updateTransaction(...args),
-      getFeatureFlags: () => selectSwapsChainFeatureFlags(store.getState()),
-      getMetaMetricsProps: () => Promise.resolve({}), // Return MetaMetrics props once we enable HW wallets for smart transactions.
-      trace: trace as TraceCallback,
-    });
-
-    const tokenSearchDiscoveryDataController =
-      new TokenSearchDiscoveryDataController({
-        tokenPricesService: codefiTokenApiV2,
-        swapsSupportedChainIds,
-        fetchSwapsTokensThresholdMs: AppConstants.SWAPS.CACHE_TOKENS_THRESHOLD,
-        fetchTokens: swapsUtils.fetchTokens,
-        messenger: this.controllerMessenger.getRestricted({
-          name: 'TokenSearchDiscoveryDataController',
-          allowedActions: ['CurrencyRateController:getState'],
-          allowedEvents: [],
-        }),
-      });
-
-    const existingControllersByName = {
-      NetworkController: networkController,
-      SmartTransactionsController: this.smartTransactionsController,
-    };
-
-    const initRequest = {
-      getState: () => store.getState(),
-      getGlobalChainId: () => currentChainId,
-      ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-      removeAccount: this.removeAccount.bind(this),
-      ///: END:ONLY_INCLUDE_IF
-      initialKeyringState,
-      qrKeyringScanner: this.qrKeyringScanner,
-    };
-
-    const { controllersByName } = initModularizedControllers({
-      controllerInitFunctions: {
-        PreferencesController: preferencesControllerInit,
-        AccountsController: accountsControllerInit,
-        ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-        SnapKeyringBuilder: snapKeyringBuilderInit,
-        ///: END:ONLY_INCLUDE_IF
-        KeyringController: keyringControllerInit,
-        PermissionController: permissionControllerInit,
-        ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
-        SubjectMetadataController: subjectMetadataControllerInit,
-        ///: END:ONLY_INCLUDE_IF
-        AccountTreeController: accountTreeControllerInit,
-        AppMetadataController: appMetadataControllerInit,
-        SelectedNetworkController: selectedNetworkControllerInit,
-        ApprovalController: ApprovalControllerInit,
-        GasFeeController: GasFeeControllerInit,
-        GatorPermissionsController: GatorPermissionsControllerInit,
-        TransactionController: TransactionControllerInit,
-        SignatureController: SignatureControllerInit,
-        CurrencyRateController: currencyRateControllerInit,
-        MultichainNetworkController: multichainNetworkControllerInit,
-        DeFiPositionsController: defiPositionsControllerInit,
-        BridgeController: bridgeControllerInit,
-        BridgeStatusController: bridgeStatusControllerInit,
-        ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
-        ExecutionService: executionServiceInit,
-        CronjobController: cronjobControllerInit,
-        SnapController: snapControllerInit,
-        SnapInterfaceController: snapInterfaceControllerInit,
-        SnapsRegistry: snapsRegistryInit,
-        NotificationServicesController: notificationServicesControllerInit,
-        NotificationServicesPushController:
-          notificationServicesPushControllerInit,
-        WebSocketService: WebSocketServiceInit,
-        ///: END:ONLY_INCLUDE_IF
-        ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-        MultichainAssetsController: multichainAssetsControllerInit,
-        MultichainAssetsRatesController: multichainAssetsRatesControllerInit,
-        MultichainBalancesController: multichainBalancesControllerInit,
-        MultichainTransactionsController: multichainTransactionsControllerInit,
-        MultichainAccountService: multichainAccountServiceInit,
-        ///: END:ONLY_INCLUDE_IF
-        SeedlessOnboardingController: seedlessOnboardingControllerInit,
-        NetworkEnablementController: networkEnablementControllerInit,
-        PerpsController: perpsControllerInit,
-        PredictController: predictControllerInit,
-        RewardsController: rewardsControllerInit,
-      },
-      persistedState: initialState as EngineState,
-      existingControllersByName,
-      baseControllerMessenger: this.controllerMessenger,
-      ...initRequest,
-    });
-
-    const accountsController = controllersByName.AccountsController;
-    const accountTreeController = controllersByName.AccountTreeController;
-    const approvalController = controllersByName.ApprovalController;
-    const gasFeeController = controllersByName.GasFeeController;
-    const signatureController = controllersByName.SignatureController;
-    const transactionController = controllersByName.TransactionController;
-    const seedlessOnboardingController =
-      controllersByName.SeedlessOnboardingController;
-    const perpsController = controllersByName.PerpsController;
-    const predictController = controllersByName.PredictController;
-    const rewardsController = controllersByName.RewardsController;
-    const gatorPermissionsController =
-      controllersByName.GatorPermissionsController;
-    const selectedNetworkController =
-      controllersByName.SelectedNetworkController;
-    const preferencesController = controllersByName.PreferencesController;
-
-    // Initialize and store RewardsDataService
-    this.rewardsDataService = new RewardsDataService({
-      messenger: this.controllerMessenger.getRestricted({
-        name: 'RewardsDataService',
-        allowedActions: [],
-        allowedEvents: [],
-      }),
-      fetch,
-      locale: I18n.locale,
-    });
-
-    // Backwards compatibility for existing references
-    this.accountsController = accountsController;
-    this.gasFeeController = gasFeeController;
-    this.gatorPermissionsController = gatorPermissionsController;
-    this.transactionController = transactionController;
-    this.permissionController = controllersByName.PermissionController;
-    this.preferencesController = preferencesController;
-    this.keyringController = controllersByName.KeyringController;
-
-    const multichainNetworkController =
-      controllersByName.MultichainNetworkController;
-    const currencyRateController = controllersByName.CurrencyRateController;
-    const bridgeController = controllersByName.BridgeController;
-
-    ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
-    const cronjobController = controllersByName.CronjobController;
-    const executionService = controllersByName.ExecutionService;
-    const snapController = controllersByName.SnapController;
-    const snapInterfaceController = controllersByName.SnapInterfaceController;
-    const snapsRegistry = controllersByName.SnapsRegistry;
-    const webSocketService = controllersByName.WebSocketService;
-    const notificationServicesController =
-      controllersByName.NotificationServicesController;
-    const notificationServicesPushController =
-      controllersByName.NotificationServicesPushController;
-    this.subjectMetadataController =
-      controllersByName.SubjectMetadataController;
-    ///: END:ONLY_INCLUDE_IF
-
-    ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-    const multichainAssetsController =
-      controllersByName.MultichainAssetsController;
-    const multichainAssetsRatesController =
-      controllersByName.MultichainAssetsRatesController;
-    const multichainBalancesController =
-      controllersByName.MultichainBalancesController;
-    const multichainTransactionsController =
-      controllersByName.MultichainTransactionsController;
-    const multichainAccountService = controllersByName.MultichainAccountService;
-    ///: END:ONLY_INCLUDE_IF
-
-    const networkEnablementController =
-      controllersByName.NetworkEnablementController;
-    networkEnablementController.init();
 
     ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
     const authenticationControllerMessenger =

--- a/app/core/Engine/controllers/network-controller-init.test.ts
+++ b/app/core/Engine/controllers/network-controller-init.test.ts
@@ -1,0 +1,66 @@
+import { buildControllerInitRequestMock } from '../utils/test-utils';
+import { ExtendedControllerMessenger } from '../../ExtendedControllerMessenger';
+import {
+  getNetworkControllerInitMessenger,
+  getNetworkControllerMessenger,
+  NetworkControllerInitMessenger,
+  type NetworkControllerMessenger,
+} from '../messengers/network-controller-messenger';
+import { ControllerInitRequest } from '../types';
+import {
+  ADDITIONAL_DEFAULT_NETWORKS,
+  getInitialNetworkControllerState,
+  networkControllerInit,
+} from './network-controller-init';
+import {
+  getDefaultNetworkControllerState,
+  NetworkController,
+} from '@metamask/network-controller';
+
+jest.mock('@metamask/network-controller');
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<
+    NetworkControllerMessenger,
+    NetworkControllerInitMessenger
+  >
+> {
+  const baseMessenger = new ExtendedControllerMessenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(baseMessenger),
+    controllerMessenger: getNetworkControllerMessenger(baseMessenger),
+    initMessenger: getNetworkControllerInitMessenger(baseMessenger),
+  };
+
+  return requestMock;
+}
+
+describe('networkControllerInit', () => {
+  jest
+    .mocked(getDefaultNetworkControllerState)
+    .mockImplementation((additionalNetworks) =>
+      jest
+        .requireActual('@metamask/network-controller')
+        .getDefaultNetworkControllerState(additionalNetworks),
+    );
+
+  it('initializes the controller', () => {
+    const { controller } = networkControllerInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(NetworkController);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    networkControllerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(NetworkController);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      state: getInitialNetworkControllerState({}),
+      additionalDefaultNetworks: ADDITIONAL_DEFAULT_NETWORKS,
+      getBlockTrackerOptions: expect.any(Function),
+      getRpcServiceOptions: expect.any(Function),
+      infuraProjectId: 'NON_EMPTY',
+    });
+  });
+});

--- a/app/core/Engine/controllers/network-controller-init.ts
+++ b/app/core/Engine/controllers/network-controller-init.ts
@@ -1,0 +1,193 @@
+import { ControllerInitFunction } from '../types';
+import {
+  getDefaultNetworkControllerState,
+  NetworkController,
+  NetworkState,
+} from '@metamask/network-controller';
+import {
+  NetworkControllerInitMessenger,
+  NetworkControllerMessenger,
+} from '../messengers/network-controller-messenger';
+import { ChainId } from '@metamask/controller-utils';
+import { getFailoverUrlsForInfuraNetwork } from '../../../util/networks/customNetworks';
+import { INFURA_PROJECT_ID } from '../../../constants/network';
+import { SECOND } from '../../../constants/time';
+import { getIsQuicknodeEndpointUrl } from './network-controller/utils';
+import {
+  onRpcEndpointDegraded,
+  onRpcEndpointUnavailable,
+} from './network-controller/messenger-action-handlers';
+import { MetricsEventBuilder } from '../../Analytics/MetricsEventBuilder';
+import { MetaMetrics } from '../../Analytics';
+import { Hex } from '@metamask/utils';
+
+const NON_EMPTY = 'NON_EMPTY';
+
+export const ADDITIONAL_DEFAULT_NETWORKS = [
+  ChainId['megaeth-testnet'],
+  ChainId['monad-testnet'],
+];
+
+export function getInitialNetworkControllerState(persistedState: {
+  NetworkController?: Partial<NetworkState>;
+}) {
+  let initialNetworkControllerState =
+    persistedState.NetworkController as NetworkState;
+
+  if (!initialNetworkControllerState) {
+    initialNetworkControllerState = getDefaultNetworkControllerState(
+      ADDITIONAL_DEFAULT_NETWORKS,
+    );
+
+    // Add failovers for default Infura RPC endpoints
+    initialNetworkControllerState.networkConfigurationsByChainId[
+      ChainId.mainnet
+    ].rpcEndpoints[0].failoverUrls =
+      getFailoverUrlsForInfuraNetwork('ethereum-mainnet');
+    initialNetworkControllerState.networkConfigurationsByChainId[
+      ChainId['linea-mainnet']
+    ].rpcEndpoints[0].failoverUrls =
+      getFailoverUrlsForInfuraNetwork('linea-mainnet');
+    initialNetworkControllerState.networkConfigurationsByChainId[
+      ChainId['base-mainnet']
+    ].rpcEndpoints[0].failoverUrls =
+      getFailoverUrlsForInfuraNetwork('base-mainnet');
+
+    // Update default popular network names
+    initialNetworkControllerState.networkConfigurationsByChainId[
+      ChainId.mainnet
+    ].name = 'Ethereum';
+    initialNetworkControllerState.networkConfigurationsByChainId[
+      ChainId['linea-mainnet']
+    ].name = 'Linea';
+    initialNetworkControllerState.networkConfigurationsByChainId[
+      ChainId['base-mainnet']
+    ].name = 'Base';
+  }
+
+  return initialNetworkControllerState;
+}
+
+/**
+ * Initialize the network controller.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @returns The initialized controller.
+ */
+export const networkControllerInit: ControllerInitFunction<
+  NetworkController,
+  NetworkControllerMessenger,
+  NetworkControllerInitMessenger
+> = ({ controllerMessenger, initMessenger, persistedState }) => {
+  const infuraProjectId = INFURA_PROJECT_ID || NON_EMPTY;
+
+  const controller = new NetworkController({
+    infuraProjectId,
+    state: getInitialNetworkControllerState(persistedState),
+    messenger: controllerMessenger,
+    getBlockTrackerOptions: () =>
+      process.env.IN_TEST
+        ? {}
+        : {
+            pollingInterval: 20 * SECOND,
+            // The retry timeout is pretty short by default, and if the endpoint is
+            // down, it will end up exhausting the max number of consecutive
+            // failures quickly.
+            retryTimeout: 20 * SECOND,
+          },
+
+    getRpcServiceOptions: (rpcEndpointUrl: string) => {
+      const maxRetries = 4;
+      const commonOptions = {
+        fetch: globalThis.fetch.bind(globalThis),
+        btoa: globalThis.btoa.bind(globalThis),
+      };
+
+      if (getIsQuicknodeEndpointUrl(rpcEndpointUrl)) {
+        return {
+          ...commonOptions,
+          policyOptions: {
+            maxRetries,
+            // When we fail over to Quicknode, we expect it to be down at
+            // first while it is being automatically activated. If an endpoint
+            // is down, the failover logic enters a "cooldown period" of 30
+            // minutes. We'd really rather not enter that for Quicknode, so
+            // keep retrying longer.
+            maxConsecutiveFailures: (maxRetries + 1) * 14,
+          },
+        };
+      }
+
+      return {
+        ...commonOptions,
+        policyOptions: {
+          maxRetries,
+          // Ensure that the circuit does not break too quickly.
+          maxConsecutiveFailures: (maxRetries + 1) * 7,
+        },
+      };
+    },
+    additionalDefaultNetworks: ADDITIONAL_DEFAULT_NETWORKS,
+  });
+
+  initMessenger.subscribe(
+    'NetworkController:rpcEndpointUnavailable',
+    async ({
+      chainId,
+      endpointUrl,
+      error,
+    }: {
+      chainId: Hex;
+      endpointUrl: string;
+      error: unknown;
+    }) => {
+      onRpcEndpointUnavailable({
+        chainId,
+        endpointUrl,
+        infuraProjectId,
+        error,
+        trackEvent: ({ event, properties }) => {
+          const metricsEvent = MetricsEventBuilder.createEventBuilder(event)
+            .addProperties(properties)
+            .build();
+          MetaMetrics.getInstance().trackEvent(metricsEvent);
+        },
+        metaMetricsId: await MetaMetrics.getInstance().getMetaMetricsId(),
+      });
+    },
+  );
+
+  initMessenger.subscribe(
+    'NetworkController:rpcEndpointDegraded',
+    async ({
+      chainId,
+      endpointUrl,
+      error,
+    }: {
+      chainId: Hex;
+      endpointUrl: string;
+      error: unknown;
+    }) => {
+      onRpcEndpointDegraded({
+        chainId,
+        endpointUrl,
+        error,
+        infuraProjectId,
+        trackEvent: ({ event, properties }) => {
+          const metricsEvent = MetricsEventBuilder.createEventBuilder(event)
+            .addProperties(properties)
+            .build();
+          MetaMetrics.getInstance().trackEvent(metricsEvent);
+        },
+        metaMetricsId: await MetaMetrics.getInstance().getMetaMetricsId(),
+      });
+    },
+  );
+
+  controller.initializeProvider();
+
+  return {
+    controller,
+  };
+};

--- a/app/core/Engine/messengers/index.ts
+++ b/app/core/Engine/messengers/index.ts
@@ -56,6 +56,10 @@ import {
   getSnapKeyringBuilderMessenger,
 } from './snap-keyring-builder-messenger';
 import { getKeyringControllerMessenger } from './keyring-controller-messenger';
+import {
+  getNetworkControllerInitMessenger,
+  getNetworkControllerMessenger,
+} from './network-controller-messenger';
 
 /**
  * The messengers for the controllers that have been.
@@ -92,6 +96,10 @@ export const CONTROLLER_MESSENGERS = {
   KeyringController: {
     getMessenger: getKeyringControllerMessenger,
     getInitMessenger: noop,
+  },
+  NetworkController: {
+    getMessenger: getNetworkControllerMessenger,
+    getInitMessenger: getNetworkControllerInitMessenger,
   },
   AppMetadataController: {
     getMessenger: getAppMetadataControllerMessenger,

--- a/app/core/Engine/messengers/network-controller-messenger.test.ts
+++ b/app/core/Engine/messengers/network-controller-messenger.test.ts
@@ -1,0 +1,24 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import {
+  getNetworkControllerMessenger,
+  getNetworkControllerInitMessenger,
+} from './network-controller-messenger';
+
+describe('getNetworkControllerMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const networkControllerMessenger = getNetworkControllerMessenger(messenger);
+
+    expect(networkControllerMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});
+
+describe('getNetworkControllerInitMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const networkControllerInitMessenger =
+      getNetworkControllerInitMessenger(messenger);
+
+    expect(networkControllerInitMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});

--- a/app/core/Engine/messengers/network-controller-messenger.ts
+++ b/app/core/Engine/messengers/network-controller-messenger.ts
@@ -1,0 +1,63 @@
+import { Messenger } from '@metamask/base-controller';
+import { ErrorReportingServiceCaptureExceptionAction } from '@metamask/error-reporting-service';
+import {
+  NetworkControllerRpcEndpointDegradedEvent,
+  NetworkControllerRpcEndpointUnavailableEvent,
+} from '@metamask/network-controller';
+
+type AllowedActions = ErrorReportingServiceCaptureExceptionAction;
+
+export type NetworkControllerMessenger = ReturnType<
+  typeof getNetworkControllerMessenger
+>;
+
+/**
+ * Get a restricted messenger for the network controller. This is scoped to the
+ * actions and events that the network controller is allowed to handle.
+ *
+ * @param messenger - The messenger to restrict.
+ * @returns The restricted messenger.
+ */
+export function getNetworkControllerMessenger(
+  messenger: Messenger<AllowedActions, never>,
+) {
+  return messenger.getRestricted({
+    name: 'NetworkController',
+    allowedActions: ['ErrorReportingService:captureException'],
+    allowedEvents: [],
+  });
+}
+
+type AllowedInitializationActions = never;
+
+type AllowedInitializationEvents =
+  | NetworkControllerRpcEndpointDegradedEvent
+  | NetworkControllerRpcEndpointUnavailableEvent;
+
+export type NetworkControllerInitMessenger = ReturnType<
+  typeof getNetworkControllerInitMessenger
+>;
+
+/**
+ * Get a restricted messenger for the network controller. This is scoped to the
+ * actions and events that the network controller is allowed to handle during
+ * initialization.
+ *
+ * @param messenger - The messenger to restrict.
+ * @returns The restricted messenger.
+ */
+export function getNetworkControllerInitMessenger(
+  messenger: Messenger<
+    AllowedInitializationActions,
+    AllowedInitializationEvents
+  >,
+) {
+  return messenger.getRestricted({
+    name: 'NetworkControllerInit',
+    allowedActions: [],
+    allowedEvents: [
+      'NetworkController:rpcEndpointDegraded',
+      'NetworkController:rpcEndpointUnavailable',
+    ],
+  });
+}

--- a/app/core/Engine/types.ts
+++ b/app/core/Engine/types.ts
@@ -693,6 +693,7 @@ export type ControllersToInitialize =
   | 'MultichainAccountService'
   | 'SnapKeyringBuilder'
   ///: END:ONLY_INCLUDE_IF
+  | 'NetworkController'
   | 'AccountTreeController'
   | 'AccountsController'
   | 'ApprovalController'

--- a/app/core/Engine/utils/utils.test.ts
+++ b/app/core/Engine/utils/utils.test.ts
@@ -88,6 +88,7 @@ import { KeyringController } from '@metamask/keyring-controller';
 import { SnapKeyringBuilder } from '../../SnapKeyring/SnapKeyring';
 import { InitModularizedControllersFunctionRequest } from '../types';
 import { QrKeyringDeferredPromiseBridge } from '@metamask/eth-qr-keyring';
+import { networkControllerInit } from '../controllers/network-controller-init';
 
 jest.mock('../controllers/accounts-controller');
 jest.mock('../controllers/rewards-controller');
@@ -210,6 +211,7 @@ describe('initModularizedControllers', () => {
   const mockPreferencesControllerInit = jest.mocked(preferencesControllerInit);
   const mockKeyringControllerInit = jest.mocked(keyringControllerInit);
   const mockSnapKeyringBuilderInit = jest.mocked(snapKeyringBuilderInit);
+  const mockNetworkControllerInit = jest.mocked(networkControllerInit);
 
   function buildModularizedControllerRequest(
     overrides?: Record<string, unknown>,
@@ -259,6 +261,7 @@ describe('initModularizedControllers', () => {
           PreferencesController: mockPreferencesControllerInit,
           KeyringController: mockKeyringControllerInit,
           SnapKeyringBuilder: mockSnapKeyringBuilderInit,
+          NetworkController: mockNetworkControllerInit,
         },
         persistedState: {},
         baseControllerMessenger: new ExtendedControllerMessenger(),
@@ -374,6 +377,9 @@ describe('initModularizedControllers', () => {
     });
     mockSnapKeyringBuilderInit.mockReturnValue({
       controller: {} as unknown as SnapKeyringBuilder,
+    });
+    mockNetworkControllerInit.mockReturnValue({
+      controller: {} as unknown as NetworkController,
     });
   });
 

--- a/app/core/Engine/utils/utils.test.ts
+++ b/app/core/Engine/utils/utils.test.ts
@@ -138,6 +138,7 @@ jest.mock('../controllers/subject-metadata-controller-init');
 jest.mock('../controllers/preferences-controller-init');
 jest.mock('../controllers/keyring-controller-init');
 jest.mock('../controllers/snap-keyring-builder-init');
+jest.mock('../controllers/network-controller-init');
 
 describe('initModularizedControllers', () => {
   const mockAccountsControllerInit = jest.mocked(accountsControllerInit);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This refactors the network controller to use modular init.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: #12876.

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces inline `NetworkController` setup with a modular init using new messengers, wires it into Engine, and adds focused tests.
> 
> - **Engine**:
>   - Replace inline `NetworkController` construction with modular `networkControllerInit` via `initModularizedControllers`; access via `controllersByName.NetworkController`.
>   - Remove direct imports/logic for default network state, failover URLs, and event subscriptions; rely on the new init module.
>   - Rewire dependent controllers (e.g., `AssetsContractController`, `TokenListController`, `RemoteFeatureFlagController`, `AccountTrackerController`, etc.) to use the initialized `NetworkController` messenger/state.
> - **New Init Module** (`app/core/Engine/controllers/network-controller-init.ts`):
>   - Defines `ADDITIONAL_DEFAULT_NETWORKS`, computes initial state (including Infura failovers and network names), configures block tracker/RPC policies (incl. Quicknode handling), subscribes to `rpcEndpointUnavailable`/`rpcEndpointDegraded`, and calls `initializeProvider()`.
> - **Messengers**:
>   - Add `getNetworkControllerMessenger` and `getNetworkControllerInitMessenger` in `messengers/network-controller-messenger.{ts,test.ts}` and register in `messengers/index.ts`.
> - **Types/Plumbing**:
>   - Add `NetworkController` to `ControllersToInitialize` and related types in `types.ts`; update tests/mocks to include `networkControllerInit`.
> - **Tests**:
>   - Add `network-controller-init.test.ts`; update `utils.test.ts` to mock/use the new controller init and messenger.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be157c2f0309f555d7a0eaa43d33b07ee48be6f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->