### PR TITLE
feat: cp-7.56.3 disable perps build flag and add belgium to build flag blocked regions fallback

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -3726,10 +3726,10 @@ app:
       MM_UNIFIED_SWAPS_ENABLED: true
     - opts:
         is_expand: false
-      MM_PERPS_ENABLED: true
+      MM_PERPS_ENABLED: false
     - opts:
         is_expand: false
-      MM_PERPS_BLOCKED_REGIONS: "US,CA-ON,GB"
+      MM_PERPS_BLOCKED_REGIONS: "US,CA-ON,GB,BE"
     - opts:
         is_expand: false
       PROJECT_LOCATION: android


### PR DESCRIPTION
### Changes:
- Disabled perps local fallback
- Added Belgium (`BE`) to geo-blocked regions local fallback list.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables `MM_PERPS_ENABLED` and adds Belgium (BE) to `MM_PERPS_BLOCKED_REGIONS` in `bitrise.yml`.
> 
> - **CI config (`bitrise.yml`)**:
>   - Set `MM_PERPS_ENABLED` to `false`.
>   - Updated `MM_PERPS_BLOCKED_REGIONS` to include `BE` (now `US,CA-ON,GB,BE`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 065d5f8751a0761c638d95a495d955ec94b0000b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->