### PR TITLE
chore: remove unnecessary waitFor wrappers around snapshots

### DIFF
--- a/app/components/UI/EvmAccountSelectorList/EvmAccountSelectorList.test.tsx
+++ b/app/components/UI/EvmAccountSelectorList/EvmAccountSelectorList.test.tsx
@@ -335,14 +335,14 @@ describe('EvmAccountSelectorList', () => {
 
   it('renders correctly', async () => {
     const { toJSON } = renderComponent(initialState);
-    await waitFor(() => expect(toJSON()).toMatchSnapshot());
+    expect(toJSON()).toMatchSnapshot();
   });
 
   it('renders all accounts with balances', async () => {
     const { queryByTestId, getAllByTestId, toJSON } =
       renderComponent(initialState);
 
-    await waitFor(async () => {
+  await waitFor(async () => {
       const businessAccountItem = await queryByTestId(
         `${AccountListBottomSheetSelectorsIDs.ACCOUNT_BALANCE_BY_ADDRESS_TEST_ID}-${BUSINESS_ACCOUNT}`,
       );
@@ -364,9 +364,8 @@ describe('EvmAccountSelectorList', () => {
 
       const accounts = getAllByTestId(regex.accountBalance);
       expect(accounts.length).toBe(2);
-
-      expect(toJSON()).toMatchSnapshot();
     });
+  expect(toJSON()).toMatchSnapshot();
   });
 
   it('renders all accounts with right accessory', async () => {
@@ -375,16 +374,15 @@ describe('EvmAccountSelectorList', () => {
       EvmAccountSelectorListRightAccessoryUseAccounts,
     );
 
-    await waitFor(() => {
+  await waitFor(() => {
       const rightAccessories = getAllByTestId(RIGHT_ACCESSORY_TEST_ID);
       expect(rightAccessories.length).toBe(2);
 
       // Check that each right accessory contains the expected content
       expect(rightAccessories[0].props.children).toContain(BUSINESS_ACCOUNT);
       expect(rightAccessories[1].props.children).toContain(PERSONAL_ACCOUNT);
-
-      expect(toJSON()).toMatchSnapshot();
     });
+  expect(toJSON()).toMatchSnapshot();
   });
   it('renders correct account names', async () => {
     const { getAllByTestId } = renderComponent(initialState);


### PR DESCRIPTION
The tests wrapped snapshot assertions in waitFor despite no async UI tree changes affecting the rendered JSON. This pattern adds flakiness and extra wait time. We now:
- Run snapshots synchronously after render when possible.
- Keep waitFor only to await element readiness, then assert the snapshot afterward.

This aligns with project testing practices and reduces brittle behavior without changing test intent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes redundant waitFor wrappers around snapshot assertions, asserting snapshots synchronously while retaining waitFor only for element readiness.
> 
> - **Tests**:
>   - Update `app/components/UI/EvmAccountSelectorList/EvmAccountSelectorList.test.tsx`:
>     - Assert snapshots synchronously (`expect(toJSON()).toMatchSnapshot()`) instead of inside `waitFor`.
>     - Keep `waitFor` solely for awaiting element queries/readiness where needed.
>     - No changes to test logic or expectations beyond snapshot timing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d85206a9cc6ce54a57896ab0c31e332d8771fdf3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->