### PR TITLE
fix: cp-7.57.0 handle string decimals in metamask pay

### DIFF
--- a/app/components/Views/confirmations/hooks/tokens/useTokenWithBalance.ts
+++ b/app/components/Views/confirmations/hooks/tokens/useTokenWithBalance.ts
@@ -62,7 +62,7 @@ export function useTokenWithBalance(tokenAddress: Hex, chainId: Hex) {
       isNative ? nativeBalanceHex : tokenBalanceHex,
     );
 
-    const decimals = token?.decimals ?? 18;
+    const decimals = Number(token?.decimals ?? 18);
     const balanceValue = balanceRawValue.shiftedBy(-decimals);
     const fiatRate = isNative ? conversionRate : tokenFiatRate;
 


### PR DESCRIPTION
## **Description**

Cherry-pick to fix [#20966](https://github.com/MetaMask/metamask-mobile/issues/20966) in `7.57.0`.

## **Changelog**

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Coerces `token.decimals` to a number in `useTokenWithBalance` to correctly compute balances and fiat values when decimals may be a string.
> 
> - **Confirmations • Tokens**:
>   - Update `app/components/Views/confirmations/hooks/tokens/useTokenWithBalance.ts` to coerce `token?.decimals` with `Number(...)` before balance math, ensuring correct balance/fiat calculations when decimals are strings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfbacf0b9186c3e0511c2c52a1ba4921d6681033. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->