### PR TITLE
fix: Fix issue 20841 QR confirmation screen appearing after re-open MM. Unable to close. cp-7.57.0

### DIFF
--- a/app/store/persistConfig.test.ts
+++ b/app/store/persistConfig.test.ts
@@ -117,6 +117,7 @@ describe('persistConfig', () => {
         'accounts',
         'confirmationMetrics',
         'alert',
+        'qrKeyringScanner',
       ]);
     });
 

--- a/app/store/persistConfig.ts
+++ b/app/store/persistConfig.ts
@@ -135,7 +135,13 @@ const persistOnboardingTransform = createTransform(
 const persistConfig = {
   key: 'root',
   version,
-  blacklist: ['rpcEvents', 'accounts', 'confirmationMetrics', 'alert'],
+  blacklist: [
+    'rpcEvents',
+    'accounts',
+    'confirmationMetrics',
+    'alert',
+    'qrKeyringScanner',
+  ],
   storage: MigratedStorage,
   transforms: [
     persistTransform,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR will fix #20841  QR confirmation screen appearing after re-open MM. Unable to close.

The issue was caused by is redux persist store the qrKeyringScanner after app close, and if user didnt close QR scanner and close the app directly.  the state of qrKeyringScanner is still isSigning = true which wlll bring up the QR scan after app reopen. the fix will be added `qrKeyringScanner` state in the blacklist list to avoid storing qrKeyringScanner state.


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: added `qrKeyringScanner` state in the blacklist list of redux persist config.

## **Related issues**

Fixes: #20841 

## **Manual testing steps**

1. Add hardware wallet
2. Import QR accounts
3. Initiate swap txn (POL -> USDT)
4. Unable to fetch quote
5. Get a quote and confirm
6. Reach qr code screen to scan and close app
7. Reopen app, the scan qr code keeps appearing

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents persisting `qrKeyringScanner` state by adding it to the redux-persist `blacklist`, with tests updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e9b5e942ebb03e3f8190929641fed0d863d5c02. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->