### PR TITLE
fix: polygon in metamask pay

### DIFF
--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
@@ -7,7 +7,7 @@ import { BigNumber } from 'bignumber.js';
 import { useTransactionPayTokenAmounts } from '../pay/useTransactionPayTokenAmounts';
 import { strings } from '../../../../../../locales/i18n';
 import { Hex } from '@metamask/utils';
-import { NATIVE_TOKEN_ADDRESS } from '../../constants/tokens';
+import { getNativeTokenAddress } from '../../utils/asset';
 
 export function useInsufficientPayTokenBalanceAlert({
   amountOverrides,
@@ -16,13 +16,14 @@ export function useInsufficientPayTokenBalanceAlert({
 } = {}): Alert[] {
   const { payToken } = useTransactionPayToken();
   const { balance, symbol } = payToken ?? {};
+  const nativeTokenAddress = getNativeTokenAddress(payToken?.chainId ?? '0x0');
 
   const { totalHuman, amounts } = useTransactionPayTokenAmounts({
     amountOverrides,
   });
 
   const tokenAmount =
-    amounts?.find((a) => a.address !== NATIVE_TOKEN_ADDRESS)
+    amounts?.find((a) => a.address !== nativeTokenAddress)
       ?.amountHumanOriginal ?? '0';
 
   const balanceValue = new BigNumber(balance ?? '0');

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenNativeAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenNativeAlert.ts
@@ -6,28 +6,26 @@ import { AlertKeys } from '../../constants/alerts';
 import { BigNumber } from 'bignumber.js';
 import { strings } from '../../../../../../locales/i18n';
 import { useTransactionTotalFiat } from '../pay/useTransactionTotalFiat';
-import { NATIVE_TOKEN_ADDRESS } from '../../constants/tokens';
 import { useTokenWithBalance } from '../tokens/useTokenWithBalance';
 import { useSelector } from 'react-redux';
 import { selectTickerByChainId } from '../../../../../selectors/networkController';
 import { RootState } from '../../../../../reducers';
+import { getNativeTokenAddress } from '../../utils/asset';
 
 export function useInsufficientPayTokenNativeAlert(): Alert[] {
   const { totalNetworkFeeMax, total } = useTransactionTotalFiat();
   const { payToken } = useTransactionPayToken();
   const { chainId } = payToken ?? {};
+  const nativeTokenAddress = getNativeTokenAddress(chainId ?? '0x0');
 
   const ticker = useSelector((state: RootState) =>
     selectTickerByChainId(state, chainId ?? '0x0'),
   );
 
-  const nativeToken = useTokenWithBalance(
-    NATIVE_TOKEN_ADDRESS,
-    chainId ?? '0x0',
-  );
+  const nativeToken = useTokenWithBalance(nativeTokenAddress, chainId ?? '0x0');
 
   const { tokenFiatAmount } = nativeToken ?? {};
-  const isPayTokenNative = payToken?.address === NATIVE_TOKEN_ADDRESS;
+  const isPayTokenNative = payToken?.address === nativeTokenAddress;
   const requiredAmount = isPayTokenNative ? total : totalNetworkFeeMax;
 
   const isInsufficient =

--- a/app/components/Views/confirmations/hooks/alerts/usePendingAmountAlerts.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/usePendingAmountAlerts.test.ts
@@ -33,6 +33,12 @@ jest.mock('../pay/useTransactionRequiredTokens', () => ({
   ],
 }));
 
+jest.mock('../transactions/useTransactionMetadataRequest', () => ({
+  useTransactionMetadataRequest: () => ({
+    chainId: '0x1',
+  }),
+}));
+
 describe('usePendingAmountAlerts', () => {
   it('returns alerts', () => {
     const { result } = renderHook(() =>

--- a/app/components/Views/confirmations/hooks/alerts/usePendingAmountAlerts.ts
+++ b/app/components/Views/confirmations/hooks/alerts/usePendingAmountAlerts.ts
@@ -4,21 +4,25 @@ import { Alert } from '../../types/alerts';
 import { useInsufficientPayTokenBalanceAlert } from './useInsufficientPayTokenBalanceAlert';
 import { usePerpsHardwareAccountAlert } from './usePerpsHardwareAccountAlert';
 import { useTransactionRequiredTokens } from '../pay/useTransactionRequiredTokens';
-import { NATIVE_TOKEN_ADDRESS } from '../../constants/tokens';
+import { getNativeTokenAddress } from '../../utils/asset';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import { Hex } from '@metamask/utils';
 
 export function usePendingAmountAlerts({
   pendingTokenAmount,
 }: {
   pendingTokenAmount: string | undefined;
 }): Alert[] {
+  const { chainId } = useTransactionMetadataRequest() || { chainId: '0x0' };
+  const requiredTokens = useTransactionRequiredTokens();
+  const nativeTokenAddress = getNativeTokenAddress(chainId as Hex);
+
   const perpsDepositMinimumAlert = usePerpsDepositMinimumAlert({
     pendingTokenAmount: pendingTokenAmount ?? '0',
   });
 
-  const requiredTokens = useTransactionRequiredTokens();
-
   const tokenAddress =
-    requiredTokens.find((t) => t.address.toLowerCase() !== NATIVE_TOKEN_ADDRESS)
+    requiredTokens.find((t) => t.address.toLowerCase() !== nativeTokenAddress)
       ?.address ?? '0x0';
 
   const insufficientTokenFundsAlert = useInsufficientPayTokenBalanceAlert({

--- a/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
@@ -2,7 +2,6 @@ import { useSelector } from 'react-redux';
 import { useTokensWithBalance } from '../../../../UI/Bridge/hooks/useTokensWithBalance';
 import { selectEnabledSourceChains } from '../../../../../core/redux/slices/bridge';
 import { useTransactionRequiredTokens } from './useTransactionRequiredTokens';
-import { NATIVE_TOKEN_ADDRESS } from '../../constants/tokens';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { orderBy } from 'lodash';
 import { useEffect, useMemo, useRef } from 'react';
@@ -13,6 +12,7 @@ import { BridgeToken } from '../../../../UI/Bridge/types';
 import { isHardwareAccount } from '../../../../../util/address';
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { getRequiredBalance } from '../../utils/transaction-pay';
+import { getNativeTokenAddress } from '../../utils/asset';
 
 const log = createProjectLogger('transaction-pay');
 
@@ -52,9 +52,11 @@ export function useAutomaticTransactionPayToken({
   let automaticToken: { address: string; chainId?: string } | undefined;
   let count = 0;
 
+  const nativeTokenAddress = getNativeTokenAddress(chainId as Hex);
+
   if (!isUpdated.current || countOnly) {
     const targetToken =
-      requiredTokens.find((token) => token.address !== NATIVE_TOKEN_ADDRESS) ??
+      requiredTokens.find((token) => token.address !== nativeTokenAddress) ??
       requiredTokens[0];
 
     const sufficientBalanceTokens = orderBy(
@@ -126,8 +128,10 @@ function isTokenSupported(
   tokens: BridgeToken[],
   requiredBalance: number | undefined,
 ): boolean {
+  const nativeTokenAddress = getNativeTokenAddress(token.chainId as Hex);
+
   const nativeToken = tokens.find(
-    (t) => t.address === NATIVE_TOKEN_ADDRESS && t.chainId === token.chainId,
+    (t) => t.address === nativeTokenAddress && t.chainId === token.chainId,
   );
 
   const tokenAmount = token?.tokenFiatAmount ?? 0;

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.ts
@@ -6,12 +6,12 @@ import { useSelector } from 'react-redux';
 import { useTransactionPayToken } from './useTransactionPayToken';
 import { useTransactionRequiredTokens } from './useTransactionRequiredTokens';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
-import { NATIVE_TOKEN_ADDRESS } from '../../constants/tokens';
 import { uniq } from 'lodash';
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 import { useTransactionPayFiat } from './useTransactionPayFiat';
 import { getRequiredBalance } from '../../utils/transaction-pay';
+import { getNativeTokenAddress } from '../../utils/asset';
 
 export function useTransactionPayAvailableTokens() {
   const supportedChains = useSelector(selectEnabledSourceChains);
@@ -68,9 +68,10 @@ export function useTransactionPayAvailableTokens() {
         return false;
       }
 
+      const nativeTokenAddress = getNativeTokenAddress(token.chainId as Hex);
+
       const nativeToken = allTokens.find(
-        (t) =>
-          t.address === NATIVE_TOKEN_ADDRESS && t.chainId === token.chainId,
+        (t) => t.address === nativeTokenAddress && t.chainId === token.chainId,
       );
 
       const hasNativeBalance = (nativeToken?.tokenFiatAmount ?? 0) > 0;

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts
@@ -6,15 +6,15 @@ import {
 } from '../../../../../core/redux/slices/confirmationMetrics';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { useDeepMemo } from '../useDeepMemo';
-import { Json } from '@metamask/utils';
+import { Hex, Json } from '@metamask/utils';
 import { TransactionType } from '@metamask/transaction-controller';
 import { RootState } from '../../../../../reducers';
 import { useTransactionPayToken } from './useTransactionPayToken';
 import { BridgeToken } from '../../../../UI/Bridge/types';
-import { NATIVE_TOKEN_ADDRESS } from '../../constants/tokens';
 import { BigNumber } from 'bignumber.js';
 import { useTokenAmount } from '../useTokenAmount';
 import { useAutomaticTransactionPayToken } from './useAutomaticTransactionPayToken';
+import { getNativeTokenAddress } from '../../utils/asset';
 
 export function useTransactionPayMetrics() {
   const dispatch = useDispatch();
@@ -28,7 +28,7 @@ export function useTransactionPayMetrics() {
   });
 
   const transactionId = transactionMeta?.id ?? '';
-  const { type } = transactionMeta ?? {};
+  const { chainId, type } = transactionMeta ?? {};
 
   const quotes = useSelector((state: RootState) =>
     selectTransactionBridgeQuotesById(state, transactionId),
@@ -64,8 +64,10 @@ export function useTransactionPayMetrics() {
     properties.simulation_sending_assets_total_value = amountPrecise ?? null;
   }
 
+  const nativeTokenAddress = getNativeTokenAddress(chainId as Hex);
+
   const nonGasQuote = quotes?.find(
-    (q) => q.request?.targetTokenAddress !== NATIVE_TOKEN_ADDRESS,
+    (q) => q.request?.targetTokenAddress !== nativeTokenAddress,
   );
 
   if (nonGasQuote) {

--- a/app/components/Views/confirmations/hooks/pay/useTransactionRequiredTokens.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionRequiredTokens.ts
@@ -1,6 +1,5 @@
 import { useEffect, useMemo } from 'react';
 import { useTransactionMaxGasCost } from '../gas/useTransactionMaxGasCost';
-import { NATIVE_TOKEN_ADDRESS } from '../../constants/tokens';
 import { Hex, createProjectLogger } from '@metamask/utils';
 import { Interface } from '@ethersproject/abi';
 import { abiERC20 } from '@metamask/metamask-eth-abis';
@@ -12,6 +11,7 @@ import { useSelector } from 'react-redux';
 import { RootState } from '../../../../../reducers';
 import { selectUSDConversionRateByChainId } from '../../../../../selectors/currencyRateController';
 import { getTokenTransferData } from '../../utils/transaction-pay';
+import { getNativeTokenAddress } from '../../utils/asset';
 
 const log = createProjectLogger('transaction-pay');
 
@@ -85,8 +85,8 @@ function useTokenTransferToken(chainId: Hex): TransactionToken | undefined {
 }
 
 function useGasToken(chainId: Hex): TransactionToken | undefined {
-  const balanceProperties = useTokenBalance(NATIVE_TOKEN_ADDRESS, chainId);
-
+  const nativeTokenAddress = getNativeTokenAddress(chainId);
+  const balanceProperties = useTokenBalance(nativeTokenAddress, chainId);
   const maxGasCostHex = useTransactionMaxGasCost();
 
   const usdConversionRate = useSelector((state: RootState) =>

--- a/app/components/Views/confirmations/hooks/tokens/useTokenWithBalance.ts
+++ b/app/components/Views/confirmations/hooks/tokens/useTokenWithBalance.ts
@@ -64,7 +64,7 @@ export function useTokenWithBalance(tokenAddress: Hex, chainId: Hex) {
       isNative ? nativeBalanceHex : tokenBalanceHex,
     );
 
-    const decimals = token?.decimals ?? 18;
+    const decimals = Number(token?.decimals ?? 18);
     const balanceValue = balanceRawValue.shiftedBy(-decimals);
     const fiatRate = isNative ? conversionRate : tokenFiatRate;
 

--- a/app/components/Views/confirmations/hooks/tokens/useTokenWithBalance.ts
+++ b/app/components/Views/confirmations/hooks/tokens/useTokenWithBalance.ts
@@ -12,11 +12,12 @@ import useFiatFormatter from '../../../../UI/SimulationDetails/FiatDisplay/useFi
 import { selectAccountBalanceByChainId } from '../../../../../selectors/accountTrackerController';
 import { selectConversionRateByChainId } from '../../../../../selectors/currencyRateController';
 import { selectTickerByChainId } from '../../../../../selectors/networkController';
-import { NATIVE_TOKEN_ADDRESS } from '../../constants/tokens';
+import { getNativeTokenAddress } from '../../utils/asset';
 
 export function useTokenWithBalance(tokenAddress: Hex, chainId: Hex) {
   const selectedAddress = useSelector(selectSelectedInternalAccountAddress);
   const fiatFormatter = useFiatFormatter();
+  const nativeTokenAddress = getNativeTokenAddress(chainId);
 
   const token = useSelector((state: RootState) =>
     selectSingleTokenByAddressAndChainId(state, tokenAddress, chainId),
@@ -52,7 +53,7 @@ export function useTokenWithBalance(tokenAddress: Hex, chainId: Hex) {
   const nativeBalanceHex = (nativeBalanceResult?.balance as Hex) ?? '0x0';
 
   const isNative =
-    tokenAddress.toLowerCase() === NATIVE_TOKEN_ADDRESS.toLowerCase();
+    tokenAddress.toLowerCase() === nativeTokenAddress.toLowerCase();
 
   return useMemo(() => {
     if (!token && !isNative) {


### PR DESCRIPTION
## **Description**

Fix support for Polygon tokens in MetaMask pay by supporting alternate native token addresses.

Also handle string `decimals` in token state.

## **Changelog**

CHANGELOG entry: Fixed bug causing crash with some payment tokens in Perps deposit

## **Related issues**

Fixes: [#20966](https://github.com/MetaMask/metamask-mobile/issues/20966)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch from a constant native token address to chain-aware `getNativeTokenAddress` across pay flows and fix token `decimals` handling.
> 
> - **MetaMask Pay (chain-aware native token)**:
>   - Replace `NATIVE_TOKEN_ADDRESS` with `getNativeTokenAddress(chainId)` in `alerts`, `pay` selection, availability, metrics, and required tokens logic (`useInsufficientPayToken*`, `usePendingAmountAlerts`, `useAutomaticTransactionPayToken`, `useTransactionPayAvailableTokens`, `useTransactionPayMetrics`, `useTransactionRequiredTokens`).
>   - Ensure comparisons/filters and token lookups use the chain’s native address; pass `chainId` where needed.
> - **Token balance handling**:
>   - In `useTokenWithBalance`, treat `decimals` as a number (cast) and compute native-vs-token balances using the chain-resolved native address.
> - **Tests**:
>   - Update `usePendingAmountAlerts.test` to mock `useTransactionMetadataRequest` for `chainId` context.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a2cb85a5f3781c816b780005717e8fe10ac37cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->