### PR TITLE
perf: add FlashList estimatedItemSize for smoother scrolling

### DIFF
--- a/app/components/UI/EvmAccountSelectorList/EvmAccountSelectorList.tsx
+++ b/app/components/UI/EvmAccountSelectorList/EvmAccountSelectorList.tsx
@@ -576,6 +576,7 @@ const EvmAccountSelectorList = ({
         data={flattenedData}
         keyExtractor={getKeyExtractor}
         renderItem={renderItem}
+        estimatedItemSize={100}
         getItemType={getItemType}
         renderScrollComponent={
           ScrollView as React.ComponentType<ScrollViewProps>


### PR DESCRIPTION
Set estimatedItemSize={100} in app/components/UI/EvmAccountSelectorList/EvmAccountSelectorList.tsx to improve virtualization and scroll performance. The value is based on the typical row height pattern (base ~78px plus conditional 22/24px), providing a reasonable average for stable measurements. No functional or UI behavior changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set estimatedItemSize=100 on `FlashList` in `app/components/UI/EvmAccountSelectorList/EvmAccountSelectorList.tsx` to improve scroll performance via better virtualization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6a28a9218e4d9e29bd32e8322ab9e5c6914e701. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->