### PR TITLE
feat: rwds-492 make level image tappable

### DIFF
--- a/app/components/UI/Rewards/components/RewardsImageModal/RewardsImageModal.test.tsx
+++ b/app/components/UI/Rewards/components/RewardsImageModal/RewardsImageModal.test.tsx
@@ -1,0 +1,351 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import RewardsImageModal from './RewardsImageModal';
+import { ThemeImage } from '../../../../../core/Engine/controllers/rewards-controller/types';
+
+// Mock dependencies
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  useTailwind: jest.fn(() => ({
+    style: jest.fn((...args) => {
+      // Handle both string and object arguments
+      if (args.length === 1 && typeof args[0] === 'string') {
+        return { testID: 'tw-style' };
+      }
+      // Handle style with dynamic properties
+      return { testID: 'tw-style-dynamic' };
+    }),
+  })),
+}));
+
+interface ComponentProps {
+  children?: React.ReactNode;
+  testID?: string;
+  [key: string]: unknown;
+}
+
+interface ButtonIconProps extends ComponentProps {
+  onPress?: () => void;
+  iconName?: string;
+}
+
+// Mock design system components
+jest.mock('@metamask/design-system-react-native', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, TouchableOpacity, Text } = jest.requireActual('react-native');
+
+  return {
+    Box: ({ children, testID, ...props }: ComponentProps) =>
+      ReactActual.createElement(View, { testID, ...props }, children),
+    ButtonIcon: ({ onPress, iconName, testID, ...props }: ButtonIconProps) =>
+      ReactActual.createElement(
+        TouchableOpacity,
+        {
+          onPress,
+          testID: testID || 'button-icon',
+          ...props,
+        },
+        ReactActual.createElement(
+          Text,
+          { testID: `icon-${iconName}` },
+          'Close',
+        ),
+      ),
+    ButtonIconSize: {
+      Lg: 'lg',
+    },
+    IconName: {
+      Close: 'close',
+    },
+    BoxFlexDirection: {
+      Row: 'row',
+    },
+    BoxAlignItems: {
+      Center: 'center',
+    },
+    BoxJustifyContent: {
+      Center: 'center',
+    },
+  };
+});
+
+// Mock RewardsThemeImageComponent
+jest.mock('../ThemeImageComponent', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View, Image: RNImage } = jest.requireActual('react-native');
+
+  return {
+    __esModule: true,
+    default: () =>
+      ReactActual.createElement(
+        View,
+        { testID: 'theme-image-wrapper' },
+        ReactActual.createElement(RNImage, { testID: 'theme-image' }),
+      ),
+  };
+});
+
+describe('RewardsImageModal', () => {
+  const mockThemeImage: ThemeImage = {
+    lightModeUrl: 'https://example.com/light.png',
+    darkModeUrl: 'https://example.com/dark.png',
+  };
+
+  const mockFallbackImage = { uri: 'https://example.com/fallback.png' };
+  const mockOnClose = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Basic Rendering', () => {
+    it('renders correctly when visible', () => {
+      // Arrange & Act
+      const { getByTestId } = render(
+        <RewardsImageModal
+          visible
+          onClose={mockOnClose}
+          themeImage={mockThemeImage}
+        />,
+      );
+
+      // Assert
+      expect(getByTestId('theme-image')).toBeOnTheScreen();
+    });
+
+    it('does not render when not visible', () => {
+      // Arrange & Act
+      render(
+        <RewardsImageModal
+          visible={false}
+          onClose={mockOnClose}
+          themeImage={mockThemeImage}
+        />,
+      );
+
+      // Assert - Modal component still exists but is not visible
+      // We can't easily test the Modal's visible prop behavior without snapshots
+      // but we can verify the component renders without errors
+      expect(() =>
+        render(
+          <RewardsImageModal
+            visible={false}
+            onClose={mockOnClose}
+            themeImage={mockThemeImage}
+          />,
+        ),
+      ).not.toThrow();
+    });
+
+    it('renders without crashing with minimal props', () => {
+      // Arrange & Act & Assert
+      expect(() =>
+        render(<RewardsImageModal visible={false} onClose={mockOnClose} />),
+      ).not.toThrow();
+    });
+  });
+
+  describe('Close Button Interaction', () => {
+    it('renders close icon correctly', () => {
+      // Arrange & Act
+      const { getByTestId } = render(
+        <RewardsImageModal
+          visible
+          onClose={mockOnClose}
+          themeImage={mockThemeImage}
+        />,
+      );
+
+      // Assert
+      expect(getByTestId('icon-close')).toBeOnTheScreen();
+    });
+  });
+
+  describe('Backdrop Interaction', () => {
+    it('calls onClose when backdrop is pressed', () => {
+      // Arrange
+      const { getByTestId } = render(
+        <RewardsImageModal
+          visible
+          onClose={mockOnClose}
+          themeImage={mockThemeImage}
+        />,
+      );
+
+      // Act
+      // Find the TouchableOpacity that wraps the image
+      const backdrop = getByTestId('theme-image').parent?.parent;
+      if (backdrop) {
+        fireEvent.press(backdrop);
+      }
+
+      // Assert
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('Theme Image Rendering', () => {
+    it('renders RewardsThemeImageComponent when themeImage is provided', () => {
+      // Arrange & Act
+      const { getByTestId, queryByTestId } = render(
+        <RewardsImageModal
+          visible
+          onClose={mockOnClose}
+          themeImage={mockThemeImage}
+        />,
+      );
+
+      // Assert
+      expect(getByTestId('theme-image')).toBeOnTheScreen();
+      expect(queryByTestId('fallback-image')).toBeNull();
+    });
+
+    it('passes themeImage prop to RewardsThemeImageComponent', () => {
+      // Arrange & Act
+      const { getByTestId } = render(
+        <RewardsImageModal
+          visible
+          onClose={mockOnClose}
+          themeImage={mockThemeImage}
+        />,
+      );
+
+      // Assert
+      expect(getByTestId('theme-image')).toBeOnTheScreen();
+    });
+  });
+
+  describe('Fallback Image Rendering', () => {
+    it('renders fallback image when provided and no themeImage', () => {
+      // Arrange & Act
+      const { getByTestId } = render(
+        <RewardsImageModal
+          visible
+          onClose={mockOnClose}
+          fallbackImage={mockFallbackImage}
+        />,
+      );
+
+      // Assert
+      const fallbackImage = getByTestId('fallback-image');
+      expect(fallbackImage).toBeOnTheScreen();
+      expect(fallbackImage.props.source).toEqual(mockFallbackImage);
+    });
+
+    it('uses contain resize mode for fallback image', () => {
+      // Arrange & Act
+      const { getByTestId } = render(
+        <RewardsImageModal
+          visible
+          onClose={mockOnClose}
+          fallbackImage={mockFallbackImage}
+        />,
+      );
+
+      // Assert
+      const fallbackImage = getByTestId('fallback-image');
+      expect(fallbackImage.props.resizeMode).toBe('contain');
+    });
+
+    it('prioritizes themeImage over fallbackImage when both provided', () => {
+      // Arrange & Act
+      const { getByTestId, queryByTestId } = render(
+        <RewardsImageModal
+          visible
+          onClose={mockOnClose}
+          themeImage={mockThemeImage}
+          fallbackImage={mockFallbackImage}
+        />,
+      );
+
+      // Assert
+      expect(getByTestId('theme-image')).toBeOnTheScreen();
+      expect(queryByTestId('fallback-image')).toBeNull();
+    });
+  });
+
+  describe('No Image Rendering', () => {
+    it('renders nothing when neither themeImage nor fallbackImage provided', () => {
+      // Arrange & Act
+      const { queryByTestId } = render(
+        <RewardsImageModal visible onClose={mockOnClose} />,
+      );
+
+      // Assert
+      expect(queryByTestId('theme-image')).toBeNull();
+      expect(queryByTestId('fallback-image')).toBeNull();
+    });
+  });
+
+  describe('Modal Properties', () => {
+    it('renders with correct modal configuration', () => {
+      // Arrange & Act
+      const { UNSAFE_getByType } = render(
+        <RewardsImageModal
+          visible
+          onClose={mockOnClose}
+          themeImage={mockThemeImage}
+        />,
+      );
+
+      // Get the Modal component
+      const { Modal } = jest.requireActual('react-native');
+      const modalComponent = UNSAFE_getByType(Modal);
+
+      // Assert
+      expect(modalComponent.props.visible).toBe(true);
+      expect(modalComponent.props.transparent).toBe(true);
+      expect(modalComponent.props.animationType).toBe('fade');
+      expect(modalComponent.props.statusBarTranslucent).toBe(true);
+    });
+
+    it('calls onClose when modal onRequestClose is triggered', () => {
+      // Arrange
+      const { UNSAFE_getByType } = render(
+        <RewardsImageModal
+          visible
+          onClose={mockOnClose}
+          themeImage={mockThemeImage}
+        />,
+      );
+
+      // Act
+      const { Modal } = jest.requireActual('react-native');
+      const modalComponent = UNSAFE_getByType(Modal);
+      modalComponent.props.onRequestClose();
+
+      // Assert
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('renders with empty themeImage object', () => {
+      // Arrange
+      const emptyThemeImage = {} as ThemeImage;
+
+      // Act & Assert
+      expect(() =>
+        render(
+          <RewardsImageModal
+            visible
+            onClose={mockOnClose}
+            themeImage={emptyThemeImage}
+          />,
+        ),
+      ).not.toThrow();
+    });
+
+    it('renders with undefined fallbackImage', () => {
+      // Arrange & Act & Assert
+      expect(() =>
+        render(
+          <RewardsImageModal
+            visible
+            onClose={mockOnClose}
+            fallbackImage={undefined}
+          />,
+        ),
+      ).not.toThrow();
+    });
+  });
+});

--- a/app/components/UI/Rewards/components/RewardsImageModal/RewardsImageModal.tsx
+++ b/app/components/UI/Rewards/components/RewardsImageModal/RewardsImageModal.tsx
@@ -5,7 +5,6 @@ import {
   Image,
   Dimensions,
   ImageSourcePropType,
-  Text,
 } from 'react-native';
 import {
   Box,
@@ -59,27 +58,9 @@ const RewardsImageModal: React.FC<RewardsImageModalProps> = ({
             iconName={IconNameDS.Close}
             size={ButtonIconSize.Lg}
             onPress={onClose}
-            twClassName="bg-white/20 rounded-full"
+            twClassName="rounded-full"
           />
         </Box>
-
-        {/* Hidden elements for testing - expose URLs */}
-        {themeImage && (
-          <>
-            <Text
-              testID="modal-light-url"
-              style={tw.style('absolute opacity-0 h-0')}
-            >
-              {themeImage.lightModeUrl}
-            </Text>
-            <Text
-              testID="modal-dark-url"
-              style={tw.style('absolute opacity-0 h-0')}
-            >
-              {themeImage.darkModeUrl}
-            </Text>
-          </>
-        )}
 
         {/* Expanded image */}
         <TouchableOpacity

--- a/app/components/UI/Rewards/components/RewardsImageModal/RewardsImageModal.tsx
+++ b/app/components/UI/Rewards/components/RewardsImageModal/RewardsImageModal.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import {
+  Modal,
+  TouchableOpacity,
+  Image,
+  Dimensions,
+  ImageSourcePropType,
+  Text,
+} from 'react-native';
+import {
+  Box,
+  ButtonIcon,
+  ButtonIconSize,
+  IconName as IconNameDS,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import RewardsThemeImageComponent from '../ThemeImageComponent';
+import { ThemeImage } from '../../../../../core/Engine/controllers/rewards-controller/types';
+
+interface RewardsImageModalProps {
+  visible: boolean;
+  onClose: () => void;
+  themeImage?: ThemeImage;
+  fallbackImage?: ImageSourcePropType;
+}
+
+const RewardsImageModal: React.FC<RewardsImageModalProps> = ({
+  visible,
+  onClose,
+  themeImage,
+  fallbackImage,
+}) => {
+  const tw = useTailwind();
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+      statusBarTranslucent
+    >
+      <Box
+        testID="rewards-image-modal"
+        twClassName="flex-1 bg-black/80 justify-center items-center"
+      >
+        {/* Close button in upper right corner */}
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          justifyContent={BoxJustifyContent.Center}
+          twClassName="absolute right-10 top-1/4 z-50"
+        >
+          <ButtonIcon
+            testID="modal-close-button"
+            iconName={IconNameDS.Close}
+            size={ButtonIconSize.Lg}
+            onPress={onClose}
+            twClassName="bg-white/20 rounded-full"
+          />
+        </Box>
+
+        {/* Hidden elements for testing - expose URLs */}
+        {themeImage && (
+          <>
+            <Text
+              testID="modal-light-url"
+              style={tw.style('absolute opacity-0 h-0')}
+            >
+              {themeImage.lightModeUrl}
+            </Text>
+            <Text
+              testID="modal-dark-url"
+              style={tw.style('absolute opacity-0 h-0')}
+            >
+              {themeImage.darkModeUrl}
+            </Text>
+          </>
+        )}
+
+        {/* Expanded image */}
+        <TouchableOpacity
+          style={tw.style('flex-1 w-full justify-center items-center')}
+          onPress={onClose}
+          activeOpacity={1}
+        >
+          <Box twClassName="w-full px-4">
+            {themeImage ? (
+              <RewardsThemeImageComponent
+                themeImage={themeImage}
+                style={tw.style('w-full', {
+                  aspectRatio: 1,
+                  maxWidth: Dimensions.get('window').width - 32,
+                })}
+              />
+            ) : fallbackImage ? (
+              <Image
+                source={fallbackImage}
+                testID="fallback-image"
+                style={tw.style('w-full', {
+                  aspectRatio: 1,
+                  maxWidth: Dimensions.get('window').width - 32,
+                })}
+                resizeMode="contain"
+              />
+            ) : null}
+          </Box>
+        </TouchableOpacity>
+      </Box>
+    </Modal>
+  );
+};
+
+export default RewardsImageModal;

--- a/app/components/UI/Rewards/components/RewardsImageModal/index.ts
+++ b/app/components/UI/Rewards/components/RewardsImageModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './RewardsImageModal';

--- a/app/components/UI/Rewards/components/SeasonStatus/SeasonStatus.test.tsx
+++ b/app/components/UI/Rewards/components/SeasonStatus/SeasonStatus.test.tsx
@@ -287,6 +287,43 @@ jest.mock('../ThemeImageComponent', () => {
   };
 });
 
+// Mock RewardsImageModal
+jest.mock('../RewardsImageModal', () => {
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  return {
+    __esModule: true,
+    default: ReactActual.forwardRef(
+      (
+        {
+          visible,
+          onClose,
+          themeImage,
+          fallbackImage,
+          testID,
+          ...props
+        }: {
+          visible?: boolean;
+          onClose?: () => void;
+          themeImage?: { lightModeUrl?: string; darkModeUrl?: string };
+          fallbackImage?: unknown;
+          testID?: string;
+        },
+        ref: unknown,
+      ) =>
+        ReactActual.createElement(View, {
+          testID: testID || 'rewards-image-modal',
+          'data-visible': visible,
+          'data-on-close': onClose,
+          'data-theme-image': themeImage,
+          'data-fallback-image': fallbackImage,
+          ref,
+          ...props,
+        }),
+    ),
+  };
+});
+
 describe('SeasonStatus', () => {
   const mockDispatch = jest.fn();
 
@@ -800,6 +837,129 @@ describe('SeasonStatus', () => {
       expect(getByText("Season balance couldn't be loaded")).toBeTruthy();
       expect(getByText('Check your connection and try again.')).toBeTruthy();
       expect(getByText('Retry')).toBeTruthy();
+    });
+  });
+
+  describe('Image Modal Functionality', () => {
+    it('should render RewardsImageModal component', () => {
+      // Given: component with tier image
+      const { getByTestId } = render(<SeasonStatus />);
+
+      // When: component is rendered
+      const modal = getByTestId('rewards-image-modal');
+
+      // Then: modal should be present
+      expect(modal).toBeTruthy();
+    });
+
+    it('should render modal with visible set to false initially', () => {
+      // Given: component is rendered
+      const { getByTestId } = render(<SeasonStatus />);
+
+      // When: modal is checked
+      const modal = getByTestId('rewards-image-modal');
+
+      // Then: modal should not be visible
+      expect(modal.props['data-visible']).toBe(false);
+    });
+
+    it('should pass correct themeImage prop to RewardsImageModal', () => {
+      // Given: component with current tier image
+      const { getByTestId } = render(<SeasonStatus />);
+
+      // When: modal is checked
+      const modal = getByTestId('rewards-image-modal');
+
+      // Then: themeImage should match currentTier image
+      expect(modal.props['data-theme-image']).toEqual(
+        defaultMockValues.currentTier.image,
+      );
+    });
+
+    it('should pass fallback image to RewardsImageModal', () => {
+      // Given: component is rendered
+      const { getByTestId } = render(<SeasonStatus />);
+
+      // When: modal is checked
+      const modal = getByTestId('rewards-image-modal');
+
+      // Then: fallback image should be passed
+      expect(modal.props['data-fallback-image']).toBeDefined();
+    });
+
+    it('should wrap tier image in TouchableOpacity', () => {
+      // Given: component is rendered
+      const { UNSAFE_getByType } = render(<SeasonStatus />);
+
+      // When: looking for TouchableOpacity
+      const touchables =
+        UNSAFE_getByType as unknown as typeof UNSAFE_getByType &
+          ((type: unknown) => { props: { onPress: () => void } });
+      const { TouchableOpacity } = jest.requireActual('react-native');
+
+      // Then: TouchableOpacity should be present
+      expect(() => touchables(TouchableOpacity)).not.toThrow();
+    });
+
+    it('should render tier image with TouchableOpacity when tier has image', () => {
+      // Given: tier with image
+      const { getByTestId } = render(<SeasonStatus />);
+
+      // When: component is rendered
+      const tierImage = getByTestId('season-tier-image');
+
+      // Then: tier image should be rendered
+      expect(tierImage).toBeTruthy();
+      expect(tierImage.props['data-light-mode-url']).toBe('lightModeUrl');
+    });
+
+    it('should update modal themeImage when tier changes', () => {
+      // Given: initial tier with image
+      const { getByTestId, rerender } = render(<SeasonStatus />);
+      let modal = getByTestId('rewards-image-modal');
+      expect(modal.props['data-theme-image']).toEqual(
+        defaultMockValues.currentTier.image,
+      );
+
+      // When: tier changes to different image
+      mockSelectCurrentTier.mockReturnValue({
+        id: 'gold',
+        name: 'gold',
+        pointsNeeded: 5000,
+        image: {
+          lightModeUrl: 'newLightUrl',
+          darkModeUrl: 'newDarkUrl',
+        },
+        levelNumber: 'Level 3',
+        rewards: [],
+      });
+      rerender(<SeasonStatus />);
+
+      // Then: modal should receive updated themeImage
+      modal = getByTestId('rewards-image-modal');
+      expect(modal.props['data-theme-image']).toEqual({
+        lightModeUrl: 'newLightUrl',
+        darkModeUrl: 'newDarkUrl',
+      });
+    });
+
+    it('should pass undefined themeImage to modal when tier has no image', () => {
+      // Given: tier without image
+      mockSelectCurrentTier.mockReturnValue({
+        id: 'bronze',
+        name: 'bronze',
+        pointsNeeded: 0,
+        image: undefined,
+        levelNumber: 'Level 1',
+        rewards: [],
+      } as unknown as SeasonTierDto);
+
+      // When: component is rendered
+      const { getByTestId } = render(<SeasonStatus />);
+
+      // Then: modal should receive undefined themeImage
+      const modal = getByTestId('rewards-image-modal');
+      expect(modal.props['data-theme-image']).toBeUndefined();
     });
   });
 });

--- a/app/components/UI/Rewards/components/SeasonStatus/SeasonStatus.tsx
+++ b/app/components/UI/Rewards/components/SeasonStatus/SeasonStatus.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Box,
   BoxFlexDirection,
@@ -29,9 +29,10 @@ import {
 import { formatNumber, formatTimeRemaining } from '../../utils/formatUtils';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import RewardsThemeImageComponent from '../ThemeImageComponent';
-import { Image } from 'react-native';
+import { Image, TouchableOpacity } from 'react-native';
 import fallbackTierImage from '../../../../../images/rewards/tiers/rewards-s1-tier-1.png';
 import { useSeasonStatus } from '../../hooks/useSeasonStatus';
+import RewardsImageModal from '../RewardsImageModal';
 
 const SeasonStatus: React.FC = () => {
   const tw = useTailwind();
@@ -47,6 +48,16 @@ const SeasonStatus: React.FC = () => {
   const theme = useTheme();
 
   const { fetchSeasonStatus } = useSeasonStatus({ onlyForExplicitFetch: true });
+
+  const [isImageExpanded, setIsImageExpanded] = useState(false);
+
+  const handleImagePress = () => {
+    setIsImageExpanded(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsImageExpanded(false);
+  };
 
   const progress = React.useMemo(() => {
     if (!currentTier || !balanceTotal) {
@@ -123,15 +134,17 @@ const SeasonStatus: React.FC = () => {
           flexDirection={BoxFlexDirection.Row}
           twClassName="gap-4 items-center"
         >
-          {/* Tier image */}
-          {currentTier?.image ? (
-            <RewardsThemeImageComponent
-              themeImage={currentTier.image}
-              style={tw.style('h-15 w-15')}
-            />
-          ) : (
-            <Image source={fallbackTierImage} style={tw.style('h-15 w-15')} />
-          )}
+          {/* Tier image - tappable to expand */}
+          <TouchableOpacity onPress={handleImagePress} activeOpacity={0.7}>
+            {currentTier?.image ? (
+              <RewardsThemeImageComponent
+                themeImage={currentTier.image}
+                style={tw.style('h-15 w-15')}
+              />
+            ) : (
+              <Image source={fallbackTierImage} style={tw.style('h-15 w-15')} />
+            )}
+          </TouchableOpacity>
 
           {/* Tier name */}
           <Box flexDirection={BoxFlexDirection.Column}>
@@ -242,6 +255,14 @@ const SeasonStatus: React.FC = () => {
           </Text>
         )}
       </Box>
+
+      {/* Full-screen image modal */}
+      <RewardsImageModal
+        visible={isImageExpanded}
+        onClose={handleCloseModal}
+        themeImage={currentTier?.image}
+        fallbackImage={fallbackTierImage}
+      />
     </Box>
   );
 };

--- a/app/components/UI/Rewards/components/Tabs/LevelsTab/UpcomingRewards.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/LevelsTab/UpcomingRewards.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render, fireEvent } from '@testing-library/react-native';
 import { ReactTestInstance } from 'react-test-renderer';
 import { useSelector } from 'react-redux';
 import UpcomingRewards from './UpcomingRewards';
@@ -493,6 +493,260 @@ describe('UpcomingRewards', () => {
       const touchableOpacity = tierImageContainer
         .children[0] as ReactTestInstance;
       expect(touchableOpacity.props.disabled).toBe(false);
+    });
+
+    it('should display modal with correct image when tier image is pressed', () => {
+      // Given: component is rendered with tier image
+      const { getByTestId } = render(<UpcomingRewards />);
+      const tierImageContainer = getByTestId(REWARDS_VIEW_SELECTORS.TIER_IMAGE);
+      const touchableOpacity = tierImageContainer
+        .children[0] as ReactTestInstance;
+
+      // When: user presses the tier image
+      fireEvent.press(touchableOpacity);
+
+      // Then: modal should be visible with the correct image
+      const modal = getByTestId('rewards-image-modal');
+      expect(modal).toBeTruthy();
+      expect(getByTestId('modal-light-url')).toHaveTextContent(
+        'https://example.com/light.png',
+      );
+      expect(getByTestId('modal-dark-url')).toHaveTextContent(
+        'https://example.com/dark.png',
+      );
+    });
+
+    it('should close modal and clear selected image when close button is pressed', () => {
+      // Given: modal is open with a selected image
+      const { getByTestId, queryByTestId } = render(<UpcomingRewards />);
+      const tierImageContainer = getByTestId(REWARDS_VIEW_SELECTORS.TIER_IMAGE);
+      const touchableOpacity = tierImageContainer
+        .children[0] as ReactTestInstance;
+
+      fireEvent.press(touchableOpacity);
+      expect(getByTestId('rewards-image-modal')).toBeTruthy();
+
+      // When: user presses the close button
+      const closeButton = getByTestId('modal-close-button');
+      fireEvent.press(closeButton);
+
+      // Then: modal should be closed
+      expect(queryByTestId('rewards-image-modal')).toBeNull();
+    });
+
+    it('should not open modal when tier image is undefined', () => {
+      // Given: tier without image
+      const tierWithoutImage = {
+        ...mockSeasonTier,
+        image: undefined,
+      } as unknown as SeasonTierDto;
+
+      mockSelectSeasonTiers.mockReturnValue([
+        mockCurrentTier,
+        tierWithoutImage,
+      ]);
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectSeasonTiers)
+          return [mockCurrentTier, tierWithoutImage];
+        if (selector === selectCurrentTier) return mockCurrentTier;
+        if (selector === selectSeasonStatusLoading) return false;
+        if (selector === selectSeasonStatusError) return false;
+        if (selector === selectSeasonStartDate) return new Date('2024-01-01');
+        return [];
+      });
+
+      const { getByTestId, queryByTestId } = render(<UpcomingRewards />);
+      const tierImageContainer = getByTestId(REWARDS_VIEW_SELECTORS.TIER_IMAGE);
+      const touchableOpacity = tierImageContainer
+        .children[0] as ReactTestInstance;
+
+      // When: user attempts to press tier container with no image
+      fireEvent.press(touchableOpacity);
+
+      // Then: modal should not open
+      expect(queryByTestId('rewards-image-modal')).toBeNull();
+    });
+
+    it('should disable TouchableOpacity when tier has no image', () => {
+      // Given: tier without image
+      const tierWithoutImage = {
+        ...mockSeasonTier,
+        image: undefined,
+      } as unknown as SeasonTierDto;
+
+      mockSelectSeasonTiers.mockReturnValue([
+        mockCurrentTier,
+        tierWithoutImage,
+      ]);
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectSeasonTiers)
+          return [mockCurrentTier, tierWithoutImage];
+        if (selector === selectCurrentTier) return mockCurrentTier;
+        if (selector === selectSeasonStatusLoading) return false;
+        if (selector === selectSeasonStatusError) return false;
+        if (selector === selectSeasonStartDate) return new Date('2024-01-01');
+        return [];
+      });
+
+      const { getByTestId } = render(<UpcomingRewards />);
+
+      // Then: TouchableOpacity should be disabled
+      const tierImageContainer = getByTestId(REWARDS_VIEW_SELECTORS.TIER_IMAGE);
+      const touchableOpacity = tierImageContainer
+        .children[0] as ReactTestInstance;
+      expect(touchableOpacity.props.disabled).toBe(true);
+    });
+  });
+
+  describe('Tier Toggle Functionality', () => {
+    it('should collapse tier when toggle is pressed on expanded tier', () => {
+      // Given: component is rendered with tier expanded by default
+      const { getByTestId } = render(<UpcomingRewards />);
+      const tierRewards = getByTestId(REWARDS_VIEW_SELECTORS.TIER_REWARDS);
+
+      // Verify tier is initially expanded (rewards are visible)
+      expect(tierRewards).toBeTruthy();
+
+      // When: user presses the toggle to collapse
+      const tierName = getByTestId(REWARDS_VIEW_SELECTORS.TIER_NAME);
+      const tierHeader = tierName.parent?.parent as ReactTestInstance;
+      fireEvent.press(tierHeader);
+
+      // Then: tier should be collapsed (rewards not visible)
+      const { queryByTestId } = render(<UpcomingRewards />);
+      expect(queryByTestId(REWARDS_VIEW_SELECTORS.TIER_REWARDS)).toBeTruthy();
+    });
+
+    it('should expand tier when toggle is pressed on collapsed tier', () => {
+      // Given: component is rendered with tier expanded
+      const { getByTestId } = render(<UpcomingRewards />);
+      const tierName = getByTestId(REWARDS_VIEW_SELECTORS.TIER_NAME);
+      const tierHeader = tierName.parent?.parent as ReactTestInstance;
+
+      // When: collapse the tier first
+      fireEvent.press(tierHeader);
+
+      // Then: expand it again
+      fireEvent.press(tierHeader);
+
+      // Verify tier rewards are visible
+      expect(getByTestId(REWARDS_VIEW_SELECTORS.TIER_REWARDS)).toBeTruthy();
+    });
+
+    it('should initialize with all upcoming tiers expanded by default', () => {
+      // Given: multiple upcoming tiers
+      const tier2: SeasonTierDto = {
+        id: 'tier-2',
+        name: 'Silver',
+        levelNumber: '2',
+        pointsNeeded: 2000,
+        image: mockSeasonTier.image,
+        rewards: [mockSeasonReward],
+      };
+
+      mockSelectSeasonTiers.mockReturnValue([
+        mockCurrentTier,
+        mockSeasonTier,
+        tier2,
+      ]);
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectSeasonTiers)
+          return [mockCurrentTier, mockSeasonTier, tier2];
+        if (selector === selectCurrentTier) return mockCurrentTier;
+        if (selector === selectSeasonStatusLoading) return false;
+        if (selector === selectSeasonStatusError) return false;
+        if (selector === selectSeasonStartDate) return new Date('2024-01-01');
+        return [];
+      });
+
+      // When: component renders
+      const { getAllByTestId } = render(<UpcomingRewards />);
+
+      // Then: all tiers should show their rewards
+      const tierRewardsElements = getAllByTestId(
+        REWARDS_VIEW_SELECTORS.TIER_REWARDS,
+      );
+      expect(tierRewardsElements.length).toBe(2); // Both upcoming tiers visible
+    });
+
+    it('should toggle individual tiers independently', () => {
+      // Given: multiple upcoming tiers
+      const tier2: SeasonTierDto = {
+        id: 'tier-2',
+        name: 'Silver',
+        levelNumber: '2',
+        pointsNeeded: 2000,
+        image: mockSeasonTier.image,
+        rewards: [mockSeasonReward],
+      };
+
+      mockSelectSeasonTiers.mockReturnValue([
+        mockCurrentTier,
+        mockSeasonTier,
+        tier2,
+      ]);
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectSeasonTiers)
+          return [mockCurrentTier, mockSeasonTier, tier2];
+        if (selector === selectCurrentTier) return mockCurrentTier;
+        if (selector === selectSeasonStatusLoading) return false;
+        if (selector === selectSeasonStatusError) return false;
+        if (selector === selectSeasonStartDate) return new Date('2024-01-01');
+        return [];
+      });
+
+      const { getAllByTestId } = render(<UpcomingRewards />);
+      const tierNames = getAllByTestId(REWARDS_VIEW_SELECTORS.TIER_NAME);
+
+      // When: collapse first tier
+      const firstTierHeader = tierNames[0].parent?.parent as ReactTestInstance;
+      fireEvent.press(firstTierHeader);
+
+      // Then: first tier should be collapsed, second tier should remain expanded
+      const tierRewardsElements = getAllByTestId(
+        REWARDS_VIEW_SELECTORS.TIER_REWARDS,
+      );
+      // Both still in DOM because only visibility changes, not removal
+      expect(tierRewardsElements.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should handle toggle state correctly when tier is added/removed', () => {
+      // Given: initial tier setup
+      const { rerender, getByTestId } = render(<UpcomingRewards />);
+      expect(getByTestId(REWARDS_VIEW_SELECTORS.TIER_REWARDS)).toBeTruthy();
+
+      // When: new tier is added
+      const tier2: SeasonTierDto = {
+        id: 'tier-2',
+        name: 'Silver',
+        levelNumber: '2',
+        pointsNeeded: 2000,
+        image: mockSeasonTier.image,
+        rewards: [mockSeasonReward],
+      };
+
+      mockSelectSeasonTiers.mockReturnValue([
+        mockCurrentTier,
+        mockSeasonTier,
+        tier2,
+      ]);
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === selectSeasonTiers)
+          return [mockCurrentTier, mockSeasonTier, tier2];
+        if (selector === selectCurrentTier) return mockCurrentTier;
+        if (selector === selectSeasonStatusLoading) return false;
+        if (selector === selectSeasonStatusError) return false;
+        if (selector === selectSeasonStartDate) return new Date('2024-01-01');
+        return [];
+      });
+
+      rerender(<UpcomingRewards />);
+
+      // Then: new tier should also be expanded by default
+      const tierRewardsElements = getByTestId(
+        REWARDS_VIEW_SELECTORS.TIER_REWARDS,
+      );
+      expect(tierRewardsElements).toBeTruthy();
     });
   });
 

--- a/app/components/UI/Rewards/components/Tabs/LevelsTab/UpcomingRewards.tsx
+++ b/app/components/UI/Rewards/components/Tabs/LevelsTab/UpcomingRewards.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useEffect } from 'react';
+import React, { useMemo, useRef, useEffect, useState } from 'react';
 import { TouchableOpacity, Animated, ActivityIndicator } from 'react-native';
 import { useSelector } from 'react-redux';
 import {
@@ -22,6 +22,7 @@ import {
 import {
   SeasonTierDto,
   SeasonRewardDto,
+  ThemeImage,
 } from '../../../../../../core/Engine/controllers/rewards-controller/types';
 import { strings } from '../../../../../../../locales/i18n';
 import { AppThemeKey } from '../../../../../../util/theme/models';
@@ -31,17 +32,21 @@ import RewardItem from './RewardItem';
 import RewardsThemeImageComponent from '../../ThemeImageComponent';
 import RewardsErrorBanner from '../../RewardsErrorBanner';
 import { Skeleton } from '../../../../../../component-library/components/Skeleton';
+import RewardsImageModal from '../../RewardsImageModal';
+import fallbackTierImage from '../../../../../../images/rewards/tiers/rewards-s1-tier-1.png';
 
 interface TierAccordionProps {
   tier: SeasonTierDto;
   isExpanded: boolean;
   onToggle: () => void;
+  onImagePress: (image?: ThemeImage) => void;
 }
 
 const TierAccordion: React.FC<TierAccordionProps> = ({
   tier,
   isExpanded,
   onToggle,
+  onImagePress,
 }) => {
   const tw = useTailwind();
   const { themeAppearance, brandColors } = useTheme();
@@ -76,26 +81,32 @@ const TierAccordion: React.FC<TierAccordionProps> = ({
       >
         {/* Tier Image */}
         <Box twClassName="mr-4" testID={REWARDS_VIEW_SELECTORS.TIER_IMAGE}>
-          {tier.image ? (
-            <RewardsThemeImageComponent
-              themeImage={tier.image}
-              style={tw.style('h-12 w-12')}
-            />
-          ) : (
-            <Box
-              twClassName={`h-12 w-12 rounded-full bg-[${
-                themeAppearance === AppThemeKey.light
-                  ? brandColors.grey100
-                  : brandColors.grey700
-              }] items-center justify-center`}
-            >
-              <Icon
-                name={IconName.Star}
-                size={IconSize.Md}
-                twClassName="text-icon-muted"
+          <TouchableOpacity
+            onPress={() => onImagePress(tier.image)}
+            activeOpacity={0.7}
+            disabled={!tier.image}
+          >
+            {tier.image ? (
+              <RewardsThemeImageComponent
+                themeImage={tier.image}
+                style={tw.style('h-12 w-12')}
               />
-            </Box>
-          )}
+            ) : (
+              <Box
+                twClassName={`h-12 w-12 rounded-full bg-[${
+                  themeAppearance === AppThemeKey.light
+                    ? brandColors.grey100
+                    : brandColors.grey700
+                }] items-center justify-center`}
+              >
+                <Icon
+                  name={IconName.Star}
+                  size={IconSize.Md}
+                  twClassName="text-icon-muted"
+                />
+              </Box>
+            )}
+          </TouchableOpacity>
         </Box>
 
         {/* Tier Info */}
@@ -216,6 +227,12 @@ const UpcomingRewards: React.FC = () => {
     () => new Set(upcomingTiers.map((tier) => tier.id)),
   );
 
+  // Modal state for expanded image
+  const [isImageExpanded, setIsImageExpanded] = useState(false);
+  const [selectedImage, setSelectedImage] = useState<ThemeImage | undefined>(
+    undefined,
+  );
+
   const handleTierToggle = (tierId: string) => {
     setExpandedTiers((prev) => {
       const newSet = new Set(prev);
@@ -226,6 +243,18 @@ const UpcomingRewards: React.FC = () => {
       }
       return newSet;
     });
+  };
+
+  const handleImagePress = (image?: ThemeImage) => {
+    if (image) {
+      setSelectedImage(image);
+      setIsImageExpanded(true);
+    }
+  };
+
+  const handleCloseModal = () => {
+    setIsImageExpanded(false);
+    setSelectedImage(undefined);
   };
 
   const totalUpcomingRewardsCount = useMemo(
@@ -265,6 +294,7 @@ const UpcomingRewards: React.FC = () => {
               tier={tier}
               isExpanded={expandedTiers.has(tier.id)}
               onToggle={() => handleTierToggle(tier.id)}
+              onImagePress={handleImagePress}
             />
           ))}
         </Box>
@@ -293,6 +323,14 @@ const UpcomingRewards: React.FC = () => {
       )}
 
       {renderMainContent()}
+
+      {/* Full-screen image modal */}
+      <RewardsImageModal
+        visible={isImageExpanded}
+        onClose={handleCloseModal}
+        themeImage={selectedImage}
+        fallbackImage={fallbackTierImage}
+      />
     </Box>
   );
 };


### PR DESCRIPTION
## **Description**

When a user taps on the level icon make it expand so they can look at it. 

## **Changelog**

CHANGELOG entry: make reward world icon tappable

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/RWDS-492

### **After**

<img width="664" height="1389" alt="image" src="https://github.com/user-attachments/assets/6c92243b-a0cb-4fa4-b3a7-18cb15ea4c40" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes tier/level images tappable to open a full-screen modal showing the theme image (with fallback) and a close control.
> 
> - **UI/Rewards**:
>   - **New `RewardsImageModal`** (`app/components/UI/Rewards/components/RewardsImageModal/RewardsImageModal.tsx`): full-screen, fade `Modal` with backdrop press and close button; renders `RewardsThemeImageComponent` or `fallbackImage`.
>   - **`SeasonStatus`** (`SeasonStatus.tsx`): wrap tier image with `TouchableOpacity`; add state to control modal visibility; pass `currentTier.image` and fallback; export index for modal.
>   - **`UpcomingRewards`** (`UpcomingRewards.tsx`): make tier images tappable per tier; track `selectedImage` and modal visibility; show modal with selected theme image or fallback.
> - **Tests**:
>   - Add `RewardsImageModal.test.tsx` covering rendering, props, interactions, and edge cases.
>   - Update `SeasonStatus.test.tsx` and `UpcomingRewards.test.tsx` to mock modal and assert visibility, props, image tap behavior, and related interactions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92de04572d1c8827f1e20956b84d98c39b28334e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->