### PR TITLE
chore: add env exp to profiler

### DIFF
--- a/app/components/UI/ProfilerManager/ProfilerManager.test.tsx
+++ b/app/components/UI/ProfilerManager/ProfilerManager.test.tsx
@@ -32,12 +32,12 @@ describe('ProfilerManager', () => {
 
   describe('environment-based enabling', () => {
     it('enables profiler when enabled prop is true', () => {
-      render(<ProfilerManager />);
+      render(<ProfilerManager enabled />);
       expect(ShakeDetector).toHaveBeenCalled();
     });
 
     it('disables profiler when enabled prop is false', () => {
-      const { toJSON } = render(<ProfilerManager />);
+      const { toJSON } = render(<ProfilerManager enabled={false} />);
       expect(toJSON()).toBeNull();
       expect(ShakeDetector).not.toHaveBeenCalled();
     });
@@ -51,12 +51,12 @@ describe('ProfilerManager', () => {
 
   describe('forced enabling via props', () => {
     it('enables profiler when forced via props regardless of environment', () => {
-      render(<ProfilerManager />);
+      render(<ProfilerManager enabled />);
       expect(ShakeDetector).toHaveBeenCalled();
     });
 
     it('disables profiler when explicitly disabled via props', () => {
-      const { toJSON } = render(<ProfilerManager />);
+      const { toJSON } = render(<ProfilerManager enabled={false} />);
       expect(toJSON()).toBeNull();
       expect(ShakeDetector).not.toHaveBeenCalled();
     });
@@ -70,7 +70,7 @@ describe('ProfilerManager', () => {
     it('toggles visibility on shake and can be closed via the close button on iOS', async () => {
       Platform.OS = 'ios';
       const { queryByText, getByText, getByTestId } = render(
-        <ProfilerManager />,
+        <ProfilerManager enabled />,
       );
       expect(queryByText('Performance Profiler')).toBeNull();
       // Trigger shake
@@ -94,7 +94,7 @@ describe('ProfilerManager', () => {
 
     it('toggles visibility on shake and calls exportTrace when Export is pressed', async () => {
       Platform.OS = 'ios';
-      const { queryByText, getByText } = render(<ProfilerManager />);
+      const { queryByText, getByText } = render(<ProfilerManager enabled />);
       expect(queryByText('Performance Profiler')).toBeNull();
 
       const firstCallProps = (ShakeDetector as jest.Mock).mock.calls[0][0];
@@ -135,7 +135,7 @@ describe('ProfilerManager', () => {
     it('toggles visibility on shake and can be closed via the close button on Android', async () => {
       Platform.OS = 'android';
       const { queryByText, getByText, getByTestId } = render(
-        <ProfilerManager />,
+        <ProfilerManager enabled />,
       );
       expect(queryByText('Performance Profiler')).toBeNull();
       // Trigger shake

--- a/app/components/UI/ProfilerManager/ProfilerManager.test.tsx
+++ b/app/components/UI/ProfilerManager/ProfilerManager.test.tsx
@@ -32,12 +32,12 @@ describe('ProfilerManager', () => {
 
   describe('environment-based enabling', () => {
     it('enables profiler when enabled prop is true', () => {
-      render(<ProfilerManager enabled />);
+      render(<ProfilerManager />);
       expect(ShakeDetector).toHaveBeenCalled();
     });
 
     it('disables profiler when enabled prop is false', () => {
-      const { toJSON } = render(<ProfilerManager enabled={false} />);
+      const { toJSON } = render(<ProfilerManager />);
       expect(toJSON()).toBeNull();
       expect(ShakeDetector).not.toHaveBeenCalled();
     });
@@ -51,12 +51,12 @@ describe('ProfilerManager', () => {
 
   describe('forced enabling via props', () => {
     it('enables profiler when forced via props regardless of environment', () => {
-      render(<ProfilerManager enabled />);
+      render(<ProfilerManager />);
       expect(ShakeDetector).toHaveBeenCalled();
     });
 
     it('disables profiler when explicitly disabled via props', () => {
-      const { toJSON } = render(<ProfilerManager enabled={false} />);
+      const { toJSON } = render(<ProfilerManager />);
       expect(toJSON()).toBeNull();
       expect(ShakeDetector).not.toHaveBeenCalled();
     });
@@ -70,7 +70,7 @@ describe('ProfilerManager', () => {
     it('toggles visibility on shake and can be closed via the close button on iOS', async () => {
       Platform.OS = 'ios';
       const { queryByText, getByText, getByTestId } = render(
-        <ProfilerManager enabled />,
+        <ProfilerManager />,
       );
       expect(queryByText('Performance Profiler')).toBeNull();
       // Trigger shake
@@ -94,7 +94,7 @@ describe('ProfilerManager', () => {
 
     it('toggles visibility on shake and calls exportTrace when Export is pressed', async () => {
       Platform.OS = 'ios';
-      const { queryByText, getByText } = render(<ProfilerManager enabled />);
+      const { queryByText, getByText } = render(<ProfilerManager />);
       expect(queryByText('Performance Profiler')).toBeNull();
 
       const firstCallProps = (ShakeDetector as jest.Mock).mock.calls[0][0];
@@ -135,7 +135,7 @@ describe('ProfilerManager', () => {
     it('toggles visibility on shake and can be closed via the close button on Android', async () => {
       Platform.OS = 'android';
       const { queryByText, getByText, getByTestId } = render(
-        <ProfilerManager enabled />,
+        <ProfilerManager />,
       );
       expect(queryByText('Performance Profiler')).toBeNull();
       // Trigger shake

--- a/app/components/UI/ProfilerManager/ProfilerManager.tsx
+++ b/app/components/UI/ProfilerManager/ProfilerManager.tsx
@@ -12,18 +12,23 @@ import {
   IconColor,
 } from '../../../component-library/components/Icons/Icon';
 
-const ProfilerManager: React.FC = () => {
-  const shouldEnableProfiler = (() => {
-    switch (process.env.METAMASK_ENVIRONMENT) {
-      case 'rc':
-        return true;
-      case 'exp':
-        return true;
-      default:
-        return false;
-    }
-  })();
+const shouldEnableProfiler = (() => {
+  switch (process.env.METAMASK_ENVIRONMENT) {
+    case 'rc':
+      return true;
+    case 'exp':
+      return true;
+    default:
+      return false;
+  }
+})();
 
+interface ProfilerManagerProps {
+  enabled?: boolean;
+}
+const ProfilerManager: React.FC<ProfilerManagerProps> = ({
+  enabled = shouldEnableProfiler,
+}) => {
   const [isVisible, setIsVisible] = useState(false);
   const [isRecording, setIsRecording] = useState(false);
   const [sessionId, setSessionId] = useState<string | null>(null);
@@ -96,7 +101,7 @@ const ProfilerManager: React.FC = () => {
     setIsVisible(false);
   }, []);
 
-  if (!shouldEnableProfiler) {
+  if (!enabled) {
     return null;
   }
 

--- a/app/components/UI/ProfilerManager/ProfilerManager.tsx
+++ b/app/components/UI/ProfilerManager/ProfilerManager.tsx
@@ -11,15 +11,19 @@ import {
   IconName,
   IconColor,
 } from '../../../component-library/components/Icons/Icon';
-import { isRc } from '../../../util/test/utils';
 
-interface ProfilerManagerProps {
-  enabled?: boolean;
-}
+const ProfilerManager: React.FC = () => {
+  const shouldEnableProfiler = (() => {
+    switch (process.env.METAMASK_ENVIRONMENT) {
+      case 'rc':
+        return true;
+      case 'exp':
+        return true;
+      default:
+        return false;
+    }
+  })();
 
-const ProfilerManager: React.FC<ProfilerManagerProps> = ({
-  enabled = isRc,
-}) => {
   const [isVisible, setIsVisible] = useState(false);
   const [isRecording, setIsRecording] = useState(false);
   const [sessionId, setSessionId] = useState<string | null>(null);
@@ -92,7 +96,7 @@ const ProfilerManager: React.FC<ProfilerManagerProps> = ({
     setIsVisible(false);
   }, []);
 
-  if (!enabled) {
+  if (!shouldEnableProfiler) {
     return null;
   }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Allow EXP builds to see react native profiler 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Allow users with EXP builds to see react native profiler

  Scenario: user wants to see react native release profiler
    Given users are on EXP builds 

    When user shakes the phone
    Then they should be able to see the react native release profiler modal 
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Profiler is now enabled by default when METAMASK_ENVIRONMENT is rc or exp, replacing the previous isRc-based toggle.
> 
> - **Profiler Manager (`app/components/UI/ProfilerManager/ProfilerManager.tsx`)**:
>   - Add `shouldEnableProfiler` based on `process.env.METAMASK_ENVIRONMENT` to enable profiler for `rc` and `exp`.
>   - Set `enabled` default to `shouldEnableProfiler` and remove `isRc` dependency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c115fd19837dc659ee06e5428210d460ca5f153. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->