### PR TITLE
feat: add how to earn for card spend

### DIFF
--- a/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.test.tsx
@@ -5,12 +5,15 @@ import { WaysToEarn, WayToEarnType } from './WaysToEarn';
 import Routes from '../../../../../../../constants/navigation/Routes';
 import { ModalType } from '../../../../components/RewardsBottomSheetModal';
 import { SwapBridgeNavigationLocation } from '../../../../../Bridge/hooks/useSwapBridgeNavigation';
+import { selectIsFirstTimePerpsUser } from '../../../../../Perps/selectors/perpsController';
+import { selectRewardsCardSpendFeatureFlags } from '../../../../../../../selectors/featureFlagController/rewards';
 
 // Mock navigation
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
 const mockGoToSwaps = jest.fn();
 let mockIsFirstTimePerpsUser = false;
+let mockIsCardSpendEnabled = false;
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(),
@@ -29,11 +32,7 @@ jest.mock('../../../../../Bridge/hooks/useSwapBridgeNavigation', () => ({
 // Mock react-redux
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
-  useSelector: jest.fn(
-    () =>
-      // For the isFirstTimePerpsUser selector
-      mockIsFirstTimePerpsUser,
-  ),
+  useSelector: jest.fn(),
 }));
 
 // Mock getNativeAssetForChainId
@@ -79,6 +78,14 @@ jest.mock('../../../../../../../../locales/i18n', () => ({
       'rewards.ways_to_earn.loyalty.sheet.description':
         'Add accounts with past swaps or bridges in MetaMask to earn loyalty bonuses. Each eligible account unlocks points in increments of 250, up to a total of 50,000. Bonuses appear shortly after you add an account.',
       'rewards.ways_to_earn.loyalty.sheet.cta_label': 'Add accounts',
+      // Card strings
+      'rewards.ways_to_earn.card.title': 'MetaMask Card',
+      'rewards.ways_to_earn.card.description': '1 point per $1 spent',
+      'rewards.ways_to_earn.card.sheet.title': 'MetaMask Card',
+      'rewards.ways_to_earn.card.sheet.points': '1 point per $1 spent',
+      'rewards.ways_to_earn.card.sheet.description':
+        'Earn points every time you use your MetaMask Card for purchases, plus 1% cash back (3% for Metal cardholders).',
+      'rewards.ways_to_earn.card.sheet.cta_label': 'Manage Card',
     };
     return mockStrings[key] || key;
   }),
@@ -115,9 +122,9 @@ jest.mock(
   () => ({
     __esModule: true,
     default: () => {
-      const React = jest.requireActual('react');
+      const ReactActual = jest.requireActual('react');
       const { Text } = jest.requireActual('react-native');
-      return React.createElement(
+      return ReactActual.createElement(
         Text,
         { testID: 'metamask-rewards-points' },
         'Points Icon',
@@ -130,11 +137,25 @@ describe('WaysToEarn', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockIsFirstTimePerpsUser = false;
+    mockIsCardSpendEnabled = false;
 
     mockUseNavigation.mockReturnValue({
       navigate: mockNavigate,
       goBack: mockGoBack,
     } as unknown as ReturnType<typeof useNavigation>);
+
+    // Assign useSelector implementation here so we can safely reference imported selectors
+    const mockUseSelector = jest.requireMock('react-redux')
+      .useSelector as jest.Mock;
+    mockUseSelector.mockImplementation((selector: unknown) => {
+      if (selector === selectIsFirstTimePerpsUser) {
+        return mockIsFirstTimePerpsUser;
+      }
+      if (selector === selectRewardsCardSpendFeatureFlags) {
+        return mockIsCardSpendEnabled;
+      }
+      return undefined;
+    });
   });
 
   it('renders the component title', () => {
@@ -147,24 +168,27 @@ describe('WaysToEarn', () => {
 
   it('renders all earning ways', () => {
     // Arrange & Act
-    const { getByText } = render(<WaysToEarn />);
+    const { getByText, queryByText } = render(<WaysToEarn />);
 
     // Assert
     expect(getByText('Swap')).toBeOnTheScreen();
     expect(getByText('Perps')).toBeOnTheScreen();
     expect(getByText('Refer friends')).toBeOnTheScreen();
     expect(getByText('Loyalty bonus')).toBeOnTheScreen();
+    // MM Card Spend hidden when flag disabled
+    expect(queryByText('MetaMask Card')).not.toBeOnTheScreen();
   });
 
   it('displays correct descriptions for each earning way', () => {
     // Arrange & Act
-    const { getByText } = render(<WaysToEarn />);
+    const { getByText, queryByText } = render(<WaysToEarn />);
 
     // Assert
     expect(getByText('80 points per $100')).toBeOnTheScreen();
     expect(getByText('10 points per $100')).toBeOnTheScreen();
     expect(getByText('10 points per 50 from friends')).toBeOnTheScreen();
     expect(getByText('Earn points from past trades')).toBeOnTheScreen();
+    expect(queryByText('1 point per $1 spent')).not.toBeOnTheScreen();
   });
 
   it('navigates to referrals when referral item is pressed', () => {
@@ -384,6 +408,47 @@ describe('WaysToEarn', () => {
       expect(WayToEarnType.PERPS).toBe('perps');
       expect(WayToEarnType.REFERRALS).toBe('referrals');
       expect(WayToEarnType.LOYALTY).toBe('loyalty');
+      expect(WayToEarnType.CARD).toBe('card');
+    });
+  });
+
+  describe('Card spend', () => {
+    it('shows Card earning way only when feature flag is enabled', () => {
+      // Arrange
+      const { queryByText, rerender } = render(<WaysToEarn />);
+
+      // Assert hidden by default
+      expect(queryByText('MetaMask Card')).not.toBeOnTheScreen();
+
+      // Enable flag
+      mockIsCardSpendEnabled = true;
+      rerender(<WaysToEarn />);
+
+      // Assert visible now
+      expect(queryByText('MetaMask Card')).toBeOnTheScreen();
+      expect(queryByText('1 point per $1 spent')).toBeOnTheScreen();
+    });
+
+    it('opens modal and navigates to Card root on CTA', () => {
+      // Arrange
+      mockIsCardSpendEnabled = true;
+      const { getByText } = render(<WaysToEarn />);
+
+      // Open card info modal
+      fireEvent.press(getByText('MetaMask Card'));
+
+      // Extract confirm action
+      const modalCall = mockNavigate.mock.calls.find(
+        (call) => call[0] === Routes.MODAL.REWARDS_BOTTOM_SHEET_MODAL,
+      );
+      const confirmAction = modalCall?.[1]?.confirmAction;
+
+      // Act
+      confirmAction?.onPress();
+
+      // Assert
+      expect(mockGoBack).toHaveBeenCalled();
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.CARD.ROOT);
     });
   });
 

--- a/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.tsx
+++ b/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.tsx
@@ -27,6 +27,7 @@ import {
 } from '../../../../../Bridge/hooks/useSwapBridgeNavigation';
 import { useSelector } from 'react-redux';
 import { selectIsFirstTimePerpsUser } from '../../../../../Perps/selectors/perpsController';
+import { selectRewardsCardSpendFeatureFlags } from '../../../../../../../selectors/featureFlagController/rewards';
 import {
   MetaMetricsEvents,
   useMetrics,
@@ -180,6 +181,7 @@ const getBottomSheetData = (type: WayToEarnType) => {
 export const WaysToEarn = () => {
   const navigation = useNavigation();
   const isFirstTimePerpsUser = useSelector(selectIsFirstTimePerpsUser);
+  const isCardSpendEnabled = useSelector(selectRewardsCardSpendFeatureFlags);
   const { trackEvent, createEventBuilder } = useMetrics();
 
   // Use the swap/bridge navigation hook
@@ -271,7 +273,11 @@ export const WaysToEarn = () => {
       <Box twClassName="rounded-xl bg-muted">
         <FlatList
           horizontal={false}
-          data={waysToEarn}
+          data={
+            isCardSpendEnabled
+              ? waysToEarn
+              : waysToEarn.filter((way) => way.type !== WayToEarnType.CARD)
+          }
           keyExtractor={(wayToEarn) => wayToEarn.title}
           ItemSeparatorComponent={Separator}
           scrollEnabled={false}

--- a/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.tsx
+++ b/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.tsx
@@ -38,6 +38,7 @@ export enum WayToEarnType {
   PERPS = 'perps',
   REFERRALS = 'referrals',
   LOYALTY = 'loyalty',
+  CARD = 'card',
 }
 
 interface WayToEarn {
@@ -71,6 +72,12 @@ const waysToEarn: WayToEarn[] = [
     title: strings('rewards.ways_to_earn.loyalty.title'),
     description: strings('rewards.ways_to_earn.loyalty.description'),
     icon: IconName.Gift,
+  },
+  {
+    type: WayToEarnType.CARD,
+    title: strings('rewards.ways_to_earn.card.title'),
+    description: strings('rewards.ways_to_earn.card.description'),
+    icon: IconName.Card,
   },
 ];
 
@@ -150,6 +157,21 @@ const getBottomSheetData = (type: WayToEarnType) => {
         ),
         ctaLabel: strings('rewards.ways_to_earn.loyalty.sheet.cta_label'),
       };
+    case WayToEarnType.CARD:
+      return {
+        title: (
+          <WaysToEarnSheetTitle
+            title={strings('rewards.ways_to_earn.card.sheet.title')}
+            points={strings('rewards.ways_to_earn.card.sheet.points')}
+          />
+        ),
+        description: (
+          <Text variant={TextVariant.BodyMd} twClassName="text-alternative">
+            {strings('rewards.ways_to_earn.card.sheet.description')}
+          </Text>
+        ),
+        ctaLabel: strings('rewards.ways_to_earn.card.sheet.cta_label'),
+      };
     default:
       throw new Error(`Unknown earning way type: ${type}`);
   }
@@ -195,6 +217,9 @@ export const WaysToEarn = () => {
       case WayToEarnType.LOYALTY:
         navigation.navigate(Routes.REWARDS_SETTINGS_VIEW);
         break;
+      case WayToEarnType.CARD:
+        navigation.navigate(Routes.CARD.ROOT);
+        break;
     }
   };
 
@@ -210,7 +235,8 @@ export const WaysToEarn = () => {
     switch (wayToEarn.type) {
       case WayToEarnType.SWAPS:
       case WayToEarnType.LOYALTY:
-      case WayToEarnType.PERPS: {
+      case WayToEarnType.PERPS:
+      case WayToEarnType.CARD: {
         const { title, description, ctaLabel } = getBottomSheetData(
           wayToEarn.type,
         );

--- a/app/selectors/featureFlagController/rewards/index.test.ts
+++ b/app/selectors/featureFlagController/rewards/index.test.ts
@@ -1,6 +1,7 @@
 import {
   selectRewardsEnabledFlag,
   selectRewardsAnnouncementModalEnabledFlag,
+  selectRewardsCardSpendFeatureFlags,
 } from '.';
 import {
   VersionGatedFeatureFlag,
@@ -125,6 +126,53 @@ describe('Rewards Feature Flag Selectors', () => {
     });
   });
 
+  describe('selectRewardsCardSpendFeatureFlags', () => {
+    it('returns true when remote flag is valid and enabled', () => {
+      const result = selectRewardsCardSpendFeatureFlags.resultFunc({
+        rewardsEnableCardSpend: {
+          enabled: true,
+          minimumVersion: '1.0.0',
+        },
+      });
+      expect(result).toBe(true);
+    });
+
+    it('returns false when remote flag is valid but disabled', () => {
+      const result = selectRewardsCardSpendFeatureFlags.resultFunc({
+        rewardsEnableCardSpend: {
+          enabled: false,
+          minimumVersion: '1.0.0',
+        },
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false when version check fails', () => {
+      mockHasMinimumRequiredVersion.mockReturnValue(false);
+      const result = selectRewardsCardSpendFeatureFlags.resultFunc({
+        rewardsEnableCardSpend: {
+          enabled: true,
+          minimumVersion: '99.0.0',
+        },
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false when remote flag is invalid', () => {
+      const result = selectRewardsCardSpendFeatureFlags.resultFunc({
+        rewardsEnableCardSpend: {
+          enabled: 'invalid',
+          minimumVersion: 123,
+        },
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false when remote feature flags are empty', () => {
+      const result = selectRewardsCardSpendFeatureFlags.resultFunc({});
+      expect(result).toBe(false);
+    });
+  });
   describe('validatedVersionGatedFeatureFlag', () => {
     const validRemoteFlag: VersionGatedFeatureFlag = {
       enabled: true,

--- a/app/selectors/featureFlagController/rewards/index.ts
+++ b/app/selectors/featureFlagController/rewards/index.ts
@@ -7,8 +7,10 @@ import {
 } from '../../../util/remoteFeatureFlag';
 
 const DEFAULT_REWARDS_ENABLED = false;
+const DEFAULT_CARD_SPEND_ENABLED = false;
 export const FEATURE_FLAG_NAME = 'rewardsEnabled';
 export const ANNOUNCEMENT_MODAL_FLAG_NAME = 'rewardsAnnouncementModalEnabled';
+export const CARD_SPEND_FLAG_NAME = 'rewardsEnableCardSpend';
 
 export const selectRewardsEnabledFlag = createSelector(
   selectRemoteFeatureFlags,
@@ -38,6 +40,23 @@ export const selectRewardsAnnouncementModalEnabledFlag = createSelector(
 
     return (
       validatedVersionGatedFeatureFlag(remoteFlag) ?? DEFAULT_REWARDS_ENABLED
+    );
+  },
+);
+
+export const selectRewardsCardSpendFeatureFlags = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) => {
+    if (!hasProperty(remoteFeatureFlags, CARD_SPEND_FLAG_NAME)) {
+      return DEFAULT_CARD_SPEND_ENABLED;
+    }
+    const cardSpendConfig = remoteFeatureFlags[
+      CARD_SPEND_FLAG_NAME
+    ] as unknown as VersionGatedFeatureFlag;
+
+    return (
+      validatedVersionGatedFeatureFlag(cardSpendConfig) ??
+      DEFAULT_CARD_SPEND_ENABLED
     );
   },
 );

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6125,6 +6125,16 @@
           "description": "Add accounts with past swaps or bridges in MetaMask to earn loyalty bonuses. Each eligible account unlocks points in increments of 250, up to a total of 50,000. Bonuses appear shortly after you add an account.",
           "cta_label": "Add accounts"
         }
+      },
+      "card": {
+        "title": "MetaMask Card",
+        "description": "1 point per $1 spent",
+        "sheet": {
+          "title": "MetaMask Card",
+          "points": "1 point per $1 spent",
+          "description": "Earn points every time you use your MetaMask Card for purchases, plus 1% cash back (3% for Metal cardholders).",
+          "cta_label": "Manage Card"
+        }
       }
     },
     "referral": {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Add how to earn for card spend. Display is based on a remote feature flag

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/RWDS-514

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [s
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-10-13 at 18 26 57" src="https://github.com/user-attachments/assets/f2f5ae07-67ae-4e78-8b91-2da7e423bb13" />
creenshots/recordings] -->
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-10-13 at 18 27 01" src="https://github.com/user-attachments/assets/2fd00d37-b5fc-475f-9e50-c005c578efc6" />

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Card spend as a new way to earn rewards, including modal content, navigation to Card, and localized strings.
> 
> - **Rewards UI**:
>   - Adds `WayToEarnType.CARD` with icon, title, and description in `app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.tsx`.
>   - Implements bottom sheet data for `CARD` (title, points, description, CTA) and includes it in modal flow and CTA handling.
>   - Navigates to `Routes.CARD.ROOT` when `CARD` CTA is pressed.
> - **Localization**:
>   - Introduces `rewards.ways_to_earn.card.*` strings in `locales/languages/en.json` (title, description, sheet content, CTA).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d22e9e1c2cb177db138486fcbad0977e0a60ee0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->