### PR TITLE
fix: Swaps incorrect token icon

### DIFF
--- a/app/components/UI/Bridge/components/BridgeDestTokenSelector/BridgeDestTokenSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeDestTokenSelector/BridgeDestTokenSelector.test.tsx
@@ -371,7 +371,7 @@ describe('BridgeDestTokenSelector', () => {
             balanceFiat: '$200000',
             chainId: '0x1',
             decimals: 18,
-            image: 'https://token2.com/logo.png',
+            image: `https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/${ethToken2Address.toLowerCase()}.png`,
             name: 'Hello Token',
             symbol: 'HELLO',
             tokenFiatAmount: 200000,

--- a/app/components/UI/Bridge/components/BridgeDestTokenSelector/__snapshots__/BridgeDestTokenSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeDestTokenSelector/__snapshots__/BridgeDestTokenSelector.test.tsx.snap
@@ -895,7 +895,7 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                                     "balanceFiat": "$200000",
                                     "chainId": "0x1",
                                     "decimals": 18,
-                                    "image": "https://token2.com/logo.png",
+                                    "image": "https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0x0000000000000000000000000000000000000002.png",
                                     "name": "Hello Token",
                                     "symbol": "HELLO",
                                     "tokenFiatAmount": 200000,
@@ -907,7 +907,7 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                                     "balanceFiat": "$20000",
                                     "chainId": "0x1",
                                     "decimals": 18,
-                                    "image": "https://token1.com/logo.png",
+                                    "image": "https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0x0000000000000000000000000000000000000001.png",
                                     "name": "Token One",
                                     "symbol": "TOKEN1",
                                     "tokenFiatAmount": 20000,
@@ -919,7 +919,7 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                                     "balanceFiat": "$6000",
                                     "chainId": "0x1",
                                     "decimals": 18,
-                                    "image": "",
+                                    "image": "https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/slip44/60.png",
                                     "name": "Ethereum",
                                     "symbol": "ETH",
                                     "tokenFiatAmount": 6000,
@@ -1036,7 +1036,7 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                                                 resizeMode="contain"
                                                 source={
                                                   {
-                                                    "uri": "https://token2.com/logo.png",
+                                                    "uri": "https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0x0000000000000000000000000000000000000002.png",
                                                   }
                                                 }
                                                 style={
@@ -1347,7 +1347,7 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                                                 resizeMode="contain"
                                                 source={
                                                   {
-                                                    "uri": "https://token1.com/logo.png",
+                                                    "uri": "https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0x0000000000000000000000000000000000000001.png",
                                                   }
                                                 }
                                                 style={

--- a/app/components/UI/Bridge/components/BridgeSourceTokenSelector/BridgeSourceTokenSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeSourceTokenSelector/BridgeSourceTokenSelector.test.tsx
@@ -136,12 +136,14 @@ describe('BridgeSourceTokenSelector', () => {
 
     // Assert - check that actions were called
     expect(setSourceToken).toHaveBeenCalledWith({
+      accountType: undefined,
       address: '0x0000000000000000000000000000000000000001',
       balance: '1.0',
       balanceFiat: '$20000',
       chainId: '0x1',
       decimals: 18,
-      image: 'https://token1.com/logo.png',
+      image:
+        'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0x0000000000000000000000000000000000000001.png',
       name: 'Token One',
       symbol: 'TOKEN1',
       tokenFiatAmount: 20000,

--- a/app/components/UI/Bridge/components/BridgeSourceTokenSelector/__snapshots__/BridgeSourceTokenSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeSourceTokenSelector/__snapshots__/BridgeSourceTokenSelector.test.tsx.snap
@@ -900,7 +900,7 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                     "balanceFiat": "$200000",
                                     "chainId": "0x1",
                                     "decimals": 18,
-                                    "image": "https://token2.com/logo.png",
+                                    "image": "https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0x0000000000000000000000000000000000000002.png",
                                     "name": "Hello Token",
                                     "symbol": "HELLO",
                                     "tokenFiatAmount": 200000,
@@ -912,7 +912,7 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                     "balanceFiat": "$80000",
                                     "chainId": "0xa",
                                     "decimals": 18,
-                                    "image": "https://token3.com/logo.png",
+                                    "image": "https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/10/erc20/0x0000000000000000000000000000000000000003.png",
                                     "name": "Foo Token",
                                     "symbol": "FOO",
                                     "tokenFiatAmount": 80000,
@@ -924,7 +924,7 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                     "balanceFiat": "$40000",
                                     "chainId": "0xa",
                                     "decimals": 18,
-                                    "image": "",
+                                    "image": "https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/10/slip44/60.png",
                                     "name": "Ethereum",
                                     "symbol": "ETH",
                                     "tokenFiatAmount": 40000,
@@ -936,7 +936,7 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                     "balanceFiat": "20000.456 USD",
                                     "chainId": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
                                     "decimals": 6,
-                                    "image": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v/logo.png",
+                                    "image": "https://static.cx.metamask.io/api/v2/tokenIcons/assets/solana/5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v.png",
                                     "name": "USD Coin",
                                     "symbol": "USDC",
                                     "tokenFiatAmount": 20000.456,
@@ -948,7 +948,7 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                     "balanceFiat": "$20000",
                                     "chainId": "0x1",
                                     "decimals": 18,
-                                    "image": "https://token1.com/logo.png",
+                                    "image": "https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0x0000000000000000000000000000000000000001.png",
                                     "name": "Token One",
                                     "symbol": "TOKEN1",
                                     "tokenFiatAmount": 20000,
@@ -960,7 +960,7 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                     "balanceFiat": "10012.3 USD",
                                     "chainId": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
                                     "decimals": 9,
-                                    "image": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v/logo.png",
+                                    "image": "https://static.cx.metamask.io/api/v2/tokenIcons/assets/solana/5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44/501.png",
                                     "name": "Solana",
                                     "symbol": "SOL",
                                     "tokenFiatAmount": 10012.3,
@@ -972,7 +972,7 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                     "balanceFiat": "$6000",
                                     "chainId": "0x1",
                                     "decimals": 18,
-                                    "image": "",
+                                    "image": "https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/slip44/60.png",
                                     "name": "Ethereum",
                                     "symbol": "ETH",
                                     "tokenFiatAmount": 6000,
@@ -984,7 +984,7 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                     "balanceFiat": "1500 USD",
                                     "chainId": "bip122:000000000019d6689c085ae165831e93",
                                     "decimals": 8,
-                                    "image": "btcIconUrl",
+                                    "image": "https://static.cx.metamask.io/api/v2/tokenIcons/assets/bip122/000000000019d6689c085ae165831e93/slip44/0.png",
                                     "name": "Bitcoin",
                                     "symbol": "BTC",
                                     "tokenFiatAmount": 1500,
@@ -1101,7 +1101,7 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                                 resizeMode="contain"
                                                 source={
                                                   {
-                                                    "uri": "https://token2.com/logo.png",
+                                                    "uri": "https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0x0000000000000000000000000000000000000002.png",
                                                   }
                                                 }
                                                 style={
@@ -1378,7 +1378,7 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                                 resizeMode="contain"
                                                 source={
                                                   {
-                                                    "uri": "https://token3.com/logo.png",
+                                                    "uri": "https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/10/erc20/0x0000000000000000000000000000000000000003.png",
                                                   }
                                                 }
                                                 style={
@@ -1962,7 +1962,7 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                                 resizeMode="contain"
                                                 source={
                                                   {
-                                                    "uri": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v/logo.png",
+                                                    "uri": "https://static.cx.metamask.io/api/v2/tokenIcons/assets/solana/5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v.png",
                                                   }
                                                 }
                                                 style={
@@ -2239,7 +2239,7 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                                 resizeMode="contain"
                                                 source={
                                                   {
-                                                    "uri": "https://token1.com/logo.png",
+                                                    "uri": "https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0x0000000000000000000000000000000000000001.png",
                                                   }
                                                 }
                                                 style={
@@ -2516,7 +2516,7 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                                 resizeMode="contain"
                                                 source={
                                                   {
-                                                    "uri": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v/logo.png",
+                                                    "uri": "https://static.cx.metamask.io/api/v2/tokenIcons/assets/solana/5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44/501.png",
                                                   }
                                                 }
                                                 style={
@@ -3100,7 +3100,7 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                                                 resizeMode="contain"
                                                 source={
                                                   {
-                                                    "uri": "btcIconUrl",
+                                                    "uri": "https://static.cx.metamask.io/api/v2/tokenIcons/assets/bip122/000000000019d6689c085ae165831e93/slip44/0.png",
                                                   }
                                                 }
                                                 style={

--- a/app/components/UI/Bridge/hooks/useTokensWithBalance/index.ts
+++ b/app/components/UI/Bridge/hooks/useTokensWithBalance/index.ts
@@ -25,6 +25,7 @@ import { toChecksumAddress } from '../../../../../util/address';
 import { selectSelectedAccountGroupInternalAccounts } from '../../../../../selectors/multichainAccounts/accountTreeController';
 import { EthScope } from '@metamask/keyring-api';
 import { useNonEvmTokensWithBalance } from '../useNonEvmTokensWithBalance';
+import { getTokenIconUrl } from '../../utils';
 
 interface CalculateFiatBalancesParams {
   assets: TokenI[];
@@ -219,7 +220,11 @@ export const useTokensWithBalance: ({
           decimals: token.decimals,
           symbol: token.isETH ? 'ETH' : token.symbol, // TODO: not sure why symbol is ETHEREUM, will also break the token icon for ETH
           chainId: token.chainId as Hex | CaipChainId,
-          image: token.image,
+          image:
+            getTokenIconUrl(
+              token.address,
+              token.chainId as Hex | CaipChainId,
+            ) || token.image,
           tokenFiatAmount: evmTokenFiatAmount ?? nonEvmTokenFiatAmount,
           balance: evmBalance ?? nonEvmBalance,
           balanceFiat: evmBalanceFiat ?? nonEvmBalanceFiat,

--- a/app/components/UI/Bridge/hooks/useTopTokens/index.ts
+++ b/app/components/UI/Bridge/hooks/useTopTokens/index.ts
@@ -25,6 +25,7 @@ import { memoize } from 'lodash';
 import { selectERC20TokensByChain } from '../../../../../selectors/tokenListController';
 import { Asset, TokenListToken } from '@metamask/assets-controllers';
 import packageJSON from '../../../../../../package.json';
+import { getTokenIconUrl } from '../../utils';
 
 const { version: clientVersion } = packageJSON;
 const MAX_TOP_TOKENS = 30;
@@ -75,7 +76,7 @@ const formatCachedTokenListControllerTokens = (
       address: tokenAddress,
       symbol: token.symbol,
       name: token.name,
-      image: token.iconUrl || '',
+      image: getTokenIconUrl(tokenAddress, chainId) || token.iconUrl || '',
       decimals: token.decimals,
       chainId: isNonEvmChainId(caipChainId) ? caipChainId : hexChainId,
       accountType: getAccountType(caipChainId),

--- a/app/components/UI/Bridge/hooks/useTopTokens/useTopTokens.test.ts
+++ b/app/components/UI/Bridge/hooks/useTopTokens/useTopTokens.test.ts
@@ -28,7 +28,7 @@ describe('useTopTokens', () => {
     address: ethToken1Address,
     symbol: 'TOKEN1',
     name: 'Token One',
-    image: 'https://token1.com/logo.png',
+    image: `https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/${ethToken1Address.toLowerCase()}.png`,
     decimals: 18,
     chainId: ethChainId,
   };
@@ -37,7 +37,7 @@ describe('useTopTokens', () => {
     address: ethToken2Address,
     symbol: 'HELLO',
     name: 'Hello Token',
-    image: 'https://token2.com/logo.png',
+    image: `https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/${ethToken2Address.toLowerCase()}.png`,
     decimals: 18,
     chainId: ethChainId,
   };

--- a/app/components/UI/Bridge/utils/index.test.ts
+++ b/app/components/UI/Bridge/utils/index.test.ts
@@ -1,5 +1,5 @@
 import '../_mocks_/initialState';
-import { isBridgeAllowed, wipeBridgeStatus } from './index';
+import { isBridgeAllowed, wipeBridgeStatus, getTokenIconUrl } from './index';
 import AppConstants from '../../../../core/AppConstants';
 import {
   ARBITRUM_CHAIN_ID,
@@ -121,6 +121,84 @@ describe('Bridge Utils', () => {
         address: testAddress,
         ignoreNetwork: false,
       });
+    });
+  });
+
+  describe('getTokenIconUrl', () => {
+    it('should return token icon URL for native token on Ethereum', () => {
+      // Arrange
+      const nativeTokenAddress = '0x0000000000000000000000000000000000000000';
+
+      // Act
+      const result = getTokenIconUrl(nativeTokenAddress, ETH_CHAIN_ID);
+
+      // Assert
+      expect(result).toBe(
+        'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/slip44/60.png',
+      );
+    });
+
+    it('should return token icon URL for ERC20 token on Ethereum', () => {
+      // Arrange
+      const usdcAddress = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+
+      // Act
+      const result = getTokenIconUrl(usdcAddress, ETH_CHAIN_ID);
+
+      // Assert
+      expect(result).toBe(
+        'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.png',
+      );
+    });
+
+    it('should return token icon URL for Solana native token', () => {
+      // Arrange
+      const solNativeAddress = '0x0000000000000000000000000000000000000000';
+
+      // Act
+      const result = getTokenIconUrl(solNativeAddress, SolScope.Mainnet);
+
+      // Assert
+      expect(result).toBe(
+        'https://static.cx.metamask.io/api/v2/tokenIcons/assets/solana/5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44/501.png',
+      );
+    });
+
+    it('should return token icon URL for Solana SPL token', () => {
+      // Arrange
+      const usdcSolanaAddress = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
+      // Act
+      const result = getTokenIconUrl(usdcSolanaAddress, SolScope.Mainnet);
+
+      // Assert
+      expect(result).toBe(
+        'https://static.cx.metamask.io/api/v2/tokenIcons/assets/solana/5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v.png',
+      );
+    });
+
+    it('should return undefined for invalid address', () => {
+      // Arrange
+      const invalidAddress = 'invalid';
+
+      // Act
+      const result = getTokenIconUrl(invalidAddress, ETH_CHAIN_ID);
+
+      // Assert
+      expect(result).toBeUndefined();
+    });
+
+    it('should return native token icon URL for empty address', () => {
+      // Arrange
+      const emptyAddress = '';
+
+      // Act
+      const result = getTokenIconUrl(emptyAddress, ETH_CHAIN_ID);
+
+      // Assert
+      expect(result).toBe(
+        'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/slip44/60.png',
+      );
     });
   });
 });

--- a/app/components/UI/Bridge/utils/index.ts
+++ b/app/components/UI/Bridge/utils/index.ts
@@ -14,7 +14,10 @@ import {
   SEI_CHAIN_ID,
 } from '@metamask/swaps-controller/dist/constants';
 import Engine from '../../../../core/Engine';
-import { isNonEvmChainId } from '@metamask/bridge-controller';
+import {
+  formatAddressToAssetId,
+  isNonEvmChainId,
+} from '@metamask/bridge-controller';
 
 const ALLOWED_CHAIN_IDS: (Hex | CaipChainId)[] = [
   ETH_CHAIN_ID,
@@ -54,4 +57,20 @@ export const wipeBridgeStatus = (
       ignoreNetwork: false,
     });
   }
+};
+
+export const getTokenIconUrl = (
+  address: string,
+  chainId: Hex | CaipChainId,
+) => {
+  const isEvmChain = !isNonEvmChainId(chainId);
+  const formattedAddress = isEvmChain ? address.toLowerCase() : address;
+
+  const assetId = formatAddressToAssetId(formattedAddress, chainId);
+  if (!assetId) {
+    return undefined;
+  }
+  return `https://static.cx.metamask.io/api/v2/tokenIcons/assets/${assetId
+    .split(':')
+    .join('/')}.png`;
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR migrates all tokens icons for Swaps to the static endpoint `https://static.cx.metamask.io/api/v2/tokenIcons/assets/...`.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3087

## **Manual testing steps**

```gherkin
Feature: Swaps token icons

  Scenario: user looking at swap tokens
    Given user is in Swaps

    When user opens token pickers
    Then icons are all there
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/86d57060-9b6e-4b47-a43b-c6eba9bbd720



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches bridge token images to static.cx CDN using a new getTokenIconUrl util and updates hooks/tests/snapshots accordingly.
> 
> - **Bridge UI/Logic**:
>   - Introduce `getTokenIconUrl(address, chainId)` in `app/components/UI/Bridge/utils/index.ts` to build static CDN token icon URLs (supports EVM, Solana, Bitcoin) using `formatAddressToAssetId`.
>   - Use CDN icons in hooks:
>     - `useTokensWithBalance`: set `image` via `getTokenIconUrl(...) || token.image`.
>     - `useTopTokens`: set `image` via `getTokenIconUrl(...) || token.iconUrl` for cached tokens.
> - **Tests**:
>   - Update expectations and snapshots to use CDN image URLs in
>     - `BridgeDestTokenSelector.test.tsx` (+ snapshot)
>     - `BridgeSourceTokenSelector.test.tsx` (+ snapshot)
>     - `useTopTokens.test.ts` (expected images)
>   - Add unit tests for `getTokenIconUrl` covering native/ERC20 (EVM), Solana native/SPL, invalid/empty addresses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 197ac6a7a3be5c02f36a1d78848f1868fd90478f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->