### PR TITLE
fix: metametrics screen not shown when goes in background during SRP flow

### DIFF
--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -1095,15 +1095,14 @@ const App: React.FC = () => {
             const currentRoute = routes[routes.length - 1];
             const prevRoute = routes[routes.length - 2];
             const currentRouteName = currentRoute?.name;
-            const currentParams = currentRoute?.params as Record<
-              string,
-              unknown
-            >;
+            const currentParams = currentRoute?.params as
+              | Record<string, unknown>
+              | undefined;
             const currentScreen = currentParams?.screen;
-            const nestedParams = currentParams?.params as Record<
-              string,
-              unknown
-            >;
+            const nestedParams =
+              currentParams?.params && typeof currentParams.params === 'object'
+                ? (currentParams.params as Record<string, unknown>)
+                : undefined;
 
             // Check if user came from lock screen (lock/unlock cycle)
             const cameFromLockScreen = prevRoute?.name === Routes.LOCK_SCREEN;

--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -1091,6 +1091,34 @@ const App: React.FC = () => {
 
           // Only show metrics optin for SRP users
           if (!isSeedlessOnboardingLoginFlow) {
+            // Check current navigation state to avoid redirecting if already on OptinMetrics
+            const currentRoute = routes[routes.length - 1];
+            const prevRoute = routes[routes.length - 2];
+            const currentRouteName = currentRoute?.name;
+            const currentParams = currentRoute?.params as Record<
+              string,
+              unknown
+            >;
+            const currentScreen = currentParams?.screen;
+            const nestedParams = currentParams?.params as Record<
+              string,
+              unknown
+            >;
+
+            // Check if user came from lock screen (lock/unlock cycle)
+            const cameFromLockScreen = prevRoute?.name === Routes.LOCK_SCREEN;
+
+            // Check if user is currently on OptinMetrics screen
+            const isCurrentlyOnOptinMetrics =
+              currentRouteName === Routes.ONBOARDING.ROOT_NAV &&
+              currentScreen === Routes.ONBOARDING.NAV &&
+              nestedParams?.screen === Routes.ONBOARDING.OPTIN_METRICS;
+
+            // Prevents the lock/unlock loop
+            if (cameFromLockScreen && isCurrentlyOnOptinMetrics) {
+              return;
+            }
+
             const isOptinMetaMetricsUISeen = await StorageWrapper.getItem(
               OPTIN_META_METRICS_UI_SEEN,
             );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
* Metametrics screen not shown when goes in background during SRP flow: https://github.com/MetaMask/metamask-mobile/issues/20437
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Metametrics screen not shown when goes in background during SRP flow

## **Related issues**

Fixes: Metametrics screen not shown when goes in background during SRP flow

## **Manual testing steps**

```gherkin
Feature: my feature name
1) Open the App.
2) Create new user via SRP flow.
3) On reaching metametrics screen, put the app in background for 5-10 secs and again comes to foreground, user should see metametrics screen.
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/c4c520cc-d51f-46a1-b989-6f4811c67fb3


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents resetting to OptinMetrics when returning from the lock screen if already on that screen, and adds a test to validate behavior.
> 
> - **Onboarding/Nav logic (`app/components/Nav/App/App.tsx`)**:
>   - Adds route checks to detect prior `Routes.LOCK_SCREEN` and current `OnboardingRootNav > OnboardingNav > OPTIN_METRICS` and early-return to avoid reset loop.
> - **Tests (`app/components/Nav/App/App.test.tsx`)**:
>   - Adds test ensuring OptinMetrics shows when not coming from lock screen (validates no unintended prevention).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 451ed1f02a1c8ff745bb840b4dc05c3013bd1b58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->