### PR TITLE
fix: cp-7.57.0 rive asset state machine name

### DIFF
--- a/app/components/UI/Bridge/hooks/useRewardsIconAnimation/useRewardsIconAnimation.test.ts
+++ b/app/components/UI/Bridge/hooks/useRewardsIconAnimation/useRewardsIconAnimation.test.ts
@@ -108,7 +108,10 @@ describe('useRewardsIconAnimation', () => {
       );
 
       // Assert
-      expect(mockFireState).toHaveBeenCalledWith('State Machine 1', 'Disable');
+      expect(mockFireState).toHaveBeenCalledWith(
+        'Rewards_Icon',
+        'Disable_left',
+      );
     });
 
     it('triggers Disable when hasRewardsError is true', () => {
@@ -121,7 +124,10 @@ describe('useRewardsIconAnimation', () => {
       );
 
       // Assert
-      expect(mockFireState).toHaveBeenCalledWith('State Machine 1', 'Disable');
+      expect(mockFireState).toHaveBeenCalledWith(
+        'Rewards_Icon',
+        'Disable_left',
+      );
     });
 
     it('triggers Start when estimatedPoints > 0 and not loading/error', () => {
@@ -134,7 +140,7 @@ describe('useRewardsIconAnimation', () => {
       );
 
       // Assert
-      expect(mockFireState).toHaveBeenCalledWith('State Machine 1', 'Start');
+      expect(mockFireState).toHaveBeenCalledWith('Rewards_Icon', 'Start');
     });
 
     it('does not trigger Start when estimatedPoints is 0', () => {
@@ -189,7 +195,10 @@ describe('useRewardsIconAnimation', () => {
       );
 
       // Assert
-      expect(mockFireState).toHaveBeenCalledWith('State Machine 1', 'Disable');
+      expect(mockFireState).toHaveBeenCalledWith(
+        'Rewards_Icon',
+        'Disable_left',
+      );
     });
 
     it('prioritizes loading state over positive points', () => {
@@ -203,7 +212,10 @@ describe('useRewardsIconAnimation', () => {
       );
 
       // Assert
-      expect(mockFireState).toHaveBeenCalledWith('State Machine 1', 'Disable');
+      expect(mockFireState).toHaveBeenCalledWith(
+        'Rewards_Icon',
+        'Disable_left',
+      );
     });
 
     it('prioritizes error state over positive points', () => {
@@ -217,7 +229,10 @@ describe('useRewardsIconAnimation', () => {
       );
 
       // Assert
-      expect(mockFireState).toHaveBeenCalledWith('State Machine 1', 'Disable');
+      expect(mockFireState).toHaveBeenCalledWith(
+        'Rewards_Icon',
+        'Disable_left',
+      );
     });
   });
 
@@ -233,7 +248,7 @@ describe('useRewardsIconAnimation', () => {
       );
 
       // Assert initial call
-      expect(mockFireState).toHaveBeenCalledWith('State Machine 1', 'Start');
+      expect(mockFireState).toHaveBeenCalledWith('Rewards_Icon', 'Start');
 
       // Clear and setup for second render
       mockFireState.mockClear();
@@ -252,7 +267,10 @@ describe('useRewardsIconAnimation', () => {
       );
 
       // Assert - should trigger Disable for loading state
-      expect(mockFireState).toHaveBeenCalledWith('State Machine 1', 'Disable');
+      expect(mockFireState).toHaveBeenCalledWith(
+        'Rewards_Icon',
+        'Disable_left',
+      );
     });
 
     it('does not retrigger when points remain unchanged', () => {
@@ -265,7 +283,7 @@ describe('useRewardsIconAnimation', () => {
       );
 
       // Assert initial call
-      expect(mockFireState).toHaveBeenCalledWith('State Machine 1', 'Start');
+      expect(mockFireState).toHaveBeenCalledWith('Rewards_Icon', 'Start');
 
       // Setup for rerender - set previous points to same value and setup fresh mocks
       mockFireState.mockClear();
@@ -299,7 +317,7 @@ describe('useRewardsIconAnimation', () => {
       );
 
       // Assert
-      expect(mockFireState).toHaveBeenCalledWith('State Machine 1', 'Start');
+      expect(mockFireState).toHaveBeenCalledWith('Rewards_Icon', 'Start');
     });
 
     it('triggers when transitioning from loading to points', () => {
@@ -316,7 +334,7 @@ describe('useRewardsIconAnimation', () => {
       );
 
       // Assert
-      expect(mockFireState).toHaveBeenCalledWith('State Machine 1', 'Start');
+      expect(mockFireState).toHaveBeenCalledWith('Rewards_Icon', 'Start');
     });
   });
 
@@ -377,7 +395,10 @@ describe('useRewardsIconAnimation', () => {
       );
 
       // Assert - should prioritize error state
-      expect(mockFireState).toHaveBeenCalledWith('State Machine 1', 'Disable');
+      expect(mockFireState).toHaveBeenCalledWith(
+        'Rewards_Icon',
+        'Disable_left',
+      );
       // Should set currentPoints to 0 due to error, then update previousPointsRef
       expect(mockPreviousPointsRef.current).toBe(0);
     });
@@ -396,7 +417,10 @@ describe('useRewardsIconAnimation', () => {
       );
 
       // Assert
-      expect(mockFireState).toHaveBeenCalledWith('State Machine 1', 'Disable');
+      expect(mockFireState).toHaveBeenCalledWith(
+        'Rewards_Icon',
+        'Disable_left',
+      );
     });
   });
 
@@ -412,7 +436,10 @@ describe('useRewardsIconAnimation', () => {
       );
 
       // Assert
-      expect(mockFireState).toHaveBeenCalledWith('State Machine 1', 'Refresh');
+      expect(mockFireState).toHaveBeenCalledWith(
+        'Rewards_Icon',
+        'Refresh_left',
+      );
     });
 
     it('does not trigger Refresh when estimatedPoints is 0', () => {
@@ -455,7 +482,10 @@ describe('useRewardsIconAnimation', () => {
       );
 
       // Assert
-      expect(mockFireState).toHaveBeenCalledWith('State Machine 1', 'Disable');
+      expect(mockFireState).toHaveBeenCalledWith(
+        'Rewards_Icon',
+        'Disable_left',
+      );
     });
 
     it('prioritizes error state over refresh', () => {
@@ -470,7 +500,10 @@ describe('useRewardsIconAnimation', () => {
       );
 
       // Assert
-      expect(mockFireState).toHaveBeenCalledWith('State Machine 1', 'Disable');
+      expect(mockFireState).toHaveBeenCalledWith(
+        'Rewards_Icon',
+        'Disable_left',
+      );
     });
   });
 
@@ -503,7 +536,7 @@ describe('useRewardsIconAnimation', () => {
       );
 
       // Assert
-      expect(mockFireState).toHaveBeenCalledWith('State Machine 1', 'Start');
+      expect(mockFireState).toHaveBeenCalledWith('Rewards_Icon', 'Start');
       expect(mockPreviousPointsRef.current).toBe(50);
     });
 
@@ -537,7 +570,7 @@ describe('useRewardsIconAnimation', () => {
       );
 
       // Assert
-      expect(mockFireState).toHaveBeenCalledWith('State Machine 1', 'Start');
+      expect(mockFireState).toHaveBeenCalledWith('Rewards_Icon', 'Start');
       expect(mockPreviousPointsRef.current).toBe(75);
     });
   });

--- a/app/components/UI/Bridge/hooks/useRewardsIconAnimation/useRewardsIconAnimation.ts
+++ b/app/components/UI/Bridge/hooks/useRewardsIconAnimation/useRewardsIconAnimation.ts
@@ -4,9 +4,9 @@ import { RiveRef } from 'rive-react-native';
 // These come from the Rive file, need to go into the Rive Editor to see them, or talk to designers
 const STATE_MACHINE_NAME = 'Rewards_Icon';
 enum RewardsIconTriggers {
-  Disable = 'Disable',
+  Disable = 'Disable_left',
   Start = 'Start',
-  Refresh = 'Refresh',
+  Refresh = 'Refresh_left',
 }
 
 interface UseRewardsIconAnimationParams {

--- a/app/components/UI/Bridge/hooks/useRewardsIconAnimation/useRewardsIconAnimation.ts
+++ b/app/components/UI/Bridge/hooks/useRewardsIconAnimation/useRewardsIconAnimation.ts
@@ -2,7 +2,7 @@ import { useRef, useEffect } from 'react';
 import { RiveRef } from 'rive-react-native';
 
 // These come from the Rive file, need to go into the Rive Editor to see them, or talk to designers
-const STATE_MACHINE_NAME = 'State Machine 1';
+const STATE_MACHINE_NAME = 'Rewards_Icon';
 enum RewardsIconTriggers {
   Disable = 'Disable',
   Start = 'Start',


### PR DESCRIPTION
## **Description**

The old animation hook used for swaps is crashing due to Rive asset state machine name change. The name change was introduced in this [PR](https://github.com/MetaMask/metamask-mobile/pull/20664) where we updated the rewards animation 

Error:
```
 ERROR  Your app just crashed. See the error below.
java.lang.Throwable: 
app.rive.runtime.kotlin.core.errors.StateMachineException: No StateMachine found with name State Machine 1.
    app.rive.runtime.kotlin.core.Artboard.stateMachine(Artboard.kt:187)
    app.rive.runtime.kotlin.controllers.RiveFileController.getOrCreateStateMachines(RiveFileController.kt:792)
    app.rive.runtime.kotlin.controllers.RiveFileController.processAllInputs(RiveFileController.kt:649)
    app.rive.runtime.kotlin.controllers.RiveFileController.advance(RiveFileController.kt:317)
    app.rive.runtime.kotlin.renderers.RiveArtboardRenderer.advance(RiveArtboardRenderer.kt:70)
```


## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/20821

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

Video shows the animation working and not crashing

https://github.com/user-attachments/assets/a729b5ab-5799-4064-8810-368d28a84e68

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update Rive state machine and trigger names in `useRewardsIconAnimation` and align tests accordingly.
> 
> - **UI/Bridge**
>   - **`useRewardsIconAnimation.ts`**: Change `STATE_MACHINE_NAME` to `Rewards_Icon`; update triggers `Disable` -> `Disable_left`, `Refresh` -> `Refresh_left`.
> - **Tests**
>   - **`useRewardsIconAnimation.test.ts`**: Update expectations to use `Rewards_Icon` and new trigger names; no behavior changes beyond name updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc1f2fb6eda848a9325b4ddcfe00b2384c6a04a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->