### PR TITLE
fix(ramp): prevent 'undefined' flash in sell amount input during load cp-7.57.0

### DIFF
--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
@@ -773,7 +773,7 @@ const BuildQuote = () => {
   }
 
   // If the current view is for Sell the amount (crypto) is displayed as is
-  let displayAmount = `${amount} ${selectedAsset?.symbol}`;
+  let displayAmount = `${amount} ${selectedAsset?.symbol ?? ''}`;
 
   // If the current ivew is for Buy we will format the amount
   if (isBuy) {
@@ -931,7 +931,11 @@ const BuildQuote = () => {
               }
               currencyCode={isBuy ? currentFiatCurrency?.symbol : undefined}
               onPress={onAmountInputPress}
-              loading={isFetchingRegions || isFetchingFiatCurrency}
+              loading={
+                isFetchingRegions ||
+                isFetchingFiatCurrency ||
+                isFetchingCryptoCurrencies
+              }
               onCurrencyPress={isBuy ? handleFiatSelectorPress : undefined}
             />
             {amountNumber > 0 &&

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
@@ -2885,23 +2885,33 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                                           onPress={[Function]}
                                           testID="amount-input"
                                         >
-                                          <Text
-                                            accessibilityRole="text"
-                                            adjustsFontSizeToFit={true}
-                                            numberOfLines={1}
+                                          <View
                                             style={
-                                              {
-                                                "color": "#121314",
-                                                "fontFamily": "Geist Medium",
-                                                "fontSize": 24,
-                                                "letterSpacing": 0,
-                                                "lineHeight": 32,
-                                              }
+                                              [
+                                                {
+                                                  "backgroundColor": "#f3f5f9",
+                                                  "borderRadius": 30,
+                                                  "padding": 14,
+                                                },
+                                                undefined,
+                                                undefined,
+                                                undefined,
+                                                {
+                                                  "width": "50%",
+                                                },
+                                                undefined,
+                                                undefined,
+                                                undefined,
+                                                undefined,
+                                                undefined,
+                                                undefined,
+                                                undefined,
+                                                undefined,
+                                                undefined,
+                                                undefined,
+                                              ]
                                             }
-                                          >
-                                            $
-                                            0
-                                          </Text>
+                                          />
                                         </TouchableOpacity>
                                       </View>
                                       <View
@@ -2922,134 +2932,33 @@ exports[`BuildQuote View Crypto Currency Data renders the loading page when cryp
                                         }
                                         testID="listitemcolumn"
                                       >
-                                        <TouchableOpacity
-                                          accessibilityRole="button"
-                                          accessible={true}
-                                          disabled={false}
-                                          hitSlop={
-                                            {
-                                              "bottom": 20,
-                                              "left": 20,
-                                              "right": 20,
-                                              "top": 20,
-                                            }
+                                        <View
+                                          style={
+                                            [
+                                              {
+                                                "backgroundColor": "#f3f5f9",
+                                                "borderRadius": 30,
+                                                "padding": 14,
+                                              },
+                                              undefined,
+                                              undefined,
+                                              undefined,
+                                              undefined,
+                                              {
+                                                "width": "30%",
+                                              },
+                                              undefined,
+                                              undefined,
+                                              undefined,
+                                              undefined,
+                                              undefined,
+                                              undefined,
+                                              undefined,
+                                              undefined,
+                                              undefined,
+                                            ]
                                           }
-                                          onPress={[Function]}
-                                          testID="select-currency"
-                                        >
-                                          <View>
-                                            <Text
-                                              style={
-                                                [
-                                                  {
-                                                    "color": "#121314",
-                                                    "fontFamily": "Geist Regular",
-                                                    "fontSize": 30,
-                                                    "marginVertical": 2,
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  {
-                                                    "color": "#121314",
-                                                  },
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                  undefined,
-                                                ]
-                                              }
-                                            >
-                                              <Text
-                                                style={
-                                                  [
-                                                    {
-                                                      "color": "#121314",
-                                                      "fontFamily": "Geist Regular",
-                                                      "fontSize": 30,
-                                                      "marginVertical": 2,
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    {
-                                                      "fontFamily": "Geist Bold",
-                                                    },
-                                                    undefined,
-                                                    {
-                                                      "color": "#121314",
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    {
-                                                      "color": "#121314",
-                                                    },
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                    undefined,
-                                                  ]
-                                                }
-                                              >
-                                                USD
-                                              </Text>
-                                                
-                                              <Text
-                                                allowFontScaling={false}
-                                                selectable={false}
-                                                style={
-                                                  [
-                                                    {
-                                                      "color": undefined,
-                                                      "fontSize": 16,
-                                                    },
-                                                    {
-                                                      "color": "#121314",
-                                                      "marginLeft": 10,
-                                                    },
-                                                    {
-                                                      "fontFamily": "Entypo",
-                                                      "fontStyle": "normal",
-                                                      "fontWeight": "normal",
-                                                    },
-                                                    {},
-                                                  ]
-                                                }
-                                              >
-                                                
-                                              </Text>
-                                            </Text>
-                                          </View>
-                                        </TouchableOpacity>
+                                        />
                                       </View>
                                     </View>
                                   </View>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR fixes a race condition where the amount input briefly displayed "0 undefined" when opening the sell feature. The fix adds isFetchingCryptoCurrencies to the loading condition so the amount input shows a skeleton loader while crypto assets are being fetched, preventing the undefined symbol from appearing.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed amount input briefly showing "undefined" when opening the sell feature

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/20835

## **Manual testing steps**

```gherkin
Feature: Sell flow amount input initialization

  Scenario: user opens sell feature from home screen
    Given user is on the home screen

    When user presses "Buy"
    And user presses "Withdraw" in the bottom menu
    Then the amount input should show a loading skeleton or "0 ETH"
    And the amount input should not display "0 undefined"
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/44ddac34-efdb-4b96-9866-9cc7b9241b3a

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/ba00c913-b9a4-4801-ac2d-991ea503d3db

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents the sell amount input from briefly showing an undefined symbol by defaulting to an empty symbol and enabling loading state while crypto assets are fetched.
> 
> - **UI (BuildQuote)**
>   - Use fallback for `displayAmount` to `${amount} ${selectedAsset?.symbol ?? ''}` to avoid showing `undefined`.
>   - Expand `AmountInput` `loading` to include `isFetchingCryptoCurrencies` so a loader shows during asset fetch.
> - **Tests**
>   - Update snapshots to reflect loading placeholders for amount and currency while fetching crypto assets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6001dae72ed3211e9049f302910dbf47fb668580. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->