### PR TITLE
fix(deposit): remove unresponsive period from keypad cp-7.57.0

### DIFF
--- a/app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.tsx
@@ -625,15 +625,7 @@ const BuildQuote = () => {
             </ListItem>
           </TouchableOpacity>
 
-          <Keypad
-            value={amount}
-            onChange={handleKeypadChange}
-            currency={selectedRegion?.currency}
-            decimals={0}
-            periodButtonProps={{
-              isDisabled: true,
-            }}
-          />
+          <Keypad value={amount} onChange={handleKeypadChange} />
         </ScreenLayout.Content>
       </ScreenLayout.Body>
       <ScreenLayout.Footer>

--- a/app/components/UI/Ramp/Deposit/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/BuildQuote/__snapshots__/BuildQuote.test.tsx.snap
@@ -1666,7 +1666,6 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                                   <TouchableOpacity
                                     accessibilityRole="button"
                                     accessible={true}
-                                    disabled={true}
                                     onPress={[Function]}
                                     style={
                                       [
@@ -1700,9 +1699,7 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                                           undefined,
                                         ]
                                       }
-                                    >
-                                      .
-                                    </Text>
+                                    />
                                   </TouchableOpacity>
                                 </View>
                                 <View
@@ -3542,7 +3539,6 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                                   <TouchableOpacity
                                     accessibilityRole="button"
                                     accessible={true}
-                                    disabled={true}
                                     onPress={[Function]}
                                     style={
                                       [
@@ -3576,9 +3572,7 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                                           undefined,
                                         ]
                                       }
-                                    >
-                                      .
-                                    </Text>
+                                    />
                                   </TouchableOpacity>
                                 </View>
                                 <View
@@ -5418,7 +5412,6 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                                   <TouchableOpacity
                                     accessibilityRole="button"
                                     accessible={true}
-                                    disabled={true}
                                     onPress={[Function]}
                                     style={
                                       [
@@ -5452,9 +5445,7 @@ exports[`BuildQuote Component Continue button functionality displays error when 
                                           undefined,
                                         ]
                                       }
-                                    >
-                                      .
-                                    </Text>
+                                    />
                                   </TouchableOpacity>
                                 </View>
                                 <View
@@ -7233,7 +7224,6 @@ exports[`BuildQuote Component Keypad Functionality displays converted token amou
                                   <TouchableOpacity
                                     accessibilityRole="button"
                                     accessible={true}
-                                    disabled={true}
                                     onPress={[Function]}
                                     style={
                                       [
@@ -7267,9 +7257,7 @@ exports[`BuildQuote Component Keypad Functionality displays converted token amou
                                           undefined,
                                         ]
                                       }
-                                    >
-                                      .
-                                    </Text>
+                                    />
                                   </TouchableOpacity>
                                 </View>
                                 <View
@@ -9048,7 +9036,6 @@ exports[`BuildQuote Component Keypad Functionality updates amount when keypad is
                                   <TouchableOpacity
                                     accessibilityRole="button"
                                     accessible={true}
-                                    disabled={true}
                                     onPress={[Function]}
                                     style={
                                       [
@@ -9082,9 +9069,7 @@ exports[`BuildQuote Component Keypad Functionality updates amount when keypad is
                                           undefined,
                                         ]
                                       }
-                                    >
-                                      .
-                                    </Text>
+                                    />
                                   </TouchableOpacity>
                                 </View>
                                 <View
@@ -10863,7 +10848,6 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
                                   <TouchableOpacity
                                     accessibilityRole="button"
                                     accessible={true}
-                                    disabled={true}
                                     onPress={[Function]}
                                     style={
                                       [
@@ -10897,9 +10881,7 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
                                           undefined,
                                         ]
                                       }
-                                    >
-                                      .
-                                    </Text>
+                                    />
                                   </TouchableOpacity>
                                 </View>
                                 <View
@@ -12771,7 +12753,6 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
                                   <TouchableOpacity
                                     accessibilityRole="button"
                                     accessible={true}
-                                    disabled={true}
                                     onPress={[Function]}
                                     style={
                                       [
@@ -12805,9 +12786,7 @@ exports[`BuildQuote Component Payment Method Selection does not open payment met
                                           undefined,
                                         ]
                                       }
-                                    >
-                                      .
-                                    </Text>
+                                    />
                                   </TouchableOpacity>
                                 </View>
                                 <View
@@ -14541,7 +14520,6 @@ exports[`BuildQuote Component Payment Method Selection does not show the duratio
                                   <TouchableOpacity
                                     accessibilityRole="button"
                                     accessible={true}
-                                    disabled={true}
                                     onPress={[Function]}
                                     style={
                                       [
@@ -14575,9 +14553,7 @@ exports[`BuildQuote Component Payment Method Selection does not show the duratio
                                           undefined,
                                         ]
                                       }
-                                    >
-                                      .
-                                    </Text>
+                                    />
                                   </TouchableOpacity>
                                 </View>
                                 <View
@@ -16356,7 +16332,6 @@ exports[`BuildQuote Component Payment Method Selection shows the right duration 
                                   <TouchableOpacity
                                     accessibilityRole="button"
                                     accessible={true}
-                                    disabled={true}
                                     onPress={[Function]}
                                     style={
                                       [
@@ -16390,9 +16365,7 @@ exports[`BuildQuote Component Payment Method Selection shows the right duration 
                                           undefined,
                                         ]
                                       }
-                                    >
-                                      .
-                                    </Text>
+                                    />
                                   </TouchableOpacity>
                                 </View>
                                 <View
@@ -18171,7 +18144,6 @@ exports[`BuildQuote Component Region Selection displays EUR currency when select
                                   <TouchableOpacity
                                     accessibilityRole="button"
                                     accessible={true}
-                                    disabled={true}
                                     onPress={[Function]}
                                     style={
                                       [
@@ -18205,9 +18177,7 @@ exports[`BuildQuote Component Region Selection displays EUR currency when select
                                           undefined,
                                         ]
                                       }
-                                    >
-                                      ,
-                                    </Text>
+                                    />
                                   </TouchableOpacity>
                                 </View>
                                 <View
@@ -19986,7 +19956,6 @@ exports[`BuildQuote Component Region Selection displays default US region on ini
                                   <TouchableOpacity
                                     accessibilityRole="button"
                                     accessible={true}
-                                    disabled={true}
                                     onPress={[Function]}
                                     style={
                                       [
@@ -20020,9 +19989,7 @@ exports[`BuildQuote Component Region Selection displays default US region on ini
                                           undefined,
                                         ]
                                       }
-                                    >
-                                      .
-                                    </Text>
+                                    />
                                   </TouchableOpacity>
                                 </View>
                                 <View
@@ -21801,7 +21768,6 @@ exports[`BuildQuote Component Region Selection does not open region modal when r
                                   <TouchableOpacity
                                     accessibilityRole="button"
                                     accessible={true}
-                                    disabled={true}
                                     onPress={[Function]}
                                     style={
                                       [
@@ -21835,9 +21801,7 @@ exports[`BuildQuote Component Region Selection does not open region modal when r
                                           undefined,
                                         ]
                                       }
-                                    >
-                                      .
-                                    </Text>
+                                    />
                                   </TouchableOpacity>
                                 </View>
                                 <View
@@ -23709,7 +23673,6 @@ exports[`BuildQuote Component Region Selection does not open region modal when r
                                   <TouchableOpacity
                                     accessibilityRole="button"
                                     accessible={true}
-                                    disabled={true}
                                     onPress={[Function]}
                                     style={
                                       [
@@ -23743,9 +23706,7 @@ exports[`BuildQuote Component Region Selection does not open region modal when r
                                           undefined,
                                         ]
                                       }
-                                    >
-                                      .
-                                    </Text>
+                                    />
                                   </TouchableOpacity>
                                 </View>
                                 <View
@@ -25522,7 +25483,6 @@ exports[`BuildQuote Component Token Selection does not open token modal when cry
                                   <TouchableOpacity
                                     accessibilityRole="button"
                                     accessible={true}
-                                    disabled={true}
                                     onPress={[Function]}
                                     style={
                                       [
@@ -25556,9 +25516,7 @@ exports[`BuildQuote Component Token Selection does not open token modal when cry
                                           undefined,
                                         ]
                                       }
-                                    >
-                                      .
-                                    </Text>
+                                    />
                                   </TouchableOpacity>
                                 </View>
                                 <View
@@ -27428,7 +27386,6 @@ exports[`BuildQuote Component Token Selection does not open token modal when cry
                                   <TouchableOpacity
                                     accessibilityRole="button"
                                     accessible={true}
-                                    disabled={true}
                                     onPress={[Function]}
                                     style={
                                       [
@@ -27462,9 +27419,7 @@ exports[`BuildQuote Component Token Selection does not open token modal when cry
                                           undefined,
                                         ]
                                       }
-                                    >
-                                      .
-                                    </Text>
+                                    />
                                   </TouchableOpacity>
                                 </View>
                                 <View
@@ -29243,7 +29198,6 @@ exports[`BuildQuote Component render matches snapshot 1`] = `
                                   <TouchableOpacity
                                     accessibilityRole="button"
                                     accessible={true}
-                                    disabled={true}
                                     onPress={[Function]}
                                     style={
                                       [
@@ -29277,9 +29231,7 @@ exports[`BuildQuote Component render matches snapshot 1`] = `
                                           undefined,
                                         ]
                                       }
-                                    >
-                                      .
-                                    </Text>
+                                    />
                                   </TouchableOpacity>
                                 </View>
                                 <View


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This pull request simplifies the `BuildQuote` component that rendered an unresponsive period button by removing unnecessary props from the `Keypad` component and updates the related test snapshots to reflect these changes. The most significant updates are focused on cleaning up the UI code and ensuring the test outputs are consistent with the new implementation.

Component simplification:

* The `Keypad` component in `BuildQuote.tsx` no longer receives extra props such as `currency`, `decimals`, and `periodButtonProps`, and is now only passed the essential `value` and `onChange` props, removing the unresponsive button.


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an unresponsive period button in the Deposit keypad.

## **Related issues**

Fixes: #21234 

## **Manual testing steps**

```gherkin
Feature: Deposit

  Scenario: user interacts with the keypad
    Given the Deposit build quote page

    When user interacts with the keypad
    Then the period button is not visible
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/8f10e103-c0cc-42d4-ba71-36781f88bd96



### **After**

<img width="400" alt="no_period" src="https://github.com/user-attachments/assets/409d8884-7531-4cf5-99f9-ecad7a69ee35" />


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the period key by simplifying `Keypad` props in `BuildQuote.tsx` and updates related snapshots.
> 
> - **UI**:
>   - Simplifies `Keypad` usage in `app/components/UI/Ramp/Deposit/Views/BuildQuote/BuildQuote.tsx` to only `value` and `onChange`, removing `currency`, `decimals`, and `periodButtonProps` (period key removed).
> - **Tests**:
>   - Updates snapshots in `BuildQuote.test.tsx.snap` reflecting the absence of the disabled period button and related text nodes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1163bd8ef9f9f25da442b8c0e3ecb2b9d7e7100. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->