### PR TITLE
feat: btc swap button, BIP44 default pair

### DIFF
--- a/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/index.tsx
+++ b/app/components/UI/Bridge/components/BridgeSourceNetworkSelector/index.tsx
@@ -31,7 +31,7 @@ import { useNetworkInfo } from '../../../../../selectors/selectedNetworkControll
 import { useSwitchNetworks } from '../../../../Views/NetworkSelector/useSwitchNetworks';
 import { CaipChainId, Hex } from '@metamask/utils';
 import { selectEvmNetworkConfigurationsByChainId } from '../../../../../selectors/networkController';
-import { getNativeSourceToken } from '../../hooks/useInitialSourceToken';
+import { getNativeSourceToken } from '../../utils/tokenUtils';
 
 const createStyles = () =>
   StyleSheet.create({

--- a/app/components/UI/Bridge/hooks/useHasSufficientGas/index.ts
+++ b/app/components/UI/Bridge/hooks/useHasSufficientGas/index.ts
@@ -7,7 +7,7 @@ import { useLatestBalance } from '../useLatestBalance';
 import { ethers } from 'ethers';
 import { CaipChainId, Hex } from '@metamask/utils';
 import { useBridgeQuoteData } from '../useBridgeQuoteData';
-import { getNativeSourceToken } from '../useInitialSourceToken';
+import { getNativeSourceToken } from '../../utils/tokenUtils';
 import { BigNumber } from 'bignumber.js';
 import { isNumberValue } from '../../../../../util/number';
 

--- a/app/components/UI/Bridge/hooks/useInitialDestToken/index.ts
+++ b/app/components/UI/Bridge/hooks/useInitialDestToken/index.ts
@@ -5,10 +5,12 @@ import {
   selectBip44DefaultPair,
 } from '../../../../../core/redux/slices/bridge';
 import { useDispatch, useSelector } from 'react-redux';
-import { getDefaultDestToken } from '../../utils/tokenUtils';
+import {
+  getDefaultDestToken,
+  getNativeSourceToken,
+} from '../../utils/tokenUtils';
 import { selectChainId } from '../../../../../selectors/networkController';
 import { BridgeViewMode, BridgeToken } from '../../types';
-import { getNativeSourceToken } from '../useInitialSourceToken';
 import { SolScope } from '@metamask/keyring-api';
 import usePrevious from '../../../../hooks/usePrevious';
 import { useEffect } from 'react';

--- a/app/components/UI/Bridge/hooks/useInitialDestToken/index.ts
+++ b/app/components/UI/Bridge/hooks/useInitialDestToken/index.ts
@@ -11,7 +11,7 @@ import {
 } from '../../utils/tokenUtils';
 import { selectChainId } from '../../../../../selectors/networkController';
 import { BridgeViewMode, BridgeToken } from '../../types';
-import { SolScope } from '@metamask/keyring-api';
+import { BtcScope, SolScope } from '@metamask/keyring-api';
 import usePrevious from '../../../../hooks/usePrevious';
 import { useEffect } from 'react';
 
@@ -39,8 +39,17 @@ export const useInitialDestToken = (
       return;
     }
 
+    // Entering Swaps NOT from asset details page or deeplink
     if (!initialDestToken && !initialSourceToken) {
       if (isSwap && bip44DefaultPair && !destToken) {
+        dispatch(setDestToken(bip44DefaultPair.destAsset));
+        return;
+      }
+    }
+
+    // Use BIP44 default pair for Bitcoin source token (i.e. entered Swaps from Bitcoin Asset Details page)
+    if (initialSourceToken && initialSourceToken.chainId === BtcScope.Mainnet) {
+      if (bip44DefaultPair && !destToken) {
         dispatch(setDestToken(bip44DefaultPair.destAsset));
         return;
       }

--- a/app/components/UI/Bridge/hooks/useInitialDestToken/useInitialDestToken.test.ts
+++ b/app/components/UI/Bridge/hooks/useInitialDestToken/useInitialDestToken.test.ts
@@ -4,7 +4,7 @@ import { useInitialDestToken } from '.';
 import { waitFor } from '@testing-library/react-native';
 import { BridgeViewMode, BridgeToken } from '../../types';
 import { DefaultSwapDestTokens } from '../../constants/default-swap-dest-tokens';
-import { SolScope } from '@metamask/keyring-api';
+import { SolScope, BtcScope } from '@metamask/keyring-api';
 import { selectChainId } from '../../../../../selectors/networkController';
 import {
   selectBridgeViewMode,
@@ -24,6 +24,7 @@ jest.mock('../../../../../core/redux/slices/bridge', () => {
     default: actual.default,
     setDestToken: jest.fn(actual.setDestToken),
     selectBridgeViewMode: jest.fn().mockReturnValue('Bridge'),
+    selectBip44DefaultPair: jest.fn(actual.selectBip44DefaultPair),
   };
 });
 
@@ -54,6 +55,14 @@ describe('useInitialDestToken', () => {
     decimals: 18,
     name: 'Mock Token',
     chainId: SolScope.Mainnet,
+  };
+
+  const mockBitcoinSourceToken: BridgeToken = {
+    address: 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh',
+    symbol: 'BTC',
+    decimals: 8,
+    name: 'Bitcoin',
+    chainId: BtcScope.Mainnet,
   };
 
   beforeEach(() => {
@@ -103,6 +112,36 @@ describe('useInitialDestToken', () => {
       expect(setDestToken).toHaveBeenCalledWith(
         DefaultSwapDestTokens[SolScope.Mainnet],
       );
+    });
+  });
+
+  describe('BIP44 Bitcoin functionality', () => {
+    it('should set bip44 default pair dest asset when source token is Bitcoin and bip44DefaultPair exists', async () => {
+      // Arrange - Bitcoin source token from Asset Details page
+      (selectBridgeViewMode as unknown as jest.Mock).mockReturnValue(
+        BridgeViewMode.Unified,
+      );
+      // Set chainId to Bitcoin to ensure correct bip44 pair selection
+      (selectChainId as unknown as jest.Mock).mockReturnValue(BtcScope.Mainnet);
+
+      // Act - Bitcoin source token
+      renderHookWithProvider(
+        () => useInitialDestToken(mockBitcoinSourceToken),
+        { state: initialState },
+      );
+
+      // Assert - Should set Ethereum as destination token based on bip44DefaultPair
+      await waitFor(() => {
+        expect(setDestToken).toHaveBeenCalledWith({
+          symbol: 'ETH',
+          name: 'Ethereum',
+          address: '0x0000000000000000000000000000000000000000',
+          decimals: 18,
+          image:
+            'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/slip44/60.png',
+          chainId: '0x1',
+        });
+      });
     });
   });
 });

--- a/app/components/UI/Bridge/hooks/useInitialSourceToken/index.ts
+++ b/app/components/UI/Bridge/hooks/useInitialSourceToken/index.ts
@@ -9,9 +9,7 @@ import { BridgeToken } from '../../types';
 import { selectEvmNetworkConfigurationsByChainId } from '../../../../../selectors/networkController';
 import { useSwitchNetworks } from '../../../../Views/NetworkSelector/useSwitchNetworks';
 import { useNetworkInfo } from '../../../../../selectors/selectedNetworkController';
-import { CaipChainId, Hex } from '@metamask/utils';
 import {
-  getNativeAssetForChainId,
   isNonEvmChainId,
   formatChainIdToCaip,
   formatChainIdToHex,
@@ -23,26 +21,7 @@ import {
   selectSelectedNonEvmNetworkChainId,
 } from '../../../../../selectors/multichainNetworkController';
 import { useEffect } from 'react';
-
-export const getNativeSourceToken = (chainId: Hex | CaipChainId) => {
-  const nativeAsset = getNativeAssetForChainId(chainId);
-
-  // getNativeAssetForChainId returns zero address for non-EVM chains, we need the CAIP assetId to get balances properly for native asset
-  const address = isNonEvmChainId(chainId)
-    ? nativeAsset.assetId
-    : nativeAsset.address;
-
-  const nativeSourceTokenFormatted: BridgeToken = {
-    address,
-    name: nativeAsset.name ?? '',
-    symbol: nativeAsset.symbol,
-    image: 'iconUrl' in nativeAsset ? nativeAsset.iconUrl || '' : '',
-    decimals: nativeAsset.decimals,
-    chainId,
-  };
-
-  return nativeSourceTokenFormatted;
-};
+import { getNativeSourceToken } from '../../utils/tokenUtils';
 
 /**
  *

--- a/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/index.ts
+++ b/app/components/UI/Bridge/hooks/useSwapBridgeNavigation/index.ts
@@ -11,13 +11,13 @@ import {
 } from '@metamask/bridge-controller';
 import { BridgeRouteParams } from '../../Views/BridgeView';
 import { EthScope } from '@metamask/keyring-api';
-import { ethers } from 'ethers';
 import { MetaMetricsEvents, useMetrics } from '../../../../hooks/useMetrics';
 import { getDecimalChainId } from '../../../../../util/networks';
 import { useAddNetwork } from '../../../../hooks/useAddNetwork';
 import { selectIsBridgeEnabledSourceFactory } from '../../../../../core/redux/slices/bridge';
 import { trace, TraceName } from '../../../../../util/trace';
 import { useCurrentNetworkInfo } from '../../../../hooks/useCurrentNetworkInfo';
+import { getNativeSourceToken } from '../../utils/tokenUtils';
 
 export enum SwapBridgeNavigationLocation {
   TabBar = 'TabBar',
@@ -105,12 +105,7 @@ export const useSwapBridgeNavigation = ({
 
       if (!sourceToken) {
         // fallback to ETH on mainnet
-        sourceToken = {
-          address: ethers.constants.AddressZero,
-          chainId: EthScope.Mainnet,
-          symbol: 'ETH',
-          decimals: 18,
-        };
+        sourceToken = getNativeSourceToken(EthScope.Mainnet);
       }
 
       const params: BridgeRouteParams = {

--- a/app/components/UI/Bridge/utils/tokenUtils.test.ts
+++ b/app/components/UI/Bridge/utils/tokenUtils.test.ts
@@ -46,7 +46,7 @@ describe('tokenUtils', () => {
         symbol: 'ETH',
         image: '',
         decimals: 18,
-        chainId: 'eip155:1',
+        chainId: '0x1',
       });
     });
 
@@ -85,7 +85,7 @@ describe('tokenUtils', () => {
         symbol: 'ETH',
         image: 'https://example.com/eth-icon.png',
         decimals: 18,
-        chainId: 'eip155:1',
+        chainId: '0x1',
       });
     });
 
@@ -104,9 +104,9 @@ describe('tokenUtils', () => {
         address: constants.AddressZero,
         name: '',
         symbol: 'ETH',
-        image: undefined,
+        image: '',
         decimals: 18,
-        chainId: 'eip155:1',
+        chainId: '0x1',
       });
     });
   });

--- a/app/components/UI/Bridge/utils/tokenUtils.ts
+++ b/app/components/UI/Bridge/utils/tokenUtils.ts
@@ -1,5 +1,6 @@
 import { CaipChainId, Hex } from '@metamask/utils';
 import {
+  formatChainIdToHex,
   getNativeAssetForChainId,
   isNonEvmChainId,
 } from '@metamask/bridge-controller';
@@ -14,20 +15,25 @@ export const getNativeSourceToken = (
 ): BridgeToken => {
   const nativeAsset = getNativeAssetForChainId(chainId);
 
-  // Use assetId for Solana to get balances properly for native SOL
+  // getNativeAssetForChainId returns zero address for non-EVM chains, we need the CAIP assetId to get balances properly for native asset
   const address = isNonEvmChainId(chainId)
     ? nativeAsset.assetId
     : nativeAsset.address;
 
-  return {
+  const formattedChainId = isNonEvmChainId(chainId)
+    ? chainId
+    : formatChainIdToHex(chainId);
+
+  const nativeSourceTokenFormatted = {
     address,
     name: nativeAsset.name ?? '',
     symbol: nativeAsset.symbol,
-    image:
-      'iconUrl' in nativeAsset ? nativeAsset.iconUrl ?? undefined : undefined,
+    image: 'iconUrl' in nativeAsset ? nativeAsset.iconUrl || '' : '',
     decimals: nativeAsset.decimals,
-    chainId,
+    chainId: formattedChainId,
   };
+
+  return nativeSourceTokenFormatted;
 };
 
 /**

--- a/app/components/UI/Swaps/useChainRedirect.ts
+++ b/app/components/UI/Swaps/useChainRedirect.ts
@@ -7,7 +7,7 @@ import {
   useSwapBridgeNavigation,
   SwapBridgeNavigationLocation,
 } from '../Bridge/hooks/useSwapBridgeNavigation';
-import { getNativeSourceToken } from '../Bridge/hooks/useInitialSourceToken';
+import { getNativeSourceToken } from '../Bridge/utils/tokenUtils';
 
 /**
  * Hook to handle chain-specific redirection logic

--- a/app/components/UI/Swaps/utils/index.js
+++ b/app/components/UI/Swaps/utils/index.js
@@ -4,9 +4,7 @@ import { swapsUtils } from '@metamask/swaps-controller';
 import { strings } from '../../../../../locales/i18n';
 import AppConstants from '../../../../core/AppConstants';
 import { NETWORKS_CHAIN_ID } from '../../../../constants/network';
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-import { SolScope } from '@metamask/keyring-api';
-///: END:ONLY_INCLUDE_IF(keyring-snaps)
+import { SolScope, BtcScope } from '@metamask/keyring-api';
 
 const {
   ETH_CHAIN_ID,
@@ -53,11 +51,9 @@ export function isSwapsAllowed(chainId) {
     allowedChainIds.push(SWAPS_TESTNET_CHAIN_ID);
   }
 
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-  if (chainId === SolScope.Mainnet) {
+  if (chainId === SolScope.Mainnet || chainId === BtcScope.Mainnet) {
     return true;
   }
-  ///: END:ONLY_INCLUDE_IF(keyring-snaps)
 
   return allowedChainIds.includes(chainId);
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR:
1. Shows swap button in BTC asset details
2. Removes an extra uneeded `getNativeSourceToken` util fn
3. Uses BIP44 default pair when entering Swaps through BTC asset details

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
4. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added Swap button for BTC asset
CHANGELOG entry: Used BIP44 default pair for BTC asset in Swaps

## **Related issues**

Resolves: https://consensyssoftware.atlassian.net/browse/SWAPS-3194
Resolves: https://consensyssoftware.atlassian.net/browse/SWAPS-3195

## **Manual testing steps**

```gherkin
Feature: BTC Asset Details and Swaps

  Scenario: user wants to swap BTC
    Given user is on BTC asset details page

    When user is in BTC asset details page
    Then they see the Swap button and are taken to Swaps when clicked on and dest token is Ethereum ETH
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

When BTC is enabled in LD, use BIP44 default pairs


https://github.com/user-attachments/assets/939306a8-61c4-4dcf-b1a9-1d97c603b7b0



When BTC is disabled in LD, default to Ethereum ETH source token

https://github.com/user-attachments/assets/dd56a5ea-88d1-4514-bbb6-673fc11f8a9c


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables BTC swaps using the BIP44 default pair and centralizes native token formatting in a shared util, updating consumers and tests.
> 
> - **Swaps/Bridge**:
>   - Enable swaps on Bitcoin by allowing `BtcScope.Mainnet` in `isSwapsAllowed`.
>   - When entering Swaps from BTC asset details, set dest token via `selectBip44DefaultPair`.
>   - Fallback to native ETH via `getNativeSourceToken` when source not bridge-enabled.
> - **Utils**:
>   - Consolidate and enhance `getNativeSourceToken` in `utils/tokenUtils` (handles CAIP→hex for EVM, non-EVM assetId, default image), and export `getDefaultDestToken`.
>   - Replace previous usages to import from `utils/tokenUtils` across hooks/components and navigation.
> - **Hooks**:
>   - `useInitialDestToken`: adds BIP44 BTC handling; avoids same-token source/dest by switching to native token when needed.
>   - `useHasSufficientGas`, `BridgeSourceNetworkSelector`, `useInitialSourceToken`, `useSwapBridgeNavigation`, `useChainRedirect`: updated to use shared util.
> - **Tests**:
>   - Update `tokenUtils` tests (EVM chainId to hex, image defaults) and add BTC BIP44 default pair test in `useInitialDestToken`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61df957305ef34b6bf7dcf582be75b1cce099115. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->