### PR TITLE
fix: update padding and icon sizing on the homepage

### DIFF
--- a/app/component-library/components-temp/MainActionButton/MainActionButton.tsx
+++ b/app/component-library/components-temp/MainActionButton/MainActionButton.tsx
@@ -70,7 +70,7 @@ const MainActionButton = ({
         <View style={styles.container}>
           <Icon
             name={iconName}
-            size={IconSize.Md}
+            size={IconSize.Lg}
             color={IconColor.Alternative}
           />
           <Text

--- a/app/component-library/components-temp/MainActionButton/__snapshots__/MainActionButton.test.tsx.snap
+++ b/app/component-library/components-temp/MainActionButton/__snapshots__/MainActionButton.test.tsx.snap
@@ -71,15 +71,15 @@ exports[`MainActionButton should render correctly 1`] = `
       <SvgMock
         color="#686e7d"
         fill="currentColor"
-        height={20}
+        height={24}
         name="Add"
         style={
           {
-            "height": 20,
-            "width": 20,
+            "height": 24,
+            "width": 24,
           }
         }
-        width={20}
+        width={24}
       />
       <Text
         accessibilityRole="text"

--- a/app/components/UI/AssetOverview/__snapshots__/AssetOverview.test.tsx.snap
+++ b/app/components/UI/AssetOverview/__snapshots__/AssetOverview.test.tsx.snap
@@ -452,15 +452,15 @@ exports[`AssetOverview should render correctly 1`] = `
               <SvgMock
                 color="#686e7d"
                 fill="currentColor"
-                height={20}
+                height={24}
                 name="AttachMoney"
                 style={
                   {
-                    "height": 20,
-                    "width": 20,
+                    "height": 24,
+                    "width": 24,
                   }
                 }
-                width={20}
+                width={24}
               />
               <Text
                 accessibilityRole="text"
@@ -565,15 +565,15 @@ exports[`AssetOverview should render correctly 1`] = `
               <SvgMock
                 color="#686e7d"
                 fill="currentColor"
-                height={20}
+                height={24}
                 name="SwapVertical"
                 style={
                   {
-                    "height": 20,
-                    "width": 20,
+                    "height": 24,
+                    "width": 24,
                   }
                 }
-                width={20}
+                width={24}
               />
               <Text
                 accessibilityRole="text"
@@ -678,15 +678,15 @@ exports[`AssetOverview should render correctly 1`] = `
               <SvgMock
                 color="#686e7d"
                 fill="currentColor"
-                height={20}
+                height={24}
                 name="Send"
                 style={
                   {
-                    "height": 20,
-                    "width": 20,
+                    "height": 24,
+                    "width": 24,
                   }
                 }
-                width={20}
+                width={24}
               />
               <Text
                 accessibilityRole="text"
@@ -791,15 +791,15 @@ exports[`AssetOverview should render correctly 1`] = `
               <SvgMock
                 color="#686e7d"
                 fill="currentColor"
-                height={20}
+                height={24}
                 name="Received"
                 style={
                   {
-                    "height": 20,
-                    "width": 20,
+                    "height": 24,
+                    "width": 24,
                   }
                 }
-                width={20}
+                width={24}
               />
               <Text
                 accessibilityRole="text"
@@ -1525,15 +1525,15 @@ exports[`AssetOverview should render native balances even if there are no accoun
               <SvgMock
                 color="#686e7d"
                 fill="currentColor"
-                height={20}
+                height={24}
                 name="AttachMoney"
                 style={
                   {
-                    "height": 20,
-                    "width": 20,
+                    "height": 24,
+                    "width": 24,
                   }
                 }
-                width={20}
+                width={24}
               />
               <Text
                 accessibilityRole="text"
@@ -1638,15 +1638,15 @@ exports[`AssetOverview should render native balances even if there are no accoun
               <SvgMock
                 color="#686e7d"
                 fill="currentColor"
-                height={20}
+                height={24}
                 name="SwapVertical"
                 style={
                   {
-                    "height": 20,
-                    "width": 20,
+                    "height": 24,
+                    "width": 24,
                   }
                 }
-                width={20}
+                width={24}
               />
               <Text
                 accessibilityRole="text"
@@ -1751,15 +1751,15 @@ exports[`AssetOverview should render native balances even if there are no accoun
               <SvgMock
                 color="#686e7d"
                 fill="currentColor"
-                height={20}
+                height={24}
                 name="Send"
                 style={
                   {
-                    "height": 20,
-                    "width": 20,
+                    "height": 24,
+                    "width": 24,
                   }
                 }
-                width={20}
+                width={24}
               />
               <Text
                 accessibilityRole="text"
@@ -1864,15 +1864,15 @@ exports[`AssetOverview should render native balances even if there are no accoun
               <SvgMock
                 color="#686e7d"
                 fill="currentColor"
-                height={20}
+                height={24}
                 name="Received"
                 style={
                   {
-                    "height": 20,
-                    "width": 20,
+                    "height": 24,
+                    "width": 24,
                   }
                 }
-                width={20}
+                width={24}
               />
               <Text
                 accessibilityRole="text"
@@ -2632,15 +2632,15 @@ exports[`AssetOverview should render native balances when non evm network is sel
               <SvgMock
                 color="#686e7d"
                 fill="currentColor"
-                height={20}
+                height={24}
                 name="AttachMoney"
                 style={
                   {
-                    "height": 20,
-                    "width": 20,
+                    "height": 24,
+                    "width": 24,
                   }
                 }
-                width={20}
+                width={24}
               />
               <Text
                 accessibilityRole="text"
@@ -2745,15 +2745,15 @@ exports[`AssetOverview should render native balances when non evm network is sel
               <SvgMock
                 color="#686e7d"
                 fill="currentColor"
-                height={20}
+                height={24}
                 name="SwapVertical"
                 style={
                   {
-                    "height": 20,
-                    "width": 20,
+                    "height": 24,
+                    "width": 24,
                   }
                 }
-                width={20}
+                width={24}
               />
               <Text
                 accessibilityRole="text"
@@ -2858,15 +2858,15 @@ exports[`AssetOverview should render native balances when non evm network is sel
               <SvgMock
                 color="#686e7d"
                 fill="currentColor"
-                height={20}
+                height={24}
                 name="Send"
                 style={
                   {
-                    "height": 20,
-                    "width": 20,
+                    "height": 24,
+                    "width": 24,
                   }
                 }
-                width={20}
+                width={24}
               />
               <Text
                 accessibilityRole="text"
@@ -2971,15 +2971,15 @@ exports[`AssetOverview should render native balances when non evm network is sel
               <SvgMock
                 color="#686e7d"
                 fill="currentColor"
-                height={20}
+                height={24}
                 name="Received"
                 style={
                   {
-                    "height": 20,
-                    "width": 20,
+                    "height": 24,
+                    "width": 24,
                   }
                 }
-                width={20}
+                width={24}
               />
               <Text
                 accessibilityRole="text"

--- a/app/components/UI/Navbar/index.js
+++ b/app/components/UI/Navbar/index.js
@@ -931,13 +931,6 @@ export function getWalletNavbarOptions(
   isRewardsEnabled = false,
 ) {
   const innerStyles = StyleSheet.create({
-    headerContainer: {
-      height: 72,
-      backgroundColor: themeColors.background,
-      borderBottomWidth: 1,
-      borderBottomColor: themeColors.border.muted,
-      alignItems: 'center',
-    },
     headerIcon: {
       color: themeColors.primary.default,
     },
@@ -1082,7 +1075,6 @@ export function getWalletNavbarOptions(
       <HeaderBase
         includesTopInset
         variant={HeaderBaseVariant.Display}
-        style={innerStyles.headerContainer}
         startAccessory={
           !isFeatureFlagEnabled && (
             <View style={innerStyles.startAccessoryContainer}>

--- a/app/components/Views/Asset/__snapshots__/index.test.js.snap
+++ b/app/components/Views/Asset/__snapshots__/index.test.js.snap
@@ -1236,15 +1236,15 @@ exports[`Asset Multichain Functionality should exclude mixed token/SOL transacti
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="AttachMoney"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -1349,15 +1349,15 @@ exports[`Asset Multichain Functionality should exclude mixed token/SOL transacti
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="SwapVertical"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -1462,15 +1462,15 @@ exports[`Asset Multichain Functionality should exclude mixed token/SOL transacti
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="Send"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -1575,15 +1575,15 @@ exports[`Asset Multichain Functionality should exclude mixed token/SOL transacti
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="Received"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -3003,15 +3003,15 @@ exports[`Asset Multichain Functionality should exclude transactions with empty a
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="AttachMoney"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -3116,15 +3116,15 @@ exports[`Asset Multichain Functionality should exclude transactions with empty a
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="SwapVertical"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -3229,15 +3229,15 @@ exports[`Asset Multichain Functionality should exclude transactions with empty a
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="Send"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -3342,15 +3342,15 @@ exports[`Asset Multichain Functionality should exclude transactions with empty a
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="Received"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -4770,15 +4770,15 @@ exports[`Asset Multichain Functionality should filter SPL token transactions cor
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="AttachMoney"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -4883,15 +4883,15 @@ exports[`Asset Multichain Functionality should filter SPL token transactions cor
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="SwapVertical"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -4996,15 +4996,15 @@ exports[`Asset Multichain Functionality should filter SPL token transactions cor
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="Send"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -5109,15 +5109,15 @@ exports[`Asset Multichain Functionality should filter SPL token transactions cor
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="Received"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -6578,15 +6578,15 @@ exports[`Asset Multichain Functionality should filter native SOL transactions co
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="AttachMoney"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -6691,15 +6691,15 @@ exports[`Asset Multichain Functionality should filter native SOL transactions co
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="SwapVertical"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -6804,15 +6804,15 @@ exports[`Asset Multichain Functionality should filter native SOL transactions co
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="Send"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -6917,15 +6917,15 @@ exports[`Asset Multichain Functionality should filter native SOL transactions co
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="Received"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -8345,15 +8345,15 @@ exports[`Asset Multichain Functionality should handle state with no multichain t
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="AttachMoney"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -8458,15 +8458,15 @@ exports[`Asset Multichain Functionality should handle state with no multichain t
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="SwapVertical"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -8571,15 +8571,15 @@ exports[`Asset Multichain Functionality should handle state with no multichain t
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="Send"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -8684,15 +8684,15 @@ exports[`Asset Multichain Functionality should handle state with no multichain t
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="Received"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -10112,15 +10112,15 @@ exports[`Asset Multichain Functionality should handle unknown SPL token filterin
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="AttachMoney"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -10225,15 +10225,15 @@ exports[`Asset Multichain Functionality should handle unknown SPL token filterin
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="SwapVertical"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -10338,15 +10338,15 @@ exports[`Asset Multichain Functionality should handle unknown SPL token filterin
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="Send"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -10451,15 +10451,15 @@ exports[`Asset Multichain Functionality should handle unknown SPL token filterin
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="Received"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -12450,15 +12450,15 @@ exports[`Asset Multichain Functionality should render non-EVM assets with Multic
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="AttachMoney"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -12563,15 +12563,15 @@ exports[`Asset Multichain Functionality should render non-EVM assets with Multic
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="SwapVertical"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -12676,15 +12676,15 @@ exports[`Asset Multichain Functionality should render non-EVM assets with Multic
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="Send"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -12789,15 +12789,15 @@ exports[`Asset Multichain Functionality should render non-EVM assets with Multic
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="Received"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -14217,15 +14217,15 @@ exports[`Asset Multichain Functionality should sort filtered transactions by tim
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="AttachMoney"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -14330,15 +14330,15 @@ exports[`Asset Multichain Functionality should sort filtered transactions by tim
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="SwapVertical"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -14443,15 +14443,15 @@ exports[`Asset Multichain Functionality should sort filtered transactions by tim
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="Send"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"
@@ -14556,15 +14556,15 @@ exports[`Asset Multichain Functionality should sort filtered transactions by tim
                                               <SvgMock
                                                 color="#686e7d"
                                                 fill="currentColor"
-                                                height={20}
+                                                height={24}
                                                 name="Received"
                                                 style={
                                                   {
-                                                    "height": 20,
-                                                    "width": 20,
+                                                    "height": 24,
+                                                    "width": 24,
                                                   }
                                                 }
-                                                width={20}
+                                                width={24}
                                               />
                                               <Text
                                                 accessibilityRole="text"

--- a/app/components/Views/AssetDetails/AssetDetailsActions/__snapshots__/AssetDetailsActions.test.tsx.snap
+++ b/app/components/Views/AssetDetails/AssetDetailsActions/__snapshots__/AssetDetailsActions.test.tsx.snap
@@ -91,15 +91,15 @@ exports[`AssetDetailsActions should render correctly 1`] = `
           <SvgMock
             color="#686e7d"
             fill="currentColor"
-            height={20}
+            height={24}
             name="AttachMoney"
             style={
               {
-                "height": 20,
-                "width": 20,
+                "height": 24,
+                "width": 24,
               }
             }
-            width={20}
+            width={24}
           />
           <Text
             accessibilityRole="text"
@@ -204,15 +204,15 @@ exports[`AssetDetailsActions should render correctly 1`] = `
           <SvgMock
             color="#686e7d"
             fill="currentColor"
-            height={20}
+            height={24}
             name="SwapVertical"
             style={
               {
-                "height": 20,
-                "width": 20,
+                "height": 24,
+                "width": 24,
               }
             }
-            width={20}
+            width={24}
           />
           <Text
             accessibilityRole="text"
@@ -317,15 +317,15 @@ exports[`AssetDetailsActions should render correctly 1`] = `
           <SvgMock
             color="#686e7d"
             fill="currentColor"
-            height={20}
+            height={24}
             name="Send"
             style={
               {
-                "height": 20,
-                "width": 20,
+                "height": 24,
+                "width": 24,
               }
             }
-            width={20}
+            width={24}
           />
           <Text
             accessibilityRole="text"
@@ -430,15 +430,15 @@ exports[`AssetDetailsActions should render correctly 1`] = `
           <SvgMock
             color="#686e7d"
             fill="currentColor"
-            height={20}
+            height={24}
             name="Received"
             style={
               {
-                "height": 20,
-                "width": 20,
+                "height": 24,
+                "width": 24,
               }
             }
-            width={20}
+            width={24}
           />
           <Text
             accessibilityRole="text"

--- a/app/components/Views/Wallet/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Wallet/__snapshots__/index.test.tsx.snap
@@ -39,27 +39,9 @@ exports[`Wallet Conditional Rendering should render banner when basic functional
           style={
             [
               {
-                "alignItems": "center",
-                "backgroundColor": {
-                  "alternative": "#f3f5f9",
-                  "alternativeHover": "#ebedf1",
-                  "alternativePressed": "#e1e4ea",
-                  "default": "#ffffff",
-                  "defaultHover": "#f6f6f7",
-                  "defaultPressed": "#ebecef",
-                  "hover": "#858b9a14",
-                  "muted": "#3c4d9d0f",
-                  "mutedHover": "#3c4d9d1a",
-                  "mutedPressed": "#3c4d9d26",
-                  "pressed": "#858b9a29",
-                  "section": "#f3f5f9",
-                  "subsection": "#ffffff",
-                },
-                "borderBottomColor": "#b7bbc866",
-                "borderBottomWidth": 1,
+                "backgroundColor": "#ffffff",
                 "flexDirection": "row",
                 "gap": 16,
-                "height": 72,
               },
               {
                 "marginTop": 0,
@@ -1240,27 +1222,9 @@ exports[`Wallet Conditional Rendering should render loader when no selected acco
           style={
             [
               {
-                "alignItems": "center",
-                "backgroundColor": {
-                  "alternative": "#f3f5f9",
-                  "alternativeHover": "#ebedf1",
-                  "alternativePressed": "#e1e4ea",
-                  "default": "#ffffff",
-                  "defaultHover": "#f6f6f7",
-                  "defaultPressed": "#ebecef",
-                  "hover": "#858b9a14",
-                  "muted": "#3c4d9d0f",
-                  "mutedHover": "#3c4d9d1a",
-                  "mutedPressed": "#3c4d9d26",
-                  "pressed": "#858b9a29",
-                  "section": "#f3f5f9",
-                  "subsection": "#ffffff",
-                },
-                "borderBottomColor": "#b7bbc866",
-                "borderBottomWidth": 1,
+                "backgroundColor": "#ffffff",
                 "flexDirection": "row",
                 "gap": 16,
-                "height": 72,
               },
               {
                 "marginTop": 0,
@@ -2441,27 +2405,9 @@ exports[`Wallet should render correctly 1`] = `
           style={
             [
               {
-                "alignItems": "center",
-                "backgroundColor": {
-                  "alternative": "#f3f5f9",
-                  "alternativeHover": "#ebedf1",
-                  "alternativePressed": "#e1e4ea",
-                  "default": "#ffffff",
-                  "defaultHover": "#f6f6f7",
-                  "defaultPressed": "#ebecef",
-                  "hover": "#858b9a14",
-                  "muted": "#3c4d9d0f",
-                  "mutedHover": "#3c4d9d1a",
-                  "mutedPressed": "#3c4d9d26",
-                  "pressed": "#858b9a29",
-                  "section": "#f3f5f9",
-                  "subsection": "#ffffff",
-                },
-                "borderBottomColor": "#b7bbc866",
-                "borderBottomWidth": 1,
+                "backgroundColor": "#ffffff",
                 "flexDirection": "row",
                 "gap": 16,
-                "height": 72,
               },
               {
                 "marginTop": 0,
@@ -3642,27 +3588,9 @@ exports[`Wallet should render correctly when Solana support is enabled 1`] = `
           style={
             [
               {
-                "alignItems": "center",
-                "backgroundColor": {
-                  "alternative": "#f3f5f9",
-                  "alternativeHover": "#ebedf1",
-                  "alternativePressed": "#e1e4ea",
-                  "default": "#ffffff",
-                  "defaultHover": "#f6f6f7",
-                  "defaultPressed": "#ebecef",
-                  "hover": "#858b9a14",
-                  "muted": "#3c4d9d0f",
-                  "mutedHover": "#3c4d9d1a",
-                  "mutedPressed": "#3c4d9d26",
-                  "pressed": "#858b9a29",
-                  "section": "#f3f5f9",
-                  "subsection": "#ffffff",
-                },
-                "borderBottomColor": "#b7bbc866",
-                "borderBottomWidth": 1,
+                "backgroundColor": "#ffffff",
                 "flexDirection": "row",
                 "gap": 16,
-                "height": 72,
               },
               {
                 "marginTop": 0,
@@ -4843,27 +4771,9 @@ exports[`Wallet should render correctly when there are no detected tokens 1`] = 
           style={
             [
               {
-                "alignItems": "center",
-                "backgroundColor": {
-                  "alternative": "#f3f5f9",
-                  "alternativeHover": "#ebedf1",
-                  "alternativePressed": "#e1e4ea",
-                  "default": "#ffffff",
-                  "defaultHover": "#f6f6f7",
-                  "defaultPressed": "#ebecef",
-                  "hover": "#858b9a14",
-                  "muted": "#3c4d9d0f",
-                  "mutedHover": "#3c4d9d1a",
-                  "mutedPressed": "#3c4d9d26",
-                  "pressed": "#858b9a29",
-                  "section": "#f3f5f9",
-                  "subsection": "#ffffff",
-                },
-                "borderBottomColor": "#b7bbc866",
-                "borderBottomWidth": 1,
+                "backgroundColor": "#ffffff",
                 "flexDirection": "row",
                 "gap": 16,
-                "height": 72,
               },
               {
                 "marginTop": 0,

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -195,6 +195,7 @@ const createStyles = ({ colors }: Theme) =>
 
     tabContainer: {
       flex: 1,
+      marginTop: 8,
     },
     loader: {
       backgroundColor: colors.background.default,
@@ -207,7 +208,7 @@ const createStyles = ({ colors }: Theme) =>
       paddingHorizontal: 16,
     },
     assetsActionsContainer: {
-      marginBottom: 24,
+      marginBottom: 16,
     },
     carousel: {
       marginBottom: 16,

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -207,7 +207,7 @@ const createStyles = ({ colors }: Theme) =>
       paddingHorizontal: 16,
     },
     assetsActionsContainer: {
-      marginBottom: 16,
+      marginBottom: 24,
     },
     carousel: {
       marginBottom: 16,


### PR DESCRIPTION
## **Description**

Homepage design tweaks
- Padding below the 4 action buttons match padding above
- Icons in 4 action buttons larger by one step
- I noticed that the top bar on the homepage is not the same as rewards. I think we can reduce some padding on homepage.

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-58

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

| Before  | After  |
|:---:|:---:|
|![before](https://github.com/user-attachments/assets/151857a3-b2c3-4236-a17e-4fddf25e7022)|![after](https://github.com/user-attachments/assets/d787102e-71df-4b1f-b017-5aa5b49f0e9e)|

https://github.com/user-attachments/assets/e1f69c51-6bd1-4cf1-aa2d-9a36bf635cfd

### **Before**

<img width="500" halt="before" src="https://github.com/user-attachments/assets/151857a3-b2c3-4236-a17e-4fddf25e7022" />

### **After**

<img width="500"  alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-10-14 at 15 27 24" src="https://github.com/user-attachments/assets/d787102e-71df-4b1f-b017-5aa5b49f0e9e" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase main action button icon size to Lg, remove custom wallet header container styling, add small top margin to wallet tabs, and update snapshots accordingly.
> 
> - **UI**:
>   - **`MainActionButton`**: Increase icon size from `IconSize.Md` to `IconSize.Lg`.
>   - **Wallet Navbar (`getWalletNavbarOptions`)**: Remove custom `headerContainer` styles and `style` prop from `HeaderBase` to use defaults.
>   - **Wallet View (`Views/Wallet/index.tsx`)**: Add `marginTop: 8` to `styles.tabContainer`.
> - **Tests/Snapshots**:
>   - Update snapshots across asset views and actions to reflect 24px icons and header styling changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e68ec692bff8d527aa99be56656043566e88bd3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->