### PR TITLE
fix(SDKConnectV2): Fix storage regression caused by #17685

### DIFF
--- a/app/core/BackgroundBridge/BackgroundBridge.js
+++ b/app/core/BackgroundBridge/BackgroundBridge.js
@@ -86,7 +86,7 @@ import { getAuthorizedScopes } from '../../selectors/permissions';
 import { SolAccountType, SolScope } from '@metamask/keyring-api';
 import { parseCaipAccountId } from '@metamask/utils';
 import { toFormattedAddress, areAddressesEqual } from '../../util/address';
-import { isSameOrigin } from '../../util/url';
+import { isSameValueOrOrigin } from '../../util/url';
 import PPOMUtil from '../../lib/ppom/ppom-util';
 import { isRelaySupported } from '../../util/transactions/transaction-relay';
 import { selectSmartTransactionsEnabled } from '../../selectors/smartTransactionsController';
@@ -457,7 +457,7 @@ export class BackgroundBridge extends EventEmitter {
     ) {
       console.warn(
         '[BackgroundBridge]: message blocked from unknown origin. Expects',
-        this.origin,
+        this.channelIdOrOrigin,
         'but received',
         msg.origin,
       );

--- a/app/core/SDKConnectV2/adapters/rpc-bridge-adapter.ts
+++ b/app/core/SDKConnectV2/adapters/rpc-bridge-adapter.ts
@@ -8,7 +8,6 @@ import { ImageSourcePropType } from 'react-native';
 import { ConnectionInfo } from '../types/connection-info';
 import { whenEngineReady } from '../utils/when-engine-ready';
 import { whenOnboardingComplete } from '../utils/when-onboarding-complete';
-import Logger from '../../../util/Logger';
 import { JsonRpcRequest } from '@metamask/utils';
 
 export class RPCBridgeAdapter

--- a/app/core/SDKConnectV2/adapters/rpc-bridge-adapter.ts
+++ b/app/core/SDKConnectV2/adapters/rpc-bridge-adapter.ts
@@ -8,6 +8,8 @@ import { ImageSourcePropType } from 'react-native';
 import { ConnectionInfo } from '../types/connection-info';
 import { whenEngineReady } from '../utils/when-engine-ready';
 import { whenOnboardingComplete } from '../utils/when-onboarding-complete';
+import Logger from '../../../util/Logger';
+import { JsonRpcRequest } from '@metamask/utils';
 
 export class RPCBridgeAdapter
   extends EventEmitter
@@ -18,7 +20,7 @@ export class RPCBridgeAdapter
   private messenger: BaseControllerMessenger | null = null;
   private initialized: Promise<void> | null = null;
   private processing = false;
-  private queue: unknown[] = [];
+  private queue: JsonRpcRequest[] = [];
 
   constructor(connInfo: ConnectionInfo) {
     super();
@@ -29,7 +31,7 @@ export class RPCBridgeAdapter
   /**
    * Sends an RPC request to the background bridge.
    */
-  public send(request: unknown): void {
+  public send(request: JsonRpcRequest): void {
     this.queue.push(request);
     this.processQueue();
   }
@@ -91,6 +93,7 @@ export class RPCBridgeAdapter
       const request = this.queue.shift();
       this.client.onMessage({
         name: 'metamask-multichain-provider',
+        origin: this.connInfo.id,
         data: request,
       });
     }

--- a/app/core/SDKConnectV2/adapters/rpc-bridge-adapter.ts
+++ b/app/core/SDKConnectV2/adapters/rpc-bridge-adapter.ts
@@ -9,6 +9,7 @@ import { ConnectionInfo } from '../types/connection-info';
 import { whenEngineReady } from '../utils/when-engine-ready';
 import { whenOnboardingComplete } from '../utils/when-onboarding-complete';
 import { JsonRpcRequest } from '@metamask/utils';
+import { whenStoreReady } from '../utils/when-store-ready';
 
 export class RPCBridgeAdapter
   extends EventEmitter
@@ -57,7 +58,11 @@ export class RPCBridgeAdapter
     if (this.initialized) return this.initialized;
 
     this.initialized = (async () => {
-      await Promise.all([whenEngineReady(), whenOnboardingComplete()]);
+      await Promise.all([
+        whenEngineReady(),
+        whenStoreReady(),
+        whenOnboardingComplete(),
+      ]);
       this.messenger = Engine.controllerMessenger;
       this.messenger.subscribe('KeyringController:unlock', this.processQueue);
       this.client = this.createClient();

--- a/app/core/SDKConnectV2/services/logger.ts
+++ b/app/core/SDKConnectV2/services/logger.ts
@@ -14,6 +14,6 @@ export default {
   },
   error: (...args: unknown[]) => {
     // eslint-disable-next-line no-console
-    console.error(prettify(prefix, ...args));
+    console.error(prefix, ...args);
   },
 };

--- a/app/core/SDKConnectV2/types/rpc-bridge-adapter.ts
+++ b/app/core/SDKConnectV2/types/rpc-bridge-adapter.ts
@@ -1,4 +1,4 @@
-import { Json, JsonRpcResponse } from '@metamask/utils';
+import { Json, JsonRpcRequest, JsonRpcResponse } from '@metamask/utils';
 
 export type RPCResponse =
   | JsonRpcResponse<Json>
@@ -11,6 +11,6 @@ export type RPCResponse =
  */
 export interface IRPCBridgeAdapter {
   on: (event: 'response', listener: (response: RPCResponse) => void) => void;
-  send: (request: unknown) => void;
+  send: (request: JsonRpcRequest) => void;
   dispose: () => void;
 }

--- a/app/util/url/index.ts
+++ b/app/util/url/index.ts
@@ -85,8 +85,11 @@ export const toPunycodeURL = (urlString: string) => {
   }
 };
 
-export function isSameOrigin(a: string, b: string) {
+export function isSameValueOrOrigin(a: string, b: string) {
   try {
+    if (a === b) {
+      return true;
+    }
     const urlA = new URL(a);
     const urlB = new URL(b);
 

--- a/app/util/url/url.test.ts
+++ b/app/util/url/url.test.ts
@@ -3,7 +3,7 @@ import {
   isBridgeUrl,
   isValidASCIIURL,
   toPunycodeURL,
-  isSameOrigin,
+  isSameValueOrOrigin,
 } from './index';
 import AppConstants from '../../core/AppConstants';
 
@@ -125,33 +125,39 @@ describe('URL Check Functions', () => {
     });
   });
 
-  describe('isSameOrigin', () => {
-    it('return true for urls with the same origin', () => {
+  describe('isSameValueOrOrigin', () => {
+    it('return true for urls with the same value or origin', () => {
       expect(
-        isSameOrigin(
+        isSameValueOrOrigin(
+          'notUrl',
+          'notUrl',
+        ),
+      ).toBeTruthy();
+      expect(
+        isSameValueOrOrigin(
           'https://metamask.io/page.html',
           'https://metamask.io/page2.html',
         ),
       ).toBeTruthy();
       expect(
-        isSameOrigin(
+        isSameValueOrOrigin(
           'https://metamask.io/other.html',
           'https://usr:pw@metamask.io/',
         ),
       ).toBeTruthy();
       expect(
-        isSameOrigin('https://metamask.io:80/page', 'https://metamask.io:80/'),
+        isSameValueOrOrigin('https://metamask.io:80/page', 'https://metamask.io:80/'),
       ).toBeTruthy();
       expect(
-        isSameOrigin('https://metamask.io:81/', 'https://metamask.io:80'),
+        isSameValueOrOrigin('https://metamask.io:81/', 'https://metamask.io:80'),
       ).toBeFalsy();
       expect(
-        isSameOrigin(
+        isSameValueOrOrigin(
           'https://en.metamask.io/page.html',
           'https://metamask.io/',
         ),
       ).toBeFalsy();
-      expect(isSameOrigin('invalid url', 'https://metamask.io/')).toBeFalsy();
+      expect(isSameValueOrOrigin('invalid url', 'https://metamask.io/')).toBeFalsy();
     });
   });
 });

--- a/app/util/url/url.test.ts
+++ b/app/util/url/url.test.ts
@@ -127,12 +127,7 @@ describe('URL Check Functions', () => {
 
   describe('isSameValueOrOrigin', () => {
     it('return true for urls with the same value or origin', () => {
-      expect(
-        isSameValueOrOrigin(
-          'notUrl',
-          'notUrl',
-        ),
-      ).toBeTruthy();
+      expect(isSameValueOrOrigin('notUrl', 'notUrl')).toBeTruthy();
       expect(
         isSameValueOrOrigin(
           'https://metamask.io/page.html',
@@ -146,10 +141,16 @@ describe('URL Check Functions', () => {
         ),
       ).toBeTruthy();
       expect(
-        isSameValueOrOrigin('https://metamask.io:80/page', 'https://metamask.io:80/'),
+        isSameValueOrOrigin(
+          'https://metamask.io:80/page',
+          'https://metamask.io:80/',
+        ),
       ).toBeTruthy();
       expect(
-        isSameValueOrOrigin('https://metamask.io:81/', 'https://metamask.io:80'),
+        isSameValueOrOrigin(
+          'https://metamask.io:81/',
+          'https://metamask.io:80',
+        ),
       ).toBeFalsy();
       expect(
         isSameValueOrOrigin(
@@ -157,7 +158,9 @@ describe('URL Check Functions', () => {
           'https://metamask.io/',
         ),
       ).toBeFalsy();
-      expect(isSameValueOrOrigin('invalid url', 'https://metamask.io/')).toBeFalsy();
+      expect(
+        isSameValueOrOrigin('invalid url', 'https://metamask.io/'),
+      ).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes storage regression caused by https://github.com/MetaMask/metamask-mobile/pull/17685

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an index-backed connection store, tightens RPC bridge typing/init and origin tagging, and replaces URL origin check with a value-or-origin comparator.
> 
> - **SDKConnectV2**:
>   - **ConnectionStore**: Switch to index-backed storage (`<prefix>_index`) with helpers (`getIndex`, `addToIndex`, `removeFromIndex`); `save/get/list/delete` updated to use index; robust handling of expired/corrupted records; comprehensive test updates incl. corrupted index and failure resilience.
>   - **RPC Bridge Adapter**: Strongly type queue and `send` as `JsonRpcRequest`; wait for `whenStoreReady()` during init; include `origin` (`connInfo.id`) in dispatched messages; interface updated accordingly.
>   - **Logger**: Simplify `error` to log raw args without prettification.
> - **BackgroundBridge**: Use `isSameValueOrOrigin` for message origin checks and log expected `channelIdOrOrigin`.
> - **URL utils**: Replace `isSameOrigin` with `isSameValueOrOrigin` (accepts exact string or same origin); update tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c72e53443f94094fbe0d124a25b95dacc1e9222. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->