### PR TITLE
fix: cp-7.58.0 metamask pay transaction failures

### DIFF
--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.test.tsx
@@ -102,11 +102,11 @@ describe('TransactionDetailsSummary', () => {
           destAsset: {
             symbol: SYMBOL_2_MOCK,
           },
+          destChainId: Number(TARGET_CHAIN_ID_MOCK),
         },
         status: {
           status: StatusTypes.COMPLETE,
           destChain: {
-            chainId: Number(TARGET_CHAIN_ID_MOCK),
             txHash: RECEIVE_HASH_MOCK,
           },
         },

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.test.tsx
@@ -217,7 +217,9 @@ describe('TransactionDetailsSummary', () => {
   it('renders bridge line alternate title if symbols loading', () => {
     useBridgeTxHistoryDataMock.mockReturnValue({
       bridgeTxHistoryItem: {
-        quote: {},
+        quote: {
+          destChainId: Number(TARGET_CHAIN_ID_MOCK),
+        },
         status: {
           status: StatusTypes.COMPLETE,
         },
@@ -231,7 +233,15 @@ describe('TransactionDetailsSummary', () => {
     });
 
     expect(
-      getByText(strings('transaction_details.summary_title.bridge_loading')),
+      getByText(
+        strings('transaction_details.summary_title.bridge_send_loading'),
+      ),
+    ).toBeDefined();
+
+    expect(
+      getByText(
+        strings('transaction_details.summary_title.bridge_receive_loading'),
+      ),
     ).toBeDefined();
   });
 

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.tsx
@@ -102,7 +102,7 @@ function TransactionSummary({
     bridgeHistory?.bridgeTxHistoryItem?.completionTime ?? time;
 
   const receiveChainIdNumber =
-    bridgeHistory?.bridgeTxHistoryItem?.status?.destChain?.chainId;
+    bridgeHistory?.bridgeTxHistoryItem?.quote?.destChainId;
 
   const receiveChainId = receiveChainIdNumber
     ? toHex(receiveChainIdNumber)

--- a/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-summary/transaction-details-summary.tsx
@@ -282,7 +282,7 @@ function getLineTitle(
           targetSymbol,
           targetChain: networkName,
         })
-      : strings('transaction_details.summary_title.bridge_loading');
+      : strings('transaction_details.summary_title.bridge_receive_loading');
   }
 
   switch (type) {
@@ -292,7 +292,7 @@ function getLineTitle(
             sourceSymbol,
             sourceChain: networkName,
           })
-        : strings('transaction_details.summary_title.bridge_loading');
+        : strings('transaction_details.summary_title.bridge_send_loading');
     case TransactionType.bridgeApproval:
       return approveSymbol
         ? strings('transaction_details.summary_title.bridge_approval', {

--- a/app/core/Engine/messengers/transaction-controller-messenger/transaction-controller-messenger.ts
+++ b/app/core/Engine/messengers/transaction-controller-messenger/transaction-controller-messenger.ts
@@ -12,7 +12,9 @@ import {
   NetworkControllerStateChangeEvent,
 } from '@metamask/network-controller';
 import {
+  TransactionControllerGetStateAction,
   TransactionControllerMessenger,
+  TransactionControllerStateChangeEvent,
   TransactionControllerTransactionApprovedEvent,
   TransactionControllerTransactionConfirmedEvent,
   TransactionControllerTransactionDroppedEvent,
@@ -46,10 +48,12 @@ type MessengerActions =
   | KeyringControllerSignTypedMessageAction
   | NetworkControllerGetEIP1559CompatibilityAction
   | NetworkControllerGetNetworkClientByIdAction
-  | RemoteFeatureFlagControllerGetStateAction;
+  | RemoteFeatureFlagControllerGetStateAction
+  | TransactionControllerGetStateAction;
 
 type MessengerEvents =
   | BridgeStatusControllerEvents
+  | TransactionControllerStateChangeEvent
   | TransactionControllerTransactionApprovedEvent
   | TransactionControllerTransactionConfirmedEvent
   | TransactionControllerTransactionDroppedEvent
@@ -90,6 +94,7 @@ export function getTransactionControllerInitMessenger(
     name: 'TransactionControllerInit',
     allowedEvents: [
       'BridgeStatusController:stateChange',
+      'TransactionController:stateChange',
       'TransactionController:transactionApproved',
       'TransactionController:transactionConfirmed',
       'TransactionController:transactionDropped',
@@ -105,11 +110,13 @@ export function getTransactionControllerInitMessenger(
       'ApprovalController:endFlow',
       'ApprovalController:startFlow',
       'ApprovalController:updateRequestState',
+      'BridgeStatusController:getState',
       'BridgeStatusController:submitTx',
       'DelegationController:signDelegation',
       'NetworkController:getEIP1559Compatibility',
       'KeyringController:signEip7702Authorization',
       'KeyringController:signTypedMessage',
+      'TransactionController:getState',
     ],
   });
 }

--- a/app/util/transactions/hooks/pay-hook.ts
+++ b/app/util/transactions/hooks/pay-hook.ts
@@ -2,16 +2,13 @@ import {
   PublishHook,
   PublishHookResult,
   TransactionMeta,
+  TransactionStatus,
 } from '@metamask/transaction-controller';
 import { Hex, createProjectLogger } from '@metamask/utils';
 import { StatusTypes } from '@metamask/bridge-controller';
-import {
-  BridgeHistoryItem,
-  BridgeStatusControllerEvents,
-} from '@metamask/bridge-status-controller';
+import { BridgeHistoryItem } from '@metamask/bridge-status-controller';
 import { TransactionControllerInitMessenger } from '../../../core/Engine/messengers/transaction-controller-messenger';
 import { store } from '../../../store';
-import { ExtractEventHandler } from '@metamask/base-controller';
 import {
   TransactionBridgeQuote,
   refreshQuote,
@@ -115,16 +112,20 @@ export class PayHook {
       sourceChainId,
     );
 
+    const requiredTransactionIds: string[] = [];
+
     const bridgeTransactionIdCollector = this.#collectTransactionIds(
       sourceChainId,
       from,
+      (id) => {
+        requiredTransactionIds.push(id);
 
-      (id) =>
         updateRequiredTransactionIds({
           transactionId,
           requiredTransactionIds: [id],
           append: true,
-        }),
+        });
+      },
     );
 
     const result = await this.#messenger.call(
@@ -136,7 +137,18 @@ export class PayHook {
 
     bridgeTransactionIdCollector.end();
 
-    log('Bridge transaction submitted', result);
+    log('Bridge transaction submitted', {
+      requiredTransactionIds,
+      result,
+    });
+
+    await Promise.all(
+      requiredTransactionIds.map((id) =>
+        this.#waitForTransactionCompletion(id),
+      ),
+    );
+
+    log('All required transactions confirmed', requiredTransactionIds);
 
     const { id: bridgeTransactionId } = result;
 
@@ -145,37 +157,100 @@ export class PayHook {
     await this.#waitForBridgeCompletion(bridgeTransactionId);
   }
 
+  async #waitForTransactionCompletion(transactionId: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const isConfirmed = (tx?: TransactionMeta, fn?: () => void) => {
+        log('Checking transaction status', tx?.status, tx?.type);
+
+        if (tx?.status === TransactionStatus.confirmed) {
+          fn?.();
+          resolve();
+          return true;
+        }
+
+        if (
+          [TransactionStatus.dropped, TransactionStatus.failed].includes(
+            tx?.status as TransactionStatus,
+          )
+        ) {
+          fn?.();
+          reject(
+            new Error(
+              `Required transaction failed - ${tx?.type} - ${tx?.error?.message}`,
+            ),
+          );
+          return true;
+        }
+      };
+
+      const initialState = this.#messenger.call(
+        'TransactionController:getState',
+      );
+
+      const initialTx = initialState.transactions.find(
+        (t) => t.id === transactionId,
+      );
+
+      if (isConfirmed(initialTx)) {
+        return;
+      }
+
+      const handler = (tx?: TransactionMeta) => {
+        const unsubscribe = () =>
+          this.#messenger.unsubscribe(
+            'TransactionController:stateChange',
+            handler,
+          );
+
+        isConfirmed(tx, unsubscribe);
+      };
+
+      this.#messenger.subscribe(
+        'TransactionController:stateChange',
+        handler,
+        (state) => state.transactions.find((tx) => tx.id === transactionId),
+      );
+    });
+  }
+
   async #waitForBridgeCompletion(transactionId: string): Promise<void> {
     return new Promise((resolve, reject) => {
-      const handler = (bridgeHistory: BridgeHistoryItem) => {
+      const isComplete = (item?: BridgeHistoryItem, fn?: () => void) => {
+        const status = item?.status?.status;
+
+        log('Checking bridge status', status ?? 'missing');
+
+        if (status === StatusTypes.COMPLETE) {
+          fn?.();
+          resolve();
+          return true;
+        }
+
+        if (status === StatusTypes.FAILED) {
+          fn?.();
+          reject(new Error('Bridge failed'));
+          return true;
+        }
+      };
+
+      const initialState = this.#messenger.call(
+        'BridgeStatusController:getState',
+      );
+
+      const initialTx = initialState.txHistory[transactionId];
+
+      if (isComplete(initialTx)) {
+        return;
+      }
+
+      const handler = (bridgeHistory?: BridgeHistoryItem) => {
         const unsubscribe = () =>
           this.#messenger.unsubscribe(
             'BridgeStatusController:stateChange',
-            handler as unknown as ExtractEventHandler<
-              BridgeStatusControllerEvents,
-              'BridgeStatusController:stateChange'
-            >,
+            handler,
           );
 
-        try {
-          const status = bridgeHistory?.status?.status;
-
-          log('Checking bridge status', status);
-
-          if (status === StatusTypes.COMPLETE) {
-            unsubscribe();
-            resolve();
-          }
-
-          if (status === StatusTypes.FAILED) {
-            unsubscribe();
-            reject(new Error('Bridge transaction failed'));
-          }
-        } catch (error) {
-          log('Error checking bridge status', error);
-          unsubscribe();
-          reject(error);
-        }
+        isComplete(bridgeHistory, unsubscribe);
       };
 
       this.#messenger.subscribe(

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6206,9 +6206,10 @@
     "summary_title": {
       "bridge_approval": "Approve {{approveSymbol}}",
       "bridge_approval_loading": "Approve",
-      "bridge_loading": "Bridge",
       "bridge_send": "Bridge {{sourceSymbol}} from {{sourceChain}}",
+      "bridge_send_loading": "Bridge Send",
       "bridge_receive": "Receive {{targetSymbol}} on {{targetChain}}",
+      "bridge_receive_loading": "Bridge Receive",
       "default": "Transaction",
       "perps_deposit": "Add funds",
       "predict_deposit": "Add funds",


### PR DESCRIPTION
## **Description**

Explicitly wait for confirmation of all required transactions when bridging funds for MetaMask Pay.

Fix display of bridge receive line in transaction details summary.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Waits for and validates required bridge-related transactions, fixes target chain resolution and loading titles in the transaction details summary, and updates messenger, i18n, and tests accordingly.
> 
> - **MetaMask Pay / Bridge flow**:
>   - Waits for all required transactions to confirm via `TransactionController:stateChange`; rejects on dropped/failed with error context.
>   - Queries initial states using `TransactionController:getState` and `BridgeStatusController:getState` before subscribing.
>   - Logs collected required tx IDs and ensures bridge completion; error text adjusted to `Bridge failed`.
> - **Messenger**:
>   - Adds `TransactionController:getState` action and `TransactionController:stateChange` event to `TransactionControllerInit`.
>   - Allows `BridgeStatusController:getState` action.
> - **Transaction details summary (UI)**:
>   - Derives receive chain from `quote.destChainId` (not `status.destChain.chainId`).
>   - Splits loading titles: `bridge_send_loading` and `bridge_receive_loading`.
> - **i18n**:
>   - Adds `transaction_details.summary_title.bridge_send_loading` and `...bridge_receive_loading` keys.
> - **Tests**:
>   - Update PayHook tests to simulate transaction state changes and failures.
>   - Adjust transaction summary tests for new loading titles and receive chain handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7b9f7da809825f70f63c8d77250f9236a539e6f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->