### PR TITLE
fix: correct Icon.types.ts path in ButtonBase README

### DIFF
--- a/app/component-library/components/Buttons/Button/foundation/ButtonBase/README.md
+++ b/app/component-library/components/Buttons/Button/foundation/ButtonBase/README.md
@@ -44,7 +44,7 @@ Optional prop for the icon name of the icon that will be displayed before the la
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ |
-| [IconName](../Icons/Icon.types.ts)                | No                                                   |
+| [IconName](../../../../Icons/Icon/Icon.types.ts)                | No                                                   |
 
 ### `endIconName`
 
@@ -52,7 +52,7 @@ Optional prop for the icon name of the icon that will be displayed after the lab
 
 | <span style="color:gray;font-size:14px">TYPE</span> | <span style="color:gray;font-size:14px">REQUIRED</span> |
 | :-------------------------------------------------- | :------------------------------------------------------ |
-| [IconName](../Icons/Icon.types.ts)                | No                                                   |
+| [IconName](../../../../Icons/Icon/Icon.types.ts)                | No                                                   |
 
 ### `isDanger`
 


### PR DESCRIPTION
Fix broken relative path references to Icon.types.ts in ButtonBase component documentation.

- Updated path from ../Icons/Icon.types.ts to ../../../../Icons/Icon/Icon.types.ts
- Fixed both startIconName and endIconName prop documentation
- Resolves broken link error in component library documentation

The Icon.types.ts file is located at app/component-library/components/Icons/Icon/Icon.types.ts,
requiring the correct relative path from the ButtonBase README location.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates broken `Icon.types.ts` link in `ButtonBase/README.md` for `startIconName` and `endIconName`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb66e512f6816b66942e4f7cdf256e2b5513d877. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->