### PR TITLE
fix: use correct metadata.name field in WalletConnect v2 session proposal

### DIFF
--- a/app/core/WalletConnect/WalletConnectV2.ts
+++ b/app/core/WalletConnect/WalletConnectV2.ts
@@ -428,7 +428,7 @@ export class WC2Manager {
     const { proposer } = params;
     const { metadata } = proposer;
     const url = metadata.url ?? '';
-    const name = metadata.description ?? '';
+    const name = metadata.name ?? '';
     const icons = metadata.icons;
     const icon = icons?.[0] ?? '';
 


### PR DESCRIPTION
This commit fixes an incorrect field usage in the WalletConnect v2 session proposal handler where metadata.description was being used as the dapp name instead of metadata.name. This was causing the wrong information to be displayed in the Redux store and UI components, showing the dapp description instead of its actual name. The fix ensures that the proper dapp name is extracted from the WalletConnect session proposal metadata and stored correctly for display purposes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace use of metadata.description with metadata.name when extracting the dapp name during WC v2 session proposals.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a81bc965623b04377b3eca26ffe00fd41f9a1abc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->