### PR TITLE
feat: social login check added in description in create password. cp-7.57.0

### DIFF
--- a/app/components/Views/ChoosePassword/index.js
+++ b/app/components/Views/ChoosePassword/index.js
@@ -797,7 +797,7 @@ class ChoosePassword extends PureComponent {
                         variant={TextVariant.BodyMD}
                         color={TextColor.Alternative}
                       >
-                        {Platform.OS === 'ios'
+                        {Platform.OS === 'ios' && this.getOauth2LoginSuccess()
                           ? strings(
                               'choose_password.description_social_login_update_ios',
                             )

--- a/app/components/Views/ChoosePassword/index.test.tsx
+++ b/app/components/Views/ChoosePassword/index.test.tsx
@@ -17,7 +17,7 @@ import StorageWrapper from '../../../store/storage-wrapper';
 import AUTHENTICATION_TYPE from '../../../constants/userProperties';
 import { BIOMETRY_TYPE } from 'react-native-keychain';
 import { Authentication } from '../../../core';
-import { InteractionManager, Alert } from 'react-native';
+import { InteractionManager, Alert, Platform } from 'react-native';
 import { EVENT_NAME } from '../../../core/Analytics';
 
 jest.mock('../../../util/metrics/TrackOnboarding/trackOnboarding');
@@ -1557,6 +1557,82 @@ describe('ChoosePassword', () => {
         });
 
         expect(submitButton.props.disabled).toBe(true);
+      });
+    });
+  });
+
+  describe('OAuth Login Description Text', () => {
+    it('should show iOS-specific description when Platform.OS is ios and OAuth login is successful', async () => {
+      // Mock Platform.OS to be 'ios'
+      const originalPlatform = Platform.OS;
+      Object.defineProperty(Platform, 'OS', {
+        writable: true,
+        value: 'ios',
+      });
+
+      const props: ChoosePasswordProps = {
+        ...defaultProps,
+        route: {
+          ...defaultProps.route,
+          params: {
+            ...defaultProps.route.params,
+            [PREVIOUS_SCREEN]: ONBOARDING,
+            oauthLoginSuccess: true,
+          },
+        },
+      };
+
+      const component = renderWithProviders(<ChoosePassword {...props} />);
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      // Check that iOS-specific text is rendered
+      expect(() =>
+        component.getByText(/Use this for wallet recovery/),
+      ).not.toThrow();
+
+      Object.defineProperty(Platform, 'OS', {
+        writable: true,
+        value: originalPlatform,
+      });
+    });
+
+    it('should show different text when Platform.OS is android and OAuth login is successful', async () => {
+      // Mock Platform.OS to be 'android'
+      const originalPlatform = Platform.OS;
+      Object.defineProperty(Platform, 'OS', {
+        writable: true,
+        value: 'android',
+      });
+
+      const props: ChoosePasswordProps = {
+        ...defaultProps,
+        route: {
+          ...defaultProps.route,
+          params: {
+            ...defaultProps.route.params,
+            [PREVIOUS_SCREEN]: ONBOARDING,
+            oauthLoginSuccess: true,
+          },
+        },
+      };
+
+      const component = renderWithProviders(<ChoosePassword {...props} />);
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      // Check that non-iOS text is rendered
+      expect(() =>
+        component.getByText(/If you lose this password/),
+      ).not.toThrow();
+
+      Object.defineProperty(Platform, 'OS', {
+        writable: true,
+        value: originalPlatform,
       });
     });
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
* social login check added in description in create password
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

fixes: #21192

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: social login check added in description in create password

## **Related issues**

Fixes: social login check added in description in create password

## **Manual testing steps**

```gherkin
Feature:
1) Open the app in ios.
2)Create wallet using social login.
3)Observe changes in "description" below text "MetaMask password".
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
https://www.figma.com/design/pViOUcmjwhEzFsdrwknpNc/Onboarding?node-id=12501-102542&m=dev
<!-- [screenshots/recordings] -->

### **After**
<img width="407" height="926" alt="social" src="https://github.com/user-attachments/assets/91c0641e-39c9-4940-8c47-29018b1144d3" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Show iOS-specific OAuth description only when OAuth login succeeded; add tests validating platform-specific text rendering.
> 
> - **ChoosePassword UI (`app/components/Views/ChoosePassword/index.js`)**:
>   - Gate iOS-specific description behind `Platform.OS === 'ios' && getOauth2LoginSuccess()` so the iOS copy shows only after successful OAuth login; otherwise use the generic description. Android warning copy unchanged.
> - **Tests (`app/components/Views/ChoosePassword/index.test.tsx`)**:
>   - Import `Platform` and add tests to assert correct description text for iOS vs Android when `oauthLoginSuccess` is true.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cbd2e52d85aa22410b7a92cbcc57f2af8f7e4e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->