### PR TITLE
fix: cp-7.57.0 target PRD for rc/pre-release

### DIFF
--- a/app/core/Engine/controllers/rewards-controller/utils/rewards-api-url.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/utils/rewards-api-url.test.ts
@@ -9,23 +9,37 @@ jest.mock('../../../../AppConstants', () => ({
 }));
 
 describe('getDefaultRewardsApiBaseUrlForMetaMaskEnv', () => {
-  it('returns UAT api url for local or dev env', async () => {
+  it('returns DEV api url for local or dev env', async () => {
     // Act
     let apiUrl = getDefaultRewardsApiBaseUrlForMetaMaskEnv('dev');
 
     // Assert
-    expect(apiUrl).toEqual('https://api.uat');
+    expect(apiUrl).toEqual('https://api.dev');
 
     // Act
     apiUrl = getDefaultRewardsApiBaseUrlForMetaMaskEnv('local');
 
     // Assert
-    expect(apiUrl).toEqual('https://api.uat');
+    expect(apiUrl).toEqual('https://api.dev');
   });
 
-  it('returns UAT api url for rc or exp env', async () => {
+  it('returns DEV api url for undefined or unknown env', async () => {
     // Act
-    let apiUrl = getDefaultRewardsApiBaseUrlForMetaMaskEnv('rc');
+    let apiUrl = getDefaultRewardsApiBaseUrlForMetaMaskEnv(undefined);
+
+    // Assert
+    expect(apiUrl).toEqual('https://api.dev');
+
+    // Act
+    apiUrl = getDefaultRewardsApiBaseUrlForMetaMaskEnv('unknown');
+
+    // Assert
+    expect(apiUrl).toEqual('https://api.dev');
+  });
+
+  it('returns UAT api url for e2e or exp env', async () => {
+    // Act
+    let apiUrl = getDefaultRewardsApiBaseUrlForMetaMaskEnv('e2e');
 
     // Assert
     expect(apiUrl).toEqual('https://api.uat');
@@ -37,15 +51,27 @@ describe('getDefaultRewardsApiBaseUrlForMetaMaskEnv', () => {
     expect(apiUrl).toEqual('https://api.uat');
   });
 
-  it('returns PRD api url for beta or production env', async () => {
+  it('returns PRD api url for production, beta, pre-release, or rc env', async () => {
     // Act
-    let apiUrl = getDefaultRewardsApiBaseUrlForMetaMaskEnv('beta');
+    let apiUrl = getDefaultRewardsApiBaseUrlForMetaMaskEnv('production');
 
     // Assert
     expect(apiUrl).toEqual('https://api.prd');
 
     // Act
-    apiUrl = getDefaultRewardsApiBaseUrlForMetaMaskEnv('production');
+    apiUrl = getDefaultRewardsApiBaseUrlForMetaMaskEnv('beta');
+
+    // Assert
+    expect(apiUrl).toEqual('https://api.prd');
+
+    // Act
+    apiUrl = getDefaultRewardsApiBaseUrlForMetaMaskEnv('pre-release');
+
+    // Assert
+    expect(apiUrl).toEqual('https://api.prd');
+
+    // Act
+    apiUrl = getDefaultRewardsApiBaseUrlForMetaMaskEnv('rc');
 
     // Assert
     expect(apiUrl).toEqual('https://api.prd');

--- a/app/core/Engine/controllers/rewards-controller/utils/rewards-api-url.ts
+++ b/app/core/Engine/controllers/rewards-controller/utils/rewards-api-url.ts
@@ -6,15 +6,15 @@ export const getDefaultRewardsApiBaseUrlForMetaMaskEnv = (
   switch (metaMaskEnv) {
     case 'e2e':
     case 'exp':
-    case 'rc':
-    case 'pre-release':
       return AppConstants.REWARDS_API_URL.UAT;
     case 'production':
     case 'beta':
+    case 'pre-release':
+    case 'rc':
       return AppConstants.REWARDS_API_URL.PRD;
     case 'dev':
     case 'local':
     default:
-      return AppConstants.REWARDS_API_URL.UAT; // temporary for v7.57, should be moved to DEV later
+      return AppConstants.REWARDS_API_URL.DEV;
   }
 };


### PR DESCRIPTION
## **Description**

Our old approach was targeting UAT for RC and pre-release, this should be PRD.

## **Changelog**

CHANGELOG entry: null`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Map rc/pre-release to PRD and dev/local/unknown to DEV; keep e2e/exp on UAT; update tests accordingly.
> 
> - **Rewards API URL mapping (`app/core/Engine/controllers/rewards-controller/utils/rewards-api-url.ts`)**:
>   - Map `rc` and `pre-release` to `PRD`.
>   - Map `dev`, `local`, and default/unknown to `DEV` (was `UAT`).
>   - Keep `e2e` and `exp` on `UAT`.
> - **Tests (`rewards-api-url.test.ts`)**:
>   - Update expectations to reflect new mappings (DEV for dev/local, PRD for rc/pre-release).
>   - Add cases for `undefined` and unknown envs → `DEV`.
>   - Use `e2e` (not `rc`) in UAT mapping test; expand PRD test to include `production`, `beta`, `pre-release`, and `rc`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be2c9b3f3114105a9c0df32f9da2bfc92ac1624d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->