### PR TITLE
fix: cp-7.57.0 hide 0 balances account picker

### DIFF
--- a/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.tsx
@@ -105,7 +105,7 @@ const AccountCell = ({
             color={TextColor.Default}
             testID={AccountCellIds.BALANCE}
           >
-            {displayBalance}
+            {totalBalance ? displayBalance : null}
           </Text>
         </TouchableOpacity>
         {!hideMenu && (

--- a/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/__snapshots__/MultichainAccountsConnectedList.test.tsx.snap
+++ b/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/__snapshots__/MultichainAccountsConnectedList.test.tsx.snap
@@ -232,9 +232,7 @@ exports[`MultichainAccountsConnectedList renders component with different accoun
                             }
                           }
                           testID="multichain-account-cell-balance"
-                        >
-                          $0.00
-                        </Text>
+                        />
                       </TouchableOpacity>
                       <TouchableOpacity
                         onPress={[Function]}
@@ -420,9 +418,7 @@ exports[`MultichainAccountsConnectedList renders component with different accoun
                             }
                           }
                           testID="multichain-account-cell-balance"
-                        >
-                          $0.00
-                        </Text>
+                        />
                       </TouchableOpacity>
                       <TouchableOpacity
                         onPress={[Function]}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

We are currently showing a balance of $0.00 in the account picker when no balance has been loaded yet, as that does not happen until the user selects the account.

Although it is possible to make changes to discern between a balance of 0 or a balance that has not yet been fetched, it involves a series of changes to controllers, state and selectors.

It's been flagged that we don't want to wrongly show a balance of 0 when the balance has not been fetched for 7.57.0, so always hiding balances of 0 is the only compromise that we can achieve before the deadline.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Changed behaviour of account picker to not show accounts with 0 balance

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/20895

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/6841b756-993c-4e69-acd6-8e4b786600c4


### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/76125d0f-0061-45d8-a97f-4d8b3d71648c


## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hide balance text when total balance is zero or unavailable in the multichain account picker and update snapshots accordingly.
> 
> - **Frontend**
>   - **Account balance display**: In `app/component-library/components-temp/MultichainAccounts/AccountCell/AccountCell.tsx`, render `null` for `testID` `multichain-account-cell-balance` when `totalBalance` is falsy (`{totalBalance ? displayBalance : null}`) instead of showing `$0.00`.
> - **Tests**
>   - **Snapshots**: Update `app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/__snapshots__/MultichainAccountsConnectedList.test.tsx.snap` to remove `$0.00` and reflect self-closing `Text` for the balance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 378472b80d9600eb2afd4eaf8afc109e744654dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->