### PR TITLE
refactor: Refactor PPOM controller to use modular init pattern

### DIFF
--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-shadow */
-import Crypto from 'react-native-quick-crypto';
 ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
 import {
   AppState,
@@ -34,7 +33,6 @@ import {
   SubjectMetadataController,
   ///: END:ONLY_INCLUDE_IF
 } from '@metamask/permission-controller';
-import { PPOMController } from '@metamask/ppom-validator';
 import { QrKeyringDeferredPromiseBridge } from '@metamask/eth-qr-keyring';
 import { LoggingController } from '@metamask/logging-controller';
 import { isTestNet } from '../../util/networks';
@@ -61,8 +59,6 @@ import { backupVault } from '../BackupVault';
 import { Hex, Json, KnownCaipNamespace } from '@metamask/utils';
 import { providerErrors } from '@metamask/rpc-errors';
 
-import { PPOM, ppomInit } from '../../lib/ppom/PPOMView';
-import RNFSStorageBackend from '../../lib/ppom/ppom-storage-backend';
 import {
   networkIdUpdated,
   networkIdWillUpdate,
@@ -169,6 +165,7 @@ import { earnControllerInit } from './controllers/earn-controller-init';
 import { rewardsDataServiceInit } from './controllers/rewards-data-service-init';
 import { swapsControllerInit } from './controllers/swaps-controller-init';
 import { remoteFeatureFlagControllerInit } from './controllers/remote-feature-flag-controller-init';
+import { ppomControllerInit } from './controllers/ppom-controller-init';
 
 // TODO: Replace "any" with type
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -348,6 +345,7 @@ export class Engine {
         NetworkEnablementController: networkEnablementControllerInit,
         PerpsController: perpsControllerInit,
         PredictController: predictControllerInit,
+        PPOMController: ppomControllerInit,
         RewardsController: rewardsControllerInit,
         RewardsDataService: rewardsDataServiceInit,
         DelegationController: DelegationControllerInit,
@@ -373,6 +371,7 @@ export class Engine {
       controllersByName.SeedlessOnboardingController;
     const perpsController = controllersByName.PerpsController;
     const predictController = controllersByName.PredictController;
+    const ppomController = controllersByName.PPOMController;
     const rewardsController = controllersByName.RewardsController;
     const gatorPermissionsController =
       controllersByName.GatorPermissionsController;
@@ -529,38 +528,7 @@ export class Engine {
       NotificationServicesPushController: notificationServicesPushController,
       ///: END:ONLY_INCLUDE_IF
       AccountsController: accountsController,
-      PPOMController: new PPOMController({
-        chainId: getGlobalChainId(networkController),
-        blockaidPublicKey: process.env.BLOCKAID_PUBLIC_KEY as string,
-        cdnBaseUrl: process.env.BLOCKAID_FILE_CDN as string,
-        messenger: this.controllerMessenger.getRestricted({
-          name: 'PPOMController',
-          allowedActions: ['NetworkController:getNetworkClientById'],
-          allowedEvents: [`${networkController.name}:networkDidChange`],
-        }),
-        onPreferencesChange: (listener) =>
-          this.controllerMessenger.subscribe(
-            `${preferencesController.name}:stateChange`,
-            listener,
-          ),
-        // TODO: Replace "any" with type
-        provider:
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          networkController.getProviderAndBlockTracker().provider as any,
-        ppomProvider: {
-          // TODO: Replace "any" with type
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          PPOM: PPOM as any,
-          ppomInit,
-        },
-        storageBackend: new RNFSStorageBackend('PPOMDB'),
-        securityAlertsEnabled:
-          initialState.PreferencesController?.securityAlertsEnabled ?? false,
-        state: initialState.PPOMController,
-        // TODO: Replace "any" with type
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        nativeCrypto: Crypto as any,
-      }),
+      PPOMController: ppomController,
       ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
       MultichainBalancesController: multichainBalancesController,
       RatesController: ratesController,

--- a/app/core/Engine/controllers/ppom-controller-init.test.ts
+++ b/app/core/Engine/controllers/ppom-controller-init.test.ts
@@ -1,0 +1,96 @@
+import { buildControllerInitRequestMock } from '../utils/test-utils';
+import { ExtendedControllerMessenger } from '../../ExtendedControllerMessenger';
+import {
+  getPPOMControllerInitMessenger,
+  getPPOMControllerMessenger,
+  PPOMControllerInitMessenger,
+  type PPOMControllerMessenger,
+} from '../messengers/ppom-controller-messenger';
+import { ControllerInitRequest } from '../types';
+import { ppomControllerInit } from './ppom-controller-init';
+import { PPOMController } from '@metamask/ppom-validator';
+
+jest.mock('@metamask/ppom-validator');
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<PPOMControllerMessenger, PPOMControllerInitMessenger>
+> {
+  const baseMessenger = new ExtendedControllerMessenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(baseMessenger),
+    controllerMessenger: getPPOMControllerMessenger(baseMessenger),
+    initMessenger: getPPOMControllerInitMessenger(baseMessenger),
+  };
+
+  // @ts-expect-error: Partial mock.
+  requestMock.getController.mockImplementation((name) => {
+    if (name === 'NetworkController') {
+      return {
+        state: {
+          selectedNetworkClientId: 'mainnet',
+        },
+
+        getNetworkClientById: jest
+          .fn()
+          .mockImplementation((networkClientId) => {
+            if (networkClientId === 'mainnet') {
+              return {
+                configuration: {
+                  chainId: '0x1',
+                },
+              };
+            }
+
+            throw new Error(`Network client "${networkClientId}" not found.`);
+          }),
+      };
+    }
+
+    throw new Error(`Controller "${name}" not found.`);
+  });
+
+  // @ts-expect-error: Partial mock.
+  baseMessenger.registerActionHandler('PreferencesController:getState', () => ({
+    securityAlertsEnabled: true,
+  }));
+
+  baseMessenger.registerActionHandler(
+    // @ts-expect-error: Partial mock.
+    'NetworkController:getSelectedNetworkClient',
+    () => ({
+      provider: {},
+    }),
+  );
+
+  return requestMock;
+}
+
+describe('ppomControllerInit', () => {
+  it('initializes the controller', () => {
+    const { controller } = ppomControllerInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(PPOMController);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    ppomControllerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(PPOMController);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      state: undefined,
+      chainId: '0x1',
+      blockaidPublicKey: process.env.BLOCKAID_PUBLIC_KEY,
+      cdnBaseUrl: process.env.BLOCKAID_FILE_CDN,
+      onPreferencesChange: expect.any(Function),
+      provider: {},
+      ppomProvider: {
+        PPOM: expect.any(Object),
+        ppomInit: expect.any(Function),
+      },
+      storageBackend: expect.any(Object),
+      securityAlertsEnabled: true,
+      nativeCrypto: Crypto,
+    });
+  });
+});

--- a/app/core/Engine/controllers/ppom-controller-init.test.ts
+++ b/app/core/Engine/controllers/ppom-controller-init.test.ts
@@ -9,6 +9,7 @@ import {
 import { ControllerInitRequest } from '../types';
 import { ppomControllerInit } from './ppom-controller-init';
 import { PPOMController } from '@metamask/ppom-validator';
+import Crypto from 'react-native-quick-crypto';
 
 jest.mock('@metamask/ppom-validator');
 

--- a/app/core/Engine/controllers/ppom-controller-init.ts
+++ b/app/core/Engine/controllers/ppom-controller-init.ts
@@ -1,0 +1,63 @@
+import { ControllerInitFunction } from '../types';
+import { PPOMController } from '@metamask/ppom-validator';
+import {
+  PPOMControllerInitMessenger,
+  PPOMControllerMessenger,
+} from '../messengers/ppom-controller-messenger';
+import { getGlobalChainId } from '../../../util/networks/global-network';
+import { PPOM, ppomInit } from '../../../lib/ppom/PPOMView';
+import RNFSStorageBackend from '../../../lib/ppom/ppom-storage-backend';
+import { assert } from '@metamask/utils';
+
+/**
+ * Initialize the PPOM controller.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @returns The initialized controller.
+ */
+export const ppomControllerInit: ControllerInitFunction<
+  PPOMController,
+  PPOMControllerMessenger,
+  PPOMControllerInitMessenger
+> = ({ controllerMessenger, initMessenger, persistedState, getController }) => {
+  const networkController = getController('NetworkController');
+  const preferencesState = initMessenger.call('PreferencesController:getState');
+  const provider = initMessenger.call(
+    'NetworkController:getSelectedNetworkClient',
+  )?.provider;
+
+  assert(provider, 'Provider is required to initialize `PPOMController`.');
+
+  const controller = new PPOMController({
+    messenger: controllerMessenger,
+
+    // @ts-expect-error: `PPOMController` does not accept partial state.
+    state: persistedState.PPOMController,
+
+    chainId: getGlobalChainId(networkController),
+    blockaidPublicKey: process.env.BLOCKAID_PUBLIC_KEY as string,
+    cdnBaseUrl: process.env.BLOCKAID_FILE_CDN as string,
+
+    onPreferencesChange: (listener) =>
+      initMessenger.subscribe('PreferencesController:stateChange', listener),
+
+    provider,
+
+    ppomProvider: {
+      // @ts-expect-error: Type of `PPOM` does not match.
+      PPOM,
+      ppomInit,
+    },
+
+    storageBackend: new RNFSStorageBackend('PPOMDB'),
+    securityAlertsEnabled: preferencesState.securityAlertsEnabled,
+
+    // @ts-expect-error: Type of `Crypto` does not match.
+    nativeCrypto: Crypto,
+  });
+
+  return {
+    controller,
+  };
+};

--- a/app/core/Engine/controllers/ppom-controller-init.ts
+++ b/app/core/Engine/controllers/ppom-controller-init.ts
@@ -52,7 +52,7 @@ export const ppomControllerInit: ControllerInitFunction<
     },
 
     storageBackend: new RNFSStorageBackend('PPOMDB'),
-    securityAlertsEnabled: preferencesState.securityAlertsEnabled,
+    securityAlertsEnabled: preferencesState.securityAlertsEnabled ?? false,
 
     // @ts-expect-error: Type of `Crypto` does not match.
     nativeCrypto: Crypto,

--- a/app/core/Engine/controllers/ppom-controller-init.ts
+++ b/app/core/Engine/controllers/ppom-controller-init.ts
@@ -8,6 +8,7 @@ import { getGlobalChainId } from '../../../util/networks/global-network';
 import { PPOM, ppomInit } from '../../../lib/ppom/PPOMView';
 import RNFSStorageBackend from '../../../lib/ppom/ppom-storage-backend';
 import { assert } from '@metamask/utils';
+import Crypto from 'react-native-quick-crypto';
 
 /**
  * Initialize the PPOM controller.

--- a/app/core/Engine/messengers/index.ts
+++ b/app/core/Engine/messengers/index.ts
@@ -107,6 +107,10 @@ import {
   getDelegationControllerMessenger,
 } from './delegation/delegation-controller-messenger';
 import { getRemoteFeatureFlagControllerMessenger } from './remote-feature-flag-controller-messenger';
+import {
+  getPPOMControllerInitMessenger,
+  getPPOMControllerMessenger,
+} from './ppom-controller-messenger';
 
 /**
  * The messengers for the controllers that have been.
@@ -307,6 +311,10 @@ export const CONTROLLER_MESSENGERS = {
   MultichainAccountService: {
     getMessenger: getMultichainAccountServiceMessenger,
     getInitMessenger: getMultichainAccountServiceInitMessenger,
+  },
+  PPOMController: {
+    getMessenger: getPPOMControllerMessenger,
+    getInitMessenger: getPPOMControllerInitMessenger,
   },
   RemoteFeatureFlagController: {
     getMessenger: getRemoteFeatureFlagControllerMessenger,

--- a/app/core/Engine/messengers/ppom-controller-messenger.test.ts
+++ b/app/core/Engine/messengers/ppom-controller-messenger.test.ts
@@ -1,0 +1,24 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import {
+  getPPOMControllerMessenger,
+  getPPOMControllerInitMessenger,
+} from './ppom-controller-messenger';
+
+describe('getPPOMControllerMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const ppomControllerMessenger = getPPOMControllerMessenger(messenger);
+
+    expect(ppomControllerMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});
+
+describe('getPPOMControllerInitializationMessenger', () => {
+  it('returns a restricted messenger for initialization', () => {
+    const messenger = new Messenger<never, never>();
+    const ppomControllerInitMessenger =
+      getPPOMControllerInitMessenger(messenger);
+
+    expect(ppomControllerInitMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});

--- a/app/core/Engine/messengers/ppom-controller-messenger.ts
+++ b/app/core/Engine/messengers/ppom-controller-messenger.ts
@@ -1,0 +1,68 @@
+import { Messenger } from '@metamask/base-controller';
+import type {
+  NetworkControllerGetNetworkClientByIdAction,
+  NetworkControllerGetSelectedNetworkClientAction,
+  NetworkControllerNetworkDidChangeEvent,
+} from '@metamask/network-controller';
+import {
+  PreferencesControllerGetStateAction,
+  PreferencesControllerStateChangeEvent,
+} from '@metamask/preferences-controller';
+
+type AllowedActions = NetworkControllerGetNetworkClientByIdAction;
+
+type AllowedEvents = NetworkControllerNetworkDidChangeEvent;
+
+export type PPOMControllerMessenger = ReturnType<
+  typeof getPPOMControllerMessenger
+>;
+
+/**
+ * Get a messenger restricted to the actions and events that the
+ * PPOM controller is allowed to handle.
+ *
+ * @param messenger - The controller messenger to restrict.
+ * @returns The restricted controller messenger.
+ */
+export function getPPOMControllerMessenger(
+  messenger: Messenger<AllowedActions, AllowedEvents>,
+) {
+  return messenger.getRestricted({
+    name: 'PPOMController',
+    allowedActions: ['NetworkController:getNetworkClientById'],
+    allowedEvents: ['NetworkController:networkDidChange'],
+  });
+}
+
+type AllowedInitializationActions =
+  | NetworkControllerGetSelectedNetworkClientAction
+  | PreferencesControllerGetStateAction;
+
+type AllowedInitializationEvents = PreferencesControllerStateChangeEvent;
+
+export type PPOMControllerInitMessenger = ReturnType<
+  typeof getPPOMControllerInitMessenger
+>;
+
+/**
+ * Get a messenger restricted to the actions and events that the
+ * PPOM controller initialization is allowed to handle.
+ *
+ * @param messenger - The controller messenger to restrict.
+ * @returns The restricted controller messenger.
+ */
+export function getPPOMControllerInitMessenger(
+  messenger: Messenger<
+    AllowedInitializationActions,
+    AllowedInitializationEvents
+  >,
+) {
+  return messenger.getRestricted({
+    name: 'PPOMController',
+    allowedActions: [
+      'NetworkController:getSelectedNetworkClient',
+      'PreferencesController:getState',
+    ],
+    allowedEvents: ['PreferencesController:stateChange'],
+  });
+}

--- a/app/core/Engine/types.ts
+++ b/app/core/Engine/types.ts
@@ -740,6 +740,7 @@ export type ControllersToInitialize =
   | 'BridgeController'
   | 'BridgeStatusController'
   | 'NetworkEnablementController'
+  | 'PPOMController'
   | 'RewardsController'
   | 'RewardsDataService'
   | 'GatorPermissionsController'


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This refactors the PPOM controller to use modular init.

Blocked by:

- https://github.com/MetaMask/metamask-mobile/pull/21135.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors PPOM controller to a modular init pattern, adds dedicated messengers and tests, and updates Engine to consume the modular controller.
> 
> - **Engine**:
>   - Replace inline `PPOMController` construction with modular `ppomControllerInit` and wire it via `controllersByName`.
>   - Remove direct dependencies on `PPOMView`/`RNFSStorageBackend`/inline wiring and use controller-provided setup instead.
> - **Controllers**:
>   - Add `ppom-controller-init` to initialize `PPOMController` (reads provider, preferences, env vars; sets storage backend and crypto).
> - **Messengers**:
>   - Introduce `ppom-controller-messenger` providing restricted messengers for controller and init; export via `messengers/index`.
> - **Types/Registry**:
>   - Register `PPOMController` in `CONTROLLER_MESSENGERS` and controller initialization types.
> - **Tests**:
>   - Add tests for `ppom-controller-init` and `ppom-controller-messenger` to validate wiring and parameters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e3db4651c59916c8f76927873cb030fed768edb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->