### PR TITLE
fix: choosePassword description update for ios and social-login user. cp-7.57.0

### DIFF
--- a/app/components/Views/ChoosePassword/index.js
+++ b/app/components/Views/ChoosePassword/index.js
@@ -797,18 +797,24 @@ class ChoosePassword extends PureComponent {
                         variant={TextVariant.BodyMD}
                         color={TextColor.Alternative}
                       >
-                        {strings(
-                          'choose_password.description_social_login_update',
+                        {Platform.OS === 'ios'
+                          ? strings(
+                              'choose_password.description_social_login_update_ios',
+                            )
+                          : strings(
+                              'choose_password.description_social_login_update',
+                            )}
+                        {Platform.OS === 'android' && (
+                          <Text
+                            variant={TextVariant.BodyMD}
+                            color={TextColor.Warning}
+                          >
+                            {' '}
+                            {strings(
+                              'choose_password.description_social_login_update_bold',
+                            )}
+                          </Text>
                         )}
-                        <Text
-                          variant={TextVariant.BodyMD}
-                          color={TextColor.Warning}
-                        >
-                          {' '}
-                          {strings(
-                            'choose_password.description_social_login_update_bold',
-                          )}
-                        </Text>
                       </Text>
                     ) : (
                       strings('choose_password.description')

--- a/app/components/Views/ChoosePassword/index.test.tsx
+++ b/app/components/Views/ChoosePassword/index.test.tsx
@@ -1595,6 +1595,50 @@ describe('ChoosePassword', () => {
           value: originalPlatform,
         });
       });
+
+      it('should show Android-specific description for OAuth login success on Android', async () => {
+        const originalPlatform = Platform.OS;
+        Object.defineProperty(Platform, 'OS', {
+          writable: true,
+          value: 'android',
+        });
+
+        const props: ChoosePasswordProps = {
+          ...defaultProps,
+          route: {
+            ...defaultProps.route,
+            params: {
+              ...defaultProps.route.params,
+              [PREVIOUS_SCREEN]: ONBOARDING,
+              oauthLoginSuccess: true,
+            },
+          },
+        };
+
+        const component = renderWithProviders(<ChoosePassword {...props} />);
+
+        await act(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 0));
+        });
+
+        // Should show Android-specific description
+        expect(
+          component.getAllByText(/If you lose this password/),
+        ).toHaveLength(1);
+        expect(component.getAllByText(/Store it somewhere safe/)).toHaveLength(
+          1,
+        );
+
+        // Should show Android-specific bold text
+        expect(component.getAllByText(/MetaMask can't reset it/)).toHaveLength(
+          1,
+        );
+
+        Object.defineProperty(Platform, 'OS', {
+          writable: true,
+          value: originalPlatform,
+        });
+      });
     });
   });
 });

--- a/app/components/Views/ChoosePassword/index.test.tsx
+++ b/app/components/Views/ChoosePassword/index.test.tsx
@@ -17,7 +17,7 @@ import StorageWrapper from '../../../store/storage-wrapper';
 import AUTHENTICATION_TYPE from '../../../constants/userProperties';
 import { BIOMETRY_TYPE } from 'react-native-keychain';
 import { Authentication } from '../../../core';
-import { InteractionManager, Alert } from 'react-native';
+import { InteractionManager, Alert, Platform } from 'react-native';
 import { EVENT_NAME } from '../../../core/Analytics';
 
 jest.mock('../../../util/metrics/TrackOnboarding/trackOnboarding');
@@ -1557,6 +1557,43 @@ describe('ChoosePassword', () => {
         });
 
         expect(submitButton.props.disabled).toBe(true);
+      });
+    });
+
+    describe('iOS OAuth Description Text', () => {
+      it('should show iOS-specific description for OAuth login success on iOS', async () => {
+        const originalPlatform = Platform.OS;
+        Object.defineProperty(Platform, 'OS', { writable: true, value: 'ios' });
+
+        const props: ChoosePasswordProps = {
+          ...defaultProps,
+          route: {
+            ...defaultProps.route,
+            params: {
+              ...defaultProps.route.params,
+              [PREVIOUS_SCREEN]: ONBOARDING,
+              oauthLoginSuccess: true,
+            },
+          },
+        };
+
+        const component = renderWithProviders(<ChoosePassword {...props} />);
+
+        await act(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 0));
+        });
+
+        // Should show iOS-specific description
+        expect(() =>
+          component.getByText(
+            /Use this for wallet recovery on all devices\. MetaMask can't reset it\./,
+          ),
+        ).not.toThrow();
+
+        Object.defineProperty(Platform, 'OS', {
+          writable: true,
+          value: originalPlatform,
+        });
       });
     });
   });

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -394,6 +394,7 @@
     "title": "MetaMask password",
     "description": "Unlocks MetaMask on this device only.",
     "description_social_login": "Use this for wallet recovery on all devices.",
+    "description_social_login_update_ios": "Use this for wallet recovery on all devices. MetaMask can't reset it.",
     "description_social_login_update" : "If you lose this password, you’ll lose access to your wallet on all devices. Store it somewhere safe,",
     "description_social_login_update_bold" : "MetaMask can't reset it.",
     "subtitle": "This password will unlock your MetaMask wallet only on this device.",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
* choosePassword description update for ios and social-login user
fixes: https://github.com/MetaMask/metamask-mobile/issues/21192
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: choosePassword description update for ios and social-login user

## **Related issues**

Fixes: choosePassword description update for ios and social-login user
https://github.com/MetaMask/metamask-mobile/issues/21022

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
https://www.figma.com/design/pViOUcmjwhEzFsdrwknpNc/Onboarding?node-id=12501-102542&m=dev
<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/f1b7406d-2253-474e-893e-fc7ffba2e297


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes OAuth success description on ChoosePassword platform-specific (iOS vs Android) and adds corresponding test and i18n string.
> 
> - **ChoosePassword view (`app/components/Views/ChoosePassword/index.js`)**:
>   - Platform-specific OAuth success description:
>     - iOS: uses `choose_password.description_social_login_update_ios` (single sentence).
>     - Android: keeps `choose_password.description_social_login_update` with separate warning text (`description_social_login_update_bold`).
> - **Tests (`app/components/Views/ChoosePassword/index.test.tsx`)**:
>   - Import `Platform`; add iOS-specific description test to validate new copy when `oauthLoginSuccess` is true on iOS.
> - **Locales (`locales/languages/en.json`)**:
>   - Add `choose_password.description_social_login_update_ios` string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89acab5156fd21318c154779d7f13079da0db77d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->