### PR TITLE
chore: update swaps rewards animation

### DIFF
--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.test.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.test.tsx
@@ -27,13 +27,6 @@ jest.mock('rive-react-native', () => {
   };
 });
 
-// Mock useRewardsIconAnimation hook
-jest.mock('../../hooks/useRewardsIconAnimation', () => ({
-  useRewardsIconAnimation: jest.fn(() => ({
-    riveRef: { current: { fireState: jest.fn() } },
-  })),
-}));
-
 const mockNavigate = jest.fn();
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -456,20 +449,20 @@ describe('QuoteDetailsCard', () => {
       );
 
       // When rendering the component
-      const { queryByText, getByText, getByTestId } = renderScreen(
+      const { getByText, getByTestId } = renderScreen(
         QuoteDetailsCard,
         { name: Routes.BRIDGE.ROOT },
         { state: testState },
       );
 
-      // Then the rewards row should be shown but without points value
+      // Then the rewards row should be shown with the animation component
       await waitFor(() => {
         expect(getByText(strings('bridge.points'))).toBeOnTheScreen();
         expect(getByTestId('mock-rive-animation')).toBeOnTheScreen();
       });
 
-      // But no numeric value should be displayed
-      expect(queryByText(/^\d+$/)).toBeNull();
+      // RewardPointsAnimation component displays 0 when estimation fails
+      expect(getByText('0')).toBeOnTheScreen();
     });
 
     it('does not display rewards row when rewards feature is disabled', async () => {
@@ -574,19 +567,19 @@ describe('QuoteDetailsCard', () => {
       );
 
       // When rendering the component
-      const { queryByText, getByText, getByTestId } = renderScreen(
+      const { getByText, getByTestId } = renderScreen(
         QuoteDetailsCard,
         { name: Routes.BRIDGE.ROOT },
         { state: testState },
       );
 
-      // Then the rewards row should be shown but without points value
+      // Then the rewards row should be shown with animation component
       await waitFor(() => {
         expect(getByText(strings('bridge.points'))).toBeOnTheScreen();
         expect(getByTestId('mock-rive-animation')).toBeOnTheScreen();
       });
-      // Points value should not be displayed while loading
-      expect(queryByText(/^\d+$/)).toBeNull();
+      // RewardPointsAnimation shows 0 while loading (estimatedPoints is null, defaults to 0)
+      expect(getByText('0')).toBeOnTheScreen();
     });
 
     it('displays rewards row but no points when engine returns zero', async () => {
@@ -703,19 +696,19 @@ describe('QuoteDetailsCard', () => {
       );
 
       // When rendering the component
-      const { queryByText, getByText, getByTestId } = renderScreen(
+      const { getByText, getByTestId } = renderScreen(
         QuoteDetailsCard,
         { name: Routes.BRIDGE.ROOT },
         { state: testState },
       );
 
-      // Then rewards row should be shown but without points value
+      // Then rewards row should be shown with animation component
       await waitFor(() => {
         expect(getByText(strings('bridge.points'))).toBeOnTheScreen();
         expect(getByTestId('mock-rive-animation')).toBeOnTheScreen();
       });
-      // No numeric value should be displayed
-      expect(queryByText(/^\d+$/)).toBeNull();
+      // RewardPointsAnimation displays 0 when estimatedPoints is null (uses ?? 0 fallback)
+      expect(getByText('0')).toBeOnTheScreen();
     });
 
     it('handles quote loading state with rewards', async () => {
@@ -754,7 +747,7 @@ describe('QuoteDetailsCard', () => {
       );
 
       // When rendering the component
-      const { queryByText, getByText } = renderScreen(
+      const { getByText } = renderScreen(
         QuoteDetailsCard,
         { name: Routes.BRIDGE.ROOT },
         { state: testState },
@@ -765,8 +758,8 @@ describe('QuoteDetailsCard', () => {
         expect(getByText(strings('bridge.points'))).toBeOnTheScreen();
       });
 
-      // But no points value should be displayed
-      expect(queryByText(/^\d+$/)).toBeNull();
+      // RewardPointsAnimation displays 0 while loading (estimatedPoints is null)
+      expect(getByText('0')).toBeOnTheScreen();
     });
   });
 });

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
@@ -32,11 +32,9 @@ import {
 } from '../../../../../core/redux/slices/bridge';
 import { getIntlNumberFormatter } from '../../../../../util/intl';
 import { useRewards } from '../../hooks/useRewards';
-import { useRewardsIconAnimation } from '../../hooks/useRewardsIconAnimation';
-import Rive, { Alignment, Fit } from 'rive-react-native';
-
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, import/no-commonjs
-const RewardsIconAnimation = require('../../../../../animations/rewards_icon_animations.riv');
+import RewardsAnimations, {
+  RewardAnimationState,
+} from '../../../Rewards/components/RewardPointsAnimation';
 
 if (
   Platform.OS === 'android' &&
@@ -74,14 +72,6 @@ const QuoteDetailsCard = () => {
     isQuoteLoading,
   });
 
-  // Use custom hook for Rive animation logic
-  const { riveRef } = useRewardsIconAnimation({
-    isRewardsLoading,
-    estimatedPoints,
-    hasRewardsError,
-    shouldShowRewardsRow,
-  });
-
   const handleSlippagePress = () => {
     navigation.navigate(Routes.BRIDGE.MODALS.ROOT, {
       screen: Routes.BRIDGE.MODALS.SLIPPAGE_MODAL,
@@ -116,13 +106,6 @@ const QuoteDetailsCard = () => {
   const formattedMinToTokenAmount = intlNumberFormatter.format(
     parseFloat(activeQuote?.minToTokenAmount?.amount || '0'),
   );
-
-  let formattedEstimatedPoints = '';
-  if (hasRewardsError) {
-    formattedEstimatedPoints = strings('bridge.unable_to_load');
-  } else if (estimatedPoints !== null) {
-    formattedEstimatedPoints = intlNumberFormatter.format(estimatedPoints);
-  }
 
   return (
     <Box>
@@ -311,18 +294,16 @@ const QuoteDetailsCard = () => {
                   justifyContent={BoxJustifyContent.Center}
                   gap={1}
                 >
-                  <Rive
-                    ref={riveRef}
-                    source={RewardsIconAnimation}
-                    fit={Fit.FitHeight}
-                    alignment={Alignment.CenterRight}
-                    style={styles.riveIcon}
+                  <RewardsAnimations
+                    value={estimatedPoints ?? 0}
+                    state={
+                      isRewardsLoading
+                        ? RewardAnimationState.Loading
+                        : hasRewardsError
+                        ? RewardAnimationState.ErrorState
+                        : RewardAnimationState.Idle
+                    }
                   />
-                  {!isRewardsLoading && (
-                    <Text variant={TextVariant.BodyMD}>
-                      {formattedEstimatedPoints}
-                    </Text>
-                  )}
                 </Box>
               ),
               ...(hasRewardsError && {


### PR DESCRIPTION
## **Description**

Updating animations for rewards 

## **Changelog**

CHANGELOG entry: Added improved rewards animation

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-62

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

iOS

https://github.com/user-attachments/assets/e8fde6d0-4217-4350-909c-37da842f0f15

Android

https://github.com/user-attachments/assets/76accc00-0c24-4d21-af8f-e27339e82edc

### **Before**

#### Swaps
https://github.com/user-attachments/assets/ff402e7d-860a-40ea-a101-5ae2cb891e91

### **After**

https://github.com/user-attachments/assets/e8fde6d0-4217-4350-909c-37da842f0f15

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace Rive + custom hook with RewardPointsAnimation for rewards points display, and adjust tests to expect animation and 0 during loading/error/null.
> 
> - **Bridge UI**:
>   - Replace `Rive` + `useRewardsIconAnimation` with `RewardPointsAnimation` in `QuoteDetailsCard`.
>   - Drive animation via `state` (`Loading` | `ErrorState` | `Idle`) and `value={estimatedPoints ?? 0}`.
>   - Remove manual points formatting/rendering; tooltip on error retained.
> - **Tests** (`QuoteDetailsCard.test.tsx`):
>   - Remove mock of `useRewardsIconAnimation`; expect animation component presence.
>   - Update assertions to expect displayed `0` for loading/error/null estimates.
>   - Minor test refactors (drop unused queries).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10692362705942edc727310b02c6c549312154bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->