### PR TITLE
fix: rewards bip-44 modify opt out event emit

### DIFF
--- a/app/components/UI/Rewards/OnboardingNavigator.test.tsx
+++ b/app/components/UI/Rewards/OnboardingNavigator.test.tsx
@@ -132,17 +132,12 @@ jest.mock('../../../reducers/rewards/selectors', () => ({
   selectOptinAllowedForGeo: jest.fn(),
 }));
 
-jest.mock('../../../selectors/accountsController', () => ({
-  selectSelectedInternalAccount: jest.fn(),
-}));
-
 // Import mocked selectors for setup
 import { selectRewardsSubscriptionId } from '../../../selectors/rewards';
 import {
   selectOnboardingActiveStep,
   selectOptinAllowedForGeo,
 } from '../../../reducers/rewards/selectors';
-import { selectSelectedInternalAccount } from '../../../selectors/accountsController';
 
 const mockSelectRewardsSubscriptionId =
   selectRewardsSubscriptionId as jest.MockedFunction<
@@ -155,10 +150,6 @@ const mockSelectOnboardingActiveStep =
 const mockSelectOptinAllowedForGeo =
   selectOptinAllowedForGeo as jest.MockedFunction<
     typeof selectOptinAllowedForGeo
-  >;
-const mockSelectSelectedInternalAccount =
-  selectSelectedInternalAccount as jest.MockedFunction<
-    typeof selectSelectedInternalAccount
   >;
 
 // Mock hooks
@@ -212,24 +203,6 @@ describe('OnboardingNavigator', () => {
     mockSelectOnboardingActiveStep.mockReturnValue(OnboardingStep.INTRO);
     mockSelectOptinAllowedForGeo.mockReturnValue(true);
     mockUseGeoRewardsMetadata.mockReturnValue(undefined);
-    mockSelectSelectedInternalAccount.mockReturnValue({
-      address: '0x123',
-      type: 'eip155:eoa',
-      id: '',
-      options: {},
-      metadata: {
-        name: '',
-        importTime: 0,
-        keyring: {
-          type: '',
-        },
-        nameLastUpdatedAt: undefined,
-        snap: undefined,
-        lastSelected: undefined,
-      },
-      scopes: [],
-      methods: [],
-    });
   });
 
   const renderWithNavigation = (component: React.ReactElement) =>

--- a/app/components/UI/Rewards/RewardsNavigator.test.tsx
+++ b/app/components/UI/Rewards/RewardsNavigator.test.tsx
@@ -127,14 +127,6 @@ jest.mock('../../../../locales/i18n', () => ({
   }),
 }));
 
-// Mock selectors
-jest.mock('../../../selectors/accountsController', () => ({
-  selectSelectedInternalAccount: () => ({
-    id: 'test-account-id',
-    address: '0x123',
-  }),
-}));
-
 jest.mock('../../../selectors/rewards', () => ({
   selectRewardsSubscriptionId: jest.fn(),
 }));

--- a/app/components/UI/Rewards/Views/RewardsDashboard.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsDashboard.test.tsx
@@ -51,10 +51,6 @@ jest.mock('../../../../selectors/rewards', () => ({
   selectRewardsSubscriptionId: jest.fn(),
 }));
 
-jest.mock('../../../../selectors/accountsController', () => ({
-  selectSelectedInternalAccount: jest.fn(),
-}));
-
 jest.mock(
   '../../../../selectors/multichainAccounts/accountTreeController',
   () => ({
@@ -69,7 +65,6 @@ import {
   selectHideCurrentAccountNotOptedInBannerArray,
 } from '../../../../reducers/rewards/selectors';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
-import { selectSelectedInternalAccount } from '../../../../selectors/accountsController';
 import { selectSelectedAccountGroup } from '../../../../selectors/multichainAccounts/accountTreeController';
 import { CURRENT_SEASON_ID } from '../../../../core/Engine/controllers/rewards-controller/types';
 
@@ -90,10 +85,6 @@ const mockSelectHideUnlinkedAccountsBanner =
 const mockSelectHideCurrentAccountNotOptedInBannerArray =
   selectHideCurrentAccountNotOptedInBannerArray as jest.MockedFunction<
     typeof selectHideCurrentAccountNotOptedInBannerArray
-  >;
-const mockSelectSelectedInternalAccount =
-  selectSelectedInternalAccount as jest.MockedFunction<
-    typeof selectSelectedInternalAccount
   >;
 const mockSelectSelectedAccountGroup =
   selectSelectedAccountGroup as jest.MockedFunction<
@@ -569,9 +560,7 @@ describe('RewardsDashboard', () => {
     mockSelectHideCurrentAccountNotOptedInBannerArray.mockReturnValue(
       defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray,
     );
-    mockSelectSelectedInternalAccount.mockReturnValue(
-      defaultSelectorValues.selectedAccount,
-    );
+
     mockSelectSelectedAccountGroup.mockReturnValue(
       defaultSelectorValues.selectedAccountGroup,
     );
@@ -600,8 +589,6 @@ describe('RewardsDashboard', () => {
         return defaultSelectorValues.hideUnlinkedAccountsBanner;
       if (selector === selectHideCurrentAccountNotOptedInBannerArray)
         return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-      if (selector === selectSelectedInternalAccount)
-        return defaultSelectorValues.selectedAccount;
       if (selector === selectSelectedAccountGroup)
         return defaultSelectorValues.selectedAccountGroup;
       return undefined;
@@ -880,8 +867,6 @@ describe('RewardsDashboard', () => {
           return defaultSelectorValues.hideUnlinkedAccountsBanner;
         if (selector === selectHideCurrentAccountNotOptedInBannerArray)
           return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedInternalAccount)
-          return defaultSelectorValues.selectedAccount;
         if (selector === selectSelectedAccountGroup)
           return defaultSelectorValues.selectedAccountGroup;
         return undefined;
@@ -1040,8 +1025,6 @@ describe('RewardsDashboard', () => {
         if (selector === selectHideUnlinkedAccountsBanner) return true;
         if (selector === selectHideCurrentAccountNotOptedInBannerArray)
           return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedInternalAccount)
-          return defaultSelectorValues.selectedAccount;
         if (selector === selectSelectedAccountGroup)
           return defaultSelectorValues.selectedAccountGroup;
         return undefined;
@@ -1131,8 +1114,6 @@ describe('RewardsDashboard', () => {
           return defaultSelectorValues.hideUnlinkedAccountsBanner;
         if (selector === selectHideCurrentAccountNotOptedInBannerArray)
           return [{ accountGroupId: 'group-1', hide: true }];
-        if (selector === selectSelectedInternalAccount)
-          return defaultSelectorValues.selectedAccount;
         if (selector === selectSelectedAccountGroup)
           return defaultSelectorValues.selectedAccountGroup;
         return undefined;
@@ -1288,8 +1269,6 @@ describe('RewardsDashboard', () => {
           return defaultSelectorValues.hideUnlinkedAccountsBanner;
         if (selector === selectHideCurrentAccountNotOptedInBannerArray)
           return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedInternalAccount)
-          return defaultSelectorValues.selectedAccount;
         if (selector === selectSelectedAccountGroup) return null;
         return undefined;
       });
@@ -1323,8 +1302,6 @@ describe('RewardsDashboard', () => {
           return defaultSelectorValues.hideUnlinkedAccountsBanner;
         if (selector === selectHideCurrentAccountNotOptedInBannerArray)
           return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedInternalAccount)
-          return defaultSelectorValues.selectedAccount;
         if (selector === selectSelectedAccountGroup)
           return { ...mockSelectedAccountGroup, id: undefined };
         return undefined;
@@ -1384,8 +1361,6 @@ describe('RewardsDashboard', () => {
           return defaultSelectorValues.hideUnlinkedAccountsBanner;
         if (selector === selectHideCurrentAccountNotOptedInBannerArray)
           return defaultSelectorValues.hideCurrentAccountNotOptedInBannerArray;
-        if (selector === selectSelectedInternalAccount)
-          return defaultSelectorValues.selectedAccount;
         if (selector === selectSelectedAccountGroup)
           return { ...mockSelectedAccountGroup, id: undefined };
         return undefined;

--- a/app/components/UI/Rewards/hooks/useOptIn.test.ts
+++ b/app/components/UI/Rewards/hooks/useOptIn.test.ts
@@ -4,7 +4,6 @@ import useOptin from './useOptIn';
 import Engine from '../../../../core/Engine';
 import { setCandidateSubscriptionId } from '../../../../reducers/rewards';
 import { useMetrics } from '../../../hooks/useMetrics';
-import { selectSelectedInternalAccount } from '../../../../selectors/accountsController';
 import { selectMultichainAccountsState2Enabled } from '../../../../selectors/featureFlagController/multichainAccounts/enabledMultichainAccounts';
 import {
   selectSelectedAccountGroup,
@@ -12,7 +11,6 @@ import {
   selectWalletByAccount,
 } from '../../../../selectors/multichainAccounts/accountTreeController';
 import { useLinkAccountGroup } from './useLinkAccountGroup';
-import { InternalAccount } from '@metamask/keyring-internal-api';
 import { AccountGroupId } from '@metamask/account-api';
 
 // Mock dependencies
@@ -38,10 +36,6 @@ jest.mock('../../../hooks/useMetrics', () => ({
     REWARDS_OPT_IN_FAILED: 'Rewards Opt-in Failed',
   },
   useMetrics: jest.fn(),
-}));
-
-jest.mock('../../../../selectors/accountsController', () => ({
-  selectSelectedInternalAccount: jest.fn(),
 }));
 
 jest.mock(
@@ -100,9 +94,7 @@ describe('useOptIn', () => {
     >;
 
   // Mock selectors
-  const mockSelectSelectedInternalAccount = jest.mocked(
-    selectSelectedInternalAccount,
-  );
+
   const mockSelectSelectedAccountGroup = jest.mocked(
     selectSelectedAccountGroup,
   );
@@ -124,13 +116,6 @@ describe('useOptIn', () => {
     }),
   });
   const mockAddTraitsToUser = jest.fn();
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const mockAccount: InternalAccount = {
-    id: 'account-1',
-    address: '0x123',
-    name: 'Test Account',
-  } as never;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const mockAccountGroup = {
@@ -163,6 +148,13 @@ describe('useOptIn', () => {
     ],
   } as never;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const mockActiveAccount = {
+    id: 'account-1',
+    address: '0x123',
+    metadata: { name: 'Account 1' },
+  } as never;
+
   const mockLinkAccountGroup = jest.fn();
 
   beforeEach(() => {
@@ -175,7 +167,6 @@ describe('useOptIn', () => {
     mockAddTraitsToUser.mockClear();
 
     // Setup default selector values
-    mockSelectSelectedInternalAccount.mockReturnValue(mockAccount);
     mockSelectSelectedAccountGroup.mockReturnValue(mockAccountGroup);
     mockSelectMultichainAccountsState2Enabled.mockReturnValue(false);
     mockSelectAccountGroupsByWallet.mockReturnValue([mockWalletSection]);
@@ -184,13 +175,13 @@ describe('useOptIn', () => {
     );
 
     mockUseSelector.mockImplementation((selector) => {
-      if (selector === selectSelectedInternalAccount) return mockAccount;
       if (selector === selectSelectedAccountGroup) return mockAccountGroup;
       if (selector === selectMultichainAccountsState2Enabled) return false;
       if (selector === selectAccountGroupsByWallet) return [mockWalletSection];
       if (selector === selectWalletByAccount)
         return (_accountId: string) => mockWallet;
-      return null;
+      // Return mockActiveAccount for any other selector (e.g., selectSelectedInternalAccount)
+      return mockActiveAccount;
     });
 
     // Setup useMetrics mock
@@ -303,14 +294,13 @@ describe('useOptIn', () => {
     it('should skip optin when no account group is selected', async () => {
       mockSelectSelectedAccountGroup.mockReturnValue(null);
       mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectSelectedInternalAccount) return mockAccount;
         if (selector === selectSelectedAccountGroup) return null;
         if (selector === selectMultichainAccountsState2Enabled) return false;
         if (selector === selectAccountGroupsByWallet)
           return [mockWalletSection];
         if (selector === selectWalletByAccount)
           return (_accountId: string) => mockWallet;
-        return null;
+        return mockActiveAccount;
       });
 
       const { result } = renderHook(() => useOptin());
@@ -331,7 +321,6 @@ describe('useOptIn', () => {
 
       mockSelectSelectedAccountGroup.mockReturnValue(accountGroupWithoutId);
       mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectSelectedInternalAccount) return mockAccount;
         if (selector === selectSelectedAccountGroup)
           return accountGroupWithoutId;
         if (selector === selectMultichainAccountsState2Enabled) return false;
@@ -339,7 +328,7 @@ describe('useOptIn', () => {
           return [mockWalletSection];
         if (selector === selectWalletByAccount)
           return (_accountId: string) => mockWallet;
-        return null;
+        return mockActiveAccount;
       });
 
       const { result } = renderHook(() => useOptin());
@@ -358,14 +347,13 @@ describe('useOptIn', () => {
       mockSelectMultichainAccountsState2Enabled.mockReturnValue(true);
 
       mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectSelectedInternalAccount) return mockAccount;
         if (selector === selectSelectedAccountGroup) return mockAccountGroup;
         if (selector === selectMultichainAccountsState2Enabled) return true;
         if (selector === selectAccountGroupsByWallet)
           return [mockWalletSection];
         if (selector === selectWalletByAccount)
           return (_accountId: string) => mockWallet;
-        return null;
+        return mockActiveAccount;
       });
     });
 
@@ -389,14 +377,13 @@ describe('useOptIn', () => {
       ]);
 
       mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectSelectedInternalAccount) return mockAccount;
         if (selector === selectSelectedAccountGroup) return mockAccountGroup;
         if (selector === selectMultichainAccountsState2Enabled) return true;
         if (selector === selectAccountGroupsByWallet)
           return [sideEffectWalletSection];
         if (selector === selectWalletByAccount)
           return (_accountId: string) => mockWallet;
-        return null;
+        return mockActiveAccount;
       });
 
       const { result } = renderHook(() => useOptin());
@@ -438,14 +425,13 @@ describe('useOptIn', () => {
       mockSelectAccountGroupsByWallet.mockReturnValue([sameGroupWalletSection]);
 
       mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectSelectedInternalAccount) return mockAccount;
         if (selector === selectSelectedAccountGroup) return mockAccountGroup;
         if (selector === selectMultichainAccountsState2Enabled) return true;
         if (selector === selectAccountGroupsByWallet)
           return [sameGroupWalletSection];
         if (selector === selectWalletByAccount)
           return (_accountId: string) => mockWallet;
-        return null;
+        return mockActiveAccount;
       });
 
       const { result } = renderHook(() => useOptin());
@@ -467,13 +453,12 @@ describe('useOptIn', () => {
       mockSelectAccountGroupsByWallet.mockReturnValue([]);
 
       mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectSelectedInternalAccount) return mockAccount;
         if (selector === selectSelectedAccountGroup) return mockAccountGroup;
         if (selector === selectMultichainAccountsState2Enabled) return true;
         if (selector === selectAccountGroupsByWallet) return [];
         if (selector === selectWalletByAccount)
           return (_accountId: string) => mockWallet;
-        return null;
+        return mockActiveAccount;
       });
 
       const { result } = renderHook(() => useOptin());
@@ -508,7 +493,6 @@ describe('useOptIn', () => {
       ] as never);
 
       mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectSelectedInternalAccount) return mockAccount;
         if (selector === selectSelectedAccountGroup) return mockAccountGroup;
         if (selector === selectMultichainAccountsState2Enabled) return true;
         if (selector === selectAccountGroupsByWallet)
@@ -528,7 +512,7 @@ describe('useOptIn', () => {
           ];
         if (selector === selectWalletByAccount)
           return (_accountId: string) => mockWallet;
-        return null;
+        return mockActiveAccount;
       });
 
       const { result } = renderHook(() => useOptin());
@@ -566,14 +550,13 @@ describe('useOptIn', () => {
       ]);
 
       mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectSelectedInternalAccount) return mockAccount;
         if (selector === selectSelectedAccountGroup) return mockAccountGroup;
         if (selector === selectMultichainAccountsState2Enabled) return true;
         if (selector === selectAccountGroupsByWallet)
           return [sideEffectWalletSection];
         if (selector === selectWalletByAccount)
           return (_accountId: string) => mockWallet;
-        return null;
+        return mockActiveAccount;
       });
 
       // Mock linkAccountGroup to throw an error
@@ -635,14 +618,13 @@ describe('useOptIn', () => {
       ]);
 
       mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectSelectedInternalAccount) return mockAccount;
         if (selector === selectSelectedAccountGroup) return mockAccountGroup;
         if (selector === selectMultichainAccountsState2Enabled) return true;
         if (selector === selectAccountGroupsByWallet)
           return [sideEffectWalletSection];
         if (selector === selectWalletByAccount)
           return (_accountId: string) => mockWallet;
-        return null;
+        return mockActiveAccount;
       });
 
       // Mock optin to fail

--- a/app/components/UI/Rewards/hooks/useOptout.ts
+++ b/app/components/UI/Rewards/hooks/useOptout.ts
@@ -12,8 +12,7 @@ import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
 import useRewardsToast from './useRewardsToast';
 import { MetaMetricsEvents, useMetrics } from '../../../hooks/useMetrics';
 import { useRewardDashboardModals } from './useRewardDashboardModals';
-import { deriveAccountMetricProps, RewardsMetricsButtons } from '../utils';
-import { selectSelectedInternalAccount } from '../../../../selectors/accountsController';
+import { RewardsMetricsButtons } from '../utils';
 import { UserProfileProperty } from '../../../../util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types';
 
 interface UseOptoutResult {
@@ -30,8 +29,6 @@ export const useOptout = (): UseOptoutResult => {
   const {
     resetAllSessionTracking: resetAllSessionTrackingForRewardsDashboardModals,
   } = useRewardDashboardModals();
-  const account = useSelector(selectSelectedInternalAccount);
-  const accountMetricsProps = deriveAccountMetricProps(account);
 
   const { showToast, RewardsToastOptions } = useRewardsToast();
   const { trackEvent, createEventBuilder, addTraitsToUser } = useMetrics();
@@ -42,9 +39,7 @@ export const useOptout = (): UseOptoutResult => {
     setIsLoading(true);
 
     trackEvent(
-      createEventBuilder(MetaMetricsEvents.REWARDS_OPT_OUT_STARTED)
-        .addProperties(accountMetricsProps)
-        .build(),
+      createEventBuilder(MetaMetricsEvents.REWARDS_OPT_OUT_STARTED).build(),
     );
 
     try {
@@ -57,9 +52,9 @@ export const useOptout = (): UseOptoutResult => {
 
       if (success) {
         trackEvent(
-          createEventBuilder(MetaMetricsEvents.REWARDS_OPT_OUT_COMPLETED)
-            .addProperties(accountMetricsProps)
-            .build(),
+          createEventBuilder(
+            MetaMetricsEvents.REWARDS_OPT_OUT_COMPLETED,
+          ).build(),
         );
         const traits = {
           [UserProfileProperty.HAS_REWARDS_OPTED_IN]: UserProfileProperty.OFF,
@@ -74,9 +69,7 @@ export const useOptout = (): UseOptoutResult => {
       }
       Logger.log('useOptout: Opt-out failed - controller returned false');
       trackEvent(
-        createEventBuilder(MetaMetricsEvents.REWARDS_OPT_OUT_FAILED)
-          .addProperties(accountMetricsProps)
-          .build(),
+        createEventBuilder(MetaMetricsEvents.REWARDS_OPT_OUT_FAILED).build(),
       );
 
       // Show error toast
@@ -90,9 +83,7 @@ export const useOptout = (): UseOptoutResult => {
       Logger.log('useOptout: Opt-out failed with exception:', error);
 
       trackEvent(
-        createEventBuilder(MetaMetricsEvents.REWARDS_OPT_OUT_FAILED)
-          .addProperties(accountMetricsProps)
-          .build(),
+        createEventBuilder(MetaMetricsEvents.REWARDS_OPT_OUT_FAILED).build(),
       );
 
       // Show error toast
@@ -111,7 +102,6 @@ export const useOptout = (): UseOptoutResult => {
     trackEvent,
     createEventBuilder,
     addTraitsToUser,
-    accountMetricsProps,
     showToast,
     RewardsToastOptions,
     dispatch,


### PR DESCRIPTION
## **Description**

Remove selected/active account specific metric metadata when emitting an event on opt out.

## **Changelog**

CHANGELOG entry: null

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes account-specific metric properties from Rewards opt-out events and refactors tests to no longer depend on the selected account selector.
> 
> - **Rewards Opt-out (hook)**:
>   - Remove usage of `selectSelectedInternalAccount` and `deriveAccountMetricProps` in `useOptout`; emit opt-out events without account-level properties.
> - **Tests**:
>   - Update/clean mocks to drop `accountsController` selected account selector across `OnboardingNavigator.test.tsx`, `RewardsNavigator.test.tsx`, `RewardsDashboard.test.tsx`, and hooks tests.
>   - Adjust test implementations/mocks to reflect event emissions without account properties and simplify selector returns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97a2dc80942f3b475c80b2570b789ef5587dbce2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->