### PR TITLE
fix: cp-7.57.0 unknown geo prevent reward onboarding

### DIFF
--- a/app/components/UI/Rewards/components/Onboarding/OnboardingIntroStep.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/OnboardingIntroStep.tsx
@@ -127,7 +127,6 @@ const OnboardingIntroStep: React.FC<{
           label: strings('rewards.onboarding.not_supported_confirm_retry'),
           onPress: () => {
             onRetry();
-            navigation.goBack();
           },
           variant: ButtonVariant.Primary,
         },

--- a/app/components/UI/Rewards/hooks/useGeoRewardsMetadata.ts
+++ b/app/components/UI/Rewards/hooks/useGeoRewardsMetadata.ts
@@ -47,6 +47,7 @@ export const useGeoRewardsMetadata = ({
 
       dispatch(setGeoRewardsMetadata(metadata));
     } catch (err) {
+      dispatch(setGeoRewardsMetadata(null));
       dispatch(setGeoRewardsMetadataError(true));
     } finally {
       isLoadingRef.current = false;

--- a/app/components/UI/Rewards/hooks/useGeoRewardsMetadata.ts
+++ b/app/components/UI/Rewards/hooks/useGeoRewardsMetadata.ts
@@ -46,7 +46,7 @@ export const useGeoRewardsMetadata = ({
       );
 
       dispatch(setGeoRewardsMetadata(metadata));
-    } catch (err) {
+    } catch {
       dispatch(setGeoRewardsMetadata(null));
       dispatch(setGeoRewardsMetadataError(true));
     } finally {

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -2000,6 +2000,10 @@ export class RewardsController extends BaseController<
         'RewardsDataService:fetchGeoLocation',
       );
 
+      if (geoLocation === 'UNKNOWN') {
+        throw new Error('Failed to fetch geo location, got default UNKNOWN');
+      }
+
       // Check if the location is supported (not in blocked regions)
       const optinAllowedForGeo = !DEFAULT_BLOCKED_REGIONS.some(
         (blockedRegion) => geoLocation.startsWith(blockedRegion),
@@ -2018,12 +2022,7 @@ export class RewardsController extends BaseController<
         'RewardsController: Failed to get geo rewards metadata:',
         error instanceof Error ? error.message : String(error),
       );
-
-      // Return fallback metadata on error
-      return {
-        geoLocation: 'UNKNOWN',
-        optinAllowedForGeo: true,
-      };
+      throw error;
     }
   }
 


### PR DESCRIPTION
## **Description**

If for some reason our geo location API check fails, we allowed rewards onboarding before this change. This change correctly blocks onboarding and gives users the ability to recheck.

## **Changelog**

CHANGELOG entry: null

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Blocks onboarding when geo check fails/unknown with a retry modal; refines geo metadata hook and controller error handling; adds focused tests.
> 
> - **UI (Onboarding)**:
>   - Show retry error modal on geo check failure with retry and cancel flows in `OnboardingIntroStep`.
>   - Adjust confirm action behavior in retry modal.
> - **Hook**:
>   - Update `useGeoRewardsMetadata` to set `metadata=null` on error, manage `error/loading` flags, and support `enabled=false` (clears state and skips fetch) with transitions.
> - **Controller**:
>   - In `RewardsController#getGeoRewardsMetadata`, treat `geoLocation==='UNKNOWN'` and data service failures as errors (rethrow) instead of returning fallback.
> - **Tests**:
>   - Add comprehensive tests for geo error retry UX in onboarding.
>   - Expand `useGeoRewardsMetadata` tests for error paths and `enabled` behavior.
>   - Update controller tests to expect throws on UNKNOWN/geo service failures and non-Error cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2181e5bf32ce7b5f7b798b54f6ae5c57f7c92ce3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->