### PR TITLE
fix: cp-7.57.0 disable swaps for unsupported chains

### DIFF
--- a/app/components/Views/Asset/utils.ts
+++ b/app/components/Views/Asset/utils.ts
@@ -19,19 +19,17 @@ export const getIsSwapsAssetAllowed = ({
   searchDiscoverySwapsTokens: string[];
   swapsTokens: Record<string, unknown>;
 }) => {
-  // EVM Swaps
-  let isEvmSwapsAssetAllowed;
+  let isSwapsAssetAllowed;
   if (asset.isETH || asset.isNative) {
     const isChainAllowed = isSwapsAllowed(asset.chainId);
-    isEvmSwapsAssetAllowed = isChainAllowed;
+    isSwapsAssetAllowed = isChainAllowed;
   } else if (isAssetFromSearch(asset)) {
-    isEvmSwapsAssetAllowed = searchDiscoverySwapsTokens?.includes(
+    isSwapsAssetAllowed = searchDiscoverySwapsTokens?.includes(
       asset.address?.toLowerCase(),
     );
   } else {
-    isEvmSwapsAssetAllowed = asset.address?.toLowerCase() in swapsTokens;
+    isSwapsAssetAllowed = asset.address?.toLowerCase() in swapsTokens;
   }
-  let isSwapsAssetAllowed = isEvmSwapsAssetAllowed;
 
   // Solana Swaps
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)

--- a/app/components/Views/Asset/utils.ts
+++ b/app/components/Views/Asset/utils.ts
@@ -2,6 +2,7 @@
 import { SolScope } from '@metamask/keyring-api';
 ///: END:ONLY_INCLUDE_IF(keyring-snaps)
 import { isAssetFromSearch } from '../../../selectors/tokenSearchDiscoveryDataController';
+import { isSwapsAllowed } from '../../UI/Swaps/utils';
 
 export const getIsSwapsAssetAllowed = ({
   asset,
@@ -21,7 +22,8 @@ export const getIsSwapsAssetAllowed = ({
   // EVM Swaps
   let isEvmSwapsAssetAllowed;
   if (asset.isETH || asset.isNative) {
-    isEvmSwapsAssetAllowed = true;
+    const isChainAllowed = isSwapsAllowed(asset.chainId);
+    isEvmSwapsAssetAllowed = isChainAllowed;
   } else if (isAssetFromSearch(asset)) {
     isEvmSwapsAssetAllowed = searchDiscoverySwapsTokens?.includes(
       asset.address?.toLowerCase(),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
**Problem**
The swaps functionality was incorrectly allowing native assets to be swapped on all chains without verifying chain support. This meant users could access the swap interface for native assets even on chains where swaps are not supported.

**Solution**
Added a chain validation check using `isSwapsAllowed` before enabling swaps for native assets. This ensures that swaps are only allowed for native assets when the chain itself is in the list of supported swap chains. Also cleans up some naming for more clarity.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed bug where native assets on unsupported networks were showing the swaps button

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/20689

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Gates EVM native asset swaps by `isSwapsAllowed(chainId)` instead of allowing them unconditionally.
> 
> - **Swaps eligibility**:
>   - In `app/components/Views/Asset/utils.ts`, replace unconditional allow for EVM native assets with `isSwapsAllowed(asset.chainId)` and add corresponding import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a622a811b8e7a52fbfb2f795fe39348f78dd359b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->