### PR TITLE
fix: return hex chainId from getChainIdForCaipChainId mock

### DIFF
--- a/app/core/WalletConnect/WalletConnect2Session.test.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.test.ts
@@ -1057,7 +1057,7 @@ describe('WalletConnect2Session', () => {
           jest.requireMock('./wc-utils') as any,
           'getChainIdForCaipChainId',
         )
-        .mockReturnValue('eip155:2');
+        .mockReturnValue('0x2');
       const handleChainChangeSpy = jest.spyOn(
         session as any,
         'handleChainChange',


### PR DESCRIPTION
Change the mocked return of getChainIdForCaipChainId from a CAIP-2 value ('eip155:2') to a hex value ('0x2') in WalletConnect2Session.test.ts. The function’s contract returns a hex chainId and downstream code parses it with parseInt(hex, 16); returning CAIP-2 caused an early “Invalid chainId” error path, making the “invalid chainId network config” test flaky and incorrect. This aligns the mock with the API and ensures the test covers the intended permission error path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Change getChainIdForCaipChainId mock in `WalletConnect2Session.test.ts` to return hex `0x2` instead of CAIP-2 `eip155:2` to align with expected API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a87d15c53fc9390d8d7eb39f23d9aa5176645b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->