### PR TITLE
fix: cp-7.57.0 prevent unnecessary reward navigation on account change

### DIFF
--- a/app/components/UI/Rewards/components/Onboarding/OnboardingIntroStep.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/OnboardingIntroStep.tsx
@@ -191,7 +191,7 @@ const OnboardingIntroStep: React.FC<{
           'RewardsController:isOptInSupported',
           account,
         );
-      } catch (error) {
+      } catch {
         return false;
       }
     });

--- a/app/components/UI/Rewards/components/Onboarding/OnboardingIntroStep.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/OnboardingIntroStep.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { Image, ImageBackground, Platform, Text as RNText } from 'react-native';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { useDispatch, useSelector } from 'react-redux';
@@ -39,6 +39,8 @@ import { isHardwareAccount } from '../../../../../util/address';
 import Engine from '../../../../../core/Engine';
 import { MetaMetricsEvents, useMetrics } from '../../../../hooks/useMetrics';
 import Device from '../../../../../util/device';
+import { REWARDS_GTM_MODAL_SHOWN } from '../../../../../constants/storage';
+import storageWrapper from '../../../../../store/storage-wrapper';
 
 /**
  * OnboardingIntroStep Component
@@ -56,6 +58,14 @@ const OnboardingIntroStep: React.FC<{
   const dispatch = useDispatch();
   const tw = useTailwind();
   const isLargeDevice = useMemo(() => Device.isLargeDevice(), []);
+
+  const setHasSeenRewardsIntroModal = useCallback(async () => {
+    await storageWrapper.setItem(REWARDS_GTM_MODAL_SHOWN, 'true');
+  }, []);
+
+  useEffect(() => {
+    setHasSeenRewardsIntroModal();
+  }, [setHasSeenRewardsIntroModal]);
 
   // Selectors
   const optinAllowedForGeo = useSelector(selectOptinAllowedForGeo);

--- a/app/components/UI/Rewards/components/Onboarding/RewardsIntroModal.test.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/RewardsIntroModal.test.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { renderWithProviders } from './testUtils';
 import RewardsIntroModal from './RewardsIntroModal';
-import storageWrapper from '../../../../../store/storage-wrapper';
-import { REWARDS_GTM_MODAL_SHOWN } from '../../../../../constants/storage';
 
 // Mock child component to capture props
 const mockOnboardingIntroStep = jest.fn((_props: Record<string, unknown>) => {
@@ -36,16 +34,5 @@ describe('RewardsIntroModal', () => {
         confirmLabel: 'mocked_rewards.onboarding.gtm_confirm',
       }),
     );
-  });
-
-  it('marks rewards intro modal as seen in storage on mount', async () => {
-    const setItemSpy = jest
-      .spyOn(storageWrapper, 'setItem')
-      .mockResolvedValueOnce(undefined);
-
-    renderWithProviders(<RewardsIntroModal />);
-
-    // Effect should trigger setItem once
-    expect(setItemSpy).toHaveBeenCalledWith(REWARDS_GTM_MODAL_SHOWN, 'true');
   });
 });

--- a/app/components/UI/Rewards/components/Onboarding/RewardsIntroModal.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/RewardsIntroModal.tsx
@@ -1,25 +1,13 @@
-import React, { useCallback, useEffect } from 'react';
+import React from 'react';
 import OnboardingIntroStep from './OnboardingIntroStep';
 import { strings } from '../../../../../../locales/i18n';
-import storageWrapper from '../../../../../store/storage-wrapper';
-import { REWARDS_GTM_MODAL_SHOWN } from '../../../../../constants/storage';
 
-const RewardsIntroModal = () => {
-  const setHasSeenRewardsIntroModal = useCallback(async () => {
-    await storageWrapper.setItem(REWARDS_GTM_MODAL_SHOWN, 'true');
-  }, []);
-
-  useEffect(() => {
-    setHasSeenRewardsIntroModal();
-  }, [setHasSeenRewardsIntroModal]);
-
-  return (
-    <OnboardingIntroStep
-      title={strings('rewards.onboarding.gtm_title')}
-      description={strings('rewards.onboarding.gtm_description')}
-      confirmLabel={strings('rewards.onboarding.gtm_confirm')}
-    />
-  );
-};
+const RewardsIntroModal = () => (
+  <OnboardingIntroStep
+    title={strings('rewards.onboarding.gtm_title')}
+    description={strings('rewards.onboarding.gtm_description')}
+    confirmLabel={strings('rewards.onboarding.gtm_confirm')}
+  />
+);
 
 export default RewardsIntroModal;

--- a/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingIntroStep.test.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingIntroStep.test.tsx
@@ -71,6 +71,7 @@ jest.mock('../OnboardingIntroStep', () => {
 });
 import { renderWithProviders, createMockDispatch } from '../testUtils';
 import Routes from '../../../../../../constants/navigation/Routes';
+import { REWARDS_GTM_MODAL_SHOWN } from '../../../../../../constants/storage';
 // Use the mocked component with no required props to avoid TS errors
 const OnboardingIntroStep = jest.requireMock('../OnboardingIntroStep')
   .default as unknown as React.ComponentType<Record<string, never>>;
@@ -121,6 +122,7 @@ const defaultAccountGroupAccounts = createMockAccountGroupAccounts([
 
 // Import the actual selectors to identify them in mocks
 import { selectSelectedAccountGroupInternalAccounts } from '../../../../../../selectors/multichainAccounts/accountTreeController';
+import storageWrapper from '../../../../../../store/storage-wrapper';
 
 // Mock redux
 const mockDispatch = createMockDispatch();
@@ -194,9 +196,22 @@ jest.mock('../../../../../../../locales/i18n', () => ({
   strings: (key: string) => `mocked_${key}`,
 }));
 
+// Mock storage wrapper
+jest.mock('../../../../../../store/storage-wrapper', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}));
+
 describe('OnboardingIntroStep', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+
+    // Reset storage mock to default (resolved promise)
+    (storageWrapper.setItem as jest.Mock).mockResolvedValue(undefined);
 
     // Reset hardware account mock to default (false)
     const mockIsHardwareAccount = jest.requireMock(
@@ -295,6 +310,25 @@ describe('OnboardingIntroStep', () => {
 
       const introImage = screen.getByTestId('intro-image');
       expect(introImage).toBeDefined();
+    });
+  });
+
+  describe('storage behavior', () => {
+    it('should set REWARDS_GTM_MODAL_SHOWN flag in storage when component mounts', async () => {
+      // Arrange - storageWrapper.setItem is already configured in beforeEach
+
+      // Act
+      renderWithProviders(<OnboardingIntroStep />);
+
+      // Assert
+      // Wait for the async storage operation to complete
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(storageWrapper.setItem).toHaveBeenCalledWith(
+        REWARDS_GTM_MODAL_SHOWN,
+        'true',
+      );
+      expect(storageWrapper.setItem).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/app/components/UI/Rewards/hooks/useRewardsIntroModal.ts
+++ b/app/components/UI/Rewards/hooks/useRewardsIntroModal.ts
@@ -64,6 +64,12 @@ export const useRewardsIntroModal = () => {
   }, [hasSeenBIP44IntroModal]);
 
   const checkAndShowRewardsIntroModal = useCallback(async () => {
+    if (subscriptionId) {
+      await StorageWrapper.setItem(REWARDS_GTM_MODAL_SHOWN, 'true');
+      setHasSeenRewardsIntroModal(true);
+      return;
+    }
+
     // Check if this is a fresh install
     const currentAppVersion = await StorageWrapper.getItem(CURRENT_APP_VERSION);
     const lastAppVersion = await StorageWrapper.getItem(LAST_APP_VERSION);

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
@@ -1608,7 +1608,7 @@ describe('RewardsDataService', () => {
       jest.clearAllMocks();
     });
 
-    it('should successfully fetch geolocation in DEV environment', async () => {
+    it('should successfully fetch geolocation using PROD URL', async () => {
       // Arrange
       const mockLocation = 'US';
       const mockResponse = {
@@ -1616,9 +1616,6 @@ describe('RewardsDataService', () => {
         text: jest.fn().mockResolvedValue(mockLocation),
       };
 
-      // Mock AppConstants to use DEV environment
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (AppConstants as any).IS_DEV = true;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       mockSuccessfulFetch.mockResolvedValue(mockResponse as any);
 
@@ -1628,21 +1625,18 @@ describe('RewardsDataService', () => {
       // Assert
       expect(result).toBe(mockLocation);
       expect(mockSuccessfulFetch).toHaveBeenCalledWith(
-        'https://on-ramp.dev-api.cx.metamask.io/geolocation',
+        'https://on-ramp.api.cx.metamask.io/geolocation',
       );
     });
 
-    it('should successfully fetch geolocation in PROD environment', async () => {
+    it('should always use PROD geolocation URL regardless of environment', async () => {
       // Arrange
-      const mockLocation = 'US';
+      const mockLocation = 'UK';
       const mockResponse = {
         ok: true,
         text: jest.fn().mockResolvedValue(mockLocation),
       };
 
-      // Mock AppConstants to use PROD environment
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (AppConstants as any).IS_DEV = false;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       mockSuccessfulFetch.mockResolvedValue(mockResponse as any);
 
@@ -1651,6 +1645,7 @@ describe('RewardsDataService', () => {
 
       // Assert
       expect(result).toBe(mockLocation);
+      // Always uses PROD URL, not DEV
       expect(mockSuccessfulFetch).toHaveBeenCalledWith(
         'https://on-ramp.api.cx.metamask.io/geolocation',
       );

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.ts
@@ -1,6 +1,5 @@
 import type { RestrictedMessenger } from '@metamask/base-controller';
 import { getVersion } from 'react-native-device-info';
-import AppConstants from '../../../../AppConstants';
 import type {
   LoginResponseDto,
   EstimatePointsDto,
@@ -642,8 +641,7 @@ export class RewardsDataService {
     let location = 'UNKNOWN';
 
     try {
-      const environment = AppConstants.IS_DEV ? 'DEV' : 'PROD';
-      const response = await successfulFetch(GEOLOCATION_URLS[environment]);
+      const response = await successfulFetch(GEOLOCATION_URLS.PROD);
 
       if (!response.ok) {
         return location;


### PR DESCRIPTION
## **Description**

When you reinstalled the app and reimported an SRP where the first account/group was tied to the rewards program, you wouldn't see the rewards gtm modal as its logic wouldn't trigger. In the same session, when switching to an account that wasn't tied to the rewards program yet, the gtm modal would trigger a navigation to the onboarding/gtm modal but then we'd detect that there was opted in for another/other accounts (i.e. primary) and the rewards dashboard would be seen.

To prevent this, in the logic that spawns the gtm modal, as soon as we detect a `subscriptionId`, we set the gtm modal seen storage prop to true, preventing it to be spawned/navigated to when changing an account that had no `subscriptionId`.

Minor extra fix; as we're moving ahead with prod readiness, we are switching the geo check URI to prod.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/21252

## **Manual testing steps**

1. Reinstall app
2. import existing SRP where primary account (first) is already opted in to rewards program but second/other accounts not
3. the primary view/wallet view will load and no gtm modal should open
4. switch to an account that is not tied to the rewards program.
5. Before this fix, you would've been redirected to the rewards program. With this fix, nothing should happen.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Marks the rewards intro modal as seen when a subscription exists and on intro step mount to prevent unwanted navigation, simplifies the intro modal, and forces the geolocation service to use the PROD URL; tests updated accordingly.
> 
> - **Rewards Onboarding**:
>   - Move `REWARDS_GTM_MODAL_SHOWN` persistence to `OnboardingIntroStep` (set on mount) and simplify `RewardsIntroModal` to be presentational only.
>   - In `useRewardsIntroModal`, if `subscriptionId` exists, set `REWARDS_GTM_MODAL_SHOWN` to `true` and skip navigation.
>   - Minor robustness: swallow errors in `RewardsController:isOptInSupported` check.
> - **Services**:
>   - `RewardsDataService.fetchGeoLocation` now always uses `GEOLOCATION_URLS.PROD`.
> - **Tests**:
>   - Update/relocate storage expectations to `OnboardingIntroStep` and `useRewardsIntroModal`.
>   - Adjust geolocation tests to expect PROD URL irrespective of environment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63407ddceb0afe78ec2d3623b895644d076e64d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->