### PR TITLE
chore: Undo recent changes to `EngineService` controller update handling

### DIFF
--- a/app/core/EngineService/EngineService.ts
+++ b/app/core/EngineService/EngineService.ts
@@ -171,9 +171,8 @@ export class EngineService {
   /**
    * Sets up persistence subscriptions for all engine controllers.
    *
-   * This method subscribes to each controller's state change events and automatically:
-   * 1. Updates Redux store with the new controller state
-   * 2. Persists the filtered state to individual filesystem storage files
+   * This method subscribes to each controller's state change events and automatically
+   * persists the filtered state to individual filesystem storage files.
    *
    * The persistence is debounced in createPersistController to prevent excessive disk writes during rapid state changes.
    */


### PR DESCRIPTION
## **Description**

A recent PR (#17685) migrated to a new storage system for controller state. This change required additional state change subscriptions, but in the process of setting those up, the "update Redux" step ended up inside of the persistence handler.

This is not ideal because it's semantically confusing (updating Redux is not related to persistence, it's how we update the UI), and it means UI updates are now slightly delayed (`getPersistentState` is now called each update before the UI is updated).

This PR reverts the changes to how Redux is updated when controller state changes without impacting the persistence handling.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
