### PR TITLE
feat(predict): claim ux

### DIFF
--- a/app/components/UI/Predict/components/PredictPositions/PredictPositions.tsx
+++ b/app/components/UI/Predict/components/PredictPositions/PredictPositions.tsx
@@ -1,29 +1,31 @@
 import React, {
-  useCallback,
-  useRef,
   forwardRef,
+  useCallback,
   useImperativeHandle,
+  useRef,
 } from 'react';
 
+import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { NavigationProp, useNavigation } from '@react-navigation/native';
 import { FlashList, FlashListRef } from '@shopify/flash-list';
+import { ActivityIndicator, View } from 'react-native';
+import { strings } from '../../../../../../locales/i18n';
+import { IconColor } from '../../../../../component-library/components/Icons/Icon';
+import Routes from '../../../../../constants/navigation/Routes';
 import { usePredictPositions } from '../../hooks/usePredictPositions';
 import { PredictPosition as PredictPositionType } from '../../types';
-import PredictPosition from '../PredictPosition/PredictPosition';
-import { NavigationProp, useNavigation } from '@react-navigation/native';
 import { PredictNavigationParamList } from '../../types/navigation';
-import Routes from '../../../../../constants/navigation/Routes';
-import PredictPositionEmpty from '../PredictPositionEmpty';
 import PredictNewButton from '../PredictNewButton';
-import { ActivityIndicator, View } from 'react-native';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
-import { IconColor } from '../../../../../component-library/components/Icons/Icon';
-import { strings } from '../../../../../../locales/i18n';
+import PredictPosition from '../PredictPosition/PredictPosition';
+import PredictPositionEmpty from '../PredictPositionEmpty';
 import PredictPositionResolved from '../PredictPositionResolved/PredictPositionResolved';
 
 export interface PredictPositionsHandle {
   refresh: () => Promise<void>;
 }
+
+const AUTO_REFRESH_TIMEOUT = 10000;
 
 const PredictPositions = forwardRef<PredictPositionsHandle>((_props, ref) => {
   const tw = useTailwind();
@@ -33,6 +35,7 @@ const PredictPositions = forwardRef<PredictPositionsHandle>((_props, ref) => {
     usePredictPositions({
       loadOnMount: true,
       refreshOnFocus: true,
+      autoRefreshTimeout: AUTO_REFRESH_TIMEOUT,
     });
   const {
     positions: claimablePositions,
@@ -40,6 +43,8 @@ const PredictPositions = forwardRef<PredictPositionsHandle>((_props, ref) => {
   } = usePredictPositions({
     claimable: true,
     loadOnMount: true,
+    refreshOnFocus: true,
+    autoRefreshTimeout: AUTO_REFRESH_TIMEOUT,
   });
   const listRef = useRef<FlashListRef<PredictPositionType>>(null);
 

--- a/app/components/UI/Predict/components/PredictPositions/PredictPositions.tsx
+++ b/app/components/UI/Predict/components/PredictPositions/PredictPositions.tsx
@@ -25,8 +25,6 @@ export interface PredictPositionsHandle {
   refresh: () => Promise<void>;
 }
 
-const AUTO_REFRESH_TIMEOUT = 10000;
-
 const PredictPositions = forwardRef<PredictPositionsHandle>((_props, ref) => {
   const tw = useTailwind();
   const navigation =
@@ -35,7 +33,6 @@ const PredictPositions = forwardRef<PredictPositionsHandle>((_props, ref) => {
     usePredictPositions({
       loadOnMount: true,
       refreshOnFocus: true,
-      autoRefreshTimeout: AUTO_REFRESH_TIMEOUT,
     });
   const {
     positions: claimablePositions,
@@ -44,7 +41,6 @@ const PredictPositions = forwardRef<PredictPositionsHandle>((_props, ref) => {
     claimable: true,
     loadOnMount: true,
     refreshOnFocus: true,
-    autoRefreshTimeout: AUTO_REFRESH_TIMEOUT,
   });
   const listRef = useRef<FlashListRef<PredictPositionType>>(null);
 

--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.test.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.test.tsx
@@ -292,29 +292,6 @@ function setupMarketsWonCardTest(
   }
   mockBalanceResult.isLoading = props.isLoading ?? false;
 
-  // Configure claimable positions mock based on props and overrides
-  if (claimablePositionsOverrides.positions !== undefined) {
-    mockClaimablePositionsResult.positions =
-      claimablePositionsOverrides.positions as unknown as PredictPosition[];
-  } else {
-    mockClaimablePositionsResult.positions = props.totalClaimableAmount
-      ? ([
-          {
-            id: 'position-1',
-            status: 'won', // Note: This should match PredictPositionStatus.WON
-            cashPnl: props.totalClaimableAmount,
-            marketId: 'market-1',
-            tokenId: 'token-1',
-            outcome: 'Yes',
-            shares: '100',
-            avgPrice: 0.5,
-            currentValue: props.totalClaimableAmount,
-          },
-        ] as unknown as typeof mockClaimablePositionsResult.positions)
-      : [];
-  }
-  mockClaimablePositionsResult.isLoading = props.isLoading ?? false;
-
   // Mock the useUnrealizedPnL hook
   const mockUseUnrealizedPnL = useUnrealizedPnL as jest.MockedFunction<
     typeof useUnrealizedPnL
@@ -333,8 +310,40 @@ function setupMarketsWonCardTest(
   });
 
   const ref = React.createRef<{ refresh: () => Promise<void> }>();
+
+  // Build claimable positions for Redux state
+  const claimablePositions =
+    claimablePositionsOverrides.positions !== undefined
+      ? (claimablePositionsOverrides.positions as unknown as PredictPosition[])
+      : props.totalClaimableAmount
+      ? ([
+          {
+            id: 'position-1',
+            status: PredictPositionStatus.WON,
+            cashPnl: props.totalClaimableAmount,
+            marketId: 'market-1',
+            tokenId: 'token-1',
+            outcome: 'Yes',
+            shares: '100',
+            avgPrice: 0.5,
+            currentValue: props.totalClaimableAmount,
+          },
+        ] as unknown as PredictPosition[])
+      : [];
+
+  // Create Redux state
+  const state = {
+    engine: {
+      backgroundState: {
+        PredictController: {
+          claimablePositions,
+        },
+      },
+    },
+  };
+
   return {
-    ...renderWithProvider(<MarketsWonCard ref={ref} />),
+    ...renderWithProvider(<MarketsWonCard ref={ref} />, { state }),
     props,
     defaultProps,
     mockUseUnrealizedPnL,

--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
@@ -132,7 +132,7 @@ const PredictPositionsHeader = forwardRef<PredictPositionsHeaderHandle>(
     const shouldShowMainCard = hasAvailableBalance || hasUnrealizedPnL;
 
     const handleClaim = async () => {
-      await claim({ positions, providerId: POLYMARKET_PROVIDER_ID });
+      await claim();
     };
 
     if (

--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
@@ -61,11 +61,14 @@ const PredictPositionsHeader = forwardRef<PredictPositionsHeaderHandle>(
       refreshOnFocus: true,
     });
     const { status } = usePredictDeposit();
-    const { positions, isLoading: isClaimablePositionsLoading } =
-      usePredictPositions({
-        claimable: true,
-        loadOnMount: true,
-      });
+    const {
+      positions,
+      isLoading: isClaimablePositionsLoading,
+      loadPositions: loadClaimablePositions,
+    } = usePredictPositions({
+      claimable: true,
+      loadOnMount: true,
+    });
     const {
       unrealizedPnL,
       isLoading: isUnrealizedPnLLoading,
@@ -91,6 +94,7 @@ const PredictPositionsHeader = forwardRef<PredictPositionsHeaderHandle>(
         await Promise.all([
           loadUnrealizedPnL({ isRefresh: true }),
           loadBalance({ isRefresh: true }),
+          loadClaimablePositions({ isRefresh: true }),
         ]);
       },
     }));

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -797,181 +797,6 @@ describe('PredictController', () => {
     });
   });
 
-  describe('transaction event handlers', () => {
-    it('update claim transaction status to ERROR on transactionFailed', () => {
-      withController(({ controller, messenger }) => {
-        const txId = 'tx-failed';
-        const txData = '0xclaimdata';
-
-        // Set up claim transaction
-        controller.updateStateForTesting((state) => {
-          state.claimTransaction = {
-            transactionId: txId,
-            chainId: 1,
-            txParams: { to: '0xclaim', data: txData, value: '0x0' },
-            status: PredictClaimStatus.PENDING,
-          };
-        });
-
-        const event = {
-          transactionMeta: {
-            id: txId,
-            hash: '0xabc',
-            status: 'failed',
-            error: { message: 'Transaction failed' },
-            txParams: {
-              from: '0x1',
-              to: '0xclaim',
-              data: txData,
-              value: '0x0',
-            },
-          },
-        };
-
-        messenger.publish(
-          'TransactionController:transactionFailed',
-          // @ts-ignore
-          event,
-        );
-
-        // Verify the claim transaction was updated to ERROR
-        expect(controller.state.claimTransaction?.status).toBe(
-          PredictClaimStatus.ERROR,
-        );
-      });
-    });
-
-    it('update claim transaction status to CANCELLED on transactionRejected', () => {
-      withController(({ controller, messenger }) => {
-        const txId = 'tx-rejected';
-        const txData = '0xclaimdata';
-
-        // Set up claim transaction
-        controller.updateStateForTesting((state) => {
-          state.claimTransaction = {
-            transactionId: txId,
-            chainId: 1,
-            txParams: { to: '0xclaim', data: txData, value: '0x0' },
-            status: PredictClaimStatus.PENDING,
-          };
-        });
-
-        const event = {
-          transactionMeta: {
-            id: txId,
-            hash: '0xdef',
-            status: 'rejected',
-            txParams: {
-              from: '0x1',
-              to: '0xclaim',
-              data: txData,
-              value: '0x0',
-            },
-          },
-        };
-
-        messenger.publish(
-          'TransactionController:transactionRejected',
-          // @ts-ignore
-          event,
-        );
-
-        // State should be updated with CANCELLED status
-        expect(controller.state.claimTransaction?.status).toBe(
-          PredictClaimStatus.CANCELLED,
-        );
-      });
-    });
-
-    it('not modify state on transactionConfirmed for unknown transaction', () => {
-      withController(({ controller, messenger }) => {
-        const initial = { ...controller.state };
-        const event = {
-          id: 'unknown-tx',
-          hash: '0xabc',
-          status: 'confirmed',
-          txParams: { from: '0x1', to: '0x2', value: '0x0' },
-        };
-
-        messenger.publish(
-          'TransactionController:transactionConfirmed',
-          // @ts-ignore
-          event,
-        );
-
-        expect(controller.state).toEqual(initial);
-      });
-    });
-
-    it('not modify state when transactionConfirmed event has no batchId or txId', () => {
-      withController(({ controller, messenger }) => {
-        const initial = { ...controller.state };
-        const event = {
-          batchId: undefined,
-          id: undefined,
-          hash: '0xabc',
-          status: 'confirmed',
-          txParams: { from: '0x1', to: '0x2', value: '0x0' },
-        };
-
-        messenger.publish(
-          'TransactionController:transactionConfirmed',
-          // @ts-ignore
-          event,
-        );
-
-        expect(controller.state).toEqual(initial);
-      });
-    });
-
-    it('not modify state when transactionFailed event has no batchId or txId', () => {
-      withController(({ controller, messenger }) => {
-        const initial = { ...controller.state };
-        const event = {
-          transactionMeta: {
-            batchId: undefined,
-            id: undefined,
-            hash: '0xabc',
-            status: 'failed',
-            error: { message: 'Transaction failed' },
-            txParams: { from: '0x1', to: '0x2', value: '0x0' },
-          },
-        };
-
-        messenger.publish(
-          'TransactionController:transactionFailed',
-          // @ts-ignore
-          event,
-        );
-
-        expect(controller.state).toEqual(initial);
-      });
-    });
-
-    it('not modify state when transactionRejected event has no batchId or txId', () => {
-      withController(({ controller, messenger }) => {
-        const initial = { ...controller.state };
-        const event = {
-          transactionMeta: {
-            batchId: undefined,
-            id: undefined,
-            hash: '0xdef',
-            status: 'rejected',
-            txParams: { from: '0x1', to: '0x2', value: '0x0' },
-          },
-        };
-
-        messenger.publish(
-          'TransactionController:transactionRejected',
-          // @ts-ignore
-          event,
-        );
-
-        expect(controller.state).toEqual(initial);
-      });
-    });
-  });
-
   describe('provider error handling', () => {
     it('throw PROVIDER_NOT_AVAILABLE when provider is missing in placeOrder', async () => {
       await withController(async ({ controller }) => {
@@ -1007,45 +832,6 @@ describe('PredictController', () => {
           }),
         ).rejects.toThrow('PROVIDER_NOT_AVAILABLE');
         expect(controller.state.lastError).toBe('PROVIDER_NOT_AVAILABLE');
-      });
-    });
-
-    it('handle missing provider in transaction confirmed handler', () => {
-      withController(({ controller, messenger }) => {
-        // Set up claim transaction
-        const txId = 'tx-missing-provider';
-        const txData = '0xclaimdata';
-        controller.updateStateForTesting((state) => {
-          state.claimTransaction = {
-            transactionId: txId,
-            chainId: 1,
-            txParams: { to: '0xclaim', data: txData, value: '0x0' },
-            status: PredictClaimStatus.PENDING,
-          };
-        });
-
-        const event = {
-          id: txId,
-          hash: '0xabc',
-          status: 'confirmed',
-          txParams: {
-            from: '0x1',
-            to: '0xclaim',
-            data: txData,
-            value: '0x0',
-          },
-        };
-
-        // Transaction confirmed handler should update claim transaction status
-        messenger.publish(
-          'TransactionController:transactionConfirmed',
-          // @ts-ignore
-          event,
-        );
-
-        expect(controller.state.claimTransaction?.status).toBe(
-          PredictClaimStatus.CONFIRMED,
-        );
       });
     });
   });
@@ -1333,17 +1119,14 @@ describe('PredictController', () => {
       withController(({ controller }) => {
         controller.updateStateForTesting((state) => {
           state.claimTransaction = {
-            transactionId: 'test-tx',
+            batchId: 'test-tx',
             chainId: 1,
-            txParams: { to: '0xclaim', data: '0xdata', value: '0x0' },
             status: PredictClaimStatus.PENDING,
           };
           state.isOnboarded = { '0x123': true };
         });
 
-        expect(controller.state.claimTransaction?.transactionId).toBe(
-          'test-tx',
-        );
+        expect(controller.state.claimTransaction?.batchId).toBe('test-tx');
         expect(controller.state.isOnboarded['0x123']).toBe(true);
       });
     });
@@ -1419,9 +1202,8 @@ describe('PredictController', () => {
         // Set up claim transaction
         controller.updateStateForTesting((state) => {
           state.claimTransaction = {
-            transactionId: txId,
+            batchId: txId,
             chainId: 1,
-            txParams: { to: '0xclaim', data: '0xdata', value: '0x0' },
             status: PredictClaimStatus.PENDING,
           };
         });
@@ -1456,86 +1238,90 @@ describe('PredictController', () => {
   });
 
   describe('claim', () => {
-    const mockPosition = {
-      marketId: 'market-1',
-      providerId: 'polymarket',
-      outcomeId: 'outcome-1',
-      outcomeTokenId: 'outcome-token-1',
-    };
-
     const mockClaim = {
       chainId: 1,
-      txParams: {
-        to: '0xclaim',
-        data: '0xclaimdata',
-        value: '0x0',
-      },
+      transactions: [
+        {
+          params: {
+            to: '0xclaim' as `0x${string}`,
+            data: '0xclaimdata' as `0x${string}`,
+            value: '0x0',
+          },
+        },
+      ],
     };
 
     it('claim a single position successfully', async () => {
-      const mockTxMeta = { id: 'claim-tx-1' } as any;
+      const mockBatchId = 'claim-batch-1';
       await withController(async ({ controller }) => {
         mockPolymarketProvider.prepareClaim = jest
           .fn()
-          .mockReturnValue(mockClaim);
-        (addTransaction as jest.Mock).mockResolvedValue({
-          transactionMeta: mockTxMeta,
+          .mockResolvedValue(mockClaim);
+        (addTransactionBatch as jest.Mock).mockResolvedValue({
+          batchId: mockBatchId,
         });
 
-        const result = await controller.claim({
-          positions: [mockPosition as any],
+        const result = await controller.claimWithConfirmation({
           providerId: 'polymarket',
         });
 
-        expect(result.transactionId).toBe(mockTxMeta.id);
+        expect(result.batchId).toBe(mockBatchId);
         expect(result.status).toBe(PredictClaimStatus.PENDING);
-        expect(controller.state.claimTransaction?.transactionId).toBe(
-          mockTxMeta.id,
-        );
+        expect(controller.state.claimTransaction?.batchId).toBe(mockBatchId);
         expect(mockPolymarketProvider.prepareClaim).toHaveBeenCalledWith({
-          positions: [mockPosition],
+          positions: expect.any(Array),
           signer: expect.objectContaining({
             address: '0x1234567890123456789012345678901234567890',
           }),
         });
-        expect(addTransaction).toHaveBeenCalled();
+        expect(addTransactionBatch).toHaveBeenCalled();
       });
     });
 
     it('claim multiple positions successfully using batch transaction', async () => {
       const mockBatchId = 'claim-batch-1';
       await withController(async ({ controller }) => {
+        const mockMultipleClaims = {
+          chainId: 1,
+          transactions: [
+            {
+              params: {
+                to: '0xclaim' as `0x${string}`,
+                data: '0xclaimdata' as `0x${string}`,
+                value: '0x0',
+              },
+            },
+            {
+              params: {
+                to: '0xclaim' as `0x${string}`,
+                data: '0xclaimdata2' as `0x${string}`,
+                value: '0x0',
+              },
+            },
+          ],
+        };
         mockPolymarketProvider.prepareClaim = jest
           .fn()
-          .mockReturnValueOnce(mockClaim)
-          .mockReturnValueOnce({
-            ...mockClaim,
-            txParams: { ...mockClaim.txParams, data: '0xclaimdata2' },
-          });
+          .mockResolvedValue(mockMultipleClaims);
         (addTransactionBatch as jest.Mock).mockResolvedValue({
           batchId: mockBatchId,
         });
 
-        const result = await controller.claim({
-          positions: [
-            mockPosition as any,
-            { ...mockPosition, outcomeId: 'outcome-2' } as any,
-          ],
+        const result = await controller.claimWithConfirmation({
           providerId: 'polymarket',
         });
 
-        expect(result.transactionId).toBeDefined();
+        expect(result.batchId).toBe(mockBatchId);
         expect(result.status).toBe(PredictClaimStatus.PENDING);
-        expect(controller.state.claimTransaction?.transactionId).toBeDefined();
-        expect(addTransaction).toHaveBeenCalled();
+        expect(controller.state.claimTransaction?.batchId).toBe(mockBatchId);
+        expect(addTransactionBatch).toHaveBeenCalled();
       });
     });
 
     it('handle claim error when provider is not available', async () => {
       await withController(async ({ controller }) => {
         await expect(
-          controller.claim({
-            positions: [mockPosition as any],
+          controller.claimWithConfirmation({
             providerId: 'nonexistent',
           }),
         ).rejects.toThrow('PROVIDER_NOT_AVAILABLE');
@@ -1551,8 +1337,7 @@ describe('PredictController', () => {
           });
 
         await expect(
-          controller.claim({
-            positions: [mockPosition as any],
+          controller.claimWithConfirmation({
             providerId: 'polymarket',
           }),
         ).rejects.toThrow('Claim preparation failed');
@@ -1700,23 +1485,21 @@ describe('PredictController', () => {
         // Set up initial claim transaction
         controller.updateStateForTesting((state) => {
           state.claimTransaction = {
-            transactionId: 'test-tx',
+            batchId: 'test-tx',
             chainId: 1,
-            txParams: { to: '0x1', data: '0xdata1', value: '0x0' },
             status: PredictClaimStatus.PENDING,
           };
         });
 
         // Verify transaction exists
         expect(controller.state.claimTransaction).toEqual({
-          transactionId: 'test-tx',
+          batchId: 'test-tx',
           chainId: 1,
-          txParams: { to: '0x1', data: '0xdata1', value: '0x0' },
           status: PredictClaimStatus.PENDING,
         });
 
         // Clear claim transaction
-        controller.clearClaimTransactions();
+        controller.clearClaimTransaction();
 
         // Verify transaction is cleared
         expect(controller.state.claimTransaction).toBeNull();
@@ -1731,7 +1514,7 @@ describe('PredictController', () => {
         });
 
         // Clear should work without error
-        expect(() => controller.clearClaimTransactions()).not.toThrow();
+        expect(() => controller.clearClaimTransaction()).not.toThrow();
 
         // Should remain null
         expect(controller.state.claimTransaction).toBeNull();

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -657,8 +657,7 @@ export class PredictController extends BaseController<
     });
 
     const { transactions, chainId } = await provider.prepareClaim({
-      // TODO: For testing purposes, we're only claiming one position at a time
-      positions: [...claimablePositions].splice(0, 1),
+      positions: claimablePositions,
       signer,
     });
     const networkClientId = NetworkController.findNetworkClientIdByChainId(

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -470,7 +470,7 @@ export class PredictController extends BaseController<
         state.lastUpdateTimestamp = Date.now();
         state.lastError = null; // Clear any previous errors
         if (params.claimable) {
-          state.claimablePositions = positions;
+          state.claimablePositions = [...positions];
         }
       });
 

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -15,15 +15,11 @@ import {
   TransactionControllerTransactionFailedEvent,
   TransactionControllerTransactionRejectedEvent,
   TransactionControllerTransactionSubmittedEvent,
-  TransactionType,
 } from '@metamask/transaction-controller';
 import { Hex, numberToHex } from '@metamask/utils';
 import Engine from '../../../../core/Engine';
 import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
-import {
-  addTransaction,
-  addTransactionBatch,
-} from '../../../../util/transaction-controller';
+import { addTransactionBatch } from '../../../../util/transaction-controller';
 import { PolymarketProvider } from '../providers/polymarket/PolymarketProvider';
 import {
   AccountState,
@@ -40,13 +36,13 @@ import {
 import {
   ClaimParams,
   GetPriceHistoryParams,
+  PredictActivity,
   PredictClaim,
   PredictClaimStatus,
   PredictDeposit,
   PredictDepositStatus,
   PredictMarket,
   PredictPosition,
-  PredictActivity,
   PredictPriceHistoryPoint,
   Result,
   UnrealizedPnL,
@@ -92,6 +88,7 @@ export type PredictControllerState = {
   lastUpdateTimestamp: number;
 
   // Claim management
+  claimablePositions: PredictPosition[] | null;
   claimTransaction: PredictClaim | null;
 
   // Deposit management
@@ -110,6 +107,7 @@ export const getDefaultPredictControllerState = (): PredictControllerState => ({
   eligibility: {},
   lastError: null,
   lastUpdateTimestamp: 0,
+  claimablePositions: null,
   claimTransaction: null,
   depositTransaction: null,
   isOnboarded: {},
@@ -122,6 +120,7 @@ const metadata = {
   eligibility: { persist: false, anonymous: false },
   lastError: { persist: false, anonymous: false },
   lastUpdateTimestamp: { persist: false, anonymous: false },
+  claimablePositions: { persist: false, anonymous: false },
   claimTransaction: { persist: false, anonymous: false },
   depositTransaction: { persist: false, anonymous: false },
   isOnboarded: { persist: true, anonymous: false },
@@ -214,27 +213,6 @@ export class PredictController extends BaseController<
 
     this.providers = new Map();
 
-    // Subscribe to TransactionController events for deposit tracking
-    this.messagingSystem.subscribe(
-      'TransactionController:transactionSubmitted',
-      this.handleTransactionSubmitted.bind(this),
-    );
-
-    this.messagingSystem.subscribe(
-      'TransactionController:transactionConfirmed',
-      this.handleTransactionConfirmed.bind(this),
-    );
-
-    this.messagingSystem.subscribe(
-      'TransactionController:transactionFailed',
-      this.handleTransactionFailed.bind(this),
-    );
-
-    this.messagingSystem.subscribe(
-      'TransactionController:transactionRejected',
-      this.handleTransactionRejected.bind(this),
-    );
-
     this.initializeProviders().catch((error) => {
       DevLogger.log('PredictController: Error initializing providers', {
         error:
@@ -254,90 +232,6 @@ export class PredictController extends BaseController<
         timestamp: new Date().toISOString(),
       });
     });
-  }
-
-  /**
-   * Handle transaction submitted event
-   */
-  private handleTransactionSubmitted(
-    _event: TransactionControllerTransactionSubmittedEvent['payload'][0],
-  ): void {
-    // TODO: Implement transaction submission tracking
-  }
-
-  /**
-   * Handle transaction confirmed event
-   */
-  private async handleTransactionConfirmed(
-    _txMeta: TransactionControllerTransactionConfirmedEvent['payload'][0],
-  ): Promise<void> {
-    const batchId = _txMeta.batchId;
-    const txId = _txMeta.id;
-    const id = batchId ?? txId;
-
-    if (!id) {
-      return;
-    }
-
-    // Check claim transaction (single tx)
-    const claimTransaction = this.state.claimTransaction;
-    if (claimTransaction?.transactionId === id) {
-      this.update((state) => {
-        if (!state.claimTransaction) return;
-        state.claimTransaction.status = PredictClaimStatus.CONFIRMED;
-      });
-      return;
-    }
-  }
-
-  /**
-   * Handle transaction failed event
-   */
-  private handleTransactionFailed(
-    _event: TransactionControllerTransactionFailedEvent['payload'][0],
-  ): void {
-    const batchId = _event.transactionMeta.batchId;
-    const txId = _event.transactionMeta.id;
-    const id = batchId ?? txId;
-
-    if (!id) {
-      return;
-    }
-
-    // Check claim transaction
-    const claimTransaction = this.state.claimTransaction;
-    if (claimTransaction?.transactionId === id) {
-      this.update((state) => {
-        if (!state.claimTransaction) return;
-        state.claimTransaction.status = PredictClaimStatus.ERROR;
-      });
-      return;
-    }
-  }
-
-  /**
-   * Handle transaction rejected event
-   */
-  private handleTransactionRejected(
-    _event: TransactionControllerTransactionRejectedEvent['payload'][0],
-  ): void {
-    const batchId = _event.transactionMeta.batchId;
-    const txId = _event.transactionMeta.id;
-    const id = batchId ?? txId;
-
-    if (!id) {
-      return;
-    }
-
-    // Check claim transaction
-    const claimTransaction = this.state.claimTransaction;
-    if (claimTransaction?.transactionId === id) {
-      this.update((state) => {
-        if (!state.claimTransaction) return;
-        state.claimTransaction.status = PredictClaimStatus.CANCELLED;
-      });
-      return;
-    }
   }
 
   /**
@@ -575,6 +469,9 @@ export class PredictController extends BaseController<
       this.update((state) => {
         state.lastUpdateTimestamp = Date.now();
         state.lastError = null; // Clear any previous errors
+        if (params.claimable) {
+          state.claimablePositions = positions;
+        }
       });
 
       return positions;
@@ -733,7 +630,9 @@ export class PredictController extends BaseController<
     }
   }
 
-  async claim({ positions, providerId }: ClaimParams): Promise<PredictClaim> {
+  async claimWithConfirmation({
+    providerId,
+  }: ClaimParams): Promise<PredictClaim> {
     const provider = this.providers.get(providerId);
     if (!provider) {
       throw new Error(PREDICT_ERROR_CODES.PROVIDER_NOT_AVAILABLE);
@@ -753,29 +652,40 @@ export class PredictController extends BaseController<
         KeyringController.signPersonalMessage(params),
     };
 
-    const claimTransaction = await provider.prepareClaim({
-      positions,
-      signer,
+    const claimablePositions = await this.getPositions({
+      claimable: true,
     });
 
-    const { transactionMeta } = await addTransaction(
-      {
-        ...claimTransaction.transactionParams,
-      },
-      {
-        networkClientId: NetworkController.findNetworkClientIdByChainId(
-          numberToHex(claimTransaction.chainId),
-        ),
-        origin: ORIGIN_METAMASK,
-        type: TransactionType.contractInteraction,
-      },
+    const { transactions, chainId } = await provider.prepareClaim({
+      // TODO: For testing purposes, we're only claiming one position at a time
+      positions: [...claimablePositions].splice(0, 1),
+      signer,
+    });
+    const networkClientId = NetworkController.findNetworkClientIdByChainId(
+      numberToHex(chainId),
     );
 
+    const { batchId } = await addTransactionBatch({
+      from: signer.address as Hex,
+      origin: ORIGIN_METAMASK,
+      networkClientId,
+      disableHook: true,
+      disableSequential: true,
+      transactions: [
+        {
+          params: {
+            to: signer.address as Hex,
+            value: '0x1',
+          },
+        },
+        ...transactions,
+      ],
+    });
+
     const predictClaim: PredictClaim = {
-      transactionId: transactionMeta.id,
-      chainId: claimTransaction.chainId,
+      batchId,
+      chainId,
       status: PredictClaimStatus.PENDING,
-      txParams: { ...claimTransaction.transactionParams, value: '0x0' },
     };
 
     this.update((state) => {
@@ -825,7 +735,7 @@ export class PredictController extends BaseController<
     this.update(updater);
   }
 
-  public clearClaimTransactions(): void {
+  public clearClaimTransaction(): void {
     this.update((state) => {
       state.claimTransaction = null;
     });

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -88,7 +88,7 @@ export type PredictControllerState = {
   lastUpdateTimestamp: number;
 
   // Claim management
-  claimablePositions: PredictPosition[] | null;
+  claimablePositions: PredictPosition[];
   claimTransaction: PredictClaim | null;
 
   // Deposit management
@@ -107,7 +107,7 @@ export const getDefaultPredictControllerState = (): PredictControllerState => ({
   eligibility: {},
   lastError: null,
   lastUpdateTimestamp: 0,
-  claimablePositions: null,
+  claimablePositions: [],
   claimTransaction: null,
   depositTransaction: null,
   isOnboarded: {},

--- a/app/components/UI/Predict/hooks/usePredictClaim.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictClaim.test.ts
@@ -1,423 +1,403 @@
-import { renderHook, act } from '@testing-library/react-native';
-
-// Mock Engine first - needs to be before the hook import
-jest.mock('../../../../core/Engine', () => {
-  const mockClearClaimTransactions = jest.fn();
-  return {
-    context: {
-      PredictController: {
-        clearClaimTransactions: mockClearClaimTransactions,
-        claimTransactions: {},
-      },
-    },
-  };
-});
-
-// eslint-disable-next-line
-const mockClearClaimTransactions = require('../../../../core/Engine').context
-  .PredictController.clearClaimTransactions;
-
-// Mock usePredictTrading hook
-const mockClaim = jest.fn();
-jest.mock('./usePredictTrading', () => ({
-  usePredictTrading: () => ({
-    claim: mockClaim,
-  }),
-}));
-
-// Factory function to create mock state
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function createMockState(overrides: any = {}): any {
-  return {
-    engine: {
-      backgroundState: {
-        PredictController: {
-          claimTransaction: null,
-          ...overrides.PredictController,
-        },
-        ...overrides,
-      },
-    },
-  };
-}
-
-// Create initial mock state
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let mockState: any = createMockState();
-
-// Mock react-redux useSelector to evaluate selectors against our mock state
-jest.mock('react-redux', () => ({
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  useSelector: jest.fn((selector: any) => selector(mockState)),
-}));
-
-// Now import the hook after all mocks are set up
+import { renderHook } from '@testing-library/react-hooks';
+import { NavigationProp } from '@react-navigation/native';
+import { useSelector } from 'react-redux';
+import React from 'react';
+import { ToastContext } from '../../../../component-library/components/Toast/Toast.context';
+import Routes from '../../../../constants/navigation/Routes';
+import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
 import { usePredictClaim } from './usePredictClaim';
-import { PredictPositionStatus } from '../types';
+import { usePredictEligibility } from './usePredictEligibility';
+import { usePredictTrading } from './usePredictTrading';
+import { useConfirmNavigation } from '../../../Views/confirmations/hooks/useConfirmNavigation';
+import { strings } from '../../../../../locales/i18n';
+import { IconName } from '../../../../component-library/components/Icons/Icon';
+import { ToastVariants } from '../../../../component-library/components/Toast';
 
-// Cast the mocked function - use the mock directly instead of accessing through Engine
-const mockClearClaimTransactionsCasted = mockClearClaimTransactions;
+// Create mock functions
+const mockNavigate = jest.fn();
+const mockNavigateToConfirmation = jest.fn();
+const mockClaimWinnings = jest.fn();
+const mockShowToast = jest.fn();
 
-// Helper function to setup test with mock state
-function setupUsePredictClaimTest(stateOverrides = {}, hookOptions = {}) {
-  jest.clearAllMocks();
-  mockState = createMockState(stateOverrides);
-  return renderHook(() => usePredictClaim(hookOptions));
-}
+// Mock dependencies
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
+  connect: jest.fn(() => (component: unknown) => component),
+}));
 
-// Helper function to create mock position
-function createMockPosition(overrides = {}) {
-  return {
-    id: 'position-123',
-    providerId: 'provider-456',
-    marketId: 'market-789',
-    outcomeId: 'outcome-101',
-    outcome: 'UP',
-    outcomeTokenId: 'outcome-token-202',
-    title: 'BTC UP',
-    icon: 'btc-icon.png',
-    amount: 50,
-    price: 1.5,
-    status: PredictPositionStatus.WON,
-    size: 50,
-    outcomeIndex: 0,
-    realizedPnl: 25,
-    curPrice: 1.8,
-    conditionId: 'condition-303',
-    percentPnl: 50,
-    cashPnl: 25,
-    initialValue: 50,
-    avgPrice: 1.5,
-    currentValue: 90,
-    endDate: '2025-12-31',
-    claimable: true,
-    ...overrides,
-  };
-}
+jest.mock('./usePredictEligibility');
+jest.mock('./usePredictTrading');
 
-// Helper function to create mock claim transaction
-function createMockClaimTransaction(overrides = {}) {
-  return {
-    positionId: 'position-123',
-    chainId: 1,
-    to: '0x1234567890123456789012345678901234567890' as const,
-    data: '0xabcdef' as const,
-    value: '0x0' as const,
-    status: 'confirmed' as const,
-    ...overrides,
-  };
-}
+jest.mock('../../../../util/theme', () => ({
+  useAppThemeFromContext: jest.fn(() => ({
+    colors: {
+      error: {
+        default: '#ca3542',
+      },
+      accent04: {
+        normal: '#89b0ff',
+      },
+    },
+  })),
+}));
 
-// Common mock data
-const mockClaimParams = {
-  positions: [createMockPosition(), createMockPosition({ id: 'position-456' })],
-};
+jest.mock('../../../Views/confirmations/hooks/useConfirmNavigation', () => ({
+  useConfirmNavigation: jest.fn(),
+}));
 
-const mockClaimResult = {
-  success: true,
-  ids: ['tx-123', 'tx-456'],
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: jest.fn(),
+}));
+
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+const mockUsePredictEligibility = usePredictEligibility as jest.MockedFunction<
+  typeof usePredictEligibility
+>;
+const mockUsePredictTrading = usePredictTrading as jest.MockedFunction<
+  typeof usePredictTrading
+>;
+const mockUseConfirmNavigation = useConfirmNavigation as jest.MockedFunction<
+  typeof useConfirmNavigation
+>;
+
+const mockNavigation = {
+  navigate: mockNavigate,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as unknown as NavigationProp<any>;
+
+const mockToastRef = {
+  current: {
+    showToast: mockShowToast,
+  },
 };
 
 describe('usePredictClaim', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockState = createMockState();
-    // Ensure the mock function is reset
-    mockClearClaimTransactionsCasted.mockReset();
+
+    // Default mock implementations
+    jest.requireMock('@react-navigation/native').useNavigation = jest
+      .fn()
+      .mockReturnValue(mockNavigation);
+
+    mockUsePredictEligibility.mockReturnValue({
+      isEligible: true,
+      refreshEligibility: jest.fn(),
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockUsePredictTrading.mockReturnValue({
+      claim: mockClaimWinnings,
+      getPositions: jest.fn(),
+      placeOrder: jest.fn(),
+      calculateBetAmounts: jest.fn(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    mockUseConfirmNavigation.mockReturnValue({
+      navigateToConfirmation: mockNavigateToConfirmation,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    mockUseSelector.mockReturnValue({
+      status: 'pending',
+    });
   });
 
-  describe('initial state', () => {
-    it('returns initial state correctly when no claim transaction exists', () => {
-      const { result } = setupUsePredictClaimTest();
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      ToastContext.Provider,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { value: { toastRef: mockToastRef as any } },
+      children,
+    );
 
-      expect(result.current.loading).toBe(false);
-      expect(result.current.completed).toBe(false);
-      expect(result.current.error).toBe(false);
-      expect(typeof result.current.claim).toBe('function');
+  describe('initialization', () => {
+    it('returns claim function and status', () => {
+      // Arrange & Act
+      const { result } = renderHook(() => usePredictClaim(), { wrapper });
+
+      // Assert
+      expect(result.current.claim).toBeInstanceOf(Function);
+      expect(result.current.status).toBe('pending');
     });
 
-    it('returns initial state correctly when claim transaction is null', () => {
-      const { result } = setupUsePredictClaimTest({
-        PredictController: {
-          claimTransaction: null,
-        },
+    it('uses default providerId when not specified', () => {
+      // Arrange & Act
+      renderHook(() => usePredictClaim(), { wrapper });
+
+      // Assert
+      expect(mockUsePredictEligibility).toHaveBeenCalledWith({
+        providerId: POLYMARKET_PROVIDER_ID,
       });
-
-      expect(result.current.loading).toBe(false);
-      expect(result.current.completed).toBe(false);
-      expect(result.current.error).toBe(false);
-    });
-  });
-
-  describe('state computation from claim transaction', () => {
-    it('computes completed state when transaction is confirmed', () => {
-      const claimTransaction = createMockClaimTransaction({
-        status: 'confirmed',
-        positionId: 'pos-1',
-      });
-
-      const { result } = setupUsePredictClaimTest({
-        PredictController: { claimTransaction },
-      });
-
-      expect(result.current.completed).toBe(true);
     });
 
-    it('computes pending state when transaction is pending', () => {
-      const claimTransaction = createMockClaimTransaction({
-        status: 'pending',
+    it('uses custom providerId when specified', () => {
+      // Arrange
+      const customProviderId = 'custom-provider';
+
+      // Act
+      renderHook(() => usePredictClaim({ providerId: customProviderId }), {
+        wrapper,
       });
 
-      const { result } = setupUsePredictClaimTest({
-        PredictController: { claimTransaction },
+      // Assert
+      expect(mockUsePredictEligibility).toHaveBeenCalledWith({
+        providerId: customProviderId,
       });
-
-      expect(result.current.loading).toBe(true); // loading = claiming || pending
-    });
-
-    it('computes error state when transaction has error status', () => {
-      const claimTransaction = createMockClaimTransaction({ status: 'error' });
-
-      const { result } = setupUsePredictClaimTest({
-        PredictController: { claimTransaction },
-      });
-
-      expect(result.current.error).toBe(true);
-    });
-
-    it('computes mixed states correctly', () => {
-      const claimTransaction = createMockClaimTransaction({
-        status: 'pending',
-        positionId: 'pos-1',
-      });
-
-      const { result } = setupUsePredictClaimTest({
-        PredictController: { claimTransaction },
-      });
-
-      expect(result.current.completed).toBe(false);
-      expect(result.current.loading).toBe(true); // has pending
-      expect(result.current.error).toBe(false);
-    });
-
-    it('handles null transaction', () => {
-      const { result } = setupUsePredictClaimTest({
-        PredictController: { claimTransaction: null },
-      });
-
-      expect(result.current.completed).toBe(false);
-      expect(result.current.loading).toBe(false);
-      expect(result.current.error).toBe(false);
     });
   });
 
   describe('claim function', () => {
-    it('claims winnings successfully and returns result', async () => {
-      mockClaim.mockResolvedValue(mockClaimResult);
-
-      const { result } = setupUsePredictClaimTest();
-
-      let claimResult;
-      await act(async () => {
-        claimResult = await result.current.claim(mockClaimParams);
+    it('navigates to unavailable modal when user is not eligible', async () => {
+      // Arrange
+      mockUsePredictEligibility.mockReturnValue({
+        isEligible: false,
+        refreshEligibility: jest.fn(),
       });
 
-      expect(mockClaim).toHaveBeenCalledWith({
-        ...mockClaimParams,
-        providerId: 'polymarket',
+      const { result } = renderHook(() => usePredictClaim(), { wrapper });
+
+      // Act
+      await result.current.claim();
+
+      // Assert
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
+        screen: Routes.PREDICT.MODALS.UNAVAILABLE,
       });
-      expect(claimResult).toEqual(mockClaimResult);
+      expect(mockNavigateToConfirmation).not.toHaveBeenCalled();
+      expect(mockClaimWinnings).not.toHaveBeenCalled();
     });
 
-    it('handles errors from claimWinnings and calls onError callback', async () => {
+    it('navigates to confirmation and claims winnings when user is eligible', async () => {
+      // Arrange
+      mockUsePredictEligibility.mockReturnValue({
+        isEligible: true,
+        refreshEligibility: jest.fn(),
+      });
+      mockClaimWinnings.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => usePredictClaim(), { wrapper });
+
+      // Act
+      await result.current.claim();
+
+      // Assert
+      expect(mockNavigateToConfirmation).toHaveBeenCalledWith({
+        headerShown: false,
+        stack: Routes.PREDICT.ROOT,
+      });
+      expect(mockClaimWinnings).toHaveBeenCalledWith({
+        providerId: POLYMARKET_PROVIDER_ID,
+      });
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('uses custom providerId when claiming', async () => {
+      // Arrange
+      const customProviderId = 'custom-provider';
+      mockUsePredictEligibility.mockReturnValue({
+        isEligible: true,
+        refreshEligibility: jest.fn(),
+      });
+      mockClaimWinnings.mockResolvedValue(undefined);
+
+      const { result } = renderHook(
+        () => usePredictClaim({ providerId: customProviderId }),
+        { wrapper },
+      );
+
+      // Act
+      await result.current.claim();
+
+      // Assert
+      expect(mockClaimWinnings).toHaveBeenCalledWith({
+        providerId: customProviderId,
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    it('displays error toast when claim fails', async () => {
+      // Arrange
       const mockError = new Error('Claim failed');
-      const onErrorMock = jest.fn();
+      mockUsePredictEligibility.mockReturnValue({
+        isEligible: true,
+        refreshEligibility: jest.fn(),
+      });
+      mockClaimWinnings.mockRejectedValue(mockError);
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined);
 
-      mockClaim.mockRejectedValue(mockError);
+      const { result } = renderHook(() => usePredictClaim(), { wrapper });
 
-      const { result } = setupUsePredictClaimTest({}, { onError: onErrorMock });
+      // Act
+      await result.current.claim();
 
-      let claimResult;
-      await act(async () => {
-        claimResult = await result.current.claim(mockClaimParams);
+      // Assert
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Failed to proceed with claim:',
+        mockError,
+      );
+      expect(mockShowToast).toHaveBeenCalledWith({
+        variant: ToastVariants.Icon,
+        labelOptions: [
+          { label: strings('predict.claim.toasts.error.title'), isBold: true },
+          { label: '\n', isBold: false },
+          {
+            label: strings('predict.claim.toasts.error.description'),
+            isBold: false,
+          },
+        ],
+        iconName: IconName.Error,
+        iconColor: '#ca3542',
+        backgroundColor: '#89b0ff',
+        hasNoTimeout: false,
+        linkButtonOptions: {
+          label: strings('predict.claim.toasts.error.try_again'),
+          onPress: expect.any(Function),
+        },
       });
 
-      expect(mockClaim).toHaveBeenCalledWith({
-        ...mockClaimParams,
-        providerId: 'polymarket',
-      });
-      expect(onErrorMock).toHaveBeenCalledWith(mockError);
-      expect(claimResult).toEqual({
-        success: false,
-        error: mockError,
-      });
+      consoleErrorSpy.mockRestore();
     });
 
-    it('returns non-success results from claimWinnings', async () => {
-      const mockErrorResult = {
-        success: false,
-        error: 'Insufficient balance',
-      };
-
-      mockClaim.mockResolvedValue(mockErrorResult);
-
-      const { result } = setupUsePredictClaimTest();
-
-      let claimResult;
-      await act(async () => {
-        claimResult = await result.current.claim(mockClaimParams);
+    it('retries claim when try again button is pressed on error toast', async () => {
+      // Arrange
+      const mockError = new Error('Claim failed');
+      mockUsePredictEligibility.mockReturnValue({
+        isEligible: true,
+        refreshEligibility: jest.fn(),
       });
+      mockClaimWinnings
+        .mockRejectedValueOnce(mockError)
+        .mockResolvedValueOnce(undefined);
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined);
 
-      expect(mockClaim).toHaveBeenCalledWith({
-        ...mockClaimParams,
-        providerId: 'polymarket',
+      const { result } = renderHook(() => usePredictClaim(), { wrapper });
+
+      // Act - first claim attempt fails
+      await result.current.claim();
+
+      // Get the onPress function from the toast call
+      const toastCall = mockShowToast.mock.calls[0][0];
+      const retryFunction = toastCall.linkButtonOptions.onPress;
+
+      // Clear mocks to track second attempt
+      mockShowToast.mockClear();
+      mockClaimWinnings.mockClear();
+      mockNavigateToConfirmation.mockClear();
+
+      // Act - retry claim
+      await retryFunction();
+
+      // Assert - second attempt should succeed
+      expect(mockNavigateToConfirmation).toHaveBeenCalledWith({
+        headerShown: false,
+        stack: Routes.PREDICT.ROOT,
       });
-      expect(claimResult).toEqual(mockErrorResult);
+      expect(mockClaimWinnings).toHaveBeenCalledWith({
+        providerId: POLYMARKET_PROVIDER_ID,
+      });
+      expect(mockShowToast).not.toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
     });
-  });
 
-  describe('error handling in claim function', () => {
-    it('calls onError callback when claimWinnings throws an error', async () => {
+    it('logs error to console when claim fails', async () => {
+      // Arrange
       const mockError = new Error('Network error');
-      const onErrorMock = jest.fn();
-
-      mockClaim.mockRejectedValue(mockError);
-
-      const { result } = setupUsePredictClaimTest({}, { onError: onErrorMock });
-
-      await act(async () => {
-        await result.current.claim(mockClaimParams);
+      mockUsePredictEligibility.mockReturnValue({
+        isEligible: true,
+        refreshEligibility: jest.fn(),
       });
+      mockClaimWinnings.mockRejectedValue(mockError);
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined);
 
-      expect(onErrorMock).toHaveBeenCalledWith(mockError);
+      const { result } = renderHook(() => usePredictClaim(), { wrapper });
+
+      // Act
+      await result.current.claim();
+
+      // Assert
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Failed to proceed with claim:',
+        mockError,
+      );
+
+      consoleErrorSpy.mockRestore();
     });
   });
 
-  describe('hook stability', () => {
-    it('returns stable function references', () => {
-      const { result, rerender } = setupUsePredictClaimTest();
+  describe('status', () => {
+    it('returns status from claimTransaction selector', () => {
+      // Arrange
+      mockUseSelector.mockReturnValue({
+        status: 'completed',
+      });
 
-      const initialClaim = result.current.claim;
+      // Act
+      const { result } = renderHook(() => usePredictClaim(), { wrapper });
 
-      rerender({});
+      // Assert
+      expect(result.current.status).toBe('completed');
+    });
 
-      expect(result.current.claim).toBe(initialClaim);
+    it('returns undefined when claimTransaction is not available', () => {
+      // Arrange
+      mockUseSelector.mockReturnValue(undefined);
+
+      // Act
+      const { result } = renderHook(() => usePredictClaim(), { wrapper });
+
+      // Assert
+      expect(result.current.status).toBeUndefined();
     });
   });
 
-  describe('memoization', () => {
-    it('recomputes completed state when claimTransaction changes', () => {
-      const { result, rerender } = setupUsePredictClaimTest();
+  describe('toast context handling', () => {
+    it('handles missing toastRef gracefully on error', async () => {
+      // Arrange
+      const mockError = new Error('Claim failed');
+      mockUsePredictEligibility.mockReturnValue({
+        isEligible: true,
+        refreshEligibility: jest.fn(),
+      });
+      mockClaimWinnings.mockRejectedValue(mockError);
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined);
 
-      expect(result.current.completed).toBe(false);
+      const noToastWrapper = ({ children }: { children: React.ReactNode }) =>
+        React.createElement(
+          ToastContext.Provider,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          { value: { toastRef: null as any } },
+          children,
+        );
 
-      // Update state with completed transaction
-      mockState = createMockState({
-        PredictController: {
-          claimTransaction: createMockClaimTransaction({ status: 'confirmed' }),
-        },
+      const { result } = renderHook(() => usePredictClaim(), {
+        wrapper: noToastWrapper,
       });
 
-      rerender(mockState);
+      // Act
+      await result.current.claim();
 
-      expect(result.current.completed).toBe(true);
-    });
-
-    it('recomputes loading state when pending transaction changes', () => {
-      const { result, rerender } = setupUsePredictClaimTest();
-
-      expect(result.current.loading).toBe(false);
-
-      // Add pending transaction
-      mockState = createMockState({
-        PredictController: {
-          claimTransaction: createMockClaimTransaction({ status: 'pending' }),
-        },
-      });
-
-      rerender(mockState);
-
-      expect(result.current.loading).toBe(true);
-    });
-  });
-
-  describe('useEffect side effects', () => {
-    it('calls onComplete callback when completed becomes true while claiming', async () => {
-      const onComplete = jest.fn();
-
-      // Start with no transaction
-      mockState = createMockState({
-        PredictController: {
-          claimTransaction: null,
-        },
-      });
-
-      const { result, rerender } = renderHook(() =>
-        usePredictClaim({ onComplete }),
+      // Assert - should not throw error even without toastRef
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Failed to proceed with claim:',
+        mockError,
       );
+      expect(mockShowToast).not.toHaveBeenCalled();
 
-      // Mock successful claim to set claiming to true
-      mockClaim.mockResolvedValueOnce({ success: true });
-
-      await act(async () => {
-        await result.current.claim({ positions: [createMockPosition()] });
-      });
-
-      // Verify claiming is true
-      expect(result.current.loading).toBe(true);
-
-      // Now simulate completion by updating state with confirmed transaction
-      mockState = createMockState({
-        PredictController: {
-          claimTransaction: createMockClaimTransaction({ status: 'confirmed' }),
-        },
-      });
-
-      // Re-render to trigger useEffect with new state
-      await act(async () => {
-        rerender({ onComplete });
-      });
-
-      expect(onComplete).toHaveBeenCalled();
-    });
-
-    it('calls onError when error status is detected while claiming', async () => {
-      const onError = jest.fn();
-
-      // Start with no transaction, then simulate error
-      mockState = createMockState({
-        PredictController: {
-          claimTransaction: null,
-        },
-      });
-
-      const { result, rerender } = renderHook(() =>
-        usePredictClaim({ onError }),
-      );
-
-      // Mock successful claim to set claiming to true
-      mockClaim.mockResolvedValueOnce({ success: true });
-
-      await act(async () => {
-        await result.current.claim({ positions: [createMockPosition()] });
-      });
-
-      // Now simulate error by updating state with error transaction
-      mockState = createMockState({
-        PredictController: {
-          claimTransaction: createMockClaimTransaction({ status: 'error' }),
-        },
-      });
-
-      // Re-render to trigger useEffect with error state
-      await act(async () => {
-        rerender({ onError });
-      });
-
-      expect(onError).toHaveBeenCalledWith(
-        new Error('Error claiming winnings'),
-      );
-      expect(mockClearClaimTransactionsCasted).toHaveBeenCalled();
+      consoleErrorSpy.mockRestore();
     });
   });
 });

--- a/app/components/UI/Predict/hooks/usePredictClaim.ts
+++ b/app/components/UI/Predict/hooks/usePredictClaim.ts
@@ -1,20 +1,36 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { ClaimParams } from '../types';
-import { usePredictTrading } from './usePredictTrading';
-import { RootState } from '../../../../reducers';
-import { createSelector } from 'reselect';
+import { NavigationProp, useNavigation } from '@react-navigation/native';
+import { useCallback, useContext } from 'react';
 import { useSelector } from 'react-redux';
-import Engine from '../../../../core/Engine';
+import { createSelector } from 'reselect';
+import { IconName } from '../../../../component-library/components/Icons/Icon';
+import { ToastVariants } from '../../../../component-library/components/Toast';
+import { ToastContext } from '../../../../component-library/components/Toast/Toast.context';
+import Routes from '../../../../constants/navigation/Routes';
+import { RootState } from '../../../../reducers';
+import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
+import { PredictNavigationParamList } from '../types/navigation';
+import { usePredictEligibility } from './usePredictEligibility';
+import { usePredictTrading } from './usePredictTrading';
+import { useAppThemeFromContext } from '../../../../util/theme';
+import { strings } from '../../../../../locales/i18n';
+import { useConfirmNavigation } from '../../../Views/confirmations/hooks/useConfirmNavigation';
 
-interface UsePredictClaimOptions {
-  onComplete?: () => void;
-  onError?: (error: Error) => void;
+interface UsePredictClaimParams {
+  providerId?: string;
 }
 
-export const usePredictClaim = (options: UsePredictClaimOptions = {}) => {
-  const { onComplete, onError } = options;
-  const [claiming, setClaiming] = useState<boolean>(false);
+export const usePredictClaim = ({
+  providerId = POLYMARKET_PROVIDER_ID,
+}: UsePredictClaimParams = {}) => {
+  const navigation =
+    useNavigation<NavigationProp<PredictNavigationParamList>>();
+  const { navigateToConfirmation } = useConfirmNavigation();
   const { claim: claimWinnings } = usePredictTrading();
+  const { isEligible } = usePredictEligibility({
+    providerId,
+  });
+  const theme = useAppThemeFromContext();
+  const { toastRef } = useContext(ToastContext);
 
   const selectClaimTransaction = createSelector(
     (state: RootState) => state.engine.backgroundState.PredictController,
@@ -22,75 +38,56 @@ export const usePredictClaim = (options: UsePredictClaimOptions = {}) => {
   );
   const claimTransaction = useSelector(selectClaimTransaction);
 
-  const completed = useMemo(() => {
-    if (!claimTransaction) {
-      return false;
-    }
-
-    return claimTransaction.status === 'confirmed';
-  }, [claimTransaction]);
-
-  const pending = useMemo(() => {
-    if (!claimTransaction) {
-      return false;
-    }
-    return claimTransaction.status === 'pending';
-  }, [claimTransaction]);
-
-  const loading = useMemo(() => claiming || pending, [claiming, pending]);
-
-  const error = useMemo(() => {
-    if (!claimTransaction) {
-      return false;
-    }
-    return claimTransaction.status === 'error';
-  }, [claimTransaction]);
-
-  useEffect(() => {
-    if (completed && claiming) {
-      setClaiming(false);
-      onComplete?.();
-    }
-  }, [completed, claiming, onComplete]);
-
-  useEffect(() => {
-    if (!claiming) {
+  const claim = useCallback(async () => {
+    if (!isEligible) {
+      navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
+        screen: Routes.PREDICT.MODALS.UNAVAILABLE,
+      });
       return;
     }
-
-    if (error) {
-      setClaiming(false);
-      Engine.context.PredictController.clearClaimTransactions();
-      onError?.(new Error('Error claiming winnings'));
-      return;
+    try {
+      navigateToConfirmation({
+        headerShown: false,
+        stack: Routes.PREDICT.ROOT,
+      });
+      await claimWinnings({ providerId });
+    } catch (err) {
+      console.error('Failed to proceed with claim:', err);
+      toastRef?.current?.showToast({
+        variant: ToastVariants.Icon,
+        labelOptions: [
+          { label: strings('predict.claim.toasts.error.title'), isBold: true },
+          { label: '\n', isBold: false },
+          {
+            label: strings('predict.claim.toasts.error.description'),
+            isBold: false,
+          },
+        ],
+        iconName: IconName.Error,
+        iconColor: theme.colors.error.default,
+        backgroundColor: theme.colors.accent04.normal,
+        hasNoTimeout: false,
+        linkButtonOptions: {
+          label: strings('predict.claim.toasts.error.try_again'),
+          onPress: () => {
+            claim();
+          },
+        },
+      });
     }
-  }, [error, claiming, onError]);
-
-  const claim = useCallback(
-    async ({
-      positions,
-      providerId = 'polymarket',
-    }: Omit<ClaimParams, 'providerId'> & { providerId?: string }) => {
-      setClaiming(true);
-      try {
-        const result = await claimWinnings({ positions, providerId });
-        return result;
-      } catch (claimError) {
-        onError?.(claimError as Error);
-        setClaiming(false);
-        return {
-          success: false,
-          error: claimError as Error,
-        };
-      }
-    },
-    [claimWinnings, onError],
-  );
+  }, [
+    claimWinnings,
+    isEligible,
+    navigateToConfirmation,
+    navigation,
+    providerId,
+    theme.colors.accent04.normal,
+    theme.colors.error.default,
+    toastRef,
+  ]);
 
   return {
     claim,
-    loading,
-    completed,
-    error,
+    status: claimTransaction?.status,
   };
 };

--- a/app/components/UI/Predict/hooks/usePredictClaimToasts.test.tsx
+++ b/app/components/UI/Predict/hooks/usePredictClaimToasts.test.tsx
@@ -1,0 +1,496 @@
+import { renderHook, act } from '@testing-library/react-native';
+import React from 'react';
+import {
+  TransactionType,
+  TransactionStatus,
+} from '@metamask/transaction-controller';
+import { usePredictClaimToasts } from './usePredictClaimToasts';
+import Engine from '../../../../core/Engine';
+import { ToastContext } from '../../../../component-library/components/Toast';
+import { PredictPositionStatus } from '../types';
+
+// Mock usePredictClaim
+const mockClaim = jest.fn();
+jest.mock('./usePredictClaim', () => ({
+  usePredictClaim: jest.fn(() => ({
+    claim: mockClaim,
+  })),
+}));
+
+// Create a mock toast ref
+const mockToastRef = {
+  current: {
+    showToast: jest.fn(),
+    closeToast: jest.fn(),
+  },
+};
+
+// Mock theme hook
+jest.mock('../../../../util/theme', () => ({
+  useAppThemeFromContext: jest.fn(() => ({
+    colors: {
+      accent04: {
+        dark: '#000000',
+        normal: '#FFFFFF',
+      },
+      success: {
+        default: '#00FF00',
+      },
+      error: {
+        default: '#FF0000',
+      },
+    },
+  })),
+}));
+
+// Mock Engine
+jest.mock('../../../../core/Engine', () => ({
+  context: {
+    PredictController: {
+      clearClaimTransaction: jest.fn(),
+    },
+  },
+  controllerMessenger: {
+    subscribe: jest.fn(),
+    unsubscribe: jest.fn(),
+  },
+}));
+
+// Mock react-redux
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let mockState: any = {
+  engine: {
+    backgroundState: {
+      PredictController: {
+        positions: [],
+      },
+    },
+  },
+};
+
+jest.mock('react-redux', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  useSelector: jest.fn((selector: any) => selector(mockState)),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  connect: () => (component: any) => component,
+}));
+
+describe('usePredictClaimToasts', () => {
+  let mockSubscribeCallback:
+    | ((payload: {
+        transactionMeta: {
+          status: string;
+          nestedTransactions?: { type: string }[];
+          metamaskPay?: { totalFiat?: string };
+        };
+      }) => void)
+    | null = null;
+
+  // Wrapper to provide ToastContext
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      ToastContext.Provider,
+      { value: { toastRef: mockToastRef } },
+      children,
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockToastRef.current.showToast.mockClear();
+    mockClaim.mockClear();
+    (
+      Engine.context.PredictController.clearClaimTransaction as jest.Mock
+    ).mockClear();
+
+    // Capture the subscribe callback
+    mockSubscribeCallback = null;
+    (Engine.controllerMessenger.subscribe as jest.Mock).mockImplementation(
+      (_event: string, callback: typeof mockSubscribeCallback) => {
+        mockSubscribeCallback = callback;
+      },
+    );
+    (Engine.controllerMessenger.unsubscribe as jest.Mock).mockClear();
+
+    mockState = {
+      engine: {
+        backgroundState: {
+          PredictController: {
+            positions: [
+              {
+                id: '1',
+                status: PredictPositionStatus.WON,
+                currentValue: 100,
+              },
+              {
+                id: '2',
+                status: PredictPositionStatus.WON,
+                currentValue: 50,
+              },
+            ],
+          },
+        },
+      },
+    };
+  });
+
+  describe('initialization', () => {
+    it('subscribes to transaction status updates on mount', () => {
+      // Arrange & Act
+      renderHook(() => usePredictClaimToasts(), { wrapper });
+
+      // Assert
+      expect(Engine.controllerMessenger.subscribe).toHaveBeenCalledWith(
+        'TransactionController:transactionStatusUpdated',
+        expect.any(Function),
+      );
+    });
+
+    it('unsubscribes from transaction status updates on unmount', () => {
+      // Arrange
+      const { unmount } = renderHook(() => usePredictClaimToasts(), {
+        wrapper,
+      });
+
+      // Act
+      unmount();
+
+      // Assert
+      expect(Engine.controllerMessenger.unsubscribe).toHaveBeenCalledWith(
+        'TransactionController:transactionStatusUpdated',
+        expect.any(Function),
+      );
+    });
+  });
+
+  describe('transaction status updates', () => {
+    it('ignores non-predict claim transactions', async () => {
+      // Arrange
+      renderHook(() => usePredictClaimToasts(), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.approved,
+            nestedTransactions: [{ type: TransactionType.swap }],
+          },
+        });
+      });
+
+      // Assert
+      expect(
+        Engine.context.PredictController.clearClaimTransaction,
+      ).not.toHaveBeenCalled();
+      expect(mockToastRef.current.showToast).not.toHaveBeenCalled();
+    });
+
+    it('shows pending toast when transaction is approved', async () => {
+      // Arrange
+      renderHook(() => usePredictClaimToasts(), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.approved,
+            nestedTransactions: [{ type: TransactionType.predictClaim }],
+            metamaskPay: { totalFiat: '$100' },
+          },
+        });
+      });
+
+      // Assert
+      expect(mockToastRef.current.showToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: expect.anything(),
+          labelOptions: expect.arrayContaining([
+            expect.objectContaining({
+              label: expect.any(String),
+            }),
+          ]),
+          iconName: expect.anything(),
+          hasNoTimeout: false,
+          startAccessory: expect.any(Object),
+        }),
+      );
+    });
+
+    it('shows pending toast with empty amount when totalFiat is not provided', async () => {
+      // Arrange
+      renderHook(() => usePredictClaimToasts(), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.approved,
+            nestedTransactions: [{ type: TransactionType.predictClaim }],
+          },
+        });
+      });
+
+      // Assert
+      expect(mockToastRef.current.showToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: expect.anything(),
+          labelOptions: expect.any(Array),
+        }),
+      );
+    });
+
+    it('shows confirmed toast when transaction is confirmed', async () => {
+      // Arrange
+      renderHook(() => usePredictClaimToasts(), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.confirmed,
+            nestedTransactions: [{ type: TransactionType.predictClaim }],
+          },
+        });
+      });
+
+      // Assert
+      expect(
+        Engine.context.PredictController.clearClaimTransaction,
+      ).toHaveBeenCalled();
+      expect(mockToastRef.current.showToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: expect.anything(),
+          labelOptions: expect.arrayContaining([
+            expect.objectContaining({
+              label: expect.any(String),
+            }),
+          ]),
+          iconName: expect.anything(),
+          hasNoTimeout: false,
+        }),
+      );
+    });
+
+    it('shows error toast when transaction fails', async () => {
+      // Arrange
+      renderHook(() => usePredictClaimToasts(), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.failed,
+            nestedTransactions: [{ type: TransactionType.predictClaim }],
+          },
+        });
+      });
+
+      // Assert
+      expect(
+        Engine.context.PredictController.clearClaimTransaction,
+      ).toHaveBeenCalled();
+      expect(mockToastRef.current.showToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: expect.anything(),
+          labelOptions: expect.any(Array),
+          iconName: expect.anything(),
+          hasNoTimeout: false,
+          linkButtonOptions: expect.objectContaining({
+            label: expect.any(String),
+            onPress: expect.any(Function),
+          }),
+        }),
+      );
+    });
+
+    it('clears claim transaction when transaction is confirmed', async () => {
+      // Arrange
+      renderHook(() => usePredictClaimToasts(), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.confirmed,
+            nestedTransactions: [{ type: TransactionType.predictClaim }],
+          },
+        });
+      });
+
+      // Assert
+      expect(
+        Engine.context.PredictController.clearClaimTransaction,
+      ).toHaveBeenCalled();
+    });
+
+    it('clears claim transaction when transaction fails', async () => {
+      // Arrange
+      renderHook(() => usePredictClaimToasts(), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.failed,
+            nestedTransactions: [{ type: TransactionType.predictClaim }],
+          },
+        });
+      });
+
+      // Assert
+      expect(
+        Engine.context.PredictController.clearClaimTransaction,
+      ).toHaveBeenCalled();
+    });
+  });
+
+  describe('toast retry functionality', () => {
+    it('calls claim function when error toast retry button is pressed', async () => {
+      // Arrange
+      renderHook(() => usePredictClaimToasts(), { wrapper });
+
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.failed,
+            nestedTransactions: [{ type: TransactionType.predictClaim }],
+          },
+        });
+      });
+
+      // Get the onPress function from the linkButtonOptions
+      const toastCall = (mockToastRef.current.showToast as jest.Mock).mock
+        .calls[0][0];
+      const onPressRetry = toastCall.linkButtonOptions?.onPress;
+
+      expect(onPressRetry).toBeDefined();
+
+      // Act
+      await act(async () => {
+        onPressRetry();
+      });
+
+      // Assert
+      expect(mockClaim).toHaveBeenCalled();
+    });
+
+    it('retry button is a valid function', async () => {
+      // Arrange
+      renderHook(() => usePredictClaimToasts(), { wrapper });
+
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.failed,
+            nestedTransactions: [{ type: TransactionType.predictClaim }],
+          },
+        });
+      });
+
+      // Get the onPress function from the linkButtonOptions
+      const toastCall = (mockToastRef.current.showToast as jest.Mock).mock
+        .calls[0][0];
+      const onPressRetry = toastCall.linkButtonOptions?.onPress;
+
+      // Assert
+      expect(onPressRetry).toBeInstanceOf(Function);
+    });
+  });
+
+  describe('claimable positions', () => {
+    it('calculates total claimable amount from won positions', async () => {
+      // Arrange
+      renderHook(() => usePredictClaimToasts(), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.confirmed,
+            nestedTransactions: [{ type: TransactionType.predictClaim }],
+          },
+        });
+      });
+
+      // Assert - the confirmed toast should be called with the total claimable amount (100 + 50 = 150)
+      expect(mockToastRef.current.showToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          labelOptions: expect.any(Array),
+        }),
+      );
+    });
+
+    it('handles empty claimable positions', async () => {
+      // Arrange
+      mockState = {
+        engine: {
+          backgroundState: {
+            PredictController: {
+              positions: [],
+            },
+          },
+        },
+      };
+      renderHook(() => usePredictClaimToasts(), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.confirmed,
+            nestedTransactions: [{ type: TransactionType.predictClaim }],
+          },
+        });
+      });
+
+      // Assert
+      expect(mockToastRef.current.showToast).toHaveBeenCalled();
+    });
+
+    it('filters only won positions for claimable amount calculation', async () => {
+      // Arrange
+      mockState = {
+        engine: {
+          backgroundState: {
+            PredictController: {
+              positions: [
+                {
+                  id: '1',
+                  status: PredictPositionStatus.WON,
+                  currentValue: 100,
+                },
+                {
+                  id: '2',
+                  status: PredictPositionStatus.LOST,
+                  currentValue: 50,
+                },
+                {
+                  id: '3',
+                  status: PredictPositionStatus.ACTIVE,
+                  currentValue: 75,
+                },
+              ],
+            },
+          },
+        },
+      };
+      renderHook(() => usePredictClaimToasts(), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.confirmed,
+            nestedTransactions: [{ type: TransactionType.predictClaim }],
+          },
+        });
+      });
+
+      // Assert - should only include the WON position (100)
+      expect(mockToastRef.current.showToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          labelOptions: expect.any(Array),
+        }),
+      );
+    });
+  });
+});

--- a/app/components/UI/Predict/hooks/usePredictClaimToasts.test.tsx
+++ b/app/components/UI/Predict/hooks/usePredictClaimToasts.test.tsx
@@ -424,7 +424,7 @@ describe('usePredictClaimToasts', () => {
       const onPressRetry = toastCall.linkButtonOptions?.onPress;
 
       // Assert
-      expect(onPressRetry).toBeInstanceOf(Function);
+      expect(onPressRetry).toEqual(expect.any(Function));
     });
   });
 

--- a/app/components/UI/Predict/hooks/usePredictClaimToasts.test.tsx
+++ b/app/components/UI/Predict/hooks/usePredictClaimToasts.test.tsx
@@ -62,7 +62,7 @@ let mockState: any = {
   engine: {
     backgroundState: {
       PredictController: {
-        positions: [],
+        claimablePositions: [],
       },
     },
   },
@@ -115,7 +115,7 @@ describe('usePredictClaimToasts', () => {
       engine: {
         backgroundState: {
           PredictController: {
-            positions: [
+            claimablePositions: [
               {
                 id: '1',
                 status: PredictPositionStatus.WON,
@@ -425,7 +425,7 @@ describe('usePredictClaimToasts', () => {
         engine: {
           backgroundState: {
             PredictController: {
-              positions: [],
+              claimablePositions: [],
             },
           },
         },
@@ -452,7 +452,7 @@ describe('usePredictClaimToasts', () => {
         engine: {
           backgroundState: {
             PredictController: {
-              positions: [
+              claimablePositions: [
                 {
                   id: '1',
                   status: PredictPositionStatus.WON,
@@ -465,7 +465,7 @@ describe('usePredictClaimToasts', () => {
                 },
                 {
                   id: '3',
-                  status: PredictPositionStatus.ACTIVE,
+                  status: PredictPositionStatus.LOST,
                   currentValue: 75,
                 },
               ],

--- a/app/components/UI/Predict/hooks/usePredictClaimToasts.test.tsx
+++ b/app/components/UI/Predict/hooks/usePredictClaimToasts.test.tsx
@@ -17,6 +17,18 @@ jest.mock('./usePredictClaim', () => ({
   })),
 }));
 
+// Mock usePredictPositions
+const mockLoadPositions = jest.fn().mockResolvedValue(undefined);
+jest.mock('./usePredictPositions', () => ({
+  usePredictPositions: jest.fn(() => ({
+    positions: [],
+    isLoading: false,
+    isRefreshing: false,
+    error: null,
+    loadPositions: mockLoadPositions,
+  })),
+}));
+
 // Create a mock toast ref
 const mockToastRef = {
   current: {
@@ -56,6 +68,10 @@ jest.mock('../../../../core/Engine', () => ({
   },
 }));
 
+// Mock account data
+const mockAccountId = 'test-account-id';
+const mockAccountAddress = '0x1234567890123456789012345678901234567890';
+
 // Mock react-redux
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let mockState: any = {
@@ -63,6 +79,22 @@ let mockState: any = {
     backgroundState: {
       PredictController: {
         claimablePositions: [],
+      },
+      AccountsController: {
+        internalAccounts: {
+          selectedAccount: mockAccountId,
+          accounts: {
+            [mockAccountId]: {
+              id: mockAccountId,
+              address: mockAccountAddress,
+              name: 'Test Account',
+              type: 'eip155:eoa',
+              metadata: {
+                lastSelected: 0,
+              },
+            },
+          },
+        },
       },
     },
   },

--- a/app/components/UI/Predict/hooks/usePredictClaimToasts.tsx
+++ b/app/components/UI/Predict/hooks/usePredictClaimToasts.tsx
@@ -38,9 +38,9 @@ export const usePredictClaimToasts = () => {
   const claimablePositions = useSelector(selectPredictClaimablePositions);
   const wonPositions = useMemo(
     () =>
-      claimablePositions?.filter(
+      claimablePositions.filter(
         (position) => position.status === PredictPositionStatus.WON,
-      ) ?? [],
+      ),
     [claimablePositions],
   );
 

--- a/app/components/UI/Predict/hooks/usePredictClaimToasts.tsx
+++ b/app/components/UI/Predict/hooks/usePredictClaimToasts.tsx
@@ -65,6 +65,6 @@ export const usePredictClaimToasts = () => {
     },
     clearTransaction: () =>
       Engine.context.PredictController.clearClaimTransaction(),
-    onConfirmed: loadPositions,
+    onConfirmed: () => loadPositions({ isRefresh: true }),
   });
 };

--- a/app/components/UI/Predict/hooks/usePredictClaimToasts.tsx
+++ b/app/components/UI/Predict/hooks/usePredictClaimToasts.tsx
@@ -20,6 +20,7 @@ import { usePredictClaim } from './usePredictClaim';
 import { useSelector } from 'react-redux';
 import { selectPredictClaimablePositions } from '../selectors/predictController';
 import { PredictPosition, PredictPositionStatus } from '../types';
+import { formatPrice } from '../utils/format';
 
 const toastStyles = StyleSheet.create({
   spinnerContainer: {
@@ -147,12 +148,16 @@ export const usePredictClaimToasts = () => {
       }
 
       if (transactionMeta.status === TransactionStatus.approved) {
-        showPendingToast(transactionMeta.metamaskPay?.totalFiat ?? '');
+        showPendingToast(
+          formatPrice(totalClaimableAmount, { maximumDecimals: 2 }),
+        );
       }
 
       if (transactionMeta.status === TransactionStatus.confirmed) {
         Engine.context.PredictController.clearClaimTransaction();
-        showConfirmedToast(totalClaimableAmount.toString());
+        showConfirmedToast(
+          formatPrice(totalClaimableAmount, { maximumDecimals: 2 }),
+        );
       }
 
       // Handle PredictDeposit failed - clear deposit in progress

--- a/app/components/UI/Predict/hooks/usePredictClaimToasts.tsx
+++ b/app/components/UI/Predict/hooks/usePredictClaimToasts.tsx
@@ -21,6 +21,7 @@ import { useSelector } from 'react-redux';
 import { selectPredictClaimablePositions } from '../selectors/predictController';
 import { PredictPosition, PredictPositionStatus } from '../types';
 import { formatPrice } from '../utils/format';
+import { usePredictPositions } from './usePredictPositions';
 
 const toastStyles = StyleSheet.create({
   spinnerContainer: {
@@ -35,6 +36,10 @@ export const usePredictClaimToasts = () => {
   const theme = useAppThemeFromContext();
   const { toastRef } = useContext(ToastContext);
   const { claim } = usePredictClaim();
+  const { loadPositions } = usePredictPositions({
+    claimable: true,
+    loadOnMount: true,
+  });
 
   const claimablePositions = useSelector(selectPredictClaimablePositions);
   const wonPositions = useMemo(
@@ -158,6 +163,7 @@ export const usePredictClaimToasts = () => {
         showConfirmedToast(
           formatPrice(totalClaimableAmount, { maximumDecimals: 2 }),
         );
+        loadPositions();
       }
 
       // Handle PredictDeposit failed - clear deposit in progress
@@ -179,6 +185,7 @@ export const usePredictClaimToasts = () => {
       );
     };
   }, [
+    loadPositions,
     showConfirmedToast,
     showErrorToast,
     showPendingToast,

--- a/app/components/UI/Predict/hooks/usePredictClaimToasts.tsx
+++ b/app/components/UI/Predict/hooks/usePredictClaimToasts.tsx
@@ -65,6 +65,10 @@ export const usePredictClaimToasts = () => {
     },
     clearTransaction: () =>
       Engine.context.PredictController.clearClaimTransaction(),
-    onConfirmed: () => loadPositions({ isRefresh: true }),
+    onConfirmed: () => {
+      loadPositions({ isRefresh: true }).catch(() => {
+        // Ignore errors when refreshing positions
+      });
+    },
   });
 };

--- a/app/components/UI/Predict/hooks/usePredictDepositToasts.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictDepositToasts.test.ts
@@ -15,6 +15,11 @@ jest.mock('@react-navigation/native', () => ({
   })),
 }));
 
+// Mock @react-navigation/stack
+jest.mock('@react-navigation/stack', () => ({
+  createStackNavigator: jest.fn(),
+}));
+
 // Mock useConfirmNavigation
 jest.mock('../../../Views/confirmations/hooks/useConfirmNavigation', () => ({
   useConfirmNavigation: jest.fn(() => ({

--- a/app/components/UI/Predict/hooks/usePredictDepositToasts.tsx
+++ b/app/components/UI/Predict/hooks/usePredictDepositToasts.tsx
@@ -1,159 +1,35 @@
-import {
-  IconColor as ReactNativeDsIconColor,
-  IconSize as ReactNativeDsIconSize,
-} from '@metamask/design-system-react-native';
-import { Spinner } from '@metamask/design-system-react-native/dist/components/temp-components/Spinner/index.cjs';
-import {
-  TransactionMeta,
-  TransactionStatus,
-  TransactionType,
-} from '@metamask/transaction-controller';
-import React, { useCallback, useContext, useEffect } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { TransactionType } from '@metamask/transaction-controller';
 import { strings } from '../../../../../locales/i18n';
-import { IconName } from '../../../../component-library/components/Icons/Icon';
-import { ToastContext } from '../../../../component-library/components/Toast';
-import { ToastVariants } from '../../../../component-library/components/Toast/Toast.types';
 import Engine from '../../../../core/Engine';
-import { useAppThemeFromContext } from '../../../../util/theme';
 import { usePredictDeposit } from './usePredictDeposit';
-
-const toastStyles = StyleSheet.create({
-  spinnerContainer: {
-    paddingRight: 12,
-    alignContent: 'center',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});
+import { usePredictToasts } from './usePredictToasts';
 
 export const usePredictDepositToasts = () => {
-  const theme = useAppThemeFromContext();
-  const { toastRef } = useContext(ToastContext);
   const { deposit } = usePredictDeposit();
 
-  const showPendingToast = useCallback(
-    () =>
-      toastRef?.current?.showToast({
-        variant: ToastVariants.Icon,
-        labelOptions: [
-          { label: strings('predict.deposit.adding_funds'), isBold: true },
-          { label: '\n', isBold: false },
-          {
-            label: strings('predict.deposit.estimated_processing_time', {
-              time: 30,
-            }),
-            isBold: false,
-          },
-        ],
-        iconName: IconName.Loading,
-        iconColor: theme.colors.accent04.dark,
-        backgroundColor: theme.colors.accent04.normal,
-        hasNoTimeout: false,
-        startAccessory: (
-          <View style={toastStyles?.spinnerContainer}>
-            <Spinner
-              color={ReactNativeDsIconColor.PrimaryDefault}
-              spinnerIconProps={{ size: ReactNativeDsIconSize.Xl }}
-            />
-          </View>
-        ),
+  usePredictToasts({
+    transactionType: TransactionType.predictDeposit,
+    pendingToastConfig: {
+      title: strings('predict.deposit.adding_funds'),
+      description: strings('predict.deposit.estimated_processing_time', {
+        time: 30,
       }),
-    [theme.colors.accent04.dark, theme.colors.accent04.normal, toastRef],
-  );
-
-  const showConfirmedToast = useCallback(
-    (amount: string) =>
-      toastRef?.current?.showToast({
-        variant: ToastVariants.Icon,
-        labelOptions: [
-          { label: strings('predict.deposit.account_ready'), isBold: true },
-          { label: '\n', isBold: false },
-          {
-            label: strings('predict.deposit.account_ready_description', {
-              amount,
-            }),
-            isBold: false,
-          },
-        ],
-        iconName: IconName.CheckBold,
-        iconColor: theme.colors.success.default,
-        backgroundColor: theme.colors.accent04.normal,
-        hasNoTimeout: false,
+    },
+    confirmedToastConfig: {
+      title: strings('predict.deposit.account_ready'),
+      description: strings('predict.deposit.account_ready_description', {
+        amount: '{amount}',
       }),
-    [theme.colors.accent04.normal, theme.colors.success.default, toastRef],
-  );
-
-  const showErrorToast = useCallback(
-    () =>
-      toastRef?.current?.showToast({
-        variant: ToastVariants.Icon,
-        labelOptions: [
-          { label: strings('predict.deposit.error_title'), isBold: true },
-          { label: '\n', isBold: false },
-          {
-            label: strings('predict.deposit.error_description'),
-            isBold: false,
-          },
-        ],
-        iconName: IconName.Error,
-        iconColor: theme.colors.error.default,
-        backgroundColor: theme.colors.accent04.normal,
-        hasNoTimeout: false,
-        linkButtonOptions: {
-          label: strings('predict.deposit.try_again'),
-          onPress: () => {
-            deposit();
-          },
-        },
-      }),
-    [
-      deposit,
-      theme.colors.accent04.normal,
-      theme.colors.error.default,
-      toastRef,
-    ],
-  );
-
-  useEffect(() => {
-    const handlePredictDepositTransactionStatusUpdate = ({
-      transactionMeta,
-    }: {
-      transactionMeta: TransactionMeta;
-    }) => {
-      const isPredictDeposit = transactionMeta?.nestedTransactions?.some(
-        (tx) => tx.type === TransactionType.predictDeposit,
-      );
-      if (!isPredictDeposit) {
-        return;
-      }
-
-      if (transactionMeta.status === TransactionStatus.approved) {
-        showPendingToast();
-      }
-
-      if (transactionMeta.status === TransactionStatus.confirmed) {
-        Engine.context.PredictController.clearDepositTransaction();
-        showConfirmedToast(transactionMeta.metamaskPay?.totalFiat ?? 'Balance');
-      }
-
-      // Handle PredictDeposit failed - clear deposit in progress
-      if (transactionMeta.status === TransactionStatus.failed) {
-        Engine.context.PredictController.clearDepositTransaction();
-        showErrorToast();
-      }
-    };
-
-    Engine.controllerMessenger.subscribe(
-      'TransactionController:transactionStatusUpdated',
-      handlePredictDepositTransactionStatusUpdate,
-    );
-
-    return () => {
-      Engine.controllerMessenger.unsubscribe(
-        'TransactionController:transactionStatusUpdated',
-        handlePredictDepositTransactionStatusUpdate,
-      );
-    };
-  }, [deposit, showConfirmedToast, showErrorToast, showPendingToast, toastRef]);
+      getAmount: (transactionMeta) =>
+        transactionMeta.metamaskPay?.totalFiat ?? 'Balance',
+    },
+    errorToastConfig: {
+      title: strings('predict.deposit.error_title'),
+      description: strings('predict.deposit.error_description'),
+      retryLabel: strings('predict.deposit.try_again'),
+      onRetry: deposit,
+    },
+    clearTransaction: () =>
+      Engine.context.PredictController.clearDepositTransaction(),
+  });
 };

--- a/app/components/UI/Predict/hooks/usePredictPositions.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictPositions.test.ts
@@ -31,6 +31,7 @@ describe('usePredictPositions', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useFakeTimers();
     mockSelectSelectedInternalAccountAddress.mockReturnValue(
       '0x1234567890123456789012345678901234567890',
     );
@@ -43,6 +44,10 @@ describe('usePredictPositions', () => {
     (usePredictTrading as jest.Mock).mockReturnValue({
       getPositions: mockGetPositions,
     });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it('loads positions on mount by default', async () => {
@@ -272,5 +277,210 @@ describe('usePredictPositions', () => {
     // Should return the positions from the provider (filtering now happens in provider)
     expect(result.current.positions).toHaveLength(1);
     expect(result.current.positions[0].providerId).toBe('p2');
+  });
+
+  it('passes marketId when specified', async () => {
+    mockGetPositions.mockResolvedValue([]);
+
+    renderHook(() => usePredictPositions({ marketId: 'market123' }));
+
+    await waitFor(() => {
+      expect(mockGetPositions).toHaveBeenCalledWith({
+        address: '0x1234567890123456789012345678901234567890',
+        providerId: undefined,
+        claimable: false,
+        marketId: 'market123',
+      });
+    });
+  });
+
+  it('handles non-Error object errors', async () => {
+    mockGetPositions.mockRejectedValue('String error message');
+
+    const { result } = renderHook(() => usePredictPositions());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('Failed to load positions');
+    expect(result.current.positions).toEqual([]);
+  });
+
+  describe('autoRefreshTimeout', () => {
+    it('does not set up auto-refresh when autoRefreshTimeout is not provided', async () => {
+      mockGetPositions.mockResolvedValue([]);
+
+      renderHook(() => usePredictPositions());
+
+      // Wait for initial load
+      await waitFor(() => {
+        expect(mockGetPositions).toHaveBeenCalledTimes(1);
+      });
+
+      // Clear mock and advance time
+      mockGetPositions.mockClear();
+      jest.advanceTimersByTime(5000);
+
+      // Should not call getPositions again
+      expect(mockGetPositions).not.toHaveBeenCalled();
+    });
+
+    it('auto-refreshes positions at specified interval', async () => {
+      mockGetPositions.mockResolvedValue([]);
+
+      renderHook(() =>
+        usePredictPositions({
+          autoRefreshTimeout: 1000,
+        }),
+      );
+
+      // Wait for initial load
+      await waitFor(() => {
+        expect(mockGetPositions).toHaveBeenCalledTimes(1);
+      });
+
+      mockGetPositions.mockClear();
+
+      // Advance time by 1 second
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      // Should have called getPositions again with isRefresh: true
+      await waitFor(() => {
+        expect(mockGetPositions).toHaveBeenCalledTimes(1);
+      });
+
+      mockGetPositions.mockClear();
+
+      // Advance time by another second
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      // Should have called getPositions again
+      await waitFor(() => {
+        expect(mockGetPositions).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('clears auto-refresh interval on unmount', async () => {
+      mockGetPositions.mockResolvedValue([]);
+
+      const { unmount } = renderHook(() =>
+        usePredictPositions({
+          autoRefreshTimeout: 1000,
+        }),
+      );
+
+      // Wait for initial load
+      await waitFor(() => {
+        expect(mockGetPositions).toHaveBeenCalledTimes(1);
+      });
+
+      mockGetPositions.mockClear();
+
+      // Unmount the hook
+      unmount();
+
+      // Advance time
+      act(() => {
+        jest.advanceTimersByTime(5000);
+      });
+
+      // Should not call getPositions after unmount
+      expect(mockGetPositions).not.toHaveBeenCalled();
+    });
+
+    it('updates auto-refresh when autoRefreshTimeout changes', async () => {
+      mockGetPositions.mockResolvedValue([]);
+
+      const { rerender } = renderHook(
+        ({ timeout }) =>
+          usePredictPositions({
+            autoRefreshTimeout: timeout,
+          }),
+        {
+          initialProps: { timeout: 1000 },
+        },
+      );
+
+      // Wait for initial load
+      await waitFor(() => {
+        expect(mockGetPositions).toHaveBeenCalledTimes(1);
+      });
+
+      mockGetPositions.mockClear();
+
+      // Change the timeout
+      rerender({ timeout: 2000 });
+
+      // Advance time by 1 second (old interval)
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      // Should not have called yet (new interval is 2 seconds)
+      expect(mockGetPositions).not.toHaveBeenCalled();
+
+      // Advance time by another second (reaching 2 seconds total)
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      // Should have called now
+      await waitFor(() => {
+        expect(mockGetPositions).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('uses isRefresh flag when auto-refreshing', async () => {
+      const positions = [
+        {
+          providerId: 'p1',
+          marketId: 'm1',
+          outcomeId: 'o1',
+          size: 1,
+          price: 1.1,
+          conditionId: 'c1',
+          icon: 'icon',
+          title: 'Title',
+          outcome: 'Yes',
+          cashPnl: 5,
+          currentValue: 11,
+          percentPnl: 3,
+          initialValue: 10.5,
+          avgPrice: 1.05,
+          redeemable: false,
+        },
+      ];
+      mockGetPositions.mockResolvedValue(positions);
+
+      const { result } = renderHook(() =>
+        usePredictPositions({
+          autoRefreshTimeout: 1000,
+        }),
+      );
+
+      // Wait for initial load
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.positions).toHaveLength(1);
+
+      // Advance time to trigger auto-refresh
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      // Should use isRefreshing, not isLoading
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.positions).toHaveLength(1);
+    });
   });
 });

--- a/app/components/UI/Predict/hooks/usePredictToasts.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictToasts.test.ts
@@ -1,0 +1,651 @@
+import { renderHook, act } from '@testing-library/react-native';
+import React from 'react';
+import {
+  TransactionType,
+  TransactionStatus,
+  TransactionMeta,
+} from '@metamask/transaction-controller';
+import { usePredictToasts } from './usePredictToasts';
+import Engine from '../../../../core/Engine';
+import { ToastContext } from '../../../../component-library/components/Toast';
+
+// Mock @react-navigation/native
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: jest.fn(() => ({
+    navigate: jest.fn(),
+  })),
+}));
+
+// Mock @react-navigation/stack
+jest.mock('@react-navigation/stack', () => ({
+  createStackNavigator: jest.fn(),
+}));
+
+// Create a mock toast ref
+const mockToastRef = {
+  current: {
+    showToast: jest.fn(),
+    closeToast: jest.fn(),
+  },
+};
+
+// Mock theme hook
+jest.mock('../../../../util/theme', () => ({
+  useAppThemeFromContext: jest.fn(() => ({
+    colors: {
+      accent04: {
+        dark: '#190066',
+        normal: '#89b0ff',
+      },
+      success: {
+        default: '#457a39',
+      },
+      error: {
+        default: '#ca3542',
+      },
+    },
+  })),
+}));
+
+// Mock Engine
+jest.mock('../../../../core/Engine', () => ({
+  context: {
+    PredictController: {
+      clearDepositTransaction: jest.fn(),
+      clearClaimTransaction: jest.fn(),
+    },
+  },
+  controllerMessenger: {
+    subscribe: jest.fn(),
+    unsubscribe: jest.fn(),
+  },
+}));
+
+describe('usePredictToasts', () => {
+  let mockSubscribeCallback:
+    | ((payload: { transactionMeta: TransactionMeta }) => void)
+    | null = null;
+
+  const mockClearTransaction = jest.fn();
+  const mockOnConfirmed = jest.fn();
+  const mockOnRetry = jest.fn();
+  const mockGetAmount = jest.fn((_transactionMeta: TransactionMeta) => '$100');
+
+  const defaultConfig = {
+    transactionType: TransactionType.predictDeposit,
+    pendingToastConfig: {
+      title: 'Processing Transaction',
+      description: 'This may take a few moments',
+      getAmount: mockGetAmount,
+    },
+    confirmedToastConfig: {
+      title: 'Transaction Confirmed',
+      description: 'Your transaction was successful for {amount}',
+      getAmount: mockGetAmount,
+    },
+    errorToastConfig: {
+      title: 'Transaction Failed',
+      description: 'Something went wrong',
+      retryLabel: 'Try Again',
+      onRetry: mockOnRetry,
+    },
+    clearTransaction: mockClearTransaction,
+    onConfirmed: mockOnConfirmed,
+  };
+
+  // Wrapper to provide ToastContext
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      ToastContext.Provider,
+      { value: { toastRef: mockToastRef } },
+      children,
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockToastRef.current.showToast.mockClear();
+    mockClearTransaction.mockClear();
+    mockOnConfirmed.mockClear();
+    mockOnRetry.mockClear();
+    mockGetAmount.mockClear();
+
+    // Capture the subscribe callback
+    mockSubscribeCallback = null;
+    (Engine.controllerMessenger.subscribe as jest.Mock).mockImplementation(
+      (_event: string, callback: typeof mockSubscribeCallback) => {
+        mockSubscribeCallback = callback;
+      },
+    );
+    (Engine.controllerMessenger.unsubscribe as jest.Mock).mockClear();
+  });
+
+  describe('initialization', () => {
+    it('subscribes to transaction status updates on mount', () => {
+      // Act
+      renderHook(() => usePredictToasts(defaultConfig), { wrapper });
+
+      // Assert
+      expect(Engine.controllerMessenger.subscribe).toHaveBeenCalledWith(
+        'TransactionController:transactionStatusUpdated',
+        expect.any(Function),
+      );
+    });
+
+    it('unsubscribes from transaction status updates on unmount', () => {
+      // Arrange
+      const { unmount } = renderHook(() => usePredictToasts(defaultConfig), {
+        wrapper,
+      });
+
+      // Act
+      unmount();
+
+      // Assert
+      expect(Engine.controllerMessenger.unsubscribe).toHaveBeenCalledWith(
+        'TransactionController:transactionStatusUpdated',
+        expect.any(Function),
+      );
+    });
+  });
+
+  describe('transaction filtering', () => {
+    it('ignores transactions that do not match the specified transaction type', async () => {
+      // Arrange
+      renderHook(() => usePredictToasts(defaultConfig), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.approved,
+            nestedTransactions: [{ type: TransactionType.swap }],
+          } as TransactionMeta,
+        });
+      });
+
+      // Assert
+      expect(mockClearTransaction).not.toHaveBeenCalled();
+      expect(mockToastRef.current.showToast).not.toHaveBeenCalled();
+    });
+
+    it('processes transactions that match the specified transaction type', async () => {
+      // Arrange
+      renderHook(() => usePredictToasts(defaultConfig), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.approved,
+            nestedTransactions: [{ type: TransactionType.predictDeposit }],
+          } as TransactionMeta,
+        });
+      });
+
+      // Assert
+      expect(mockToastRef.current.showToast).toHaveBeenCalled();
+    });
+
+    it('handles transactions with multiple nested transactions correctly', async () => {
+      // Arrange
+      renderHook(() => usePredictToasts(defaultConfig), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.approved,
+            nestedTransactions: [
+              { type: TransactionType.swap },
+              { type: TransactionType.predictDeposit },
+            ],
+          } as TransactionMeta,
+        });
+      });
+
+      // Assert
+      expect(mockToastRef.current.showToast).toHaveBeenCalled();
+    });
+  });
+
+  describe('approved transaction status', () => {
+    it('shows pending toast when transaction is approved', async () => {
+      // Arrange
+      renderHook(() => usePredictToasts(defaultConfig), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.approved,
+            nestedTransactions: [{ type: TransactionType.predictDeposit }],
+          } as TransactionMeta,
+        });
+      });
+
+      // Assert
+      expect(mockToastRef.current.showToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: expect.anything(),
+          labelOptions: expect.arrayContaining([
+            expect.objectContaining({
+              label: 'Processing Transaction',
+              isBold: true,
+            }),
+          ]),
+          startAccessory: expect.anything(),
+        }),
+      );
+    });
+
+    it('calls getAmount with transaction metadata when showing pending toast', async () => {
+      // Arrange
+      renderHook(() => usePredictToasts(defaultConfig), { wrapper });
+      const transactionMeta = {
+        status: TransactionStatus.approved,
+        nestedTransactions: [{ type: TransactionType.predictDeposit }],
+      } as TransactionMeta;
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta,
+        });
+      });
+
+      // Assert
+      expect(mockGetAmount).toHaveBeenCalledWith(transactionMeta);
+    });
+
+    it('shows pending toast without amount when getAmount is not provided', async () => {
+      // Arrange
+      const configWithoutPendingAmount = {
+        ...defaultConfig,
+        pendingToastConfig: {
+          title: 'Processing',
+          description: 'Please wait',
+        },
+      };
+      renderHook(() => usePredictToasts(configWithoutPendingAmount), {
+        wrapper,
+      });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.approved,
+            nestedTransactions: [{ type: TransactionType.predictDeposit }],
+          } as TransactionMeta,
+        });
+      });
+
+      // Assert
+      expect(mockToastRef.current.showToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          labelOptions: expect.arrayContaining([
+            expect.objectContaining({
+              label: 'Processing',
+              isBold: true,
+            }),
+          ]),
+        }),
+      );
+    });
+
+    it('does not clear transaction when status is approved', async () => {
+      // Arrange
+      renderHook(() => usePredictToasts(defaultConfig), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.approved,
+            nestedTransactions: [{ type: TransactionType.predictDeposit }],
+          } as TransactionMeta,
+        });
+      });
+
+      // Assert
+      expect(mockClearTransaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('confirmed transaction status', () => {
+    it('shows confirmed toast when transaction is confirmed', async () => {
+      // Arrange
+      renderHook(() => usePredictToasts(defaultConfig), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.confirmed,
+            nestedTransactions: [{ type: TransactionType.predictDeposit }],
+          } as TransactionMeta,
+        });
+      });
+
+      // Assert
+      expect(mockToastRef.current.showToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: expect.anything(),
+          labelOptions: expect.arrayContaining([
+            expect.objectContaining({
+              label: 'Transaction Confirmed',
+              isBold: true,
+            }),
+          ]),
+        }),
+      );
+    });
+
+    it('calls getAmount with transaction metadata when showing confirmed toast', async () => {
+      // Arrange
+      renderHook(() => usePredictToasts(defaultConfig), { wrapper });
+      const transactionMeta = {
+        status: TransactionStatus.confirmed,
+        nestedTransactions: [{ type: TransactionType.predictDeposit }],
+      } as TransactionMeta;
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta,
+        });
+      });
+
+      // Assert
+      expect(mockGetAmount).toHaveBeenCalledWith(transactionMeta);
+    });
+
+    it('replaces {amount} placeholder in confirmed toast description', async () => {
+      // Arrange
+      renderHook(() => usePredictToasts(defaultConfig), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.confirmed,
+            nestedTransactions: [{ type: TransactionType.predictDeposit }],
+          } as TransactionMeta,
+        });
+      });
+
+      // Assert
+      expect(mockToastRef.current.showToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          labelOptions: expect.arrayContaining([
+            expect.objectContaining({
+              label: 'Your transaction was successful for $100',
+            }),
+          ]),
+        }),
+      );
+    });
+
+    it('clears transaction when transaction is confirmed', async () => {
+      // Arrange
+      renderHook(() => usePredictToasts(defaultConfig), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.confirmed,
+            nestedTransactions: [{ type: TransactionType.predictDeposit }],
+          } as TransactionMeta,
+        });
+      });
+
+      // Assert
+      expect(mockClearTransaction).toHaveBeenCalled();
+    });
+
+    it('calls onConfirmed callback when transaction is confirmed', async () => {
+      // Arrange
+      renderHook(() => usePredictToasts(defaultConfig), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.confirmed,
+            nestedTransactions: [{ type: TransactionType.predictDeposit }],
+          } as TransactionMeta,
+        });
+      });
+
+      // Assert
+      expect(mockOnConfirmed).toHaveBeenCalled();
+    });
+
+    it('does not call onConfirmed callback when it is not provided', async () => {
+      // Arrange
+      const configWithoutOnConfirmed = {
+        ...defaultConfig,
+        onConfirmed: undefined,
+      };
+      renderHook(() => usePredictToasts(configWithoutOnConfirmed), {
+        wrapper,
+      });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.confirmed,
+            nestedTransactions: [{ type: TransactionType.predictDeposit }],
+          } as TransactionMeta,
+        });
+      });
+
+      // Assert
+      expect(mockOnConfirmed).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('failed transaction status', () => {
+    it('shows error toast when transaction fails', async () => {
+      // Arrange
+      renderHook(() => usePredictToasts(defaultConfig), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.failed,
+            nestedTransactions: [{ type: TransactionType.predictDeposit }],
+          } as TransactionMeta,
+        });
+      });
+
+      // Assert
+      expect(mockToastRef.current.showToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: expect.anything(),
+          labelOptions: expect.arrayContaining([
+            expect.objectContaining({
+              label: 'Transaction Failed',
+              isBold: true,
+            }),
+            expect.objectContaining({
+              label: 'Something went wrong',
+              isBold: false,
+            }),
+          ]),
+          linkButtonOptions: expect.objectContaining({
+            label: 'Try Again',
+            onPress: mockOnRetry,
+          }),
+        }),
+      );
+    });
+
+    it('clears transaction when transaction fails', async () => {
+      // Arrange
+      renderHook(() => usePredictToasts(defaultConfig), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.failed,
+            nestedTransactions: [{ type: TransactionType.predictDeposit }],
+          } as TransactionMeta,
+        });
+      });
+
+      // Assert
+      expect(mockClearTransaction).toHaveBeenCalled();
+    });
+
+    it('does not call onConfirmed callback when transaction fails', async () => {
+      // Arrange
+      renderHook(() => usePredictToasts(defaultConfig), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.failed,
+            nestedTransactions: [{ type: TransactionType.predictDeposit }],
+          } as TransactionMeta,
+        });
+      });
+
+      // Assert
+      expect(mockOnConfirmed).not.toHaveBeenCalled();
+    });
+
+    it('calls retry function when error toast retry button is pressed', async () => {
+      // Arrange
+      renderHook(() => usePredictToasts(defaultConfig), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.failed,
+            nestedTransactions: [{ type: TransactionType.predictDeposit }],
+          } as TransactionMeta,
+        });
+      });
+
+      // Assert - Get the onPress function from the linkButtonOptions
+      const toastCall = (mockToastRef.current.showToast as jest.Mock).mock
+        .calls[0][0];
+      const onPressRetry = toastCall.linkButtonOptions?.onPress;
+
+      expect(onPressRetry).toBe(mockOnRetry);
+    });
+  });
+
+  describe('different transaction types', () => {
+    it('works with predictClaim transaction type', async () => {
+      // Arrange
+      const claimConfig = {
+        ...defaultConfig,
+        transactionType: TransactionType.predictClaim,
+      };
+      renderHook(() => usePredictToasts(claimConfig), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.confirmed,
+            nestedTransactions: [{ type: TransactionType.predictClaim }],
+          } as TransactionMeta,
+        });
+      });
+
+      // Assert
+      expect(mockToastRef.current.showToast).toHaveBeenCalled();
+      expect(mockClearTransaction).toHaveBeenCalled();
+    });
+
+    it('ignores predictClaim transactions when configured for predictDeposit', async () => {
+      // Arrange
+      renderHook(() => usePredictToasts(defaultConfig), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.confirmed,
+            nestedTransactions: [{ type: TransactionType.predictClaim }],
+          } as TransactionMeta,
+        });
+      });
+
+      // Assert
+      expect(mockToastRef.current.showToast).not.toHaveBeenCalled();
+      expect(mockClearTransaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('toast styling', () => {
+    it('includes spinner accessory for pending toast', async () => {
+      // Arrange
+      renderHook(() => usePredictToasts(defaultConfig), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.approved,
+            nestedTransactions: [{ type: TransactionType.predictDeposit }],
+          } as TransactionMeta,
+        });
+      });
+
+      // Assert
+      const toastCall = (mockToastRef.current.showToast as jest.Mock).mock
+        .calls[0][0];
+      expect(toastCall.startAccessory).toBeDefined();
+    });
+
+    it('uses success icon color for confirmed toast', async () => {
+      // Arrange
+      renderHook(() => usePredictToasts(defaultConfig), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.confirmed,
+            nestedTransactions: [{ type: TransactionType.predictDeposit }],
+          } as TransactionMeta,
+        });
+      });
+
+      // Assert
+      const toastCall = (mockToastRef.current.showToast as jest.Mock).mock
+        .calls[0][0];
+      expect(toastCall.iconColor).toBe('#457a39'); // success.default
+    });
+
+    it('uses error icon color for failed toast', async () => {
+      // Arrange
+      renderHook(() => usePredictToasts(defaultConfig), { wrapper });
+
+      // Act
+      await act(async () => {
+        mockSubscribeCallback?.({
+          transactionMeta: {
+            status: TransactionStatus.failed,
+            nestedTransactions: [{ type: TransactionType.predictDeposit }],
+          } as TransactionMeta,
+        });
+      });
+
+      // Assert
+      const toastCall = (mockToastRef.current.showToast as jest.Mock).mock
+        .calls[0][0];
+      expect(toastCall.iconColor).toBe('#ca3542'); // error.default
+    });
+  });
+});

--- a/app/components/UI/Predict/hooks/usePredictToasts.tsx
+++ b/app/components/UI/Predict/hooks/usePredictToasts.tsx
@@ -1,0 +1,222 @@
+import {
+  IconColor as ReactNativeDsIconColor,
+  IconSize as ReactNativeDsIconSize,
+} from '@metamask/design-system-react-native';
+import { Spinner } from '@metamask/design-system-react-native/dist/components/temp-components/Spinner/index.cjs';
+import {
+  TransactionMeta,
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import React, { useCallback, useContext, useEffect } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { IconName } from '../../../../component-library/components/Icons/Icon';
+import { ToastContext } from '../../../../component-library/components/Toast';
+import { ToastVariants } from '../../../../component-library/components/Toast/Toast.types';
+import Engine from '../../../../core/Engine';
+import { useAppThemeFromContext } from '../../../../util/theme';
+
+const toastStyles = StyleSheet.create({
+  spinnerContainer: {
+    paddingRight: 12,
+    alignContent: 'center',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+
+interface ToastConfig {
+  title: string;
+  description: string;
+}
+
+interface PendingToastConfig extends ToastConfig {
+  getAmount?: (transactionMeta: TransactionMeta) => string;
+}
+
+interface ConfirmedToastConfig extends ToastConfig {
+  getAmount: (transactionMeta: TransactionMeta) => string;
+}
+
+interface ErrorToastConfig extends ToastConfig {
+  retryLabel: string;
+  onRetry: () => void;
+}
+
+interface UsePredictToastsParams {
+  transactionType: TransactionType;
+  pendingToastConfig: PendingToastConfig;
+  confirmedToastConfig: ConfirmedToastConfig;
+  errorToastConfig: ErrorToastConfig;
+  clearTransaction: () => void;
+  onConfirmed?: () => void;
+}
+
+export const usePredictToasts = ({
+  transactionType,
+  pendingToastConfig,
+  confirmedToastConfig,
+  errorToastConfig,
+  clearTransaction,
+  onConfirmed,
+}: UsePredictToastsParams) => {
+  const theme = useAppThemeFromContext();
+  const { toastRef } = useContext(ToastContext);
+
+  const showPendingToast = useCallback(
+    (amount?: string) => {
+      const title = amount
+        ? pendingToastConfig.title.replace('{amount}', amount)
+        : pendingToastConfig.title;
+
+      return toastRef?.current?.showToast({
+        variant: ToastVariants.Icon,
+        labelOptions: [
+          { label: title, isBold: true },
+          { label: '\n', isBold: false },
+          {
+            label: pendingToastConfig.description,
+            isBold: false,
+          },
+        ],
+        iconName: IconName.Loading,
+        iconColor: theme.colors.accent04.dark,
+        backgroundColor: theme.colors.accent04.normal,
+        hasNoTimeout: false,
+        startAccessory: (
+          <View style={toastStyles?.spinnerContainer}>
+            <Spinner
+              color={ReactNativeDsIconColor.PrimaryDefault}
+              spinnerIconProps={{ size: ReactNativeDsIconSize.Xl }}
+            />
+          </View>
+        ),
+      });
+    },
+    [
+      pendingToastConfig.description,
+      pendingToastConfig.title,
+      theme.colors.accent04.dark,
+      theme.colors.accent04.normal,
+      toastRef,
+    ],
+  );
+
+  const showConfirmedToast = useCallback(
+    (amount: string) => {
+      const description = confirmedToastConfig.description.replace(
+        '{amount}',
+        amount,
+      );
+
+      return toastRef?.current?.showToast({
+        variant: ToastVariants.Icon,
+        labelOptions: [
+          { label: confirmedToastConfig.title, isBold: true },
+          { label: '\n', isBold: false },
+          {
+            label: description,
+            isBold: false,
+          },
+        ],
+        iconName: IconName.CheckBold,
+        iconColor: theme.colors.success.default,
+        backgroundColor: theme.colors.accent04.normal,
+        hasNoTimeout: false,
+      });
+    },
+    [
+      confirmedToastConfig.description,
+      confirmedToastConfig.title,
+      theme.colors.accent04.normal,
+      theme.colors.success.default,
+      toastRef,
+    ],
+  );
+
+  const showErrorToast = useCallback(
+    () =>
+      toastRef?.current?.showToast({
+        variant: ToastVariants.Icon,
+        labelOptions: [
+          { label: errorToastConfig.title, isBold: true },
+          { label: '\n', isBold: false },
+          {
+            label: errorToastConfig.description,
+            isBold: false,
+          },
+        ],
+        iconName: IconName.Error,
+        iconColor: theme.colors.error.default,
+        backgroundColor: theme.colors.accent04.normal,
+        hasNoTimeout: false,
+        linkButtonOptions: {
+          label: errorToastConfig.retryLabel,
+          onPress: errorToastConfig.onRetry,
+        },
+      }),
+    [
+      errorToastConfig.description,
+      errorToastConfig.onRetry,
+      errorToastConfig.retryLabel,
+      errorToastConfig.title,
+      theme.colors.accent04.normal,
+      theme.colors.error.default,
+      toastRef,
+    ],
+  );
+
+  useEffect(() => {
+    const handleTransactionStatusUpdate = ({
+      transactionMeta,
+    }: {
+      transactionMeta: TransactionMeta;
+    }) => {
+      const isTargetTransaction = transactionMeta?.nestedTransactions?.some(
+        (tx) => tx.type === transactionType,
+      );
+      if (!isTargetTransaction) {
+        return;
+      }
+
+      if (transactionMeta.status === TransactionStatus.approved) {
+        const amount = pendingToastConfig.getAmount?.(transactionMeta);
+        showPendingToast(amount);
+      }
+
+      if (transactionMeta.status === TransactionStatus.confirmed) {
+        clearTransaction();
+        const amount = confirmedToastConfig.getAmount(transactionMeta);
+        showConfirmedToast(amount);
+        onConfirmed?.();
+      }
+
+      if (transactionMeta.status === TransactionStatus.failed) {
+        clearTransaction();
+        showErrorToast();
+      }
+    };
+
+    Engine.controllerMessenger.subscribe(
+      'TransactionController:transactionStatusUpdated',
+      handleTransactionStatusUpdate,
+    );
+
+    return () => {
+      Engine.controllerMessenger.unsubscribe(
+        'TransactionController:transactionStatusUpdated',
+        handleTransactionStatusUpdate,
+      );
+    };
+  }, [
+    clearTransaction,
+    confirmedToastConfig,
+    onConfirmed,
+    pendingToastConfig,
+    showConfirmedToast,
+    showErrorToast,
+    showPendingToast,
+    toastRef,
+    transactionType,
+  ]);
+};

--- a/app/components/UI/Predict/hooks/usePredictTrading.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictTrading.test.ts
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react-native';
 import Engine from '../../../../core/Engine';
 import { usePredictTrading } from './usePredictTrading';
-import { PredictPositionStatus, Side } from '../types';
+import { Side } from '../types';
 
 // Mock Engine
 jest.mock('../../../../core/Engine', () => ({
@@ -11,6 +11,7 @@ jest.mock('../../../../core/Engine', () => ({
       getClaimablePositions: jest.fn(),
       placeOrder: jest.fn(),
       claim: jest.fn(),
+      claimWithConfirmation: jest.fn(),
       calculateBetAmounts: jest.fn(),
       calculateCashOutAmounts: jest.fn(),
       getBalance: jest.fn(),
@@ -186,61 +187,6 @@ describe('usePredictTrading', () => {
   });
 
   describe('claim', () => {
-    const mockClaimablePositions = [
-      {
-        id: 'position-123',
-        providerId: 'provider-456',
-        marketId: 'market-789',
-        outcomeId: 'outcome-101',
-        outcome: 'UP',
-        outcomeTokenId: 'outcome-token-202',
-        title: 'BTC UP',
-        icon: 'btc-icon.png',
-        amount: 100,
-        price: 1.0,
-        status: PredictPositionStatus.REDEEMABLE,
-        size: 100,
-        outcomeIndex: 0,
-        realizedPnl: 50,
-        curPrice: 1.5,
-        conditionId: 'condition-303',
-        percentPnl: 50,
-        cashPnl: 50,
-        redeemable: true,
-        initialValue: 100,
-        avgPrice: 1.0,
-        currentValue: 150,
-        endDate: '2025-01-01',
-        claimable: false,
-      },
-      {
-        id: 'position-456',
-        providerId: 'provider-789',
-        marketId: 'market-101',
-        outcomeId: 'outcome-202',
-        outcome: 'DOWN',
-        outcomeTokenId: 'outcome-token-303',
-        title: 'ETH DOWN',
-        icon: 'eth-icon.png',
-        amount: 75,
-        price: 1.2,
-        status: PredictPositionStatus.REDEEMABLE,
-        size: 75,
-        outcomeIndex: 1,
-        realizedPnl: 25,
-        curPrice: 1.5,
-        conditionId: 'condition-404',
-        percentPnl: 33.33,
-        cashPnl: 25,
-        redeemable: true,
-        initialValue: 75,
-        avgPrice: 1.2,
-        currentValue: 112.5,
-        endDate: '2025-02-01',
-        claimable: false,
-      },
-    ];
-
     it('calls PredictController.claim and returns result', async () => {
       const mockClaimResult = {
         txMeta: { id: 'tx-789', hash: '0xghi789' },
@@ -248,19 +194,19 @@ describe('usePredictTrading', () => {
         claimedAmount: 175,
       };
 
-      (Engine.context.PredictController.claim as jest.Mock).mockResolvedValue(
-        mockClaimResult,
-      );
+      (
+        Engine.context.PredictController.claimWithConfirmation as jest.Mock
+      ).mockResolvedValue(mockClaimResult);
 
       const { result } = renderHook(() => usePredictTrading());
 
       const response = await result.current.claim({
-        positions: mockClaimablePositions,
         providerId: 'polymarket',
       });
 
-      expect(Engine.context.PredictController.claim).toHaveBeenCalledWith({
-        positions: mockClaimablePositions,
+      expect(
+        Engine.context.PredictController.claimWithConfirmation,
+      ).toHaveBeenCalledWith({
         providerId: 'polymarket',
       });
       expect(response).toEqual(mockClaimResult);
@@ -268,69 +214,15 @@ describe('usePredictTrading', () => {
 
     it('handles errors from PredictController.claim', async () => {
       const mockError = new Error('Failed to claim winnings');
-      (Engine.context.PredictController.claim as jest.Mock).mockRejectedValue(
-        mockError,
-      );
+      (
+        Engine.context.PredictController.claimWithConfirmation as jest.Mock
+      ).mockRejectedValue(mockError);
 
       const { result } = renderHook(() => usePredictTrading());
 
       await expect(
-        result.current.claim({
-          positions: mockClaimablePositions,
-          providerId: 'polymarket',
-        }),
+        result.current.claim({ providerId: 'polymarket' }),
       ).rejects.toThrow('Failed to claim winnings');
-    });
-
-    it('handles empty positions array', async () => {
-      const mockClaimResult = {
-        txMeta: { id: 'tx-empty', hash: '0xempty' },
-        success: true,
-        claimedAmount: 0,
-      };
-
-      (Engine.context.PredictController.claim as jest.Mock).mockResolvedValue(
-        mockClaimResult,
-      );
-
-      const { result } = renderHook(() => usePredictTrading());
-
-      const response = await result.current.claim({
-        positions: [],
-        providerId: 'polymarket',
-      });
-
-      expect(Engine.context.PredictController.claim).toHaveBeenCalledWith({
-        positions: [],
-        providerId: 'polymarket',
-      });
-      expect(response).toEqual(mockClaimResult);
-    });
-
-    it('handles single position claim', async () => {
-      const singlePosition = [mockClaimablePositions[0]];
-      const mockClaimResult = {
-        txMeta: { id: 'tx-single', hash: '0xsingle' },
-        success: true,
-        claimedAmount: 150,
-      };
-
-      (Engine.context.PredictController.claim as jest.Mock).mockResolvedValue(
-        mockClaimResult,
-      );
-
-      const { result } = renderHook(() => usePredictTrading());
-
-      const response = await result.current.claim({
-        positions: singlePosition,
-        providerId: 'polymarket',
-      });
-
-      expect(Engine.context.PredictController.claim).toHaveBeenCalledWith({
-        positions: singlePosition,
-        providerId: 'polymarket',
-      });
-      expect(response).toEqual(mockClaimResult);
     });
   });
 

--- a/app/components/UI/Predict/hooks/usePredictTrading.ts
+++ b/app/components/UI/Predict/hooks/usePredictTrading.ts
@@ -17,7 +17,7 @@ export function usePredictTrading() {
 
   const claim = useCallback(async (claimParams: ClaimParams) => {
     const controller = Engine.context.PredictController;
-    return controller.claim(claimParams);
+    return controller.claimWithConfirmation(claimParams);
   }, []);
 
   const placeOrder = useCallback(async (params: PlaceOrderParams) => {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -1152,7 +1152,7 @@ describe('PolymarketProvider', () => {
 
       expect(result).toEqual({
         chainId: 137, // POLYGON_MAINNET_CHAIN_ID
-        transactionParams: {
+        transactions: {
           data: '0xencodedclaim',
           to: '0xConditionalTokensAddress',
           value: '0x0',
@@ -1200,7 +1200,7 @@ describe('PolymarketProvider', () => {
 
       expect(result).toEqual({
         chainId: 137,
-        transactionParams: {
+        transactions: {
           data: '0xencodedclaim',
           to: '0xConditionalTokensAddress',
           value: '0x0',

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -477,7 +477,7 @@ export class PolymarketProvider implements PredictProvider {
     });
     return {
       chainId: POLYGON_MAINNET_CHAIN_ID,
-      transactionParams: claimTransaction,
+      transactions: claimTransaction,
     };
   }
 

--- a/app/components/UI/Predict/providers/polymarket/safe/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/safe/utils.test.ts
@@ -28,6 +28,30 @@ import { PredictPosition, PredictPositionStatus } from '../../../types';
 import { isSmartContractAddress } from '../../../../../../util/transactions';
 import { getAllowance, getIsApprovedForAll } from '../utils';
 
+jest.mock('@metamask/transaction-controller', () => ({
+  TransactionType: {
+    cancel: 'cancel',
+    contractInteraction: 'contractInteraction',
+    deployContract: 'deployContract',
+    incoming: 'incoming',
+    personalSign: 'personalSign',
+    retry: 'retry',
+    sign: 'sign',
+    signTypedData: 'signTypedData',
+    simpleSend: 'simpleSend',
+    smart: 'smart',
+    swap: 'swap',
+    swapAndSend: 'swapAndSend',
+    swapApproval: 'swapApproval',
+    tokenMethodApprove: 'tokenMethodApprove',
+    tokenMethodIncreaseAllowance: 'tokenMethodIncreaseAllowance',
+    tokenMethodSetApprovalForAll: 'tokenMethodSetApprovalForAll',
+    tokenMethodTransfer: 'tokenMethodTransfer',
+    tokenMethodTransferFrom: 'tokenMethodTransferFrom',
+    tokenMethodSafeTransferFrom: 'tokenMethodSafeTransferFrom',
+  },
+}));
+
 jest.mock('../../../../../../core/Engine', () => ({
   context: {
     NetworkController: {
@@ -973,17 +997,19 @@ describe('safe utils', () => {
       setupMocksForFeeAuth();
 
       // When generating claim transaction
-      const tx = await getClaimTransaction({
+      const txs = await getClaimTransaction({
         signer,
         positions,
         safeAddress: TEST_SAFE_ADDRESS,
       });
 
       // Then transaction is returned with correct structure
-      expect(tx).toHaveProperty('from', signer.address);
-      expect(tx).toHaveProperty('to', TEST_SAFE_ADDRESS);
-      expect(tx).toHaveProperty('data');
-      expect(tx.data).toMatch(/^0x[a-f0-9]+$/);
+      expect(Array.isArray(txs)).toBe(true);
+      expect(txs).toHaveLength(1);
+      expect(txs[0]).toHaveProperty('params');
+      expect(txs[0].params).toHaveProperty('to', TEST_SAFE_ADDRESS);
+      expect(txs[0].params).toHaveProperty('data');
+      expect(txs[0].params.data).toMatch(/^0x[a-f0-9]+$/);
     });
 
     it('handles multiple positions in one transaction', async () => {
@@ -997,16 +1023,18 @@ describe('safe utils', () => {
       setupMocksForFeeAuth();
 
       // When generating claim transaction
-      const tx = await getClaimTransaction({
+      const txs = await getClaimTransaction({
         signer,
         positions,
         safeAddress: TEST_SAFE_ADDRESS,
       });
 
       // Then single transaction is returned with all claims
-      expect(tx).toHaveProperty('from');
-      expect(tx).toHaveProperty('to');
-      expect(tx).toHaveProperty('data');
+      expect(Array.isArray(txs)).toBe(true);
+      expect(txs).toHaveLength(1);
+      expect(txs[0]).toHaveProperty('params');
+      expect(txs[0].params).toHaveProperty('to');
+      expect(txs[0].params).toHaveProperty('data');
     });
 
     it('signs the claim transaction', async () => {
@@ -1036,14 +1064,14 @@ describe('safe utils', () => {
       setupMocksForFeeAuth();
 
       // When generating claim transaction
-      const tx = await getClaimTransaction({
+      const txs = await getClaimTransaction({
         signer,
         positions,
         safeAddress: customSafeAddress,
       });
 
       // Then transaction is sent to the provided Safe address
-      expect(tx.to).toBe(customSafeAddress);
+      expect(txs[0].params.to).toBe(customSafeAddress);
     });
 
     it('creates transaction for negRisk positions', async () => {
@@ -1054,15 +1082,17 @@ describe('safe utils', () => {
       setupMocksForFeeAuth();
 
       // When generating claim transaction
-      const tx = await getClaimTransaction({
+      const txs = await getClaimTransaction({
         signer,
         positions: [negRiskPosition],
         safeAddress: TEST_SAFE_ADDRESS,
       });
 
       // Then transaction is generated successfully
-      expect(tx).toBeDefined();
-      expect(tx.data).toMatch(/^0x[a-f0-9]+$/);
+      expect(txs).toBeDefined();
+      expect(Array.isArray(txs)).toBe(true);
+      expect(txs).toHaveLength(1);
+      expect(txs[0].params.data).toMatch(/^0x[a-f0-9]+$/);
     });
   });
 });

--- a/app/components/UI/Predict/providers/polymarket/safe/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/safe/utils.ts
@@ -46,6 +46,7 @@ import {
   getIsApprovedForAll,
 } from '../utils';
 import { PredictPosition } from '../../..';
+import { TransactionType } from '@metamask/transaction-controller';
 
 function joinHexData(hexData: string[]): string {
   return `0x${hexData
@@ -660,9 +661,13 @@ export const getClaimTransaction = async ({
     safeAddress,
     txn: safeTxn,
   });
-  return {
-    from: signer.address as Hex,
-    to: safeAddress as Hex,
-    data: callData as Hex,
-  };
+  return [
+    {
+      params: {
+        to: safeAddress as Hex,
+        data: callData as Hex,
+      },
+      type: TransactionType.predictClaim,
+    },
+  ];
 };

--- a/app/components/UI/Predict/providers/types.ts
+++ b/app/components/UI/Predict/providers/types.ts
@@ -93,11 +93,14 @@ export interface ClaimOrderParams {
 
 export interface ClaimOrderResponse {
   chainId: number;
-  transactionParams: {
-    from: Hex;
-    to: Hex;
-    data: Hex;
-  };
+  transactions: {
+    params: {
+      to: Hex;
+      data?: Hex;
+      value?: Hex;
+    };
+    type?: TransactionType;
+  }[];
 }
 
 export interface GetPositionsParams {

--- a/app/components/UI/Predict/routes/index.tsx
+++ b/app/components/UI/Predict/routes/index.tsx
@@ -6,7 +6,6 @@ import Routes from '../../../../constants/navigation/Routes';
 import { Confirm } from '../../../Views/confirmations/components/confirm';
 import PredictMarketDetails from '../views/PredictMarketDetails';
 import PredictMarketList from '../views/PredictMarketList';
-import PredictTabView from '../views/PredictTabView';
 import PredictUnavailableModal from '../views/PredictUnavailableModal';
 import PredictBuyPreview from '../views/PredictBuyPreview/PredictBuyPreview';
 import PredictActivityDetail from '../components/PredictActivityDetail/PredictActivityDetail';
@@ -60,15 +59,7 @@ const PredictModalStack = () => (
 );
 
 const PredictScreenStack = () => (
-  <Stack.Navigator initialRouteName={Routes.PREDICT.ROOT}>
-    <Stack.Screen
-      name={Routes.PREDICT.ROOT}
-      component={PredictTabView}
-      options={{
-        headerShown: false,
-      }}
-    />
-
+  <Stack.Navigator initialRouteName={Routes.PREDICT.MARKET_LIST}>
     <Stack.Screen
       name={Routes.PREDICT.MARKET_LIST}
       component={PredictMarketList}

--- a/app/components/UI/Predict/selectors/predictController/index.ts
+++ b/app/components/UI/Predict/selectors/predictController/index.ts
@@ -15,8 +15,15 @@ const selectPredictClaimTransaction = createSelector(
   (predictControllerState) => predictControllerState?.claimTransaction || null,
 );
 
+const selectPredictClaimablePositions = createSelector(
+  selectPredictControllerState,
+  (predictControllerState) =>
+    predictControllerState?.claimablePositions || null,
+);
+
 export {
   selectPredictControllerState,
   selectPredictDepositTransaction,
   selectPredictClaimTransaction,
+  selectPredictClaimablePositions,
 };

--- a/app/components/UI/Predict/selectors/predictController/index.ts
+++ b/app/components/UI/Predict/selectors/predictController/index.ts
@@ -17,8 +17,7 @@ const selectPredictClaimTransaction = createSelector(
 
 const selectPredictClaimablePositions = createSelector(
   selectPredictControllerState,
-  (predictControllerState) =>
-    predictControllerState?.claimablePositions || null,
+  (predictControllerState) => predictControllerState?.claimablePositions || [],
 );
 
 export {

--- a/app/components/UI/Predict/types/index.ts
+++ b/app/components/UI/Predict/types/index.ts
@@ -1,7 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
 
-import { Hex } from '@metamask/utils';
-
 export enum Side {
   BUY = 'BUY',
   SELL = 'SELL',
@@ -232,7 +230,6 @@ export type PredictPosition = {
 };
 
 export interface ClaimParams {
-  positions: PredictPosition[];
   providerId: string;
 }
 
@@ -253,14 +250,9 @@ export interface UnrealizedPnL {
 }
 
 export type PredictClaim = {
-  transactionId: string;
+  batchId: string;
   chainId: number;
   status: PredictClaimStatus;
-  txParams: {
-    to: Hex;
-    data: Hex;
-    value: Hex;
-  };
 };
 
 export type PredictDeposit = {

--- a/app/components/UI/Predict/views/PredictTabView/PredictTabView.test.tsx
+++ b/app/components/UI/Predict/views/PredictTabView/PredictTabView.test.tsx
@@ -5,6 +5,20 @@ jest.mock('../../hooks/usePredictDepositToasts', () => ({
   usePredictDepositToasts: jest.fn(),
 }));
 
+jest.mock('../../hooks/usePredictClaimToasts', () => ({
+  usePredictClaimToasts: jest.fn(() => ({
+    showSuccessToast: jest.fn(),
+    showErrorToast: jest.fn(),
+  })),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: jest.fn(() => ({
+    navigate: jest.fn(),
+  })),
+}));
+
 const renderWithProviders = (component: React.ReactElement) =>
   render(component);
 

--- a/app/components/UI/Predict/views/PredictTabView/PredictTabView.tsx
+++ b/app/components/UI/Predict/views/PredictTabView/PredictTabView.tsx
@@ -9,6 +9,7 @@ import PredictPositions, {
 } from '../../components/PredictPositions/PredictPositions';
 import PredictAddFundsSheet from '../../components/PredictAddFundsSheet/PredictAddFundsSheet';
 import { usePredictDepositToasts } from '../../hooks/usePredictDepositToasts';
+import { usePredictClaimToasts } from '../../hooks/usePredictClaimToasts';
 
 interface PredictTabViewProps {}
 
@@ -20,6 +21,7 @@ const PredictTabView: React.FC<PredictTabViewProps> = () => {
   const predictPositionsHeaderRef = useRef<PredictPositionsHeaderHandle>(null);
 
   usePredictDepositToasts();
+  usePredictClaimToasts();
 
   const handleRefresh = useCallback(async () => {
     setIsRefreshing(true);

--- a/app/components/Views/confirmations/components/predict-confirmations/predict-claim-amount/predict-claim-amount.test.tsx
+++ b/app/components/Views/confirmations/components/predict-confirmations/predict-claim-amount/predict-claim-amount.test.tsx
@@ -5,6 +5,7 @@ import { simpleSendTransactionControllerMock } from '../../../__mocks__/controll
 import { transactionApprovalControllerMock } from '../../../__mocks__/controllers/approval-controller-mock';
 import { otherControllersMock } from '../../../__mocks__/controllers/other-controllers-mock';
 import { PredictClaimAmount } from './predict-claim-amount';
+import { PredictPositionStatus } from '../../../../../UI/Predict';
 
 function render() {
   return renderWithProvider(<PredictClaimAmount />, {
@@ -13,18 +14,61 @@ function render() {
       simpleSendTransactionControllerMock,
       transactionApprovalControllerMock,
       otherControllersMock,
+      {
+        engine: {
+          backgroundState: {
+            PredictController: {
+              claimablePositions: [
+                {
+                  id: 'position-1',
+                  providerId: 'polymarket',
+                  marketId: 'market-1',
+                  outcomeId: 'outcome-1',
+                  outcomeTokenId: 'token-1',
+                  outcome: 'Yes',
+                  title: 'Test Position 1',
+                  icon: 'icon.png',
+                  amount: 100,
+                  price: 1.0,
+                  status: PredictPositionStatus.WON,
+                  size: 100,
+                  outcomeIndex: 0,
+                  realizedPnl: 0,
+                  curPrice: 1.5,
+                  conditionId: 'condition-1',
+                  percentPnl: 20.23,
+                  cashPnl: 46.35,
+                  initialValue: 182.74,
+                  avgPrice: 1.0,
+                  currentValue: 229.09,
+                  endDate: '2025-01-01',
+                  claimable: true,
+                  redeemable: true,
+                  negRisk: false,
+                },
+              ],
+            },
+          },
+        },
+      },
     ),
   });
 }
 
 describe('PredictClaimAmount', () => {
   it('renders formatted winnings', () => {
+    // Given a won position with currentValue of 229.09
     const { getByText } = render();
+
+    // Then the formatted winnings amount is displayed
     expect(getByText('$229.09')).toBeDefined();
   });
 
   it('renders formatted change and percentage', () => {
+    // Given a won position with cashPnl of 46.35 and currentValue of 229.09
     const { getByText } = render();
-    expect(getByText('+$46.35 (20.23%)')).toBeDefined();
+
+    // Then the formatted change and percentage is displayed
+    expect(getByText('+$46.35 (+20.23%)')).toBeDefined();
   });
 });

--- a/app/components/Views/confirmations/components/predict-confirmations/predict-claim-amount/predict-claim-amount.tsx
+++ b/app/components/Views/confirmations/components/predict-confirmations/predict-claim-amount/predict-claim-amount.tsx
@@ -7,13 +7,13 @@ import Text, {
 } from '../../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../../../component-library/hooks';
 import { Box } from '../../../../../UI/Box/Box';
-import { PredictPositionStatus } from '../../../../../UI/Predict';
 import { selectPredictClaimablePositions } from '../../../../../UI/Predict/selectors/predictController';
 import {
   formatPercentage,
   formatPrice,
 } from '../../../../../UI/Predict/utils/format';
 import styleSheet from './predict-claim-amount.styles';
+import { PredictPositionStatus } from '../../../../../UI/Predict/types';
 
 export function PredictClaimAmount() {
   const { styles } = useStyles(styleSheet, {});

--- a/app/components/Views/confirmations/components/predict-confirmations/predict-claim-amount/predict-claim-amount.tsx
+++ b/app/components/Views/confirmations/components/predict-confirmations/predict-claim-amount/predict-claim-amount.tsx
@@ -21,9 +21,9 @@ export function PredictClaimAmount() {
   const claimablePositions = useSelector(selectPredictClaimablePositions);
   const wonPositions = useMemo(
     () =>
-      claimablePositions?.filter(
+      claimablePositions.filter(
         (position) => position.status === PredictPositionStatus.WON,
-      ) ?? [],
+      ),
     [claimablePositions],
   );
 

--- a/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.test.tsx
+++ b/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.test.tsx
@@ -7,6 +7,145 @@ import { transactionApprovalControllerMock } from '../../../__mocks__/controller
 import { otherControllersMock } from '../../../__mocks__/controllers/other-controllers-mock';
 import { strings } from '../../../../../../../locales/i18n';
 import { fireEvent } from '@testing-library/react-native';
+import { PredictPositionStatus } from '../../../../../UI/Predict';
+
+const mockWonPositions = [
+  {
+    id: 'position-1',
+    providerId: 'polymarket',
+    marketId: 'market-1',
+    outcomeId: 'outcome-1',
+    outcomeTokenId: 'token-1',
+    outcome: 'Yes',
+    title: 'Market 1',
+    icon: 'https://example.com/icon1.png',
+    amount: 100,
+    price: 1.0,
+    status: PredictPositionStatus.WON,
+    size: 100,
+    outcomeIndex: 0,
+    realizedPnl: 0,
+    curPrice: 1.5,
+    conditionId: 'condition-1',
+    percentPnl: 50,
+    cashPnl: 50,
+    initialValue: 100,
+    avgPrice: 1.0,
+    currentValue: 150,
+    endDate: '2025-01-01',
+    claimable: true,
+    redeemable: true,
+    negRisk: false,
+  },
+  {
+    id: 'position-2',
+    providerId: 'polymarket',
+    marketId: 'market-2',
+    outcomeId: 'outcome-2',
+    outcomeTokenId: 'token-2',
+    outcome: 'No',
+    title: 'Market 2',
+    icon: 'https://example.com/icon2.png',
+    amount: 200,
+    price: 1.2,
+    status: PredictPositionStatus.WON,
+    size: 200,
+    outcomeIndex: 1,
+    realizedPnl: 0,
+    curPrice: 1.8,
+    conditionId: 'condition-2',
+    percentPnl: 50,
+    cashPnl: 100,
+    initialValue: 200,
+    avgPrice: 1.2,
+    currentValue: 300,
+    endDate: '2025-01-02',
+    claimable: true,
+    redeemable: true,
+    negRisk: false,
+  },
+  {
+    id: 'position-3',
+    providerId: 'polymarket',
+    marketId: 'market-3',
+    outcomeId: 'outcome-3',
+    outcomeTokenId: 'token-3',
+    outcome: 'Yes',
+    title: 'Market 3',
+    icon: 'https://example.com/icon3.png',
+    amount: 300,
+    price: 0.8,
+    status: PredictPositionStatus.WON,
+    size: 300,
+    outcomeIndex: 0,
+    realizedPnl: 0,
+    curPrice: 1.2,
+    conditionId: 'condition-3',
+    percentPnl: 50,
+    cashPnl: 150,
+    initialValue: 300,
+    avgPrice: 0.8,
+    currentValue: 450,
+    endDate: '2025-01-03',
+    claimable: true,
+    redeemable: true,
+    negRisk: false,
+  },
+  {
+    id: 'position-4',
+    providerId: 'polymarket',
+    marketId: 'market-4',
+    outcomeId: 'outcome-4',
+    outcomeTokenId: 'token-4',
+    outcome: 'No',
+    title: 'Market 4',
+    icon: 'https://example.com/icon4.png',
+    amount: 400,
+    price: 0.9,
+    status: PredictPositionStatus.WON,
+    size: 400,
+    outcomeIndex: 1,
+    realizedPnl: 0,
+    curPrice: 1.4,
+    conditionId: 'condition-4',
+    percentPnl: 55,
+    cashPnl: 200,
+    initialValue: 400,
+    avgPrice: 0.9,
+    currentValue: 600,
+    endDate: '2025-01-04',
+    claimable: true,
+    redeemable: true,
+    negRisk: false,
+  },
+  {
+    id: 'position-5',
+    providerId: 'polymarket',
+    marketId: 'market-5',
+    outcomeId: 'outcome-5',
+    outcomeTokenId: 'token-5',
+    outcome: 'Yes',
+    title: 'Market 5',
+    icon: 'https://example.com/icon5.png',
+    amount: 500,
+    price: 1.1,
+    status: PredictPositionStatus.WON,
+    size: 500,
+    outcomeIndex: 0,
+    realizedPnl: 0,
+    curPrice: 1.6,
+    conditionId: 'condition-5',
+    percentPnl: 45,
+    cashPnl: 250,
+    initialValue: 500,
+    avgPrice: 1.1,
+    currentValue: 750,
+    endDate: '2025-01-05',
+    claimable: true,
+    redeemable: true,
+    negRisk: false,
+  },
+];
 
 function render({ onPress }: { onPress?: () => void } = {}) {
   return renderWithProvider(<PredictClaimFooter onPress={onPress ?? noop} />, {
@@ -15,30 +154,47 @@ function render({ onPress }: { onPress?: () => void } = {}) {
       simpleSendTransactionControllerMock,
       transactionApprovalControllerMock,
       otherControllersMock,
+      {
+        engine: {
+          backgroundState: {
+            PredictController: {
+              claimablePositions: mockWonPositions,
+            },
+          },
+        },
+      },
     ),
   });
 }
 
 describe('PredictClaimFooter', () => {
   it('renders market count', () => {
+    // Given 5 won positions
     const { getByText } = render();
 
+    // Then the market count is displayed
     expect(
       getByText(strings('confirm.predict_claim.footer_top', { count: 5 })),
     ).toBeDefined();
   });
 
   it('renders market images', () => {
+    // Given 5 won positions with icons
     const { getAllByTestId } = render();
+
+    // Then the avatar group shows up to 3 avatars
     expect(getAllByTestId('token-avatar-image')).toHaveLength(3);
   });
 
   it('calls onPress when button is pressed', () => {
+    // Given a button with an onPress handler
     const onPressMock = jest.fn();
     const { getByText } = render({ onPress: onPressMock });
 
+    // When the button is pressed
     fireEvent.press(getByText(strings('confirm.predict_claim.button_label')));
 
+    // Then the onPress handler is called
     expect(onPressMock).toHaveBeenCalled();
   });
 });

--- a/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.tsx
+++ b/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.tsx
@@ -1,27 +1,23 @@
-import React from 'react';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../../component-library/components/Texts/Text';
-import { Box } from '../../../../../UI/Box/Box';
-import Button, {
-  ButtonVariants,
-} from '../../../../../../component-library/components/Buttons/Button';
-import { useStyles } from '../../../../../../component-library/hooks';
-import styleSheet from './predict-claim-footer.styles';
-import AvatarGroup from '../../../../../../component-library/components/Avatars/AvatarGroup';
+import React, { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { strings } from '../../../../../../../locales/i18n';
 import {
   AvatarSize,
   AvatarVariant,
 } from '../../../../../../component-library/components/Avatars/Avatar';
-import { strings } from '../../../../../../../locales/i18n';
-import {
-  getPredictMarketImage,
-  selectPredictClaimDataByTransactionId,
-} from '../predict-temp';
-import { RootState } from '../../../../../../reducers';
-import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
-import { useSelector } from 'react-redux';
+import AvatarGroup from '../../../../../../component-library/components/Avatars/AvatarGroup';
+import Button, {
+  ButtonVariants,
+} from '../../../../../../component-library/components/Buttons/Button';
+import Text, {
+  TextColor,
+  TextVariant,
+} from '../../../../../../component-library/components/Texts/Text';
+import { useStyles } from '../../../../../../component-library/hooks';
+import { Box } from '../../../../../UI/Box/Box';
+import { PredictPositionStatus } from '../../../../../UI/Predict';
+import { selectPredictClaimablePositions } from '../../../../../UI/Predict/selectors/predictController';
+import styleSheet from './predict-claim-footer.styles';
 
 export interface PredictClaimFooterProps {
   onPress: () => void;
@@ -29,17 +25,18 @@ export interface PredictClaimFooterProps {
 
 export function PredictClaimFooter({ onPress }: PredictClaimFooterProps) {
   const { styles } = useStyles(styleSheet, {});
-  const { id: transactionId } = useTransactionMetadataRequest() ?? {};
 
-  const { marketIds } =
-    useSelector((state: RootState) =>
-      selectPredictClaimDataByTransactionId(state, transactionId ?? ''),
-    ) ?? {};
+  const claimablePositions = useSelector(selectPredictClaimablePositions);
+  const wonPositions = useMemo(
+    () =>
+      claimablePositions?.filter(
+        (position) => position.status === PredictPositionStatus.WON,
+      ) ?? [],
+    [claimablePositions],
+  );
 
-  if (!marketIds) return null;
-
-  const networkAvatars = marketIds.map((marketId) => ({
-    imageSource: getPredictMarketImage(marketId),
+  const networkAvatars = wonPositions.map((position) => ({
+    imageSource: { uri: position.icon },
     variant: AvatarVariant.Token as const,
   }));
 
@@ -48,7 +45,7 @@ export function PredictClaimFooter({ onPress }: PredictClaimFooterProps) {
       <Box style={styles.top}>
         <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
           {strings('confirm.predict_claim.footer_top', {
-            count: marketIds.length,
+            count: wonPositions.length,
           })}
         </Text>
         <AvatarGroup

--- a/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.tsx
+++ b/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.tsx
@@ -15,9 +15,9 @@ import Text, {
 } from '../../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../../../component-library/hooks';
 import { Box } from '../../../../../UI/Box/Box';
-import { PredictPositionStatus } from '../../../../../UI/Predict';
 import { selectPredictClaimablePositions } from '../../../../../UI/Predict/selectors/predictController';
 import styleSheet from './predict-claim-footer.styles';
+import { PredictPositionStatus } from '../../../../../UI/Predict/types';
 
 export interface PredictClaimFooterProps {
   onPress: () => void;

--- a/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.tsx
+++ b/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.tsx
@@ -29,9 +29,9 @@ export function PredictClaimFooter({ onPress }: PredictClaimFooterProps) {
   const claimablePositions = useSelector(selectPredictClaimablePositions);
   const wonPositions = useMemo(
     () =>
-      claimablePositions?.filter(
+      claimablePositions.filter(
         (position) => position.status === PredictPositionStatus.WON,
-      ) ?? [],
+      ),
     [claimablePositions],
   );
 

--- a/app/core/Engine/Engine.test.ts
+++ b/app/core/Engine/Engine.test.ts
@@ -224,6 +224,7 @@ describe('Engine', () => {
         lastError: null,
         lastUpdateTimestamp: 0,
         claimTransaction: null,
+        claimablePositions: [],
         depositTransaction: null,
         isOnboarded: {},
       },

--- a/app/core/Engine/controllers/predict-controller/index.test.ts
+++ b/app/core/Engine/controllers/predict-controller/index.test.ts
@@ -64,6 +64,7 @@ describe('predict controller init', () => {
       lastError: null,
       lastUpdateTimestamp: Date.now(),
       claimTransaction: null,
+      claimablePositions: [],
       depositTransaction: null,
       isOnboarded: {},
     };

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1662,6 +1662,23 @@
       "total_net_pnl": "Total Net P&L",
       "market_net_pnl": "Market Net P&L",
       "activity_details": "Activity details"
+    },
+    "claim": {
+      "toasts": {
+        "pending": {
+          "title": "Claiming {{amount}}",
+          "description": "Est. {{time}} seconds"
+        },
+        "confirmed": {
+          "title": "Claimed",
+          "description": "{{amount}} added to your balance"
+        },
+        "error": {
+          "title": "Something went wrong",
+          "description": "Failed to proceed with claim",
+          "try_again": "Try again"
+        }
+      }
     }
   },
   "receive": {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Revamps Predict claim UX to use batched transactions and toast notifications, persists claimable positions in state, and updates hooks, UI, provider/types, routes, tests, and locales.
> 
> - **Predict Controller/State**:
>   - Store `claimablePositions` in controller state; update on `getPositions({ claimable: true })`.
>   - Switch claim to batched flow `claimWithConfirmation` (track via `batchId`); add `clearClaimTransaction`.
>   - Remove granular tx event handlers for claim; simplify tracking.
> - **Providers/Types**:
>   - `prepareClaim` now returns `transactions[]`; Safe utils return batched tx (typed `predictClaim`).
>   - Update types: `PredictClaim` uses `batchId`; `ClaimParams` no longer carries positions; provider/types adjusted accordingly.
> - **Hooks/Toasts**:
>   - New `usePredictToasts` infra; refactor `usePredictDepositToasts` to use it.
>   - Add `usePredictClaimToasts` (pending/confirmed/error toasts, refresh claimables).
>   - Rewrite `usePredictClaim` to handle eligibility, navigate to confirmation, and error toasts.
>   - `usePredictTrading.claim` now calls controller `claimWithConfirmation`.
>   - `usePredictPositions` adds `marketId` and `autoRefreshTimeout`.
> - **UI**:
>   - `PredictPositionsHeader` reads claimables from selector and triggers `claim()` directly; simplifies loading.
>   - `PredictClaimAmount`/`PredictClaimFooter` compute from Redux claimables and format outputs.
>   - `PredictTabView` wires in claim/deposit toasts.
> - **Routing**:
>   - Adjust Predict stack initial routing (favor `MARKET_LIST` over tab view).
> - **Selectors/Locales**:
>   - Add `selectPredictClaimablePositions`.
>   - Add i18n strings for claim toasts/messages.
> - **Tests**:
>   - Extensive updates/coverage for controller, hooks, providers, utils, views, and engine initial state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ab1e51447ae3a84edf8008b8af641d8a81eae50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->