### PR TITLE
INFRA-2999-FixAutoCreateReleasePR

### DIFF
--- a/.github/workflows/auto-create-release-pr.yml
+++ b/.github/workflows/auto-create-release-pr.yml
@@ -3,6 +3,11 @@ name: Auto Create Release PR
 on:
   create:
 
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   extract:
     if: ${{ github.ref_type == 'branch' && startsWith(github.ref, 'refs/heads/release/') }}

--- a/.github/workflows/auto-create-release-pr.yml.disabled
+++ b/.github/workflows/auto-create-release-pr.yml.disabled
@@ -35,3 +35,5 @@ jobs:
       google-application-creds-base64: ${{ secrets.GCP_RLS_SHEET_ACCOUNT_BASE64 }}
     with:
       semver-version: ${{ needs.extract.outputs.semver }}
+      # mobile-build-version: ${{ needs.generate-build-version.outputs.build-version }}
+      # https://github.com/MetaMask/metamask-mobile/blob/main/.github/workflows/update-latest-build-version.yml

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -6,10 +6,16 @@ on:
       semver-version:
         description: 'A semantic version, eg: x.x.x'
         required: true
+      mobile-build-version:
+        description: 'Mobile build number (integer). Must be provided for mobile releases.'
+        required: true
 
   workflow_call:
     inputs:
       semver-version:
+        required: true
+        type: string
+      mobile-build-version:
         required: true
         type: string
     secrets:
@@ -71,8 +77,32 @@ jobs:
         run: |
           .github/scripts/resolve-previous-ref.sh
 
+  validate-build-number:
+    runs-on: ubuntu-latest
+    steps:
+      # Ensures a manual build number is provided and is numeric (digits only)
+      - name: Validate mobile-build-version
+        shell: bash
+        env:
+          INPUT_BUILD: ${{ inputs.mobile-build-version }}
+        run: |
+          # Validation policy:
+          # - Required (non-empty)
+          # - Digits-only regex: ^[0-9]+$
+          #   Valid: 1, 42, 20251003, 123456
+          #   Invalid: '', '1.2', '+1', '0x10', 'abc', spaces
+          set -euo pipefail
+          if [ -z "${INPUT_BUILD:-}" ]; then
+            echo "Error: mobile-build-version is required and must be provided." >&2
+            exit 1
+          fi
+          if ! [[ "${INPUT_BUILD}" =~ ^[0-9]+$ ]]; then
+            echo "Error: mobile-build-version must be digits only, got: ${INPUT_BUILD}" >&2
+            exit 1
+          fi
+
   create-release-pr:
-    needs: [resolve-bases, resolve-previous-ref]
+    needs: [resolve-bases, resolve-previous-ref, validate-build-number]
     name: Create Release Pull Request using Github Tools
     uses: MetaMask/github-tools/.github/workflows/create-release-pr.yml@76945f3d14e057e13d95e641d6993ea735b089c1
     with:
@@ -81,6 +111,7 @@ jobs:
       release-pr-base-branch: ${{ needs.resolve-bases.outputs.release_base }}
       semver-version: ${{ inputs.semver-version }}
       previous-version-ref: ${{ needs.resolve-previous-ref.outputs.previous_ref }}
+      mobile-build-version: ${{ inputs.mobile-build-version }}
       github-tools-version: 76945f3d14e057e13d95e641d6993ea735b089c1
     secrets:
       # This token needs write permissions to metamask-mobile & read permissions to metamask-planning

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -91,6 +91,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
 
   add-e2e-label:
     needs: create-release-pr


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix the following errors in auto-create-release-pr gh workflow. https://github.com/MetaMask/metamask-mobile/actions/runs/18220412940

and create release PR workflow: https://github.com/consensys-test/metamask-mobile-test-workflow/actions/runs/18172027424

**Create Release PR Workflow Error**
- Had to pass new required parameter **mobile-build-version** to workflow.
To summarize issue is that the workflow for MM Mobile expects a mobile-build-version parameter [here](https://github.com/MetaMask/metamask-mobile/blob/main/.github/workflows/create-release-pr.yml#L74#L93) that is not being passed to it. Both MM extension and MM mobile use this [create-release-pr workflow](https://github.com/MetaMask/metamask-mobile/blob/main/.github/workflows/create-release-pr.yml) but extension does not expect that argument while mobile does ([here](https://github.com/MetaMask/github-tools/blob/main/.github/workflows/create-release-pr.yml#L145)).

Tested Here (new error likely due to fork): https://github.com/consensys-test/metamask-mobile-test-workflow/actions/runs/18230229652/job/51911612221


**AutoCreateRelease PR Workflow Error**

[Invalid workflow file: .github/workflows/auto-create-release-pr.yml#L105](https://github.com/MetaMask/metamask-mobile/actions/runs/18220412940/workflow)
The workflow is not valid. .github/workflows/auto-create-release-pr.yml (Line: 105, Col: 3): Error calling workflow 'MetaMask/metamask-mobile/.github/workflows/create-release-pr.yml@3c9fef6d6ca2ea0095804c961c895feb3cfb1f4a'. The nested job 'generate-build-version' is requesting 'id-token: write', but is only allowed 'id-token: none'.

This error does not happen in fork repo (with same code).
https://github.com/consensys-test/metamask-mobile-test-workflow/actions/workflows/auto-create-release-pr.yml

Theory for why it fails here but not in fork:

  - The create event reads workflow files from the default branch of the repo where the event fires. In the main repo, the default branch still allowed id-token: none for the calling job, but the called reusable workflow’s job requests id-token: write → validation error. In the fork, the default branch likely already had the updated permissions or the repo settings allow OIDC, so it succeeds.
  - Also, org-level “Workflow permissions” can differ. If the main repo has stricter defaults (no OIDC unless explicitly granted), gives this failure; the fork may have “Read and write” + OIDC enabled.

- What the change does
  - In `.github/workflows/auto-create-release-pr.yml`:
    - Added top-level permissions with `id-token: write`.
    - Added `id-token: write` to the `call-create-release-pr` job.
  - In `.github/workflows/create-release-pr.yml`:
    - Added `id-token: write` to the `create-release-pr` job.
  - Effect: Explicitly grants OIDC token permission from the caller to the reusable workflow so its nested job (`generate-build-version`) can obtain `id-token: write`, resolving the validation error.

- If error persists
  - Ensure these permission changes are on the default branch of the main repo before the create event fires.
  - In repo settings (Actions → General), set Workflow permissions to “Read and write” and enable “Allow GitHub Actions to create and read OIDC tokens.”


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add required `mobile-build-version` input with validation and grant `id-token: write` to fix release PR workflows.
> 
> - **Workflows**:
>   - **`create-release-pr.yml`**:
>     - Add required `inputs.mobile-build-version` (dispatch and call) and pass it to `MetaMask/github-tools` workflow.
>     - New `validate-build-number` job enforces digits-only build number; gate `create-release-pr` on it.
>     - Grant `permissions` including `id-token: write` to support OIDC in called workflow.
>   - **`auto-create-release-pr.yml.disabled`**:
>     - Add top-level `permissions` with `contents`, `pull-requests`, and `id-token: write`.
>     - Update called workflow inputs/permissions; include commented guidance for `mobile-build-version` integration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45f1c848afd1ad1b42873546ea9e9dcc7005f347. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->