### PR TITLE
chore: useBridgeQuoteEvents hook

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -81,6 +81,7 @@ import ApprovalText from '../../components/ApprovalText';
 import { RootState } from '../../../../../reducers/index.ts';
 import { BRIDGE_MM_FEE_RATE } from '@metamask/bridge-controller';
 import { isNullOrUndefined } from '@metamask/utils';
+import { useBridgeQuoteEvents } from '../../hooks/useBridgeQuoteEvents/index.ts';
 
 export interface BridgeRouteParams {
   sourcePage: string;
@@ -176,6 +177,7 @@ const BridgeView = () => {
     isExpired,
     willRefresh,
     blockaidError,
+    shouldShowPriceImpactWarning,
   } = useBridgeQuoteData({
     latestSourceAtomicBalance: latestSourceBalance?.atomicBalance,
   });
@@ -201,6 +203,22 @@ const BridgeView = () => {
   });
 
   const shouldDisplayQuoteDetails = hasQuoteDetails && !isInputFocused;
+
+  const isSubmitDisabled =
+    hasInsufficientBalance ||
+    isSubmittingTx ||
+    (isHardwareAddress && isSolanaSourced) ||
+    !!blockaidError ||
+    !hasSufficientGas;
+
+  useBridgeQuoteEvents({
+    hasInsufficientBalance,
+    hasNoQuotesAvailable: isNoQuotesAvailable,
+    hasInsufficientGas: !hasSufficientGas,
+    hasTxAlert: Boolean(blockaidError),
+    isSubmitDisabled,
+    isPriceImpactWarningVisible: shouldShowPriceImpactWarning,
+  });
 
   // Compute error state directly from dependencies
   const isError = isNoQuotesAvailable || quoteFetchError;
@@ -338,7 +356,7 @@ const BridgeView = () => {
     }
   }, [isExpired, willRefresh, navigation, isSelectingRecipient]);
 
-  const renderBottomContent = () => {
+  const renderBottomContent = (submitDisabled: boolean) => {
     if (shouldDisplayKeypad && !isLoading) {
       return (
         <Box style={styles.buttonContainer}>
@@ -412,13 +430,7 @@ const BridgeView = () => {
             onPress={handleContinue}
             style={styles.button}
             testID="bridge-confirm-button"
-            isDisabled={
-              hasInsufficientBalance ||
-              isSubmittingTx ||
-              (isHardwareAddress && isSolanaSourced) ||
-              !!blockaidError ||
-              !hasSufficientGas
-            }
+            isDisabled={submitDisabled}
           />
           {hasFee ? (
             <Text
@@ -534,7 +546,7 @@ const BridgeView = () => {
             ) : null}
           </Box>
         </ScrollView>
-        {renderBottomContent()}
+        {renderBottomContent(isSubmitDisabled)}
       </Box>
     </ScreenView>
   );

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
@@ -28,7 +28,6 @@ import {
   selectSourceAmount,
   selectDestToken,
   selectSourceToken,
-  selectBridgeFeatureFlags,
   selectDestAddress,
   selectIsSwap,
 } from '../../../../../core/redux/slices/bridge';
@@ -63,11 +62,11 @@ const QuoteDetailsCard: React.FC = () => {
     formattedQuoteData,
     activeQuote,
     isLoading: isQuoteLoading,
+    shouldShowPriceImpactWarning,
   } = useBridgeQuoteData();
   const sourceToken = useSelector(selectSourceToken);
   const destToken = useSelector(selectDestToken);
   const sourceAmount = useSelector(selectSourceAmount);
-  const bridgeFeatureFlags = useSelector(selectBridgeFeatureFlags);
   const destAddress = useSelector(selectDestAddress);
   const isSwap = useSelector(selectIsSwap);
   const internalAccounts = useSelector(selectInternalAccounts);
@@ -133,18 +132,7 @@ const QuoteDetailsCard: React.FC = () => {
 
   const { networkFee, rate, priceImpact, slippage } = formattedQuoteData;
 
-  // Check if price impact warning should be shown
   const gasIncluded = !!activeQuote?.quote.gasIncluded;
-  const rawPriceImpact = activeQuote?.quote.priceData?.priceImpact;
-  const shouldShowPriceImpactWarning =
-    rawPriceImpact !== undefined &&
-    bridgeFeatureFlags?.priceImpactThreshold &&
-    ((gasIncluded &&
-      Number(rawPriceImpact) >=
-        bridgeFeatureFlags.priceImpactThreshold.gasless) ||
-      (!gasIncluded &&
-        Number(rawPriceImpact) >=
-          bridgeFeatureFlags.priceImpactThreshold.normal));
 
   const formattedMinToTokenAmount = intlNumberFormatter.format(
     parseFloat(activeQuote?.minToTokenAmount?.amount || '0'),

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/index.ts
@@ -193,6 +193,18 @@ export const useBridgeQuoteData = ({
     !bestQuote && quotesLastFetched && !isLoading,
   );
 
+  // Check if price impact warning should be shown
+  const shouldShowPriceImpactWarning = Boolean(
+    activeQuote?.quote.priceData?.priceImpact !== undefined &&
+      bridgeFeatureFlags?.priceImpactThreshold &&
+      ((activeQuote?.quote.gasIncluded &&
+        Number(activeQuote?.quote.priceData?.priceImpact) >=
+          bridgeFeatureFlags.priceImpactThreshold.gasless) ||
+        (!activeQuote?.quote.gasIncluded &&
+          Number(activeQuote?.quote.priceData?.priceImpact) >=
+            bridgeFeatureFlags.priceImpactThreshold.normal)),
+  );
+
   const validateQuote = useCallback(async () => {
     // Increment validation ID for this request
     const validationId = ++currentValidationIdRef.current;
@@ -252,5 +264,6 @@ export const useBridgeQuoteData = ({
     willRefresh,
     isExpired,
     blockaidError,
+    shouldShowPriceImpactWarning,
   };
 };

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/index.ts
@@ -1,0 +1,81 @@
+import { useSelector } from 'react-redux';
+import {
+  selectBridgeControllerState,
+  selectBridgeQuotes,
+} from '../../../../../core/redux/slices/bridge';
+import { useEffect, useMemo } from 'react';
+import Engine from '../../../../../core/Engine';
+import {
+  formatProviderLabel,
+  UnifiedSwapBridgeEventName,
+} from '@metamask/bridge-controller';
+
+/**
+ * Hook for publishing the QuotesReceived event
+ */
+export const useBridgeQuoteEvents = ({
+  hasInsufficientBalance,
+  hasNoQuotesAvailable,
+  hasInsufficientGas,
+  hasTxAlert,
+  isSubmitDisabled,
+  isPriceImpactWarningVisible,
+}: {
+  hasInsufficientBalance: boolean;
+  hasNoQuotesAvailable: boolean;
+  hasInsufficientGas: boolean;
+  hasTxAlert: boolean;
+  isSubmitDisabled: boolean;
+  isPriceImpactWarningVisible: boolean;
+}) => {
+  const { quoteFetchError, quotesRefreshCount } = useSelector(
+    selectBridgeControllerState,
+  );
+  const { activeQuote, recommendedQuote, isLoading } =
+    useSelector(selectBridgeQuotes);
+
+  const warnings = useMemo(() => {
+    const latestWarnings = [];
+
+    hasNoQuotesAvailable && latestWarnings.push('no_quotes');
+    hasInsufficientGas &&
+      latestWarnings.push('insufficient_gas_for_selected_quote');
+    hasInsufficientBalance && latestWarnings.push('insufficient_balance');
+    hasTxAlert && latestWarnings.push('tx_alert');
+    isPriceImpactWarningVisible && latestWarnings.push('price_impact_warning');
+
+    return latestWarnings;
+  }, [
+    hasNoQuotesAvailable,
+    hasInsufficientGas,
+    hasInsufficientBalance,
+    hasTxAlert,
+    isPriceImpactWarningVisible,
+  ]);
+
+  // Emit QuotesReceived event each time quotes are fetched successfully
+  useEffect(() => {
+    if (!isLoading && quotesRefreshCount > 0 && !quoteFetchError) {
+      Engine.context.BridgeController.trackUnifiedSwapBridgeEvent(
+        UnifiedSwapBridgeEventName.QuotesReceived,
+        {
+          can_submit: isSubmitDisabled,
+          gas_included: Boolean(activeQuote?.quote?.gasIncluded),
+          gas_included_7702: Boolean(activeQuote?.quote?.gasIncluded7702),
+          quoted_time_minutes: activeQuote?.estimatedProcessingTimeInSeconds
+            ? activeQuote.estimatedProcessingTimeInSeconds / 60
+            : 0,
+          usd_quoted_gas: Number(activeQuote?.gasFee?.effective?.usd ?? 0),
+          usd_quoted_return: Number(activeQuote?.toTokenAmount?.usd ?? 0),
+          best_quote_provider: recommendedQuote
+            ? formatProviderLabel(recommendedQuote.quote)
+            : undefined,
+          provider: activeQuote ? formatProviderLabel(activeQuote.quote) : '_',
+          warnings,
+          price_impact: Number(activeQuote?.quote.priceData?.priceImpact ?? 0),
+        },
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [quotesRefreshCount]);
+};

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/index.ts
@@ -59,7 +59,7 @@ export const useBridgeQuoteEvents = ({
       Engine.context.BridgeController.trackUnifiedSwapBridgeEvent(
         UnifiedSwapBridgeEventName.QuotesReceived,
         {
-          can_submit: isSubmitDisabled,
+          can_submit: !isSubmitDisabled,
           gas_included: Boolean(activeQuote?.quote?.gasIncluded),
           gas_included_7702: Boolean(activeQuote?.quote?.gasIncluded7702),
           quoted_time_minutes: activeQuote?.estimatedProcessingTimeInSeconds

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/useBridgeQuoteEvents.test.tsx
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/useBridgeQuoteEvents.test.tsx
@@ -1,0 +1,113 @@
+import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
+import { useBridgeQuoteEvents } from '.';
+import Engine from '../../../../../core/Engine';
+import { createBridgeTestState } from '../../testUtils';
+import { mockQuoteWithMetadata } from '../../_mocks_/bridgeQuoteWithMetadata';
+import { RequestStatus } from '@metamask/bridge-controller';
+
+jest.mock('../../../../../core/Engine', () => ({
+  context: {
+    ...jest.requireActual('../../../../../core/Engine').context,
+    BridgeController: {
+      trackUnifiedSwapBridgeEvent: jest.fn(),
+    },
+  },
+}));
+
+describe('useBridgeQuoteEvents', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    [{ quotesLoadingStatus: RequestStatus.LOADING }],
+    [{ quotesRefreshCount: 0 }],
+    [{ quoteFetchError: 'Error fetching quotes' }],
+  ])(
+    'should not publish QuotesReceived event when bridge-controller state has %s',
+    async (stateOverrides) => {
+      const bridgeControllerOverrides = {
+        quotesLoadingStatus: null,
+        quoteFetchError: null,
+        quotes: [mockQuoteWithMetadata],
+        quotesRefreshCount: 1,
+        ...stateOverrides,
+      };
+      const testState = createBridgeTestState({
+        bridgeControllerOverrides,
+      });
+      renderHookWithProvider(
+        () =>
+          useBridgeQuoteEvents({
+            hasNoQuotesAvailable: false,
+            hasInsufficientBalance: false,
+            hasInsufficientGas: false,
+            hasTxAlert: false,
+            isSubmitDisabled: false,
+            isPriceImpactWarningVisible: false,
+          }),
+        { state: testState },
+      );
+      expect(
+        Engine.context.BridgeController.trackUnifiedSwapBridgeEvent,
+      ).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    [{ hasNoQuotesAvailable: true }, ['no_quotes']],
+    [{ hasInsufficientGas: true }, ['insufficient_gas_for_selected_quote']],
+    [{ hasInsufficientBalance: true }, ['insufficient_balance']],
+    [{ hasTxAlert: true }, ['tx_alert']],
+    [{ isPriceImpactWarningVisible: true }, ['price_impact_warning']],
+    [
+      { hasTxAlert: true, isPriceImpactWarningVisible: true },
+      ['tx_alert', 'price_impact_warning'],
+    ],
+    [{}, []],
+  ])(
+    'should publish QuotesReceived event with warnings: %s',
+    async (hookArgs, warnings) => {
+      const bridgeControllerOverrides = {
+        quotesLoadingStatus: null,
+        quoteFetchError: null,
+        quotes: [mockQuoteWithMetadata],
+        quotesRefreshCount: 1,
+      };
+      const testState = createBridgeTestState({
+        bridgeControllerOverrides,
+      });
+      renderHookWithProvider(
+        () =>
+          useBridgeQuoteEvents({
+            hasNoQuotesAvailable: false,
+            hasInsufficientBalance: false,
+            hasInsufficientGas: false,
+            hasTxAlert: false,
+            isSubmitDisabled: false,
+            isPriceImpactWarningVisible: false,
+            ...hookArgs,
+          }),
+        { state: testState },
+      );
+
+      expect(
+        Engine.context.BridgeController.trackUnifiedSwapBridgeEvent,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        Engine.context.BridgeController.trackUnifiedSwapBridgeEvent,
+      ).toHaveBeenCalledWith('Unified SwapBridge Quotes Received', {
+        best_quote_provider: 'lifi_jupiter',
+        can_submit: false,
+        gas_included: false,
+        gas_included_7702: false,
+        price_impact: -0.001991570073761955,
+        provider: 'lifi_jupiter',
+        quoted_time_minutes: 0.08333333333333333,
+        usd_quoted_gas: 0,
+        usd_quoted_return: 0,
+        warnings,
+      });
+    },
+  );
+});

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/useBridgeQuoteEvents.test.tsx
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteEvents/useBridgeQuoteEvents.test.tsx
@@ -98,7 +98,7 @@ describe('useBridgeQuoteEvents', () => {
         Engine.context.BridgeController.trackUnifiedSwapBridgeEvent,
       ).toHaveBeenCalledWith('Unified SwapBridge Quotes Received', {
         best_quote_provider: 'lifi_jupiter',
-        can_submit: false,
+        can_submit: true,
         gas_included: false,
         gas_included_7702: false,
         price_impact: -0.001991570073761955,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds a hook to publish the Quotes Received Mixpanel event. See bugbot comment for more details

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: feat: publish swap QuotesReceived event

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3139

## **Manual testing steps**

```gherkin
Feature: QuotesReceived event

  Scenario: user requests swap quotes
    Given there are no network errors

    When user searches MixPanel
    Then they should see Quotes Received events with expected properties
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**

N/A

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a hook to publish Unified SwapBridge QuotesReceived events, integrates it in BridgeView, and moves price-impact warning logic into useBridgeQuoteData with UI updates.
> 
> - **Analytics**:
>   - **New hook**: `useBridgeQuoteEvents` publishes `QuotesReceived` with provider, gas flags, quoted times, USD amounts, price impact, submit availability, and aggregated warnings.
> - **BridgeView**:
>   - Integrates `useBridgeQuoteEvents` with state-derived flags (`hasInsufficientBalance`, `hasInsufficientGas`, `hasTxAlert`, `hasNoQuotesAvailable`, `isSubmitDisabled`, `isPriceImpactWarningVisible`).
>   - Refactors button disabled logic into `isSubmitDisabled`; updates `renderBottomContent(submitDisabled)` and button `isDisabled` usage.
> - **Quote/Price Impact**:
>   - Moves price-impact warning computation into `useBridgeQuoteData` as `shouldShowPriceImpactWarning` (based on feature flags and `gasIncluded`); consumed by UI.
>   - Simplifies `QuoteDetailsCard` by using `shouldShowPriceImpactWarning` and removing local flag logic and feature-flag selector.
> - **Tests**:
>   - Adds tests for `useBridgeQuoteEvents` event emission and warnings.
>   - Updates `useBridgeQuoteData` tests, including thresholds and new `shouldShowPriceImpactWarning` output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd93e28cb65e666f45c2a9eb49b011bf87f94bcc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->