### PR TITLE
fix: transaction pay loading

### DIFF
--- a/app/components/Views/confirmations/components/footer/footer.test.tsx
+++ b/app/components/Views/confirmations/components/footer/footer.test.tsx
@@ -23,6 +23,7 @@ import {
 } from '../../__mocks__/controllers/transaction-controller-mock';
 import { transactionApprovalControllerMock } from '../../__mocks__/controllers/approval-controller-mock';
 import { TransactionType } from '@metamask/transaction-controller';
+import { useIsTransactionPayLoading } from '../../hooks/pay/useIsTransactionPayLoading';
 
 const mockConfirmSpy = jest.fn();
 const mockRejectSpy = jest.fn();
@@ -67,6 +68,8 @@ jest.mock('../../hooks/metrics/useConfirmationAlertMetrics', () => ({
   useConfirmationAlertMetrics: jest.fn(),
 }));
 
+jest.mock('../../hooks/pay/useIsTransactionPayLoading');
+
 const mockTrackAlertMetrics = jest.fn();
 
 (useConfirmationAlertMetrics as jest.Mock).mockReturnValue({
@@ -87,21 +90,30 @@ const mockAlerts = [
 
 describe('Footer', () => {
   const mockUseConfirmationContext = jest.mocked(useConfirmationContext);
+  const useIsTransactionPayLoadingMock = jest.mocked(
+    useIsTransactionPayLoading,
+  );
+
   beforeEach(() => {
     jest.clearAllMocks();
+
     mockUseConfirmationContext.mockReturnValue({
       isFooterVisible: true,
       isTransactionValueUpdating: false,
       setIsFooterVisible: jest.fn(),
       setIsTransactionValueUpdating: jest.fn(),
     });
+
     (useAlerts as jest.Mock).mockReturnValue({
       fieldAlerts: [],
       hasDangerAlerts: false,
     });
+
     (useAlertsConfirmed as jest.Mock).mockReturnValue({
       hasUnconfirmedDangerAlerts: false,
     });
+
+    useIsTransactionPayLoadingMock.mockReturnValue({ isLoading: false });
   });
 
   it('should render correctly', () => {
@@ -205,6 +217,8 @@ describe('Footer', () => {
   });
 
   it('disables confirm button if quotes are loading', () => {
+    useIsTransactionPayLoadingMock.mockReturnValue({ isLoading: true });
+
     const state = merge(
       {},
       simpleSendTransactionControllerMock,
@@ -385,18 +399,13 @@ describe('Footer', () => {
         hasUnconfirmedDangerAlerts: true,
       });
 
+      useIsTransactionPayLoadingMock.mockReturnValue({ isLoading: true });
+
       const { getByText } = renderWithProvider(<Footer />, {
         state: merge(
           {},
           simpleSendTransactionControllerMock,
           transactionApprovalControllerMock,
-          {
-            confirmationMetrics: {
-              isTransactionBridgeQuotesLoadingById: {
-                [transactionIdMock]: true,
-              },
-            },
-          },
         ),
       });
 

--- a/app/components/Views/confirmations/components/footer/footer.tsx
+++ b/app/components/Views/confirmations/components/footer/footer.tsx
@@ -30,13 +30,11 @@ import { useConfirmActions } from '../../hooks/useConfirmActions';
 import { isStakingConfirmation } from '../../utils/confirm';
 import styleSheet from './footer.styles';
 import Routes from '../../../../../constants/navigation/Routes';
-import { selectIsTransactionBridgeQuotesLoadingById } from '../../../../../core/redux/slices/confirmationMetrics';
-import { useSelector } from 'react-redux';
-import { RootState } from '../../../../../reducers';
 import { TransactionType } from '@metamask/transaction-controller';
 import { REDESIGNED_TRANSFER_TYPES } from '../../constants/confirmations';
 import { hasTransactionType } from '../../utils/transaction';
 import { PredictClaimFooter } from '../predict-confirmations/predict-claim-footer/predict-claim-footer';
+import { useIsTransactionPayLoading } from '../../hooks/pay/useIsTransactionPayLoading';
 
 const HIDE_FOOTER_BY_DEFAULT_TYPES = [
   TransactionType.perpsDeposit,
@@ -61,6 +59,7 @@ export const Footer = () => {
   const transactionType = transactionMetadata?.type as TransactionType;
   const isStakingConfirmationBool = isStakingConfirmation(transactionType);
   const isSendReq = REDESIGNED_TRANSFER_TYPES.includes(transactionType);
+  const { isLoading: isPayLoading } = useIsTransactionPayLoading();
 
   const { isFooterVisible: isFooterVisibleFlag, isTransactionValueUpdating } =
     useConfirmationContext();
@@ -69,13 +68,6 @@ export const Footer = () => {
 
   const [confirmAlertModalVisible, setConfirmAlertModalVisible] =
     useState(false);
-
-  const isQuotesLoading = useSelector((state: RootState) =>
-    selectIsTransactionBridgeQuotesLoadingById(
-      state,
-      transactionMetadata?.id ?? '',
-    ),
-  );
 
   const showConfirmAlertModal = useCallback(() => {
     setConfirmAlertModalVisible(true);
@@ -122,7 +114,7 @@ export const Footer = () => {
       return strings('confirm.qr_get_sign');
     }
 
-    if (isQuotesLoading) {
+    if (isPayLoading) {
       return strings('confirm.confirm');
     }
 
@@ -140,7 +132,7 @@ export const Footer = () => {
   };
 
   const getStartIcon = () => {
-    if (isQuotesLoading) {
+    if (isPayLoading) {
       return undefined;
     }
 
@@ -156,7 +148,7 @@ export const Footer = () => {
     needsCameraPermission ||
     hasBlockingAlerts ||
     isTransactionValueUpdating ||
-    isQuotesLoading;
+    isPayLoading;
 
   const buttons = [
     {
@@ -170,7 +162,7 @@ export const Footer = () => {
     {
       variant: ButtonVariants.Primary,
       isDanger:
-        !isQuotesLoading &&
+        !isPayLoading &&
         (securityAlertResponse?.result_type === ResultType.Malicious ||
           hasDangerAlerts),
       isDisabled: isConfirmDisabled,

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -24,13 +24,11 @@ import {
   CustomAmountSkeleton,
 } from '../../transactions/custom-amount';
 import { useSelector } from 'react-redux';
-import {
-  selectIsTransactionBridgeQuotesLoadingById,
-  selectTransactionBridgeQuotesById,
-} from '../../../../../../core/redux/slices/confirmationMetrics';
+import { selectTransactionBridgeQuotesById } from '../../../../../../core/redux/slices/confirmationMetrics';
 import { RootState } from '../../../../../../reducers';
 import { useTransactionPayTokenAmounts } from '../../../hooks/pay/useTransactionPayTokenAmounts';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
+import { useIsTransactionPayLoading } from '../../../hooks/pay/useIsTransactionPayLoading';
 
 export interface CustomAmountInfoProps {
   currency?: string;
@@ -148,17 +146,14 @@ function useIsResultReady({
   const transactionMeta = useTransactionMetadataRequest();
   const { amounts: sourceAmounts } = useTransactionPayTokenAmounts();
   const transactionId = transactionMeta?.id ?? '';
+  const { isLoading } = useIsTransactionPayLoading();
 
   const quotes = useSelector((state: RootState) =>
     selectTransactionBridgeQuotesById(state, transactionId),
   );
 
-  const isQuotesLoading = useSelector((state: RootState) =>
-    selectIsTransactionBridgeQuotesLoadingById(state, transactionId),
-  );
-
   return (
     !isKeyboardVisible &&
-    (isQuotesLoading || Boolean(quotes?.length) || sourceAmounts?.length === 0)
+    (isLoading || Boolean(quotes?.length) || sourceAmounts?.length === 0)
   );
 }

--- a/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
@@ -15,8 +15,10 @@ import {
   TransactionControllerState,
   TransactionType,
 } from '@metamask/transaction-controller';
+import { useIsTransactionPayLoading } from '../../../hooks/pay/useIsTransactionPayLoading';
 
 jest.mock('../../../hooks/pay/useTransactionTotalFiat');
+jest.mock('../../../hooks/pay/useIsTransactionPayLoading');
 
 const TRANSACTION_FEE_MOCK = '$1.23';
 const NETWORK_FEE_MOCK = '$0.45';
@@ -24,10 +26,8 @@ const BRIDGE_FEE_MOCK = '$0.78';
 
 function render({
   quotes = [],
-  isLoading = false,
 }: {
   quotes?: Partial<TransactionBridgeQuote>[];
-  isLoading?: boolean;
 } = {}) {
   const state = merge(
     {},
@@ -35,9 +35,6 @@ function render({
     transactionApprovalControllerMock,
     {
       confirmationMetrics: {
-        isTransactionBridgeQuotesLoadingById: {
-          [transactionIdMock]: isLoading,
-        },
         transactionBridgeQuotesById: {
           [transactionIdMock]: quotes,
         },
@@ -55,6 +52,9 @@ function render({
 
 describe('BridgeFeeRow', () => {
   const useTransactionTotalFiatMock = jest.mocked(useTransactionTotalFiat);
+  const useIsTransactionPayLoadingMock = jest.mocked(
+    useIsTransactionPayLoading,
+  );
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -64,6 +64,8 @@ describe('BridgeFeeRow', () => {
       totalNativeEstimatedFormatted: NETWORK_FEE_MOCK,
       totalBridgeFeeFormatted: BRIDGE_FEE_MOCK,
     } as ReturnType<typeof useTransactionTotalFiat>);
+
+    useIsTransactionPayLoadingMock.mockReturnValue({ isLoading: false });
   });
 
   it('renders transaction fee', async () => {
@@ -99,7 +101,10 @@ describe('BridgeFeeRow', () => {
   });
 
   it('renders skeletons if quotes loading', async () => {
-    const { getByTestId } = render({ isLoading: true });
+    useIsTransactionPayLoadingMock.mockReturnValue({ isLoading: true });
+
+    const { getByTestId } = render();
+
     expect(getByTestId('bridge-fee-row-skeleton')).toBeDefined();
     expect(getByTestId('metamask-fee-row-skeleton')).toBeDefined();
   });

--- a/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
+++ b/app/components/Views/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
@@ -1,10 +1,7 @@
 import React, { ReactNode } from 'react';
 import InfoRow from '../../UI/info-row';
 import { useTransactionMetadataOrThrow } from '../../../hooks/transactions/useTransactionMetadataRequest';
-import {
-  selectIsTransactionBridgeQuotesLoadingById,
-  selectTransactionBridgeQuotesById,
-} from '../../../../../../core/redux/slices/confirmationMetrics';
+import { selectTransactionBridgeQuotesById } from '../../../../../../core/redux/slices/confirmationMetrics';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../../../../../reducers';
 import Text, {
@@ -22,17 +19,15 @@ import { Box } from '../../../../../UI/Box/Box';
 import { FlexDirection, JustifyContent } from '../../../../../UI/Box/box.types';
 import { SkeletonRow } from '../skeleton-row';
 import { hasTransactionType } from '../../../utils/transaction';
+import { useIsTransactionPayLoading } from '../../../hooks/pay/useIsTransactionPayLoading';
 
 export function BridgeFeeRow() {
+  const fiatFormatter = useFiatFormatter();
+  const { totalTransactionFeeFormatted } = useTransactionTotalFiat();
+  const { isLoading } = useIsTransactionPayLoading();
+
   const transactionMetadata = useTransactionMetadataOrThrow();
   const { id: transactionId } = transactionMetadata;
-
-  const { totalTransactionFeeFormatted } = useTransactionTotalFiat();
-  const fiatFormatter = useFiatFormatter();
-
-  const isQuotesLoading = useSelector((state: RootState) =>
-    selectIsTransactionBridgeQuotesLoadingById(state, transactionId),
-  );
 
   const quotes = useSelector((state: RootState) =>
     selectTransactionBridgeQuotesById(state, transactionId),
@@ -40,7 +35,7 @@ export function BridgeFeeRow() {
 
   const hasQuotes = Boolean(quotes?.length);
 
-  if (isQuotesLoading) {
+  if (isLoading) {
     return (
       <>
         <SkeletonRow testId="bridge-fee-row-skeleton" />

--- a/app/components/Views/confirmations/components/rows/bridge-time-row/bridge-time-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/bridge-time-row/bridge-time-row.test.tsx
@@ -9,13 +9,14 @@ import {
 import { transactionApprovalControllerMock } from '../../../__mocks__/controllers/approval-controller-mock';
 import { TransactionBridgeQuote } from '../../../utils/bridge';
 import { ConfirmationMetricsState } from '../../../../../../core/redux/slices/confirmationMetrics';
+import { useIsTransactionPayLoading } from '../../../hooks/pay/useIsTransactionPayLoading';
+
+jest.mock('../../../hooks/pay/useIsTransactionPayLoading');
 
 function render({
   quotes = [],
-  isLoading = false,
 }: {
   quotes?: Partial<TransactionBridgeQuote>[];
-  isLoading?: boolean;
 } = {}) {
   const state = merge(
     {},
@@ -23,9 +24,6 @@ function render({
     transactionApprovalControllerMock,
     {
       confirmationMetrics: {
-        isTransactionBridgeQuotesLoadingById: {
-          [transactionIdMock]: isLoading,
-        },
         transactionBridgeQuotesById: {
           [transactionIdMock]: quotes,
         },
@@ -37,8 +35,14 @@ function render({
 }
 
 describe('BridgeTimeRow', () => {
+  const useIsTransactionPayLoadingMock = jest.mocked(
+    useIsTransactionPayLoading,
+  );
+
   beforeEach(() => {
     jest.resetAllMocks();
+
+    useIsTransactionPayLoadingMock.mockReturnValue({ isLoading: false });
   });
 
   it('renders total estimated time', async () => {
@@ -57,7 +61,10 @@ describe('BridgeTimeRow', () => {
   });
 
   it('renders skeleton if quotes loading', async () => {
-    const { getByTestId } = render({ isLoading: true });
+    useIsTransactionPayLoadingMock.mockReturnValue({ isLoading: true });
+
+    const { getByTestId } = render();
+
     expect(getByTestId(`bridge-time-row-skeleton`)).toBeDefined();
   });
 });

--- a/app/components/Views/confirmations/components/rows/bridge-time-row/bridge-time-row.tsx
+++ b/app/components/Views/confirmations/components/rows/bridge-time-row/bridge-time-row.tsx
@@ -2,27 +2,22 @@ import React from 'react';
 import { strings } from '../../../../../../../locales/i18n';
 import InfoRow from '../../UI/info-row';
 import { useTransactionMetadataOrThrow } from '../../../hooks/transactions/useTransactionMetadataRequest';
-import {
-  selectIsTransactionBridgeQuotesLoadingById,
-  selectTransactionBridgeQuotesById,
-} from '../../../../../../core/redux/slices/confirmationMetrics';
+import { selectTransactionBridgeQuotesById } from '../../../../../../core/redux/slices/confirmationMetrics';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../../../../../reducers';
 import Text from '../../../../../../component-library/components/Texts/Text';
 import { SkeletonRow } from '../skeleton-row';
+import { useIsTransactionPayLoading } from '../../../hooks/pay/useIsTransactionPayLoading';
 
 export function BridgeTimeRow() {
   const { id: transactionId } = useTransactionMetadataOrThrow();
-
-  const isQuotesLoading = useSelector((state: RootState) =>
-    selectIsTransactionBridgeQuotesLoadingById(state, transactionId),
-  );
+  const { isLoading } = useIsTransactionPayLoading();
 
   const quotes = useSelector((state: RootState) =>
     selectTransactionBridgeQuotesById(state, transactionId),
   );
 
-  const showEstimate = isQuotesLoading || Boolean(quotes?.length);
+  const showEstimate = isLoading || Boolean(quotes?.length);
 
   const estimatedTimeSeconds = quotes?.reduce(
     (acc, quote) => acc + quote.estimatedProcessingTimeInSeconds,
@@ -33,7 +28,7 @@ export function BridgeTimeRow() {
     return null;
   }
 
-  if (isQuotesLoading) {
+  if (isLoading) {
     return <SkeletonRow testId="bridge-time-row-skeleton" />;
   }
 

--- a/app/components/Views/confirmations/components/rows/total-row/total-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/total-row/total-row.test.tsx
@@ -3,36 +3,30 @@ import { useTransactionTotalFiat } from '../../../hooks/pay/useTransactionTotalF
 import { TotalRow } from './total-row';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import { merge } from 'lodash';
-import {
-  simpleSendTransactionControllerMock,
-  transactionIdMock,
-} from '../../../__mocks__/controllers/transaction-controller-mock';
-import { ConfirmationMetricsState } from '../../../../../../core/redux/slices/confirmationMetrics';
+import { simpleSendTransactionControllerMock } from '../../../__mocks__/controllers/transaction-controller-mock';
 import { transactionApprovalControllerMock } from '../../../__mocks__/controllers/approval-controller-mock';
+import { useIsTransactionPayLoading } from '../../../hooks/pay/useIsTransactionPayLoading';
 
 jest.mock('../../../hooks/pay/useTransactionTotalFiat');
+jest.mock('../../../hooks/pay/useIsTransactionPayLoading');
 
 const TOTAL_FIAT_MOCK = '$123.456';
 
-function render({ isLoading }: { isLoading?: boolean } = {}) {
+function render() {
   return renderWithProvider(<TotalRow />, {
     state: merge(
       {},
       simpleSendTransactionControllerMock,
       transactionApprovalControllerMock,
-      {
-        confirmationMetrics: {
-          isTransactionBridgeQuotesLoadingById: {
-            [transactionIdMock]: isLoading,
-          },
-        } as unknown as ConfirmationMetricsState,
-      },
     ),
   });
 }
 
 describe('TotalRow', () => {
   const useTransactionTotalFiatMock = jest.mocked(useTransactionTotalFiat);
+  const useIsTransactionPayLoadingMock = jest.mocked(
+    useIsTransactionPayLoading,
+  );
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -41,6 +35,8 @@ describe('TotalRow', () => {
       total: '123.456',
       totalFormatted: TOTAL_FIAT_MOCK,
     } as ReturnType<typeof useTransactionTotalFiat>);
+
+    useIsTransactionPayLoadingMock.mockReturnValue({ isLoading: false });
   });
 
   it('renders the total amount', () => {
@@ -49,7 +45,10 @@ describe('TotalRow', () => {
   });
 
   it('renders skeleton when quotes are loading', () => {
-    const { getByTestId } = render({ isLoading: true });
+    useIsTransactionPayLoadingMock.mockReturnValue({ isLoading: true });
+
+    const { getByTestId } = render();
+
     expect(getByTestId('total-row-skeleton')).toBeDefined();
   });
 });

--- a/app/components/Views/confirmations/components/rows/total-row/total-row.tsx
+++ b/app/components/Views/confirmations/components/rows/total-row/total-row.tsx
@@ -3,22 +3,15 @@ import Text from '../../../../../../component-library/components/Texts/Text';
 import InfoRow from '../../UI/info-row';
 import { useTransactionTotalFiat } from '../../../hooks/pay/useTransactionTotalFiat';
 import { strings } from '../../../../../../../locales/i18n';
-import { useTransactionMetadataOrThrow } from '../../../hooks/transactions/useTransactionMetadataRequest';
-import { useSelector } from 'react-redux';
-import { selectIsTransactionBridgeQuotesLoadingById } from '../../../../../../core/redux/slices/confirmationMetrics';
-import { RootState } from '../../../../../../reducers';
 import { View } from 'react-native';
 import { SkeletonRow } from '../skeleton-row';
+import { useIsTransactionPayLoading } from '../../../hooks/pay/useIsTransactionPayLoading';
 
 export function TotalRow() {
-  const { id: transactionId } = useTransactionMetadataOrThrow();
   const { totalFormatted } = useTransactionTotalFiat({ log: true });
+  const { isLoading } = useIsTransactionPayLoading();
 
-  const isQuotesLoading = useSelector((state: RootState) =>
-    selectIsTransactionBridgeQuotesLoadingById(state, transactionId),
-  );
-
-  if (isQuotesLoading) {
+  if (isLoading) {
     return <SkeletonRow testId="total-row-skeleton" />;
   }
 

--- a/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.test.ts
@@ -15,8 +15,10 @@ import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
 import { AlertKeys } from '../../constants/alerts';
 import { TransactionBridgeQuote } from '../../utils/bridge';
 import { strings } from '../../../../../../locales/i18n';
+import { useIsTransactionPayLoading } from '../pay/useIsTransactionPayLoading';
 
 jest.mock('../pay/useTransactionPayToken');
+jest.mock('../pay/useIsTransactionPayLoading');
 
 const STATE_MOCK = merge(
   {},
@@ -29,10 +31,8 @@ const CHAIN_ID_MOCK = '0x123' as Hex;
 
 function runHook({
   quotes,
-  isQuotesLoading,
 }: {
   quotes?: Partial<TransactionBridgeQuote>[];
-  isQuotesLoading?: boolean;
 } = {}) {
   const state = cloneDeep(STATE_MOCK);
 
@@ -40,9 +40,6 @@ function runHook({
     metricsById: {},
     transactionBridgeQuotesById: {
       [transactionIdMock]: quotes ?? undefined,
-    },
-    isTransactionBridgeQuotesLoadingById: {
-      [transactionIdMock]: isQuotesLoading ?? false,
     },
   } as unknown as ConfirmationMetricsState;
 
@@ -53,6 +50,9 @@ function runHook({
 
 describe('useNoPayTokenQuotesAlert', () => {
   const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
+  const useIsTransactionPayLoadingMock = jest.mocked(
+    useIsTransactionPayLoading,
+  );
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -63,6 +63,8 @@ describe('useNoPayTokenQuotesAlert', () => {
         chainId: CHAIN_ID_MOCK,
       },
     } as ReturnType<typeof useTransactionPayToken>);
+
+    useIsTransactionPayLoadingMock.mockReturnValue({ isLoading: false });
   });
 
   it('returns alert if pay token selected and no quotes available', () => {
@@ -85,7 +87,10 @@ describe('useNoPayTokenQuotesAlert', () => {
   });
 
   it('returns no alerts if quotes loading', () => {
-    const { result } = runHook({ isQuotesLoading: true });
+    useIsTransactionPayLoadingMock.mockReturnValue({ isLoading: true });
+
+    const { result } = runHook();
+
     expect(result.current).toStrictEqual([]);
   });
 

--- a/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.ts
@@ -1,31 +1,26 @@
 import { useSelector } from 'react-redux';
 import { useTransactionPayToken } from '../pay/useTransactionPayToken';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
-import {
-  selectIsTransactionBridgeQuotesLoadingById,
-  selectTransactionBridgeQuotesById,
-} from '../../../../../core/redux/slices/confirmationMetrics';
+import { selectTransactionBridgeQuotesById } from '../../../../../core/redux/slices/confirmationMetrics';
 import { RootState } from '../../../../../reducers';
 import { useMemo } from 'react';
 import { AlertKeys } from '../../constants/alerts';
 import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
 import { Severity } from '../../types/alerts';
 import { strings } from '../../../../../../locales/i18n';
+import { useIsTransactionPayLoading } from '../pay/useIsTransactionPayLoading';
 
 export function useNoPayTokenQuotesAlert() {
   const transactionMeta = useTransactionMetadataRequest();
   const transactionId = transactionMeta?.id ?? '';
   const { payToken } = useTransactionPayToken();
+  const { isLoading } = useIsTransactionPayLoading();
 
   const quotes = useSelector((state: RootState) =>
     selectTransactionBridgeQuotesById(state, transactionId),
   );
 
-  const quotesLoading = useSelector((state: RootState) =>
-    selectIsTransactionBridgeQuotesLoadingById(state, transactionId),
-  );
-
-  const showAlert = payToken && !quotesLoading && quotes === undefined;
+  const showAlert = payToken && !isLoading && quotes === undefined;
 
   return useMemo(() => {
     if (!showAlert) {

--- a/app/components/Views/confirmations/hooks/pay/useIsTransactionPayLoading.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useIsTransactionPayLoading.test.ts
@@ -1,0 +1,51 @@
+import { merge } from 'lodash';
+import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
+import {
+  simpleSendTransactionControllerMock,
+  transactionIdMock,
+} from '../../__mocks__/controllers/transaction-controller-mock';
+import { useIsTransactionPayLoading } from './useIsTransactionPayLoading';
+import { transactionApprovalControllerMock } from '../../__mocks__/controllers/approval-controller-mock';
+
+function runHook({
+  isQuotesLoading,
+  isUpdating,
+}: {
+  isQuotesLoading?: boolean;
+  isUpdating?: boolean;
+} = {}) {
+  const { result } = renderHookWithProvider(useIsTransactionPayLoading, {
+    state: merge(
+      {},
+      simpleSendTransactionControllerMock,
+      transactionApprovalControllerMock,
+      {
+        confirmationMetrics: {
+          isTransactionBridgeQuotesLoadingById: {
+            [transactionIdMock]: isQuotesLoading,
+          },
+          isTransactionUpdating: { [transactionIdMock]: isUpdating },
+        },
+      },
+    ),
+  });
+
+  return result;
+}
+
+describe('useIsTransactionPayLoading', () => {
+  it('returns true if quotes loading', () => {
+    const result = runHook({ isQuotesLoading: true });
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('returns true if transaction updating', () => {
+    const result = runHook({ isUpdating: true });
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('returns false if neither quotes loading nor transaction updating', () => {
+    const result = runHook({ isQuotesLoading: false, isUpdating: false });
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/app/components/Views/confirmations/hooks/pay/useIsTransactionPayLoading.ts
+++ b/app/components/Views/confirmations/hooks/pay/useIsTransactionPayLoading.ts
@@ -1,0 +1,23 @@
+import { useSelector } from 'react-redux';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { RootState } from '../../../../../reducers';
+import {
+  selectIsTransactionBridgeQuotesLoadingById,
+  selectIsTransactionUpdatingById,
+} from '../../../../../core/redux/slices/confirmationMetrics';
+
+export function useIsTransactionPayLoading() {
+  const { id: transactionId } = useTransactionMetadataRequest() ?? { id: '' };
+
+  const isBridgeQuotesLoading = useSelector((state: RootState) =>
+    selectIsTransactionBridgeQuotesLoadingById(state, transactionId),
+  );
+
+  const isUpdating = useSelector((state: RootState) =>
+    selectIsTransactionUpdatingById(state, transactionId),
+  );
+
+  const isLoading = isBridgeQuotesLoading || isUpdating;
+
+  return { isLoading };
+}

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -4,8 +4,6 @@ import { useTokenFiatRate } from '../tokens/useTokenFiatRates';
 import { BigNumber } from 'bignumber.js';
 import { useTransactionMetadataRequest } from './useTransactionMetadataRequest';
 import { TransactionMeta } from '@metamask/transaction-controller';
-import { setTransactionBridgeQuotesLoading } from '../../../../../core/redux/slices/confirmationMetrics';
-import { useDispatch } from 'react-redux';
 import { useTransactionPayToken } from '../pay/useTransactionPayToken';
 import { useUpdateTokenAmount } from './useUpdateTokenAmount';
 import { getTokenTransferData } from '../../utils/transaction-pay';
@@ -13,12 +11,11 @@ import { getTokenTransferData } from '../../utils/transaction-pay';
 export const MAX_LENGTH = 28;
 
 export function useTransactionCustomAmount() {
-  const dispatch = useDispatch();
   const [amountFiat, setAmountFiat] = useState('0');
   const [isInputChanged, setInputChanged] = useState(false);
 
   const transactionMeta = useTransactionMetadataRequest() as TransactionMeta;
-  const { chainId, id: transactionId } = transactionMeta;
+  const { chainId } = transactionMeta;
 
   const tokenAddress = getTokenAddress(transactionMeta);
   const tokenFiatRate = useTokenFiatRate(tokenAddress, chainId);
@@ -69,12 +66,8 @@ export function useTransactionCustomAmount() {
   );
 
   const updateTokenAmount = useCallback(() => {
-    dispatch(
-      setTransactionBridgeQuotesLoading({ transactionId, isLoading: true }),
-    );
-
     updateTokenAmountCallback(amountHuman);
-  }, [amountHuman, dispatch, transactionId, updateTokenAmountCallback]);
+  }, [amountHuman, updateTokenAmountCallback]);
 
   return {
     amountFiat,

--- a/app/components/Views/confirmations/hooks/transactions/useUpdateTokenAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useUpdateTokenAmount.test.ts
@@ -13,8 +13,17 @@ import {
 } from '../../__mocks__/controllers/other-controllers-mock';
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { toHex } from 'viem';
+import { setTransactionUpdating } from '../../../../../core/redux/slices/confirmationMetrics';
+import { act } from '@testing-library/react-native';
 
 jest.mock('../../../../../util/transaction-controller');
+
+jest.mock('../../../../../core/redux/slices/confirmationMetrics', () => ({
+  ...(jest.requireActual(
+    '../../../../../core/redux/slices/confirmationMetrics',
+  ) as object),
+  setTransactionUpdating: jest.fn(),
+}));
 
 const TOKEN_TRANSFER_DATA_MOCK =
   '0xa9059cbb0000000000000000000000005aeda56215b167893e80b4fe645ba6d5bab767de0000000000000000000000000000000000000000000000000000000000000001';
@@ -48,11 +57,13 @@ function runHook({
 describe('useUpdateTokenAmount', () => {
   const updateEditableParamsMock = jest.mocked(updateEditableParams);
   const updateAtomicBatchDataMock = jest.mocked(updateAtomicBatchData);
+  const setTransactionUpdatingMock = jest.mocked(setTransactionUpdating);
 
   beforeEach(() => {
     jest.resetAllMocks();
 
     updateAtomicBatchDataMock.mockResolvedValue('0x0');
+    setTransactionUpdatingMock.mockReturnValue({ type: 'test' } as never);
   });
 
   it('updates all transaction data with new amount', () => {
@@ -103,6 +114,27 @@ describe('useUpdateTokenAmount', () => {
           0,
           TOKEN_TRANSFER_DATA_MOCK.length - 4,
         ) + toHex(15000).substring(2),
+    });
+  });
+
+  it('sets updating', async () => {
+    const { result } = runHook({
+      transactionMeta: {
+        txParams: {
+          data: TOKEN_TRANSFER_DATA_MOCK,
+          from: '0x13',
+          to: tokenAddress1Mock,
+        },
+      },
+    });
+
+    await act(async () => {
+      result.current.updateTokenAmount('1.5');
+    });
+
+    expect(setTransactionUpdatingMock).toHaveBeenCalledWith({
+      transactionId: expect.any(String),
+      isUpdating: true,
     });
   });
 });

--- a/app/core/redux/slices/confirmationMetrics/index.test.ts
+++ b/app/core/redux/slices/confirmationMetrics/index.test.ts
@@ -11,6 +11,8 @@ import reducer, {
   selectTransactionBridgeQuotesById,
   selectIsTransactionBridgeQuotesLoadingById,
   setTransactionBridgeQuotesLoading,
+  setTransactionUpdating,
+  selectIsTransactionUpdatingById,
 } from './index';
 import { RootState } from '../../../../reducers';
 import { TransactionBridgeQuote } from '../../../../components/Views/confirmations/utils/bridge';
@@ -225,6 +227,41 @@ describe('confirmationMetrics slice', () => {
       const state = reducer(initialState, action);
 
       expect(state.isTransactionBridgeQuotesLoadingById[ID_MOCK]).toBe(true);
+    });
+  });
+
+  describe('setTransactionUpdating', () => {
+    it('updates updating state for ID', () => {
+      const action = setTransactionUpdating({
+        transactionId: ID_MOCK,
+        isUpdating: true,
+      });
+
+      const state = reducer(initialState, action);
+
+      expect(state.isTransactionUpdating[ID_MOCK]).toBe(true);
+    });
+  });
+
+  describe('selectIsTransactionUpdatingById', () => {
+    it('returns true if set as updating in state', () => {
+      const state = {
+        confirmationMetrics: {
+          isTransactionUpdating: { [ID_MOCK]: true },
+        },
+      } as unknown as RootState;
+
+      expect(selectIsTransactionUpdatingById(state, ID_MOCK)).toBe(true);
+    });
+
+    it('returns false if not in state', () => {
+      const state = {
+        confirmationMetrics: {
+          isTransactionUpdating: {},
+        },
+      } as unknown as RootState;
+
+      expect(selectIsTransactionUpdatingById(state, ID_MOCK)).toBe(false);
     });
   });
 });

--- a/app/core/redux/slices/confirmationMetrics/index.ts
+++ b/app/core/redux/slices/confirmationMetrics/index.ts
@@ -23,6 +23,7 @@ export interface ConfirmationMetricsState {
     TransactionBridgeQuote[] | undefined
   >;
   isTransactionBridgeQuotesLoadingById: Record<string, boolean>;
+  isTransactionUpdating: Record<string, boolean>;
 }
 
 export const initialState: ConfirmationMetricsState = {
@@ -30,6 +31,7 @@ export const initialState: ConfirmationMetricsState = {
   transactionPayTokenById: {},
   transactionBridgeQuotesById: {},
   isTransactionBridgeQuotesLoadingById: {},
+  isTransactionUpdating: {},
 };
 
 const name = 'confirmationMetrics';
@@ -89,6 +91,17 @@ const slice = createSlice({
       const { transactionId, isLoading } = action.payload;
       state.isTransactionBridgeQuotesLoadingById[transactionId] = isLoading;
     },
+
+    setTransactionUpdating: (
+      state,
+      action: PayloadAction<{
+        transactionId: string;
+        isUpdating: boolean;
+      }>,
+    ) => {
+      const { transactionId, isUpdating } = action.payload;
+      state.isTransactionUpdating[transactionId] = isUpdating;
+    },
   },
 });
 
@@ -102,6 +115,7 @@ export const {
   setTransactionPayToken,
   setTransactionBridgeQuotes,
   setTransactionBridgeQuotesLoading,
+  setTransactionUpdating,
 } = actions;
 
 // Selectors
@@ -128,4 +142,11 @@ export const selectIsTransactionBridgeQuotesLoadingById = createSelector(
   (_: RootState, transactionId: string) => transactionId,
   (isTransactionBridgeQuotesLoadingById, transactionId) =>
     isTransactionBridgeQuotesLoadingById[transactionId] ?? false,
+);
+
+export const selectIsTransactionUpdatingById = createSelector(
+  (state: RootState) => state[name].isTransactionUpdating,
+  (_: RootState, transactionId: string) => transactionId,
+  (isTransactionUpdating, transactionId) =>
+    isTransactionUpdating[transactionId] ?? false,
 );


### PR DESCRIPTION
## **Description**

Show skeletons in MetaMask pay rows if quotes are loading, or transaction data is updating.

Determined using new `useIsTransactionPayLoading` hook and `isTransactionUpdating` reducer state.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds useIsTransactionPayLoading and isTransactionUpdating to drive loading states across confirmation UI, updating rows/footer behavior and tests.
> 
> - **Hooks/UI**:
>   - Add `useIsTransactionPayLoading` to centralize pay loading (bridge quotes loading or transaction updating).
>   - Update `Footer`, `BridgeFeeRow`, `BridgeTimeRow`, `TotalRow`, and `CustomAmountInfo` to use `isLoading` for labels, icons, disabled state, and skeletons.
>   - Refactor `useTransactionCustomAmount` to stop dispatching quotes-loading; rely on `useUpdateTokenAmount`.
>   - Enhance `useUpdateTokenAmount` to track previous amount and dispatch `setTransactionUpdating` while data updates.
>   - Adjust `useNoPayTokenQuotesAlert` to suppress alert during `isLoading`.
> - **Redux**:
>   - Extend `confirmationMetrics` with `isTransactionUpdating`, action `setTransactionUpdating`, and selector `selectIsTransactionUpdatingById`.
> - **Tests**:
>   - Add tests for `useIsTransactionPayLoading` and updating behavior; update component and alert tests to mock new hook and states.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1dc51c4a18e2a0cc1ea99504c5a9ffb2e65d11f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->