### PR TITLE
feat: retry in perps deposit transaction details

### DIFF
--- a/app/components/Views/confirmations/components/UI/Tooltip/Tooltip.tsx
+++ b/app/components/Views/confirmations/components/UI/Tooltip/Tooltip.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useState } from 'react';
-import { View } from 'react-native';
+import { View, ViewStyle } from 'react-native';
 import ButtonIcon, {
   ButtonIconSizes,
 } from '../../../../../../component-library/components/Buttons/ButtonIcon';
@@ -16,6 +16,8 @@ interface TooltipProps {
   content: string | ReactNode;
   iconColor?: IconColor;
   iconName?: IconName;
+  iconSize?: ButtonIconSizes;
+  iconStyle?: ViewStyle;
   onPress?: () => void;
   title?: string;
   tooltipTestId?: string;
@@ -71,6 +73,8 @@ const Tooltip = ({
   onPress,
   iconName = IconName.Info,
   iconColor = IconColor.Muted,
+  iconSize = ButtonIconSizes.Sm,
+  iconStyle = {},
 }: TooltipProps) => {
   const [open, setOpen] = useState(false);
 
@@ -85,8 +89,9 @@ const Tooltip = ({
         iconColor={iconColor}
         iconName={iconName}
         onPress={handlePress}
-        size={ButtonIconSizes.Sm}
+        size={iconSize}
         testID={`${tooltipTestId}-open-btn`}
+        style={iconStyle}
       />
       <TooltipModal
         open={open}

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.styles.ts
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.styles.ts
@@ -5,7 +5,7 @@ import { Theme } from '../../../../../../util/theme/models';
 const styleSheet = (_params: { theme: Theme }) =>
   StyleSheet.create({
     container: {
-      marginVertical: 32,
+      marginVertical: 12,
     },
   });
 

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from 'react';
 import { Box } from '../../../../../UI/Box/Box';
-import { TokenIcon, TokenIconVariant } from '../../token-icon';
 import Text, {
   TextVariant,
 } from '../../../../../../component-library/components/Texts/Text';
@@ -11,7 +10,6 @@ import {
   hasTransactionType,
   parseStandardTokenTransactionData,
 } from '../../../utils/transaction';
-import { Hex } from '@metamask/utils';
 import { useTokensWithBalance } from '../../../../../UI/Bridge/hooks/useTokensWithBalance';
 import { Result } from '@ethersproject/abi';
 import { calcTokenAmount } from '../../../../../../util/transactions';
@@ -63,15 +61,7 @@ export function TransactionDetailsHero() {
       gap={12}
       style={styles.container}
     >
-      <Box>
-        <TokenIcon
-          chainId={chainId}
-          address={to as Hex}
-          variant={TokenIconVariant.Hero}
-          showNetwork={false}
-        />
-      </Box>
-      <Text variant={TextVariant.HeadingLG}>${amountHuman}</Text>
+      <Text variant={TextVariant.DisplayLG}>${amountHuman}</Text>
     </Box>
   );
 }

--- a/app/components/Views/confirmations/components/activity/transaction-details-retry/index.ts
+++ b/app/components/Views/confirmations/components/activity/transaction-details-retry/index.ts
@@ -1,0 +1,1 @@
+export * from './transaction-details-retry';

--- a/app/components/Views/confirmations/components/activity/transaction-details-retry/transaction-details-retry.styles.ts
+++ b/app/components/Views/confirmations/components/activity/transaction-details-retry/transaction-details-retry.styles.ts
@@ -1,0 +1,12 @@
+import { StyleSheet } from 'react-native';
+
+import { Theme } from '../../../../../../util/theme/models';
+
+const styleSheet = (_params: { theme: Theme }) =>
+  StyleSheet.create({
+    button: {
+      marginBottom: 20,
+    },
+  });
+
+export default styleSheet;

--- a/app/components/Views/confirmations/components/activity/transaction-details-retry/transaction-details-retry.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-retry/transaction-details-retry.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import renderWithProvider from '../../../../../../util/test/renderWithProvider';
+import { TransactionDetailsRetry } from './transaction-details-retry';
+import { strings } from '../../../../../../../locales/i18n';
+import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
+import {
+  TransactionMeta,
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import { useConfirmNavigation } from '../../../hooks/useConfirmNavigation';
+import { useTokenAmount } from '../../../hooks/useTokenAmount';
+import { fireEvent } from '@testing-library/react-native';
+import Routes from '../../../../../../constants/navigation/Routes';
+
+jest.mock('../../../hooks/activity/useTransactionDetails');
+jest.mock('../../../hooks/useConfirmNavigation');
+jest.mock('../../../hooks/useTokenAmount');
+
+const FIAT_MOCK = '123.45';
+
+const TRANSACTION_META_MOCK = {
+  status: TransactionStatus.failed,
+  type: TransactionType.perpsDeposit,
+} as TransactionMeta;
+
+function render() {
+  return renderWithProvider(<TransactionDetailsRetry />);
+}
+
+describe('TransactionDetailsRetry', () => {
+  const useTransactionDetailsMock = jest.mocked(useTransactionDetails);
+  const useConfirmNavigationMock = jest.mocked(useConfirmNavigation);
+  const useTokenAmountMock = jest.mocked(useTokenAmount);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    useTransactionDetailsMock.mockReturnValue({
+      transactionMeta: TRANSACTION_META_MOCK,
+    });
+
+    useConfirmNavigationMock.mockReturnValue({
+      navigateToConfirmation: jest.fn(),
+    });
+
+    useTokenAmountMock.mockReturnValue({
+      fiatUnformatted: FIAT_MOCK,
+    } as ReturnType<typeof useTokenAmount>);
+  });
+
+  it('renders button', () => {
+    const { getByText } = render();
+
+    expect(
+      getByText(strings('transaction_details.label.retry_button')),
+    ).toBeDefined();
+  });
+
+  it('does not render if transaction is not a perps deposit', () => {
+    useTransactionDetailsMock.mockReturnValue({
+      transactionMeta: {
+        ...TRANSACTION_META_MOCK,
+        type: TransactionType.simpleSend,
+      },
+    });
+
+    const { queryByText } = render();
+
+    expect(
+      queryByText(strings('transaction_details.label.retry_button')),
+    ).toBeNull();
+  });
+
+  it('does not render if transaction status is not failed', () => {
+    useTransactionDetailsMock.mockReturnValue({
+      transactionMeta: {
+        ...TRANSACTION_META_MOCK,
+        status: TransactionStatus.confirmed,
+      },
+    });
+
+    const { queryByText } = render();
+
+    expect(
+      queryByText(strings('transaction_details.label.retry_button')),
+    ).toBeNull();
+  });
+
+  it('navigates to confirmation with amount on press', () => {
+    const navigateToConfirmation = jest.fn();
+
+    useConfirmNavigationMock.mockReturnValue({
+      navigateToConfirmation,
+    });
+
+    const { getByText } = render();
+
+    fireEvent.press(
+      getByText(strings('transaction_details.label.retry_button')),
+    );
+
+    expect(navigateToConfirmation).toHaveBeenCalledWith({
+      stack: Routes.PERPS.ROOT,
+      amount: FIAT_MOCK,
+    });
+  });
+});

--- a/app/components/Views/confirmations/components/activity/transaction-details-retry/transaction-details-retry.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-retry/transaction-details-retry.tsx
@@ -1,0 +1,59 @@
+import React, { useCallback, useMemo } from 'react';
+import {
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
+import Button, {
+  ButtonVariants,
+  ButtonWidthTypes,
+} from '../../../../../../component-library/components/Buttons/Button';
+import { Box } from '../../../../../UI/Box/Box';
+import { AlignItems, FlexDirection } from '../../../../../UI/Box/box.types';
+import { usePerpsTrading } from '../../../../../UI/Perps/hooks';
+import { noop } from 'lodash';
+import { useConfirmNavigation } from '../../../hooks/useConfirmNavigation';
+import Routes from '../../../../../../constants/navigation/Routes';
+import { useTokenAmount } from '../../../hooks/useTokenAmount';
+import { BigNumber } from 'bignumber.js';
+import { strings } from '../../../../../../../locales/i18n';
+
+export function TransactionDetailsRetry() {
+  const { transactionMeta } = useTransactionDetails();
+  const { status } = transactionMeta;
+  const { depositWithConfirmation } = usePerpsTrading();
+  const { navigateToConfirmation } = useConfirmNavigation();
+  const { fiatUnformatted } = useTokenAmount({ transactionMeta });
+
+  const amount = useMemo(
+    () => new BigNumber(fiatUnformatted ?? '0').toFixed(2),
+    [fiatUnformatted],
+  );
+
+  const handlePress = useCallback(async () => {
+    navigateToConfirmation({
+      stack: Routes.PERPS.ROOT,
+      amount,
+    });
+
+    depositWithConfirmation().catch(noop);
+  }, [amount, depositWithConfirmation, navigateToConfirmation]);
+
+  if (
+    status !== TransactionStatus.failed ||
+    transactionMeta.type !== TransactionType.perpsDeposit
+  ) {
+    return null;
+  }
+
+  return (
+    <Box flexDirection={FlexDirection.Column} alignItems={AlignItems.stretch}>
+      <Button
+        width={ButtonWidthTypes.Full}
+        onPress={handlePress}
+        label={strings('transaction_details.label.retry_button')}
+        variant={ButtonVariants.Primary}
+      />
+    </Box>
+  );
+}

--- a/app/components/Views/confirmations/components/activity/transaction-details-retry/transaction-details-retry.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-retry/transaction-details-retry.tsx
@@ -53,6 +53,7 @@ export function TransactionDetailsRetry() {
         onPress={handlePress}
         label={strings('transaction_details.label.retry_button')}
         variant={ButtonVariants.Primary}
+        style={{marginBottom: 20}}
       />
     </Box>
   );

--- a/app/components/Views/confirmations/components/activity/transaction-details-retry/transaction-details-retry.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-retry/transaction-details-retry.tsx
@@ -17,8 +17,11 @@ import Routes from '../../../../../../constants/navigation/Routes';
 import { useTokenAmount } from '../../../hooks/useTokenAmount';
 import { BigNumber } from 'bignumber.js';
 import { strings } from '../../../../../../../locales/i18n';
+import { useStyles } from '../../../../../../component-library/hooks';
+import styleSheet from './transaction-details-retry.styles';
 
 export function TransactionDetailsRetry() {
+  const { styles } = useStyles(styleSheet, {});
   const { transactionMeta } = useTransactionDetails();
   const { status } = transactionMeta;
   const { depositWithConfirmation } = usePerpsTrading();
@@ -53,7 +56,7 @@ export function TransactionDetailsRetry() {
         onPress={handlePress}
         label={strings('transaction_details.label.retry_button')}
         variant={ButtonVariants.Primary}
-        style={{marginBottom: 20}}
+        style={styles.button}
       />
     </Box>
   );

--- a/app/components/Views/confirmations/components/activity/transaction-details-status-icon/index.ts
+++ b/app/components/Views/confirmations/components/activity/transaction-details-status-icon/index.ts
@@ -1,1 +1,0 @@
-export * from './transaction-details-status-icon';

--- a/app/components/Views/confirmations/components/activity/transaction-details-status-icon/transaction-details-status-icon.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-status-icon/transaction-details-status-icon.tsx
@@ -17,8 +17,10 @@ import { BridgeHistoryItem } from '@metamask/bridge-status-controller';
 import { StatusTypes } from '@metamask/bridge-controller';
 
 export function TransactionDetailsStatusIcon({
+  isBridgeReceive,
   transactionMeta,
 }: {
+  isBridgeReceive?: boolean;
   transactionMeta: TransactionMeta;
 }) {
   const { status: statusRaw } = transactionMeta;
@@ -27,9 +29,10 @@ export function TransactionDetailsStatusIcon({
     evmTxMeta: transactionMeta,
   });
 
-  const status = bridgeTxHistoryItem
-    ? getBridgeStatus(bridgeTxHistoryItem)
-    : statusRaw;
+  const status =
+    bridgeTxHistoryItem && isBridgeReceive
+      ? getBridgeStatus(bridgeTxHistoryItem)
+      : statusRaw;
 
   const iconName = getStatusIcon(status);
   const iconColour = getStatusColour(status);
@@ -75,7 +78,7 @@ function getStatusIcon(status: TransactionStatus): IconName | undefined {
   }
 }
 
-function getStatusColour(status: TransactionStatus): IconColor {
+export function getStatusColour(status: TransactionStatus): IconColor {
   switch (status) {
     case TransactionStatus.confirmed:
       return IconColor.Success;

--- a/app/components/Views/confirmations/components/activity/transaction-details-status-row/transaction-details-status-row.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-status-row/transaction-details-status-row.test.tsx
@@ -9,12 +9,19 @@ import { TransactionDetailsStatusRow } from './transaction-details-status-row';
 import { strings } from '../../../../../../../locales/i18n';
 import { merge } from 'lodash';
 import { otherControllersMock } from '../../../__mocks__/controllers/other-controllers-mock';
+import { simpleSendTransactionControllerMock } from '../../../__mocks__/controllers/transaction-controller-mock';
+import { transactionApprovalControllerMock } from '../../../__mocks__/controllers/approval-controller-mock';
 
 jest.mock('../../../hooks/activity/useTransactionDetails');
 
 function render() {
   return renderWithProvider(<TransactionDetailsStatusRow />, {
-    state: merge({}, otherControllersMock),
+    state: merge(
+      {},
+      simpleSendTransactionControllerMock,
+      transactionApprovalControllerMock,
+      otherControllersMock,
+    ),
   });
 }
 

--- a/app/components/Views/confirmations/components/activity/transaction-details-status-row/transaction-details-status-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-status-row/transaction-details-status-row.tsx
@@ -1,55 +1,15 @@
 import React from 'react';
 import { strings } from '../../../../../../../locales/i18n';
 import { TransactionDetailsRow } from '../transaction-details-row/transaction-details-row';
-import Text, {
-  TextColor,
-} from '../../../../../../component-library/components/Texts/Text';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
-import { TransactionStatus } from '@metamask/transaction-controller';
-import { Box } from '../../../../../UI/Box/Box';
-import { AlignItems, FlexDirection } from '../../../../../UI/Box/box.types';
-import { TransactionDetailsStatusIcon } from '../transaction-details-status-icon';
+import { TransactionDetailsStatus } from '../transaction-details-status';
 
 export function TransactionDetailsStatusRow() {
   const { transactionMeta } = useTransactionDetails();
 
-  const statusText = getStatusText(transactionMeta.status);
-  const statusColor = getStatusColour(transactionMeta.status);
-
   return (
     <TransactionDetailsRow label={strings('transactions.status')}>
-      <Box
-        flexDirection={FlexDirection.Row}
-        gap={6}
-        alignItems={AlignItems.center}
-      >
-        <TransactionDetailsStatusIcon transactionMeta={transactionMeta} />
-        <Text color={statusColor}>{statusText}</Text>
-      </Box>
+      <TransactionDetailsStatus transactionMeta={transactionMeta} />
     </TransactionDetailsRow>
   );
-}
-
-function getStatusText(status: TransactionStatus): string {
-  switch (status) {
-    case TransactionStatus.confirmed:
-      return strings('transaction.confirmed');
-    case TransactionStatus.failed:
-    case TransactionStatus.dropped:
-      return strings('transaction.failed');
-    default:
-      return strings('transaction.pending');
-  }
-}
-
-function getStatusColour(status: TransactionStatus): TextColor {
-  switch (status) {
-    case TransactionStatus.confirmed:
-      return TextColor.Success;
-    case TransactionStatus.failed:
-    case TransactionStatus.dropped:
-      return TextColor.Error;
-    default:
-      return TextColor.Warning;
-  }
 }

--- a/app/components/Views/confirmations/components/activity/transaction-details-status-row/transaction-details-status-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-status-row/transaction-details-status-row.tsx
@@ -8,8 +8,11 @@ export function TransactionDetailsStatusRow() {
   const { transactionMeta } = useTransactionDetails();
 
   return (
-    <TransactionDetailsRow label={strings('transactions.status')}>
+    <>
+      <TransactionDetailsRow label={strings('transactions.status')}>
+        <></>
+      </TransactionDetailsRow>
       <TransactionDetailsStatus transactionMeta={transactionMeta} />
-    </TransactionDetailsRow>
+    </>
   );
 }

--- a/app/components/Views/confirmations/components/activity/transaction-details-status/index.ts
+++ b/app/components/Views/confirmations/components/activity/transaction-details-status/index.ts
@@ -1,0 +1,1 @@
+export * from './transaction-details-status';

--- a/app/components/Views/confirmations/components/activity/transaction-details-status/transaction-details-status.styles.ts
+++ b/app/components/Views/confirmations/components/activity/transaction-details-status/transaction-details-status.styles.ts
@@ -1,0 +1,13 @@
+import { StyleSheet } from 'react-native';
+
+import { Theme } from '../../../../../../util/theme/models';
+
+const styleSheet = (_params: { theme: Theme }) =>
+  StyleSheet.create({
+    tooltipIcon: {
+      width: 20,
+      height: 20,
+    },
+  });
+
+export default styleSheet;

--- a/app/components/Views/confirmations/components/activity/transaction-details-status/transaction-details-status.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-status/transaction-details-status.test.tsx
@@ -4,22 +4,27 @@ import {
   TransactionMeta,
   TransactionStatus,
 } from '@metamask/transaction-controller';
-import { TransactionDetailsStatusIcon } from './transaction-details-status-icon';
 import { fireEvent } from '@testing-library/react-native';
 import { merge } from 'lodash';
 import { otherControllersMock } from '../../../__mocks__/controllers/other-controllers-mock';
 import { useBridgeTxHistoryData } from '../../../../../../util/bridge/hooks/useBridgeTxHistoryData';
 import { StatusTypes } from '@metamask/bridge-controller';
+import { TransactionDetailsStatus } from './transaction-details-status';
+import { strings } from '../../../../../../../locales/i18n';
 
 jest.mock('../../../hooks/activity/useTransactionDetails');
 jest.mock('../../../../../../util/bridge/hooks/useBridgeTxHistoryData');
 
 const ERROR_MESSAGE_MOCK = 'Test Error';
 
-function render(transactionMeta: Partial<TransactionMeta> = {}) {
+function render(
+  transactionMeta: Partial<TransactionMeta> = {},
+  { isBridgeReceive = false } = {},
+) {
   return renderWithProvider(
-    <TransactionDetailsStatusIcon
+    <TransactionDetailsStatus
       transactionMeta={transactionMeta as TransactionMeta}
+      isBridgeReceive={isBridgeReceive}
     />,
     {
       state: merge({}, otherControllersMock),
@@ -27,7 +32,7 @@ function render(transactionMeta: Partial<TransactionMeta> = {}) {
   );
 }
 
-describe('TransactionDetailsStatusIcon', () => {
+describe('TransactionDetailsStatus', () => {
   const useBridgeTxHistoryDataMock = jest.mocked(useBridgeTxHistoryData);
 
   beforeEach(() => {
@@ -39,12 +44,13 @@ describe('TransactionDetailsStatusIcon', () => {
     });
   });
 
-  it('renders success icon if confirmed', () => {
-    const { getByTestId } = render({
+  it('renders success if confirmed', () => {
+    const { getByTestId, getByText } = render({
       status: TransactionStatus.confirmed,
     });
 
     expect(getByTestId('status-icon-confirmed')).toBeDefined();
+    expect(getByText(strings('transaction.confirmed'))).toBeDefined();
   });
 
   it.each([
@@ -52,11 +58,12 @@ describe('TransactionDetailsStatusIcon', () => {
     TransactionStatus.signed,
     TransactionStatus.unapproved,
   ])('renders spinner if status is %s', (status) => {
-    const { getByTestId } = render({
+    const { getByTestId, getByText } = render({
       status,
     });
 
     expect(getByTestId('status-spinner')).toBeDefined();
+    expect(getByText(strings('transaction.pending'))).toBeDefined();
   });
 
   it('renders error message if status is failed', () => {
@@ -70,6 +77,7 @@ describe('TransactionDetailsStatusIcon', () => {
 
     fireEvent.press(getByTestId('status-tooltip-open-btn'));
 
+    expect(getByText(strings('transaction.failed'))).toBeDefined();
     expect(getByText(ERROR_MESSAGE_MOCK)).toBeDefined();
   });
 
@@ -92,6 +100,7 @@ describe('TransactionDetailsStatusIcon', () => {
 
     fireEvent.press(getByTestId('status-tooltip-open-btn'));
 
+    expect(getByText(strings('transaction.failed'))).toBeDefined();
     expect(getByText(ERROR_MESSAGE_MOCK)).toBeDefined();
   });
 
@@ -102,9 +111,10 @@ describe('TransactionDetailsStatusIcon', () => {
       },
     } as ReturnType<typeof useBridgeTxHistoryData>);
 
-    const { getByTestId } = render();
+    const { getByTestId, getByText } = render({}, { isBridgeReceive: true });
 
     expect(getByTestId('status-icon-confirmed')).toBeDefined();
+    expect(getByText(strings('transaction.confirmed'))).toBeDefined();
   });
 
   it.each([StatusTypes.PENDING, StatusTypes.UNKNOWN])(
@@ -116,9 +126,10 @@ describe('TransactionDetailsStatusIcon', () => {
         },
       } as ReturnType<typeof useBridgeTxHistoryData>);
 
-      const { getByTestId } = render();
+      const { getByTestId, getByText } = render({}, { isBridgeReceive: true });
 
       expect(getByTestId('status-spinner')).toBeDefined();
+      expect(getByText(strings('transaction.pending'))).toBeDefined();
     },
   );
 
@@ -129,8 +140,9 @@ describe('TransactionDetailsStatusIcon', () => {
       },
     } as ReturnType<typeof useBridgeTxHistoryData>);
 
-    const { getByTestId } = render();
+    const { getByTestId, getByText } = render({}, { isBridgeReceive: true });
 
     expect(getByTestId('status-icon-failed')).toBeDefined();
+    expect(getByText(strings('transaction.failed'))).toBeDefined();
   });
 });

--- a/app/components/Views/confirmations/components/activity/transaction-details-status/transaction-details-status.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-status/transaction-details-status.tsx
@@ -15,12 +15,23 @@ import { View } from 'react-native';
 import { useBridgeTxHistoryData } from '../../../../../../util/bridge/hooks/useBridgeTxHistoryData';
 import { BridgeHistoryItem } from '@metamask/bridge-status-controller';
 import { StatusTypes } from '@metamask/bridge-controller';
+import { AlignItems, FlexDirection } from '../../../../../UI/Box/box.types';
+import Text, {
+  TextColor,
+  TextVariant,
+} from '../../../../../../component-library/components/Texts/Text';
+import { Box } from '../../../../../UI/Box/Box';
+import { strings } from '../../../../../../../locales/i18n';
 
-export function TransactionDetailsStatusIcon({
+export function TransactionDetailsStatus({
+  gap,
   isBridgeReceive,
+  text,
   transactionMeta,
 }: {
+  gap?: number;
   isBridgeReceive?: boolean;
+  text?: string;
   transactionMeta: TransactionMeta;
 }) {
   const { status: statusRaw } = transactionMeta;
@@ -34,8 +45,36 @@ export function TransactionDetailsStatusIcon({
       ? getBridgeStatus(bridgeTxHistoryItem)
       : statusRaw;
 
+  const statusText = text ?? getStatusText(status);
+
+  const textColour =
+    text && status !== TransactionStatus.failed
+      ? undefined
+      : getTextColour(status);
+
+  return (
+    <Box
+      flexDirection={FlexDirection.Row}
+      gap={gap ?? 6}
+      alignItems={AlignItems.center}
+    >
+      <StatusIcon status={status} transactionMeta={transactionMeta} />
+      <Text color={textColour} variant={TextVariant.BodyMDMedium}>
+        {statusText}
+      </Text>
+    </Box>
+  );
+}
+
+function StatusIcon({
+  status,
+  transactionMeta,
+}: {
+  status: TransactionStatus;
+  transactionMeta: TransactionMeta;
+}) {
   const iconName = getStatusIcon(status);
-  const iconColour = getStatusColour(status);
+  const iconColour = getIconColour(status);
   const errorMessage = getErrorMessage(transactionMeta);
 
   if (status === TransactionStatus.failed && errorMessage) {
@@ -69,16 +108,16 @@ export function TransactionDetailsStatusIcon({
 function getStatusIcon(status: TransactionStatus): IconName | undefined {
   switch (status) {
     case TransactionStatus.confirmed:
-      return IconName.Check;
+      return IconName.Confirmation;
     case TransactionStatus.failed:
     case TransactionStatus.dropped:
-      return IconName.Close;
+      return IconName.CircleX;
     default:
       return undefined;
   }
 }
 
-export function getStatusColour(status: TransactionStatus): IconColor {
+function getIconColour(status: TransactionStatus): IconColor {
   switch (status) {
     case TransactionStatus.confirmed:
       return IconColor.Success;
@@ -87,6 +126,30 @@ export function getStatusColour(status: TransactionStatus): IconColor {
       return IconColor.Error;
     default:
       return IconColor.Warning;
+  }
+}
+
+function getStatusText(status: TransactionStatus): string {
+  switch (status) {
+    case TransactionStatus.confirmed:
+      return strings('transaction.confirmed');
+    case TransactionStatus.failed:
+    case TransactionStatus.dropped:
+      return strings('transaction.failed');
+    default:
+      return strings('transaction.pending');
+  }
+}
+
+function getTextColour(status: TransactionStatus): TextColor {
+  switch (status) {
+    case TransactionStatus.confirmed:
+      return TextColor.Success;
+    case TransactionStatus.failed:
+    case TransactionStatus.dropped:
+      return TextColor.Error;
+    default:
+      return TextColor.Warning;
   }
 }
 

--- a/app/components/Views/confirmations/components/activity/transaction-details-status/transaction-details-status.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-status/transaction-details-status.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import Icon, {
   IconColor,
   IconName,
+  IconSize,
 } from '../../../../../../component-library/components/Icons/Icon';
 import Tooltip from '../../UI/Tooltip';
 import AnimatedSpinner, {
@@ -15,13 +16,20 @@ import { View } from 'react-native';
 import { useBridgeTxHistoryData } from '../../../../../../util/bridge/hooks/useBridgeTxHistoryData';
 import { BridgeHistoryItem } from '@metamask/bridge-status-controller';
 import { StatusTypes } from '@metamask/bridge-controller';
-import { AlignItems, FlexDirection } from '../../../../../UI/Box/box.types';
+import {
+  AlignItems,
+  FlexDirection,
+  JustifyContent,
+} from '../../../../../UI/Box/box.types';
 import Text, {
   TextColor,
   TextVariant,
 } from '../../../../../../component-library/components/Texts/Text';
 import { Box } from '../../../../../UI/Box/Box';
 import { strings } from '../../../../../../../locales/i18n';
+import { ButtonIconSizes } from '../../../../../../component-library/components/Buttons/ButtonIcon';
+import { useStyles } from '../../../../../../component-library/hooks';
+import styleSheet from './transaction-details-status.styles';
 
 export function TransactionDetailsStatus({
   gap,
@@ -57,6 +65,7 @@ export function TransactionDetailsStatus({
       flexDirection={FlexDirection.Row}
       gap={gap ?? 6}
       alignItems={AlignItems.center}
+      justifyContent={JustifyContent.spaceBetween}
     >
       <StatusIcon status={status} transactionMeta={transactionMeta} />
       <Text color={textColour} variant={TextVariant.BodyMDMedium}>
@@ -73,6 +82,7 @@ function StatusIcon({
   status: TransactionStatus;
   transactionMeta: TransactionMeta;
 }) {
+  const { styles } = useStyles(styleSheet, {});
   const iconName = getStatusIcon(status);
   const iconColour = getIconColour(status);
   const errorMessage = getErrorMessage(transactionMeta);
@@ -82,6 +92,8 @@ function StatusIcon({
       <Tooltip
         iconColor={iconColour}
         iconName={iconName}
+        iconSize={ButtonIconSizes.Md}
+        iconStyle={styles.tooltipIcon}
         tooltipTestId="status-tooltip"
         content={errorMessage}
       />
@@ -94,6 +106,7 @@ function StatusIcon({
         testID={`status-icon-${status}`}
         name={iconName}
         color={iconColour}
+        size={IconSize.Md}
       />
     );
   }

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.styles.ts
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.styles.ts
@@ -14,10 +14,10 @@ const styleSheet = (params: { theme: Theme; vars: { isLast?: boolean } }) => {
       marginLeft: 9,
       marginRight: 22,
       width: isLast ? 0 : 2,
-      marginVertical: 3,
+      margin: -3,
     },
     secondary: {
-      paddingBottom: 12,
+      paddingBottom: 8,
     },
     lineContainer: {
       padding: 6,

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.test.tsx
@@ -17,6 +17,7 @@ import { selectBridgeHistoryForAccount } from '../../../../../../selectors/bridg
 import { BridgeHistoryItem } from '@metamask/bridge-status-controller';
 import { useNetworkName } from '../../../hooks/useNetworkName';
 import { Hex } from '@metamask/utils';
+import { useTokenAmount } from '../../../hooks/useTokenAmount';
 
 const mockNavigate = jest.fn();
 
@@ -25,6 +26,7 @@ jest.mock('../../../../../../util/bridge/hooks/useBridgeTxHistoryData');
 jest.mock('../../../../../UI/Bridge/hooks/useMultichainBlockExplorerTxUrl');
 jest.mock('../../../../../../selectors/bridgeStatusController');
 jest.mock('../../../hooks/useNetworkName');
+jest.mock('../../../hooks/useTokenAmount');
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -76,6 +78,7 @@ describe('TransactionDetailsSummary', () => {
   const useTransactionDetailsMock = jest.mocked(useTransactionDetails);
   const useBridgeTxHistoryDataMock = jest.mocked(useBridgeTxHistoryData);
   const useNetworkNameMock = jest.mocked(useNetworkName);
+  const useTokenAmountMock = jest.mocked(useTokenAmount);
 
   const useMultichainBlockExplorerTxUrlMock = jest.mocked(
     useMultichainBlockExplorerTxUrl,
@@ -142,6 +145,8 @@ describe('TransactionDetailsSummary', () => {
       bridgeTxHistoryItem: undefined,
       isBridgeComplete: null,
     });
+
+    useTokenAmountMock.mockReturnValue({} as ReturnType<typeof useTokenAmount>);
   });
 
   it('renders perps deposit line title', () => {

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.tsx
@@ -26,7 +26,6 @@ import {
 } from '@metamask/transaction-controller';
 import { useBridgeTxHistoryData } from '../../../../../../util/bridge/hooks/useBridgeTxHistoryData';
 import { BridgeHistoryItem } from '@metamask/bridge-status-controller';
-import { TransactionDetailsStatusIcon } from '../transaction-details-status-icon';
 import ButtonIcon from '../../../../../../component-library/components/Buttons/ButtonIcon';
 import { IconName } from '../../../../../../component-library/components/Icons/Icon';
 import { useNavigation } from '@react-navigation/native';
@@ -37,6 +36,7 @@ import { hasTransactionType } from '../../../utils/transaction';
 import { Hex } from '@metamask/utils';
 import { toHex } from '@metamask/controller-utils';
 import { useNetworkName } from '../../../hooks/useNetworkName';
+import { TransactionDetailsStatus } from '../transaction-details-status';
 
 export function TransactionDetailsSummary() {
   const { styles } = useStyles(styleSheet, {});
@@ -139,23 +139,19 @@ function TransactionSummary({
       <SummaryLine
         chainId={chainIdHex}
         isLast={isLast}
-        status={<TransactionDetailsStatusIcon transactionMeta={transaction} />}
         time={time}
         title={title}
+        transaction={transaction}
         transactionHash={txHash}
       />
       {receiveChainId && (
         <SummaryLine
           chainId={receiveChainId}
+          isBridgeReceive
           isLast={isLast}
-          status={
-            <TransactionDetailsStatusIcon
-              transactionMeta={transaction}
-              isBridgeReceive
-            />
-          }
           time={receiveTime}
           title={receiveTitle}
+          transaction={transaction}
           transactionHash={receiveHash}
         />
       )}
@@ -165,17 +161,19 @@ function TransactionSummary({
 
 function SummaryLine({
   chainId,
+  isBridgeReceive,
   isLast,
-  status,
   time,
   title,
+  transaction,
   transactionHash,
 }: {
   chainId: Hex;
+  isBridgeReceive?: boolean;
   isLast: boolean;
-  status: React.ReactNode;
   time: number;
   title: string;
+  transaction: TransactionMeta;
   transactionHash: string | undefined;
 }) {
   const { styles } = useStyles(styleSheet, { isLast });
@@ -212,14 +210,12 @@ function SummaryLine({
         justifyContent={JustifyContent.spaceBetween}
         alignItems={AlignItems.center}
       >
-        <Box
-          flexDirection={FlexDirection.Row}
-          alignItems={AlignItems.center}
+        <TransactionDetailsStatus
+          transactionMeta={transaction}
+          isBridgeReceive={isBridgeReceive}
+          text={title}
           gap={12}
-        >
-          {status}
-          <Text variant={TextVariant.BodyMD}>{title}</Text>
-        </Box>
+        />
         {explorerTxUrl && (
           <ButtonIcon
             testID="block-explorer-button"

--- a/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.tsx
@@ -22,6 +22,7 @@ import { TransactionDetailsNetworkFeeRow } from '../transaction-details-network-
 import { TransactionDetailsBridgeFeeRow } from '../transaction-details-bridge-fee-row';
 import { hasTransactionType } from '../../../utils/transaction';
 import { ScrollView } from 'react-native';
+import { TransactionDetailsRetry } from '../transaction-details-retry';
 
 export function TransactionDetails() {
   const { styles } = useStyles(styleSheet, {});
@@ -51,6 +52,7 @@ export function TransactionDetails() {
         <TransactionDetailsTotalRow />
         <TransactionDetailDivider />
         <TransactionDetailsSummary />
+        <TransactionDetailsRetry />
       </Box>
     </ScrollView>
   );

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
@@ -9,10 +9,13 @@ import { useTokenFiatRate } from '../tokens/useTokenFiatRates';
 import { useTransactionPayToken } from '../pay/useTransactionPayToken';
 import { useUpdateTokenAmount } from './useUpdateTokenAmount';
 import { TransactionMeta } from '@metamask/transaction-controller';
+import { useParams } from '../../../../../util/navigation/navUtils';
 
 jest.mock('../tokens/useTokenFiatRates');
 jest.mock('../transactions/useUpdateTokenAmount');
 jest.mock('../pay/useTransactionPayToken');
+jest.mock('../useTokenAmount');
+jest.mock('../../../../../util/navigation/navUtils');
 
 const TOKEN_TRANSFER_DATA =
   '0xa9059cbb0000000000000000000000005a52e96bacdabb82fd05763e25335261b270efcb0000000000000000000000000000000000000000000000004563918244f40000';
@@ -45,6 +48,7 @@ describe('useTransactionCustomAmount', () => {
   const useTokenFiatRateMock = jest.mocked(useTokenFiatRate);
   const useUpdateTokenAmountMock = jest.mocked(useUpdateTokenAmount);
   const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
+  const useParamsMock = jest.mocked(useParams);
 
   const updateTokenAmountMock: ReturnType<
     typeof useUpdateTokenAmount
@@ -62,6 +66,8 @@ describe('useTransactionCustomAmount', () => {
     useTransactionPayTokenMock.mockReturnValue({
       payToken: { tokenFiatAmount: 1234.56 },
     } as ReturnType<typeof useTransactionPayToken>);
+
+    useParamsMock.mockReturnValue({ amount: '43.21' });
   });
 
   it('returns pending amount provided by updatePendingAmount', async () => {
@@ -177,5 +183,11 @@ describe('useTransactionCustomAmount', () => {
     });
 
     expect(result.current.amountFiat).toBe('530.86');
+  });
+
+  it('returns default amount from params if available', async () => {
+    const { result } = runHook();
+
+    expect(result.current.amountFiat).toBe('43.21');
   });
 });

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -7,11 +7,13 @@ import { TransactionMeta } from '@metamask/transaction-controller';
 import { useTransactionPayToken } from '../pay/useTransactionPayToken';
 import { useUpdateTokenAmount } from './useUpdateTokenAmount';
 import { getTokenTransferData } from '../../utils/transaction-pay';
+import { useParams } from '../../../../../util/navigation/navUtils';
 
 export const MAX_LENGTH = 28;
 
 export function useTransactionCustomAmount() {
-  const [amountFiat, setAmountFiat] = useState('0');
+  const { amount: defaultAmount } = useParams<{ amount?: string }>();
+  const [amountFiat, setAmountFiat] = useState(defaultAmount ?? '0');
   const [isInputChanged, setInputChanged] = useState(false);
 
   const transactionMeta = useTransactionMetadataRequest() as TransactionMeta;

--- a/app/components/Views/confirmations/hooks/useConfirmNavigation.ts
+++ b/app/components/Views/confirmations/hooks/useConfirmNavigation.ts
@@ -10,6 +10,7 @@ const ROUTE = Routes.FULL_SCREEN_CONFIRMATIONS.REDESIGNED_CONFIRMATIONS;
 const ROUTE_NO_HEADER = Routes.FULL_SCREEN_CONFIRMATIONS.NO_HEADER;
 
 export type ConfirmNavigateOptions = {
+  amount?: string;
   headerShown?: boolean;
   stack?: string;
 } & ConfirmationParams;

--- a/app/components/Views/confirmations/hooks/useNetworkName.test.ts
+++ b/app/components/Views/confirmations/hooks/useNetworkName.test.ts
@@ -1,0 +1,51 @@
+import { Hex } from '@metamask/utils';
+import { useNetworkName } from './useNetworkName';
+import { renderHookWithProvider } from '../../../../util/test/renderWithProvider';
+import { merge } from 'lodash';
+import { otherControllersMock } from '../__mocks__/controllers/other-controllers-mock';
+
+const CHAIN_ID_CUSTOM_MOCK = '0x123';
+const NAME_CUSTOM_MOCK = 'Custom Network';
+
+function runHook(chainId: Hex | undefined) {
+  const { result } = renderHookWithProvider(() => useNetworkName(chainId), {
+    state: merge({}, otherControllersMock, {
+      engine: {
+        backgroundState: {
+          NetworkController: {
+            networkConfigurationsByChainId: {
+              [CHAIN_ID_CUSTOM_MOCK]: {
+                name: NAME_CUSTOM_MOCK,
+              },
+            },
+          },
+        },
+      },
+    }),
+  });
+
+  return result;
+}
+
+describe('useNetworkName', () => {
+  it('returns undefined if chainId is undefined', () => {
+    const result = runHook(undefined);
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns short name from network list', () => {
+    const result = runHook('0x1');
+    expect(result.current).toBe('Ethereum');
+  });
+
+  it('returns nickname from network configuration if network list name is not available', () => {
+    const result = runHook(CHAIN_ID_CUSTOM_MOCK);
+    expect(result.current).toBe(NAME_CUSTOM_MOCK);
+  });
+
+  it('returns chain ID if no name or nickname is available', () => {
+    const unknownChainId = '0x9999';
+    const result = runHook(unknownChainId);
+    expect(result.current).toBe(unknownChainId);
+  });
+});

--- a/app/components/Views/confirmations/hooks/useNetworkName.ts
+++ b/app/components/Views/confirmations/hooks/useNetworkName.ts
@@ -1,0 +1,23 @@
+import { Hex } from '@metamask/utils';
+import { useSelector } from 'react-redux';
+import { selectEvmNetworkConfigurationsByChainId } from '../../../../selectors/networkController';
+import NetworkList from '../../../../util/networks';
+
+export function useNetworkName(chainId: Hex | undefined) {
+  const networkConfigurations = useSelector(
+    selectEvmNetworkConfigurationsByChainId,
+  );
+
+  if (!chainId) {
+    return undefined;
+  }
+
+  const nickname = networkConfigurations[chainId].name;
+
+  const name = Object.values(NetworkList).find(
+    (network: { chainId?: Hex; shortName: string }) =>
+      network.chainId === chainId,
+  )?.shortName;
+
+  return name ?? nickname ?? chainId;
+}

--- a/app/components/Views/confirmations/hooks/useNetworkName.ts
+++ b/app/components/Views/confirmations/hooks/useNetworkName.ts
@@ -12,7 +12,7 @@ export function useNetworkName(chainId: Hex | undefined) {
     return undefined;
   }
 
-  const nickname = networkConfigurations[chainId].name;
+  const nickname = networkConfigurations[chainId]?.name;
 
   const name = Object.values(NetworkList).find(
     (network: { chainId?: Hex; shortName: string }) =>

--- a/app/components/Views/confirmations/hooks/useTokenAmount.ts
+++ b/app/components/Views/confirmations/hooks/useTokenAmount.ts
@@ -1,7 +1,10 @@
 import { BigNumber } from 'bignumber.js';
 import { useSelector } from 'react-redux';
 import { NetworkClientId } from '@metamask/network-controller';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 
 import I18n from '../../../../../locales/i18n';
@@ -38,6 +41,8 @@ interface TokenAmountProps {
    * Optional value in wei to display. If not provided, the amount from the transactionMetadata will be used.
    */
   amountWei?: string;
+
+  transactionMeta?: TransactionMeta;
 }
 
 interface TokenAmount {
@@ -86,8 +91,11 @@ const useTokenDecimals = (
 
 export const useTokenAmount = ({
   amountWei,
+  transactionMeta,
 }: TokenAmountProps = {}): TokenAmount => {
   const fiatFormatter = useFiatFormatter();
+  const currentTransaction = useTransactionMetadataOrThrow();
+  const transaction = transactionMeta ?? currentTransaction;
 
   const {
     chainId,
@@ -95,7 +103,7 @@ export const useTokenAmount = ({
     networkClientId,
     txParams,
     type: transactionType,
-  } = useTransactionMetadataOrThrow();
+  } = transaction;
 
   const contractExchangeRates = useSelector((state: RootState) =>
     selectContractExchangeRatesByChainId(state, chainId as Hex),

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6194,6 +6194,7 @@
       "bridge_fee": "Bridge fee",
       "network_fee": "Network fee",
       "paid_with": "Paid with",
+      "retry_button": "Try again",
       "total": "Total"
     },
     "summary_title": {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6208,7 +6208,8 @@
       "predict_deposit": "Add funds",
       "swap": "Swap tokens",
       "swap_approval": "Approve tokens"
-    }
+    },
+    "perps_deposit_solution": "You now have {{fiat}} of USDC on Arbitrum. Try your deposit again."
   },
   "sdk_connect_v2": {
     "show_loading": {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6197,10 +6197,11 @@
       "total": "Total"
     },
     "summary_title": {
-      "bridge": "Bridge from {{sourceSymbol}} to {{targetSymbol}}",
       "bridge_approval": "Approve {{approveSymbol}}",
       "bridge_approval_loading": "Approve",
       "bridge_loading": "Bridge",
+      "bridge_send": "Bridge {{sourceSymbol}} from {{sourceChain}}",
+      "bridge_receive": "Receive {{targetSymbol}} on {{targetChain}}",
       "default": "Transaction",
       "perps_deposit": "Add funds",
       "predict_deposit": "Add funds",


### PR DESCRIPTION
## **Description**

Update the transaction details for a Perps deposit, including:

- Retry button to trigger deposit with same amount.
- Additional summary line for bridge receiving transaction.
- Display solution text if bridge was successful but deposit failed.
- Update icons and styling.

## **Changelog**

CHANGELOG entry: Add retry button to Perps deposit transaction details

## **Related issues**

Fixes: [#5949](https://github.com/MetaMask/MetaMask-planning/issues/5949)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

https://github.com/user-attachments/assets/884fb4e5-1ce7-482c-be67-68ef4453b3a8

<img width="250" alt="Success" src="https://github.com/user-attachments/assets/e21ab442-86cc-4f55-9adb-8b9feb401dd8" />

<img width="250" alt="Pending" src="https://github.com/user-attachments/assets/cd29ab70-b4d2-4e4a-b790-53174c18e8d2" />

<img width="250" alt="Status" src="https://github.com/user-attachments/assets/b16486a0-fa0f-4210-9ae6-a8d226b2cd70" />

<img width="250" alt="Button" src="https://github.com/user-attachments/assets/c707ad84-df99-485f-afd2-564962d3803e" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a retry action for failed perps deposits and revamps transaction status and summary (including bridge send/receive details), with supporting hooks, props, and copy updates.
> 
> - **Confirmations UI (Activity)**:
>   - **Retry action**: New `TransactionDetailsRetry` shows a "Try again" button for failed `perpsDeposit`, navigates with prefilled `amount` and triggers `depositWithConfirmation`.
>   - **Status overhaul**: Replace `transaction-details-status-icon` with `TransactionDetailsStatus` (new icons, error tooltip, pending/confirmed/failed handling, bridge receive awareness, solution text when bridge succeeded but deposit failed).
>   - **Summary enhancements**: `TransactionDetailsSummary` now splits bridge into send/receive lines (with network names, completion time, correct explorer links) and uses the new status component; minor style tweaks.
>   - **Hero tweaks**: Remove token icon, adjust spacing, and use larger display text for amount; smaller container margins.
> - **Hooks/Utils**:
>   - `useTokenAmount` accepts `transactionMeta`; `useNetworkName` added; `useConfirmNavigation` supports `amount`; `useTransactionCustomAmount` seeds default from nav params.
> - **Components/Props**:
>   - `Tooltip` supports `iconSize` and `iconStyle`.
> - **i18n**:
>   - New/updated strings for retry, bridge send/receive titles, and perps deposit solution.
> - **Tests**: Comprehensive tests added/updated for retry, status, summary, network name, and custom amount hooks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08ff7ec86afb0d79d4d0946e7e5d5f5ecd48cb08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->