### PR TITLE
fix: cp-7.57.0 prevent duplicate points events api calls

### DIFF
--- a/app/components/UI/Rewards/hooks/usePointsEvents.test.ts
+++ b/app/components/UI/Rewards/hooks/usePointsEvents.test.ts
@@ -4,6 +4,7 @@ import { waitFor } from '@testing-library/react-native';
 // Add longer timeout for waitFor to prevent test flakiness
 const waitForOptions = { timeout: 5000 };
 import { usePointsEvents } from './usePointsEvents';
+import { PaginatedPointsEventsDto } from '../../../../core/Engine/controllers/rewards-controller/types';
 
 // Mock Engine
 const mockCall = jest.fn();
@@ -78,7 +79,6 @@ describe('usePointsEvents', () => {
     results: [mockPointsEvent],
     has_more: true,
     cursor: 'next-cursor',
-    total_results: 10,
   };
 
   beforeEach(() => {
@@ -991,6 +991,445 @@ describe('usePointsEvents', () => {
     });
   });
 
+  describe('refreshWithoutForceFresh functionality', () => {
+    it('should call refresh with forceFresh=false when refreshWithoutForceFresh is called', async () => {
+      const { result } = renderHook(() =>
+        usePointsEvents({
+          seasonId: 'season-1',
+          subscriptionId: 'sub-1',
+        }),
+      );
+
+      // Wait for initial load
+      await waitFor(
+        () => expect(result.current.isLoading).toBe(false),
+        waitForOptions,
+      );
+
+      // Reset mock to track the next call
+      mockCall.mockClear();
+
+      // Get the refreshWithoutForceFresh function from the hook
+      // Since it's not exposed directly, we'll test it through the event subscription
+      // We need to simulate the event callback being called
+      const subscriptionCalls = mockUseInvalidateByRewardEvents.mock.calls;
+      const pointsEventsUpdatedCallback = subscriptionCalls.find((call) =>
+        call[0].includes('RewardsController:pointsEventsUpdated'),
+      )?.[1];
+
+      expect(pointsEventsUpdatedCallback).toBeDefined();
+
+      // Call the callback (this simulates the event being triggered)
+      await act(async () => {
+        await pointsEventsUpdatedCallback();
+      });
+
+      // Verify API call with forceFresh=false
+      expect(mockCall).toHaveBeenCalledWith(
+        'RewardsController:getPointsEvents',
+        {
+          seasonId: 'season-1',
+          subscriptionId: 'sub-1',
+          cursor: null,
+          forceFresh: false,
+        },
+      );
+    });
+  });
+
+  describe('refresh forceFresh parameter handling', () => {
+    it('should call API with forceFresh=true when refresh is called without parameter', async () => {
+      const { result } = renderHook(() =>
+        usePointsEvents({
+          seasonId: 'season-1',
+          subscriptionId: 'sub-1',
+        }),
+      );
+
+      // Wait for initial load
+      await waitFor(
+        () => expect(result.current.isLoading).toBe(false),
+        waitForOptions,
+      );
+
+      // Reset mock to track the next call
+      mockCall.mockClear();
+
+      // Call refresh without parameter (should default to forceFresh=true)
+      act(() => {
+        result.current.refresh();
+      });
+
+      // Wait for refresh to complete
+      await waitFor(
+        () => expect(result.current.isRefreshing).toBe(false),
+        waitForOptions,
+      );
+
+      // Verify API call with forceFresh=true
+      expect(mockCall).toHaveBeenCalledWith(
+        'RewardsController:getPointsEvents',
+        {
+          seasonId: 'season-1',
+          subscriptionId: 'sub-1',
+          cursor: null,
+          forceFresh: true,
+        },
+      );
+    });
+
+    it('should call API with forceFresh=false when refresh is called with false parameter', async () => {
+      const { result } = renderHook(() =>
+        usePointsEvents({
+          seasonId: 'season-1',
+          subscriptionId: 'sub-1',
+        }),
+      );
+
+      // Wait for initial load
+      await waitFor(
+        () => expect(result.current.isLoading).toBe(false),
+        waitForOptions,
+      );
+
+      // Reset mock to track the next call
+      mockCall.mockClear();
+
+      // Call refresh with forceFresh=false
+      act(() => {
+        result.current.refresh(false);
+      });
+
+      // Wait for refresh to complete
+      await waitFor(
+        () => expect(result.current.isRefreshing).toBe(false),
+        waitForOptions,
+      );
+
+      // Verify API call with forceFresh=false
+      expect(mockCall).toHaveBeenCalledWith(
+        'RewardsController:getPointsEvents',
+        {
+          seasonId: 'season-1',
+          subscriptionId: 'sub-1',
+          cursor: null,
+          forceFresh: false,
+        },
+      );
+    });
+  });
+
+  describe('edge cases and additional error handling', () => {
+    it('should handle empty results from API', async () => {
+      // Mock response with empty results
+      mockCall.mockResolvedValueOnce({
+        results: [],
+        has_more: false,
+        cursor: null,
+      });
+
+      const { result } = renderHook(() =>
+        usePointsEvents({
+          seasonId: 'season-1',
+          subscriptionId: 'sub-1',
+        }),
+      );
+
+      // Wait for the data to load
+      await waitFor(
+        () => expect(result.current.isLoading).toBe(false),
+        waitForOptions,
+      );
+
+      // Verify empty results are handled correctly
+      expect(result.current.pointsEvents).toEqual([]);
+      expect(result.current.hasMore).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+
+    it('should handle null cursor in API response', async () => {
+      // Mock response with null cursor
+      mockCall.mockResolvedValueOnce({
+        results: [mockPointsEvent],
+        has_more: false,
+        cursor: null,
+      });
+
+      const { result } = renderHook(() =>
+        usePointsEvents({
+          seasonId: 'season-1',
+          subscriptionId: 'sub-1',
+        }),
+      );
+
+      // Wait for the data to load
+      await waitFor(
+        () => expect(result.current.isLoading).toBe(false),
+        waitForOptions,
+      );
+
+      // Verify null cursor is handled correctly
+      expect(result.current.pointsEvents).toEqual([mockPointsEvent]);
+      expect(result.current.hasMore).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+
+    it('should handle fetchPointsEvents early return when seasonId is missing', async () => {
+      const { result } = renderHook(() =>
+        usePointsEvents({
+          seasonId: undefined,
+          subscriptionId: 'sub-1',
+        }),
+      );
+
+      // Should not be loading since seasonId is undefined
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.pointsEvents).toEqual(null);
+      expect(mockCall).not.toHaveBeenCalled();
+    });
+
+    it('should handle fetchPointsEvents early return when subscriptionId is empty', async () => {
+      const { result } = renderHook(() =>
+        usePointsEvents({
+          seasonId: 'season-1',
+          subscriptionId: '',
+        }),
+      );
+
+      // Should not be loading since subscriptionId is empty
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.pointsEvents).toEqual(null);
+      expect(mockCall).not.toHaveBeenCalled();
+    });
+
+    it('should handle concurrent fetchPointsEvents calls by using isLoadingRef', async () => {
+      // Mock a slow API response
+      let resolvePromise: (value: PaginatedPointsEventsDto) => void = () => {
+        // do nothing
+      };
+      const slowPromise = new Promise((resolve) => {
+        resolvePromise = resolve;
+      });
+      mockCall.mockReturnValueOnce(slowPromise);
+
+      const { result } = renderHook(() =>
+        usePointsEvents({
+          seasonId: 'season-1',
+          subscriptionId: 'sub-1',
+        }),
+      );
+
+      // Should be loading initially
+      expect(result.current.isLoading).toBe(true);
+
+      // Try to trigger another fetch while the first one is still pending
+      // This should be prevented by isLoadingRef
+      const subscriptionCalls = mockUseInvalidateByRewardEvents.mock.calls;
+      const accountLinkedCallback = subscriptionCalls.find((call) =>
+        call[0].includes('RewardsController:accountLinked'),
+      )?.[1];
+
+      if (accountLinkedCallback) {
+        await act(async () => {
+          await accountLinkedCallback();
+        });
+      }
+
+      // Resolve the slow promise
+      if (resolvePromise) {
+        resolvePromise(
+          mockPaginatedResponse as unknown as PaginatedPointsEventsDto,
+        );
+      }
+
+      // Wait for completion
+      await waitFor(
+        () => expect(result.current.isLoading).toBe(false),
+        waitForOptions,
+      );
+
+      // Should only have been called once due to isLoadingRef protection
+      expect(mockCall).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle refresh error and maintain refreshing state correctly', async () => {
+      const { result } = renderHook(() =>
+        usePointsEvents({
+          seasonId: 'season-1',
+          subscriptionId: 'sub-1',
+        }),
+      );
+
+      // Wait for initial load
+      await waitFor(
+        () => expect(result.current.isLoading).toBe(false),
+        waitForOptions,
+      );
+
+      // Mock error for refresh
+      const refreshError = new Error('Refresh failed');
+      mockCall.mockRejectedValueOnce(refreshError);
+
+      // Call refresh
+      act(() => {
+        result.current.refresh();
+      });
+
+      // Verify refreshing state starts as true
+      expect(result.current.isRefreshing).toBe(true);
+
+      // Wait for refresh to complete with error
+      await waitFor(
+        () => expect(result.current.isRefreshing).toBe(false),
+        waitForOptions,
+      );
+
+      // Verify error was set and refreshing state is false
+      expect(result.current.error).toBe('Refresh failed');
+      expect(result.current.isRefreshing).toBe(false);
+    });
+
+    it('should handle loadMore error and maintain loadingMore state correctly', async () => {
+      const { result } = renderHook(() =>
+        usePointsEvents({
+          seasonId: 'season-1',
+          subscriptionId: 'sub-1',
+        }),
+      );
+
+      // Wait for initial load
+      await waitFor(
+        () => expect(result.current.isLoading).toBe(false),
+        waitForOptions,
+      );
+
+      // Mock error for loadMore
+      const loadMoreError = new Error('Load more failed');
+      mockCall.mockRejectedValueOnce(loadMoreError);
+
+      // Call loadMore
+      act(() => {
+        result.current.loadMore();
+      });
+
+      // Verify loadingMore state starts as true
+      expect(result.current.isLoadingMore).toBe(true);
+
+      // Wait for loadMore to complete with error
+      await waitFor(
+        () => expect(result.current.isLoadingMore).toBe(false),
+        waitForOptions,
+      );
+
+      // Verify error was set and loadingMore state is false
+      expect(result.current.error).toBe('Load more failed');
+      expect(result.current.isLoadingMore).toBe(false);
+    });
+
+    it('should handle loadMore when cursor is null', async () => {
+      // Mock response with null cursor
+      mockCall.mockResolvedValueOnce({
+        results: [mockPointsEvent],
+        has_more: false,
+        cursor: null,
+      });
+
+      const { result } = renderHook(() =>
+        usePointsEvents({
+          seasonId: 'season-1',
+          subscriptionId: 'sub-1',
+        }),
+      );
+
+      // Wait for initial load
+      await waitFor(
+        () => expect(result.current.isLoading).toBe(false),
+        waitForOptions,
+      );
+
+      // Reset mock to track the next call
+      mockCall.mockClear();
+
+      // Call loadMore when cursor is null
+      act(() => {
+        result.current.loadMore();
+      });
+
+      // Should not make API call since cursor is null
+      expect(mockCall).not.toHaveBeenCalled();
+    });
+
+    it('should handle loadMore when hasMore is false', async () => {
+      // Mock response with has_more: false
+      mockCall.mockResolvedValueOnce({
+        results: [mockPointsEvent],
+        has_more: false,
+        cursor: 'some-cursor',
+      });
+
+      const { result } = renderHook(() =>
+        usePointsEvents({
+          seasonId: 'season-1',
+          subscriptionId: 'sub-1',
+        }),
+      );
+
+      // Wait for initial load
+      await waitFor(
+        () => expect(result.current.isLoading).toBe(false),
+        waitForOptions,
+      );
+
+      // Reset mock to track the next call
+      mockCall.mockClear();
+
+      // Call loadMore when hasMore is false
+      act(() => {
+        result.current.loadMore();
+      });
+
+      // Should not make API call since hasMore is false
+      expect(mockCall).not.toHaveBeenCalled();
+    });
+
+    it('should handle loadMore when already loading more', async () => {
+      const { result } = renderHook(() =>
+        usePointsEvents({
+          seasonId: 'season-1',
+          subscriptionId: 'sub-1',
+        }),
+      );
+
+      // Wait for initial load
+      await waitFor(
+        () => expect(result.current.isLoading).toBe(false),
+        waitForOptions,
+      );
+
+      // Reset mock to track the next call
+      mockCall.mockClear();
+
+      // Call loadMore
+      act(() => {
+        result.current.loadMore();
+      });
+
+      // Call loadMore again while still loading
+      act(() => {
+        result.current.loadMore();
+      });
+
+      // Wait for loadMore to complete
+      await waitFor(
+        () => expect(result.current.isLoadingMore).toBe(false),
+        waitForOptions,
+      );
+
+      // Should only have been called once
+      expect(mockCall).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('event subscriptions', () => {
     it('should subscribe to reward events', () => {
       renderHook(() =>
@@ -1002,11 +1441,22 @@ describe('usePointsEvents', () => {
 
       // Verify subscription to events
       expect(mockUseInvalidateByRewardEvents).toHaveBeenCalledWith(
-        [
-          'RewardsController:accountLinked',
-          'RewardsController:rewardClaimed',
-          'RewardsController:pointsEventsUpdated',
-        ],
+        ['RewardsController:accountLinked', 'RewardsController:rewardClaimed'],
+        expect.any(Function),
+      );
+    });
+
+    it('should subscribe to pointsEventsUpdated event separately', () => {
+      renderHook(() =>
+        usePointsEvents({
+          seasonId: 'season-1',
+          subscriptionId: 'sub-1',
+        }),
+      );
+
+      // Verify separate subscription to pointsEventsUpdated event
+      expect(mockUseInvalidateByRewardEvents).toHaveBeenCalledWith(
+        ['RewardsController:pointsEventsUpdated'],
         expect.any(Function),
       );
     });

--- a/app/components/UI/Rewards/hooks/usePointsEvents.ts
+++ b/app/components/UI/Rewards/hooks/usePointsEvents.ts
@@ -21,7 +21,7 @@ export interface UsePointsEventsResult {
   hasMore: boolean;
   error: string | null;
   loadMore: () => void;
-  refresh: () => void;
+  refresh: (forceFresh?: boolean) => void;
   isRefreshing: boolean;
 }
 
@@ -134,16 +134,23 @@ export const usePointsEvents = (
     uiStorePointsEvents,
   ]);
 
-  const refresh = useCallback(async () => {
-    setIsRefreshing(true);
-    setCursor(null);
-    setHasMore(true);
-    await fetchPointsEvents({
-      isInitial: true,
-      forceFresh: true,
-    });
-    setIsRefreshing(false);
-  }, [fetchPointsEvents]);
+  const refresh = useCallback(
+    async (forceFresh = true) => {
+      setIsRefreshing(true);
+      setCursor(null);
+      setHasMore(true);
+      await fetchPointsEvents({
+        isInitial: true,
+        forceFresh,
+      });
+      setIsRefreshing(false);
+    },
+    [fetchPointsEvents],
+  );
+
+  const refreshWithoutForceFresh = useCallback(async () => {
+    refresh(false);
+  }, [refresh]);
 
   // Listen for activeTab changes to refresh when switching to activity tab
   useEffect(() => {
@@ -154,12 +161,15 @@ export const usePointsEvents = (
 
   // Listen for reward claimed events to trigger refetch
   useInvalidateByRewardEvents(
-    [
-      'RewardsController:accountLinked',
-      'RewardsController:rewardClaimed',
-      'RewardsController:pointsEventsUpdated',
-    ],
+    ['RewardsController:accountLinked', 'RewardsController:rewardClaimed'],
     refresh,
+  );
+
+  useInvalidateByRewardEvents(
+    ['RewardsController:pointsEventsUpdated'],
+    // Don't force fresh when points events are updated; this event is only emitted when we've just fetched new points events
+    // otherwise we'll fetch the same points events again
+    refreshWithoutForceFresh,
   );
 
   return {

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -170,7 +170,7 @@ interface CacheOptions<T> {
   readCache: CacheReader<T>;
   fetchFresh: () => Promise<T>;
   writeCache: CacheWriter<T>;
-  swrCallback?: (fresh: T) => void; // Callback triggered after SWR refresh, to invalidate cache
+  swrCallback?: (old: T, fresh: T) => void; // Callback triggered after SWR refresh, to invalidate cache
 }
 
 /**
@@ -201,7 +201,7 @@ export async function wrapWithCache<T>({
           try {
             const fresh = await fetchFresh();
             writeCache(key, fresh);
-            swrCallback(fresh);
+            swrCallback(cached.payload, fresh);
           } catch (err) {
             Logger.log(
               'SWR revalidation failed:',
@@ -339,7 +339,6 @@ export class RewardsController extends BaseController<
       })),
       has_more: pointsEvents.has_more,
       cursor: pointsEvents.cursor,
-      total_results: pointsEvents.total_results,
       lastFetched: Date.now(),
     };
   }
@@ -354,7 +353,6 @@ export class RewardsController extends BaseController<
         timestamp: new Date(r.timestamp),
         updatedAt: new Date(r.updatedAt),
       })),
-      total_results: state.total_results,
       cursor: state.cursor,
       has_more: state.has_more,
     };
@@ -1226,8 +1224,7 @@ export class RewardsController extends BaseController<
     params: GetPointsEventsDto,
   ): Promise<PaginatedPointsEventsDto> {
     const rewardsEnabled = selectRewardsEnabledFlag(store.getState());
-    if (!rewardsEnabled)
-      return { has_more: false, cursor: null, total_results: 0, results: [] };
+    if (!rewardsEnabled) return { has_more: false, cursor: null, results: [] };
 
     // If cursor is provided, always fetch fresh and do not touch cache
     if (params.cursor) {
@@ -1290,12 +1287,19 @@ export class RewardsController extends BaseController<
             this.#convertPointsEventsToState(pointsEventsDto);
         });
       },
-      swrCallback: () => {
-        // Let UI know first page cache has been refreshed so it can re-query
-        this.messagingSystem.publish('RewardsController:pointsEventsUpdated', {
-          seasonId: params.seasonId,
-          subscriptionId: params.subscriptionId,
-        });
+      swrCallback: (old, fresh) => {
+        const oldMostRecentId = old?.results?.[0]?.id || '';
+        const freshMostRecentId = fresh?.results?.[0]?.id || '';
+        if (oldMostRecentId !== freshMostRecentId) {
+          // Let UI know first page cache has been refreshed so it can re-query
+          this.messagingSystem.publish(
+            'RewardsController:pointsEventsUpdated',
+            {
+              seasonId: params.seasonId,
+              subscriptionId: params.subscriptionId,
+            },
+          );
+        }
       },
     });
 
@@ -1319,7 +1323,6 @@ export class RewardsController extends BaseController<
         : {
             has_more: false,
             cursor: null,
-            total_results: 0,
             results: [],
           };
     }

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -1291,6 +1291,13 @@ export class RewardsController extends BaseController<
         const oldMostRecentId = old?.results?.[0]?.id || '';
         const freshMostRecentId = fresh?.results?.[0]?.id || '';
         if (oldMostRecentId !== freshMostRecentId) {
+          Logger.log(
+            'RewardsController: Emitting pointsEventsUpdated event due to new points events',
+            {
+              seasonId: params.seasonId,
+              subscriptionId: params.subscriptionId,
+            },
+          );
           // Let UI know first page cache has been refreshed so it can re-query
           this.messagingSystem.publish(
             'RewardsController:pointsEventsUpdated',

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
@@ -313,7 +313,6 @@ describe('RewardsDataService', () => {
     const mockPointsEventsResponse = {
       has_more: true,
       cursor: 'next-cursor-123',
-      total_results: 100,
       results: [
         {
           id: 'event-123',

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -172,7 +172,6 @@ export interface GetPointsEventsLastUpdatedDto {
 export interface PaginatedPointsEventsDto {
   has_more: boolean;
   cursor: string | null;
-  total_results: number;
   results: PointsEventDto[];
 }
 
@@ -584,7 +583,6 @@ export type PointsEventsDtoState = {
   }[];
   has_more: boolean;
   cursor: string | null;
-  total_results: number;
   lastFetched: number;
 };
 


### PR DESCRIPTION
## **Description**

The client is always making two calls to /last-updated due to how the `swr` is currently implemented in the rewards controller. With this change this logic is now smarter so that it only conditionally emits the points event updated event. The UI hook is also smarter and will not force refresh for this event as we want to read from the cache.

## **Changelog**

CHANGELOG entry: null


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make points events SWR emit updates only when data changes, update UI hook to avoid forced refresh for that event, and drop total_results from points events DTO/state with tests updated.
> 
> - **Rewards (Controller/Cache/SWR)**:
>   - Make `wrapWithCache` `swrCallback(old, fresh)` and only publish `RewardsController:pointsEventsUpdated` when most recent event ID changes.
>   - Respect `forceFresh` in `getPointsEvents`; return empty payload when disabled; remove `total_results` usage and state handling; include `pointsEvents` in cache invalidation.
> - **UI Hook (`usePointsEvents`)**:
>   - Change `refresh` to `(forceFresh = true)` and add `refreshWithoutForceFresh`.
>   - Split event subscriptions: account/claim -> `refresh(true)`; `pointsEventsUpdated` -> `refresh(false)`.
> - **Types**:
>   - Remove `total_results` from `PaginatedPointsEventsDto` and `PointsEventsDtoState`.
> - **Tests**:
>   - Update/extend tests for new hook API, SWR callback signature, conditional event emission, error/edge cases, and removal of `total_results`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47ec764a0e41271c821e51a63b5f175a64d67151. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->