### PR TITLE
fix: cp-7.56.5 - Use SharedDeeplinkManager to parse instead of Linking API

### DIFF
--- a/app/components/UI/Carousel/index.test.tsx
+++ b/app/components/UI/Carousel/index.test.tsx
@@ -7,7 +7,8 @@ import {
   renderHook,
 } from '@testing-library/react-native';
 import { useSelector, useDispatch } from 'react-redux';
-import { Linking } from 'react-native';
+import SharedDeeplinkManager from '../../../core/DeeplinkManager/SharedDeeplinkManager';
+import AppConstants from '../../../core/AppConstants';
 import Carousel, { useFetchCarouselSlides } from './';
 import { WalletViewSelectorsIDs } from '../../../../e2e/selectors/wallet/WalletView.selectors';
 import { backgroundState } from '../../../util/test/initial-root-state';
@@ -66,8 +67,8 @@ jest.mock('../../../components/hooks/useMetrics', () => ({
   }),
 }));
 
-jest.mock('react-native/Libraries/Linking/Linking', () => ({
-  openURL: jest.fn(() => Promise.resolve()),
+jest.mock('../../../core/DeeplinkManager/SharedDeeplinkManager', () => ({
+  parse: jest.fn(() => Promise.resolve()),
 }));
 
 jest.mock('./fetchCarouselSlidesFromContentful', () => ({
@@ -212,7 +213,12 @@ describe('Carousel Navigation', () => {
     const { findByTestId } = render(<Carousel />);
     const slide = await findByTestId('carousel-slide-url-slide');
     fireEvent.press(slide);
-    expect(Linking.openURL).toHaveBeenCalledWith('https://metamask.io');
+    expect(SharedDeeplinkManager.parse).toHaveBeenCalledWith(
+      'https://metamask.io',
+      {
+        origin: AppConstants.DEEPLINKS.ORIGIN_DEEPLINK,
+      },
+    );
   });
 
   it('navigates to buy flow for fund slides', async () => {

--- a/app/components/UI/Carousel/index.tsx
+++ b/app/components/UI/Carousel/index.tsx
@@ -6,7 +6,7 @@ import React, {
   useEffect,
   useRef,
 } from 'react';
-import { Linking, Dimensions, Animated } from 'react-native';
+import { Dimensions, Animated } from 'react-native';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 import { CarouselProps, CarouselSlide, NavigationAction } from './types';
@@ -42,6 +42,8 @@ import { selectContentfulCarouselEnabledFlag } from './selectors/featureFlags';
 import { createBuyNavigationDetails } from '../Ramp/Aggregator/routes/utils';
 import Routes from '../../../constants/navigation/Routes';
 import { subscribeToContentPreviewToken } from '../../../actions/notification/helpers';
+import AppConstants from '../../../core/AppConstants';
+import SharedDeeplinkManager from '../../../core/DeeplinkManager/SharedDeeplinkManager';
 
 const MAX_CAROUSEL_SLIDES = 8;
 
@@ -339,10 +341,13 @@ const CarouselComponent: FC<CarouselProps> = ({ style, onEmptyState }) => {
   ]);
 
   const openUrl =
-    (href: string): (() => Promise<void>) =>
+    (href: string): (() => Promise<boolean>) =>
     () =>
-      Linking.openURL(href).catch((error) => {
+      SharedDeeplinkManager.parse(href, {
+        origin: AppConstants.DEEPLINKS.ORIGIN_DEEPLINK,
+      }).catch((error) => {
         console.error('Failed to open URL:', error);
+        return false;
       });
 
   const handleSlideClick = useCallback(

--- a/app/components/Views/Notifications/Details/Footers/AnnouncementCtaFooter.tsx
+++ b/app/components/Views/Notifications/Details/Footers/AnnouncementCtaFooter.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { Linking } from 'react-native';
 import Button, {
   ButtonVariants,
   ButtonWidthTypes,
 } from '../../../../../component-library/components/Buttons/Button';
 import { ModalFooterAnnouncementCta } from '../../../../../util/notifications/notification-states/types/NotificationModalDetails';
 import useStyles from '../useStyles';
+import SharedDeeplinkManager from '../../../../../core/DeeplinkManager/SharedDeeplinkManager';
+import AppConstants from '../../../../../core/AppConstants';
 
 type AnnouncementCtaFooterProps = ModalFooterAnnouncementCta;
 
@@ -28,7 +29,11 @@ export default function AnnouncementCtaFooter(
       width={ButtonWidthTypes.Full}
       label={mobileLinkText}
       style={styles.ctaBtn}
-      onPress={() => Linking.openURL(mobileLinkUrl)}
+      onPress={() =>
+        SharedDeeplinkManager.parse(mobileLinkUrl, {
+          origin: AppConstants.DEEPLINKS.ORIGIN_DEEPLINK,
+        })
+      }
     />
   );
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This change updates the CMS UI to leverage deeplinking routing directly instead of relying on the Linking mechanism. This allows us to bypass Branch's redirect behavior and routes users to the correct places in the app.

Thread - https://consensys.slack.com/archives/C084W4VFHCK/p1759935685920429

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

When tapping on the carousel items with universal links, iOS would push users out to the AppStore

<!-- [screenshots/recordings] -->

### **After**

Dapp opens from carousel
https://github.com/user-attachments/assets/d0ae6ae5-21bb-4ba9-adac-c400b01dd356

Perps opens from carousel
https://github.com/user-attachments/assets/ad3fdcb4-3855-46e8-872d-529b8568d8f5


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces direct Linking.openURL calls with SharedDeeplinkManager.parse (with origin) in carousel and announcement CTA, and updates tests accordingly.
> 
> - **UI**:
>   - **Carousel** (`app/components/UI/Carousel/index.tsx`):
>     - Replace `Linking.openURL` with `SharedDeeplinkManager.parse(href, { origin: AppConstants.DEEPLINKS.ORIGIN_DEEPLINK })`.
>     - Adjust `openUrl` return type and error handling.
>     - Add imports for `AppConstants` and `SharedDeeplinkManager`.
>   - **Notifications** (`.../AnnouncementCtaFooter.tsx`):
>     - Use `SharedDeeplinkManager.parse(mobileLinkUrl, { origin: AppConstants.DEEPLINKS.ORIGIN_DEEPLINK })` instead of `Linking.openURL`.
>     - Add required imports.
> - **Tests** (`app/components/UI/Carousel/index.test.tsx`):
>   - Mock `SharedDeeplinkManager.parse` and assert it’s called with URL and origin instead of `Linking.openURL`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfea96ec077c47c759692fcc3a04a31e303f414b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->