### PR TITLE
fix: "rootSpan.addEvent is not a function" blocking Perps connection cp-7.57.0

### DIFF
--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -1,5 +1,4 @@
 import { captureException, setMeasurement } from '@sentry/react-native';
-import type { Span } from '@sentry/core';
 import BackgroundTimer from 'react-native-background-timer';
 import performance from 'react-native-performance';
 import { v4 as uuidv4 } from 'uuid';
@@ -9,12 +8,7 @@ import { selectSelectedInternalAccountByScope } from '../../../../selectors/mult
 import { store } from '../../../../store';
 import Device from '../../../../util/device';
 import Logger from '../../../../util/Logger';
-import {
-  trace,
-  endTrace,
-  TraceName,
-  TraceOperation,
-} from '../../../../util/trace';
+import { endTrace, TraceName } from '../../../../util/trace';
 import { PERPS_CONSTANTS, PERFORMANCE_CONFIG } from '../constants/perpsConfig';
 import { PERPS_ERROR_CODES } from '../controllers/PerpsController';
 import { getStreamManagerInstance } from '../providers/PerpsStreamManager';
@@ -403,12 +397,6 @@ class PerpsConnectionManagerClass {
       let traceData: Record<string, string | number | boolean> | undefined;
 
       try {
-        const traceSpan = trace({
-          name: TraceName.PerpsConnectionEstablishment,
-          id: traceId,
-          op: TraceOperation.PerpsOperation,
-        }) as Span;
-
         DevLogger.log('PerpsConnectionManager: Initializing connection');
 
         // Stage 1: Initialize providers
@@ -419,7 +407,6 @@ class PerpsConnectionManagerClass {
           PerpsMeasurementName.PERPS_PROVIDER_INIT,
           performance.now() - initStart,
           'millisecond',
-          traceSpan,
         );
 
         // Stage 2: Get account state - may fail if still initializing
@@ -452,7 +439,6 @@ class PerpsConnectionManagerClass {
           PerpsMeasurementName.PERPS_ACCOUNT_STATE_FETCH,
           performance.now() - accountStart,
           'millisecond',
-          traceSpan,
         );
 
         this.isConnected = true;
@@ -477,7 +463,6 @@ class PerpsConnectionManagerClass {
           PerpsMeasurementName.PERPS_WEBSOCKET_CONNECTION_ESTABLISHMENT,
           connectionDuration,
           'millisecond',
-          traceSpan,
         );
 
         DevLogger.log('PerpsConnectionManager: Successfully connected');
@@ -489,7 +474,6 @@ class PerpsConnectionManagerClass {
           PerpsMeasurementName.PERPS_SUBSCRIPTIONS_PRELOAD,
           performance.now() - preloadStart,
           'millisecond',
-          traceSpan,
         );
 
         // Track total connection time including preload (user-perceived performance)
@@ -509,7 +493,6 @@ class PerpsConnectionManagerClass {
           PerpsMeasurementName.PERPS_WEBSOCKET_CONNECTION_WITH_PRELOAD,
           totalConnectionDuration,
           'millisecond',
-          traceSpan,
         );
 
         traceData = {
@@ -600,12 +583,6 @@ class PerpsConnectionManagerClass {
     this.isConnecting = true;
 
     try {
-      const traceSpan = trace({
-        name: TraceName.PerpsAccountSwitchReconnection,
-        id: traceId,
-        op: TraceOperation.PerpsOperation,
-      }) as Span;
-
       // Stage 1: Clean up existing connections and clear caches
       const cleanupStart = performance.now();
       this.cleanupPreloadedSubscriptions();
@@ -621,7 +598,6 @@ class PerpsConnectionManagerClass {
         PerpsMeasurementName.PERPS_RECONNECTION_CLEANUP,
         performance.now() - cleanupStart,
         'millisecond',
-        traceSpan,
       );
 
       // Reset connection state (but keep isConnecting = true)
@@ -638,7 +614,6 @@ class PerpsConnectionManagerClass {
         PerpsMeasurementName.PERPS_CONTROLLER_REINIT,
         performance.now() - reinitStart,
         'millisecond',
-        traceSpan,
       );
 
       // Wait for initialization to complete - platform-specific timing for reliability
@@ -678,7 +653,6 @@ class PerpsConnectionManagerClass {
         PerpsMeasurementName.PERPS_NEW_ACCOUNT_FETCH,
         performance.now() - accountStart,
         'millisecond',
-        traceSpan,
       );
 
       this.isConnected = true;
@@ -697,7 +671,6 @@ class PerpsConnectionManagerClass {
         PerpsMeasurementName.PERPS_RECONNECTION_PRELOAD,
         performance.now() - preloadStart,
         'millisecond',
-        traceSpan,
       );
 
       // Track account switch reconnection performance including preload
@@ -717,7 +690,6 @@ class PerpsConnectionManagerClass {
         PerpsMeasurementName.PERPS_WEBSOCKET_ACCOUNT_SWITCH_RECONNECTION,
         reconnectionDuration,
         'millisecond',
-        traceSpan,
       );
 
       traceData = {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Could not connect to Perps on main, I suspected https://github.com/MetaMask/metamask-mobile/pull/20817 as the error in the console was:

`rootSpan.addEvent is not a function`

The issue occurred because trace() returns a TraceContext, not a Span. The code was casting this TraceContext as a Span and passed it to setMeasurement, which expects a real `Span` object with an addEvent method. This caused the error when `setMeasurement` tried to call `addEvent` on the typecasted `Span` that did not have the same API.

Using trace() with callback functions gives us access to the actual Span object, which should preserve the initial intent of the previous code, while addressing the issue causing Sentry errors blocking Perps connection.

Root Cause:
* trace() → returns TraceContext
* Code → incorrectly casted a TraceContext as a Span
* setMeasurement → expects real Span with addEvent method
* Result → runtime error

## **Changelog**

CHANGELOG entry: Fixes breaking issue in Sentry blocking Perps connection

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors tracing in `PerpsConnectionManager` to use callback-based `trace` for real `Span` context, fixing runtime errors and preserving performance measurements during connect and reconnection flows.
> 
> - **PerpsConnectionManager (`app/components/UI/Perps/services/PerpsConnectionManager.ts`)**:
>   - **Tracing Refactor**: Replace casted `Span` usage with callback-based `trace(...)` to access a real `Span` for:
>     - `PerpsConnectionEstablishment` (initial connect flow)
>     - `PerpsAccountSwitchReconnection` (account/network reconnection flow)
>   - **Metrics**: Update `setMeasurement(...)` calls to pass the real `span`; keep and clarify performance logs for connection, preload, and reconnection durations.
>   - **Trace Data Handling**: Capture `trace` callback results and assign to `traceData` for `endTrace(...)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fc2a66f550d01382cc4c43f32dfd35a6fe24fee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->