### PR TITLE
fix: Fix simulation total value to be settled in `properties` instead of `sensitiveProperties`

### DIFF
--- a/app/components/UI/SimulationDetails/useSimulationMetrics.test.ts
+++ b/app/components/UI/SimulationDetails/useSimulationMetrics.test.ts
@@ -367,7 +367,7 @@ describe('useSimulationMetrics', () => {
         balanceChanges: [balanceChange1, balanceChange2],
       },
       expect.objectContaining({
-        sensitiveProperties: expect.objectContaining({
+        properties: expect.objectContaining({
           [property]: 2.46,
         }),
       }),

--- a/app/components/UI/SimulationDetails/useSimulationMetrics.ts
+++ b/app/components/UI/SimulationDetails/useSimulationMetrics.ts
@@ -90,14 +90,11 @@ export function useSimulationMetrics({
     simulation_latency: simulationLatency,
     ...getProperties(receivingAssets, 'simulation_receiving_assets_'),
     ...getProperties(sendingAssets, 'simulation_sending_assets_'),
+    ...getTotalValueProperty(receivingAssets, 'simulation_receiving_assets_'),
+    ...getTotalValueProperty(sendingAssets, 'simulation_sending_assets_'),
   };
 
-  const sensitiveProperties = {
-    ...getSensitiveProperties(receivingAssets, 'simulation_receiving_assets_'),
-    ...getSensitiveProperties(sendingAssets, 'simulation_sending_assets_'),
-  };
-
-  const params = { properties, sensitiveProperties };
+  const params = { properties };
 
   const shouldSkipMetrics =
     !enableMetrics ||
@@ -169,7 +166,7 @@ function getProperties(changes: BalanceChange[], prefix: string) {
   return getPrefixProperties({ quantity, type, value }, prefix);
 }
 
-function getSensitiveProperties(changes: BalanceChange[], prefix: string) {
+function getTotalValueProperty(changes: BalanceChange[], prefix: string) {
   const fiatAmounts = changes.map((change) => change.usdAmount);
   const totalFiat = calculateTotalFiat(fiatAmounts);
   const totalValue = totalFiat ? totalFiat.abs().toNumber() : undefined;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to change simulation total value property to be settled in `properties` instead of `sensitiveProperties`. The aim here is to have 0 `sensitiveProperties` in the transaction life cycle events so we wont have duplicated events. 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5937

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves simulation total value metrics into `properties`, removes `sensitiveProperties`, and updates tests accordingly.
> 
> - **Metrics (useSimulationMetrics)**
>   - Move `simulation_receiving_assets_total_value` and `simulation_sending_assets_total_value` into `properties` via new `getTotalValueProperty`.
>   - Remove `sensitiveProperties` from params; delete `getSensitiveProperties` usage.
>   - Aggregate total values with existing asset metrics in `properties`.
> - **Tests**
>   - Update expectations to assert total value under `properties` instead of `sensitiveProperties`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e497be3418320e0035b657368ee44aa67b70b8ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->