### PR TITLE
feat: debounce metamask pay alerts

### DIFF
--- a/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.test.tsx
+++ b/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.test.tsx
@@ -36,8 +36,9 @@ describe('DepositKeyboard', () => {
     expect(queryByTestId('deposit-keyboard-done-button')).toBeNull();
   });
 
-  it('shows done button if input is not empty', () => {
+  it('shows done button if hasInput set', () => {
     const { getByTestId } = render({
+      hasInput: true,
       value: '1',
     });
 
@@ -49,6 +50,7 @@ describe('DepositKeyboard', () => {
 
     const { getByTestId } = render({
       onDonePress: onDonePressMock,
+      hasInput: true,
       value: '1',
     });
 

--- a/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.tsx
+++ b/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.tsx
@@ -35,6 +35,7 @@ const PERCENTAGE_BUTTONS = [
 
 export interface DepositKeyboardProps {
   alertMessage?: string;
+  hasInput?: boolean;
   onChange: (value: string) => void;
   onPercentagePress: (percentage: number) => void;
   onDonePress: () => void;
@@ -44,6 +45,7 @@ export interface DepositKeyboardProps {
 export const DepositKeyboard = memo(
   ({
     alertMessage,
+    hasInput,
     onChange,
     onDonePress,
     onPercentagePress,
@@ -52,7 +54,6 @@ export const DepositKeyboard = memo(
     const currentCurrency = PERPS_CURRENCY;
     const { styles } = useStyles(styleSheet, {});
     const valueString = value.toString();
-    const hasInput = valueString && valueString !== '0' && valueString !== '';
 
     const handleChange = useCallback(
       (data: KeypadChangeData) => {

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -77,6 +77,8 @@ describe('CustomAmountInfo', () => {
     useTransactionCustomAmountMock.mockReturnValue({
       amountFiat: '123.45',
       amountHuman: '0',
+      amountHumanDebounced: '0',
+      hasInput: true,
       isInputChanged: false,
       updatePendingAmount: noop,
       updatePendingAmountPercentage: noop,

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -50,6 +50,8 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     const {
       amountFiat,
       amountHuman,
+      amountHumanDebounced,
+      hasInput,
       isInputChanged,
       updatePendingAmount,
       updatePendingAmountPercentage,
@@ -59,7 +61,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     const { alertMessage, keyboardAlertMessage, excludeBannerKeys } =
       useTransactionCustomAmountAlerts({
         isInputChanged,
-        pendingTokenAmount: amountHuman,
+        pendingTokenAmount: amountHumanDebounced,
       });
 
     useEffect(() => {
@@ -114,6 +116,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
             onChange={updatePendingAmount}
             onDonePress={handleDone}
             onPercentagePress={updatePendingAmountPercentage}
+            hasInput={hasInput}
           />
         )}
       </Box>

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Hex } from '@metamask/utils';
 import { useTokenFiatRate } from '../tokens/useTokenFiatRates';
 import { BigNumber } from 'bignumber.js';
@@ -8,13 +8,28 @@ import { useTransactionPayToken } from '../pay/useTransactionPayToken';
 import { useUpdateTokenAmount } from './useUpdateTokenAmount';
 import { getTokenTransferData } from '../../utils/transaction-pay';
 import { useParams } from '../../../../../util/navigation/navUtils';
+import { debounce } from 'lodash';
 
 export const MAX_LENGTH = 28;
+const DEBOUNCE_DELAY = 500;
 
 export function useTransactionCustomAmount() {
   const { amount: defaultAmount } = useParams<{ amount?: string }>();
   const [amountFiat, setAmountFiat] = useState(defaultAmount ?? '0');
   const [isInputChanged, setInputChanged] = useState(false);
+  const [hasInput, setHasInput] = useState(false);
+
+  const [amountHumanDebounced, setAmountHumanDebounced] = useState(
+    defaultAmount ?? '0',
+  );
+
+  const debounceSetAmountDelayed = useMemo(
+    () =>
+      debounce((value: string) => {
+        setAmountHumanDebounced(value);
+      }, DEBOUNCE_DELAY),
+    [],
+  );
 
   const transactionMeta = useTransactionMetadataRequest() as TransactionMeta;
   const { chainId } = transactionMeta;
@@ -35,6 +50,20 @@ export function useTransactionCustomAmount() {
     [amountFiat, tokenFiatRate],
   );
 
+  useEffect(() => {
+    debounceSetAmountDelayed(amountHuman);
+  }, [amountHuman, debounceSetAmountDelayed]);
+
+  useEffect(() => {
+    if (amountHumanDebounced !== '0') {
+      setInputChanged(true);
+    }
+
+    setHasInput(
+      Boolean(amountHumanDebounced?.length) && amountHumanDebounced !== '0',
+    );
+  }, [amountHumanDebounced]);
+
   const updatePendingAmount = useCallback((value: string) => {
     let newAmount = value.replace(/^0+/, '') || '0';
 
@@ -47,7 +76,6 @@ export function useTransactionCustomAmount() {
     }
 
     setAmountFiat(newAmount);
-    setInputChanged(true);
   }, []);
 
   const updatePendingAmountPercentage = useCallback(
@@ -74,6 +102,8 @@ export function useTransactionCustomAmount() {
   return {
     amountFiat,
     amountHuman,
+    amountHumanDebounced,
+    hasInput,
     isInputChanged,
     updatePendingAmount,
     updatePendingAmountPercentage,

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -18,10 +18,7 @@ export function useTransactionCustomAmount() {
   const [amountFiat, setAmountFiat] = useState(defaultAmount ?? '0');
   const [isInputChanged, setInputChanged] = useState(false);
   const [hasInput, setHasInput] = useState(false);
-
-  const [amountHumanDebounced, setAmountHumanDebounced] = useState(
-    defaultAmount ?? '0',
-  );
+  const [amountHumanDebounced, setAmountHumanDebounced] = useState('0');
 
   const debounceSetAmountDelayed = useMemo(
     () =>


### PR DESCRIPTION
## **Description**

Debounce custom amount input in MetaMask Pay in order to delay alerts and percentage button display.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#5946](https://github.com/MetaMask/MetaMask-planning/issues/5946)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Debounces custom amount handling, introduces `hasInput` and `amountHumanDebounced`, wires them into alerts and `DepositKeyboard`, and updates tests accordingly.
> 
> - **Hooks**:
>   - Debounce custom amount with 500ms delay in `useTransactionCustomAmount` using `lodash/debounce`.
>   - Add `amountHumanDebounced` and `hasInput`; set `isInputChanged` after debounce.
>   - Update `pendingTokenAmount` usage in `useTransactionCustomAmountAlerts` to `amountHumanDebounced`.
> - **Components**:
>   - `DepositKeyboard`: accept `hasInput` prop (no longer derived from `value`) to control percentage vs done button.
>   - `CustomAmountInfo`: consume `hasInput`/`amountHumanDebounced` from hook and pass `hasInput` to `DepositKeyboard`.
> - **Tests**:
>   - Update tests to use fake timers and verify debounce-driven `isInputChanged`/`hasInput`.
>   - Adjust tests to pass `hasInput` to `DepositKeyboard` and to use params conditionally.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7683c343e3a93db2f0a71769bf907416aad685ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->