### PR TITLE
fix: now consider non-EVM account names for group names - cp-7.57.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
     "@ledgerhq/react-native-hw-transport-ble": "^6.34.1",
     "@metamask/abi-utils": "^3.0.0",
     "@metamask/account-api": "^0.12.0",
-    "@metamask/account-tree-controller": "^1.4.2",
+    "@metamask/account-tree-controller": "^1.5.0",
     "@metamask/accounts-controller": "^33.1.0",
     "@metamask/address-book-controller": "^6.1.0",
     "@metamask/app-metadata-controller": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6858,9 +6858,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/account-tree-controller@npm:^1.4.2":
-  version: 1.4.2
-  resolution: "@metamask/account-tree-controller@npm:1.4.2"
+"@metamask/account-tree-controller@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "@metamask/account-tree-controller@npm:1.5.0"
   dependencies:
     "@metamask/base-controller": ^8.4.1
     "@metamask/snaps-sdk": ^9.0.0
@@ -6878,7 +6878,7 @@ __metadata:
     "@metamask/providers": ^22.0.0
     "@metamask/snaps-controllers": ^14.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: eab5dbd501b5792c9ecf29d7a45f88769f4e7dd18c7057faa3755f251a8a595e2f7daedf454a856d9746cb8bccda85805ea965d16fd4f4623fa541329545cdf8
+  checksum: d431e54de741b7b571d56daa63f91e827c2ddbb6ed648205f0cf850d92de1980bbfce0794dd5c8f62c4af36146fd4f8e00c4bbd5822735d7dae0a15209a4630b
   languageName: node
   linkType: hard
 
@@ -34093,7 +34093,7 @@ __metadata:
     "@ledgerhq/react-native-hw-transport-ble": ^6.34.1
     "@metamask/abi-utils": ^3.0.0
     "@metamask/account-api": ^0.12.0
-    "@metamask/account-tree-controller": ^1.4.2
+    "@metamask/account-tree-controller": ^1.5.0
     "@metamask/accounts-controller": ^33.1.0
     "@metamask/address-book-controller": ^6.1.0
     "@metamask/app-metadata-controller": ^1.0.0


### PR DESCRIPTION
## **Description**

Migrating from an older version like 13.3.0 where your accounts were named that way:

- Index 1:
  * My EVM account (1)
  * Solana Account 1
  * Bitcoin Account 1
- Index 2
  * `<no EVM account>`
  * My Solana account (2)
  * Bitcoin Account 2
- Index 3
  * `<no EVM account>`
  * `<no Solana account>`
  * My Bitcoin account (3)

TODO

To:

TODO

Group names have been computed based on each existing accounts.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:
- https://github.com/MetaMask/metamask-extension/issues/36826

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update @metamask/account-tree-controller to ^1.5.0 and refresh yarn.lock.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2517fe29f6a0593cedcca9bd620fb52fdadfe640. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->