### PR TITLE
fix: resolve perps onboarding layout issues with longer translations

### DIFF
--- a/app/components/UI/Perps/components/PerpsGTMModal/PerpsGTMModal.styles.ts
+++ b/app/components/UI/Perps/components/PerpsGTMModal/PerpsGTMModal.styles.ts
@@ -37,8 +37,6 @@ const scaleHorizontal = (size: number) => Math.ceil(size * widthScale);
 const createStyles = (
   theme: Theme,
   isDarkMode: boolean,
-  titleFontSize?: number | null,
-  subtitleFontSize?: number | null,
   useSystemFont?: boolean,
 ) =>
   StyleSheet.create({
@@ -46,32 +44,31 @@ const createStyles = (
       flex: 1,
       backgroundColor: theme.colors.background.default,
     },
+    scrollableContent: {
+      flex: 1,
+    },
+    scrollContentContainer: {
+      flexGrow: 1,
+    },
     headerContainer: {
       alignItems: 'center',
       paddingTop: scaleVertical(50),
       paddingHorizontal: scaleHorizontal(16),
-      minHeight: '35%',
-      maxHeight: '40%',
+      marginBottom: scaleVertical(20),
     },
     contentImageContainer: {
-      flex: 1,
       alignItems: 'center',
       justifyContent: 'center',
-      paddingHorizontal: scaleHorizontal(20),
-      paddingVertical: scaleVertical(10),
+      marginTop: 'auto',
     },
     image: {
       width: '100%',
-      height: '100%',
+      height: scaleVertical(380),
       resizeMode: 'contain',
-      minWidth: '80%',
-      minHeight: '80%',
     },
     title: {
-      fontSize: titleFontSize || scaleFont(useSystemFont ? 44 : 47), // Slightly smaller base for system fonts
-      lineHeight: titleFontSize
-        ? titleFontSize + 1
-        : scaleFont(useSystemFont ? 46 : 48),
+      fontSize: scaleFont(useSystemFont ? 44 : 47), // Slightly smaller base for system fonts
+      lineHeight: scaleFont(useSystemFont ? 46 : 48),
       textAlign: 'center',
       paddingTop: scaleVertical(12),
       fontFamily: useSystemFont
@@ -91,8 +88,8 @@ const createStyles = (
       paddingTop: scaleVertical(10),
       paddingHorizontal: scaleHorizontal(8),
       textAlign: 'center',
-      fontSize: subtitleFontSize || scaleFont(16),
-      lineHeight: subtitleFontSize ? subtitleFontSize + 4 : scaleFont(20),
+      fontSize: scaleFont(16),
+      lineHeight: scaleFont(20),
       fontFamily: useSystemFont
         ? Platform.OS === 'ios'
           ? 'System'

--- a/app/components/UI/Perps/components/PerpsGTMModal/PerpsGTMModal.styles.ts
+++ b/app/components/UI/Perps/components/PerpsGTMModal/PerpsGTMModal.styles.ts
@@ -1,5 +1,5 @@
 import { Platform, StyleSheet, Dimensions } from 'react-native';
-import { colors as importedColors } from '../../../../../styles/common';
+
 import { Theme } from '@metamask/design-tokens';
 
 // Responsive scaling utilities
@@ -15,15 +15,6 @@ const isIOS = Platform.OS === 'ios';
 const baseHeight = isIOS ? BASE_HEIGHT_IOS : BASE_HEIGHT_ANDROID;
 
 const widthScale = screenWidth / BASE_WIDTH;
-const heightScale = screenHeight / baseHeight;
-
-// Use more conservative scaling to prevent excessive padding
-const scale = Math.min(widthScale, heightScale);
-const conservativeScale = Math.min(scale, 1.2); // Cap scaling at 120%
-
-// Platform-aware responsive scaling functions
-const scaleSize = (size: number) => Math.ceil(size * conservativeScale);
-const scaleFont = (size: number) => Math.ceil(size * conservativeScale);
 
 // For vertical spacing, use percentage of available height instead of pure scaling
 const scaleVertical = (size: number) => {
@@ -34,11 +25,7 @@ const scaleVertical = (size: number) => {
 
 const scaleHorizontal = (size: number) => Math.ceil(size * widthScale);
 
-const createStyles = (
-  theme: Theme,
-  isDarkMode: boolean,
-  useSystemFont?: boolean,
-) =>
+const createStyles = (theme: Theme) =>
   StyleSheet.create({
     pageContainer: {
       flex: 1,
@@ -67,62 +54,14 @@ const createStyles = (
       resizeMode: 'contain',
     },
     title: {
-      fontSize: scaleFont(useSystemFont ? 44 : 47), // Slightly smaller base for system fonts
-      lineHeight: scaleFont(useSystemFont ? 46 : 48),
       textAlign: 'center',
       paddingTop: scaleVertical(12),
-      fontFamily: useSystemFont
-        ? Platform.OS === 'ios'
-          ? 'System'
-          : 'Roboto'
-        : Platform.OS === 'ios'
-        ? 'MM Poly'
-        : 'MM Poly Regular',
-      fontWeight: useSystemFont
-        ? '700'
-        : Platform.OS === 'ios'
-        ? '900'
-        : 'normal',
-    },
-    titleDescription: {
-      paddingTop: scaleVertical(10),
-      paddingHorizontal: scaleHorizontal(8),
-      textAlign: 'center',
-      fontSize: scaleFont(16),
-      lineHeight: scaleFont(20),
-      fontFamily: useSystemFont
-        ? Platform.OS === 'ios'
-          ? 'System'
-          : 'Roboto'
-        : 'Geist-Regular',
-      fontWeight: '500',
     },
     footerContainer: {
       display: 'flex',
       rowGap: scaleVertical(8),
       paddingHorizontal: scaleHorizontal(30),
       paddingBottom: scaleVertical(12),
-    },
-    tryNowButton: {
-      borderRadius: scaleSize(12),
-      backgroundColor: isDarkMode
-        ? importedColors.white
-        : importedColors.btnBlack,
-    },
-    tryNowButtonText: {
-      color: isDarkMode ? importedColors.btnBlack : importedColors.white,
-      fontWeight: '600',
-      fontSize: scaleFont(16),
-    },
-    notNowButton: {
-      borderRadius: scaleSize(12),
-      backgroundColor: theme.colors.background.default,
-      borderWidth: 1,
-      borderColor: importedColors.transparent,
-    },
-    notNowButtonText: {
-      fontWeight: '500',
-      fontSize: scaleFont(16),
     },
   });
 

--- a/app/components/UI/Perps/components/PerpsGTMModal/PerpsGTMModal.test.tsx
+++ b/app/components/UI/Perps/components/PerpsGTMModal/PerpsGTMModal.test.tsx
@@ -1,15 +1,17 @@
+// Mock the textUtils module first
+jest.mock('../../utils/textUtils');
+
 import React from 'react';
 import { fireEvent, waitFor } from '@testing-library/react-native';
 import PerpsGTMModal from './PerpsGTMModal';
 import StorageWrapper from '../../../../../store/storage-wrapper';
+import { hasNonLatinCharacters } from '../../utils/textUtils';
 
 import Routes from '../../../../../constants/navigation/Routes';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { PERPS_GTM_MODAL_SHOWN } from '../../../../../constants/storage';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../util/test/initial-root-state';
-
-const mockHasNonLatinCharacters = jest.fn(() => false);
 
 const mockTheme = {
   colors: {
@@ -84,7 +86,7 @@ describe('PerpsGTMModal', () => {
     jest.clearAllMocks();
     (StorageWrapper.getItem as jest.Mock).mockResolvedValue('false');
     mockUseColorScheme.mockReturnValue('light'); // Default to light mode
-    mockHasNonLatinCharacters.mockReturnValue(false); // Default to Latin characters
+    (hasNonLatinCharacters as jest.Mock).mockReturnValue(false); // Default to Latin characters
   });
 
   it('renders correctly with all main elements', async () => {
@@ -175,7 +177,7 @@ describe('PerpsGTMModal', () => {
   });
 
   it('handles system font when non-Latin characters are detected', async () => {
-    mockHasNonLatinCharacters.mockReturnValue(true);
+    (hasNonLatinCharacters as jest.Mock).mockReturnValue(true);
 
     const { getByText } = renderWithProvider(<PerpsGTMModal />, {
       state: initialState,
@@ -188,7 +190,7 @@ describe('PerpsGTMModal', () => {
       );
 
       // Check that hasNonLatinCharacters was called
-      expect(mockHasNonLatinCharacters).toHaveBeenCalled();
+      expect(hasNonLatinCharacters).toHaveBeenCalled();
 
       // Verify elements exist
       expect(titleElement).toBeDefined();
@@ -197,7 +199,7 @@ describe('PerpsGTMModal', () => {
   });
 
   it('handles MM Poly font when Latin characters are detected', async () => {
-    mockHasNonLatinCharacters.mockReturnValue(false);
+    (hasNonLatinCharacters as jest.Mock).mockReturnValue(false);
 
     const { getByText } = renderWithProvider(<PerpsGTMModal />, {
       state: initialState,
@@ -210,7 +212,7 @@ describe('PerpsGTMModal', () => {
       );
 
       // Check that hasNonLatinCharacters was called
-      expect(mockHasNonLatinCharacters).toHaveBeenCalled();
+      expect(hasNonLatinCharacters).toHaveBeenCalled();
 
       // Verify elements exist
       expect(titleElement).toBeDefined();

--- a/app/components/UI/Perps/components/PerpsGTMModal/PerpsGTMModal.tsx
+++ b/app/components/UI/Perps/components/PerpsGTMModal/PerpsGTMModal.tsx
@@ -1,17 +1,16 @@
 import { useNavigation } from '@react-navigation/native';
 import React from 'react';
-import { Image, View, useColorScheme, ScrollView } from 'react-native';
+import { Image, View, ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { strings } from '../../../../../../locales/i18n';
-import ButtonBase from '../../../../../component-library/components/Buttons/Button/foundation/ButtonBase';
-import Button, {
-  ButtonSize,
-  ButtonVariants,
-  ButtonWidthTypes,
-} from '../../../../../component-library/components/Buttons/Button';
-import Text, {
+import {
+  Text,
   TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
+  FontFamily,
+  Button,
+  ButtonVariant,
+  ButtonSize,
+} from '@metamask/design-system-react-native';
 import { useMetrics } from '../../../../../components/hooks/useMetrics';
 import Routes from '../../../../../constants/navigation/Routes';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
@@ -28,21 +27,16 @@ import {
   PERPS_GTM_MODAL_ENGAGE,
   PERPS_GTM_WHATS_NEW_MODAL,
 } from '../../constants/perpsConfig';
-import { hasNonLatinCharacters } from '../../utils/textUtils';
 
 const PerpsGTMModal = () => {
   const { trackEvent, createEventBuilder } = useMetrics();
   const { navigate } = useNavigation();
   const theme = useTheme();
 
-  const isDarkMode = useColorScheme() === 'dark';
-
   const titleText = strings('perps.gtm_content.title');
   const subtitleText = strings('perps.gtm_content.title_description');
-  const useSystemFont =
-    hasNonLatinCharacters(titleText) || hasNonLatinCharacters(subtitleText);
 
-  const styles = createStyles(theme, isDarkMode, useSystemFont);
+  const styles = createStyles(theme);
 
   const handleClose = async () => {
     await StorageWrapper.setItem(PERPS_GTM_MODAL_SHOWN, 'true');
@@ -91,12 +85,14 @@ const PerpsGTMModal = () => {
       >
         {/* Header Section */}
         <View style={styles.headerContainer}>
-          <Text style={styles.title} variant={TextVariant.HeadingLG}>
+          <Text
+            variant={TextVariant.DisplayLg}
+            fontFamily={FontFamily.Hero}
+            twClassName="text-center"
+          >
             {titleText}
           </Text>
-          <Text variant={TextVariant.BodyMD} style={styles.titleDescription}>
-            {subtitleText}
-          </Text>
+          <Text twClassName="text-center">{subtitleText}</Text>
         </View>
 
         {/* Content Section */}
@@ -107,39 +103,23 @@ const PerpsGTMModal = () => {
 
       {/* Footer Section */}
       <View style={styles.footerContainer}>
-        <ButtonBase
+        <Button
           onPress={() => tryPerpsNow()}
           testID={PerpsGTMModalSelectorsIDs.PERPS_TRY_NOW_BUTTON}
           size={ButtonSize.Lg}
-          width={ButtonWidthTypes.Full}
-          style={styles.tryNowButton}
-          activeOpacity={0.6}
-          label={
-            <Text
-              variant={TextVariant.BodyMDMedium}
-              style={styles.tryNowButtonText}
-            >
-              {strings('perps.gtm_content.try_now')}
-            </Text>
-          }
-        />
+          isFullWidth
+        >
+          {strings('perps.gtm_content.try_now')}
+        </Button>
         <Button
-          variant={ButtonVariants.Secondary}
+          variant={ButtonVariant.Secondary}
           onPress={() => handleClose()}
           testID={PerpsGTMModalSelectorsIDs.PERPS_NOT_NOW_BUTTON}
-          width={ButtonWidthTypes.Full}
+          isFullWidth
           size={ButtonSize.Lg}
-          style={styles.notNowButton}
-          activeOpacity={0.6}
-          label={
-            <Text
-              variant={TextVariant.BodyMDMedium}
-              style={styles.notNowButtonText}
-            >
-              {strings('perps.gtm_content.not_now')}
-            </Text>
-          }
-        />
+        >
+          {strings('perps.gtm_content.not_now')}
+        </Button>
       </View>
     </SafeAreaView>
   );

--- a/app/components/UI/Perps/components/PerpsGTMModal/PerpsGTMModal.tsx
+++ b/app/components/UI/Perps/components/PerpsGTMModal/PerpsGTMModal.tsx
@@ -1,6 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
-import React, { useState } from 'react';
-import { Image, View, useColorScheme } from 'react-native';
+import React from 'react';
+import { Image, View, useColorScheme, ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { strings } from '../../../../../../locales/i18n';
 import ButtonBase from '../../../../../component-library/components/Buttons/Button/foundation/ButtonBase';
@@ -28,10 +28,7 @@ import {
   PERPS_GTM_MODAL_ENGAGE,
   PERPS_GTM_WHATS_NEW_MODAL,
 } from '../../constants/perpsConfig';
-import {
-  createFontScaleHandler,
-  hasNonLatinCharacters,
-} from '../../utils/textUtils';
+import { hasNonLatinCharacters } from '../../utils/textUtils';
 
 const PerpsGTMModal = () => {
   const { trackEvent, createEventBuilder } = useMetrics();
@@ -39,37 +36,13 @@ const PerpsGTMModal = () => {
   const theme = useTheme();
 
   const isDarkMode = useColorScheme() === 'dark';
-  const [titleFontSize, setTitleFontSize] = useState<number | null>(null);
-  const [subtitleFontSize, setSubtitleFontSize] = useState<number | null>(null);
 
   const titleText = strings('perps.gtm_content.title');
   const subtitleText = strings('perps.gtm_content.title_description');
   const useSystemFont =
     hasNonLatinCharacters(titleText) || hasNonLatinCharacters(subtitleText);
 
-  const styles = createStyles(
-    theme,
-    isDarkMode,
-    titleFontSize,
-    subtitleFontSize,
-    useSystemFont,
-  );
-
-  const handleTitleLayout = createFontScaleHandler({
-    maxHeight: useSystemFont ? 100 : 120, // System fonts typically render taller
-    currentFontSize: styles.title.fontSize,
-    setter: setTitleFontSize,
-    minFontSize: useSystemFont ? 28 : 32, // Slightly smaller min for system fonts
-    currentValue: titleFontSize,
-  });
-
-  const handleSubtitleLayout = createFontScaleHandler({
-    maxHeight: useSystemFont ? 70 : 80, // System fonts typically render taller
-    currentFontSize: styles.titleDescription.fontSize,
-    setter: setSubtitleFontSize,
-    minFontSize: useSystemFont ? 12 : 14, // Slightly smaller min for system fonts
-    currentValue: subtitleFontSize,
-  });
+  const styles = createStyles(theme, isDarkMode, useSystemFont);
 
   const handleClose = async () => {
     await StorageWrapper.setItem(PERPS_GTM_MODAL_SHOWN, 'true');
@@ -111,28 +84,26 @@ const PerpsGTMModal = () => {
       style={styles.pageContainer}
       testID={PerpsGTMModalSelectorsIDs.PERPS_GTM_MODAL}
     >
-      {/* Header Section */}
-      <View style={styles.headerContainer}>
-        <Text
-          style={styles.title}
-          variant={TextVariant.HeadingLG}
-          onLayout={handleTitleLayout}
-        >
-          {titleText}
-        </Text>
-        <Text
-          variant={TextVariant.BodyMD}
-          style={styles.titleDescription}
-          onLayout={handleSubtitleLayout}
-        >
-          {subtitleText}
-        </Text>
-      </View>
+      <ScrollView
+        style={styles.scrollableContent}
+        contentContainerStyle={styles.scrollContentContainer}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Header Section */}
+        <View style={styles.headerContainer}>
+          <Text style={styles.title} variant={TextVariant.HeadingLG}>
+            {titleText}
+          </Text>
+          <Text variant={TextVariant.BodyMD} style={styles.titleDescription}>
+            {subtitleText}
+          </Text>
+        </View>
 
-      {/* Content Section */}
-      <View style={styles.contentImageContainer}>
-        <Image source={Character} style={styles.image} />
-      </View>
+        {/* Content Section */}
+        <View style={styles.contentImageContainer}>
+          <Image source={Character} style={styles.image} />
+        </View>
+      </ScrollView>
 
       {/* Footer Section */}
       <View style={styles.footerContainer}>

--- a/app/components/UI/Perps/utils/__mocks__/textUtils.ts
+++ b/app/components/UI/Perps/utils/__mocks__/textUtils.ts
@@ -1,0 +1,1 @@
+export const hasNonLatinCharacters = jest.fn(() => false);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Fixed layout breaking issues in perps onboarding components when using longer translations (e.g., French, German). The original implementation used fixed height constraints and font scaling which caused text overflow and poor user experience with non-English languages.

**What changed:**
- **PerpsGTMModal**: Added ScrollView, removed percentage-based height constraints, used `marginTop: 'auto'` to align image to bottom with no gap to buttons

**Why:**
- Fixed height containers couldn't accommodate longer translations
- Font scaling made text illegible when trying to fit
- Layout broke causing poor UX for international users

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed perps onboarding layout issues with longer translations by implementing scrollable containers and removing fixed height constraints.

## **Related issues**

Fixes: N/A - Addresses layout issues identified during internationalization testing

## **Manual testing steps**

```gherkin
Feature: Perps onboarding layout with longer translations

  Scenario: user views perps tutorial with longer translations
    Given the app is set to French language
    When user navigates to perps tutorial from main menu
    And user views each tutorial screen
    Then all text content should be readable without overflow
    And images should display properly without layout breaking
    And Continue/Skip buttons should remain accessible at bottom
    And content should scroll when needed for longer text

  Scenario: user views perps GTM modal with longer translations
    Given the app is set to French language
    When user triggers the perps GTM modal
    Then the title and description text should be fully visible
    And the character image should align to bottom with no gap to buttons
    And content should scroll if text exceeds available space
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Layout breaking with French translations (text cut off, poor spacing)

https://github.com/user-attachments/assets/28bb6fdd-0c51-4016-8ddb-d0df57eee658

### **After**

Scrollable layout accommodates any translation length while keeping buttons accessible

https://github.com/user-attachments/assets/a0c630ee-61a6-4ff2-af65-8a4d99b8cd99

Testing on Android with very large font size

https://github.com/user-attachments/assets/b87da571-1ba3-4f12-93b5-23eafe9cc248

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.