### PR TITLE
feat: cp-7.57.0 support external-link for notifications

### DIFF
--- a/app/components/Views/Notifications/Details/Footers/AnnouncementCtaFooter.test.tsx
+++ b/app/components/Views/Notifications/Details/Footers/AnnouncementCtaFooter.test.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { Linking } from 'react-native';
+import { fireEvent, render } from '@testing-library/react-native';
+import AnnouncementCtaFooter from './AnnouncementCtaFooter';
+import SharedDeeplinkManager from '../../../../../core/DeeplinkManager/SharedDeeplinkManager';
+import AppConstants from '../../../../../core/AppConstants';
+import Logger from '../../../../../util/Logger';
+import { ModalFooterType } from '../../../../../util/notifications/constants/config';
+
+jest.mock('react-native/Libraries/Linking/Linking', () => ({
+  openURL: jest.fn(),
+}));
+
+jest.mock('../../../../../core/DeeplinkManager/SharedDeeplinkManager', () => ({
+  parse: jest.fn(),
+}));
+
+jest.mock('../../../../../util/Logger', () => ({
+  error: jest.fn(),
+}));
+
+jest.mock('../useStyles', () => ({
+  __esModule: true,
+  default: () => ({
+    styles: {
+      ctaBtn: {},
+    },
+    theme: {},
+  }),
+}));
+
+describe('AnnouncementCtaFooter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (Linking.openURL as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  describe('with externalLink', () => {
+    it('renders button with external link text', () => {
+      const props = {
+        type: ModalFooterType.ANNOUNCEMENT_CTA,
+        externalLink: {
+          externalLinkUrl: 'https://metamask.io/test',
+          externalLinkText: 'Learn More',
+        },
+      } as const;
+
+      const { getByText } = render(<AnnouncementCtaFooter {...props} />);
+
+      expect(getByText('Learn More')).toBeOnTheScreen();
+    });
+
+    it('calls Linking.openURL when external link button is pressed', () => {
+      const props = {
+        type: ModalFooterType.ANNOUNCEMENT_CTA,
+        externalLink: {
+          externalLinkUrl: 'https://metamask.io/test',
+          externalLinkText: 'Learn More',
+        },
+      } as const;
+
+      const { getByText } = render(<AnnouncementCtaFooter {...props} />);
+      const button = getByText('Learn More');
+      fireEvent.press(button);
+
+      expect(Linking.openURL).toHaveBeenCalledWith('https://metamask.io/test');
+    });
+
+    it('logs error when Linking.openURL fails', async () => {
+      const testError = new Error('Failed to open URL');
+      (Linking.openURL as jest.Mock).mockRejectedValueOnce(testError);
+
+      const props = {
+        type: ModalFooterType.ANNOUNCEMENT_CTA,
+        externalLink: {
+          externalLinkUrl: 'https://metamask.io/test',
+          externalLinkText: 'Learn More',
+        },
+      } as const;
+
+      const { getByText } = render(<AnnouncementCtaFooter {...props} />);
+      const button = getByText('Learn More');
+      fireEvent.press(button);
+
+      await new Promise(process.nextTick);
+
+      expect(Logger.error).toHaveBeenCalledWith(
+        testError,
+        'Error opening external URL',
+      );
+    });
+  });
+
+  describe('with mobileLink', () => {
+    it('renders button with mobile link text', () => {
+      const props = {
+        type: ModalFooterType.ANNOUNCEMENT_CTA,
+        mobileLink: {
+          mobileLinkUrl: 'metamask://swap',
+          mobileLinkText: 'Try Swap',
+        },
+      } as const;
+
+      const { getByText } = render(<AnnouncementCtaFooter {...props} />);
+
+      expect(getByText('Try Swap')).toBeOnTheScreen();
+    });
+
+    it('calls SharedDeeplinkManager.parse when mobile link button is pressed', () => {
+      const props = {
+        type: ModalFooterType.ANNOUNCEMENT_CTA,
+        mobileLink: {
+          mobileLinkUrl: 'metamask://swap',
+          mobileLinkText: 'Try Swap',
+        },
+      } as const;
+
+      const { getByText } = render(<AnnouncementCtaFooter {...props} />);
+      const button = getByText('Try Swap');
+      fireEvent.press(button);
+
+      expect(SharedDeeplinkManager.parse).toHaveBeenCalledWith(
+        'metamask://swap',
+        {
+          origin: AppConstants.DEEPLINKS.ORIGIN_DEEPLINK,
+        },
+      );
+    });
+  });
+});

--- a/app/util/notifications/notification-states/feature-announcement/feature-announcement.tsx
+++ b/app/util/notifications/notification-states/feature-announcement/feature-announcement.tsx
@@ -49,6 +49,7 @@ const state: NotificationState<FeatureAnnouncementNotification> = {
     footer: {
       type: ModalFooterType.ANNOUNCEMENT_CTA,
       mobileLink: notification.data.mobileLink,
+      externalLink: notification.data.externalLink,
     },
     /**
      * TODO support mobile links

--- a/app/util/notifications/notification-states/types/NotificationModalDetails.ts
+++ b/app/util/notifications/notification-states/types/NotificationModalDetails.ts
@@ -198,6 +198,7 @@ export interface ModalFooterBlockExplorer {
 export interface ModalFooterAnnouncementCta {
   type: ModalFooterType.ANNOUNCEMENT_CTA;
   mobileLink?: FeatureAnnouncementRawNotification['data']['mobileLink'];
+  externalLink?: FeatureAnnouncementRawNotification['data']['externalLink'];
 }
 
 export type ModalFooter = ModalFooterBlockExplorer | ModalFooterAnnouncementCta;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
We were not supporting external links in the notification details page and that lead to not showing the CTA button. As a workarounf the team was trying to use mobileLink but that was redirecting to a 404 becase the mobileLink only supports deeplinks

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: added support for external-links in notifications

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/21357

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/8a54a700-dae1-491f-a387-902f9b568463

https://github.com/user-attachments/assets/1e1d6227-029a-4100-96ac-a49caad06316

### **After**

https://github.com/user-attachments/assets/62a7f5e6-b184-4fcb-843a-70a7e698be5a

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds external-link support to announcement CTA footer (using Linking with error logging), updates notification state/types, and adds tests; mobile deeplinks still supported.
> 
> - **Notifications UI**:
>   - **`AnnouncementCtaFooter`** (`app/components/.../AnnouncementCtaFooter.tsx`):
>     - Supports `externalLink` (opens via `Linking.openURL`, logs errors with `Logger`).
>     - Retains `mobileLink` handling via `SharedDeeplinkManager.parse`.
>     - Centralizes CTA config selection.
> - **Notification State**:
>   - Passes `externalLink` in `feature-announcement` modal details.
> - **Types**:
>   - Extends `ModalFooterAnnouncementCta` to include optional `externalLink`.
> - **Tests**:
>   - Adds coverage for button rendering and actions for both `externalLink` and `mobileLink`, including error path for failed `openURL`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a60a06658e88c3b36611c01d6d4faefa2944bb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->