### PR TITLE
feat: update transaction pay bridge estimates

### DIFF
--- a/app/components/Views/confirmations/components/rows/bridge-time-row/bridge-time-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/bridge-time-row/bridge-time-row.test.tsx
@@ -10,6 +10,7 @@ import { transactionApprovalControllerMock } from '../../../__mocks__/controller
 import { TransactionBridgeQuote } from '../../../utils/bridge';
 import { ConfirmationMetricsState } from '../../../../../../core/redux/slices/confirmationMetrics';
 import { useIsTransactionPayLoading } from '../../../hooks/pay/useIsTransactionPayLoading';
+import { QuoteResponse } from '@metamask/bridge-controller';
 
 jest.mock('../../../hooks/pay/useIsTransactionPayLoading');
 
@@ -45,19 +46,47 @@ describe('BridgeTimeRow', () => {
     useIsTransactionPayLoadingMock.mockReturnValue({ isLoading: false });
   });
 
-  it('renders total estimated time', async () => {
+  it.each([
+    ['less than 30 seconds', [11, 18], '< 1 min'],
+    ['exactly 30 seconds', [12, 18], '< 1 min'],
+    ['less than 60 seconds', [35, 10], '1 min'],
+    ['exactly 60 seconds', [30, 30], '1 min'],
+    ['greater than 60 seconds', [30, 31], '2 min'],
+    ['greater than 120 seconds', [60, 61], '3 min'],
+  ])(
+    'renders total estimated time if %s',
+    async (_title: string, durations: number[], expected: string) => {
+      const { getByText } = render({
+        quotes: durations.map(
+          (duration) =>
+            ({
+              estimatedProcessingTimeInSeconds: duration,
+              quote: {
+                srcChainId: 1,
+                destChainId: 2,
+              },
+            } as QuoteResponse),
+        ),
+      });
+
+      expect(getByText(expected)).toBeDefined();
+    },
+  );
+
+  it('renders total estimated time if payment token on same chain', async () => {
     const { getByText } = render({
       quotes: [
         {
-          estimatedProcessingTimeInSeconds: 11,
-        },
-        {
-          estimatedProcessingTimeInSeconds: 14,
-        },
+          estimatedProcessingTimeInSeconds: 120,
+          quote: {
+            srcChainId: 1,
+            destChainId: 1,
+          },
+        } as QuoteResponse,
       ],
     });
 
-    expect(getByText(`25 sec`)).toBeDefined();
+    expect(getByText('2 sec')).toBeDefined();
   });
 
   it('renders skeleton if quotes loading', async () => {

--- a/app/components/Views/confirmations/components/rows/bridge-time-row/bridge-time-row.tsx
+++ b/app/components/Views/confirmations/components/rows/bridge-time-row/bridge-time-row.tsx
@@ -9,6 +9,8 @@ import Text from '../../../../../../component-library/components/Texts/Text';
 import { SkeletonRow } from '../skeleton-row';
 import { useIsTransactionPayLoading } from '../../../hooks/pay/useIsTransactionPayLoading';
 
+const SAME_CHAIN_DURATION_SECONDS = 2;
+
 export function BridgeTimeRow() {
   const { id: transactionId } = useTransactionMetadataOrThrow();
   const { isLoading } = useIsTransactionPayLoading();
@@ -24,6 +26,10 @@ export function BridgeTimeRow() {
     0,
   );
 
+  const isSameChainPayment = (quotes ?? []).some(
+    (quote) => quote.quote.srcChainId === quote.quote.destChainId,
+  );
+
   if (!showEstimate) {
     return null;
   }
@@ -35,8 +41,26 @@ export function BridgeTimeRow() {
   return (
     <InfoRow label={strings('confirm.label.bridge_estimated_time')}>
       <Text>
-        {estimatedTimeSeconds} {strings('unit.second')}
+        {formatSeconds(estimatedTimeSeconds ?? 0, isSameChainPayment)}
       </Text>
     </InfoRow>
   );
+}
+
+function formatSeconds(seconds: number, isSameChainPayment: boolean) {
+  if (isSameChainPayment) {
+    return `${SAME_CHAIN_DURATION_SECONDS} ${strings('unit.second')}`;
+  }
+
+  if (seconds <= 30) {
+    return `< 1 ${strings('unit.minute')}`;
+  }
+
+  if (seconds <= 60) {
+    return `1 ${strings('unit.minute')}`;
+  }
+
+  const minutes = Math.ceil(seconds / 60);
+
+  return `${minutes} ${strings('unit.minute')}`;
 }


### PR DESCRIPTION
## **Description**

Format MetaMask pay estimated durations in minute bands such as `< 1 min` and `2 min`.

## **Changelog**

CHANGELOG entry: Format Perps deposit estimated durations into minute bands

## **Related issues**

Fixes: [#5916](https://github.com/MetaMask/MetaMask-planning/issues/5916)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Formats bridge estimated time into minute bands with a special 2-second value when payment is on the same chain, and updates tests accordingly.
> 
> - **UI (Confirmations)**:
>   - Update `bridge-time-row.tsx` to display estimated time using minute bands via `formatSeconds`:
>     - `<= 30 sec` => `< 1 min`, `<= 60 sec` => `1 min`, otherwise ceil to `N min`.
>     - Special-case when any quote has `srcChainId === destChainId` to show `2 sec`.
> - **Tests**:
>   - Refactor `bridge-time-row.test.tsx` to parameterize scenarios covering second-to-minute banding and the same-chain `2 sec` case.
>   - Use `QuoteResponse` type for quotes in tests and retain loading skeleton check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f6e8d6e5ea4c46bbd5de6c346c7e2239d177c2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->