### PR TITLE
fix: clarify error when missing network configuration in hasPermissionsToSwitchChainRequest

### DIFF
--- a/app/core/WalletConnect/wc-utils.ts
+++ b/app/core/WalletConnect/wc-utils.ts
@@ -335,7 +335,7 @@ export const hasPermissionsToSwitchChainRequest = async (
   if (!existingNetwork) {
     DevLogger.log(`WC::checkWCPermissions no existing network found`);
     throw rpcErrors.invalidParams({
-      message: `Invalid parameters: active chainId is different than the one provided.`,
+      message: `Unsupported chainId: ${hexChainIdString}. No network configuration found for the requested chain.`,
     });
   }
 


### PR DESCRIPTION
Replaced misleading invalidParams message (“active chainId is different…”) with a precise explanation when no network configuration exists for the requested chain. This improves developer diagnostics and user-facing clarity without altering logic or return shape.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines the invalidParams error to specify the unsupported chainId when no network configuration exists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89028fca7860cbbdea1983bff4674a60b91869df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->