### PR TITLE
fix: seedless-rehydrate and sync issue cp-7.57.0

### DIFF
--- a/app/core/Authentication/Authentication.test.ts
+++ b/app/core/Authentication/Authentication.test.ts
@@ -115,6 +115,7 @@ jest.mock('../Engine', () => ({
     SeedlessOnboardingController: {
       addNewSecretData: jest.fn(),
       updateBackupMetadataState: jest.fn(),
+      state: { vault: null },
     },
 
     MultichainAccountService: {
@@ -1110,6 +1111,7 @@ describe('Authentication', () => {
         submitGlobalPassword: jest.fn(),
         checkIsPasswordOutdated: jest.fn(),
         setLocked: jest.fn().mockResolvedValue(undefined),
+        state: { vault: 'seedless onboarding vault' },
       } as unknown as SeedlessOnboardingController<EncryptionKey>;
       Engine.context.KeyringController = {
         setLocked: jest.fn(),
@@ -1208,6 +1210,8 @@ describe('Authentication', () => {
       ).mockResolvedValueOnce({
         id: 'new-keyring-id',
       });
+      Engine.context.SeedlessOnboardingController.state.vault =
+        'seedless onboarding vault';
 
       await Authentication.userEntryAuth(mockPassword, mockAuthData);
 
@@ -2025,6 +2029,7 @@ describe('Authentication', () => {
       Engine.context.SeedlessOnboardingController = {
         addNewSecretData: jest.fn().mockResolvedValue(undefined),
         updateBackupMetadataState: jest.fn(),
+        state: { vault: 'seedless onboarding vault' },
       } as unknown as SeedlessOnboardingController<EncryptionKey>;
 
       // Mock Engine.setSelectedAddress
@@ -2048,6 +2053,10 @@ describe('Authentication', () => {
       } as unknown as ReduxStore);
     });
 
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
     it('throw when call import seedless mnemonic and return account details without seedless flow', async () => {
       // Arrange
       const mnemonic = 'test mnemonic phrase for wallet';
@@ -2065,6 +2074,7 @@ describe('Authentication', () => {
           },
         }),
       } as unknown as ReduxStore);
+      Engine.context.SeedlessOnboardingController.state.vault = undefined;
 
       // Act
       await expect(
@@ -2122,6 +2132,8 @@ describe('Authentication', () => {
       const error = new Error('Failed to add new keyring');
       Engine.context.KeyringController.addNewKeyring.mockRejectedValue(error);
 
+      Engine.context.SeedlessOnboardingController.state.vault =
+        'seedless onboarding vault';
       // Act & Assert
       await expect(
         Authentication.importSeedlessMnemonicToVault(mnemonic),
@@ -2133,6 +2145,8 @@ describe('Authentication', () => {
       const mnemonic = 'test mnemonic phrase for wallet';
       const error = new Error('Failed to get accounts');
       mockKeyring.getAccounts.mockRejectedValue(error);
+      Engine.context.SeedlessOnboardingController.state.vault =
+        'seedless onboarding vault';
 
       // Act & Assert
       await expect(

--- a/app/core/Authentication/Authentication.test.ts
+++ b/app/core/Authentication/Authentication.test.ts
@@ -2641,6 +2641,7 @@ describe('Authentication', () => {
       mockConvertEnglishWordlistIndicesToCodepoints.mockReturnValue(
         Buffer.from('test mnemonic phrase'),
       );
+      mockUint8ArrayToMnemonic.mockReturnValue('test mnemonic phrase');
     });
 
     it('sync seed phrases with private key and mnemonic secrets', async () => {

--- a/app/core/Authentication/Authentication.ts
+++ b/app/core/Authentication/Authentication.ts
@@ -811,7 +811,7 @@ class AuthenticationService {
             secret.data,
             wordlist,
           );
-          const mnemonicToRestore = Buffer.from(encodedSrp).toString('utf8');
+          const mnemonicToRestore = encodedSrp.toString('utf8');
 
           // import the new mnemonic to the current vault
           const keyringMetadata = await this.importSeedlessMnemonicToVault(

--- a/app/core/Authentication/Authentication.ts
+++ b/app/core/Authentication/Authentication.ts
@@ -838,9 +838,9 @@ class AuthenticationService {
   importSeedlessMnemonicToVault = async (
     mnemonic: string,
   ): Promise<KeyringMetadata> => {
-    const isSeedlessOnboardingFlow = selectSeedlessOnboardingLoginFlow(
-      ReduxService.store.getState(),
-    );
+    const isSeedlessOnboardingFlow =
+      Engine.context.SeedlessOnboardingController.state.vault != null;
+
     if (!isSeedlessOnboardingFlow) {
       throw new Error('Not in seedless onboarding flow');
     }

--- a/app/core/Authentication/Authentication.ts
+++ b/app/core/Authentication/Authentication.ts
@@ -786,52 +786,62 @@ class AuthenticationService {
       throw new Error('No root SRP found');
     }
 
+    const allErrors: Error[] = [];
     for (const secret of otherSecrets) {
-      // import SRP secret
-      // Get the SRP hash, and find the hash in the local state
-      const secretDataHash =
-        SeedlessOnboardingController.getSecretDataBackupState(
-          secret.data,
-          secret.type,
-        );
-
-      if (!secretDataHash) {
-        // If SRP is not in the local state, import it to the vault
-
-        // import private key secret
-        if (secret.type === SecretType.PrivateKey) {
-          await this.importAccountFromPrivateKey(bytesToHex(secret.data), {
-            shouldCreateSocialBackup: false,
-            shouldSelectAccount: false,
-          });
-          continue;
-        } else if (secret.type === SecretType.Mnemonic) {
-          // convert the seed phrase to a mnemonic (string)
-          const encodedSrp = convertEnglishWordlistIndicesToCodepoints(
+      try {
+        // import SRP secret
+        // Get the SRP hash, and find the hash in the local state
+        const secretDataHash =
+          SeedlessOnboardingController.getSecretDataBackupState(
             secret.data,
-            wordlist,
-          );
-          const mnemonicToRestore = encodedSrp.toString('utf8');
-
-          // import the new mnemonic to the current vault
-          const keyringMetadata = await this.importSeedlessMnemonicToVault(
-            mnemonicToRestore,
-          );
-
-          // discover multichain accounts from imported srp
-          if (isMultichainAccountsState2Enabled()) {
-            // NOTE: Initial implementation of discovery was not awaited, thus we also follow this pattern here.
-            this.attemptMultichainAccountWalletDiscovery(keyringMetadata.id);
-          } else {
-            this.addMultichainAccounts([keyringMetadata]);
-          }
-        } else {
-          Logger.error(
-            new Error('SeedlessOnboardingController: Unknown secret type'),
             secret.type,
           );
+
+        if (!secretDataHash) {
+          // If SRP is not in the local state, import it to the vault
+
+          // import private key secret
+          if (secret.type === SecretType.PrivateKey) {
+            await this.importAccountFromPrivateKey(bytesToHex(secret.data), {
+              shouldCreateSocialBackup: false,
+              shouldSelectAccount: false,
+            });
+            continue;
+          } else if (secret.type === SecretType.Mnemonic) {
+            // convert the seed phrase to a mnemonic (string)
+            const encodedSrp = convertEnglishWordlistIndicesToCodepoints(
+              secret.data,
+              wordlist,
+            );
+            const mnemonicToRestore = encodedSrp.toString('utf8');
+
+            // import the new mnemonic to the current vault
+            const keyringMetadata = await this.importSeedlessMnemonicToVault(
+              mnemonicToRestore,
+            );
+
+            // discover multichain accounts from imported srp
+            if (isMultichainAccountsState2Enabled()) {
+              // NOTE: Initial implementation of discovery was not awaited, thus we also follow this pattern here.
+              this.attemptMultichainAccountWalletDiscovery(keyringMetadata.id);
+            } else {
+              this.addMultichainAccounts([keyringMetadata]);
+            }
+          } else {
+            Logger.error(
+              new Error('SeedlessOnboardingController: Unknown secret type'),
+              secret.type,
+            );
+          }
         }
+      } catch (error) {
+        allErrors.push(error as Error);
+        Logger.error(error as Error, 'Seedless - syncSeedPhrases error');
       }
+    }
+    if (allErrors.length > 0) {
+      // throw first error
+      throw allErrors[0];
     }
   };
 

--- a/app/core/Authentication/Authentication.ts
+++ b/app/core/Authentication/Authentication.ts
@@ -44,7 +44,6 @@ import {
 import { selectExistingUser } from '../../reducers/user/selectors';
 import { wordlist } from '@metamask/scure-bip39/dist/wordlists/english';
 import {
-  convertEnglishWordlistIndicesToCodepoints,
   convertMnemonicToWordlistIndices,
   uint8ArrayToMnemonic,
 } from '../../util/mnemonic';
@@ -809,11 +808,8 @@ class AuthenticationService {
             continue;
           } else if (secret.type === SecretType.Mnemonic) {
             // convert the seed phrase to a mnemonic (string)
-            const encodedSrp = convertEnglishWordlistIndicesToCodepoints(
-              secret.data,
-              wordlist,
-            );
-            const mnemonicToRestore = encodedSrp.toString('utf8');
+            const encodedSrp = uint8ArrayToMnemonic(secret.data, wordlist);
+            const mnemonicToRestore = encodedSrp;
 
             // import the new mnemonic to the current vault
             const keyringMetadata = await this.importSeedlessMnemonicToVault(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Redux state is slow to update causing incorrect state check during social login rehydration.
This is causing the rehydration do not sync over all SRPs.

syncSeedPhrase is failing due to unexpected duplicated SRP from the Seedless data.
This break the for loop sync flow and causing the sync failed


This pr replace redux state check with direct controller state check.
This pr also catch and swallow the unexpected error to forward the for loop.
The error is then broadcast after the loop is completed 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

Fixes:
https://github.com/MetaMask/metamask-mobile/issues/20730
## **Manual testing steps**

```gherkin
Feature: fix srps sync across device

  Scenario: user have social Wallet in extension and mobile
    Given user add new srp on extension

    When user click on account menu on mobile
    Then user should able to see new account imported from extension
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches seedless-flow checks from Redux to controller state, improves SRP sync with per-secret error handling and updated mnemonic conversion, and updates tests accordingly.
> 
> - **Authentication**:
>   - **Seedless flow gating**: `importSeedlessMnemonicToVault` now checks `Engine.context.SeedlessOnboardingController.state.vault` (instead of Redux selector).
>   - **SRP sync**: In `syncSeedPhrases`, wrap each secret import in try/catch, collect errors, and throw the first after processing; log unknown types.
>   - **Mnemonic conversion**: Replace `convertEnglishWordlistIndicesToCodepoints` usage with `uint8ArrayToMnemonic(secret.data, wordlist)`.
>   - **Discovery**: Continue multichain discovery after importing mnemonics (accounting for feature flag path).
> - **Tests**:
>   - Add/adjust mocks for `SeedlessOnboardingController.state.vault`; set per-test where needed; add `afterEach` to clear mocks.
>   - Update rehydration/import tests to use new mnemonic conversion and controller-state checks; add/adjust expectations for error handling and discovery paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 107921da66781b52aa1454b781d3a06f3b967a04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->