### PR TITLE
feat: Swaps show BTC Native Segwit tag

### DIFF
--- a/app/components/UI/Bridge/components/BridgeDestTokenSelector/__snapshots__/BridgeDestTokenSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeDestTokenSelector/__snapshots__/BridgeDestTokenSelector.test.tsx.snap
@@ -889,6 +889,7 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                               data={
                                 [
                                   {
+                                    "accountType": undefined,
                                     "address": "0x0000000000000000000000000000000000000002",
                                     "balance": "2.0",
                                     "balanceFiat": "$200000",
@@ -900,6 +901,7 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                                     "tokenFiatAmount": 200000,
                                   },
                                   {
+                                    "accountType": undefined,
                                     "address": "0x0000000000000000000000000000000000000001",
                                     "balance": "1.0",
                                     "balanceFiat": "$20000",
@@ -911,6 +913,7 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                                     "tokenFiatAmount": 20000,
                                   },
                                   {
+                                    "accountType": undefined,
                                     "address": "0x0000000000000000000000000000000000000000",
                                     "balance": "3.0",
                                     "balanceFiat": "$6000",
@@ -1145,11 +1148,13 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                                           <View
                                             alignItems="center"
                                             flexDirection="row"
+                                            gap={4}
                                             style={
                                               [
                                                 {
                                                   "alignItems": "center",
                                                   "flexDirection": "row",
+                                                  "gap": 4,
                                                 },
                                                 undefined,
                                               ]
@@ -1454,11 +1459,13 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                                           <View
                                             alignItems="center"
                                             flexDirection="row"
+                                            gap={4}
                                             style={
                                               [
                                                 {
                                                   "alignItems": "center",
                                                   "flexDirection": "row",
+                                                  "gap": 4,
                                                 },
                                                 undefined,
                                               ]
@@ -1793,11 +1800,13 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                                           <View
                                             alignItems="center"
                                             flexDirection="row"
+                                            gap={4}
                                             style={
                                               [
                                                 {
                                                   "alignItems": "center",
                                                   "flexDirection": "row",
+                                                  "gap": 4,
                                                 },
                                                 undefined,
                                               ]

--- a/app/components/UI/Bridge/components/BridgeSourceTokenSelector/__snapshots__/BridgeSourceTokenSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeSourceTokenSelector/__snapshots__/BridgeSourceTokenSelector.test.tsx.snap
@@ -894,6 +894,7 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                               data={
                                 [
                                   {
+                                    "accountType": undefined,
                                     "address": "0x0000000000000000000000000000000000000002",
                                     "balance": "2.0",
                                     "balanceFiat": "$200000",
@@ -905,6 +906,7 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                     "tokenFiatAmount": 200000,
                                   },
                                   {
+                                    "accountType": undefined,
                                     "address": "0x0000000000000000000000000000000000000003",
                                     "balance": "5.0",
                                     "balanceFiat": "$80000",
@@ -916,6 +918,7 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                     "tokenFiatAmount": 80000,
                                   },
                                   {
+                                    "accountType": undefined,
                                     "address": "0x0000000000000000000000000000000000000000",
                                     "balance": "20.0",
                                     "balanceFiat": "$40000",
@@ -927,6 +930,7 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                     "tokenFiatAmount": 40000,
                                   },
                                   {
+                                    "accountType": "solana:data-account",
                                     "address": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
                                     "balance": "20000.456",
                                     "balanceFiat": "20000.456 USD",
@@ -938,6 +942,7 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                     "tokenFiatAmount": 20000.456,
                                   },
                                   {
+                                    "accountType": undefined,
                                     "address": "0x0000000000000000000000000000000000000001",
                                     "balance": "1.0",
                                     "balanceFiat": "$20000",
@@ -949,6 +954,7 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                     "tokenFiatAmount": 20000,
                                   },
                                   {
+                                    "accountType": "solana:data-account",
                                     "address": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501",
                                     "balance": "100.123",
                                     "balanceFiat": "10012.3 USD",
@@ -960,6 +966,7 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                     "tokenFiatAmount": 10012.3,
                                   },
                                   {
+                                    "accountType": undefined,
                                     "address": "0x0000000000000000000000000000000000000000",
                                     "balance": "3.0",
                                     "balanceFiat": "$6000",
@@ -971,6 +978,7 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                     "tokenFiatAmount": 6000,
                                   },
                                   {
+                                    "accountType": "bip122:p2wpkh",
                                     "address": "bip122:000000000019d6689c085ae165831e93/slip44:0",
                                     "balance": "0.015",
                                     "balanceFiat": "1500 USD",
@@ -1205,11 +1213,13 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                           <View
                                             alignItems="center"
                                             flexDirection="row"
+                                            gap={4}
                                             style={
                                               [
                                                 {
                                                   "alignItems": "center",
                                                   "flexDirection": "row",
+                                                  "gap": 4,
                                                 },
                                                 undefined,
                                               ]
@@ -1480,11 +1490,13 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                           <View
                                             alignItems="center"
                                             flexDirection="row"
+                                            gap={4}
                                             style={
                                               [
                                                 {
                                                   "alignItems": "center",
                                                   "flexDirection": "row",
+                                                  "gap": 4,
                                                 },
                                                 undefined,
                                               ]
@@ -1785,11 +1797,13 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                           <View
                                             alignItems="center"
                                             flexDirection="row"
+                                            gap={4}
                                             style={
                                               [
                                                 {
                                                   "alignItems": "center",
                                                   "flexDirection": "row",
+                                                  "gap": 4,
                                                 },
                                                 undefined,
                                               ]
@@ -2060,11 +2074,13 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                           <View
                                             alignItems="center"
                                             flexDirection="row"
+                                            gap={4}
                                             style={
                                               [
                                                 {
                                                   "alignItems": "center",
                                                   "flexDirection": "row",
+                                                  "gap": 4,
                                                 },
                                                 undefined,
                                               ]
@@ -2335,11 +2351,13 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                           <View
                                             alignItems="center"
                                             flexDirection="row"
+                                            gap={4}
                                             style={
                                               [
                                                 {
                                                   "alignItems": "center",
                                                   "flexDirection": "row",
+                                                  "gap": 4,
                                                 },
                                                 undefined,
                                               ]
@@ -2610,11 +2628,13 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                           <View
                                             alignItems="center"
                                             flexDirection="row"
+                                            gap={4}
                                             style={
                                               [
                                                 {
                                                   "alignItems": "center",
                                                   "flexDirection": "row",
+                                                  "gap": 4,
                                                 },
                                                 undefined,
                                               ]
@@ -2915,11 +2935,13 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                           <View
                                             alignItems="center"
                                             flexDirection="row"
+                                            gap={4}
                                             style={
                                               [
                                                 {
                                                   "alignItems": "center",
                                                   "flexDirection": "row",
+                                                  "gap": 4,
                                                 },
                                                 undefined,
                                               ]
@@ -3190,11 +3212,13 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                           <View
                                             alignItems="center"
                                             flexDirection="row"
+                                            gap={4}
                                             style={
                                               [
                                                 {
                                                   "alignItems": "center",
                                                   "flexDirection": "row",
+                                                  "gap": 4,
                                                 },
                                                 undefined,
                                               ]
@@ -3214,6 +3238,32 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                             >
                                               BTC
                                             </Text>
+                                            <View
+                                              style={
+                                                {
+                                                  "backgroundColor": "#f3f5f9",
+                                                  "borderRadius": 4,
+                                                  "height": 24,
+                                                  "justifyContent": "center",
+                                                  "paddingHorizontal": 8,
+                                                }
+                                              }
+                                            >
+                                              <Text
+                                                accessibilityRole="text"
+                                                style={
+                                                  {
+                                                    "color": "#686e7d",
+                                                    "fontFamily": "Geist Medium",
+                                                    "fontSize": 12,
+                                                    "letterSpacing": 0.25,
+                                                    "lineHeight": 20,
+                                                  }
+                                                }
+                                              >
+                                                Native SegWit
+                                              </Text>
+                                            </View>
                                           </View>
                                           <Text
                                             accessibilityRole="text"

--- a/app/components/UI/Bridge/components/TokenSelectorItem.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.tsx
@@ -41,6 +41,8 @@ import TagBase, {
   TagShape,
   TagSeverity,
 } from '../../../../component-library/base-components/TagBase';
+import Tag from '../../../../component-library/components/Tags/Tag';
+import { accountTypeLabel } from '../../Tokens/TokenList/TokenListItem/TokenListItemBip44';
 import { RootState } from '../../../../reducers';
 
 const createStyles = ({
@@ -145,6 +147,10 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
   const balance = shouldShowBalance ? fiatValue : undefined;
   const secondaryBalance = shouldShowBalance ? balanceWithSymbol : undefined;
 
+  const label = token.accountType
+    ? accountTypeLabel[token.accountType]
+    : undefined;
+
   return (
     <Box
       flexDirection={FlexDirection.Row}
@@ -204,8 +210,10 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
             <Box
               flexDirection={FlexDirection.Row}
               alignItems={AlignItems.center}
+              gap={4}
             >
               <Text variant={TextVariant.BodyLGMedium}>{token.symbol}</Text>
+              {label && <Tag label={label} />}
               {isNoFeeAsset && (
                 <TagBase
                   shape={TagShape.Rectangle}

--- a/app/components/UI/Bridge/hooks/useNonEvmAccountIds/index.ts
+++ b/app/components/UI/Bridge/hooks/useNonEvmAccountIds/index.ts
@@ -1,1 +1,0 @@
-export { useNonEvmAccountIds } from './useNonEvmAccountIds';

--- a/app/components/UI/Bridge/hooks/useNonEvmAccounts/index.ts
+++ b/app/components/UI/Bridge/hooks/useNonEvmAccounts/index.ts
@@ -1,0 +1,1 @@
+export { useNonEvmAccounts } from './useNonEvmAccounts';

--- a/app/components/UI/Bridge/hooks/useNonEvmAccounts/useNonEvmAccounts.ts
+++ b/app/components/UI/Bridge/hooks/useNonEvmAccounts/useNonEvmAccounts.ts
@@ -3,12 +3,13 @@ import { selectSelectedAccountGroupInternalAccounts } from '../../../../../selec
 import { useMemo } from 'react';
 import { selectEnabledSourceChains } from '../../../../../core/redux/slices/bridge';
 import { isNonEvmChainId } from '@metamask/bridge-controller';
+import { InternalAccount } from '@metamask/keyring-internal-api';
 
 /**
  * Hook to get account IDs for non-EVM accounts
  * @returns {string[]} Array of account IDs for accounts that have non-EVM scopes
  */
-export const useNonEvmAccountIds = (): string[] => {
+export const useNonEvmAccounts = (): InternalAccount[] => {
   const enabledSourceChains = useSelector(selectEnabledSourceChains);
   const enabledSourceChainIds = useMemo(
     () =>
@@ -20,15 +21,13 @@ export const useNonEvmAccountIds = (): string[] => {
     selectSelectedAccountGroupInternalAccounts,
   );
 
-  const nonEvmAccountIds = useMemo(
+  const nonEvmAccounts = useMemo(
     () =>
-      selectedAccountGroupInternalAccounts
-        .filter((account) =>
-          account.scopes.some((scope) => enabledSourceChainIds.includes(scope)),
-        )
-        .map((account) => account.id),
+      selectedAccountGroupInternalAccounts.filter((account) =>
+        account.scopes.some((scope) => enabledSourceChainIds.includes(scope)),
+      ),
     [selectedAccountGroupInternalAccounts, enabledSourceChainIds],
   );
 
-  return nonEvmAccountIds;
+  return nonEvmAccounts;
 };

--- a/app/components/UI/Bridge/hooks/useNonEvmTokensWithBalance/useNonEvmTokensWithBalance.ts
+++ b/app/components/UI/Bridge/hooks/useNonEvmTokensWithBalance/useNonEvmTokensWithBalance.ts
@@ -1,7 +1,7 @@
 import { useSelector } from 'react-redux';
 import { RootState } from '../../../../../reducers';
-import { selectMultichainTokenListForAccountIdAnyChain } from '../../../../../selectors/multichain';
-import { useNonEvmAccountIds } from '../useNonEvmAccountIds';
+import { selectMultichainTokenListForAccountAnyChain } from '../../../../../selectors/multichain';
+import { useNonEvmAccounts } from '../useNonEvmAccounts';
 import { useMemo } from 'react';
 
 /**
@@ -9,21 +9,23 @@ import { useMemo } from 'react';
  * @returns Combined array of tokens from all non-EVM accounts
  */
 export const useNonEvmTokensWithBalance = () => {
-  const nonEvmAccountIds = useNonEvmAccountIds();
+  const nonEvmAccounts = useNonEvmAccounts();
   const nonEvmTokens = useSelector(
     useMemo(
       () => (state: RootState) => {
         const tokens: ReturnType<
-          typeof selectMultichainTokenListForAccountIdAnyChain
+          typeof selectMultichainTokenListForAccountAnyChain
         > = [];
-        for (const accountId of nonEvmAccountIds) {
-          const tokensForAccountId =
-            selectMultichainTokenListForAccountIdAnyChain(state, accountId);
-          tokens.push(...tokensForAccountId);
+        for (const account of nonEvmAccounts) {
+          const tokensForAccount = selectMultichainTokenListForAccountAnyChain(
+            state,
+            account,
+          );
+          tokens.push(...tokensForAccount);
         }
         return tokens;
       },
-      [nonEvmAccountIds],
+      [nonEvmAccounts],
     ),
   );
 

--- a/app/components/UI/Bridge/hooks/useTopTokens/index.ts
+++ b/app/components/UI/Bridge/hooks/useTopTokens/index.ts
@@ -4,11 +4,13 @@ import {
   formatAddressToAssetId,
   formatChainIdToCaip,
   formatChainIdToHex,
+  isBitcoinChainId,
   isNonEvmChainId,
 } from '@metamask/bridge-controller';
 import { useAsyncResult } from '../../../../hooks/useAsyncResult';
 import { Hex, CaipChainId, isCaipChainId } from '@metamask/utils';
 import { handleFetch, toChecksumHexAddress } from '@metamask/controller-utils';
+import { BtcAccountType } from '@metamask/keyring-api';
 import { BridgeToken } from '../../types';
 import { useEffect, useMemo } from 'react';
 import Engine from '../../../../../core/Engine';
@@ -21,12 +23,29 @@ import { RootState } from '../../../../../reducers';
 import { BRIDGE_API_BASE_URL } from '../../../../../constants/bridge';
 import { memoize } from 'lodash';
 import { selectERC20TokensByChain } from '../../../../../selectors/tokenListController';
-import { TokenListToken } from '@metamask/assets-controllers';
+import { Asset, TokenListToken } from '@metamask/assets-controllers';
 import packageJSON from '../../../../../../package.json';
 
 const { version: clientVersion } = packageJSON;
 const MAX_TOP_TOKENS = 30;
 export const memoizedFetchBridgeTokens = memoize(fetchBridgeTokens);
+
+/**
+ * Only needed for BTC
+ * @param chainId - The chain ID to get the account type for
+ * @returns The account type for the chain ID
+ */
+const getAccountType = (
+  chainId: Hex | CaipChainId,
+): Asset['accountType'] | undefined => {
+  let accountType: Asset['accountType'] | undefined;
+
+  if (isBitcoinChainId(chainId)) {
+    accountType = BtcAccountType.P2wpkh;
+  }
+
+  return accountType;
+};
 
 /**
  * Convert cached tokens from TokenListController to BridgeToken format
@@ -59,6 +78,7 @@ const formatCachedTokenListControllerTokens = (
       image: token.iconUrl || '',
       decimals: token.decimals,
       chainId: isNonEvmChainId(caipChainId) ? caipChainId : hexChainId,
+      accountType: getAccountType(caipChainId),
     };
   });
 
@@ -169,7 +189,9 @@ export const useTopTokens = ({
       const hexChainId = formatChainIdToHex(bridgeAsset.chainId);
 
       // Convert non-EVM addresses to CAIP format for consistent deduplication
-      const tokenAddress = isNonEvmChainId(caipChainId)
+      const isNonEvmChain = isNonEvmChainId(caipChainId);
+
+      const tokenAddress = isNonEvmChain
         ? bridgeAsset.assetId
         : bridgeAsset.address;
 
@@ -180,6 +202,7 @@ export const useTopTokens = ({
         image: bridgeAsset.iconUrl || bridgeAsset.icon || '',
         decimals: bridgeAsset.decimals,
         chainId: isNonEvmChainId(caipChainId) ? caipChainId : hexChainId,
+        accountType: getAccountType(caipChainId),
       };
     });
 

--- a/app/components/UI/Bridge/hooks/useTopTokens/index.ts
+++ b/app/components/UI/Bridge/hooks/useTopTokens/index.ts
@@ -88,9 +88,9 @@ export const useTopTokens = ({
     : !swapsTopAssets;
 
   // Get cached tokens from TokenListController
-  const cachedTokensByChain = useSelector(selectERC20TokensByChain);
-  const cachedTokensForChain = useMemo(() => {
-    if (!chainId || !cachedTokensByChain) return null;
+  const cachedEvmTokensByChain = useSelector(selectERC20TokensByChain);
+  const cachedEvmTokensForChain = useMemo(() => {
+    if (!chainId || !cachedEvmTokensByChain) return null;
 
     if (isNonEvmChainId(chainId)) {
       return null;
@@ -102,12 +102,12 @@ export const useTopTokens = ({
       : chainId;
 
     // Type assertion for the cache object which may have chainId keys
-    return cachedTokensByChain[hexChainId]?.data || null;
-  }, [chainId, cachedTokensByChain]);
+    return cachedEvmTokensByChain[hexChainId]?.data || null;
+  }, [chainId, cachedEvmTokensByChain]);
 
   // Check if we have cached tokens to avoid unnecessary API calls
   const hasCachedTokens = Boolean(
-    cachedTokensForChain && Object.keys(cachedTokensForChain).length > 0,
+    cachedEvmTokensForChain && Object.keys(cachedEvmTokensForChain).length > 0,
   );
 
   // Get top assets for Solana from Bridge API feature flags for now,
@@ -144,9 +144,9 @@ export const useTopTokens = ({
     }
 
     // If we have cached tokens, use them instead of fetching from bridge API
-    if (hasCachedTokens && cachedTokensForChain) {
+    if (hasCachedTokens && cachedEvmTokensForChain) {
       return formatCachedTokenListControllerTokens(
-        cachedTokensForChain,
+        cachedEvmTokensForChain,
         chainId,
       );
     }
@@ -184,7 +184,7 @@ export const useTopTokens = ({
     });
 
     return bridgeTokenObj;
-  }, [chainId, hasCachedTokens, cachedTokensForChain]);
+  }, [chainId, hasCachedTokens, cachedEvmTokensForChain]);
 
   // Merge the top assets from the Swaps API with the token data from the bridge API
   const { topTokens, remainingTokens } = useMemo(() => {

--- a/app/components/UI/Bridge/types.ts
+++ b/app/components/UI/Bridge/types.ts
@@ -1,3 +1,4 @@
+import { Asset } from '@metamask/assets-controllers';
 import { TxData, Quote } from '@metamask/bridge-controller';
 import { Hex, CaipChainId } from '@metamask/utils';
 
@@ -16,6 +17,7 @@ export interface BridgeToken {
   balanceFiat?: string; // A formatted fiat value, e.g. "$100.12345", "100.12345 cad"
   tokenFiatAmount?: number; // A sortable fiat value in the user's currency, e.g. 100.12345
   currencyExchangeRate?: number; // A rate of the token in the user's currency, e.g. 100.12345
+  accountType?: Asset['accountType'];
 }
 
 // TODO: use type from @metamask/bridge-controller once "approval" is made optional

--- a/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItemBip44.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItemBip44.tsx
@@ -42,7 +42,7 @@ import AssetLogo from '../../../Assets/components/AssetLogo/AssetLogo';
 
 export const ACCOUNT_TYPE_LABEL_TEST_ID = 'account-type-label';
 
-const accountTypeLabel: Partial<Record<KeyringAccountType, string>> = {
+export const accountTypeLabel: Partial<Record<KeyringAccountType, string>> = {
   [BtcAccountType.P2pkh]: 'Legacy',
   [BtcAccountType.P2sh]: 'Nested SegWit',
   [BtcAccountType.P2wpkh]: 'Native SegWit',

--- a/app/selectors/multichain/multichain.ts
+++ b/app/selectors/multichain/multichain.ts
@@ -277,17 +277,19 @@ export const selectMultichainTokenListForAccountId = createDeepEqualSelector(
   },
 );
 
-export const selectMultichainTokenListForAccountIdAnyChain =
+export const selectMultichainTokenListForAccountAnyChain =
   createDeepEqualSelector(
     selectMultichainBalances,
     selectMultichainAssets,
     selectMultichainAssetsMetadata,
     selectMultichainAssetsRates,
-    (_: RootState, accountId: string | undefined) => accountId,
-    (multichainBalances, assets, assetsMetadata, assetsRates, accountId) => {
-      if (!accountId) {
+    (_: RootState, account: InternalAccount | undefined) => account,
+    (multichainBalances, assets, assetsMetadata, assetsRates, account) => {
+      if (!account) {
         return [];
       }
+
+      const accountId = account.id;
 
       const assetIds = assets?.[accountId] || [];
       const balances = multichainBalances?.[accountId];
@@ -332,6 +334,7 @@ export const selectMultichainTokenListForAccountIdAnyChain =
           aggregators: [],
           isETH: false,
           ticker: metadata.symbol,
+          accountType: account.type,
         });
       }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR adds the Native Segwit tag to BTC in Swaps.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added the Native Segwit tag to BTC in Swaps.

## **Related issues**

Resolves: https://consensyssoftware.atlassian.net/browse/SWAPS-3203

## **Manual testing steps**

```gherkin
Feature: BTC Native Segwit tag in Swaps

  Scenario: user wants to swap to/from BTC
    Given user is in Swaps

    When user opens the source/destination token selector
    Then they see the Native Segwit tag for BTC
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="598" height="1144" alt="Screenshot 2025-10-15 at 3 31 24 PM" src="https://github.com/user-attachments/assets/7f91d957-177b-4b78-b1b6-33ebfbba9125" />

<img width="554" height="1100" alt="Screenshot 2025-10-15 at 3 31 16 PM" src="https://github.com/user-attachments/assets/dee9c985-fde7-4b1c-9dc4-14b7173a4a9c" />



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Displays account-type tags (e.g., Native SegWit) for BTC in Bridge token selectors and propagates accountType across selectors, hooks, and token models.
> 
> - **UI**
>   - `TokenSelectorItem`: Renders a `Tag` next to token symbol when `token.accountType` is present.
>   - Snapshot updates for Bridge Source/Dest selectors (layout gap tweaks and BTC "Native SegWit" badge display).
> - **Data/Types**
>   - `BridgeToken`: Add `accountType` field.
>   - `useTopTokens`: Populate `accountType` (sets BTC to Native SegWit) and use cached tokens when available.
>   - Non‑EVM accounts/tokens:
>     - New `useNonEvmAccounts` hook (replaces `useNonEvmAccountIds`).
>     - `useNonEvmTokensWithBalance`: Now consumes `useNonEvmAccounts` and new selector.
>     - Selector renamed to `selectMultichainTokenListForAccountAnyChain` (accepts `InternalAccount`) and includes `accountType` in returned tokens.
>   - `useTokensWithBalance`: Merges non‑EVM tokens and forwards `accountType` to UI.
> - **Misc**
>   - Export updates for new hooks; remove old non-EVM account IDs index.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee2149cb68d9fc63c393ebfbc408fd49dddc6427. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->