### PR TITLE
fix: update font size in RPC flow

### DIFF
--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
@@ -2256,7 +2256,7 @@ export class NetworkSettings extends PureComponent {
                       this.onRpcItemAdd(rpcUrlForm, rpcNameForm);
                     }}
                     width={ButtonWidthTypes.Auto}
-                    labelTextVariant={TextVariant.DisplayMD}
+                    labelTextVariant={TextVariant.BodyMD}
                     isDisabled={!!warningRpcUrl}
                     testID={NetworksViewSelectorsIDs.ADD_RPC_BUTTON}
                   />
@@ -2325,7 +2325,7 @@ export class NetworkSettings extends PureComponent {
                       this.onBlockExplorerItemAdd(blockExplorerUrlForm);
                     }}
                     width={ButtonWidthTypes.Full}
-                    labelTextVariant={TextVariant.DisplayMD}
+                    labelTextVariant={TextVariant.BodyMD}
                     isDisabled={
                       !blockExplorerUrl ||
                       !blockExplorerUrlForm ||
@@ -2401,7 +2401,7 @@ export class NetworkSettings extends PureComponent {
                     }}
                     testID={NetworksViewSelectorsIDs.ADD_BLOCK_EXPLORER}
                     width={ButtonWidthTypes.Auto}
-                    labelTextVariant={TextVariant.DisplayMD}
+                    labelTextVariant={TextVariant.BodyMD}
                   />
                 </View>
               </ScrollView>
@@ -2509,7 +2509,7 @@ export class NetworkSettings extends PureComponent {
                       this.closeRpcModal();
                     }}
                     width={ButtonWidthTypes.Auto}
-                    labelTextVariant={TextVariant.DisplayMD}
+                    labelTextVariant={TextVariant.BodyMD}
                     testID={NetworksViewSelectorsIDs.ADD_RPC_BUTTON}
                   />
                 </View>


### PR DESCRIPTION
## **Description**

### Problem
Fonts too big

### Solution
Make fonts small

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/21054

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

`~`

### **Before**
<img width="500"  alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-10-10 at 11 20 05" src="https://github.com/user-attachments/assets/d5a6cfb4-8f30-4ec4-b84c-25b25f5ca53d" />

<img width="500"  alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-10-10 at 11 18 04" src="https://github.com/user-attachments/assets/b703de76-dccb-4d85-a871-dffd434788db" />

<!-- [screenshots/recordings] -->

### **After**

<img width="500" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-10-10 at 11 20 55" src="https://github.com/user-attachments/assets/ca29462d-275f-410e-bcae-db2ddd70f4be" />

<img width="500"  alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-10-10 at 11 22 30" src="https://github.com/user-attachments/assets/4e1e7425-2a9c-4530-a4c9-a892012b5255" />


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches button label text from `DisplayMD` to `BodyMD` for Add RPC and Add Block Explorer actions in Network Settings modals.
> 
> - **UI (Network Settings)** in `app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js`:
>   - Change `labelTextVariant` from `TextVariant.DisplayMD` to `TextVariant.BodyMD` for:
>     - `ButtonPrimary` Add RPC URL (Add RPC form modal)
>     - `ButtonPrimary` Add Block Explorer URL (Add Block Explorer form modal)
>     - `ButtonLink` Add Block Explorer URL (Block Explorer list modal)
>     - `ButtonLink` Add RPC URL (RPC list modal)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41991b3751530962b37f3d6b4c26359e3621e20a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->