### PR TITLE
ci(merge queue): Add merge group to workflow trigger

### DIFF
--- a/.github/workflows/check-template-and-add-labels.yml
+++ b/.github/workflows/check-template-and-add-labels.yml
@@ -5,10 +5,12 @@ on:
     types: [opened, edited, labeled, unlabeled, reopened]
   pull_request_target:
     types: [opened, edited, labeled, unlabeled, reopened]
+  merge_group:
 
 jobs:
   check-template-and-add-labels:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'merge_group' }} # Skip this step for merge_group events
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

We'd like to add `check-template-and-add-labels` workflow to required status checks to make sure PRs only get merged when this workflow is successful.

The problem is that since this workflow currently don't include the `merge_group` event in the `on` configuration, it causes the new status check to remain unresolved for PRs in the merge queue.

The purpose of this PR is to modify our existing workflow to accommodate the `merge_group` event while skipping the check when it's triggered by this event.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add merge_group trigger to the workflow and skip the job when the event is merge_group.
> 
> - **CI/CD**:
>   - **Workflow `/.github/workflows/check-template-and-add-labels.yml`**:
>     - Add `merge_group` to `on` triggers.
>     - Add job-level condition `if: ${{ github.event_name != 'merge_group' }}` to skip execution for merge group events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03051ef3d5c662a06a0bed1a56152f844c80995b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->