### PR TITLE
fix(predict): market details tabs

### DIFF
--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -519,24 +519,19 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
       edges={['left', 'right', 'bottom']}
       testID="predict-market-details-screen"
     >
-      <ScrollView
-        style={tw.style('flex-1')}
-        contentContainerStyle={[
-          tw.style('px-3 pb-8 gap-4'),
-          { paddingTop: insets.top + 12 },
-        ]}
-        showsVerticalScrollIndicator={false}
-      >
-        {renderHeader()}
-        {singleOutcomeMarket && renderCurrentPrediction()}
-        <PredictDetailsChart
-          data={chartData}
-          timeframes={PRICE_HISTORY_TIMEFRAMES}
-          selectedTimeframe={selectedTimeframe}
-          onTimeframeChange={handleTimeframeChange}
-          isLoading={isFetching}
-          emptyLabel={chartEmptyLabel}
-        />
+      <Box twClassName="flex-1">
+        <Box twClassName="px-3 gap-4" style={{ paddingTop: insets.top + 12 }}>
+          {renderHeader()}
+          {singleOutcomeMarket && renderCurrentPrediction()}
+          <PredictDetailsChart
+            data={chartData}
+            timeframes={PRICE_HISTORY_TIMEFRAMES}
+            selectedTimeframe={selectedTimeframe}
+            onTimeframeChange={handleTimeframeChange}
+            isLoading={isFetching}
+            emptyLabel={chartEmptyLabel}
+          />
+        </Box>
         <ScrollableTabView
           renderTabBar={() => (
             <TabBar
@@ -544,30 +539,36 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
               testID={PredictMarketDetailsSelectorsIDs.TAB_BAR}
             />
           )}
-          style={tw.style('mt-2')}
+          style={tw.style('flex-1 mt-2')}
           initialPage={0}
         >
-          <Box
+          <ScrollView
             key="about"
             {...{ tabLabel: 'About' }}
-            twClassName="pt-4"
+            style={tw.style('flex-1')}
+            contentContainerStyle={tw.style('px-3 pt-4 pb-8')}
+            showsVerticalScrollIndicator={false}
             testID={PredictMarketDetailsSelectorsIDs.ABOUT_TAB}
           >
             {renderAboutSection()}
-          </Box>
-          <Box
+          </ScrollView>
+          <ScrollView
             key="positions"
             {...{ tabLabel: 'Positions' }}
-            twClassName="pt-4"
+            style={tw.style('flex-1')}
+            contentContainerStyle={tw.style('px-3 pt-4 pb-8')}
+            showsVerticalScrollIndicator={false}
             testID={PredictMarketDetailsSelectorsIDs.POSITIONS_TAB}
           >
             {renderPositionsSection()}
-          </Box>
+          </ScrollView>
           {multipleOutcomes && (
-            <Box
+            <ScrollView
               key="outcomes"
               {...{ tabLabel: 'Outcomes' }}
-              twClassName="pt-4"
+              style={tw.style('flex-1')}
+              contentContainerStyle={tw.style('px-3 pt-4 pb-8')}
+              showsVerticalScrollIndicator={false}
               testID={PredictMarketDetailsSelectorsIDs.OUTCOMES_TAB}
             >
               <Box>
@@ -583,10 +584,10 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
                   />
                 ))}
               </Box>
-            </Box>
+            </ScrollView>
           )}
         </ScrollableTabView>
-      </ScrollView>
+      </Box>
       <Box twClassName="px-3 bg-default border-t border-muted">
         {singleOutcomeMarket && renderActionButtons()}
       </Box>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This change fixes the UI for the Predict Market Details screen. More specifically, the UI under the tabs was not showing on Android.

With this change:
- it works on both iOS and Android
- scroll is now under each tab, rather than for the whole screen

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/acd45b86-b6ac-416a-a9aa-4c63195bdb71




## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces outer screen scroll with per-tab ScrollViews and makes the tab view flex correctly to fix Android rendering and enable independent tab scrolling.
> 
> - **Predict UI** (`PredictMarketDetails.tsx`):
>   - **Layout restructure**: Replace top-level `ScrollView` with container `Box`; move header and chart into a padded `Box`.
>   - **Tabs**: Make `ScrollableTabView` `style={tw.style('flex-1 mt-2')}`; wrap `About`, `Positions`, and `Outcomes` in individual `ScrollView`s with `contentContainerStyle` padding and hidden scrollbars.
>   - **Behavior**: Enables per-tab scrolling and fixes content visibility on Android.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bf5b444be68c4fb6729c2ef317d3860c8faa3d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->