### PR TITLE
fix: cp-7.57.0 Fix insufficient alert on send max

### DIFF
--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.test.ts
@@ -9,7 +9,6 @@ import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
 import { Severity } from '../../types/alerts';
 import { selectNetworkConfigurations } from '../../../../../selectors/networkController';
 import { useConfirmActions } from '../useConfirmActions';
-import { useMaxValueMode } from '../useMaxValueMode';
 import { useTransactionPayToken } from '../pay/useTransactionPayToken';
 import { noop } from 'lodash';
 
@@ -34,7 +33,6 @@ jest.mock('@react-navigation/native', () => {
     }),
   };
 });
-jest.mock('../useMaxValueMode');
 jest.mock('../useConfirmActions');
 jest.mock('../transactions/useTransactionMetadataRequest');
 jest.mock('../pay/useTransactionPayToken');
@@ -51,7 +49,6 @@ describe('useInsufficientBalanceAlert', () => {
   );
   const mockUseAccountNativeBalance = jest.mocked(useAccountNativeBalance);
   const mockUseConfirmActions = jest.mocked(useConfirmActions);
-  const mockUseMaxValueMode = jest.mocked(useMaxValueMode);
   const mockSelectNetworkConfigurations = jest.mocked(
     selectNetworkConfigurations,
   );
@@ -99,9 +96,6 @@ describe('useInsufficientBalanceAlert', () => {
       }
       return key;
     });
-    mockUseMaxValueMode.mockReturnValue({
-      maxValueMode: false,
-    });
     mockUseConfirmActions.mockReturnValue({
       onReject: jest.fn(),
       onConfirm: jest.fn(),
@@ -110,15 +104,6 @@ describe('useInsufficientBalanceAlert', () => {
 
   it('return empty array when no transaction metadata is available', () => {
     mockUseTransactionMetadataRequest.mockReturnValue(undefined);
-
-    const { result } = renderHook(() => useInsufficientBalanceAlert());
-    expect(result.current).toEqual([]);
-  });
-
-  it('return empty array when max value mode is enabled', () => {
-    mockUseMaxValueMode.mockReturnValue({
-      maxValueMode: true,
-    });
 
     const { result } = renderHook(() => useInsufficientBalanceAlert());
     expect(result.current).toEqual([]);
@@ -219,9 +204,10 @@ describe('useInsufficientBalanceAlert', () => {
 
   describe('when ignoreGasFeeToken is true', () => {
     it('returns empty array', () => {
-      mockUseMaxValueMode.mockReturnValue({
-        maxValueMode: true,
-      });
+      mockUseAccountNativeBalance.mockReturnValue({
+        balanceWeiInHex: '0xC',
+      } as unknown as ReturnType<typeof useAccountNativeBalance>);
+
       const { result } = renderHook(() =>
         useInsufficientBalanceAlert({ ignoreGasFeeToken: true }),
       );

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.test.ts
@@ -11,6 +11,7 @@ import { selectNetworkConfigurations } from '../../../../../selectors/networkCon
 import { useConfirmActions } from '../useConfirmActions';
 import { useTransactionPayToken } from '../pay/useTransactionPayToken';
 import { noop } from 'lodash';
+import { useConfirmationContext } from '../../context/confirmation-context';
 
 jest.mock('../../../../../util/navigation/navUtils', () => ({
   useParams: jest.fn().mockReturnValue({
@@ -42,6 +43,7 @@ jest.mock('../../../../../selectors/networkController');
 jest.mock('../../../../../reducers/transaction', () => ({
   selectTransactionState: jest.fn(),
 }));
+jest.mock('../../context/confirmation-context');
 
 describe('useInsufficientBalanceAlert', () => {
   const mockUseTransactionMetadataRequest = jest.mocked(
@@ -53,7 +55,7 @@ describe('useInsufficientBalanceAlert', () => {
     selectNetworkConfigurations,
   );
   const mockUseTransactionPayToken = jest.mocked(useTransactionPayToken);
-
+  const mockUseConfirmationContext = jest.mocked(useConfirmationContext);
   const mockChainId = '0x1';
   const mockFromAddress = '0x123';
   const mockNativeCurrency = 'ETH';
@@ -100,10 +102,22 @@ describe('useInsufficientBalanceAlert', () => {
       onReject: jest.fn(),
       onConfirm: jest.fn(),
     });
+    mockUseConfirmationContext.mockReturnValue({
+      isTransactionValueUpdating: false,
+    } as unknown as ReturnType<typeof useConfirmationContext>);
   });
 
   it('return empty array when no transaction metadata is available', () => {
     mockUseTransactionMetadataRequest.mockReturnValue(undefined);
+
+    const { result } = renderHook(() => useInsufficientBalanceAlert());
+    expect(result.current).toEqual([]);
+  });
+
+  it('return empty array when isTransactionValueUpdating is true', () => {
+    mockUseConfirmationContext.mockReturnValue({
+      isTransactionValueUpdating: true,
+    } as unknown as ReturnType<typeof useConfirmationContext>);
 
     const { result } = renderHook(() => useInsufficientBalanceAlert());
     expect(result.current).toEqual([]);

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
@@ -17,7 +17,6 @@ import { Alert, Severity } from '../../types/alerts';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { useAccountNativeBalance } from '../useAccountNativeBalance';
 import { useConfirmActions } from '../useConfirmActions';
-import { useMaxValueMode } from '../useMaxValueMode';
 import { useTransactionPayToken } from '../pay/useTransactionPayToken';
 
 const HEX_ZERO = '0x0';
@@ -34,12 +33,11 @@ export const useInsufficientBalanceAlert = ({
     transactionMetadata?.chainId as Hex,
     transactionMetadata?.txParams?.from as string,
   );
-  const { maxValueMode } = useMaxValueMode();
   const { onReject } = useConfirmActions();
   const { payToken } = useTransactionPayToken();
 
   return useMemo(() => {
-    if (!transactionMetadata || maxValueMode) {
+    if (!transactionMetadata) {
       return [];
     }
 
@@ -98,7 +96,6 @@ export const useInsufficientBalanceAlert = ({
   }, [
     balanceWeiInHex,
     ignoreGasFeeToken,
-    maxValueMode,
     navigation,
     networkConfigurations,
     onReject,

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
@@ -18,6 +18,7 @@ import { useTransactionMetadataRequest } from '../transactions/useTransactionMet
 import { useAccountNativeBalance } from '../useAccountNativeBalance';
 import { useConfirmActions } from '../useConfirmActions';
 import { useTransactionPayToken } from '../pay/useTransactionPayToken';
+import { useConfirmationContext } from '../../context/confirmation-context';
 
 const HEX_ZERO = '0x0';
 
@@ -33,11 +34,12 @@ export const useInsufficientBalanceAlert = ({
     transactionMetadata?.chainId as Hex,
     transactionMetadata?.txParams?.from as string,
   );
+  const { isTransactionValueUpdating } = useConfirmationContext();
   const { onReject } = useConfirmActions();
   const { payToken } = useTransactionPayToken();
 
   return useMemo(() => {
-    if (!transactionMetadata) {
+    if (!transactionMetadata || isTransactionValueUpdating) {
       return [];
     }
 
@@ -96,6 +98,7 @@ export const useInsufficientBalanceAlert = ({
   }, [
     balanceWeiInHex,
     ignoreGasFeeToken,
+    isTransactionValueUpdating,
     navigation,
     networkConfigurations,
     onReject,

--- a/app/components/Views/confirmations/hooks/useMaxValueRefresher.ts
+++ b/app/components/Views/confirmations/hooks/useMaxValueRefresher.ts
@@ -44,7 +44,10 @@ export function useMaxValueRefresher() {
       updateEditableParams(id, {
         value: maxValueHex,
       });
-      setValueJustUpdated(true);
+      // Do it on the next tick to avoid race condition in insufficient balance alert
+      setTimeout(() => {
+        setValueJustUpdated(true);
+      }, 0);
     }
   }, [
     balanceWeiInHex,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to remove "sendMax" condition from insufficient gas alert.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fix insufficient gas alert when sending max native token.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/20932

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/c4fbe231-bb75-4ea8-9421-7ffb6910f8dd



### **After**


https://github.com/user-attachments/assets/5a77398f-1dd2-4b1d-87bb-53b62e45271c



## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces `sendMax`/`maxValueMode` check with `isTransactionValueUpdating` for insufficient balance alerts and defers max-value refresh state update to prevent a race.
> 
> - **Alerts**:
>   - Update `useInsufficientBalanceAlert` to use `useConfirmationContext().isTransactionValueUpdating` instead of `useMaxValueMode()` to suppress alerts while value is updating.
>   - Maintain existing logic for fee calculations and `payToken`/`ignoreGasFeeToken` handling.
> - **Hooks**:
>   - In `useMaxValueRefresher`, defer `setValueJustUpdated(true)` with `setTimeout(…, 0)` to avoid race conditions with the insufficient balance alert.
> - **Tests**:
>   - Update `useInsufficientBalanceAlert.test.ts` to mock `useConfirmationContext` and add case for `isTransactionValueUpdating = true`; remove reliance on `useMaxValueMode` except where irrelevant; adjust mocks accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b26682dc77bdf34d979fca4350657cd84fa9ab64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->