### PR TITLE
feat: control btc provider state via remote feature flag

### DIFF
--- a/app/core/Engine/controllers/multichain-account-service/multichain-account-service-init.ts
+++ b/app/core/Engine/controllers/multichain-account-service/multichain-account-service-init.ts
@@ -10,6 +10,7 @@ import Engine from '../../Engine';
 import { forwardSelectedAccountGroupToSnapKeyring } from '../../../SnapKeyring/utils/forwardSelectedAccountGroupToSnapKeyring';
 import { MultichainAccountServiceInitMessenger } from '../../messengers/multichain-account-service-messenger/multichain-account-service-messenger';
 import { isBitcoinAccountsFeatureEnabled } from '../../../../multichain-bitcoin/remote-feature-flag';
+import { RemoteFeatureFlagControllerState } from '@metamask/remote-feature-flag-controller';
 
 /**
  * Initialize the multichain account service.
@@ -76,10 +77,9 @@ export const multichainAccountServiceInit: ControllerInitFunction<
   let currentBitcoinEnabled = initialBitcoinEnabled;
   initMessenger.subscribe(
     'RemoteFeatureFlagController:stateChange',
-    (state: unknown) => {
+    (state: RemoteFeatureFlagControllerState) => {
       const bitcoinAccountsEnabled = isBitcoinAccountsFeatureEnabled(
-        (state as { remoteFeatureFlags?: { bitcoinAccounts?: unknown } })
-          ?.remoteFeatureFlags?.bitcoinAccounts,
+        state.remoteFeatureFlags.bitcoinAccounts,
       );
 
       // Only react if the flag actually changed

--- a/app/core/Engine/messengers/multichain-account-service-messenger/multichain-account-service-messenger.ts
+++ b/app/core/Engine/messengers/multichain-account-service-messenger/multichain-account-service-messenger.ts
@@ -19,8 +19,10 @@ import {
   NetworkControllerGetNetworkClientByIdAction,
 } from '@metamask/network-controller';
 import { MultichainAccountServiceMultichainAccountGroupUpdatedEvent } from '@metamask/multichain-account-service';
-import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
-import type { RemoteFeatureFlagControllerStateChangeEvent } from '@metamask/remote-feature-flag-controller/dist/remote-feature-flag-controller.d.cts';
+import {
+  RemoteFeatureFlagControllerGetStateAction,
+  RemoteFeatureFlagControllerStateChangeEvent,
+} from '@metamask/remote-feature-flag-controller';
 
 type Actions =
   | AccountsControllerListMultichainAccountsAction

--- a/app/selectors/featureFlagController/bitcoinAccountsEnabled/index.test.ts
+++ b/app/selectors/featureFlagController/bitcoinAccountsEnabled/index.test.ts
@@ -2,6 +2,8 @@ import { selectIsBitcoinAccountsEnabled } from '.';
 import mockedEngine from '../../../core/__mocks__/MockedEngine';
 import { mockedEmptyFlagsState, mockedUndefinedFlagsState } from '../mocks';
 import packageJson from '../../../../package.json';
+import type { BitcoinAccountsFeatureFlag } from '../../../multichain-bitcoin/remote-feature-flag';
+import { FeatureFlags } from '@metamask/remote-feature-flag-controller';
 
 jest.mock('../../../core/Engine', () => ({
   init: () => mockedEngine.init(),
@@ -19,7 +21,7 @@ afterEach(() => {
 });
 
 // Helper function to create mock state with bitcoinAccounts flag
-function mockStateWith(bitcoinAccounts: unknown) {
+function mockStateWith(bitcoinAccounts: BitcoinAccountsFeatureFlag) {
   return {
     engine: {
       backgroundState: {
@@ -27,7 +29,8 @@ function mockStateWith(bitcoinAccounts: unknown) {
           cacheTimestamp: 0,
           remoteFeatureFlags: {
             bitcoinAccounts,
-          },
+            // Not sure why this cannot be inferred properly.
+          } as unknown as FeatureFlags,
         },
       },
     },
@@ -83,6 +86,7 @@ describe('selectIsBitcoinAccountsEnabled', () => {
   });
 
   it('returns false when flag structure is invalid', () => {
+    // @ts-expect-error - Testing error case.
     const mockedState = mockStateWith({
       enabled: true,
       // Missing minimumVersion - should return false for safety

--- a/app/selectors/featureFlagController/bitcoinAccountsEnabled/index.ts
+++ b/app/selectors/featureFlagController/bitcoinAccountsEnabled/index.ts
@@ -8,7 +8,8 @@ import { isBitcoinAccountsFeatureEnabled } from '../../../multichain-bitcoin/rem
  */
 export const selectIsBitcoinAccountsEnabled = createSelector(
   selectRemoteFeatureFlags,
-  ({ bitcoinAccounts }): boolean => {
+  (remoteFeatureFlags): boolean => {
+    const { bitcoinAccounts } = remoteFeatureFlags;
     return isBitcoinAccountsFeatureEnabled(bitcoinAccounts);
   },
 );

--- a/app/store/migrations/index.ts
+++ b/app/store/migrations/index.ts
@@ -288,7 +288,7 @@ export const asyncifyMigrations = (
    * - This function "redistributes" the single object back into individual controller files
    * - Then strips engine.backgroundState from redux to maintain the new architecture
    * - "repacking" the single object back into distributed files
-   *
+   * 
    * CRITICAL: Only strips engine.backgroundState if ALL controllers save successfully.
    * Failed controllers are preserved to prevent data loss.
    */
@@ -300,7 +300,7 @@ export const asyncifyMigrations = (
         string,
         unknown,
       ][];
-
+      
       let failedControllers = 0;
       const failedControllerStates: Record<string, unknown> = {};
 
@@ -333,7 +333,7 @@ export const asyncifyMigrations = (
         const { engine: _engine, ...rest } = s;
         return rest as unknown;
       }
-
+      
       // Keep failed controllers in engine.backgroundState to prevent data loss
       captureException(
         new Error(


### PR DESCRIPTION
## **Description**

Some fixes for:
- https://github.com/MetaMask/metamask-mobile/pull/20989

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wire BTC provider enable/disable and wallet alignment to the remote feature flag controller, add typed init messaging, and update selectors/tests accordingly.
> 
> - **Engine**:
>   - **MultichainAccountService init**: Reads `RemoteFeatureFlagController:getState` and subscribes to `RemoteFeatureFlagController:stateChange` (typed) to enable/disable `btcProvider` and trigger `alignWallets` when `remoteFeatureFlags.bitcoinAccounts` is enabled.
> - **Messaging**:
>   - Update init messenger to allow `RemoteFeatureFlagController:getState` and `RemoteFeatureFlagController:stateChange` using exported types, removing ad-hoc/unknown typing.
> - **Selectors**:
>   - Improve typing for `selectIsBitcoinAccountsEnabled` by handling `remoteFeatureFlags` explicitly; strengthen test types and cases.
> - **Tests**:
>   - Refactor `multichain-account-service-init` tests to mock `RemoteFeatureFlagController:getState`, use spies on `AccountProviderWrapper.setEnabled` and `MultichainAccountService.alignWallets`, and cover enabled/disabled/min-version scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4341f11d5fbe36e3c392d6271003e58fdb1a1ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->