### PR TITLE
fix: cp-7.57.0 wallet initiated Send transactions are validated by security alerts API on mobile

### DIFF
--- a/app/components/Views/confirmations/utils/send.test.ts
+++ b/app/components/Views/confirmations/utils/send.test.ts
@@ -4,6 +4,7 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 
+import ppomUtil from '../../../../lib/ppom/ppom-util';
 // eslint-disable-next-line import/no-namespace
 import * as TransactionUtils from '../../../../util/transaction-controller';
 // eslint-disable-next-line import/no-namespace
@@ -33,6 +34,11 @@ jest.mock('../../../../core/Engine', () => ({
       findNetworkClientIdByChainId: jest.fn().mockReturnValue('mainnet'),
     },
   },
+}));
+
+jest.mock('../../../../lib/ppom/ppom-util', () => ({
+  ...jest.requireActual('../../../../lib/ppom/ppom-util'),
+  validateRequest: jest.fn(),
 }));
 
 describe('handleSendPageNavigation', () => {
@@ -160,6 +166,27 @@ describe('submitEvmTransaction', () => {
       value: '10',
     });
     expect(mockAddTransaction).toHaveBeenCalled();
+  });
+
+  it('invokes ppomUtil.validateRequest', () => {
+    jest.spyOn(TransactionUtils, 'addTransaction').mockImplementation(() =>
+      Promise.resolve({
+        result: Promise.resolve('123'),
+        transactionMeta: { id: '123' } as TransactionMeta,
+      }),
+    );
+    const mockValidateRequest = jest
+      .spyOn(ppomUtil, 'validateRequest')
+      .mockImplementation(() => Promise.resolve());
+
+    submitEvmTransaction({
+      asset: { isNative: true } as AssetType,
+      chainId: '0x1',
+      from: '0x935E73EDb9fF52E23BaC7F7e043A1ecD06d05477',
+      to: '0xeDd1935e28b253C7905Cf5a944f0B5830FFA967b',
+      value: '10',
+    });
+    expect(mockValidateRequest).toHaveBeenCalled();
   });
 
   describe('sets transaction type', () => {

--- a/app/components/Views/confirmations/utils/send.ts
+++ b/app/components/Views/confirmations/utils/send.ts
@@ -3,15 +3,19 @@ import { BigNumber } from 'bignumber.js';
 import { Hex } from '@metamask/utils';
 import { Nft } from '@metamask/assets-controllers';
 import {
+  SecurityAlertResponse,
+  TransactionMeta,
   TransactionParams,
   TransactionType,
 } from '@metamask/transaction-controller';
 import { addHexPrefix } from 'ethereumjs-util';
 import { encode } from '@metamask/abi-utils';
 import { toHex } from '@metamask/controller-utils';
+import { v4 as uuid } from 'uuid';
 
 import Engine from '../../../../core/Engine';
 import Routes from '../../../../constants/navigation/Routes';
+import ppomUtil from '../../../../lib/ppom/ppom-util';
 import { MetaMetrics, MetaMetricsEvents } from '../../../../core/Analytics';
 import { MetricsEventBuilder } from '../../../../core/Analytics/MetricsEventBuilder';
 import { addTransaction } from '../../../../util/transaction-controller';
@@ -195,6 +199,32 @@ export const prepareEVMTransaction = (
   return trxnParams;
 };
 
+const validateSend = (
+  trxnParams: TransactionParams,
+  chainId: Hex,
+  networkClientId: string,
+) => {
+  const securityAlertId = uuid();
+  ppomUtil.validateRequest(
+    {
+      id: securityAlertId,
+      jsonrpc: '2.0',
+      method: 'eth_sendTransaction',
+      origin: MMM_ORIGIN,
+      params: [trxnParams],
+    },
+    {
+      transactionMeta: {
+        chainId,
+        networkClientId,
+        txParams: trxnParams,
+      } as TransactionMeta,
+      securityAlertId,
+    },
+  );
+  return { securityAlertId } as SecurityAlertResponse;
+};
+
 export const submitEvmTransaction = async ({
   asset,
   chainId,
@@ -224,10 +254,17 @@ export const submitEvmTransaction = async ({
     transactionType = TransactionType.tokenMethodSafeTransferFrom;
   }
 
+  const securityAlertResponse = validateSend(
+    trxnParams,
+    chainId,
+    networkClientId,
+  );
+
   await addTransaction(trxnParams, {
     origin: MMM_ORIGIN,
     networkClientId,
     type: transactionType,
+    securityAlertResponse,
   });
 };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Send requests should be validated by PPOM.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5969

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**
todo

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Integrates PPOM validation into `submitEvmTransaction`, forwarding `securityAlertResponse` to `addTransaction`, with tests ensuring `ppomUtil.validateRequest` is invoked.
> 
> - **Confirmations utils (`app/components/Views/confirmations/utils/send.ts`)**:
>   - Add `validateSend` to call `ppomUtil.validateRequest` with an `eth_sendTransaction` payload and context (`transactionMeta`, `securityAlertId` via `uuid`).
>   - Update `submitEvmTransaction` to invoke `validateSend` and pass `securityAlertResponse` to `addTransaction`.
> - **Tests (`app/components/Views/confirmations/utils/send.test.ts`)**:
>   - Mock `ppom-util` and add test asserting `validateRequest` is called during `submitEvmTransaction`.
>   - Keep existing tests for navigation, transaction prep, and type selection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea8691857ac69d457141b8a5683dcbe497122b76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->