### PR TITLE
fix: account backup screen ui in SRP flow. 

### DIFF
--- a/app/components/Views/AccountBackupStep1/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/AccountBackupStep1/__snapshots__/index.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`AccountBackupStep1 Snapshots android render matches snapshot 1`] = `
       "bottom": "additive",
       "left": "off",
       "right": "off",
-      "top": "off",
+      "top": "additive",
     }
   }
   style={
@@ -258,7 +258,7 @@ exports[`AccountBackupStep1 Snapshots android render matches snapshot with statu
       "bottom": "additive",
       "left": "off",
       "right": "off",
-      "top": "off",
+      "top": "additive",
     }
   }
   style={
@@ -509,7 +509,7 @@ exports[`AccountBackupStep1 Snapshots iOS render matches snapshot 1`] = `
       "bottom": "additive",
       "left": "off",
       "right": "off",
-      "top": "off",
+      "top": "additive",
     }
   }
   style={
@@ -760,7 +760,7 @@ exports[`AccountBackupStep1 Theme appearance renders dark SRP design image by de
       "bottom": "additive",
       "left": "off",
       "right": "off",
-      "top": "off",
+      "top": "additive",
     }
   }
   style={
@@ -1011,7 +1011,7 @@ exports[`AccountBackupStep1 Theme appearance renders light SRP design image for 
       "bottom": "additive",
       "left": "off",
       "right": "off",
-      "top": "off",
+      "top": "additive",
     }
   }
   style={

--- a/app/components/Views/AccountBackupStep1/index.js
+++ b/app/components/Views/AccountBackupStep1/index.js
@@ -201,7 +201,7 @@ const AccountBackupStep1 = (props) => {
   };
 
   return (
-    <SafeAreaView style={styles.mainWrapper} edges={['bottom']}>
+    <SafeAreaView style={styles.mainWrapper} edges={['top', 'bottom']}>
       <ScrollView
         contentContainerStyle={styles.scrollviewWrapper}
         style={styles.mainWrapper}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
* Fix: Account backup screen ui in SRP flow. (https://github.com/MetaMask/metamask-mobile/issues/20889)
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: BugFix: Account backup screen ui in SRP flow. https://github.com/MetaMask/metamask-mobile/issues/20889

## **Related issues**

Fixes: Account backup screen ui in SRP flow. https://github.com/MetaMask/metamask-mobile/issues/20889

## **Manual testing steps**

```gherkin
Feature: my feature name
1) Open the App.
2) Create new wallet using SRP flow.
3) Do create and confirm password on password screen. Go ahead.
3) Notice changes in `Secure your wallet` screen. 
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
https://github.com/MetaMask/metamask-mobile/issues/20889
<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/38f1769a-4f37-4e2a-a041-4e3f7dda9e70


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds top safe area handling to `AccountBackupStep1` (`edges` now include `top`) and updates related Jest snapshots.
> 
> - **UI/Layout**:
>   - Update `SafeAreaView` in `app/components/Views/AccountBackupStep1/index.js` to use `edges` = `['top', 'bottom']` (was `['bottom']`).
> - **Tests**:
>   - Refresh snapshots in `app/components/Views/AccountBackupStep1/__snapshots__/index.test.tsx.snap` to reflect `top` edge as `additive`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb41190523e58f1c183c2ee45af467e4e79c706c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->