### PR TITLE
fix: adds backup button click handler and navigates to backup flow

### DIFF
--- a/app/components/Views/MultichainAccounts/AccountGroupDetails/components/SecretRecoveryPhrase.test.tsx
+++ b/app/components/Views/MultichainAccounts/AccountGroupDetails/components/SecretRecoveryPhrase.test.tsx
@@ -83,4 +83,21 @@ describe('SecretRecoveryPhrase', () => {
       keyringId: 'mock-entropy-source',
     });
   });
+
+  it('navigates to manual backup flow when backup button is pressed', () => {
+    const { getByText } = renderWithProvider(
+      <SecretRecoveryPhrase account={mockAccount} />,
+      { state: mockInitialState },
+    );
+
+    const backupButton = getByText(
+      strings('multichain_accounts.export_credentials.backup'),
+    );
+    fireEvent.press(backupButton);
+
+    expect(mockNavigate).toHaveBeenCalledWith('SetPasswordFlow', {
+      screen: 'ManualBackupStep1',
+      params: { backupFlow: true },
+    });
+  });
 });

--- a/app/components/Views/MultichainAccounts/AccountGroupDetails/components/SecretRecoveryPhrase.tsx
+++ b/app/components/Views/MultichainAccounts/AccountGroupDetails/components/SecretRecoveryPhrase.tsx
@@ -58,6 +58,13 @@ export const SecretRecoveryPhrase = ({
     }
   }, [navigation, account?.options.entropySource]);
 
+  const handleBackupPressed = useCallback(() => {
+    navigation.navigate(Routes.SET_PASSWORD_FLOW.ROOT, {
+      screen: Routes.SET_PASSWORD_FLOW.MANUAL_BACKUP_STEP_1,
+      params: { backupFlow: true },
+    });
+  }, [navigation]);
+
   return (
     <TouchableOpacity
       style={styles.secretRecoveryPhrase}
@@ -73,12 +80,14 @@ export const SecretRecoveryPhrase = ({
         gap={8}
       >
         {showSeedphraseBackReminder && (
-          <Text
-            variant={TextVariant.BodyMDMedium}
-            color={TextColor.Alternative}
-          >
-            {strings('multichain_accounts.export_credentials.backup')}
-          </Text>
+          <TouchableOpacity onPress={handleBackupPressed}>
+            <Text
+              variant={TextVariant.BodyMDMedium}
+              color={TextColor.Alternative}
+            >
+              {strings('multichain_accounts.export_credentials.backup')}
+            </Text>
+          </TouchableOpacity>
         )}
         <Icon
           name={IconName.ArrowRight}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR adds backup button click handler on the new account details screen.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added a backup button click handler on new account details screen

## **Related issues**

Fixes:
Jira ticket: https://consensyssoftware.atlassian.net/browse/MUL-877
## **Manual testing steps**

```gherkin
Feature: Backup SRP

  Scenario: user goes to manual backup SRP screen
    Given user onboarded without backup SRP

    When user navigates to account details and clicks "Backup" text on the SRP burron
    Then user is navigated to backup srp flow (first screen asks for password)
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/deb0e131-a7af-4a75-9876-0b85e86fb7df


### **After**

https://github.com/user-attachments/assets/b6ab9788-38ad-4caa-b7b3-0440ade7fe61


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make the SRP backup label clickable to launch the manual backup flow and add a test to verify navigation.
> 
> - **UI/Navigation**
>   - In `SecretRecoveryPhrase.tsx`, wrap backup label in a `TouchableOpacity` with `handleBackupPressed` to navigate to `Routes.SET_PASSWORD_FLOW.MANUAL_BACKUP_STEP_1` with `{ backupFlow: true }`.
>   - Preserve existing SRP reveal navigation via `onExportMnemonic`.
> - **Tests**
>   - In `SecretRecoveryPhrase.test.tsx`, add test asserting backup label press navigates to `SetPasswordFlow` → `ManualBackupStep1` with `{ backupFlow: true }`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62d2290a05e6da47792d45cb8f05b48681399895. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->