### PR TITLE
fix: cp-7.57.0 Minimal pending deposit UI

### DIFF
--- a/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.tsx
@@ -306,10 +306,8 @@ const PerpsMarketBalanceActions: React.FC<
               }
               size={ButtonSize.Lg}
               onPress={handleAddFunds}
-              disabled={isDepositInProgress}
               isFullWidth
               testID={PerpsMarketBalanceActionsSelectorsIDs.ADD_FUNDS_BUTTON}
-              style={isDepositInProgress ? tw.style('opacity-50') : undefined}
             >
               {strings('perps.add_funds')}
             </Button>
@@ -322,27 +320,14 @@ const PerpsMarketBalanceActions: React.FC<
                 variant={ButtonVariant.Secondary}
                 size={ButtonSize.Lg}
                 onPress={handleWithdraw}
-                disabled={isDepositInProgress}
                 isFullWidth
                 testID={PerpsMarketBalanceActionsSelectorsIDs.WITHDRAW_BUTTON}
-                style={isDepositInProgress ? tw.style('opacity-50') : undefined}
               >
                 {strings('perps.withdraw')}
               </Button>
             </Box>
           )}
         </Box>
-
-        {/* Deposit Progress Message */}
-        {isDepositInProgress && (
-          <Text
-            variant={TextVariant.BodyXS}
-            color={TextColor.Alternative}
-            style={tw.style('text-center pb-4')}
-          >
-            {strings('perps.deposit_pending_try_again')}
-          </Text>
-        )}
       </Box>
 
       {/* Eligibility Modal */}

--- a/app/components/UI/Perps/components/PerpsTabControlBar/PerpsTabControlBar.tsx
+++ b/app/components/UI/Perps/components/PerpsTabControlBar/PerpsTabControlBar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { TouchableOpacity, View, ActivityIndicator } from 'react-native';
+import { TouchableOpacity, View } from 'react-native';
 import Animated from 'react-native-reanimated';
 import { useStyles } from '../../../../../component-library/hooks';
 import Text, {
@@ -18,7 +18,6 @@ import {
 } from '../../utils/formatUtils';
 import { PerpsTabViewSelectorsIDs } from '../../../../../../e2e/selectors/Perps/Perps.selectors';
 import { BigNumber } from 'bignumber.js';
-import { usePerpsDepositProgress } from '../../hooks/usePerpsDepositProgress';
 import {
   Icon,
   IconColor,
@@ -39,7 +38,6 @@ export const PerpsTabControlBar: React.FC<PerpsTabControlBarProps> = ({
   const { styles } = useStyles(styleSheet, {});
   // Use live account data with 1 second throttle for balance display
   const { account: perpsAccount } = usePerpsLiveAccount({ throttleMs: 1000 });
-  const { isDepositInProgress } = usePerpsDepositProgress();
 
   // Use the reusable hooks for balance animation
   const {
@@ -156,7 +154,6 @@ export const PerpsTabControlBar: React.FC<PerpsTabControlBarProps> = ({
           style={balancePillContainerStyle}
           onPress={handlePress}
           testID={PerpsTabViewSelectorsIDs.BALANCE_BUTTON}
-          disabled={isDepositInProgress}
         >
           <View style={styles.leftSection}>
             <Text
@@ -164,38 +161,29 @@ export const PerpsTabControlBar: React.FC<PerpsTabControlBarProps> = ({
               color={TextColor.Alternative}
               style={styles.titleText}
             >
-              {isDepositInProgress
-                ? strings('perps.deposit_in_progress')
-                : strings('perps.available_balance')}
+              {strings('perps.available_balance')}
             </Text>
           </View>
           <View style={styles.rightSection}>
-            {isDepositInProgress ? (
-              <ActivityIndicator
-                size="small"
-                color={styles.activityIndicator.color}
-              />
-            ) : (
-              <Animated.View
-                style={[
-                  getBalanceAnimatedStyle,
-                  styles.availableBalanceContainer,
-                ]}
+            <Animated.View
+              style={[
+                getBalanceAnimatedStyle,
+                styles.availableBalanceContainer,
+              ]}
+            >
+              <Text
+                variant={TextVariant.BodyMDMedium}
+                color={TextColor.Default}
+                testID={PerpsTabViewSelectorsIDs.BALANCE_VALUE}
               >
-                <Text
-                  variant={TextVariant.BodyMDMedium}
-                  color={TextColor.Default}
-                  testID={PerpsTabViewSelectorsIDs.BALANCE_VALUE}
-                >
-                  {formatPerpsFiat(availableBalance)}
-                </Text>
-                <Icon
-                  name={IconName.ArrowRight}
-                  size={IconSize.Sm}
-                  color={IconColor.IconAlternative}
-                />
-              </Animated.View>
-            )}
+                {formatPerpsFiat(availableBalance)}
+              </Text>
+              <Icon
+                name={IconName.ArrowRight}
+                size={IconSize.Sm}
+                color={IconColor.IconAlternative}
+              />
+            </Animated.View>
           </View>
         </TouchableOpacity>
       )}

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -879,7 +879,6 @@
     "refresh_balance": "Refresh Balance",
     "add_funds": "Add funds",
     "deposit_in_progress": "Deposit in progress",
-    "deposit_pending_try_again": "Deposit pending. Try again when complete.",
     "your_positions": "Your positions",
     "loading_positions": "Loading positions...",
     "refreshing_positions": "Refreshing positions...",


### PR DESCRIPTION
## **Description**

Updates the pending deposit flow to no disable buttons while deposit is in progress, as well as removing the warning text below.

Additionally, fixes flickering in the Est. Points component of the close position screen, related to websocket price updates causing the skeleton loader to re-render whenever prices changed.

## **Changelog**

CHANGELOG entry: Updates pending deposit UI
CHANGELOG entry: Fixes flickering bug in Est points during close perps position

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1818
Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1826

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/2fc70977-9c15-4d54-a7b4-2618dfd3bf58

https://github.com/user-attachments/assets/e1c78bb2-941a-4525-b714-dc809d02b410


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables actions during pending deposits and removes deposit-in-progress indicators/spinners and related string.
> 
> - **Perps UI**:
>   - **`PerpsTabControlBar.tsx`**:
>     - Removes deposit-in-progress state handling: no spinner, no "deposit in progress" label, button no longer disabled; always shows `perps.available_balance` with animated balance and arrow.
>   - **`PerpsMarketBalanceActions.tsx`**:
>     - Stops disabling "Add funds"/"Withdraw" during deposits and removes opacity styling and post-buttons "deposit pending" message.
> - **i18n**:
>   - Removes `perps.deposit_pending_try_again` from `locales/languages/en.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9008a0629834d8f2859977fb3148a8cd32490438. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->