### PR TITLE
fix(predict): change order toasts and show claim amount correctly

### DIFF
--- a/app/components/UI/Predict/components/PredictPositionResolved/PredictPositionResolved.test.tsx
+++ b/app/components/UI/Predict/components/PredictPositionResolved/PredictPositionResolved.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react-native';
+import { render, screen, fireEvent } from '@testing-library/react-native';
 import PredictPositionResolved from './PredictPositionResolved';
 import {
   PredictPositionStatus,
@@ -61,7 +61,7 @@ describe('PredictPositionResolved', () => {
     expect(
       screen.getByText('$123.45 on Yes • Ended 2 days ago'),
     ).toBeOnTheScreen();
-    expect(screen.getByText('Won $2,222.22')).toBeOnTheScreen();
+    expect(screen.getByText('Won $2,345.67')).toBeOnTheScreen();
   });
 
   it('renders losing position correctly', () => {
@@ -96,11 +96,23 @@ describe('PredictPositionResolved', () => {
   });
 
   it('calls onPress when position is tapped', () => {
-    // const mockOnPress = jest.fn();
+    const mockOnPress = jest.fn();
+    render(
+      <PredictPositionResolved position={basePosition} onPress={mockOnPress} />,
+    );
+
+    const touchableElement = screen.getByText(basePosition.title);
+    fireEvent.press(touchableElement);
+
+    expect(mockOnPress).toHaveBeenCalledWith(basePosition);
+    expect(mockOnPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when onPress is not provided', () => {
     renderComponent();
 
-    // Since we can't easily test TouchableOpacity onPress, we'll test that the component renders
-    // The onPress functionality would be tested in integration tests
-    expect(screen.getByText(basePosition.title)).toBeOnTheScreen();
+    const touchableElement = screen.getByText(basePosition.title);
+    // Should not throw when onPress is not provided
+    expect(() => fireEvent.press(touchableElement)).not.toThrow();
   });
 });

--- a/app/components/UI/Predict/components/PredictPositionResolved/PredictPositionResolved.tsx
+++ b/app/components/UI/Predict/components/PredictPositionResolved/PredictPositionResolved.tsx
@@ -68,8 +68,7 @@ const PredictPositionResolved: React.FC<PredictPositionResolvedProps> = ({
       <View>
         {percentPnl > 0 ? (
           <Text variant={TextVariant.BodyMD} color={TextColor.Success}>
-            Won{' '}
-            {formatPrice(currentValue - initialValue, { maximumDecimals: 2 })}
+            Won {formatPrice(currentValue, { maximumDecimals: 2 })}
           </Text>
         ) : (
           <Text variant={TextVariant.BodyMD} color={TextColor.Error}>

--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
@@ -104,7 +104,8 @@ const PredictPositionsHeader = forwardRef<PredictPositionsHeaderHandle>(
     const totalClaimableAmount = useMemo(
       () =>
         wonPositions.reduce(
-          (sum: number, position: PredictPosition) => sum + position.cashPnl,
+          (sum: number, position: PredictPosition) =>
+            sum + position.currentValue,
           0,
         ),
       [wonPositions],

--- a/app/components/UI/Predict/hooks/usePredictPlaceOrder.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictPlaceOrder.test.ts
@@ -15,12 +15,17 @@ jest.mock('../../../../core/SDKConnect/utils/DevLogger');
 jest.mock('./usePredictTrading');
 jest.mock('./usePredictBalance');
 jest.mock('../../../../../locales/i18n', () => ({
-  strings: (key: string) => {
+  strings: (key: string, options?: Record<string, unknown>) => {
     const translations: Record<string, string> = {
       'predict.prediction_placed': 'Prediction placed',
+      'predict.cashed_out': 'Cashed out',
+      'predict.cashed_out_subtitle': `You claimed $${options?.amount || '0'}`,
     };
     return translations[key] || key;
   },
+}));
+jest.mock('../utils/format', () => ({
+  formatPrice: (value: number) => value.toFixed(2),
 }));
 jest.mock('react', () => ({
   ...jest.requireActual('react'),
@@ -133,7 +138,7 @@ describe('usePredictPlaceOrder', () => {
       expect(result.current.result).toEqual(mockSuccessResult);
     });
 
-    it('shows success toast when order is placed successfully', async () => {
+    it('shows success toast when BUY order is placed successfully', async () => {
       mockPlaceOrder.mockResolvedValue(mockSuccessResult);
 
       const { result } = renderHook(() => usePredictPlaceOrder());
@@ -155,6 +160,60 @@ describe('usePredictPlaceOrder', () => {
           hasNoTimeout: false,
         }),
       );
+    });
+
+    it('shows cashed out toast when SELL order is placed successfully', async () => {
+      mockPlaceOrder.mockResolvedValue(mockSuccessResult);
+
+      const sellOrderParams = {
+        ...mockOrderParams,
+        preview: createMockOrderPreview({
+          side: Side.SELL,
+          minAmountReceived: 150,
+        }),
+      };
+
+      const { result } = renderHook(() => usePredictPlaceOrder());
+
+      await act(async () => {
+        await result.current.placeOrder(sellOrderParams);
+      });
+
+      expect(mockToastRef.current?.showToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: ToastVariants.Icon,
+          iconName: IconName.Check,
+          labelOptions: expect.arrayContaining([
+            expect.objectContaining({
+              label: expect.stringContaining('Cashed out'),
+              isBold: true,
+            }),
+          ]),
+          hasNoTimeout: false,
+        }),
+      );
+    });
+
+    it('reloads balance after successful order placement', async () => {
+      mockPlaceOrder.mockResolvedValue(mockSuccessResult);
+      const mockLoadBalance = jest.fn();
+      mockUsePredictBalance.mockReturnValue({
+        balance: 1000,
+        isLoading: false,
+        isRefreshing: false,
+        error: null,
+        hasNoBalance: false,
+        loadBalance: mockLoadBalance,
+      });
+
+      const { result } = renderHook(() => usePredictPlaceOrder());
+
+      await act(async () => {
+        await result.current.placeOrder(mockOrderParams);
+      });
+
+      expect(mockLoadBalance).toHaveBeenCalledWith({ isRefresh: true });
+      expect(mockLoadBalance).toHaveBeenCalledTimes(1);
     });
 
     it('calls onComplete callback when provided and order succeeds', async () => {

--- a/app/components/UI/Predict/hooks/usePredictPlaceOrder.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictPlaceOrder.test.ts
@@ -14,6 +14,14 @@ jest.mock('../../../../component-library/components/Toast');
 jest.mock('../../../../core/SDKConnect/utils/DevLogger');
 jest.mock('./usePredictTrading');
 jest.mock('./usePredictBalance');
+jest.mock('../../../../../locales/i18n', () => ({
+  strings: (key: string) => {
+    const translations: Record<string, string> = {
+      'predict.prediction_placed': 'Prediction placed',
+    };
+    return translations[key] || key;
+  },
+}));
 jest.mock('react', () => ({
   ...jest.requireActual('react'),
   useContext: jest.fn(),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Change the text for place order toasts
- Show the total amount to claim on claim button

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates BUY/SELL order toasts and reloads balance post-order, computes claim button total from current values, and changes resolved position win display to show total value; tests updated accordingly.
> 
> - **Predict UI**:
>   - `PredictPositionResolved`: Winning state now shows `Won <currentValue>` instead of profit difference; adds tap handler support without requiring `onPress`.
>   - `PredictPositionsHeader`: `totalClaimableAmount` now sums `position.currentValue` for the claim button text.
> - **Hooks**:
>   - `usePredictPlaceOrder`: Adds BUY/SELL-specific toasts ("Prediction placed" vs "Cashed out" with amount), uses i18n and `formatPrice`, and refreshes balance via `usePredictBalance` after success.
> - **Tests**:
>   - Update/add tests for new toast messages, SELL cash-out flow, balance reload, and press handling in `PredictPositionResolved`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5615a19c922d91fb3db40fe8d8f67711a06ebf5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->