### PR TITLE
fix: cp-7.57.0 app bricks on asset sorting

### DIFF
--- a/app/components/UI/Tokens/util/sortAssets.test.ts
+++ b/app/components/UI/Tokens/util/sortAssets.test.ts
@@ -149,6 +149,43 @@ describe('sortAssets function - nested value handling with dates and numeric sor
       sortedByCategory[sortedByCategory.length - 1].profile.info?.category,
     ).toBeUndefined();
   });
+
+  test('handles null values when sorting with alphaNumeric', () => {
+    const assetWithNull = {
+      name: null as unknown as string,
+      balance: '700',
+      createdAt: new Date('2024-06-01'),
+      profile: { id: '5', info: { category: 'platinum' } },
+    };
+
+    const sortedByName = sortAssets([...mockAssets, assetWithNull], {
+      key: 'name',
+      sortCallback: 'alphaNumeric',
+      order: 'asc',
+    });
+
+    expect(sortedByName[sortedByName.length - 1].name).toBeNull();
+    expect(sortedByName[0].name).toBe('Asset A');
+    expect(sortedByName[1].name).toBe('Asset B');
+  });
+
+  test('handles null values in descending order', () => {
+    const assetWithNull = {
+      name: null as unknown as string,
+      balance: '700',
+      createdAt: new Date('2024-06-01'),
+      profile: { id: '5', info: { category: 'platinum' } },
+    };
+
+    const sortedByName = sortAssets([...mockAssets, assetWithNull], {
+      key: 'name',
+      sortCallback: 'alphaNumeric',
+      order: 'dsc',
+    });
+
+    expect(sortedByName[sortedByName.length - 1].name).toBeNull();
+    expect(sortedByName[0].name).toBe('Asset Z');
+  });
 });
 
 // Utility function to generate large mock data

--- a/app/components/UI/Tokens/util/sortAssets.ts
+++ b/app/components/UI/Tokens/util/sortAssets.ts
@@ -41,11 +41,11 @@ export function sortAssets<T>(
     const bValue = getNestedValue(b, key);
 
     // Always move undefined values to the end, regardless of sort order
-    if (aValue === undefined) {
+    if (aValue == null) {
       return 1;
     }
 
-    if (bValue === undefined) {
+    if (bValue == null) {
       return -1;
     }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
From the Home token list, if the user sets a sort/filter such as Descending by balance, the app crashes to the generic error screen on next render and becomes unrecoverable. Force-quitting and relaunching does not help; only uninstall + reinstall clears the state. The crash message indicates the Wallet view throws on `localeCompare` of `null`.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/21218

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update `sortAssets` to move nullish values to the end during sorting and add tests for null handling in alphaNumeric asc/desc cases.
> 
> - **Utils**:
>   - Update `app/components/UI/Tokens/util/sortAssets.ts` to treat `null` like `undefined` (`aValue == null` / `bValue == null`) so nullish values are always placed at the end regardless of order.
> - **Tests**:
>   - Add tests in `app/components/UI/Tokens/util/sortAssets.test.ts` to verify alphaNumeric sorting with `null` names in both ascending and descending orders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 420abbcb2f59ae6792accc0b035d5219360bf578. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->