### PR TITLE
fix: replace `any` types with proper TypeScript types in theme utilities

### DIFF
--- a/app/util/theme/index.ts
+++ b/app/util/theme/index.ts
@@ -11,6 +11,7 @@ import { AppThemeKey, Theme } from './models';
 import { useSelector } from 'react-redux';
 import { lightTheme, darkTheme, brandColor } from '@metamask/design-tokens';
 import Device from '../device';
+import type { RootState } from '../../reducers';
 
 /**
  * This is needed to make our unit tests pass since Enzyme doesn't support contextType
@@ -24,9 +25,7 @@ export const mockTheme = {
   brandColors: brandColor,
 };
 
-// TODO: Replace "any" with type
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const ThemeContext = React.createContext<any>(undefined);
+export const ThemeContext = React.createContext<Theme | undefined>(undefined);
 
 /**
  * Utility function for getting asset from theme (Class components)
@@ -37,16 +36,12 @@ export const ThemeContext = React.createContext<any>(undefined);
  * @param dark Dark asset
  * @returns
  */
-export const getAssetFromTheme = (
+export const getAssetFromTheme = <T>(
   appTheme: AppThemeKey,
   osColorScheme: ColorSchemeName,
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  light: any,
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  dark: any,
-) => {
+  light: T,
+  dark: T,
+): T => {
   let asset = light;
   switch (appTheme) {
     case AppThemeKey.light:
@@ -105,9 +100,7 @@ const useColorSchemeCustom = (
 export const useAppTheme = (): Theme => {
   const osThemeName = useColorSchemeCustom();
   const appTheme: AppThemeKey = useSelector(
-    // TODO: Replace "any" with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (state: any) => state.user.appTheme,
+    (state: RootState) => state.user.appTheme,
   );
   const themeAppearance = getAssetFromTheme(
     appTheme,
@@ -199,13 +192,9 @@ export const useTheme = (): Theme => {
  * @param dark Dark asset
  * @returns Asset based on theme
  */
-// TODO: Replace "any" with type
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const useAssetFromTheme = (light: any, dark: any) => {
+export const useAssetFromTheme = <T>(light: T, dark: T): T => {
   const osColorScheme = useColorScheme();
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const appTheme = useSelector((state: any) => state.user.appTheme);
+  const appTheme = useSelector((state: RootState) => state.user.appTheme);
   const asset = getAssetFromTheme(appTheme, osColorScheme, light, dark);
 
   return asset;


### PR DESCRIPTION
## **Description**

Replace all instances of `any` type with proper TypeScript types in theme utilities to improve type safety and remove technical debt. 

**Changes:**
- ThemeContext: `any` → `Theme | undefined`
- getAssetFromTheme: `any` parameters → generic `<T>`
- useSelector: `state: any` → `state: RootState`
- useAssetFromTheme: `any` parameters → generic `<T>`
- Added missing RootState import

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A (technical debt cleanup)

## **Manual testing steps**

```gherkin
Feature: Theme utilities type safety

  Scenario: Theme functions work with proper types
    Given the app is running
    When theme utilities are used throughout the app
    Then TypeScript compilation succeeds without any type errors
```

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and Coding Standards
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR
- [ ] I confirm that this PR addresses all acceptance criteria