### PR TITLE
Fix changelog for create release PR workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,30 +10,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [7.56.4]
 
 ### Fixed
-* fix: address feature flag config issue
+- fix: address feature flag config issue
 
 ## [7.56.3]
 
 ### Fixed
-* fix: remove unintended metrics from transaction finalised event ([#20733](https://github.com/MetaMask/metamask-mobile/pull/20733))							
-* fix: force rendering on token list when order changes ([#20771](https://github.com/MetaMask/metamask-mobile/pull/20771)) 									
-* fix: add contentful max version number segmentation ([#20769](https://github.com/MetaMask/metamask-mobile/pull/20769))									
+- fix: remove unintended metrics from transaction finalised event ([#20733](https://github.com/MetaMask/metamask-mobile/pull/20733))							
+- fix: force rendering on token list when order changes ([#20771](https://github.com/MetaMask/metamask-mobile/pull/20771)) 									
+- fix: add contentful max version number segmentation ([#20769](https://github.com/MetaMask/metamask-mobile/pull/20769))									
 
 ## [7.56.2]
 
 ### Fixed
-* fix: address feature flag config issue
+- fix: address feature flag config issue
 
 ## [7.56.1]
 
 ### Fixed
-* fix: in recipient validations for internal accounts ([#20694](https://github.com/MetaMask/metamask-mobile/pull/20694)) 
-* feat: iOS Rehydration Flow Update to release/7.56.1 ([#20681](https://github.com/MetaMask/metamask-mobile/pull/20681))
-* feat: social login success screen added for social login users and ios platform. ([#20679](https://github.com/MetaMask/metamask-mobile/pull/20679))
-* fix: Returned Scrollview to Perps and Defi tab cp-7.56.1 ([#20650](https://github.com/MetaMask/metamask-mobile/pull/20650))
-* fix: missing transactions in activity after perps deposit (\#20507) ([09ef7e5](https://github.com/MetaMask/metamask-mobile/commit/09ef7e5f5111d0d3592b5e6d60499f31dc22f013))
-* fix: cp-7.56.1 Temp Revert page-level scroll for Wallet (#20579) ([#20616](https://github.com/MetaMask/metamask-mobile/pull/20616)) 
-* fix: Temp Revert page-level scroll for Wallet (\#20579) ([9022244](https://github.com/MetaMask/metamask-mobile/commit/902224410fbdf37250b990c75986eb7a948fb5ec))
+- fix: in recipient validations for internal accounts ([#20694](https://github.com/MetaMask/metamask-mobile/pull/20694)) 
+- feat: iOS Rehydration Flow Update to release/7.56.1 ([#20681](https://github.com/MetaMask/metamask-mobile/pull/20681))
+- feat: social login success screen added for social login users and ios platform. ([#20679](https://github.com/MetaMask/metamask-mobile/pull/20679))
+- fix: Returned Scrollview to Perps and Defi tab cp-7.56.1 ([#20650](https://github.com/MetaMask/metamask-mobile/pull/20650))
+- fix: missing transactions in activity after perps deposit (\#20507) ([09ef7e5](https://github.com/MetaMask/metamask-mobile/commit/09ef7e5f5111d0d3592b5e6d60499f31dc22f013))
+- fix: cp-7.56.1 Temp Revert page-level scroll for Wallet (#20579) ([#20616](https://github.com/MetaMask/metamask-mobile/pull/20616)) 
+- fix: Temp Revert page-level scroll for Wallet (\#20579) ([9022244](https://github.com/MetaMask/metamask-mobile/commit/902224410fbdf37250b990c75986eb7a948fb5ec))
 
 ## [7.56.0]
 

--- a/scripts/auto-changelog.sh
+++ b/scripts/auto-changelog.sh
@@ -6,6 +6,14 @@ set -o pipefail
 
 readonly URL='https://github.com/MetaMask/metamask-mobile'
 
+# Ensure existing changelog entries use hyphen bullets so older
+# @metamask/auto-changelog versions can parse the file correctly.
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+  sed -i'' 's/^\* /- /' CHANGELOG.md
+else
+  sed -i '' 's/^\* /- /' CHANGELOG.md
+fi
+
 git fetch --tags
 
 most_recent_tag="$(git describe --tags "$(git rev-list --tags --max-count=1)")"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix for the following error.
 [error](https://github.com/MetaMask/metamask-mobile/actions/runs/18575221900/job/52958813309):
```
Checking for existing branch release/7.58.0-Changelog
Creating new branch release/7.58.0-Changelog
Switched to a new branch 'release/7.58.0-Changelog'
Branch release/7.58.0-Changelog ready
Generating changelog for mobile via npx @metamask/auto-changelog@4.1.0..
npm warn exec The following package was not found and will be installed: @metamask/auto-changelog@4.1.0
Error: Unrecognized line: '* fix: address feature flag config issue'
    at parseChangelog (/home/runner/.npm/_npx/6cfb3df63ccce84f/node_modules/@metamask/auto-changelog/dist/parse-changelog.js:147:19)
    at updateChangelog (/home/runner/.npm/_npx/6cfb3df63ccce84f/node_modules/@metamask/auto-changelog/dist/update-changelog.js:107:60)
    at update (/home/runner/.npm/_npx/6cfb3df63ccce84f/node_modules/@metamask/auto-changelog/dist/cli.js:91:78)
    at async main (/home/runner/.npm/_npx/6cfb3df63ccce84f/node_modules/@metamask/auto-changelog/dist/cli.js:368:9)
Error: Process completed with exit code 1.
```

Successfully tested in: https://github.com/consensys-test/metamask-mobile-test-workflow/actions/runs/18657295493


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes CHANGELOG bullets to hyphens and updates the auto-changelog script to auto-normalize bullet markers for compatibility.
> 
> - **Changelog**:
>   - Convert leading `*` bullets to `-` in `CHANGELOG.md` entries (e.g., `7.56.4`, `7.56.3`, `7.56.2`, `7.56.1`).
> - **Scripts**:
>   - Update `scripts/auto-changelog.sh` to pre-normalize `CHANGELOG.md` bullets from `*` to `-` on macOS/Linux before generation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b464961b42d233f9c837348b3d7e1ae5d744a44. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->