### PR TITLE
feat (ramps): reset input when keyboard is reopened

### DIFF
--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
@@ -715,6 +715,30 @@ describe('BuildQuote View', () => {
         screen.getByText(`Minimum deposit is ${denomSymbol}${MIN_LIMIT}`),
       ).toBeTruthy();
     });
+
+    it('clears the amount when the keyboard is freshly opened', () => {
+      // Arrange - render component and set initial amount
+      render(BuildQuote);
+      const denomSymbol =
+        mockUseFiatCurrenciesValues.currentFiatCurrency?.denomSymbol;
+
+      // Set an existing amount first
+      fireEvent.press(getByRoleButton(`${denomSymbol}0`));
+      fireEvent.press(getByRoleButton('1'));
+      fireEvent.press(getByRoleButton('0'));
+      fireEvent.press(getByRoleButton('0'));
+      fireEvent.press(getByRoleButton('Done'));
+
+      // Verify the amount is set
+      expect(getByRoleButton(`${denomSymbol}100`)).toBeTruthy();
+
+      // Act - open keyboard and press a digit
+      fireEvent.press(getByRoleButton(`${denomSymbol}100`));
+      fireEvent.press(getByRoleButton('2'));
+
+      // Assert - amount should be cleared and show only the new digit
+      expect(getByRoleButton(`${denomSymbol}2`)).toBeTruthy();
+    });
   });
 
   describe('Amount to sell input', () => {
@@ -884,6 +908,29 @@ describe('BuildQuote View', () => {
       fireEvent.press(getByRoleButton(`0.73 ${symbol}`));
       fireEvent.press(getByRoleButton('50%'));
       expect(getByRoleButton(`0.5 ${symbol}`)).toBeTruthy();
+    });
+
+    it('clears the amount when the keyboard is freshly opened', () => {
+      // Arrange - render component and set initial amount
+      render(BuildQuote);
+      const symbol = mockUseRampSDKValues.selectedAsset?.symbol;
+
+      // Set an existing amount first
+      fireEvent.press(getByRoleButton(`0 ${symbol}`));
+      fireEvent.press(getByRoleButton('1'));
+      fireEvent.press(getByRoleButton('0'));
+      fireEvent.press(getByRoleButton('0'));
+      fireEvent.press(getByRoleButton('Done'));
+
+      // Verify the amount is set
+      expect(getByRoleButton(`100 ${symbol}`)).toBeTruthy();
+
+      // Act - open keyboard and press a digit
+      fireEvent.press(getByRoleButton(`100 ${symbol}`));
+      fireEvent.press(getByRoleButton('2'));
+
+      // Assert - amount should be cleared and show only the new digit
+      expect(getByRoleButton(`2 ${symbol}`)).toBeTruthy();
     });
   });
 

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
@@ -12,6 +12,7 @@ import useCryptoCurrencies from '../../hooks/useCryptoCurrencies';
 import useFiatCurrencies from '../../hooks/useFiatCurrencies';
 import usePaymentMethods from '../../hooks/usePaymentMethods';
 import useGasPriceEstimation from '../../hooks/useGasPriceEstimation';
+import { BuildQuoteSelectors } from '../../../../../../../e2e/selectors/Ramps/BuildQuote.selectors';
 import {
   mockCryptoCurrenciesData,
   mockFiatCurrenciesData,
@@ -721,18 +722,22 @@ describe('BuildQuote View', () => {
       const denomSymbol =
         mockUseFiatCurrenciesValues.currentFiatCurrency?.denomSymbol;
 
-      fireEvent.press(getByRoleButton(`${denomSymbol}0`));
+      fireEvent.press(screen.getByTestId(BuildQuoteSelectors.AMOUNT_INPUT));
       fireEvent.press(getByRoleButton('1'));
       fireEvent.press(getByRoleButton('0'));
       fireEvent.press(getByRoleButton('0'));
       fireEvent.press(getByRoleButton('Done'));
 
-      expect(getByRoleButton(`${denomSymbol}100`)).toBeTruthy();
+      expect(
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_INPUT),
+      ).toHaveTextContent(`${denomSymbol}100`);
 
-      fireEvent.press(getByRoleButton(`${denomSymbol}100`));
+      fireEvent.press(screen.getByTestId(BuildQuoteSelectors.AMOUNT_INPUT));
       fireEvent.press(getByRoleButton('2'));
 
-      expect(getByRoleButton(`${denomSymbol}2`)).toBeTruthy();
+      expect(
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_INPUT),
+      ).toHaveTextContent(`${denomSymbol}2`);
     });
   });
 
@@ -909,18 +914,22 @@ describe('BuildQuote View', () => {
       render(BuildQuote);
       const symbol = mockUseRampSDKValues.selectedAsset?.symbol;
 
-      fireEvent.press(getByRoleButton(`0 ${symbol}`));
+      fireEvent.press(screen.getByTestId(BuildQuoteSelectors.AMOUNT_INPUT));
       fireEvent.press(getByRoleButton('1'));
       fireEvent.press(getByRoleButton('0'));
       fireEvent.press(getByRoleButton('0'));
       fireEvent.press(getByRoleButton('Done'));
 
-      expect(getByRoleButton(`100 ${symbol}`)).toBeTruthy();
+      expect(
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_INPUT),
+      ).toHaveTextContent(`100 ${symbol}`);
 
-      fireEvent.press(getByRoleButton(`100 ${symbol}`));
+      fireEvent.press(screen.getByTestId(BuildQuoteSelectors.AMOUNT_INPUT));
       fireEvent.press(getByRoleButton('2'));
 
-      expect(getByRoleButton(`2 ${symbol}`)).toBeTruthy();
+      expect(
+        screen.getByTestId(BuildQuoteSelectors.AMOUNT_INPUT),
+      ).toHaveTextContent(`2 ${symbol}`);
     });
   });
 

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.test.tsx
@@ -717,26 +717,21 @@ describe('BuildQuote View', () => {
     });
 
     it('clears the amount when the keyboard is freshly opened', () => {
-      // Arrange - render component and set initial amount
       render(BuildQuote);
       const denomSymbol =
         mockUseFiatCurrenciesValues.currentFiatCurrency?.denomSymbol;
 
-      // Set an existing amount first
       fireEvent.press(getByRoleButton(`${denomSymbol}0`));
       fireEvent.press(getByRoleButton('1'));
       fireEvent.press(getByRoleButton('0'));
       fireEvent.press(getByRoleButton('0'));
       fireEvent.press(getByRoleButton('Done'));
 
-      // Verify the amount is set
       expect(getByRoleButton(`${denomSymbol}100`)).toBeTruthy();
 
-      // Act - open keyboard and press a digit
       fireEvent.press(getByRoleButton(`${denomSymbol}100`));
       fireEvent.press(getByRoleButton('2'));
 
-      // Assert - amount should be cleared and show only the new digit
       expect(getByRoleButton(`${denomSymbol}2`)).toBeTruthy();
     });
   });
@@ -911,25 +906,20 @@ describe('BuildQuote View', () => {
     });
 
     it('clears the amount when the keyboard is freshly opened', () => {
-      // Arrange - render component and set initial amount
       render(BuildQuote);
       const symbol = mockUseRampSDKValues.selectedAsset?.symbol;
 
-      // Set an existing amount first
       fireEvent.press(getByRoleButton(`0 ${symbol}`));
       fireEvent.press(getByRoleButton('1'));
       fireEvent.press(getByRoleButton('0'));
       fireEvent.press(getByRoleButton('0'));
       fireEvent.press(getByRoleButton('Done'));
 
-      // Verify the amount is set
       expect(getByRoleButton(`100 ${symbol}`)).toBeTruthy();
 
-      // Act - open keyboard and press a digit
       fireEvent.press(getByRoleButton(`100 ${symbol}`));
       fireEvent.press(getByRoleButton('2'));
 
-      // Assert - amount should be cleared and show only the new digit
       expect(getByRoleButton(`2 ${symbol}`)).toBeTruthy();
     });
   });

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
@@ -99,6 +99,7 @@ import { trace, endTrace, TraceName } from '../../../../../../util/trace';
 
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { createUnsupportedRegionModalNavigationDetails } from '../../components/UnsupportedRegionModal';
+import { regex } from '../../../../../../util/regex';
 
 // TODO: Replace "any" with type
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -501,7 +502,7 @@ const BuildQuote = () => {
       let newValue = `${value}`;
       let newValueAsNumber = valueAsNumber;
 
-      if (isKeyboardFreshlyOpened && /^[0-9]$/.test(pressedKey)) {
+      if (isKeyboardFreshlyOpened && regex.hasOneDigit.test(pressedKey)) {
         newValue = pressedKey;
         newValueAsNumber = Number(pressedKey);
       }

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
@@ -498,27 +498,24 @@ const BuildQuote = () => {
       valueAsNumber: number;
       pressedKey: Keys;
     }) => {
+      let newValue = `${value}`;
+      let newValueAsNumber = valueAsNumber;
+
       if (isKeyboardFreshlyOpened && /^[0-9]$/.test(pressedKey)) {
-        setAmount(pressedKey);
-        setAmountNumber(Number(pressedKey));
-        if (isSell) {
-          setAmountBNMinimalUnit(
-            toTokenMinimalUnit(pressedKey, selectedAsset?.decimals ?? 0) as BN4,
-          );
-        }
-        setIsKeyboardFreshlyOpened(false);
-      } else {
-        setAmount(`${value}`);
-        setAmountNumber(valueAsNumber);
-        if (isSell) {
-          setAmountBNMinimalUnit(
-            toTokenMinimalUnit(`${value}`, selectedAsset?.decimals ?? 0) as BN4,
-          );
-        }
-        if (isKeyboardFreshlyOpened) {
-          setIsKeyboardFreshlyOpened(false);
-        }
+        newValue = pressedKey;
+        newValueAsNumber = Number(pressedKey);
       }
+
+      setAmount(newValue);
+      setAmountNumber(newValueAsNumber);
+
+      if (isSell) {
+        setAmountBNMinimalUnit(
+          toTokenMinimalUnit(newValue, selectedAsset?.decimals ?? 0) as BN4,
+        );
+      }
+
+      setIsKeyboardFreshlyOpened(false);
     },
     [isSell, selectedAsset?.decimals, isKeyboardFreshlyOpened],
   );

--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
@@ -498,13 +498,7 @@ const BuildQuote = () => {
       valueAsNumber: number;
       pressedKey: Keys;
     }) => {
-      // If keyboard is freshly opened and a digit key is pressed, clear the existing amount first
-      if (
-        isKeyboardFreshlyOpened &&
-        pressedKey >= Keys.Digit0 &&
-        pressedKey <= Keys.Digit9
-      ) {
-        // Clear the amount and start fresh with just the pressed digit
+      if (isKeyboardFreshlyOpened && /^[0-9]$/.test(pressedKey)) {
         setAmount(pressedKey);
         setAmountNumber(Number(pressedKey));
         if (isSell) {
@@ -514,7 +508,6 @@ const BuildQuote = () => {
         }
         setIsKeyboardFreshlyOpened(false);
       } else {
-        // Normal behavior - use the calculated value
         setAmount(`${value}`);
         setAmountNumber(valueAsNumber);
         if (isSell) {
@@ -522,7 +515,6 @@ const BuildQuote = () => {
             toTokenMinimalUnit(`${value}`, selectedAsset?.decimals ?? 0) as BN4,
           );
         }
-        // Reset fresh keyboard flag after any input
         if (isKeyboardFreshlyOpened) {
           setIsKeyboardFreshlyOpened(false);
         }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes a small UX bug when the user types a new amount into the buy input. Previously the new amount was appended to the old amount. Now the amount will be cleared so the new amount can be entered correctly.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Improved buy amount input UX

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-1026

## **Manual testing steps**

```gherkin
Feature: Improved buy amount input UX

  Scenario: user types a new amount into the buy input
    Given user visits buy page and enters an amount such as 500
    When user closes the keyboard
    And user opens the keyboard to type a new amount
    Then the previous value is cleared so the new amount can be typed
    Instead of the new amount being appended to the previous amount
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

Video demo of before/after: https://www.loom.com/share/bea1704740594c4abd372b010b560321

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resets the amount input on fresh keypad open (buy and sell), updates keypad handler to use pressed key, and adds tests verifying the behavior.
> 
> - **UI (BuildQuote)**:
>   - Add `isKeyboardFreshlyOpened` state to control input clearing on fresh keypad open.
>   - Update keypad handlers: `onAmountInputPress`, `handleKeypadDone`, and back handler to manage the fresh-open state.
>   - Change `Keypad` import to `Keypad, { Keys }` and extend `onChange` to accept `pressedKey` for first-digit replacement logic.
>   - Maintain amount/BN updates for sell flow when editing.
> - **Tests (BuildQuote.test.tsx)**:
>   - Import `BuildQuoteSelectors` and use `AMOUNT_INPUT` test id.
>   - Add tests for clearing amount on fresh keypad open for both buy and sell inputs.
>   - Adjust submit button and related expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df09ce4fe42f8385bf3d505d559877306a708304. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->