### PR TITLE
chore: Bump main version to 7.58.0

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -187,7 +187,7 @@ android {
         applicationId "io.metamask"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionName "7.57.0"
+        versionName "7.58.0"
         versionCode 2296
         testBuildType System.getProperty('testBuildType', 'debug')
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -3762,13 +3762,13 @@ app:
       PROJECT_LOCATION_IOS: ios
     - opts:
         is_expand: false
-      VERSION_NAME: 7.57.0
+      VERSION_NAME: 7.58.0
     - opts:
         is_expand: false
       VERSION_NUMBER: 2349
     - opts:
         is_expand: false
-      FLASK_VERSION_NAME: 7.57.0
+      FLASK_VERSION_NAME: 7.58.0
     - opts:
         is_expand: false
       FLASK_VERSION_NUMBER: 2349

--- a/ios/MetaMask.xcodeproj/project.pbxproj
+++ b/ios/MetaMask.xcodeproj/project.pbxproj
@@ -1311,7 +1311,7 @@
 					"${inherited}",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 7.57.0;
+				MARKETING_VERSION = 7.58.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
@@ -1377,7 +1377,7 @@
 					"${inherited}",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 7.57.0;
+				MARKETING_VERSION = 7.58.0;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
@@ -1446,7 +1446,7 @@
 					"\"$(SRCROOT)/MetaMask/System/Library/Frameworks\"",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 7.57.0;
+				MARKETING_VERSION = 7.58.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
@@ -1510,7 +1510,7 @@
 					"\"$(SRCROOT)/MetaMask/System/Library/Frameworks\"",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 7.57.0;
+				MARKETING_VERSION = 7.58.0;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = (
@@ -1676,7 +1676,7 @@
 					"\"$(SRCROOT)/MetaMask/System/Library/Frameworks\"",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 7.57.0;
+				MARKETING_VERSION = 7.58.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = (
 					"$(inherited)",
@@ -1743,7 +1743,7 @@
 					"\"$(SRCROOT)/MetaMask/System/Library/Frameworks\"",
 				);
 				LLVM_LTO = YES;
-				MARKETING_VERSION = 7.57.0;
+				MARKETING_VERSION = 7.58.0;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CFLAGS = (
 					"$(inherited)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask",
-  "version": "7.57.0",
+  "version": "7.58.0",
   "private": true,
   "scripts": {
     "install:foundryup": "yarn mm-foundryup",


### PR DESCRIPTION
## Version Bump After Release

This PR bumps the main branch version from 7.57.0 to 7.58.0 after cutting the release branch.

### Why this is needed:
- **Nightly builds**: Each nightly build needs to be one minor version ahead of the current release candidate
- **Version conflicts**: Prevents conflicts between nightlies and release candidates
- **Platform alignment**: Maintains version alignment between MetaMask mobile and extension
- **Update systems**: Ensures nightlies are accepted by app stores and browser update systems

### What changed:
- Version bumped from `7.57.0` to `7.58.0`
- Platform: `mobile`
- Files updated by `set-semvar-version.sh` script

### Next steps:
This PR should be **manually reviewed and merged by the release manager** to maintain proper version flow.

### Related:
- Release version: 7.57.0
- Release branch: release/7.57.0
- Platform: mobile
- Test mode: false

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps version to 7.58.0 across Android, iOS project settings, Bitrise envs, and package.json.
> 
> - **Version bump to `7.58.0`**:
>   - **Android**: Update `android/app/build.gradle` `versionName` to `7.58.0`.
>   - **iOS**: Update `MARKETING_VERSION` to `7.58.0` across targets in `ios/MetaMask.xcodeproj/project.pbxproj`.
>   - **CI**: Update Bitrise envs `VERSION_NAME` and `FLASK_VERSION_NAME` to `7.58.0` in `bitrise.yml`.
>   - **Repo metadata**: Update `package.json` `version` to `7.58.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40108afab641f902571db21260c45500b4c98e4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->