### PR TITLE
refactor: Refactor remaining controllers to use modular init pattern

### DIFF
--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -8,7 +8,6 @@ import {
 ///: END:ONLY_INCLUDE_IF
 import { CodefiTokenPricesServiceV2 } from '@metamask/assets-controllers';
 import { AccountsController } from '@metamask/accounts-controller';
-import { AddressBookController } from '@metamask/address-book-controller';
 import { ComposableController } from '@metamask/composable-controller';
 import {
   KeyringController,
@@ -169,6 +168,7 @@ import { ppomControllerInit } from './controllers/ppom-controller-init';
 import { errorReportingServiceInit } from './controllers/error-reporting-service-init';
 import { loggingControllerInit } from './controllers/logging-controller-init';
 import { phishingControllerInit } from './controllers/phishing-controller-init';
+import { addressBookControllerInit } from './controllers/address-book-controller-init';
 
 // TODO: Replace "any" with type
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -349,6 +349,7 @@ export class Engine {
         RewardsController: rewardsControllerInit,
         RewardsDataService: rewardsDataServiceInit,
         DelegationController: DelegationControllerInit,
+        AddressBookController: addressBookControllerInit,
       },
       persistedState: initialState as EngineState,
       baseControllerMessenger: this.controllerMessenger,
@@ -381,6 +382,7 @@ export class Engine {
       controllersByName.SelectedNetworkController;
     const preferencesController = controllersByName.PreferencesController;
     const delegationController = controllersByName.DelegationController;
+    const addressBookController = controllersByName.AddressBookController;
 
     // Backwards compatibility for existing references
     this.accountsController = accountsController;
@@ -465,14 +467,7 @@ export class Engine {
       KeyringController: this.keyringController,
       AccountTreeController: accountTreeController,
       AccountTrackerController: accountTrackerController,
-      AddressBookController: new AddressBookController({
-        messenger: this.controllerMessenger.getRestricted({
-          name: 'AddressBookController',
-          allowedActions: [],
-          allowedEvents: [],
-        }),
-        state: initialState.AddressBookController,
-      }),
+      AddressBookController: addressBookController,
       AppMetadataController: controllersByName.AppMetadataController,
       AssetsContractController: assetsContractController,
       NftController: nftController,

--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -34,7 +34,6 @@ import {
   ///: END:ONLY_INCLUDE_IF
 } from '@metamask/permission-controller';
 import { QrKeyringDeferredPromiseBridge } from '@metamask/eth-qr-keyring';
-import { LoggingController } from '@metamask/logging-controller';
 import { isTestNet } from '../../util/networks';
 import { deprecatedGetNetworkId } from '../../util/networks/engineNetworkUtils';
 import AppConstants from '../AppConstants';
@@ -170,6 +169,7 @@ import { swapsControllerInit } from './controllers/swaps-controller-init';
 import { remoteFeatureFlagControllerInit } from './controllers/remote-feature-flag-controller-init';
 import { ppomControllerInit } from './controllers/ppom-controller-init';
 import { errorReportingServiceInit } from './controllers/error-reporting-service-init';
+import { loggingControllerInit } from './controllers/logging-controller-init';
 
 // TODO: Replace "any" with type
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -277,6 +277,7 @@ export class Engine {
     const { controllersByName } = initModularizedControllers({
       controllerInitFunctions: {
         ErrorReportingService: errorReportingServiceInit,
+        LoggingController: loggingControllerInit,
         PreferencesController: preferencesControllerInit,
         RemoteFeatureFlagController: remoteFeatureFlagControllerInit,
         NetworkController: networkControllerInit,
@@ -354,6 +355,7 @@ export class Engine {
       ...initRequest,
     });
 
+    const loggingController = controllersByName.LoggingController;
     const remoteFeatureFlagController =
       controllersByName.RemoteFeatureFlagController;
     const accountsController = controllersByName.AccountsController;
@@ -448,19 +450,6 @@ export class Engine {
     const networkEnablementController =
       controllersByName.NetworkEnablementController;
     networkEnablementController.init();
-
-    const loggingController = new LoggingController({
-      messenger: this.controllerMessenger.getRestricted<
-        'LoggingController',
-        never,
-        never
-      >({
-        name: 'LoggingController',
-        allowedActions: [],
-        allowedEvents: [],
-      }),
-      state: initialState.LoggingController,
-    });
 
     const phishingController = new PhishingController({
       messenger: this.controllerMessenger.getRestricted({

--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -129,8 +129,6 @@ import {
   MultichainRouterMessenger,
   MultichainRouterArgs,
 } from '@metamask/snaps-controllers';
-import { ErrorReportingService } from '@metamask/error-reporting-service';
-import { captureException } from '@sentry/react-native';
 import { WebSocketServiceInit } from './controllers/snaps/websocket-service-init';
 import { networkEnablementControllerInit } from './controllers/network-enablement-controller/network-enablement-controller-init';
 
@@ -171,6 +169,7 @@ import { rewardsDataServiceInit } from './controllers/rewards-data-service-init'
 import { swapsControllerInit } from './controllers/swaps-controller-init';
 import { remoteFeatureFlagControllerInit } from './controllers/remote-feature-flag-controller-init';
 import { ppomControllerInit } from './controllers/ppom-controller-init';
+import { errorReportingServiceInit } from './controllers/error-reporting-service-init';
 
 // TODO: Replace "any" with type
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -261,20 +260,6 @@ export class Engine {
 
     this.controllerMessenger = new ExtendedControllerMessenger();
 
-    const errorReportingServiceMessenger =
-      this.controllerMessenger.getRestricted({
-        name: 'ErrorReportingService',
-        allowedActions: [],
-        allowedEvents: [],
-      });
-    // We only use the ErrorReportingService through the
-    // messenger. But we need to assign a variable to make Sonar happy.
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const errorReportingService = new ErrorReportingService({
-      messenger: errorReportingServiceMessenger,
-      captureException,
-    });
-
     const codefiTokenApiV2 = new CodefiTokenPricesServiceV2();
 
     const initRequest = {
@@ -291,6 +276,7 @@ export class Engine {
 
     const { controllersByName } = initModularizedControllers({
       controllerInitFunctions: {
+        ErrorReportingService: errorReportingServiceInit,
         PreferencesController: preferencesControllerInit,
         RemoteFeatureFlagController: remoteFeatureFlagControllerInit,
         NetworkController: networkControllerInit,

--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -18,7 +18,6 @@ import {
   ///: END:ONLY_INCLUDE_IF
 } from '@metamask/keyring-controller';
 import { NetworkState, NetworkStatus } from '@metamask/network-controller';
-import { PhishingController } from '@metamask/phishing-controller';
 import {
   TransactionController,
   TransactionMeta,
@@ -119,7 +118,6 @@ import { TransactionControllerInit } from './controllers/transaction-controller'
 import { defiPositionsControllerInit } from './controllers/defi-positions-controller/defi-positions-controller-init';
 import { SignatureControllerInit } from './controllers/signature-controller';
 import { GasFeeControllerInit } from './controllers/gas-fee-controller';
-import { isProductSafetyDappScanningEnabled } from '../../util/phishingDetection';
 import { appMetadataControllerInit } from './controllers/app-metadata-controller';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { toFormattedAddress } from '../../util/address';
@@ -170,6 +168,7 @@ import { remoteFeatureFlagControllerInit } from './controllers/remote-feature-fl
 import { ppomControllerInit } from './controllers/ppom-controller-init';
 import { errorReportingServiceInit } from './controllers/error-reporting-service-init';
 import { loggingControllerInit } from './controllers/logging-controller-init';
+import { phishingControllerInit } from './controllers/phishing-controller-init';
 
 // TODO: Replace "any" with type
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -344,6 +343,7 @@ export class Engine {
         SeedlessOnboardingController: seedlessOnboardingControllerInit,
         NetworkEnablementController: networkEnablementControllerInit,
         PerpsController: perpsControllerInit,
+        PhishingController: phishingControllerInit,
         PredictController: predictControllerInit,
         PPOMController: ppomControllerInit,
         RewardsController: rewardsControllerInit,
@@ -371,6 +371,7 @@ export class Engine {
     const seedlessOnboardingController =
       controllersByName.SeedlessOnboardingController;
     const perpsController = controllersByName.PerpsController;
+    const phishingController = controllersByName.PhishingController;
     const predictController = controllersByName.PredictController;
     const ppomController = controllersByName.PPOMController;
     const rewardsController = controllersByName.RewardsController;
@@ -450,18 +451,6 @@ export class Engine {
     const networkEnablementController =
       controllersByName.NetworkEnablementController;
     networkEnablementController.init();
-
-    const phishingController = new PhishingController({
-      messenger: this.controllerMessenger.getRestricted({
-        name: 'PhishingController',
-        allowedActions: [],
-        allowedEvents: [],
-      }),
-    });
-
-    if (!isProductSafetyDappScanningEnabled()) {
-      phishingController.maybeUpdateState();
-    }
 
     ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
     snapController.init();

--- a/app/core/Engine/controllers/address-book-controller-init.test.ts
+++ b/app/core/Engine/controllers/address-book-controller-init.test.ts
@@ -1,0 +1,42 @@
+import { buildControllerInitRequestMock } from '../utils/test-utils';
+import { ExtendedControllerMessenger } from '../../ExtendedControllerMessenger';
+import {
+  getAddressBookControllerMessenger,
+  type AddressBookControllerMessenger,
+} from '../messengers/address-book-controller-messenger';
+import { ControllerInitRequest } from '../types';
+import { addressBookControllerInit } from './address-book-controller-init';
+import { AddressBookController } from '@metamask/address-book-controller';
+
+jest.mock('@metamask/address-book-controller');
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<AddressBookControllerMessenger>
+> {
+  const baseMessenger = new ExtendedControllerMessenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(baseMessenger),
+    controllerMessenger: getAddressBookControllerMessenger(baseMessenger),
+    initMessenger: undefined,
+  };
+
+  return requestMock;
+}
+
+describe('AddressBookControllerInit', () => {
+  it('initializes the controller', () => {
+    const { controller } = addressBookControllerInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(AddressBookController);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    addressBookControllerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(AddressBookController);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      state: undefined,
+    });
+  });
+});

--- a/app/core/Engine/controllers/address-book-controller-init.ts
+++ b/app/core/Engine/controllers/address-book-controller-init.ts
@@ -1,0 +1,24 @@
+import { ControllerInitFunction } from '../types';
+import { AddressBookController } from '@metamask/address-book-controller';
+import { AddressBookControllerMessenger } from '../messengers/address-book-controller-messenger';
+
+/**
+ * Initialize the address book controller.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @returns The initialized controller.
+ */
+export const addressBookControllerInit: ControllerInitFunction<
+  AddressBookController,
+  AddressBookControllerMessenger
+> = ({ controllerMessenger, persistedState }) => {
+  const controller = new AddressBookController({
+    messenger: controllerMessenger,
+    state: persistedState.AddressBookController,
+  });
+
+  return {
+    controller,
+  };
+};

--- a/app/core/Engine/controllers/error-reporting-service-init.test.ts
+++ b/app/core/Engine/controllers/error-reporting-service-init.test.ts
@@ -1,0 +1,42 @@
+import { buildControllerInitRequestMock } from '../utils/test-utils';
+import { ExtendedControllerMessenger } from '../../ExtendedControllerMessenger';
+import {
+  getErrorReportingServiceMessenger,
+  type ErrorReportingServiceMessenger,
+} from '../messengers/error-reporting-service-messenger';
+import { ControllerInitRequest } from '../types';
+import { errorReportingServiceInit } from './error-reporting-service-init';
+import { ErrorReportingService } from '@metamask/error-reporting-service';
+
+jest.mock('@metamask/error-reporting-service');
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<ErrorReportingServiceMessenger>
+> {
+  const baseMessenger = new ExtendedControllerMessenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(baseMessenger),
+    controllerMessenger: getErrorReportingServiceMessenger(baseMessenger),
+    initMessenger: undefined,
+  };
+
+  return requestMock;
+}
+
+describe('errorReportingServiceInit', () => {
+  it('initializes the controller', () => {
+    const { controller } = errorReportingServiceInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(ErrorReportingService);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    errorReportingServiceInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(ErrorReportingService);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      captureException: expect.any(Function),
+    });
+  });
+});

--- a/app/core/Engine/controllers/error-reporting-service-init.ts
+++ b/app/core/Engine/controllers/error-reporting-service-init.ts
@@ -1,0 +1,25 @@
+import { ControllerInitFunction } from '../types';
+import { ErrorReportingService } from '@metamask/error-reporting-service';
+import { ErrorReportingServiceMessenger } from '../messengers/error-reporting-service-messenger';
+import { captureException } from '@sentry/react-native';
+
+/**
+ * Initialize the error reporting service.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @returns The initialized controller.
+ */
+export const errorReportingServiceInit: ControllerInitFunction<
+  ErrorReportingService,
+  ErrorReportingServiceMessenger
+> = ({ controllerMessenger }) => {
+  const controller = new ErrorReportingService({
+    messenger: controllerMessenger,
+    captureException,
+  });
+
+  return {
+    controller,
+  };
+};

--- a/app/core/Engine/controllers/logging-controller-init.test.ts
+++ b/app/core/Engine/controllers/logging-controller-init.test.ts
@@ -1,0 +1,42 @@
+import { buildControllerInitRequestMock } from '../utils/test-utils';
+import { ExtendedControllerMessenger } from '../../ExtendedControllerMessenger';
+import {
+  getLoggingControllerMessenger,
+  type LoggingControllerMessenger,
+} from '../messengers/logging-controller-messenger';
+import { ControllerInitRequest } from '../types';
+import { loggingControllerInit } from './logging-controller-init';
+import { LoggingController } from '@metamask/logging-controller';
+
+jest.mock('@metamask/logging-controller');
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<LoggingControllerMessenger>
+> {
+  const baseMessenger = new ExtendedControllerMessenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(baseMessenger),
+    controllerMessenger: getLoggingControllerMessenger(baseMessenger),
+    initMessenger: undefined,
+  };
+
+  return requestMock;
+}
+
+describe('LoggingControllerInit', () => {
+  it('initializes the controller', () => {
+    const { controller } = loggingControllerInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(LoggingController);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    loggingControllerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(LoggingController);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      state: undefined,
+    });
+  });
+});

--- a/app/core/Engine/controllers/logging-controller-init.ts
+++ b/app/core/Engine/controllers/logging-controller-init.ts
@@ -1,0 +1,24 @@
+import { ControllerInitFunction } from '../types';
+import { LoggingController } from '@metamask/logging-controller';
+import { LoggingControllerMessenger } from '../messengers/logging-controller-messenger';
+
+/**
+ * Initialize the logging controller.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @returns The initialized controller.
+ */
+export const loggingControllerInit: ControllerInitFunction<
+  LoggingController,
+  LoggingControllerMessenger
+> = ({ controllerMessenger, persistedState }) => {
+  const controller = new LoggingController({
+    messenger: controllerMessenger,
+    state: persistedState.LoggingController,
+  });
+
+  return {
+    controller,
+  };
+};

--- a/app/core/Engine/controllers/multichain-router-init.test.ts
+++ b/app/core/Engine/controllers/multichain-router-init.test.ts
@@ -1,0 +1,47 @@
+import { buildControllerInitRequestMock } from '../utils/test-utils';
+import { ExtendedControllerMessenger } from '../../ExtendedControllerMessenger';
+import {
+  getMultichainRouterInitMessenger,
+  getMultichainRouterMessenger,
+  MultichainRouterInitMessenger,
+  type MultichainRouterMessenger,
+} from '../messengers/multichain-router-messenger';
+import { ControllerInitRequest } from '../types';
+import { multichainRouterInit } from './multichain-router-init';
+import { MultichainRouter } from '@metamask/snaps-controllers';
+
+jest.mock('@metamask/snaps-controllers');
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<
+    MultichainRouterMessenger,
+    MultichainRouterInitMessenger
+  >
+> {
+  const baseMessenger = new ExtendedControllerMessenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(baseMessenger),
+    controllerMessenger: getMultichainRouterMessenger(baseMessenger),
+    initMessenger: getMultichainRouterInitMessenger(baseMessenger),
+  };
+
+  return requestMock;
+}
+
+describe('MultichainRouterInit', () => {
+  it('initializes the controller', () => {
+    const { controller } = multichainRouterInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(MultichainRouter);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    multichainRouterInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(MultichainRouter);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      withSnapKeyring: expect.any(Function),
+    });
+  });
+});

--- a/app/core/Engine/controllers/multichain-router-init.ts
+++ b/app/core/Engine/controllers/multichain-router-init.ts
@@ -1,0 +1,67 @@
+import { ControllerInitFunction } from '../types';
+import { MultichainRouter } from '@metamask/snaps-controllers';
+import {
+  MultichainRouterInitMessenger,
+  MultichainRouterMessenger,
+} from '../messengers/multichain-router-messenger';
+import { SnapKeyring } from '@metamask/eth-snap-keyring';
+import { KeyringTypes } from '@metamask/keyring-controller';
+
+/**
+ * Initialize the multichain router.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @returns The initialized controller.
+ */
+export const multichainRouterInit: ControllerInitFunction<
+  MultichainRouter,
+  MultichainRouterMessenger,
+  MultichainRouterInitMessenger
+> = ({ controllerMessenger, initMessenger }) => {
+  const getSnapKeyring = async (): Promise<SnapKeyring> => {
+    // TODO: Replace `getKeyringsByType` with `withKeyring`
+    let [snapKeyring] = initMessenger.call(
+      'KeyringController:getKeyringsByType',
+      KeyringTypes.snap,
+    );
+
+    if (!snapKeyring) {
+      await initMessenger.call(
+        'KeyringController:addNewKeyring',
+        KeyringTypes.snap,
+      );
+
+      // TODO: Replace `getKeyringsByType` with `withKeyring`
+      [snapKeyring] = initMessenger.call(
+        'KeyringController:getKeyringsByType',
+        KeyringTypes.snap,
+      );
+    }
+    return snapKeyring as SnapKeyring;
+  };
+
+  // This fixes an issue where `withKeyring` would lock the `KeyringController`
+  // mutex. That meant that if a snap requested a keyring operation (like
+  // requesting entropy) while the `KeyringController` was locked, it would
+  // cause a deadlock. This is a temporary fix until we can refactor how we
+  // handle requests to the Snaps Keyring.
+  const withSnapKeyring = async (
+    operation: ({ keyring }: { keyring: unknown }) => void,
+  ) => {
+    const keyring = await getSnapKeyring();
+    return operation({ keyring });
+  };
+
+  const controller = new MultichainRouter({
+    // @ts-expect-error: Type for messenger seems to be incorrect.
+    messenger: controllerMessenger,
+
+    // @ts-expect-error: Type for `withSnapKeyring` is different.
+    withSnapKeyring,
+  });
+
+  return {
+    controller,
+  };
+};

--- a/app/core/Engine/controllers/phishing-controller-init.test.ts
+++ b/app/core/Engine/controllers/phishing-controller-init.test.ts
@@ -1,0 +1,41 @@
+import { buildControllerInitRequestMock } from '../utils/test-utils';
+import { ExtendedControllerMessenger } from '../../ExtendedControllerMessenger';
+import {
+  getPhishingControllerMessenger,
+  type PhishingControllerMessenger,
+} from '../messengers/phishing-controller-messenger';
+import { ControllerInitRequest } from '../types';
+import { phishingControllerInit } from './phishing-controller-init';
+import { PhishingController } from '@metamask/phishing-controller';
+
+jest.mock('@metamask/phishing-controller');
+
+function getInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<PhishingControllerMessenger>
+> {
+  const baseMessenger = new ExtendedControllerMessenger<never, never>();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(baseMessenger),
+    controllerMessenger: getPhishingControllerMessenger(baseMessenger),
+    initMessenger: undefined,
+  };
+
+  return requestMock;
+}
+
+describe('PhishingControllerInit', () => {
+  it('initializes the controller', () => {
+    const { controller } = phishingControllerInit(getInitRequestMock());
+    expect(controller).toBeInstanceOf(PhishingController);
+  });
+
+  it('passes the proper arguments to the controller', () => {
+    phishingControllerInit(getInitRequestMock());
+
+    const controllerMock = jest.mocked(PhishingController);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+    });
+  });
+});

--- a/app/core/Engine/controllers/phishing-controller-init.test.ts
+++ b/app/core/Engine/controllers/phishing-controller-init.test.ts
@@ -21,6 +21,17 @@ function getInitRequestMock(): jest.Mocked<
     initMessenger: undefined,
   };
 
+  // @ts-expect-error: Partial mock.
+  requestMock.getState.mockImplementation(() => ({
+    engine: {
+      backgroundState: {
+        RemoteFeatureFlagController: {
+          remoteFeatureFlags: {},
+        },
+      },
+    },
+  }));
+
   return requestMock;
 }
 

--- a/app/core/Engine/controllers/phishing-controller-init.ts
+++ b/app/core/Engine/controllers/phishing-controller-init.ts
@@ -1,0 +1,28 @@
+import { ControllerInitFunction } from '../types';
+import { PhishingController } from '@metamask/phishing-controller';
+import { PhishingControllerMessenger } from '../messengers/phishing-controller-messenger';
+import { isProductSafetyDappScanningEnabled } from '../../../util/phishingDetection';
+
+/**
+ * Initialize the phishing controller.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @returns The initialized controller.
+ */
+export const phishingControllerInit: ControllerInitFunction<
+  PhishingController,
+  PhishingControllerMessenger
+> = ({ controllerMessenger }) => {
+  const controller = new PhishingController({
+    messenger: controllerMessenger,
+  });
+
+  if (!isProductSafetyDappScanningEnabled()) {
+    controller.maybeUpdateState();
+  }
+
+  return {
+    controller,
+  };
+};

--- a/app/core/Engine/controllers/phishing-controller-init.ts
+++ b/app/core/Engine/controllers/phishing-controller-init.ts
@@ -13,12 +13,12 @@ import { isProductSafetyDappScanningEnabled } from '../../../util/phishingDetect
 export const phishingControllerInit: ControllerInitFunction<
   PhishingController,
   PhishingControllerMessenger
-> = ({ controllerMessenger }) => {
+> = ({ controllerMessenger, getState }) => {
   const controller = new PhishingController({
     messenger: controllerMessenger,
   });
 
-  if (!isProductSafetyDappScanningEnabled()) {
+  if (!isProductSafetyDappScanningEnabled(getState())) {
     controller.maybeUpdateState();
   }
 

--- a/app/core/Engine/messengers/address-book-controller-messenger.test.ts
+++ b/app/core/Engine/messengers/address-book-controller-messenger.test.ts
@@ -1,0 +1,12 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import { getAddressBookControllerMessenger } from './address-book-controller-messenger';
+
+describe('getAddressBookControllerMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const addressBookControllerMessenger =
+      getAddressBookControllerMessenger(messenger);
+
+    expect(addressBookControllerMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});

--- a/app/core/Engine/messengers/address-book-controller-messenger.ts
+++ b/app/core/Engine/messengers/address-book-controller-messenger.ts
@@ -1,0 +1,26 @@
+import { Messenger } from '@metamask/base-controller';
+
+type AllowedActions = never;
+
+type AllowedEvents = never;
+
+export type AddressBookControllerMessenger = ReturnType<
+  typeof getAddressBookControllerMessenger
+>;
+
+/**
+ * Get a messenger restricted to the actions and events that the
+ * address book controller is allowed to handle.
+ *
+ * @param messenger - The controller messenger to restrict.
+ * @returns The restricted controller messenger.
+ */
+export function getAddressBookControllerMessenger(
+  messenger: Messenger<AllowedActions, AllowedEvents>,
+) {
+  return messenger.getRestricted({
+    name: 'AddressBookController',
+    allowedActions: [],
+    allowedEvents: [],
+  });
+}

--- a/app/core/Engine/messengers/error-reporting-service-messenger.test.ts
+++ b/app/core/Engine/messengers/error-reporting-service-messenger.test.ts
@@ -1,0 +1,12 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import { getErrorReportingServiceMessenger } from './error-reporting-service-messenger';
+
+describe('getErrorReportingServiceMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const errorReportingServiceMessenger =
+      getErrorReportingServiceMessenger(messenger);
+
+    expect(errorReportingServiceMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});

--- a/app/core/Engine/messengers/error-reporting-service-messenger.ts
+++ b/app/core/Engine/messengers/error-reporting-service-messenger.ts
@@ -1,0 +1,26 @@
+import { Messenger } from '@metamask/base-controller';
+
+type AllowedActions = never;
+
+type AllowedEvents = never;
+
+export type ErrorReportingServiceMessenger = ReturnType<
+  typeof getErrorReportingServiceMessenger
+>;
+
+/**
+ * Get a messenger restricted to the actions and events that the
+ * error reporting service is allowed to handle.
+ *
+ * @param messenger - The controller messenger to restrict.
+ * @returns The restricted controller messenger.
+ */
+export function getErrorReportingServiceMessenger(
+  messenger: Messenger<AllowedActions, AllowedEvents>,
+) {
+  return messenger.getRestricted({
+    name: 'ErrorReportingService',
+    allowedActions: [],
+    allowedEvents: [],
+  });
+}

--- a/app/core/Engine/messengers/index.ts
+++ b/app/core/Engine/messengers/index.ts
@@ -119,6 +119,10 @@ import { getErrorReportingServiceMessenger } from './error-reporting-service-mes
 import { getLoggingControllerMessenger } from './logging-controller-messenger';
 import { getPhishingControllerMessenger } from './phishing-controller-messenger';
 import { getAddressBookControllerMessenger } from './address-book-controller-messenger';
+import {
+  getMultichainRouterInitMessenger,
+  getMultichainRouterMessenger,
+} from './multichain-router-messenger';
 
 /**
  * The messengers for the controllers that have been.
@@ -274,6 +278,10 @@ export const CONTROLLER_MESSENGERS = {
   MultichainBalancesController: {
     getMessenger: getMultichainBalancesControllerMessenger,
     getInitMessenger: noop,
+  },
+  MultichainRouter: {
+    getMessenger: getMultichainRouterMessenger,
+    getInitMessenger: getMultichainRouterInitMessenger,
   },
   MultichainTransactionsController: {
     getMessenger: getMultichainTransactionsControllerMessenger,

--- a/app/core/Engine/messengers/index.ts
+++ b/app/core/Engine/messengers/index.ts
@@ -117,6 +117,7 @@ import {
   getPPOMControllerMessenger,
 } from './ppom-controller-messenger';
 import { getErrorReportingServiceMessenger } from './error-reporting-service-messenger';
+import { getLoggingControllerMessenger } from './logging-controller-messenger';
 
 /**
  * The messengers for the controllers that have been.
@@ -148,6 +149,10 @@ export const CONTROLLER_MESSENGERS = {
   },
   ErrorReportingService: {
     getMessenger: getErrorReportingServiceMessenger,
+    getInitMessenger: noop,
+  },
+  LoggingController: {
+    getMessenger: getLoggingControllerMessenger,
     getInitMessenger: noop,
   },
   TokenListController: {

--- a/app/core/Engine/messengers/index.ts
+++ b/app/core/Engine/messengers/index.ts
@@ -116,6 +116,7 @@ import {
   getPPOMControllerInitMessenger,
   getPPOMControllerMessenger,
 } from './ppom-controller-messenger';
+import { getErrorReportingServiceMessenger } from './error-reporting-service-messenger';
 
 /**
  * The messengers for the controllers that have been.
@@ -144,6 +145,10 @@ export const CONTROLLER_MESSENGERS = {
   EarnController: {
     getMessenger: getEarnControllerMessenger,
     getInitMessenger: getEarnControllerInitMessenger,
+  },
+  ErrorReportingService: {
+    getMessenger: getErrorReportingServiceMessenger,
+    getInitMessenger: noop,
   },
   TokenListController: {
     getMessenger: getTokenListControllerMessenger,

--- a/app/core/Engine/messengers/index.ts
+++ b/app/core/Engine/messengers/index.ts
@@ -51,7 +51,6 @@ import { getNotificationServicesPushControllerMessenger } from './notifications/
 import { getGasFeeControllerMessenger } from './gas-fee-controller-messenger/gas-fee-controller-messenger';
 import { getSignatureControllerMessenger } from './signature-controller-messenger';
 import { getSeedlessOnboardingControllerMessenger } from './seedless-onboarding-controller-messenger';
-
 import { getApprovalControllerMessenger } from './approval-controller-messenger';
 import { getPerpsControllerMessenger } from './perps-controller-messenger';
 import { getPredictControllerMessenger } from './predict-controller-messenger';
@@ -119,6 +118,7 @@ import {
 import { getErrorReportingServiceMessenger } from './error-reporting-service-messenger';
 import { getLoggingControllerMessenger } from './logging-controller-messenger';
 import { getPhishingControllerMessenger } from './phishing-controller-messenger';
+import { getAddressBookControllerMessenger } from './address-book-controller-messenger';
 
 /**
  * The messengers for the controllers that have been.
@@ -135,6 +135,10 @@ export const CONTROLLER_MESSENGERS = {
   AccountTreeController: {
     getMessenger: getAccountTreeControllerMessenger,
     getInitMessenger: getAccountTreeControllerInitMessenger,
+  },
+  AddressBookController: {
+    getMessenger: getAddressBookControllerMessenger,
+    getInitMessenger: noop,
   },
   ApprovalController: {
     getMessenger: getApprovalControllerMessenger,

--- a/app/core/Engine/messengers/index.ts
+++ b/app/core/Engine/messengers/index.ts
@@ -118,6 +118,7 @@ import {
 } from './ppom-controller-messenger';
 import { getErrorReportingServiceMessenger } from './error-reporting-service-messenger';
 import { getLoggingControllerMessenger } from './logging-controller-messenger';
+import { getPhishingControllerMessenger } from './phishing-controller-messenger';
 
 /**
  * The messengers for the controllers that have been.
@@ -326,6 +327,10 @@ export const CONTROLLER_MESSENGERS = {
   MultichainAccountService: {
     getMessenger: getMultichainAccountServiceMessenger,
     getInitMessenger: getMultichainAccountServiceInitMessenger,
+  },
+  PhishingController: {
+    getMessenger: getPhishingControllerMessenger,
+    getInitMessenger: noop,
   },
   PPOMController: {
     getMessenger: getPPOMControllerMessenger,

--- a/app/core/Engine/messengers/logging-controller-messenger.test.ts
+++ b/app/core/Engine/messengers/logging-controller-messenger.test.ts
@@ -1,0 +1,11 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import { getLoggingControllerMessenger } from './logging-controller-messenger';
+
+describe('getLoggingControllerMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const loggingControllerMessenger = getLoggingControllerMessenger(messenger);
+
+    expect(loggingControllerMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});

--- a/app/core/Engine/messengers/logging-controller-messenger.ts
+++ b/app/core/Engine/messengers/logging-controller-messenger.ts
@@ -1,0 +1,26 @@
+import { Messenger } from '@metamask/base-controller';
+
+type AllowedActions = never;
+
+type AllowedEvents = never;
+
+export type LoggingControllerMessenger = ReturnType<
+  typeof getLoggingControllerMessenger
+>;
+
+/**
+ * Get a messenger restricted to the actions and events that the
+ * logging controller is allowed to handle.
+ *
+ * @param messenger - The controller messenger to restrict.
+ * @returns The restricted controller messenger.
+ */
+export function getLoggingControllerMessenger(
+  messenger: Messenger<AllowedActions, AllowedEvents>,
+) {
+  return messenger.getRestricted({
+    name: 'LoggingController',
+    allowedActions: [],
+    allowedEvents: [],
+  });
+}

--- a/app/core/Engine/messengers/multichain-router-messenger.test.ts
+++ b/app/core/Engine/messengers/multichain-router-messenger.test.ts
@@ -1,0 +1,24 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import {
+  getMultichainRouterMessenger,
+  getMultichainRouterInitMessenger,
+} from './multichain-router-messenger';
+
+describe('getMultichainRouterMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const multichainRouterMessenger = getMultichainRouterMessenger(messenger);
+
+    expect(multichainRouterMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});
+
+describe('getMultichainRouterInitMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const multichainRouterInitMessenger =
+      getMultichainRouterInitMessenger(messenger);
+
+    expect(multichainRouterInitMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});

--- a/app/core/Engine/messengers/multichain-router-messenger.ts
+++ b/app/core/Engine/messengers/multichain-router-messenger.ts
@@ -1,0 +1,70 @@
+import { Messenger } from '@metamask/base-controller';
+import { GetAllSnaps, HandleSnapRequest } from '@metamask/snaps-controllers';
+import { GetPermissions } from '@metamask/permission-controller';
+import { AccountsControllerListMultichainAccountsAction } from '@metamask/accounts-controller';
+import {
+  KeyringControllerAddNewKeyringAction,
+  KeyringControllerGetKeyringsByTypeAction,
+} from '@metamask/keyring-controller';
+
+type AllowedActions =
+  | GetAllSnaps
+  | HandleSnapRequest
+  | GetPermissions
+  | AccountsControllerListMultichainAccountsAction;
+
+type AllowedEvents = never;
+
+export type MultichainRouterMessenger = ReturnType<
+  typeof getMultichainRouterMessenger
+>;
+
+/**
+ * Get a messenger restricted to the actions and events that the
+ * multichain router is allowed to handle.
+ *
+ * @param messenger - The controller messenger to restrict.
+ * @returns The restricted controller messenger.
+ */
+export function getMultichainRouterMessenger(
+  messenger: Messenger<AllowedActions, AllowedEvents>,
+) {
+  return messenger.getRestricted({
+    name: 'MultichainRouter',
+    allowedActions: [
+      'SnapController:getAll',
+      'SnapController:handleRequest',
+      'PermissionController:getPermissions',
+      'AccountsController:listMultichainAccounts',
+    ],
+    allowedEvents: [],
+  });
+}
+
+type AllowedInitializationActions =
+  | KeyringControllerAddNewKeyringAction
+  | KeyringControllerGetKeyringsByTypeAction;
+
+export type MultichainRouterInitMessenger = ReturnType<
+  typeof getMultichainRouterInitMessenger
+>;
+
+/**
+ * Get a messenger restricted to the initialization actions that the
+ * multichain router is allowed to handle.
+ *
+ * @param messenger - The controller messenger to restrict.
+ * @returns The restricted controller messenger.
+ */
+export function getMultichainRouterInitMessenger(
+  messenger: Messenger<AllowedInitializationActions, never>,
+) {
+  return messenger.getRestricted({
+    name: 'MultichainRouterInit',
+    allowedActions: [
+      'KeyringController:addNewKeyring',
+      'KeyringController:getKeyringsByType',
+    ],
+    allowedEvents: [],
+  });
+}

--- a/app/core/Engine/messengers/phishing-controller-messenger.test.ts
+++ b/app/core/Engine/messengers/phishing-controller-messenger.test.ts
@@ -1,0 +1,12 @@
+import { Messenger, RestrictedMessenger } from '@metamask/base-controller';
+import { getPhishingControllerMessenger } from './phishing-controller-messenger';
+
+describe('getPhishingControllerMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = new Messenger<never, never>();
+    const phishingControllerMessenger =
+      getPhishingControllerMessenger(messenger);
+
+    expect(phishingControllerMessenger).toBeInstanceOf(RestrictedMessenger);
+  });
+});

--- a/app/core/Engine/messengers/phishing-controller-messenger.ts
+++ b/app/core/Engine/messengers/phishing-controller-messenger.ts
@@ -1,0 +1,26 @@
+import { Messenger } from '@metamask/base-controller';
+
+type AllowedActions = never;
+
+type AllowedEvents = never;
+
+export type PhishingControllerMessenger = ReturnType<
+  typeof getPhishingControllerMessenger
+>;
+
+/**
+ * Get a messenger restricted to the actions and events that the
+ * phishing controller is allowed to handle.
+ *
+ * @param messenger - The controller messenger to restrict.
+ * @returns The restricted controller messenger.
+ */
+export function getPhishingControllerMessenger(
+  messenger: Messenger<AllowedActions, AllowedEvents>,
+) {
+  return messenger.getRestricted({
+    name: 'PhishingController',
+    allowedActions: [],
+    allowedEvents: [],
+  });
+}

--- a/app/core/Engine/types.ts
+++ b/app/core/Engine/types.ts
@@ -177,6 +177,7 @@ import {
   WebSocketService,
   WebSocketServiceActions,
   WebSocketServiceEvents,
+  MultichainRouter,
 } from '@metamask/snaps-controllers';
 ///: END:ONLY_INCLUDE_IF
 import {
@@ -350,6 +351,7 @@ import { QrKeyringDeferredPromiseBridge } from '@metamask/eth-qr-keyring';
 type RequiredControllers = Omit<
   Controllers,
   | 'ErrorReportingService'
+  | 'MultichainRouter'
   | 'PPOMController'
   | 'RewardsDataService'
   | 'SnapKeyringBuilder'
@@ -361,6 +363,7 @@ type RequiredControllers = Omit<
 type OptionalControllers = Pick<
   Controllers,
   | 'ErrorReportingService'
+  | 'MultichainRouter'
   | 'PPOMController'
   | 'RewardsDataService'
   | 'SnapKeyringBuilder'
@@ -589,6 +592,7 @@ export type Controllers = {
   MultichainAssetsRatesController: MultichainAssetsRatesController;
   RatesController: RatesController;
   MultichainAssetsController: MultichainAssetsController;
+  MultichainRouter: MultichainRouter;
   MultichainTransactionsController: MultichainTransactionsController;
   MultichainAccountService: MultichainAccountService;
   SnapKeyringBuilder: SnapKeyringBuilder;
@@ -730,6 +734,7 @@ export type ControllersToInitialize =
   | 'MultichainAssetsController'
   | 'MultichainAssetsRatesController'
   | 'MultichainBalancesController'
+  | 'MultichainRouter'
   | 'MultichainTransactionsController'
   | 'MultichainAccountService'
   | 'RatesController'

--- a/app/core/Engine/types.ts
+++ b/app/core/Engine/types.ts
@@ -708,6 +708,7 @@ export type BaseRestrictedControllerMessenger = RestrictedMessenger<
  */
 export type ControllersToInitialize =
   | 'AccountTrackerController'
+  | 'AddressBookController'
   | 'AssetsContractController'
   ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
   | 'AuthenticationController'

--- a/app/core/Engine/types.ts
+++ b/app/core/Engine/types.ts
@@ -748,6 +748,7 @@ export type ControllersToInitialize =
   | 'MultichainNetworkController'
   | 'NftController'
   | 'NftDetectionController'
+  | 'PhishingController'
   | 'RemoteFeatureFlagController'
   | 'SignatureController'
   | 'SeedlessOnboardingController'

--- a/app/core/Engine/types.ts
+++ b/app/core/Engine/types.ts
@@ -316,7 +316,10 @@ import {
   AppMetadataControllerEvents,
   AppMetadataControllerState,
 } from '@metamask/app-metadata-controller';
-import type { ErrorReportingServiceActions } from '@metamask/error-reporting-service';
+import type {
+  ErrorReportingService,
+  ErrorReportingServiceActions,
+} from '@metamask/error-reporting-service';
 import {
   AccountTreeController,
   AccountTreeControllerState,
@@ -346,7 +349,10 @@ import { QrKeyringDeferredPromiseBridge } from '@metamask/eth-qr-keyring';
  */
 type RequiredControllers = Omit<
   Controllers,
-  'PPOMController' | 'RewardsDataService' | 'SnapKeyringBuilder'
+  | 'ErrorReportingService'
+  | 'PPOMController'
+  | 'RewardsDataService'
+  | 'SnapKeyringBuilder'
 >;
 
 /**
@@ -354,7 +360,10 @@ type RequiredControllers = Omit<
  */
 type OptionalControllers = Pick<
   Controllers,
-  'PPOMController' | 'RewardsDataService' | 'SnapKeyringBuilder'
+  | 'ErrorReportingService'
+  | 'PPOMController'
+  | 'RewardsDataService'
+  | 'SnapKeyringBuilder'
 >;
 
 /**
@@ -532,6 +541,7 @@ export type Controllers = {
   ApprovalController: ApprovalController;
   AssetsContractController: AssetsContractController;
   CurrencyRateController: CurrencyRateController;
+  ErrorReportingService: ErrorReportingService;
   GasFeeController: GasFeeController;
   KeyringController: KeyringController;
   LoggingController: LoggingController;
@@ -725,6 +735,7 @@ export type ControllersToInitialize =
   | 'SnapKeyringBuilder'
   ///: END:ONLY_INCLUDE_IF
   | 'EarnController'
+  | 'ErrorReportingService'
   | 'NetworkController'
   | 'AccountTreeController'
   | 'AccountsController'

--- a/app/core/Engine/types.ts
+++ b/app/core/Engine/types.ts
@@ -736,6 +736,7 @@ export type ControllersToInitialize =
   ///: END:ONLY_INCLUDE_IF
   | 'EarnController'
   | 'ErrorReportingService'
+  | 'LoggingController'
   | 'NetworkController'
   | 'AccountTreeController'
   | 'AccountsController'

--- a/app/util/phishingDetection.ts
+++ b/app/util/phishingDetection.ts
@@ -12,8 +12,9 @@ import { selectProductSafetyDappScanningEnabled } from '../selectors/featureFlag
  * Checks if product safety dapp scanning is enabled
  * @returns {boolean} Whether product safety dapp scanning is enabled
  */
-export const isProductSafetyDappScanningEnabled = (): boolean =>
-  selectProductSafetyDappScanningEnabled(store.getState());
+export const isProductSafetyDappScanningEnabled = (
+  state = store.getState(),
+): boolean => selectProductSafetyDappScanningEnabled(state);
 
 /**
  * Gets detailed phishing test results for an origin

--- a/package.json
+++ b/package.json
@@ -224,7 +224,7 @@
     "@metamask/eip-5792-middleware": "^1.2.3",
     "@metamask/eip1193-permission-middleware": "^1.0.0",
     "@metamask/ens-resolver-snap": "^1.0.0",
-    "@metamask/error-reporting-service": "^2.0.0",
+    "@metamask/error-reporting-service": "^2.2.1",
     "@metamask/eth-hd-keyring": "^13.0.0",
     "@metamask/eth-json-rpc-filters": "^9.0.0",
     "@metamask/eth-json-rpc-middleware": "^19.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7305,12 +7305,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/error-reporting-service@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@metamask/error-reporting-service@npm:2.0.0"
+"@metamask/error-reporting-service@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "@metamask/error-reporting-service@npm:2.2.1"
   dependencies:
-    "@metamask/base-controller": ^8.0.1
-  checksum: 210f7d6b76aac0ba0164f3c6986987cc3e7c7681f8dc2d0e3470995c109009b95eeae14207fc89e261469f61dd3ae04aa9d0b022137ecc9ec1a4a12a44cdb76c
+    "@metamask/base-controller": ^8.4.1
+  checksum: b32c24120583d10c23babe648ccb864f389621ce4c2121484deed748f254529be2ea62d3079847f7fa16e648bac0a94e643aea46f1ce84ada54b2f798a091d8f
   languageName: node
   linkType: hard
 
@@ -34073,7 +34073,7 @@ __metadata:
     "@metamask/eip-5792-middleware": ^1.2.3
     "@metamask/eip1193-permission-middleware": ^1.0.0
     "@metamask/ens-resolver-snap": ^1.0.0
-    "@metamask/error-reporting-service": ^2.0.0
+    "@metamask/error-reporting-service": ^2.2.1
     "@metamask/eslint-config-typescript": ^9.0.0
     "@metamask/eslint-plugin-design-tokens": ^1.0.0
     "@metamask/eth-hd-keyring": ^13.0.0


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This refactors the remaining controllers and services to use the modular init pattern.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors Engine to initialize Logging, Phishing, Address Book, Error Reporting, and Multichain Router via modular init with restricted messengers, adds their init/messenger modules and tests, updates types, and bumps error-reporting-service.
> 
> - **Engine refactor**:
>   - Uses `initModularizedControllers` for `LoggingController`, `PhishingController`, `AddressBookController`, `ErrorReportingService`, and `MultichainRouter`.
>   - Removes inline construction and manual messenger wiring for these components; references now come from `controllersByName`.
>   - Replaces `multichainRouter` manual setup with `multichainRouterInit`.
> - **New controller/service init modules**:
>   - `controllers/logging-controller-init.ts`, `controllers/phishing-controller-init.ts`, `controllers/address-book-controller-init.ts`, `controllers/error-reporting-service-init.ts`, `controllers/multichain-router-init.ts` (+ unit tests for each).
> - **Messengers**:
>   - Adds restricted messengers for `LoggingController`, `PhishingController`, `AddressBookController`, `ErrorReportingService`, and `MultichainRouter` (including init messenger) with tests; registers them in `messengers/index.ts`.
> - **Types**:
>   - Extends `Controllers`, `ControllersToInitialize`, and related types to include `ErrorReportingService` and `MultichainRouter`; adjusts required/optional controller sets.
> - **Utilities**:
>   - `isProductSafetyDappScanningEnabled` now accepts optional state parameter.
> - **Dependencies**:
>   - Bumps `@metamask/error-reporting-service` to `^2.2.1` (lockfile updated).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21858031e450528ad3811b1f26c9a26be90d308a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->