### PR TITLE
chore: bump `@metamask/token-search-discovery-controller` to `^3.5.0`

### DIFF
--- a/app/core/Engine/types.ts
+++ b/app/core/Engine/types.ts
@@ -248,11 +248,9 @@ import {
 import {
   TokenSearchDiscoveryController,
   TokenSearchDiscoveryControllerState,
-} from '@metamask/token-search-discovery-controller';
-import {
   TokenSearchDiscoveryControllerActions,
   TokenSearchDiscoveryControllerEvents,
-} from '@metamask/token-search-discovery-controller/dist/token-search-discovery-controller.cjs';
+} from '@metamask/token-search-discovery-controller';
 import { SnapKeyringEvents } from '@metamask/eth-snap-keyring';
 import {
   MultichainNetworkController,

--- a/package.json
+++ b/package.json
@@ -294,7 +294,7 @@
     "@metamask/stake-sdk": "^3.2.0",
     "@metamask/swappable-obj-proxy": "^2.1.0",
     "@metamask/swaps-controller": "^14.0.0",
-    "@metamask/token-search-discovery-controller": "^3.1.0",
+    "@metamask/token-search-discovery-controller": "^3.5.0",
     "@metamask/transaction-controller": "^60.9.0",
     "@metamask/tron-wallet-snap": "^1.5.0",
     "@metamask/utils": "^11.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8798,13 +8798,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/token-search-discovery-controller@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "@metamask/token-search-discovery-controller@npm:3.1.0"
+"@metamask/token-search-discovery-controller@npm:^3.5.0":
+  version: 3.5.0
+  resolution: "@metamask/token-search-discovery-controller@npm:3.5.0"
   dependencies:
-    "@metamask/base-controller": "npm:^8.0.0"
-    "@metamask/utils": "npm:^11.2.0"
-  checksum: 10/0bfb84e638e75c84def9e832d4d3def060fb13a594dfe38500e0f381a91d8435f34417747425b141a696f0987720a3fb7809017c5cf277dcf7138723b3fad296
+    "@metamask/base-controller": "npm:^8.4.1"
+    "@metamask/utils": "npm:^11.8.1"
+  checksum: 10/6db85c29f2200192e0e88ddd307ef49728385dee04f99d3b7299bdccff6e24277b4a39592a5d7752e9f2ab11737a1b0bfa0e19147df4a294a6605335aaa87850
   languageName: node
   linkType: hard
 
@@ -34198,7 +34198,7 @@ __metadata:
     "@metamask/test-dapp": "npm:9.5.0"
     "@metamask/test-dapp-multichain": "npm:^0.17.1"
     "@metamask/test-dapp-solana": "npm:^0.3.0"
-    "@metamask/token-search-discovery-controller": "npm:^3.1.0"
+    "@metamask/token-search-discovery-controller": "npm:^3.5.0"
     "@metamask/transaction-controller": "npm:^60.9.0"
     "@metamask/tron-wallet-snap": "npm:^1.5.0"
     "@metamask/utils": "npm:^11.8.1"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR bumps `@metamask/token-search-discovery-controller` from `^3.1.0` to `^3.5.0`.

Key changes by version:
	•	3.2.0 – Added swappable param to discovery endpoints ([changelog](https://github.com/MetaMask/core/blob/main/packages/token-search-discovery-controller/CHANGELOG.md#320))
	•	3.3.0 – Added searchTokensFormatted as new controller method ([changelog](https://github.com/MetaMask/core/blob/main/packages/token-search-discovery-controller/CHANGELOG.md#330))
	•	3.4.0 – Added new metadata properties ([changelog](https://github.com/MetaMask/core/blob/main/packages/token-search-discovery-controller/CHANGELOG.md#340))
	•	3.5.0 – Added missing messenger type exports to prevent imports from dist, which would break once moduleResolution is updated to Node16 ([changelog](https://github.com/MetaMask/core/blob/main/packages/token-search-discovery-controller/CHANGELOG.md#350)).

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `@metamask/token-search-discovery-controller` to `^3.5.0` and switches `TokenSearchDiscovery` action/event imports to the main package exports.
> 
> - **Dependencies**
>   - Bump `@metamask/token-search-discovery-controller` from `^3.1.0` to `^3.5.0`.
> - **Engine Types**
>   - In `app/core/Engine/types.ts`, consolidate `TokenSearchDiscoveryController*` imports to `@metamask/token-search-discovery-controller` (remove imports from `dist/...cjs`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef29cd376156a4692fe1542ec5a325d9788b007d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->