### PR TITLE
fix: fix displayed warning for network

### DIFF
--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
@@ -1482,9 +1482,11 @@ export class NetworkSettings extends PureComponent {
     this.getCurrentState();
   };
 
-  onTickerChange = async (ticker) => {
-    await this.setState({ ticker, validatedSymbol: false });
-    this.getCurrentState();
+  onTickerChange = (ticker) => {
+    this.setState({ ticker, validatedSymbol: false }, () => {
+      this.getCurrentState();
+      this.validateSymbol();
+    });
   };
 
   // this function will autofill the symbol field with the value in parameter

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
@@ -1182,6 +1182,9 @@ export class NetworkSettings extends PureComponent {
    */
   validateSymbol = (chainToMatch = null) => {
     const { ticker, networkList, chainId } = this.state;
+    const { networkConfigurations } = this.props;
+    const networkConfiguration = networkConfigurations[chainId];
+    const networkConfigurationSymbol = networkConfiguration?.nativeCurrency;
 
     if (isWhitelistedSymbol(chainId, ticker)) {
       return this.setState({
@@ -1196,7 +1199,9 @@ export class NetworkSettings extends PureComponent {
       return;
     }
 
-    const symbol = chainToMatch
+    const symbol = networkConfigurationSymbol
+      ? networkConfigurationSymbol
+      : chainToMatch
       ? chainToMatch?.nativeCurrency?.symbol ?? null
       : networkList?.nativeCurrency?.symbol ?? null;
 

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.test.tsx
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.test.tsx
@@ -1091,6 +1091,32 @@ describe('NetworkSettings', () => {
       expect(instance.state.warningSymbol).toBeUndefined(); // No warning for valid symbol
     });
 
+    it('should not show warning symbol for Sepolia when getting symbol from network configuration', async () => {
+      const instance = wrapper.instance();
+
+      wrapper.setProps({
+        useSafeChainsListValidation: true,
+        networkConfigurations: {
+          '0xaa36a7': {
+            chainId: '0xaa36a7',
+            defaultBlockExplorerUrlIndex: 0,
+            defaultRpcEndpointIndex: 0,
+            name: 'Sepolia',
+            nativeCurrency: 'SepoliaETH',
+          },
+        },
+      });
+
+      instance.setState({
+        chainId: '0xaa36a7', // Sepolia chain ID
+        ticker: 'SepoliaETH',
+      });
+
+      await instance.validateSymbol();
+
+      expect(instance.state.warningSymbol).toBeUndefined(); // No warning for valid symbol
+    });
+
     it('should validateChainIdOnSubmit', async () => {
       const instance = wrapper.instance();
 

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.test.tsx
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.test.tsx
@@ -1117,6 +1117,28 @@ describe('NetworkSettings', () => {
       expect(instance.state.warningSymbol).toBeUndefined(); // No warning for valid symbol
     });
 
+    it('should fallback to chainToMatch symbol if network configuration is not found and show warning symbol', async () => {
+      const instance = wrapper.instance();
+
+      wrapper.setProps({
+        useSafeChainsListValidation: true,
+        networkConfigurations: {},
+      });
+
+      instance.setState({
+        chainId: '0xaa36a7', // Sepolia chain ID
+        ticker: 'SepoliaETH',
+      });
+
+      const chainToMatch = {
+        name: 'Test Network',
+        nativeCurrency: { symbol: 'TEST' },
+      };
+      await instance.validateSymbol(chainToMatch);
+
+      expect(instance.state.warningSymbol).toBe('TEST');
+    });
+
     it('should validateChainIdOnSubmit', async () => {
       const instance = wrapper.instance();
 


### PR DESCRIPTION
## **Description**

This PR fixes the display of symbol warning for SepoliaETH.
This was happening because the code was prioritizing the value we get from https://chainid.network/chains.json which has `"symbol": "ETH"`, for the Sepolia network.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug that was causing the user to see ETH as a suggested correct symbol for SepoliaETH.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/20757

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/9096c15f-68fa-499f-ba81-c57d37fd3218

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/f023bd9e-8e4d-40bd-a6e7-91e6a658354f

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Symbol validation now prefers `nativeCurrency` from `networkConfigurations` and revalidates on ticker updates; adds tests for Sepolia and fallback behavior.
> 
> - **Networks Settings (`app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js`)**:
>   - Update `validateSymbol` to prioritize `networkConfigurations[chainId]?.nativeCurrency` over Safe Chains list/network list when suggesting the symbol.
>   - Change `onTickerChange` to use `setState` callback, calling `getCurrentState` and `validateSymbol` immediately after ticker updates.
> - **Tests (`index.test.tsx`)**:
>   - Add tests ensuring no warning for Sepolia when symbol comes from `networkConfigurations` and fallback to `chainToMatch` when config is absent.
>   - Maintain existing validations for whitelisted symbols and general symbol/chain ID checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab709f2edc6817ba02c076092cdd1e8a779fcdae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->