### PR TITLE
feat(MultichainAccountsConnectedList): do not redirect to main page after account selection

### DIFF
--- a/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/MultichainAccountsConnectedList.test.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/MultichainAccountsConnectedList.test.tsx
@@ -15,7 +15,6 @@ import {
 } from '../../../../component-library/components-temp/MultichainAccounts/test-utils';
 import { ToastContext } from '../../../../component-library/components/Toast/Toast.context';
 import { ToastVariants } from '../../../../component-library/components/Toast/Toast.types';
-import Routes from '../../../../constants/navigation/Routes';
 
 const mockSetSelectedAccountGroup = jest.fn();
 jest.mock('../../../../core/Engine', () => ({
@@ -482,7 +481,7 @@ describe('MultichainAccountsConnectedList', () => {
       });
     });
 
-    it('navigates to browser home after showing toast', () => {
+    it('shows toast when account is selected without navigation', () => {
       // Given a connected account
       const { getByText } = renderMultichainAccountsConnectedList();
 
@@ -490,9 +489,9 @@ describe('MultichainAccountsConnectedList', () => {
       const accountCell = getByText('Account 1');
       fireEvent.press(accountCell);
 
-      // Then should navigate to browser home
-      expect(mockNavigate).toHaveBeenCalledTimes(1);
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.BROWSER.HOME);
+      // Then should show toast but not navigate
+      expect(mockShowToast).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/MultichainAccountsConnectedList.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/MultichainAccountsConnectedList.tsx
@@ -31,8 +31,6 @@ import { ToastVariants } from '../../../../component-library/components/Toast/To
 import { selectAvatarAccountType } from '../../../../selectors/settings';
 import { RootState } from '../../../../reducers';
 import { selectIconSeedAddressesByAccountGroupIds } from '../../../../selectors/multichainAccounts/accounts';
-import Routes from '../../../../constants/navigation/Routes';
-import { useNavigation } from '@react-navigation/native';
 
 const MultichainAccountsConnectedList = ({
   privacyMode,
@@ -49,7 +47,6 @@ const MultichainAccountsConnectedList = ({
   });
   const { toastRef } = useContext(ToastContext);
   const accountAvatarType = useSelector(selectAvatarAccountType);
-  const navigation = useNavigation();
 
   const selectedAccountGroup = useSelector(selectSelectedAccountGroup);
   const accountGroups = useSelector(selectAccountGroups);
@@ -86,9 +83,8 @@ const MultichainAccountsConnectedList = ({
         accountAvatarType,
         hasNoTimeout: false,
       });
-      navigation.navigate(Routes.BROWSER.HOME);
     },
-    [navigation, iconSeedAddresses, accountAvatarType, toastRef, accountGroups],
+    [iconSeedAddresses, accountAvatarType, toastRef, accountGroups],
   );
 
   const renderItem = useCallback(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR removes redirect from accounts selection on MultichainAccountsConnectedList. After this change user can switch accounts on MultichainAccountsConnectedList, but needs to click "Connect" button on the footer, for the request to be finishes and sent back to dapp.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug that was causing dapp connection to fail when switching between accounts during the connect request

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/21061

## **Manual testing steps**

```gherkin
Feature: Switch accounts during dapp connection

  Scenario: user changes account during dapp connection
    Given user has more than one accounts and initiated dapp connection

    When user clicks account cell to switch accounts
    Then the connect request is not closed yet, user needs to click "Connect" button
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/b97f61ea-c620-4018-b488-ee0b34d1679e


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Selecting an account now shows the activation toast without navigating away from the connected accounts list.
> 
> - **UI/Behavior**:
>   - `MultichainAccountsConnectedList.tsx`: Remove navigation to `Routes.BROWSER.HOME` from `handleSelectAccount`; keep toast display; drop `useNavigation`/`Routes` imports.
> - **Tests**:
>   - `MultichainAccountsConnectedList.test.tsx`: Update expectations to assert toast shown and no navigation; adjust test name and remove `Routes` usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a48d076222b26d8e3ed15c18a17a2a9905d497d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->