### PR TITLE
fix: tab bar alignment

### DIFF
--- a/app/component-library/components/Navigation/TabBar/TabBar.tsx
+++ b/app/component-library/components/Navigation/TabBar/TabBar.tsx
@@ -130,7 +130,7 @@ const TabBar = ({ state, descriptors, navigation }: TabBarProps) => {
     <View ref={tabBarRef}>
       <Box
         flexDirection={BoxFlexDirection.Row}
-        alignItems={BoxAlignItems.Center}
+        alignItems={BoxAlignItems.End}
         twClassName="w-full pt-3 px-2 bg-default border-t border-muted"
         style={[tw.style(`pb-[${bottomInset}px]`)]}
       >

--- a/app/component-library/components/Navigation/TabBar/__snapshots__/TabBar.test.tsx.snap
+++ b/app/component-library/components/Navigation/TabBar/__snapshots__/TabBar.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`TabBar renders correctly 1`] = `
     style={
       [
         {
-          "alignItems": "center",
+          "alignItems": "flex-end",
           "backgroundColor": "#ffffff",
           "borderColor": "#b7bbc866",
           "borderTopWidth": 1,

--- a/app/component-library/components/Tags/Tag/Tag.tsx
+++ b/app/component-library/components/Tags/Tag/Tag.tsx
@@ -17,7 +17,9 @@ const Tag = ({ label, style, ...props }: TagProps) => {
 
   return (
     <View style={styles.base} {...props}>
-      <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>{label}</Text>
+      <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+        {label}
+      </Text>
     </View>
   );
 };


### PR DESCRIPTION

## **Description**

This pull request makes minor visual and formatting adjustments to the `TabBar` and `Tag` components. The most significant change is updating the alignment of items in the `TabBar` to improve its appearance at the bottom of the screen.

**TabBar alignment update:**

* Changed the `alignItems` property from `center` to `end` in the `TabBar` component, ensuring tab items are aligned to the bottom edge for a more consistent look. (`TabBar.tsx`)
* Updated the corresponding snapshot test to reflect the new `alignItems: flex-end` style, keeping tests in sync with the UI change. (`TabBar.test.tsx.snap`)

**Tag component formatting:**

* Reformatted the `Text` element in the `Tag` component for improved readability, without changing its functionality. (`Tag.tsx`)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Trade Tab Bar Button

  Scenario: user visits the home page
    Given the app is in the home page

    When user looks at the tab bar buttons
    Then they are aligned
```

## **Screenshots/Recordings**

### **Before/After**

https://github.com/user-attachments/assets/ded7a378-3412-4859-b544-298271663810

### **Before**

<img width="353" height="152" alt="align_before" src="https://github.com/user-attachments/assets/707238a4-179e-436a-a83c-44a55a5122f6" />


### **After**

<img width="353" height="152" alt="align_after" src="https://github.com/user-attachments/assets/1921b409-3ab4-413f-97e8-392a10bfca5e" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bottom-aligns TabBar items and updates snapshot; minor non-functional formatting in Tag component.
> 
> - **Navigation**
>   - `TabBar`: Change `alignItems` from `Center` to `End` to bottom-align tabs in `TabBar.tsx`.
>   - Tests: Update snapshot to expect `alignItems: flex-end` in `TabBar.test.tsx.snap`.
> - **Tags**
>   - `Tag`: Reformat `Text` element (no functional changes) in `Tag.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28969788fd0c0b7664eab3c54f67d46efa0f5be3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->