### PR TITLE
chore: cp-7.57.0 chain filtering should not affect account picker balances

### DIFF
--- a/app/selectors/assets/balances.ts
+++ b/app/selectors/assets/balances.ts
@@ -150,8 +150,42 @@ export const selectBalanceForAllWallets = createSelector(
     ),
 );
 
+export const selectBalanceForAllWalletsAndChains = createSelector(
+  [
+    selectAccountTreeStateForBalances,
+    selectAccountsStateForBalances,
+    selectTokenBalancesStateForBalances,
+    selectTokenRatesStateForBalances,
+    selectMultichainAssetsRatesStateForBalances,
+    selectMultichainBalancesStateForBalances,
+    selectTokensStateForBalances,
+    selectCurrencyRateStateForBalances,
+  ],
+  (
+    accountTreeState,
+    accountsState,
+    tokenBalancesState,
+    tokenRatesState,
+    multichainRatesState,
+    multichainBalancesState,
+    tokensState,
+    currencyRateState,
+  ) =>
+    calculateBalanceForAllWallets(
+      accountTreeState,
+      accountsState,
+      tokenBalancesState,
+      tokenRatesState,
+      multichainRatesState,
+      multichainBalancesState,
+      tokensState,
+      currencyRateState,
+      undefined,
+    ),
+);
+
 export const selectBalanceByAccountGroup = (groupId: string) =>
-  createSelector([selectBalanceForAllWallets], (allBalances) => {
+  createSelector([selectBalanceForAllWalletsAndChains], (allBalances) => {
     const walletId = groupId.split('/')[0];
     const wallet = allBalances.wallets[walletId] ?? null;
     const { userCurrency } = allBalances;
@@ -165,6 +199,7 @@ export const selectBalanceByAccountGroup = (groupId: string) =>
     }
     return wallet.groups[groupId];
   });
+
 export const selectBalanceByWallet = (walletId: string) =>
   createSelector([selectBalanceForAllWallets], (allBalances) => {
     const wallet = allBalances.wallets[walletId] ?? null;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
When filtering by chain on build 2600, the balances also filter by chain in the accounts picker, which is not the expected user behavior. The user expects filtering by chain to only impact the tokens and balances displayed on the homepage, not the accounts picker. This issue was not present in versions 7.56 or 7.55. A video demonstrating the issue is attached. This needs to be investigated and resolved to align with user expectations.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: accounts list item balances should not be scoped by chain

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-1379

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/c5b855db-fb1e-40b7-b717-757276e96256

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/6d90d86c-241b-4160-a5b8-38b8b786e880

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Account picker balances now use an all-chains balance selector, decoupling them from the chain filter.
> 
> - **Selectors**:
>   - **New**: `selectBalanceForAllWalletsAndChains` calculates balances across all chains (passes `undefined` for `enabledNetworkMap`).
>   - **Change**: `selectBalanceByAccountGroup` now reads from `selectBalanceForAllWalletsAndChains` so account group balances are not scoped by chain.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14a34077a9326b81dd81135790ebeee201b799ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->