### PR TITLE
chore: update `CODEOWNERS.md` -> `@metamask/sdk-devs` to `@metamask/wallet-integrations`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -65,17 +65,19 @@ app/core/Analytics/events/confirmations                     @MetaMask/confirmati
 ppom                                                        @MetaMask/confirmations
 app/selectors/featureFlagController/confirmations/          @MetaMask/confirmations
 
-# All below files are maintained by the SDK team because they contain SDK related code, WalletConnect integrations, or critical SDK flows.
-app/actions/sdk   @MetaMask/sdk-devs
-app/components/Approvals/WalletConnectApproval   @MetaMask/sdk-devs
-app/components/Views/SDK   @MetaMask/sdk-devs
-app/components/Views/WalletConnectSessions   @MetaMask/sdk-devs
-app/core/BackgroundBridge/WalletConnectPort.ts   @MetaMask/sdk-devs
-app/core/RPCMethods/RPCMethodMiddleware.ts   @MetaMask/sdk-devs
-app/core/SDKConnect   @MetaMask/sdk-devs
-app/core/WalletConnect   @MetaMask/sdk-devs
-app/reducers/sdk   @MetaMask/sdk-devs
-app/util/walletconnect.js   @MetaMask/sdk-devs
+# Wallet integrations Team
+app/actions/sdk                                             @MetaMask/wallet-integrations
+app/components/Approvals/WalletConnectApproval              @MetaMask/wallet-integrations
+app/components/Views/SDK                                    @MetaMask/wallet-integrations
+app/components/Views/WalletConnectSessions                  @MetaMask/wallet-integrations
+app/core/BackgroundBridge/WalletConnectPort.ts              @MetaMask/wallet-integrations
+app/core/RPCMethods                                         @MetaMask/wallet-integrations
+app/core/SDKConnect                                         @MetaMask/wallet-integrations
+app/core/SDKConnectV2                                       @MetaMask/wallet-integrations
+app/core/WalletConnect                                      @MetaMask/wallet-integrations
+app/reducers/sdk                                            @MetaMask/wallet-integrations
+app/util/walletconnect.js                                   @MetaMask/wallet-integrations
+app/util/permissions/                                       @MetaMask/wallet-integrations
 
 # Accounts Team
 app/core/Encryptor/                                         @MetaMask/accounts-engineers
@@ -121,9 +123,6 @@ app/core/Engine/controllers/TokenSearchDiscoveryController @MetaMask/portfolio
 # Co-owned by Confirmations team and Core Platform team
 app/components/UI/TemplateRenderer   @MetaMask/confirmations @MetaMask/core-platform
 
-# Wallet API Platform Team
-app/core/RPCMethods/                 @MetaMask/wallet-api-platform-engineers
-app/util/permissions/                @MetaMask/wallet-api-platform-engineers
 
 # Earn Team
 app/components/UI/Stake              @MetaMask/metamask-earn


### PR DESCRIPTION
Recently the SDK team has merged with the Wallet API team to become the Wallet Integrations team, as such we need to update codeownership

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates CODEOWNERS to move SDK, WalletConnect, RPCMethods, and permissions paths from sdk-devs and wallet-api to wallet-integrations, adding `SDKConnectV2` coverage.
> 
> - **CODEOWNERS updates**:
>   - Replaces SDK ownership (`@MetaMask/sdk-devs`) with `@MetaMask/wallet-integrations` for:
>     - `app/actions/sdk`, `app/components/Approvals/WalletConnectApproval`, `app/components/Views/SDK`, `app/components/Views/WalletConnectSessions`, `app/core/BackgroundBridge/WalletConnectPort.ts`, `app/core/SDKConnect`, `app/core/WalletConnect`, `app/reducers/sdk`, `app/util/walletconnect.js`.
>     - Expands coverage to `app/core/RPCMethods` and `app/util/permissions/` (moved from wallet-api platform), and adds `app/core/SDKConnectV2`.
>   - Removes prior wallet API platform ownership for `app/core/RPCMethods/` and `app/util/permissions/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05081697fa266259a8d05c5ff91b58bfb282dd16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->