### PR TITLE
fix: cp-7.57.0 fix padding after tabslist change

### DIFF
--- a/app/components/UI/Rewards/Views/RewardsSettingsView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsSettingsView.tsx
@@ -41,9 +41,9 @@ const RewardsSettingsView: React.FC = () => {
 
   return (
     <ErrorBoundary navigation={navigation} view="RewardsSettingsView">
-      <Box twClassName="px-4 py-4 flex-1 gap-4">
+      <Box twClassName="py-4 flex-1 gap-4">
         {/* Section 1: Connect Multiple Accounts */}
-        <Box twClassName="gap-4">
+        <Box twClassName="gap-4 px-4">
           <Box twClassName="gap-2">
             <Text variant={TextVariant.HeadingMd}>
               {strings('rewards.settings.subtitle')}

--- a/app/components/UI/Rewards/components/RewardsErrorBanner.tsx
+++ b/app/components/UI/Rewards/components/RewardsErrorBanner.tsx
@@ -50,18 +50,12 @@ const RewardsErrorBanner: React.FC<RewardsErrorBannerProps> = ({
     <Box twClassName="flex-1 gap-4">
       <Box twClassName="gap-1">
         {/* Title */}
-        <Text
-          variant={TextVariant.BodyMd}
-          fontWeight={FontWeight.Bold}
-          twClassName="text-white"
-        >
+        <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Bold}>
           {title}
         </Text>
 
         {/* Description */}
-        <Text variant={TextVariant.BodyMd} twClassName="text-white">
-          {description}
-        </Text>
+        <Text variant={TextVariant.BodyMd}>{description}</Text>
       </Box>
 
       {/* Button Section */}

--- a/app/components/UI/Rewards/components/Settings/RewardSettingsTabs.tsx
+++ b/app/components/UI/Rewards/components/Settings/RewardSettingsTabs.tsx
@@ -127,7 +127,7 @@ const OptOutFooter = memo(() => {
   }, [showOptoutBottomSheet, trackEvent, createEventBuilder]);
 
   return (
-    <Box twClassName="gap-4 flex-col">
+    <Box twClassName="my-4 gap-4 flex-col">
       <Box twClassName="gap-2">
         <Text variant={TextVariant.HeadingSm}>
           {strings('rewards.optout.title')}
@@ -205,7 +205,7 @@ const RewardSettingsTabs: React.FC<RewardSettingsTabsProps> = ({
             ListFooterComponent={<OptOutFooter />}
           />
         ) : (
-          <Box twClassName="py-8 items-center">
+          <Box twClassName="py-4 items-center">
             <Text
               variant={TextVariant.BodyMd}
               twClassName="text-alternative text-center"

--- a/app/components/UI/Rewards/components/Tabs/LevelsTab/RewardsClaimBottomSheetModal.tsx
+++ b/app/components/UI/Rewards/components/Tabs/LevelsTab/RewardsClaimBottomSheetModal.tsx
@@ -233,7 +233,7 @@ const RewardsClaimBottomSheetModal = ({
 
   const renderTitle = () => (
     <Box twClassName="flex-row items-center justify-between w-full">
-      <Text variant={TextVariant.HeadingSm} twClassName="w-[80%]">
+      <Text variant={TextVariant.HeadingLg} twClassName="w-[80%]">
         {title}
       </Text>
       <Box

--- a/app/components/UI/Rewards/components/Tabs/LevelsTab/RewardsClaimBottomSheetModal.tsx
+++ b/app/components/UI/Rewards/components/Tabs/LevelsTab/RewardsClaimBottomSheetModal.tsx
@@ -145,7 +145,7 @@ const RewardsClaimBottomSheetModal = ({
 
       handleModalClose();
       showToast();
-    } catch (error) {
+    } catch {
       // keep modal open to display error message
     }
   }, [

--- a/app/components/UI/Rewards/components/Tabs/LevelsTab/UnlockedRewards.tsx
+++ b/app/components/UI/Rewards/components/Tabs/LevelsTab/UnlockedRewards.tsx
@@ -114,7 +114,7 @@ const UnlockedRewards: React.FC = () => {
 
   return (
     <Box
-      twClassName="p-4 gap-4"
+      twClassName="pt-2 pb-6 px-4 gap-4"
       testID={REWARDS_VIEW_SELECTORS.UNLOCKED_REWARDS}
     >
       {/* Always show section header */}

--- a/app/components/UI/Rewards/components/Tabs/LevelsTab/UpcomingRewards.tsx
+++ b/app/components/UI/Rewards/components/Tabs/LevelsTab/UpcomingRewards.tsx
@@ -275,7 +275,7 @@ const UpcomingRewards: React.FC = () => {
   };
 
   return (
-    <Box twClassName="p-4 gap-4">
+    <Box twClassName="pt-2 pb-4 px-4 gap-4">
       {/* Always show section header */}
       <SectionHeader
         count={totalUpcomingRewardsCount}

--- a/app/components/UI/Rewards/components/Tabs/OverviewTab/ActiveBoosts.tsx
+++ b/app/components/UI/Rewards/components/Tabs/OverviewTab/ActiveBoosts.tsx
@@ -269,7 +269,7 @@ const ActiveBoosts: React.FC<{
   }
 
   return (
-    <Box twClassName="pt-4 pb-4 gap-4">
+    <Box twClassName="pt-2 pb-4 gap-4">
       {/* Always show section header */}
       <SectionHeader
         count={activeBoosts?.length || null}

--- a/app/components/UI/Rewards/components/Tabs/OverviewTab/ActiveBoosts.tsx
+++ b/app/components/UI/Rewards/components/Tabs/OverviewTab/ActiveBoosts.tsx
@@ -231,7 +231,7 @@ const ActiveBoosts: React.FC<{
       !hasError
     ) {
       return (
-        <Skeleton style={tw.style('h-32 bg-rounded')} width={CARD_WIDTH} />
+        <Skeleton style={tw.style('h-32 mx-4 bg-rounded')} width={CARD_WIDTH} />
       );
     }
 

--- a/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.tsx
+++ b/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.tsx
@@ -256,7 +256,7 @@ export const WaysToEarn = () => {
           scrollEnabled={false}
           renderItem={({ item: wayToEarn }) => (
             <ButtonBase
-              twClassName="h-auto px-4 py-4 bg-inherit"
+              twClassName="h-auto px-4 py-3 bg-inherit"
               onPress={() => handleEarningWayPress(wayToEarn)}
             >
               <Box


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/20991

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/a71c094e-ca11-4193-85c3-1a63ce7630a0



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines spacing across Rewards screens, updates claim modal title size, and simplifies error banner/text styling.
> 
> - **UI/Rewards spacing adjustments**:
>   - `RewardsSettingsView`: shift horizontal padding to inner section (`px-4` moved), reduce container padding.
>   - `RewardSettingsTabs`: add `my-4` margin; reduce empty-state padding.
>   - `UnlockedRewards` and `UpcomingRewards`: replace `p-4` with finer `pt/pb/px` values for tighter vertical rhythm.
>   - `ActiveBoosts`: add `mx-4` to loading skeleton; reduce top padding.
>   - `WaysToEarn`: decrease list item vertical padding from `py-4` to `py-3`.
> - **Typography and styling**:
>   - `RewardsClaimBottomSheetModal`: increase title to `HeadingLg`; minor try/catch cleanup.
>   - `RewardsErrorBanner`: remove forced white text, relying on default theme colors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4066de5bfd497e3e4ee391a9ac2503a84b6ac0c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->