### PR TITLE
feat: cp-7.58.0 max button in perps deposit

### DIFF
--- a/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.tsx
+++ b/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.tsx
@@ -28,8 +28,8 @@ const PERCENTAGE_BUTTONS = [
     value: 50,
   },
   {
-    label: '90%',
-    value: 90,
+    label: 'Max',
+    value: 100,
   },
 ];
 

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
@@ -315,5 +315,20 @@ describe('useTransactionCustomAmount', () => {
 
       expect(result.current.amountFiat).toBe('1234.56');
     });
+
+    it('minus no buffer if 100 but all required tokens have sufficient balance and skipIfBalance', async () => {
+      useTransactionRequiredTokensMock.mockReturnValue([
+        { skipIfBalance: true, amountRaw: '1', balanceRaw: '1' },
+        { skipIfBalance: true, amountRaw: '1', balanceRaw: '1' },
+      ] as TransactionToken[]);
+
+      const { result } = runHook();
+
+      await act(async () => {
+        result.current.updatePendingAmountPercentage(100);
+      });
+
+      expect(result.current.amountFiat).toBe('1234.56');
+    });
   });
 });

--- a/package.json
+++ b/package.json
@@ -294,7 +294,7 @@
     "@metamask/swappable-obj-proxy": "^2.1.0",
     "@metamask/swaps-controller": "^14.0.0",
     "@metamask/token-search-discovery-controller": "^3.1.0",
-    "@metamask/transaction-controller": "^60.6.0",
+    "@metamask/transaction-controller": "^60.9.0",
     "@metamask/tron-wallet-snap": "^1.4.0",
     "@metamask/utils": "^11.8.1",
     "@ngraveio/bc-ur": "^1.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8789,9 +8789,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:^60.6.0, @metamask/transaction-controller@npm:^60.7.0":
-  version: 60.7.0
-  resolution: "@metamask/transaction-controller@npm:60.7.0"
+"@metamask/transaction-controller@npm:^60.7.0, @metamask/transaction-controller@npm:^60.9.0":
+  version: 60.9.0
+  resolution: "@metamask/transaction-controller@npm:60.9.0"
   dependencies:
     "@ethereumjs/common": ^4.4.0
     "@ethereumjs/tx": ^5.4.0
@@ -8821,7 +8821,7 @@ __metadata:
     "@metamask/gas-fee-controller": ^24.0.0
     "@metamask/network-controller": ^24.0.0
     "@metamask/remote-feature-flag-controller": ^1.5.0
-  checksum: b68795b84ba99e46ea97a6e5e65ff1cd98b57f275f69bcc8cb419af950d434e7fe0eaa77515e5ece1fc65c9af1224fc22fe358619c85c254f75018e7b8a81c6d
+  checksum: 0cf4105e5e4fcce8518a0535c013fc4036d3709c25179b8708ba908fb9cd7998f259645e53ea80ecd5df4b0f631f8606972b652f199b79a803c2575ecdaba0c5
   languageName: node
   linkType: hard
 
@@ -34152,7 +34152,7 @@ __metadata:
     "@metamask/test-dapp-multichain": ^0.17.1
     "@metamask/test-dapp-solana": ^0.3.0
     "@metamask/token-search-discovery-controller": ^3.1.0
-    "@metamask/transaction-controller": ^60.6.0
+    "@metamask/transaction-controller": ^60.9.0
     "@metamask/tron-wallet-snap": ^1.4.0
     "@metamask/utils": ^11.8.1
     "@ngraveio/bc-ur": ^1.1.6


### PR DESCRIPTION
## **Description**

Add a `Max` button to the Perps deposit confirmation, which automatically subtracts the appropriate buffers from the token amount based on the MetaMask Pay feature flags and if the token is native.

## **Changelog**

CHANGELOG entry: Add max button to Perps deposit

## **Related issues**

Fixes: [#5947](https://github.com/MetaMask/MetaMask-planning/issues/5947)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Max button for Perps deposit that sets amount to 100% minus dynamic buffers (feature flags, required tokens, native token), updates rounding, adds tests, and bumps transaction-controller.
> 
> - **Perps Deposit UI**:
>   - Replace `90%` quick action with **`Max` (100%)** in `deposit-keyboard.tsx`.
> - **Amount Logic** (`useTransactionCustomAmount`):
>   - Introduce `useMaxPercentage` to compute effective max based on `selectMetaMaskPayFlags`, `useTransactionRequiredTokens`, and native token detection.
>   - For `100%`, subtract buffers (initial/subsequent; extra if pay token is native); skip buffers if pay token matches required token or required tokens have sufficient balance with `skipIfBalance`.
>   - Change percentage rounding to `ROUND_DOWN` and use computed max percentage.
> - **Tests**:
>   - Expand `useTransactionCustomAmount.test.ts` to cover buffered `100%` cases, native token, matching required token, and `skipIfBalance`; update mocks accordingly.
> - **Dependencies**:
>   - Bump `@metamask/transaction-controller` to `^60.9.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca20bbdf820cb7b9470c7cffc80debb369d8707b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->