### PR TITLE
refactor: use bumped notification controller config cleanup

### DIFF
--- a/app/core/Engine/controllers/notifications/create-notification-services-controller.ts
+++ b/app/core/Engine/controllers/notifications/create-notification-services-controller.ts
@@ -1,3 +1,4 @@
+import { getVersion } from 'react-native-device-info';
 import {
   NotificationServicesControllerMessenger,
   NotificationServicesControllerState,
@@ -16,6 +17,7 @@ export const createNotificationServicesController = (props: {
         platform: 'mobile',
         accessToken: process.env.FEATURES_ANNOUNCEMENTS_ACCESS_TOKEN ?? '',
         spaceId: process.env.FEATURES_ANNOUNCEMENTS_SPACE_ID ?? '',
+        platformVersion: getVersion(),
       },
     },
   });

--- a/app/core/Engine/controllers/notifications/create-notification-services-push-controller.ts
+++ b/app/core/Engine/controllers/notifications/create-notification-services-push-controller.ts
@@ -4,6 +4,7 @@ import {
   defaultState,
   Controller as NotificationServicesPushController,
 } from '@metamask/notification-services-controller/push-services';
+import I18n from '../../../../../locales/i18n';
 import Logger from '../../../../util/Logger';
 import {
   createRegToken,
@@ -28,6 +29,7 @@ export const createNotificationServicesPushController = (props: {
           deleteRegToken,
           subscribeToPushNotifications: createSubscribeToPushNotifications(),
         },
+        getLocale: () => I18n.locale,
       },
     });
 

--- a/app/selectors/notifications/index.tsx
+++ b/app/selectors/notifications/index.tsx
@@ -13,9 +13,6 @@ import {
 import { createDeepEqualSelector } from '../util';
 import { RootState } from '../../reducers';
 import { selectRemoteFeatureFlags } from '../featureFlagController';
-import featureAnnouncement, {
-  isFilteredFeatureAnnonucementNotification,
-} from '../../util/notifications/notification-states/feature-announcement/feature-announcement';
 
 type NotificationServicesState = NotificationServicesControllerState;
 
@@ -84,20 +81,8 @@ export const getmetamaskNotificationsReadList = createSelector(
 );
 export const getNotificationsList = createDeepEqualSelector(
   selectNotificationServicesControllerState,
-  (notificationServicesControllerState: NotificationServicesState) => {
-    const notificationList =
-      notificationServicesControllerState.metamaskNotificationsList;
-
-    return notificationList.filter((n) => {
-      // Check announcements
-      if (featureAnnouncement.guardFn(n)) {
-        return isFilteredFeatureAnnonucementNotification(n);
-      }
-
-      // Return rest
-      return true;
-    });
-  },
+  (notificationServicesControllerState: NotificationServicesState) =>
+    notificationServicesControllerState.metamaskNotificationsList,
 );
 
 export const getMetamaskNotificationsUnreadCount = createSelector(

--- a/app/util/notifications/notification-states/feature-announcement/feature-announcement.tsx
+++ b/app/util/notifications/notification-states/feature-announcement/feature-announcement.tsx
@@ -1,5 +1,3 @@
-import compareVersions from 'compare-versions';
-import { getVersion } from 'react-native-device-info';
 import { TRIGGER_TYPES } from '@metamask/notification-services-controller/notification-services';
 import {
   ModalFieldType,
@@ -11,76 +9,12 @@ import { NotificationState } from '../types/NotificationState';
 import { getNotificationBadge } from '../../methods/common';
 import METAMASK_FOX from '../../../../images/branding/fox.png';
 
-// TODO - this is to be replaced by CORE
-const hasMinRequiredVersion = (minRequiredVersion: string) => {
-  if (!minRequiredVersion) return false;
-  const currentVersion = getVersion();
-  return compareVersions.compare(currentVersion, minRequiredVersion, '>');
-};
-
-const hasMaxRequiredVersion = (maxRequiredVersion: string) => {
-  if (!maxRequiredVersion) return false;
-  const currentVersion = getVersion();
-  return compareVersions.compare(currentVersion, maxRequiredVersion, '<');
-};
-
-export function isValidMinimumVersion(contentfulMinimumVersionNumber?: string) {
-  // Field is not set, show by default
-  if (!contentfulMinimumVersionNumber) {
-    return true;
-  }
-
-  try {
-    return hasMinRequiredVersion(contentfulMinimumVersionNumber);
-  } catch {
-    // Invalid mobile version number, not showing banner
-    return false;
-  }
-}
-
-export function isValidMaximumVersion(contentfulMaximumVersionNumber?: string) {
-  // Field is not set, show by default
-  if (!contentfulMaximumVersionNumber) {
-    return true;
-  }
-
-  try {
-    return hasMaxRequiredVersion(contentfulMaximumVersionNumber);
-  } catch {
-    // Invalid mobile version number, not showing banner
-    return false;
-  }
-}
-
 type FeatureAnnouncementNotification =
   ExtractedNotification<TRIGGER_TYPES.FEATURES_ANNOUNCEMENT>;
 
 const isFeatureAnnouncementNotification = isOfTypeNodeGuard([
   TRIGGER_TYPES.FEATURES_ANNOUNCEMENT,
 ]);
-
-export const isFilteredFeatureAnnonucementNotification = (
-  n: FeatureAnnouncementNotification,
-) => {
-  if (!isFeatureAnnouncementNotification(n)) {
-    return false;
-  }
-
-  // Field is not set, so show by default
-  if (!n.data.mobileMinimumVersionNumber) {
-    return true;
-  }
-
-  try {
-    const isValidMin = isValidMinimumVersion(n.data.mobileMinimumVersionNumber);
-    const isValidMax = isValidMaximumVersion(n.data.mobileMaximumVersionNumber);
-
-    return isValidMin && isValidMax;
-  } catch {
-    // Invalid mobile version number, not showing notification
-    return false;
-  }
-};
 
 const state: NotificationState<FeatureAnnouncementNotification> = {
   guardFn: isFeatureAnnouncementNotification,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

cleans up notification version filtering

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-1362

## **Manual testing steps**

No real tests here, since this is mostly a cleanup.
We can potentially test to see if feature announcement notifications still are fetched and shown.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes client-side feature announcement version filtering, adds platformVersion and locale to notification services configs, and simplifies notification selectors.
> 
> - **Notifications Services**:
>   - Pass `platformVersion` via `env.featureAnnouncements.platformVersion` in `create-notification-services-controller.ts`.
>   - Add `getLocale: () => I18n.locale` to push controller config in `create-notification-services-push-controller.ts`.
> - **Selectors**:
>   - Simplify `getNotificationsList` to return `metamaskNotificationsList` without feature-announcement version filtering in `selectors/notifications/index.tsx`.
> - **Feature Announcement State**:
>   - Remove version comparison helpers and `isFilteredFeatureAnnonucementNotification` export in `feature-announcement.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6417002821c7a0565245f0a9884957ead73e76ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->