### PR TITLE
feat: Add build type to version string

### DIFF
--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -924,7 +924,12 @@ export const getRpcMethodMiddleware = ({
         if (!appVersion) {
           appVersion = await getVersion();
         }
-        res.result = `MetaMask/${appVersion}/Mobile`;
+        const buildType = process.env.METAMASK_BUILD_TYPE;
+        const version =
+          buildType === 'main' || buildType === 'qa'
+            ? appVersion
+            : `${appVersion}-${buildType}`;
+        res.result = `MetaMask/${version}/Mobile`;
       },
 
       wallet_scanQRCode: () =>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Add build type to version string when `METAMASK_BUILD_TYPE` is not a main or QA build as those are treated as the main flavor of MetaMask.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> `web3_clientVersion` now appends `METAMASK_BUILD_TYPE` to the version (except for `main` and `qa`).
> 
> - **RPC Middleware (`app/core/RPCMethods/RPCMethodMiddleware.ts`)**:
>   - `web3_clientVersion`: Read `process.env.METAMASK_BUILD_TYPE` and include it in the returned version string; for `main`/`qa` use plain app version, otherwise return `MetaMask/<version>-<buildType>/Mobile`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ab761589760901527e124856e2abdb35c178f7b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->