### PR TITLE
feat(ds): accept labelTextVariant prop

### DIFF
--- a/app/component-library/components-temp/CustomSpendCap/__snapshots__/CustomSpendCap.test.tsx.snap
+++ b/app/component-library/components-temp/CustomSpendCap/__snapshots__/CustomSpendCap.test.tsx.snap
@@ -91,7 +91,6 @@ exports[`CustomSpendCap should match snapshot 1`] = `
     <Text
       accessibilityRole="link"
       accessible={true}
-      labelTextVariant="sBodyMD"
       onPress={[Function]}
       onPressIn={[Function]}
       onPressOut={[Function]}
@@ -112,7 +111,7 @@ exports[`CustomSpendCap should match snapshot 1`] = `
         style={
           {
             "color": "#4459ff",
-            "fontFamily": "Geist Medium",
+            "fontFamily": "Geist Regular",
             "fontSize": 16,
             "letterSpacing": 0,
             "lineHeight": 24,

--- a/app/component-library/components/Buttons/Button/variants/ButtonLink/ButtonLink.tsx
+++ b/app/component-library/components/Buttons/Button/variants/ButtonLink/ButtonLink.tsx
@@ -28,6 +28,7 @@ const ButtonLink: React.FC<ButtonLinkProps> = ({
   isDanger = false,
   size = DEFAULT_BUTTONLINK_SIZE,
   label,
+  labelTextVariant = DEFAULT_BUTTONLINK_LABEL_TEXTVARIANT,
   ...props
 }) => {
   const [pressed, setPressed] = useState(false);
@@ -61,7 +62,7 @@ const ButtonLink: React.FC<ButtonLinkProps> = ({
   const renderLabel = () =>
     typeof label === 'string' ? (
       <Text
-        variant={DEFAULT_BUTTONLINK_LABEL_TEXTVARIANT}
+        variant={labelTextVariant}
         color={getLabelColor()}
         style={pressed && styles.pressedText}
       >

--- a/app/component-library/components/Buttons/Button/variants/ButtonPrimary/ButtonPrimary.tsx
+++ b/app/component-library/components/Buttons/Button/variants/ButtonPrimary/ButtonPrimary.tsx
@@ -22,6 +22,7 @@ const ButtonPrimary = ({
   isDanger = false,
   isInverse = false,
   label,
+  labelTextVariant = DEFAULT_BUTTONPRIMARY_LABEL_TEXTVARIANT,
   ...props
 }: ButtonPrimaryProps) => {
   const [pressed, setPressed] = useState(false);
@@ -77,10 +78,7 @@ const ButtonPrimary = ({
 
   const renderLabel = () =>
     typeof label === 'string' ? (
-      <TextComponent
-        variant={DEFAULT_BUTTONPRIMARY_LABEL_TEXTVARIANT}
-        color={textColor}
-      >
+      <TextComponent variant={labelTextVariant} color={textColor}>
         {label}
       </TextComponent>
     ) : (

--- a/app/component-library/components/Buttons/Button/variants/ButtonSecondary/ButtonSecondary.tsx
+++ b/app/component-library/components/Buttons/Button/variants/ButtonSecondary/ButtonSecondary.tsx
@@ -22,6 +22,7 @@ const ButtonSecondary = ({
   isDanger = false,
   isInverse = false,
   label,
+  labelTextVariant = DEFAULT_BUTTONSECONDARY_LABEL_TEXTVARIANT,
   ...props
 }: ButtonSecondaryProps) => {
   const [pressed, setPressed] = useState(false);
@@ -84,10 +85,7 @@ const ButtonSecondary = ({
 
   const renderLabel = () =>
     typeof label === 'string' ? (
-      <TextComponent
-        variant={DEFAULT_BUTTONSECONDARY_LABEL_TEXTVARIANT}
-        color={textColor}
-      >
+      <TextComponent variant={labelTextVariant} color={textColor}>
         {label}
       </TextComponent>
     ) : (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This pull request updates the button components to allow customization of the label text variant through the existing `labelTextVariant` prop, instead of always using the default variant. This makes it easier to control the appearance of button labels across the app.

**Button component improvements:**

* Added a `labelTextVariant` prop to `ButtonLink`, `ButtonPrimary`, and `ButtonSecondary` components, allowing consumers to specify the text variant for button labels. [[1]](diffhunk://#diff-9f3f9206e446a576c40400f8192441bf2f5d373e74561a05db091eb77b3b4d4bR31) [[2]](diffhunk://#diff-dd64da281e626e3e2deeea3430c29420ca565900d86487b9194c0cbb38d63d1dR25) [[3]](diffhunk://#diff-9c3d2c416c6ffcc8478b789108ef30caed0595fc25ad828f28709af061f896e9R25)
* Updated the label rendering logic in all three button components to use the existing `labelTextVariant` prop instead of the hardcoded default value. [[1]](diffhunk://#diff-9f3f9206e446a576c40400f8192441bf2f5d373e74561a05db091eb77b3b4d4bL64-R65) [[2]](diffhunk://#diff-dd64da281e626e3e2deeea3430c29420ca565900d86487b9194c0cbb38d63d1dL80-R81) [[3]](diffhunk://#diff-9c3d2c416c6ffcc8478b789108ef30caed0595fc25ad828f28709af061f896e9L87-R88)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Button component

  Scenario: user uses specific text variant for button label
    Given a button component

    When user sets label as string and label text variant prop
    Then label is rendered with proper text variant
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/be21d296-3562-42e6-b330-18bab5a27b35



<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/da7577ac-cdf0-4a62-87eb-c2c0eadef333



## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expose and use `labelTextVariant` on `ButtonLink`, `ButtonPrimary`, and `ButtonSecondary`; update related snapshot.
> 
> - **Components**
>   - **Buttons**:
>     - `ButtonLink`, `ButtonPrimary`, `ButtonSecondary`: add `labelTextVariant` prop (defaulting to existing constants) and use it when rendering label text instead of hardcoded defaults.
> - **Tests**
>   - Update `CustomSpendCap` snapshot to reflect label variant/styling changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6471c322ea0db2cdb7d91eedf4a82899bda9347a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->