### PR TITLE
feat(deposit): implement user limits fetch before proceeding with an order

### DIFF
--- a/app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.tsx
@@ -134,13 +134,6 @@ const BuildQuote = () => {
     amount,
   );
 
-  const [, getUserLimits] = useDepositSdkMethod(
-    { method: 'getUserLimits', onMount: false, throws: true },
-    selectedRegion?.currency || '',
-    selectedPaymentMethod?.id || '',
-    'SIMPLE',
-  );
-
   const {
     tokenAmount,
     isLoading: isLoadingTokenAmount,
@@ -306,93 +299,6 @@ const BuildQuote = () => {
         return;
       }
 
-      try {
-        const userLimits = await getUserLimits();
-
-        if (!userLimits) {
-          setError(strings('deposit.buildQuote.limitError'));
-          setIsLoading(false);
-          return;
-        }
-
-        if (userLimits?.remaining) {
-          const { remaining } = userLimits;
-
-          const dailyLimit = remaining['1'];
-          const monthlyLimit = remaining['30'];
-          const yearlyLimit = remaining['365'];
-
-          if (
-            dailyLimit === undefined ||
-            monthlyLimit === undefined ||
-            yearlyLimit === undefined
-          ) {
-            setError(strings('deposit.buildQuote.limitError'));
-            setIsLoading(false);
-            return;
-          }
-
-          if (amountAsNumber > dailyLimit) {
-            setError(
-              strings('deposit.buildQuote.limitExceeded', {
-                period: 'daily',
-                remaining: formatCurrency(
-                  dailyLimit,
-                  selectedRegion?.currency || '',
-                  {
-                    currencyDisplay: 'narrowSymbol',
-                  },
-                ),
-              }),
-            );
-            setIsLoading(false);
-            return;
-          }
-
-          if (amountAsNumber > monthlyLimit) {
-            setError(
-              strings('deposit.buildQuote.limitExceeded', {
-                period: 'monthly',
-                remaining: formatCurrency(
-                  monthlyLimit,
-                  selectedRegion?.currency || '',
-                  {
-                    currencyDisplay: 'narrowSymbol',
-                  },
-                ),
-              }),
-            );
-            setIsLoading(false);
-            return;
-          }
-
-          if (amountAsNumber > yearlyLimit) {
-            setError(
-              strings('deposit.buildQuote.limitExceeded', {
-                period: 'yearly',
-                remaining: formatCurrency(
-                  yearlyLimit,
-                  selectedRegion?.currency || '',
-                  {
-                    currencyDisplay: 'narrowSymbol',
-                  },
-                ),
-              }),
-            );
-            setIsLoading(false);
-            return;
-          }
-        }
-      } catch (limitsError) {
-        Logger.error(
-          limitsError as Error,
-          'Deposit::BuildQuote - Error checking user limits',
-        );
-        setError(strings('deposit.buildQuote.limitError'));
-        setIsLoading(false);
-        return;
-      }
-
       trackEvent('RAMPS_ORDER_SELECTED', {
         ramp_type: 'DEPOSIT',
         amount_source: quote.fiatAmount,
@@ -454,7 +360,6 @@ const BuildQuote = () => {
     selectedRegion?.currency,
     isAuthenticated,
     getQuote,
-    getUserLimits,
     routeAfterAuthentication,
     navigateToVerifyIdentity,
     shouldRouteImmediately,

--- a/app/components/UI/Ramp/Deposit/hooks/useDepositRouting.ts
+++ b/app/components/UI/Ramp/Deposit/hooks/useDepositRouting.ts
@@ -90,6 +90,12 @@ export const useDepositRouting = () => {
     throws: true,
   });
 
+  const [, getUserLimits] = useDepositSdkMethod({
+    method: 'getUserLimits',
+    onMount: false,
+    throws: true,
+  });
+
   const popToBuildQuote = useCallback(() => {
     navigation.dispatch((state) => {
       const buildQuoteIndex = state.routes.findIndex(
@@ -107,6 +113,64 @@ export const useDepositRouting = () => {
       };
     });
   }, [navigation]);
+
+  const checkUserLimits = useCallback(
+    async (quote: BuyQuote, kycType: string) => {
+      const userLimits = await getUserLimits(
+        selectedRegion?.currency || '',
+        selectedPaymentMethod?.id || '',
+        kycType,
+      );
+
+      if (!userLimits?.remaining) {
+        throw new Error(strings('deposit.buildQuote.limitError'));
+      }
+
+      const { remaining } = userLimits;
+      const dailyLimit = remaining['1'];
+      const monthlyLimit = remaining['30'];
+      const yearlyLimit = remaining['365'];
+
+      if (
+        dailyLimit === undefined ||
+        monthlyLimit === undefined ||
+        yearlyLimit === undefined
+      ) {
+        throw new Error(strings('deposit.buildQuote.limitError'));
+      }
+
+      const depositAmount = quote.fiatAmount;
+      const currency = selectedRegion?.currency || '';
+
+      if (depositAmount > dailyLimit) {
+        throw new Error(
+          strings('deposit.buildQuote.limitExceeded', {
+            period: 'daily',
+            remaining: `${dailyLimit} ${currency}`,
+          }),
+        );
+      }
+
+      if (depositAmount > monthlyLimit) {
+        throw new Error(
+          strings('deposit.buildQuote.limitExceeded', {
+            period: 'monthly',
+            remaining: `${monthlyLimit} ${currency}`,
+          }),
+        );
+      }
+
+      if (depositAmount > yearlyLimit) {
+        throw new Error(
+          strings('deposit.buildQuote.limitExceeded', {
+            period: 'yearly',
+            remaining: `${yearlyLimit} ${currency}`,
+          }),
+        );
+      }
+    },
+    [getUserLimits, selectedRegion?.currency, selectedPaymentMethod?.id],
+  );
 
   const navigateToVerifyIdentityCallback = useCallback(
     ({ quote }: { quote: BuyQuote }) => {
@@ -349,6 +413,8 @@ export const useDepositRouting = () => {
                 throw new Error('Missing user details');
               }
 
+              await checkUserLimits(quote, requirements.kycType);
+
               if (selectedPaymentMethod?.isManualBankTransfer) {
                 const order = await createOrder(
                   quote,
@@ -489,6 +555,7 @@ export const useDepositRouting = () => {
       createOrder,
       requestOtt,
       generatePaymentUrl,
+      checkUserLimits,
       selectedWalletAddress,
       themeAppearance,
       colors,

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -595,8 +595,8 @@
       "quoteFetchError": "Failed to fetch quote.",
       "kycFormsFetchError": "Failed to fetch KYC forms.",
       "title": "Deposit",
-      "limitExceeded": "This deposit would exceed your {{period}} limit. Your remaining limit is {{remaining}}",
-      "limitError": "Failed to check your deposit limits."
+      "limitExceeded": "This deposit would exceed your {{period}} limit. Your deposit including fees must be {{remaining}} or less.",
+      "limitError": "Failed to check your deposit limits. Please try again later."
     },
     "token_modal": {
       "select_a_token": "Select a Token",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -594,7 +594,9 @@
       "unexpectedError": "An unexpected error occurred.",
       "quoteFetchError": "Failed to fetch quote.",
       "kycFormsFetchError": "Failed to fetch KYC forms.",
-      "title": "Deposit"
+      "title": "Deposit",
+      "limitExceeded": "This deposit would exceed your {{period}} limit. Your remaining limit is {{remaining}}",
+      "limitError": "Failed to check your deposit limits."
     },
     "token_modal": {
       "select_a_token": "Select a Token",

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
   },
   "dependencies": {
     "@config-plugins/detox": "^9.0.0",
-    "@consensys/native-ramps-sdk": "^2.1.4",
+    "@consensys/native-ramps-sdk": "2.1.5",
     "@consensys/on-ramp-sdk": "2.1.11",
     "@craftzdog/react-native-buffer": "^6.1.0",
     "@deeeed/hyperliquid-node20": "^0.23.1-node20.1",

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
   },
   "dependencies": {
     "@config-plugins/detox": "^9.0.0",
-    "@consensys/native-ramps-sdk": "^2.1.2",
+    "@consensys/native-ramps-sdk": "^2.1.4",
     "@consensys/on-ramp-sdk": "2.1.11",
     "@craftzdog/react-native-buffer": "^6.1.0",
     "@deeeed/hyperliquid-node20": "^0.23.1-node20.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2046,9 +2046,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@consensys/native-ramps-sdk@npm:^2.1.4":
-  version: 2.1.4
-  resolution: "@consensys/native-ramps-sdk@npm:2.1.4"
+"@consensys/native-ramps-sdk@npm:2.1.5":
+  version: 2.1.5
+  resolution: "@consensys/native-ramps-sdk@npm:2.1.5"
   dependencies:
     "@metamask/utils": ^11.5.0
     async: ^3.2.3
@@ -2057,7 +2057,7 @@ __metadata:
     crypto-js: ^4.2.0
     reflect-metadata: ^0.1.13
     uuid: ^9.0.0
-  checksum: 05690153f4af7d9864c78df4cd44c7c5da42edbcac975bfb6c40c2c41ce97c7fe90bac5fec203a2a7ea0f7d9ca85e237445bc068f3fb89dd571a2f4f3c6ace90
+  checksum: 4e2253858a221845579dc289400fd871b259dd1062537042cafa0c9417924ae9b2ca09187facabfce9eeb96f22113df7fad0801bee4164f9069003a4851f75d3
   languageName: node
   linkType: hard
 
@@ -34070,7 +34070,7 @@ __metadata:
     "@babel/register": ^7.24.6
     "@babel/runtime": ^7.25.0
     "@config-plugins/detox": ^9.0.0
-    "@consensys/native-ramps-sdk": ^2.1.4
+    "@consensys/native-ramps-sdk": 2.1.5
     "@consensys/on-ramp-sdk": 2.1.11
     "@craftzdog/react-native-buffer": ^6.1.0
     "@cucumber/message-streams": ^4.0.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -2046,9 +2046,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@consensys/native-ramps-sdk@npm:^2.1.2":
-  version: 2.1.2
-  resolution: "@consensys/native-ramps-sdk@npm:2.1.2"
+"@consensys/native-ramps-sdk@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "@consensys/native-ramps-sdk@npm:2.1.4"
   dependencies:
     "@metamask/utils": ^11.5.0
     async: ^3.2.3
@@ -2057,7 +2057,7 @@ __metadata:
     crypto-js: ^4.2.0
     reflect-metadata: ^0.1.13
     uuid: ^9.0.0
-  checksum: 6db885cebb8ccc6c859c55f22bf686d842b0975f97d98c09eec48b52e7601fdb338c9f201182ec9f32cac07e84a98dc3e981a675e6a71a4ea8dbc298bc5a0be0
+  checksum: 05690153f4af7d9864c78df4cd44c7c5da42edbcac975bfb6c40c2c41ce97c7fe90bac5fec203a2a7ea0f7d9ca85e237445bc068f3fb89dd571a2f4f3c6ace90
   languageName: node
   linkType: hard
 
@@ -34070,7 +34070,7 @@ __metadata:
     "@babel/register": ^7.24.6
     "@babel/runtime": ^7.25.0
     "@config-plugins/detox": ^9.0.0
-    "@consensys/native-ramps-sdk": ^2.1.2
+    "@consensys/native-ramps-sdk": ^2.1.4
     "@consensys/on-ramp-sdk": 2.1.11
     "@craftzdog/react-native-buffer": ^6.1.0
     "@cucumber/message-streams": ^4.0.1


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Implement user deposit limits validation (daily/monthly/yearly) in the authenticated deposit flow. 
Checks limits after KYC approval using the user's actual KYC type, and displays clear error messages when deposit amount including fees would exceed remaining limits.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added Deposit limits

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-2669?atlOrigin=eyJpIjoiNWVhOWFiMzA1Yzg4NDAxY2IzZjBkZWMzYThjMzRhZDYiLCJwIjoiaiJ9

## **Manual testing steps**

```gherkin
Feature: Deposit Limits Validation

  Scenario: User exceeds daily/monthly/yearly deposit limit
    Given user is authenticated and KYC approved
    And user has $100 daily/monthly/yearly limit remaining
    And user has selected USD as currency
    
    When user enters $200 deposit amount
    And user clicks Continue
    Then error message should display "This deposit would exceed your daily/monthly/yearly limit. Your deposit including fees must be $100 USD or less."
    And user should remain on build quote screen

  Scenario: User successfully deposits within daily limit
    Given user is authenticated and KYC approved
    And user has $300 daily limit remaining
    And user has selected USD as currency
    
    When user enters $100 deposit amount
    And user clicks Continue
    Then deposit should proceed to payment screen
    And no error message should be displayed
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
No limits check.

### **After**

<!-- [screenshots/recordings] -->
<img width="301" height="655" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-15 at 15 03 28" src="https://github.com/user-attachments/assets/3070cf38-8a01-48ae-8d7b-e9f121b20c46" />
<img width="301" height="655" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-15 at 14 54 53" src="https://github.com/user-attachments/assets/88c33ae1-714d-444d-b0c7-0dbb22bc6059" />


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Integrates `getUserLimits` into the authenticated deposit flow to block deposits exceeding daily/monthly/yearly limits, with new i18n messages and tests; bumps native ramps SDK.
> 
> - **Deposit flow**:
>   - Add `getUserLimits` via `useDepositSdkMethod` and new `checkUserLimits(quote, kycType)` to enforce daily/monthly/yearly remaining limits before creating orders or generating payment URLs.
>   - Pass actual KYC type to limits check; use region currency in messages.
> - **UX/i18n**:
>   - Add strings `deposit.buildQuote.limitExceeded` and `deposit.buildQuote.limitError` for clear limit errors.
> - **Tests**:
>   - Extend `useDepositRouting.test.ts` with cases for within-limits, daily/monthly/yearly exceed, null/undefined limits, and correct KYC type propagation.
> - **Dependencies**:
>   - Bump `@consensys/native-ramps-sdk` to `2.1.5`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e56b0649266247d93bcbc7e2ae194145530e4596. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->