### PR TITLE
fix(deposit): payment method duration badge

### DIFF
--- a/app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.test.tsx
@@ -277,7 +277,7 @@ describe('BuildQuote Component', () => {
       expect(screen.toJSON()).toMatchSnapshot();
     });
 
-    it.only('does not show the duration when selected payment method is null', () => {
+    it('does not show the duration when selected payment method is null', () => {
       mockUseDepositSDK.mockReturnValue(
         createMockSDKReturn({
           selectedPaymentMethod: null,

--- a/app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.test.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.test.tsx
@@ -30,6 +30,7 @@ import {
   MOCK_USE_PAYMENT_METHODS_RETURN,
   MOCK_CRYPTOCURRENCIES,
   MOCK_PAYMENT_METHODS,
+  MOCK_SEPA_BANK_TRANSFER_PAYMENT_METHOD,
 } from '../../testUtils';
 
 const createMockInteractionManager = () => ({
@@ -264,6 +265,28 @@ describe('BuildQuote Component', () => {
   });
 
   describe('Payment Method Selection', () => {
+    it('shows the right duration for the selected payment method', () => {
+      mockUseDepositSDK.mockReturnValue(
+        createMockSDKReturn({
+          selectedPaymentMethod: {
+            ...MOCK_SEPA_BANK_TRANSFER_PAYMENT_METHOD,
+          },
+        }),
+      );
+      render(BuildQuote);
+      expect(screen.toJSON()).toMatchSnapshot();
+    });
+
+    it.only('does not show the duration when selected payment method is null', () => {
+      mockUseDepositSDK.mockReturnValue(
+        createMockSDKReturn({
+          selectedPaymentMethod: null,
+        }),
+      );
+      render(BuildQuote);
+      expect(screen.toJSON()).toMatchSnapshot();
+    });
+
     it('navigates to payment method selection when payment button is pressed', () => {
       render(BuildQuote);
       const payWithButton = screen.getByText('Pay with');

--- a/app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.tsx
@@ -604,12 +604,16 @@ const BuildQuote = () => {
               </ListItemColumn>
 
               <ListItemColumn>
-                <TagBase
-                  includesBorder
-                  textProps={{ variant: TextVariant.BodySM }}
-                >
-                  {strings('deposit.payment_duration.instant')}
-                </TagBase>
+                {selectedPaymentMethod ? (
+                  <TagBase
+                    includesBorder
+                    textProps={{ variant: TextVariant.BodySM }}
+                  >
+                    {strings(
+                      `deposit.payment_duration.${selectedPaymentMethod.duration}`,
+                    )}
+                  </TagBase>
+                ) : null}
               </ListItemColumn>
               <ListItemColumn>
                 <Icon

--- a/app/components/UI/Ramp/Deposit/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
@@ -447,7 +447,7 @@ exports[`BuildQuote Component Continue button functionality displays error when 
             <View
               collapsable={false}
               enabled={false}
-              handlerTag={22}
+              handlerTag={24}
               handlerType="PanGestureHandler"
               onGestureHandlerEvent={[Function]}
               onGestureHandlerStateChange={[Function]}
@@ -2323,7 +2323,7 @@ exports[`BuildQuote Component Continue button functionality displays error when 
             <View
               collapsable={false}
               enabled={false}
-              handlerTag={24}
+              handlerTag={26}
               handlerType="PanGestureHandler"
               onGestureHandlerEvent={[Function]}
               onGestureHandlerStateChange={[Function]}
@@ -4199,7 +4199,7 @@ exports[`BuildQuote Component Continue button functionality displays error when 
             <View
               collapsable={false}
               enabled={false}
-              handlerTag={26}
+              handlerTag={28}
               handlerType="PanGestureHandler"
               onGestureHandlerEvent={[Function]}
               onGestureHandlerStateChange={[Function]}
@@ -6075,7 +6075,7 @@ exports[`BuildQuote Component Keypad Functionality displays converted token amou
             <View
               collapsable={false}
               enabled={false}
-              handlerTag={15}
+              handlerTag={17}
               handlerType="PanGestureHandler"
               onGestureHandlerEvent={[Function]}
               onGestureHandlerStateChange={[Function]}
@@ -7890,7 +7890,7 @@ exports[`BuildQuote Component Keypad Functionality updates amount when keypad is
             <View
               collapsable={false}
               enabled={false}
-              handlerTag={14}
+              handlerTag={16}
               handlerType="PanGestureHandler"
               onGestureHandlerEvent={[Function]}
               onGestureHandlerStateChange={[Function]}
@@ -9705,7 +9705,7 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
             <View
               collapsable={false}
               enabled={false}
-              handlerTag={10}
+              handlerTag={12}
               handlerType="PanGestureHandler"
               onGestureHandlerEvent={[Function]}
               onGestureHandlerStateChange={[Function]}
@@ -11520,7 +11520,7 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
             <View
               collapsable={false}
               enabled={false}
-              handlerTag={9}
+              handlerTag={11}
               handlerType="PanGestureHandler"
               onGestureHandlerEvent={[Function]}
               onGestureHandlerStateChange={[Function]}
@@ -13428,7 +13428,7 @@ exports[`BuildQuote Component Payment Method Selection does not show the duratio
             <View
               collapsable={false}
               enabled={false}
-              handlerTag={1}
+              handlerTag={9}
               handlerType="PanGestureHandler"
               onGestureHandlerEvent={[Function]}
               onGestureHandlerStateChange={[Function]}
@@ -15198,7 +15198,7 @@ exports[`BuildQuote Component Payment Method Selection shows the right duration 
             <View
               collapsable={false}
               enabled={false}
-              handlerTag={1}
+              handlerTag={8}
               handlerType="PanGestureHandler"
               onGestureHandlerEvent={[Function]}
               onGestureHandlerStateChange={[Function]}
@@ -24366,7 +24366,7 @@ exports[`BuildQuote Component Token Selection does not open token modal when cry
             <View
               collapsable={false}
               enabled={false}
-              handlerTag={13}
+              handlerTag={15}
               handlerType="PanGestureHandler"
               onGestureHandlerEvent={[Function]}
               onGestureHandlerStateChange={[Function]}
@@ -26179,7 +26179,7 @@ exports[`BuildQuote Component Token Selection does not open token modal when cry
             <View
               collapsable={false}
               enabled={false}
-              handlerTag={12}
+              handlerTag={14}
               handlerType="PanGestureHandler"
               onGestureHandlerEvent={[Function]}
               onGestureHandlerStateChange={[Function]}

--- a/app/components/UI/Ramp/Deposit/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
@@ -12981,6 +12981,3591 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
 </View>
 `;
 
+exports[`BuildQuote Component Payment Method Selection does not show the duration when selected payment method is null 1`] = `
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <RNCSafeAreaProvider
+    onInsetsChange={[Function]}
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      pointerEvents="box-none"
+      style={
+        {
+          "zIndex": 1,
+        }
+      }
+    >
+      <View
+        accessibilityElementsHidden={false}
+        importantForAccessibility="auto"
+        onLayout={[Function]}
+        pointerEvents="box-none"
+        style={null}
+      >
+        <View
+          collapsable={false}
+          pointerEvents="box-none"
+          style={
+            {
+              "bottom": 0,
+              "left": 0,
+              "opacity": 1,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "zIndex": 0,
+            }
+          }
+        >
+          <View
+            collapsable={false}
+            style={
+              {
+                "backgroundColor": "#ffffff",
+                "borderBottomColor": "rgb(216, 216, 216)",
+                "elevation": 0,
+                "flex": 1,
+                "shadowColor": "rgb(216, 216, 216)",
+                "shadowOffset": {
+                  "height": 0.5,
+                  "width": 0,
+                },
+                "shadowOpacity": 0,
+                "shadowRadius": 0,
+              }
+            }
+          />
+        </View>
+        <View
+          collapsable={false}
+          pointerEvents="box-none"
+          style={
+            {
+              "height": 64,
+              "maxHeight": undefined,
+              "minHeight": undefined,
+              "opacity": undefined,
+              "transform": undefined,
+            }
+          }
+        >
+          <View
+            pointerEvents="none"
+            style={
+              {
+                "height": 20,
+              }
+            }
+          />
+          <View
+            pointerEvents="box-none"
+            style={
+              {
+                "alignItems": "center",
+                "flex": 1,
+                "flexDirection": "row",
+                "justifyContent": "center",
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              pointerEvents="box-none"
+              style={
+                {
+                  "alignItems": "flex-start",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "left": 0,
+                  "opacity": 1,
+                  "position": "absolute",
+                  "top": 0,
+                }
+              }
+            >
+              <View
+                style={
+                  [
+                    {
+                      "transform": [
+                        {
+                          "scale": 1,
+                        },
+                      ],
+                    },
+                    {
+                      "alignItems": "center",
+                      "justifyContent": "center",
+                    },
+                  ]
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": false,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    [
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "transparent",
+                        "borderRadius": 2,
+                        "height": 40,
+                        "justifyContent": "center",
+                        "opacity": 1,
+                        "width": 40,
+                      },
+                      {
+                        "marginHorizontal": 16,
+                      },
+                    ]
+                  }
+                  testID="deposit-configuration-menu-button"
+                >
+                  <SvgMock
+                    fill="currentColor"
+                    name="MoreHorizontal"
+                    style={
+                      [
+                        {
+                          "color": "#121314",
+                          "height": 24,
+                          "width": 24,
+                        },
+                        undefined,
+                      ]
+                    }
+                  />
+                </View>
+              </View>
+            </View>
+            <View
+              collapsable={false}
+              pointerEvents="box-none"
+              style={
+                {
+                  "marginHorizontal": 72,
+                  "opacity": 1,
+                }
+              }
+            >
+              <TouchableOpacity
+                activeOpacity={1}
+                onPress={[Function]}
+                style={
+                  {
+                    "alignItems": "center",
+                    "justifyContent": "center",
+                  }
+                }
+              >
+                <Text
+                  accessibilityRole="text"
+                  numberOfLines={1}
+                  style={
+                    {
+                      "color": "#121314",
+                      "fontFamily": "Geist Bold",
+                      "fontSize": 16,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                    }
+                  }
+                >
+                  Deposit
+                </Text>
+              </TouchableOpacity>
+            </View>
+            <View
+              collapsable={false}
+              pointerEvents="box-none"
+              style={
+                {
+                  "alignItems": "flex-end",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            >
+              <View
+                style={
+                  [
+                    {
+                      "transform": [
+                        {
+                          "scale": 1,
+                        },
+                      ],
+                    },
+                    {
+                      "alignItems": "center",
+                      "justifyContent": "center",
+                    },
+                  ]
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": false,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    [
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "transparent",
+                        "borderRadius": 2,
+                        "height": 40,
+                        "justifyContent": "center",
+                        "opacity": 1,
+                        "width": 40,
+                      },
+                      {
+                        "marginHorizontal": 16,
+                      },
+                    ]
+                  }
+                  testID="button-icon"
+                >
+                  <SvgMock
+                    fill="currentColor"
+                    name="Close"
+                    style={
+                      [
+                        {
+                          "color": "#121314",
+                          "height": 24,
+                          "width": 24,
+                        },
+                        undefined,
+                      ]
+                    }
+                  />
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <RNSScreenContainer
+      onLayout={[Function]}
+      style={
+        {
+          "flex": 1,
+        }
+      }
+    >
+      <RNSScreen
+        activityState={2}
+        collapsable={false}
+        gestureResponseDistance={
+          {
+            "bottom": -1,
+            "end": -1,
+            "start": -1,
+            "top": -1,
+          }
+        }
+        onGestureCancel={[Function]}
+        pointerEvents="box-none"
+        sheetAllowedDetents="large"
+        sheetCornerRadius={-1}
+        sheetExpandsWhenScrolledToEdge={true}
+        sheetGrabberVisible={false}
+        sheetLargestUndimmedDetent="all"
+        style={
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "zIndex": undefined,
+          }
+        }
+      >
+        <View
+          collapsable={false}
+          style={
+            {
+              "opacity": 1,
+            }
+          }
+        />
+        <View
+          accessibilityElementsHidden={false}
+          closing={false}
+          gestureVelocityImpact={0.3}
+          importantForAccessibility="auto"
+          onClose={[Function]}
+          onGestureBegin={[Function]}
+          onGestureCanceled={[Function]}
+          onGestureEnd={[Function]}
+          onOpen={[Function]}
+          onTransition={[Function]}
+          pointerEvents="box-none"
+          style={
+            [
+              {
+                "overflow": undefined,
+              },
+              {
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+            ]
+          }
+          transitionSpec={
+            {
+              "close": {
+                "animation": "spring",
+                "config": {
+                  "damping": 500,
+                  "mass": 3,
+                  "overshootClamping": true,
+                  "restDisplacementThreshold": 10,
+                  "restSpeedThreshold": 10,
+                  "stiffness": 1000,
+                },
+              },
+              "open": {
+                "animation": "spring",
+                "config": {
+                  "damping": 500,
+                  "mass": 3,
+                  "overshootClamping": true,
+                  "restDisplacementThreshold": 10,
+                  "restSpeedThreshold": 10,
+                  "stiffness": 1000,
+                },
+              },
+            }
+          }
+        >
+          <View
+            collapsable={false}
+            needsOffscreenAlphaCompositing={false}
+            pointerEvents="box-none"
+            style={
+              {
+                "flex": 1,
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              enabled={false}
+              handlerTag={1}
+              handlerType="PanGestureHandler"
+              onGestureHandlerEvent={[Function]}
+              onGestureHandlerStateChange={[Function]}
+              style={
+                {
+                  "flex": 1,
+                  "transform": [
+                    {
+                      "translateX": 0,
+                    },
+                    {
+                      "translateX": 0,
+                    },
+                  ],
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                pointerEvents="none"
+                style={
+                  {
+                    "backgroundColor": "rgb(242, 242, 242)",
+                    "bottom": 0,
+                    "left": 0,
+                    "position": "absolute",
+                    "shadowColor": "#000",
+                    "shadowOffset": {
+                      "height": 1,
+                      "width": -1,
+                    },
+                    "shadowOpacity": 0.3,
+                    "shadowRadius": 5,
+                    "top": 0,
+                    "width": 3,
+                  }
+                }
+              />
+              <View
+                style={
+                  [
+                    {
+                      "flex": 1,
+                      "overflow": "hidden",
+                    },
+                    [
+                      {
+                        "backgroundColor": "rgb(242, 242, 242)",
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+              >
+                <View
+                  style={
+                    {
+                      "flex": 1,
+                      "flexDirection": "column-reverse",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <RNCSafeAreaView
+                      edges={
+                        {
+                          "bottom": "additive",
+                          "left": "additive",
+                          "right": "additive",
+                          "top": "off",
+                        }
+                      }
+                      style={
+                        {
+                          "flex": 1,
+                        }
+                      }
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "backgroundColor": "#ffffff",
+                              "flex": 1,
+                            },
+                            undefined,
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            [
+                              {
+                                "flex": 1,
+                              },
+                              undefined,
+                            ]
+                          }
+                        >
+                          <View
+                            style={
+                              [
+                                {
+                                  "padding": 15,
+                                },
+                                undefined,
+                                {
+                                  "flex": 1,
+                                },
+                              ]
+                            }
+                          >
+                            <View
+                              style={
+                                {
+                                  "flexDirection": "row",
+                                  "fontWeight": 500,
+                                  "gap": 12,
+                                  "justifyContent": "center",
+                                }
+                              }
+                            >
+                              <TouchableOpacity
+                                onPress={[Function]}
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                    "alignSelf": "flex-start",
+                                    "backgroundColor": "#ffffff",
+                                    "borderColor": "#b7bbc866",
+                                    "borderRadius": 12,
+                                    "borderWidth": 1,
+                                    "flexDirection": "row",
+                                    "gap": 10,
+                                    "justifyContent": "space-between",
+                                    "padding": 8,
+                                  }
+                                }
+                                testID="ramps-account-picker"
+                              >
+                                <Text
+                                  accessibilityRole="text"
+                                  style={
+                                    {
+                                      "color": "#121314",
+                                      "fontFamily": "Geist Regular",
+                                      "fontSize": 16,
+                                      "letterSpacing": 0,
+                                      "lineHeight": 24,
+                                    }
+                                  }
+                                >
+                                  Account is loading...
+                                </Text>
+                              </TouchableOpacity>
+                              <TouchableOpacity
+                                disabled={false}
+                                onPress={[Function]}
+                                style={
+                                  {
+                                    "backgroundColor": "#ffffff",
+                                    "borderColor": "#b7bbc866",
+                                    "borderRadius": 12,
+                                    "borderWidth": 1,
+                                    "paddingHorizontal": 16,
+                                    "paddingVertical": 8,
+                                  }
+                                }
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "flexDirection": "row",
+                                      "gap": 8,
+                                    }
+                                  }
+                                >
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Regular",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
+                                    }
+                                  >
+                                    🇺🇸
+                                  </Text>
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Regular",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
+                                    }
+                                  >
+                                    US
+                                  </Text>
+                                  <SvgMock
+                                    color="#686e7d"
+                                    fill="currentColor"
+                                    height={16}
+                                    name="ArrowDown"
+                                    style={
+                                      {
+                                        "height": 16,
+                                        "width": 16,
+                                      }
+                                    }
+                                    width={16}
+                                  />
+                                </View>
+                              </TouchableOpacity>
+                            </View>
+                            <View
+                              style={
+                                {
+                                  "alignItems": "center",
+                                  "flex": 1,
+                                  "gap": 16,
+                                  "justifyContent": "center",
+                                }
+                              }
+                            >
+                              <View>
+                                <Text
+                                  accessibilityRole="text"
+                                  adjustsFontSizeToFit={true}
+                                  numberOfLines={1}
+                                  style={
+                                    {
+                                      "color": "#121314",
+                                      "fontFamily": "Geist Regular",
+                                      "fontSize": 64,
+                                      "fontWeight": 400,
+                                      "letterSpacing": 0,
+                                      "lineHeight": 72,
+                                      "textAlign": "center",
+                                    }
+                                  }
+                                >
+                                  $0
+                                </Text>
+                                <Text
+                                  accessibilityRole="text"
+                                  style={
+                                    {
+                                      "color": "#686e7d",
+                                      "fontFamily": "Geist Regular",
+                                      "fontSize": 16,
+                                      "letterSpacing": 0,
+                                      "lineHeight": 24,
+                                      "textAlign": "center",
+                                    }
+                                  }
+                                >
+                                  0
+                                   
+                                  USDC
+                                </Text>
+                              </View>
+                              <TouchableOpacity
+                                disabled={false}
+                                onPress={[Function]}
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "#b7bbc866",
+                                      "borderRadius": 100,
+                                      "borderWidth": 1,
+                                      "flexDirection": "row",
+                                      "gap": 8,
+                                      "paddingLeft": 8,
+                                      "paddingRight": 12,
+                                      "paddingVertical": 8,
+                                    }
+                                  }
+                                >
+                                  <View
+                                    onLayout={[Function]}
+                                    style={
+                                      {
+                                        "alignSelf": "flex-start",
+                                        "position": "relative",
+                                      }
+                                    }
+                                    testID="badge-wrapper-badge"
+                                  >
+                                    <View>
+                                      <View
+                                        style={
+                                          {
+                                            "backgroundColor": "#ffffff",
+                                            "borderRadius": 16,
+                                            "height": 32,
+                                            "overflow": "hidden",
+                                            "width": 32,
+                                          }
+                                        }
+                                      >
+                                        <Image
+                                          onError={[Function]}
+                                          resizeMode="contain"
+                                          source={
+                                            {
+                                              "uri": "https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48.png",
+                                            }
+                                          }
+                                          style={
+                                            {
+                                              "flex": 1,
+                                              "height": undefined,
+                                              "width": undefined,
+                                            }
+                                          }
+                                          testID="token-avatar-image"
+                                        />
+                                      </View>
+                                    </View>
+                                    <View
+                                      style={
+                                        {
+                                          "alignItems": "center",
+                                          "aspectRatio": 1,
+                                          "bottom": 0,
+                                          "height": 0,
+                                          "justifyContent": "center",
+                                          "position": "absolute",
+                                          "right": 0,
+                                          "transform": [
+                                            {
+                                              "translateX": 0,
+                                            },
+                                            {
+                                              "translateY": 0,
+                                            },
+                                          ],
+                                        }
+                                      }
+                                    >
+                                      <View
+                                        onLayout={[Function]}
+                                        style={
+                                          {
+                                            "alignItems": "center",
+                                            "aspectRatio": 1,
+                                            "height": "50%",
+                                            "justifyContent": "center",
+                                            "maxHeight": 24,
+                                            "minHeight": 8,
+                                            "opacity": 0,
+                                          }
+                                        }
+                                        testID="badgenetwork"
+                                      >
+                                        <View
+                                          style={
+                                            {
+                                              "alignItems": "center",
+                                              "backgroundColor": "#ffffff",
+                                              "borderColor": "#ffffff",
+                                              "borderRadius": 8,
+                                              "borderWidth": 2,
+                                              "height": 32,
+                                              "justifyContent": "center",
+                                              "overflow": "hidden",
+                                              "shadowColor": "#0000001a",
+                                              "shadowOffset": {
+                                                "height": 2,
+                                                "width": 0,
+                                              },
+                                              "shadowOpacity": 1,
+                                              "shadowRadius": 4,
+                                              "transform": [
+                                                {
+                                                  "scale": 1,
+                                                },
+                                              ],
+                                              "width": 32,
+                                            }
+                                          }
+                                        >
+                                          <Image
+                                            onError={[Function]}
+                                            resizeMode="contain"
+                                            source={1}
+                                            style={
+                                              {
+                                                "height": 32,
+                                                "width": 32,
+                                              }
+                                            }
+                                            testID="network-avatar-image"
+                                          />
+                                        </View>
+                                      </View>
+                                    </View>
+                                  </View>
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 24,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 32,
+                                      }
+                                    }
+                                  >
+                                    USDC
+                                  </Text>
+                                  <SvgMock
+                                    color="#686e7d"
+                                    fill="currentColor"
+                                    height={16}
+                                    name="ArrowDown"
+                                    style={
+                                      {
+                                        "height": 16,
+                                        "width": 16,
+                                      }
+                                    }
+                                    width={16}
+                                  />
+                                </View>
+                              </TouchableOpacity>
+                            </View>
+                            <TouchableOpacity
+                              disabled={false}
+                              onPress={[Function]}
+                              style={
+                                {
+                                  "borderColor": "#b7bbc866",
+                                  "borderRadius": 12,
+                                  "borderWidth": 1,
+                                  "marginBottom": 16,
+                                }
+                              }
+                            >
+                              <View
+                                accessibilityRole="none"
+                                accessible={true}
+                                style={
+                                  {
+                                    "padding": 16,
+                                  }
+                                }
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "flexDirection": "row",
+                                    }
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      {
+                                        "flex": 1,
+                                      }
+                                    }
+                                    testID="listitemcolumn"
+                                  >
+                                    <Text
+                                      accessibilityRole="text"
+                                      style={
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Regular",
+                                          "fontSize": 16,
+                                          "letterSpacing": 0,
+                                          "lineHeight": 24,
+                                        }
+                                      }
+                                    >
+                                      Pay with
+                                    </Text>
+                                    <Text
+                                      accessibilityRole="text"
+                                      style={
+                                        {
+                                          "color": "#686e7d",
+                                          "fontFamily": "Geist Regular",
+                                          "fontSize": 14,
+                                          "letterSpacing": 0,
+                                          "lineHeight": 22,
+                                        }
+                                      }
+                                    >
+                                       
+                                    </Text>
+                                  </View>
+                                  <View
+                                    accessible={false}
+                                    style={
+                                      {
+                                        "width": 8,
+                                      }
+                                    }
+                                    testID="listitem-gap"
+                                  />
+                                  <View
+                                    style={
+                                      {
+                                        "flex": -1,
+                                      }
+                                    }
+                                    testID="listitemcolumn"
+                                  />
+                                  <View
+                                    accessible={false}
+                                    style={
+                                      {
+                                        "width": 8,
+                                      }
+                                    }
+                                    testID="listitem-gap"
+                                  />
+                                  <View
+                                    style={
+                                      {
+                                        "flex": -1,
+                                      }
+                                    }
+                                    testID="listitemcolumn"
+                                  >
+                                    <SvgMock
+                                      color="#686e7d"
+                                      fill="currentColor"
+                                      height={20}
+                                      name="ArrowRight"
+                                      style={
+                                        {
+                                          "height": 20,
+                                          "width": 20,
+                                        }
+                                      }
+                                      width={20}
+                                    />
+                                  </View>
+                                </View>
+                              </View>
+                            </TouchableOpacity>
+                            <View
+                              style={
+                                [
+                                  {
+                                    "display": "flex",
+                                    "gap": 12,
+                                  },
+                                  undefined,
+                                ]
+                              }
+                            >
+                              <View
+                                style={
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
+                                }
+                              >
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      1
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      2
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      3
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                              </View>
+                              <View
+                                style={
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
+                                }
+                              >
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      4
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      5
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      6
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                              </View>
+                              <View
+                                style={
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
+                                }
+                              >
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      7
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      8
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      9
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                              </View>
+                              <View
+                                style={
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
+                                }
+                              >
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    disabled={true}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        {
+                                          "backgroundColor": "transparent",
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      .
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      0
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    delayLongPress={500}
+                                    onLongPress={[Function]}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                    testID="keypad-delete-button"
+                                  >
+                                    <SvgMock
+                                      fill="currentColor"
+                                      name="Backspace"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "height": 32,
+                                            "width": 32,
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    />
+                                  </TouchableOpacity>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                        </View>
+                        <View>
+                          <View
+                            style={
+                              [
+                                {
+                                  "padding": 15,
+                                },
+                                undefined,
+                                undefined,
+                              ]
+                            }
+                          >
+                            <TouchableOpacity
+                              accessibilityRole="button"
+                              accessible={true}
+                              activeOpacity={1}
+                              disabled={true}
+                              loading={false}
+                              onPressIn={[Function]}
+                              onPressOut={[Function]}
+                              style={
+                                {
+                                  "alignItems": "center",
+                                  "alignSelf": "stretch",
+                                  "backgroundColor": "#121314",
+                                  "borderRadius": 12,
+                                  "flexDirection": "row",
+                                  "height": 48,
+                                  "justifyContent": "center",
+                                  "opacity": 0.5,
+                                  "overflow": "hidden",
+                                  "paddingHorizontal": 16,
+                                }
+                              }
+                            >
+                              <Text
+                                accessibilityRole="text"
+                                style={
+                                  {
+                                    "color": "#ffffff",
+                                    "fontFamily": "Geist Medium",
+                                    "fontSize": 16,
+                                    "letterSpacing": 0,
+                                    "lineHeight": 24,
+                                  }
+                                }
+                              >
+                                Continue
+                              </Text>
+                            </TouchableOpacity>
+                          </View>
+                        </View>
+                      </View>
+                    </RNCSafeAreaView>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </RNSScreen>
+    </RNSScreenContainer>
+  </RNCSafeAreaProvider>
+</View>
+`;
+
+exports[`BuildQuote Component Payment Method Selection shows the right duration for the selected payment method 1`] = `
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <RNCSafeAreaProvider
+    onInsetsChange={[Function]}
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      collapsable={false}
+      pointerEvents="box-none"
+      style={
+        {
+          "zIndex": 1,
+        }
+      }
+    >
+      <View
+        accessibilityElementsHidden={false}
+        importantForAccessibility="auto"
+        onLayout={[Function]}
+        pointerEvents="box-none"
+        style={null}
+      >
+        <View
+          collapsable={false}
+          pointerEvents="box-none"
+          style={
+            {
+              "bottom": 0,
+              "left": 0,
+              "opacity": 1,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "zIndex": 0,
+            }
+          }
+        >
+          <View
+            collapsable={false}
+            style={
+              {
+                "backgroundColor": "#ffffff",
+                "borderBottomColor": "rgb(216, 216, 216)",
+                "elevation": 0,
+                "flex": 1,
+                "shadowColor": "rgb(216, 216, 216)",
+                "shadowOffset": {
+                  "height": 0.5,
+                  "width": 0,
+                },
+                "shadowOpacity": 0,
+                "shadowRadius": 0,
+              }
+            }
+          />
+        </View>
+        <View
+          collapsable={false}
+          pointerEvents="box-none"
+          style={
+            {
+              "height": 64,
+              "maxHeight": undefined,
+              "minHeight": undefined,
+              "opacity": undefined,
+              "transform": undefined,
+            }
+          }
+        >
+          <View
+            pointerEvents="none"
+            style={
+              {
+                "height": 20,
+              }
+            }
+          />
+          <View
+            pointerEvents="box-none"
+            style={
+              {
+                "alignItems": "center",
+                "flex": 1,
+                "flexDirection": "row",
+                "justifyContent": "center",
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              pointerEvents="box-none"
+              style={
+                {
+                  "alignItems": "flex-start",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "left": 0,
+                  "opacity": 1,
+                  "position": "absolute",
+                  "top": 0,
+                }
+              }
+            >
+              <View
+                style={
+                  [
+                    {
+                      "transform": [
+                        {
+                          "scale": 1,
+                        },
+                      ],
+                    },
+                    {
+                      "alignItems": "center",
+                      "justifyContent": "center",
+                    },
+                  ]
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": false,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    [
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "transparent",
+                        "borderRadius": 2,
+                        "height": 40,
+                        "justifyContent": "center",
+                        "opacity": 1,
+                        "width": 40,
+                      },
+                      {
+                        "marginHorizontal": 16,
+                      },
+                    ]
+                  }
+                  testID="deposit-configuration-menu-button"
+                >
+                  <SvgMock
+                    fill="currentColor"
+                    name="MoreHorizontal"
+                    style={
+                      [
+                        {
+                          "color": "#121314",
+                          "height": 24,
+                          "width": 24,
+                        },
+                        undefined,
+                      ]
+                    }
+                  />
+                </View>
+              </View>
+            </View>
+            <View
+              collapsable={false}
+              pointerEvents="box-none"
+              style={
+                {
+                  "marginHorizontal": 72,
+                  "opacity": 1,
+                }
+              }
+            >
+              <TouchableOpacity
+                activeOpacity={1}
+                onPress={[Function]}
+                style={
+                  {
+                    "alignItems": "center",
+                    "justifyContent": "center",
+                  }
+                }
+              >
+                <Text
+                  accessibilityRole="text"
+                  numberOfLines={1}
+                  style={
+                    {
+                      "color": "#121314",
+                      "fontFamily": "Geist Bold",
+                      "fontSize": 16,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                    }
+                  }
+                >
+                  Deposit
+                </Text>
+              </TouchableOpacity>
+            </View>
+            <View
+              collapsable={false}
+              pointerEvents="box-none"
+              style={
+                {
+                  "alignItems": "flex-end",
+                  "bottom": 0,
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            >
+              <View
+                style={
+                  [
+                    {
+                      "transform": [
+                        {
+                          "scale": 1,
+                        },
+                      ],
+                    },
+                    {
+                      "alignItems": "center",
+                      "justifyContent": "center",
+                    },
+                  ]
+                }
+              >
+                <View
+                  accessibilityState={
+                    {
+                      "busy": undefined,
+                      "checked": undefined,
+                      "disabled": false,
+                      "expanded": undefined,
+                      "selected": undefined,
+                    }
+                  }
+                  accessibilityValue={
+                    {
+                      "max": undefined,
+                      "min": undefined,
+                      "now": undefined,
+                      "text": undefined,
+                    }
+                  }
+                  accessible={true}
+                  collapsable={false}
+                  focusable={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    [
+                      {
+                        "alignItems": "center",
+                        "backgroundColor": "transparent",
+                        "borderRadius": 2,
+                        "height": 40,
+                        "justifyContent": "center",
+                        "opacity": 1,
+                        "width": 40,
+                      },
+                      {
+                        "marginHorizontal": 16,
+                      },
+                    ]
+                  }
+                  testID="button-icon"
+                >
+                  <SvgMock
+                    fill="currentColor"
+                    name="Close"
+                    style={
+                      [
+                        {
+                          "color": "#121314",
+                          "height": 24,
+                          "width": 24,
+                        },
+                        undefined,
+                      ]
+                    }
+                  />
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+    <RNSScreenContainer
+      onLayout={[Function]}
+      style={
+        {
+          "flex": 1,
+        }
+      }
+    >
+      <RNSScreen
+        activityState={2}
+        collapsable={false}
+        gestureResponseDistance={
+          {
+            "bottom": -1,
+            "end": -1,
+            "start": -1,
+            "top": -1,
+          }
+        }
+        onGestureCancel={[Function]}
+        pointerEvents="box-none"
+        sheetAllowedDetents="large"
+        sheetCornerRadius={-1}
+        sheetExpandsWhenScrolledToEdge={true}
+        sheetGrabberVisible={false}
+        sheetLargestUndimmedDetent="all"
+        style={
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "zIndex": undefined,
+          }
+        }
+      >
+        <View
+          collapsable={false}
+          style={
+            {
+              "opacity": 1,
+            }
+          }
+        />
+        <View
+          accessibilityElementsHidden={false}
+          closing={false}
+          gestureVelocityImpact={0.3}
+          importantForAccessibility="auto"
+          onClose={[Function]}
+          onGestureBegin={[Function]}
+          onGestureCanceled={[Function]}
+          onGestureEnd={[Function]}
+          onOpen={[Function]}
+          onTransition={[Function]}
+          pointerEvents="box-none"
+          style={
+            [
+              {
+                "overflow": undefined,
+              },
+              {
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+            ]
+          }
+          transitionSpec={
+            {
+              "close": {
+                "animation": "spring",
+                "config": {
+                  "damping": 500,
+                  "mass": 3,
+                  "overshootClamping": true,
+                  "restDisplacementThreshold": 10,
+                  "restSpeedThreshold": 10,
+                  "stiffness": 1000,
+                },
+              },
+              "open": {
+                "animation": "spring",
+                "config": {
+                  "damping": 500,
+                  "mass": 3,
+                  "overshootClamping": true,
+                  "restDisplacementThreshold": 10,
+                  "restSpeedThreshold": 10,
+                  "stiffness": 1000,
+                },
+              },
+            }
+          }
+        >
+          <View
+            collapsable={false}
+            needsOffscreenAlphaCompositing={false}
+            pointerEvents="box-none"
+            style={
+              {
+                "flex": 1,
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              enabled={false}
+              handlerTag={1}
+              handlerType="PanGestureHandler"
+              onGestureHandlerEvent={[Function]}
+              onGestureHandlerStateChange={[Function]}
+              style={
+                {
+                  "flex": 1,
+                  "transform": [
+                    {
+                      "translateX": 0,
+                    },
+                    {
+                      "translateX": 0,
+                    },
+                  ],
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                pointerEvents="none"
+                style={
+                  {
+                    "backgroundColor": "rgb(242, 242, 242)",
+                    "bottom": 0,
+                    "left": 0,
+                    "position": "absolute",
+                    "shadowColor": "#000",
+                    "shadowOffset": {
+                      "height": 1,
+                      "width": -1,
+                    },
+                    "shadowOpacity": 0.3,
+                    "shadowRadius": 5,
+                    "top": 0,
+                    "width": 3,
+                  }
+                }
+              />
+              <View
+                style={
+                  [
+                    {
+                      "flex": 1,
+                      "overflow": "hidden",
+                    },
+                    [
+                      {
+                        "backgroundColor": "rgb(242, 242, 242)",
+                      },
+                      undefined,
+                    ],
+                  ]
+                }
+              >
+                <View
+                  style={
+                    {
+                      "flex": 1,
+                      "flexDirection": "column-reverse",
+                    }
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "flex": 1,
+                      }
+                    }
+                  >
+                    <RNCSafeAreaView
+                      edges={
+                        {
+                          "bottom": "additive",
+                          "left": "additive",
+                          "right": "additive",
+                          "top": "off",
+                        }
+                      }
+                      style={
+                        {
+                          "flex": 1,
+                        }
+                      }
+                    >
+                      <View
+                        style={
+                          [
+                            {
+                              "backgroundColor": "#ffffff",
+                              "flex": 1,
+                            },
+                            undefined,
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            [
+                              {
+                                "flex": 1,
+                              },
+                              undefined,
+                            ]
+                          }
+                        >
+                          <View
+                            style={
+                              [
+                                {
+                                  "padding": 15,
+                                },
+                                undefined,
+                                {
+                                  "flex": 1,
+                                },
+                              ]
+                            }
+                          >
+                            <View
+                              style={
+                                {
+                                  "flexDirection": "row",
+                                  "fontWeight": 500,
+                                  "gap": 12,
+                                  "justifyContent": "center",
+                                }
+                              }
+                            >
+                              <TouchableOpacity
+                                onPress={[Function]}
+                                style={
+                                  {
+                                    "alignItems": "center",
+                                    "alignSelf": "flex-start",
+                                    "backgroundColor": "#ffffff",
+                                    "borderColor": "#b7bbc866",
+                                    "borderRadius": 12,
+                                    "borderWidth": 1,
+                                    "flexDirection": "row",
+                                    "gap": 10,
+                                    "justifyContent": "space-between",
+                                    "padding": 8,
+                                  }
+                                }
+                                testID="ramps-account-picker"
+                              >
+                                <Text
+                                  accessibilityRole="text"
+                                  style={
+                                    {
+                                      "color": "#121314",
+                                      "fontFamily": "Geist Regular",
+                                      "fontSize": 16,
+                                      "letterSpacing": 0,
+                                      "lineHeight": 24,
+                                    }
+                                  }
+                                >
+                                  Account is loading...
+                                </Text>
+                              </TouchableOpacity>
+                              <TouchableOpacity
+                                disabled={false}
+                                onPress={[Function]}
+                                style={
+                                  {
+                                    "backgroundColor": "#ffffff",
+                                    "borderColor": "#b7bbc866",
+                                    "borderRadius": 12,
+                                    "borderWidth": 1,
+                                    "paddingHorizontal": 16,
+                                    "paddingVertical": 8,
+                                  }
+                                }
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "flexDirection": "row",
+                                      "gap": 8,
+                                    }
+                                  }
+                                >
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Regular",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
+                                    }
+                                  >
+                                    🇺🇸
+                                  </Text>
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Regular",
+                                        "fontSize": 16,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 24,
+                                      }
+                                    }
+                                  >
+                                    US
+                                  </Text>
+                                  <SvgMock
+                                    color="#686e7d"
+                                    fill="currentColor"
+                                    height={16}
+                                    name="ArrowDown"
+                                    style={
+                                      {
+                                        "height": 16,
+                                        "width": 16,
+                                      }
+                                    }
+                                    width={16}
+                                  />
+                                </View>
+                              </TouchableOpacity>
+                            </View>
+                            <View
+                              style={
+                                {
+                                  "alignItems": "center",
+                                  "flex": 1,
+                                  "gap": 16,
+                                  "justifyContent": "center",
+                                }
+                              }
+                            >
+                              <View>
+                                <Text
+                                  accessibilityRole="text"
+                                  adjustsFontSizeToFit={true}
+                                  numberOfLines={1}
+                                  style={
+                                    {
+                                      "color": "#121314",
+                                      "fontFamily": "Geist Regular",
+                                      "fontSize": 64,
+                                      "fontWeight": 400,
+                                      "letterSpacing": 0,
+                                      "lineHeight": 72,
+                                      "textAlign": "center",
+                                    }
+                                  }
+                                >
+                                  $0
+                                </Text>
+                                <Text
+                                  accessibilityRole="text"
+                                  style={
+                                    {
+                                      "color": "#686e7d",
+                                      "fontFamily": "Geist Regular",
+                                      "fontSize": 16,
+                                      "letterSpacing": 0,
+                                      "lineHeight": 24,
+                                      "textAlign": "center",
+                                    }
+                                  }
+                                >
+                                  0
+                                   
+                                  USDC
+                                </Text>
+                              </View>
+                              <TouchableOpacity
+                                disabled={false}
+                                onPress={[Function]}
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "backgroundColor": "#3c4d9d0f",
+                                      "borderColor": "#b7bbc866",
+                                      "borderRadius": 100,
+                                      "borderWidth": 1,
+                                      "flexDirection": "row",
+                                      "gap": 8,
+                                      "paddingLeft": 8,
+                                      "paddingRight": 12,
+                                      "paddingVertical": 8,
+                                    }
+                                  }
+                                >
+                                  <View
+                                    onLayout={[Function]}
+                                    style={
+                                      {
+                                        "alignSelf": "flex-start",
+                                        "position": "relative",
+                                      }
+                                    }
+                                    testID="badge-wrapper-badge"
+                                  >
+                                    <View>
+                                      <View
+                                        style={
+                                          {
+                                            "backgroundColor": "#ffffff",
+                                            "borderRadius": 16,
+                                            "height": 32,
+                                            "overflow": "hidden",
+                                            "width": 32,
+                                          }
+                                        }
+                                      >
+                                        <Image
+                                          onError={[Function]}
+                                          resizeMode="contain"
+                                          source={
+                                            {
+                                              "uri": "https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48.png",
+                                            }
+                                          }
+                                          style={
+                                            {
+                                              "flex": 1,
+                                              "height": undefined,
+                                              "width": undefined,
+                                            }
+                                          }
+                                          testID="token-avatar-image"
+                                        />
+                                      </View>
+                                    </View>
+                                    <View
+                                      style={
+                                        {
+                                          "alignItems": "center",
+                                          "aspectRatio": 1,
+                                          "bottom": 0,
+                                          "height": 0,
+                                          "justifyContent": "center",
+                                          "position": "absolute",
+                                          "right": 0,
+                                          "transform": [
+                                            {
+                                              "translateX": 0,
+                                            },
+                                            {
+                                              "translateY": 0,
+                                            },
+                                          ],
+                                        }
+                                      }
+                                    >
+                                      <View
+                                        onLayout={[Function]}
+                                        style={
+                                          {
+                                            "alignItems": "center",
+                                            "aspectRatio": 1,
+                                            "height": "50%",
+                                            "justifyContent": "center",
+                                            "maxHeight": 24,
+                                            "minHeight": 8,
+                                            "opacity": 0,
+                                          }
+                                        }
+                                        testID="badgenetwork"
+                                      >
+                                        <View
+                                          style={
+                                            {
+                                              "alignItems": "center",
+                                              "backgroundColor": "#ffffff",
+                                              "borderColor": "#ffffff",
+                                              "borderRadius": 8,
+                                              "borderWidth": 2,
+                                              "height": 32,
+                                              "justifyContent": "center",
+                                              "overflow": "hidden",
+                                              "shadowColor": "#0000001a",
+                                              "shadowOffset": {
+                                                "height": 2,
+                                                "width": 0,
+                                              },
+                                              "shadowOpacity": 1,
+                                              "shadowRadius": 4,
+                                              "transform": [
+                                                {
+                                                  "scale": 1,
+                                                },
+                                              ],
+                                              "width": 32,
+                                            }
+                                          }
+                                        >
+                                          <Image
+                                            onError={[Function]}
+                                            resizeMode="contain"
+                                            source={1}
+                                            style={
+                                              {
+                                                "height": 32,
+                                                "width": 32,
+                                              }
+                                            }
+                                            testID="network-avatar-image"
+                                          />
+                                        </View>
+                                      </View>
+                                    </View>
+                                  </View>
+                                  <Text
+                                    accessibilityRole="text"
+                                    style={
+                                      {
+                                        "color": "#121314",
+                                        "fontFamily": "Geist Bold",
+                                        "fontSize": 24,
+                                        "letterSpacing": 0,
+                                        "lineHeight": 32,
+                                      }
+                                    }
+                                  >
+                                    USDC
+                                  </Text>
+                                  <SvgMock
+                                    color="#686e7d"
+                                    fill="currentColor"
+                                    height={16}
+                                    name="ArrowDown"
+                                    style={
+                                      {
+                                        "height": 16,
+                                        "width": 16,
+                                      }
+                                    }
+                                    width={16}
+                                  />
+                                </View>
+                              </TouchableOpacity>
+                            </View>
+                            <TouchableOpacity
+                              disabled={false}
+                              onPress={[Function]}
+                              style={
+                                {
+                                  "borderColor": "#b7bbc866",
+                                  "borderRadius": 12,
+                                  "borderWidth": 1,
+                                  "marginBottom": 16,
+                                }
+                              }
+                            >
+                              <View
+                                accessibilityRole="none"
+                                accessible={true}
+                                style={
+                                  {
+                                    "padding": 16,
+                                  }
+                                }
+                              >
+                                <View
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "flexDirection": "row",
+                                    }
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      {
+                                        "flex": 1,
+                                      }
+                                    }
+                                    testID="listitemcolumn"
+                                  >
+                                    <Text
+                                      accessibilityRole="text"
+                                      style={
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Regular",
+                                          "fontSize": 16,
+                                          "letterSpacing": 0,
+                                          "lineHeight": 24,
+                                        }
+                                      }
+                                    >
+                                      Pay with
+                                    </Text>
+                                    <Text
+                                      accessibilityRole="text"
+                                      style={
+                                        {
+                                          "color": "#686e7d",
+                                          "fontFamily": "Geist Regular",
+                                          "fontSize": 14,
+                                          "letterSpacing": 0,
+                                          "lineHeight": 22,
+                                        }
+                                      }
+                                    >
+                                      SEPA Bank Transfer
+                                    </Text>
+                                  </View>
+                                  <View
+                                    accessible={false}
+                                    style={
+                                      {
+                                        "width": 8,
+                                      }
+                                    }
+                                    testID="listitem-gap"
+                                  />
+                                  <View
+                                    style={
+                                      {
+                                        "flex": -1,
+                                      }
+                                    }
+                                    testID="listitemcolumn"
+                                  >
+                                    <View
+                                      accessibilityRole="none"
+                                      accessible={true}
+                                      onLayout={[Function]}
+                                      style={
+                                        {
+                                          "alignSelf": "flex-start",
+                                          "backgroundColor": "#ffffff",
+                                          "borderColor": "#b7bbc8",
+                                          "borderRadius": 999,
+                                          "borderWidth": 1,
+                                          "color": "#121314",
+                                          "padding": 16,
+                                          "paddingHorizontal": 8,
+                                          "paddingVertical": 2,
+                                        }
+                                      }
+                                      testID="tagbase"
+                                    >
+                                      <View
+                                        style={
+                                          {
+                                            "alignItems": "center",
+                                            "flexDirection": "row",
+                                          }
+                                        }
+                                      >
+                                        <Text
+                                          accessibilityRole="text"
+                                          style={
+                                            {
+                                              "color": "#121314",
+                                              "fontFamily": "Geist Regular",
+                                              "fontSize": 14,
+                                              "letterSpacing": 0,
+                                              "lineHeight": 22,
+                                            }
+                                          }
+                                          testID="tagbase-text"
+                                        >
+                                          1 to 2 days
+                                        </Text>
+                                      </View>
+                                    </View>
+                                  </View>
+                                  <View
+                                    accessible={false}
+                                    style={
+                                      {
+                                        "width": 8,
+                                      }
+                                    }
+                                    testID="listitem-gap"
+                                  />
+                                  <View
+                                    style={
+                                      {
+                                        "flex": -1,
+                                      }
+                                    }
+                                    testID="listitemcolumn"
+                                  >
+                                    <SvgMock
+                                      color="#686e7d"
+                                      fill="currentColor"
+                                      height={20}
+                                      name="ArrowRight"
+                                      style={
+                                        {
+                                          "height": 20,
+                                          "width": 20,
+                                        }
+                                      }
+                                      width={20}
+                                    />
+                                  </View>
+                                </View>
+                              </View>
+                            </TouchableOpacity>
+                            <View
+                              style={
+                                [
+                                  {
+                                    "display": "flex",
+                                    "gap": 12,
+                                  },
+                                  undefined,
+                                ]
+                              }
+                            >
+                              <View
+                                style={
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
+                                }
+                              >
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      1
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      2
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      3
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                              </View>
+                              <View
+                                style={
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
+                                }
+                              >
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      4
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      5
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      6
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                              </View>
+                              <View
+                                style={
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
+                                }
+                              >
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      7
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      8
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      9
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                              </View>
+                              <View
+                                style={
+                                  [
+                                    {
+                                      "display": "flex",
+                                      "flexDirection": "row",
+                                      "gap": 12,
+                                      "justifyContent": "space-between",
+                                    },
+                                    undefined,
+                                  ]
+                                }
+                              >
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    disabled={true}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        {
+                                          "backgroundColor": "transparent",
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      .
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "backgroundColor": "#3c4d9d0f",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      accessibilityRole="none"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "fontFamily": "Geist Bold",
+                                            "fontSize": 32,
+                                            "fontWeight": "500",
+                                            "letterSpacing": 0,
+                                            "lineHeight": 40,
+                                            "textAlign": "center",
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    >
+                                      0
+                                    </Text>
+                                  </TouchableOpacity>
+                                </View>
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "display": "flex",
+                                        "flexBasis": "0%",
+                                        "flexGrow": 1,
+                                        "flexShrink": 1,
+                                      },
+                                      undefined,
+                                    ]
+                                  }
+                                >
+                                  <TouchableOpacity
+                                    accessibilityRole="button"
+                                    accessible={true}
+                                    delayLongPress={500}
+                                    onLongPress={[Function]}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "borderRadius": 12,
+                                          "height": 40,
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                        },
+                                        undefined,
+                                      ]
+                                    }
+                                    testID="keypad-delete-button"
+                                  >
+                                    <SvgMock
+                                      fill="currentColor"
+                                      name="Backspace"
+                                      style={
+                                        [
+                                          {
+                                            "color": "#121314",
+                                            "height": 32,
+                                            "width": 32,
+                                          },
+                                          undefined,
+                                        ]
+                                      }
+                                    />
+                                  </TouchableOpacity>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                        </View>
+                        <View>
+                          <View
+                            style={
+                              [
+                                {
+                                  "padding": 15,
+                                },
+                                undefined,
+                                undefined,
+                              ]
+                            }
+                          >
+                            <TouchableOpacity
+                              accessibilityRole="button"
+                              accessible={true}
+                              activeOpacity={1}
+                              disabled={true}
+                              loading={false}
+                              onPressIn={[Function]}
+                              onPressOut={[Function]}
+                              style={
+                                {
+                                  "alignItems": "center",
+                                  "alignSelf": "stretch",
+                                  "backgroundColor": "#121314",
+                                  "borderRadius": 12,
+                                  "flexDirection": "row",
+                                  "height": 48,
+                                  "justifyContent": "center",
+                                  "opacity": 0.5,
+                                  "overflow": "hidden",
+                                  "paddingHorizontal": 16,
+                                }
+                              }
+                            >
+                              <Text
+                                accessibilityRole="text"
+                                style={
+                                  {
+                                    "color": "#ffffff",
+                                    "fontFamily": "Geist Medium",
+                                    "fontSize": 16,
+                                    "letterSpacing": 0,
+                                    "lineHeight": 24,
+                                  }
+                                }
+                              >
+                                Continue
+                              </Text>
+                            </TouchableOpacity>
+                          </View>
+                        </View>
+                      </View>
+                    </RNCSafeAreaView>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </RNSScreen>
+    </RNSScreenContainer>
+  </RNCSafeAreaProvider>
+</View>
+`;
+
 exports[`BuildQuote Component Region Selection displays EUR currency when selectedRegion is EUR 1`] = `
 <View
   style={


### PR DESCRIPTION

## **Description**

This pull request enhances the `BuildQuote` component by improving how payment method durations are displayed and tested. The updates ensure that the correct duration is shown for the selected payment method, and that no duration is shown when no payment method is selected. Additionally, new tests have been added to verify this behavior.

**Improvements to payment method duration display:**

* The `BuildQuote` component now conditionally displays the payment duration tag only if a payment method is selected, and dynamically shows the correct duration based on the selected method.

**Testing enhancements:**

* Added a mock payment method (`MOCK_SEPA_BANK_TRANSFER_PAYMENT_METHOD`) to the test utilities for more comprehensive testing.
* Added tests to verify that the correct duration is shown for the selected payment method and that no duration is shown when no payment method is selected.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug displaying wrong duration for Deposit payment methods

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-2738

## **Manual testing steps**

```gherkin
Feature: Deposit

  Scenario: user selects a bank transfer payment method
    Given use visits the Deposit flow

    When user selects a Bank transfer payment method
    Then the right duration value shows in the UI
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="400" alt="pm_badge_before" src="https://github.com/user-attachments/assets/fc5b3378-0886-449c-b709-ef3382e4a1f9" />


### **After**

<img width="400" alt="pm_badge_after" src="https://github.com/user-attachments/assets/4ea9975d-b3bb-48c9-9536-9fe86ef0786b" />


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make the payment method duration badge show the selected method’s duration and hide it when no method is selected, with tests and snapshots updated.
> 
> - **BuildQuote UI (`app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.tsx`)**:
>   - **Payment Duration Badge**: Render duration tag only when `selectedPaymentMethod` exists; label now sourced from `deposit.payment_duration.${selectedPaymentMethod.duration}` instead of hardcoded `instant`.
> - **Tests (`BuildQuote.test.tsx`)**:
>   - Add `MOCK_SEPA_BANK_TRANSFER_PAYMENT_METHOD` for duration scenarios.
>   - Add tests to verify correct duration display and no badge when `selectedPaymentMethod` is `null`.
>   - Update snapshots to reflect new conditional rendering and dynamic labels.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0a069a7d6e1933206e4d1b6cc8f1f9aff698449. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->