### PR TITLE
fix: metamask pay metrics in finalized events

### DIFF
--- a/app/core/Engine/controllers/transaction-controller/event-handlers/metrics.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/event-handlers/metrics.test.ts
@@ -48,6 +48,17 @@ jest.mock('../../../Engine', () => ({
   context: {},
 }));
 
+jest.mock('../event_properties/metamask-pay', () => ({
+  getMetaMaskPayProperties: jest.fn().mockReturnValue({
+    properties: {
+      builder_test: true,
+    },
+    sensitiveProperties: {
+      builder_sensitive_test: true,
+    },
+  }),
+}));
+
 describe('Transaction Metric Event Handlers', () => {
   const mockGetSmartTransactionMetricsProperties = jest.mocked(
     getSmartTransactionMetricsProperties,
@@ -193,6 +204,25 @@ describe('Transaction Metric Event Handlers', () => {
     }).not.toThrow();
   });
 
+  it('includes builder metrics', async () => {
+    await handleTransactionSubmittedEventForMetrics(
+      mockTransactionMeta,
+      mockTransactionMetricRequest,
+    );
+
+    expect(mockEventBuilder.addProperties).toHaveBeenCalledWith(
+      expect.objectContaining({
+        builder_test: true,
+      }),
+    );
+
+    expect(mockEventBuilder.addSensitiveProperties).toHaveBeenCalledWith(
+      expect.objectContaining({
+        builder_sensitive_test: true,
+      }),
+    );
+  });
+
   describe('handleTransactionFinalized', () => {
     it('adds STX metrics properties if smart transactions are enabled', async () => {
       // Force the selector to return true
@@ -248,6 +278,25 @@ describe('Transaction Metric Event Handlers', () => {
       expect(mockEventBuilder.addProperties).toHaveBeenCalled();
       expect(mockEventBuilder.addProperties).not.toHaveBeenCalledWith(
         expect.objectContaining(mockSmartTransactionMetricsProperties),
+      );
+    });
+
+    it('includes builder metrics', async () => {
+      await handleTransactionApprovedEventForMetrics(
+        mockTransactionMeta,
+        mockTransactionMetricRequest,
+      );
+
+      expect(mockEventBuilder.addProperties).toHaveBeenCalledWith(
+        expect.objectContaining({
+          builder_test: true,
+        }),
+      );
+
+      expect(mockEventBuilder.addSensitiveProperties).toHaveBeenCalledWith(
+        expect.objectContaining({
+          builder_sensitive_test: true,
+        }),
       );
     });
   });

--- a/app/core/Engine/controllers/transaction-controller/event-handlers/metrics.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/event-handlers/metrics.test.ts
@@ -282,7 +282,7 @@ describe('Transaction Metric Event Handlers', () => {
     });
 
     it('includes builder metrics', async () => {
-      await handleTransactionApprovedEventForMetrics(
+      await handleTransactionFinalizedEventForMetrics(
         mockTransactionMeta,
         mockTransactionMetricRequest,
       );

--- a/app/core/Engine/controllers/transaction-controller/event-handlers/metrics.ts
+++ b/app/core/Engine/controllers/transaction-controller/event-handlers/metrics.ts
@@ -14,6 +14,7 @@ import {
 } from '../utils';
 import type {
   TransactionEventHandlerRequest,
+  TransactionMetrics,
   TransactionMetricsBuilder,
 } from '../types';
 import { getMetaMaskPayProperties } from '../event_properties/metamask-pay';
@@ -41,37 +42,11 @@ const createTransactionEventHandler =
           transactionEventHandlerRequest,
         );
 
-      const metrics = {
-        properties: defaultTransactionMetricProperties.properties,
-        sensitiveProperties:
-          defaultTransactionMetricProperties.sensitiveProperties,
-      };
-
-      const allTransactions =
-        transactionEventHandlerRequest.getState()?.engine?.backgroundState
-          ?.TransactionController?.transactions ?? [];
-
-      const getUIMetrics = getConfirmationMetricProperties.bind(
-        null,
-        transactionEventHandlerRequest.getState,
-      );
-
-      const getState = transactionEventHandlerRequest.getState;
-
-      for (const builder of METRICS_BUILDERS) {
-        try {
-          const currentMetrics = builder({
-            transactionMeta,
-            allTransactions,
-            getUIMetrics,
-            getState,
-          });
-
-          merge(metrics, currentMetrics);
-        } catch (error) {
-          // Intentionally empty
-        }
-      }
+      const metrics = getBuilderMetrics({
+        defaultMetrics: defaultTransactionMetricProperties,
+        request: transactionEventHandlerRequest,
+        transactionMeta,
+      });
 
       const event = generateEvent({
         ...defaultTransactionMetricProperties,
@@ -159,6 +134,7 @@ export async function handleTransactionFinalizedEventForMetrics(
       properties: {},
       sensitiveProperties: {},
     };
+
     try {
       const { getState, initMessenger, smartTransactionsController } =
         transactionEventHandlerRequest;
@@ -196,8 +172,13 @@ export async function handleTransactionFinalizedEventForMetrics(
       },
     );
 
-    // Generate and track the event
-    const event = generateEvent(mergedEventProperties);
+    const metrics = getBuilderMetrics({
+      defaultMetrics: mergedEventProperties,
+      request: transactionEventHandlerRequest,
+      transactionMeta,
+    });
+
+    const event = generateEvent({ ...mergedEventProperties, ...metrics });
 
     log('Finalized event', event);
 
@@ -221,4 +202,47 @@ function retryIfEngineNotInitialized(fn: () => void): boolean {
 
     return true;
   }
+}
+
+function getBuilderMetrics({
+  defaultMetrics,
+  request,
+  transactionMeta,
+}: {
+  defaultMetrics: TransactionMetrics;
+  request: TransactionEventHandlerRequest;
+  transactionMeta: TransactionMeta;
+}) {
+  const metrics = {
+    properties: { ...defaultMetrics.properties },
+    sensitiveProperties: { ...defaultMetrics.sensitiveProperties },
+  };
+
+  const allTransactions =
+    request.getState()?.engine?.backgroundState?.TransactionController
+      ?.transactions ?? [];
+
+  const getUIMetrics = getConfirmationMetricProperties.bind(
+    null,
+    request.getState,
+  );
+
+  const getState = request.getState;
+
+  for (const builder of METRICS_BUILDERS) {
+    try {
+      const currentMetrics = builder({
+        transactionMeta,
+        allTransactions,
+        getUIMetrics,
+        getState,
+      });
+
+      merge(metrics, currentMetrics);
+    } catch (error) {
+      // Intentionally empty
+    }
+  }
+
+  return metrics;
 }


### PR DESCRIPTION
## **Description**

Ensure MetaMask Pay metrics are included in the transaction finalized events.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#6022](https://github.com/MetaMask/MetaMask-planning/issues/6022)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures MetaMask Pay builder metrics are included for submitted and finalized transaction events, extracting builder aggregation into a reusable helper.
> 
> - **Transaction metrics handlers**:
>   - Extract builder aggregation into `getBuilderMetrics`, reusing across generic handlers and `handleTransactionFinalizedEventForMetrics`.
>   - Include builder metrics (e.g., from `getMetaMaskPayProperties`) in both submitted and finalized events by merging with default/SMART/RPC props.
> - **Tests**:
>   - Mock MetaMask Pay metrics builder and assert builder properties and sensitive properties are added for submitted and finalized events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6e951f4b059f394fa39adc2d1e6371cdc11ecae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->