### PR TITLE
feat(card): cp-7.58 display card button with geolocation and feature flag guards

### DIFF
--- a/app/components/UI/Card/Views/CardHome/CardHome.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.tsx
@@ -53,6 +53,7 @@ import { DEPOSIT_SUPPORTED_TOKENS } from '../../constants';
 import { useCardSDK } from '../../sdk';
 import Routes from '../../../../../constants/navigation/Routes';
 import useIsBaanxLoginEnabled from '../../hooks/isBaanxLoginEnabled';
+import { selectIsAuthenticatedCard } from '../../../../../core/redux/slices/card';
 
 /**
  * CardHome Component
@@ -70,11 +71,8 @@ const CardHome = () => {
   const [openAddFundsBottomSheet, setOpenAddFundsBottomSheet] = useState(false);
   const [retries, setRetries] = useState(0);
   const sheetRef = useRef<BottomSheetRef>(null);
-  const {
-    isAuthenticated,
-    logoutFromProvider,
-    isLoading: isSDKLoading,
-  } = useCardSDK();
+  const isAuthenticated = useSelector(selectIsAuthenticatedCard);
+  const { logoutFromProvider, isLoading: isSDKLoading } = useCardSDK();
   const isBaanxLoginEnabled = useIsBaanxLoginEnabled();
 
   const { trackEvent, createEventBuilder } = useMetrics();

--- a/app/components/UI/Card/hooks/isBaanxLoginEnabled.test.ts
+++ b/app/components/UI/Card/hooks/isBaanxLoginEnabled.test.ts
@@ -9,187 +9,82 @@ jest.mock('../sdk', () => ({
 
 const mockUseCardSDK = useCardSDK as jest.MockedFunction<typeof useCardSDK>;
 
+const createMockSDK = (isBaanxLoginEnabled: boolean): Partial<CardSDK> => ({
+  get isBaanxLoginEnabled() {
+    return isBaanxLoginEnabled;
+  },
+  get isCardEnabled() {
+    return true;
+  },
+  get supportedTokens() {
+    return [];
+  },
+  isCardHolder: jest.fn(),
+  getGeoLocation: jest.fn(),
+  getSupportedTokensAllowances: jest.fn(),
+  getPriorityToken: jest.fn(),
+});
+
+const mockCardSDKResponse = (sdk: Partial<CardSDK> | null) => {
+  mockUseCardSDK.mockReturnValue({
+    sdk: sdk as CardSDK | null,
+    isLoading: false,
+    logoutFromProvider: jest.fn(),
+    userCardLocation: 'international',
+  });
+};
+
 describe('useIsBaanxLoginEnabled', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should return false when SDK is null', () => {
-    mockUseCardSDK.mockReturnValue({
-      sdk: null,
-      isAuthenticated: false,
-      setIsAuthenticated: jest.fn(),
-      isLoading: false,
-      logoutFromProvider: jest.fn(),
-      userCardLocation: 'international',
-    });
+  it('returns false when SDK is null', () => {
+    // Given: SDK is not available
+    mockCardSDKResponse(null);
 
+    // When: hook is rendered
     const { result } = renderHook(() => useIsBaanxLoginEnabled());
 
+    // Then: should return false
     expect(result.current).toBe(false);
-    expect(mockUseCardSDK).toHaveBeenCalledTimes(1);
   });
 
-  it('should return false when SDK is undefined', () => {
-    mockUseCardSDK.mockReturnValue({
-      sdk: null,
-      isAuthenticated: false,
-      setIsAuthenticated: jest.fn(),
-      isLoading: false,
-      logoutFromProvider: jest.fn(),
-      userCardLocation: 'international',
-    });
+  it('returns true when Baanx login is enabled', () => {
+    // Given: SDK with Baanx login enabled
+    mockCardSDKResponse(createMockSDK(true));
 
+    // When: hook is rendered
     const { result } = renderHook(() => useIsBaanxLoginEnabled());
 
-    expect(result.current).toBe(false);
-    expect(mockUseCardSDK).toHaveBeenCalledTimes(1);
-  });
-
-  it('should return true when SDK exists and isBaanxLoginEnabled is true', () => {
-    const mockSdk = {
-      get isBaanxLoginEnabled() {
-        return true;
-      },
-      get isCardEnabled() {
-        return true;
-      },
-      get supportedTokens() {
-        return [];
-      },
-      isCardHolder: jest.fn(),
-      getGeoLocation: jest.fn(),
-      getSupportedTokensAllowances: jest.fn(),
-      getPriorityToken: jest.fn(),
-    };
-
-    mockUseCardSDK.mockReturnValue({
-      sdk: mockSdk as unknown as CardSDK,
-      isAuthenticated: false,
-      setIsAuthenticated: jest.fn(),
-      isLoading: false,
-      logoutFromProvider: jest.fn(),
-      userCardLocation: 'international',
-    });
-
-    const { result } = renderHook(() => useIsBaanxLoginEnabled());
-
+    // Then: should return true
     expect(result.current).toBe(true);
-    expect(mockUseCardSDK).toHaveBeenCalledTimes(1);
   });
 
-  it('should return false when SDK exists and isBaanxLoginEnabled is false', () => {
-    const mockSdk = {
-      get isBaanxLoginEnabled() {
-        return false;
-      },
-      get isCardEnabled() {
-        return true;
-      },
-      get supportedTokens() {
-        return [];
-      },
-      isCardHolder: jest.fn(),
-      getGeoLocation: jest.fn(),
-      getSupportedTokensAllowances: jest.fn(),
-      getPriorityToken: jest.fn(),
-    };
+  it('returns false when Baanx login is disabled', () => {
+    // Given: SDK with Baanx login disabled
+    mockCardSDKResponse(createMockSDK(false));
 
-    mockUseCardSDK.mockReturnValue({
-      sdk: mockSdk as unknown as CardSDK,
-      isAuthenticated: false,
-      setIsAuthenticated: jest.fn(),
-      isLoading: false,
-      logoutFromProvider: jest.fn(),
-      userCardLocation: 'international',
-    });
-
+    // When: hook is rendered
     const { result } = renderHook(() => useIsBaanxLoginEnabled());
 
+    // Then: should return false
     expect(result.current).toBe(false);
-    expect(mockUseCardSDK).toHaveBeenCalledTimes(1);
   });
 
-  it('should call useCardSDK hook correctly', () => {
-    const mockSdk = {
-      get isBaanxLoginEnabled() {
-        return true;
-      },
-      get isCardEnabled() {
-        return true;
-      },
-      get supportedTokens() {
-        return [];
-      },
-      isCardHolder: jest.fn(),
-      getGeoLocation: jest.fn(),
-      getSupportedTokensAllowances: jest.fn(),
-      getPriorityToken: jest.fn(),
-    };
-
-    mockUseCardSDK.mockReturnValue({
-      sdk: mockSdk as unknown as CardSDK,
-      isAuthenticated: false,
-      setIsAuthenticated: jest.fn(),
-      isLoading: false,
-      logoutFromProvider: jest.fn(),
-      userCardLocation: 'international',
-    });
-
-    renderHook(() => useIsBaanxLoginEnabled());
-
-    expect(mockUseCardSDK).toHaveBeenCalledWith();
-    expect(mockUseCardSDK).toHaveBeenCalledTimes(1);
-  });
-
-  it('should re-render when SDK value changes', () => {
-    const mockSdk = {
-      get isBaanxLoginEnabled() {
-        return false;
-      },
-      get isCardEnabled() {
-        return true;
-      },
-      get supportedTokens() {
-        return [];
-      },
-      isCardHolder: jest.fn(),
-      getGeoLocation: jest.fn(),
-      getSupportedTokensAllowances: jest.fn(),
-      getPriorityToken: jest.fn(),
-    };
-
-    mockUseCardSDK.mockReturnValue({
-      sdk: mockSdk as unknown as CardSDK,
-      isAuthenticated: false,
-      setIsAuthenticated: jest.fn(),
-      isLoading: false,
-      logoutFromProvider: jest.fn(),
-      userCardLocation: 'international',
-    });
-
+  it('updates when SDK value changes', () => {
+    // Given: SDK with Baanx login disabled
+    mockCardSDKResponse(createMockSDK(false));
     const { result, rerender } = renderHook(() => useIsBaanxLoginEnabled());
 
+    // Then: should return false initially
     expect(result.current).toBe(false);
 
-    const updatedMockSdk = {
-      ...mockSdk,
-      get isBaanxLoginEnabled() {
-        return true;
-      },
-    };
-
-    mockUseCardSDK.mockReturnValue({
-      sdk: updatedMockSdk as unknown as CardSDK,
-      isAuthenticated: false,
-      setIsAuthenticated: jest.fn(),
-      isLoading: false,
-      logoutFromProvider: jest.fn(),
-      userCardLocation: 'international',
-    });
-
+    // When: SDK changes to enable Baanx login
+    mockCardSDKResponse(createMockSDK(true));
     rerender();
 
+    // Then: should return true
     expect(result.current).toBe(true);
   });
 });

--- a/app/components/UI/Card/hooks/useCardProviderAuthentication.ts
+++ b/app/components/UI/Card/hooks/useCardProviderAuthentication.ts
@@ -4,6 +4,8 @@ import { storeCardBaanxToken } from '../util/cardTokenVault';
 import { generatePKCEPair, generateState } from '../util/pkceHelpers';
 import { CardError, CardErrorType, CardLocation } from '../types';
 import { strings } from '../../../../../locales/i18n';
+import { useDispatch } from 'react-redux';
+import { setIsAuthenticatedCard as setIsAuthenticatedAction } from '../../../../core/redux/slices/card';
 
 /**
  * Maps CardError types to user-friendly localized error messages
@@ -45,9 +47,10 @@ const useCardProviderAuthentication = (): {
   error: string | null;
   clearError: () => void;
 } => {
+  const dispatch = useDispatch();
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-  const { sdk, setIsAuthenticated } = useCardSDK();
+  const { sdk } = useCardSDK();
 
   const clearError = useCallback(() => {
     setError(null);
@@ -105,7 +108,7 @@ const useCardProviderAuthentication = (): {
         });
 
         setError(null);
-        setIsAuthenticated(true);
+        dispatch(setIsAuthenticatedAction(true));
       } catch (err) {
         const errorMessage = getErrorMessage(err);
         setError(errorMessage);
@@ -115,7 +118,7 @@ const useCardProviderAuthentication = (): {
         setLoading(false);
       }
     },
-    [sdk, setIsAuthenticated],
+    [sdk, dispatch],
   );
 
   return useMemo(

--- a/app/components/UI/Card/hooks/useCardholderCheck.test.ts
+++ b/app/components/UI/Card/hooks/useCardholderCheck.test.ts
@@ -55,11 +55,13 @@ describe('useCardholderCheck', () => {
     accounts: [
       {
         type: 'eip155:eoa',
-        caipAccountId: 'eip155:1:0x123',
+        address: '0x123',
+        scopes: ['eip155:59144'],
       },
       {
         type: 'eip155:eoa',
-        caipAccountId: 'eip155:1:0x456',
+        address: '0x456',
+        scopes: ['eip155:59144'],
       },
     ],
   };
@@ -91,7 +93,7 @@ describe('useCardholderCheck', () => {
 
     expect(mockDispatch).toHaveBeenCalledWith(
       loadCardholderAccounts({
-        caipAccountIds: ['eip155:1:0x123', 'eip155:1:0x456'],
+        caipAccountIds: ['eip155:0:0x123', 'eip155:0:0x456'],
         cardFeatureFlag: mockCardFeatureFlag,
       }),
     );
@@ -133,15 +135,18 @@ describe('useCardholderCheck', () => {
     const accountsWithNonEOA = [
       {
         type: 'eip155:eoa',
-        caipAccountId: 'eip155:1:0x123',
+        address: '0x123',
+        scopes: ['eip155:59144'],
       },
       {
         type: 'eip155:erc4337',
-        caipAccountId: 'eip155:1:0x456',
+        address: '0x456',
+        scopes: ['eip155:59144'],
       },
       {
         type: 'eip155:eoa',
-        caipAccountId: 'eip155:1:0x789',
+        address: '0x789',
+        scopes: ['eip155:59144'],
       },
     ];
 
@@ -151,7 +156,7 @@ describe('useCardholderCheck', () => {
 
     expect(mockDispatch).toHaveBeenCalledWith(
       loadCardholderAccounts({
-        caipAccountIds: ['eip155:1:0x123', 'eip155:1:0x789'],
+        caipAccountIds: ['eip155:0:0x123', 'eip155:0:0x789'],
         cardFeatureFlag: mockCardFeatureFlag,
       }),
     );
@@ -161,11 +166,13 @@ describe('useCardholderCheck', () => {
     const accountsWithoutEOA = [
       {
         type: 'eip155:erc4337',
-        caipAccountId: 'eip155:1:0x123',
+        address: '0x123',
+        scopes: ['eip155:59144'],
       },
       {
         type: 'eip155:erc4337',
-        caipAccountId: 'eip155:1:0x456',
+        address: '0x456',
+        scopes: ['eip155:59144'],
       },
     ];
 
@@ -223,7 +230,8 @@ describe('useCardholderCheck', () => {
     const newAccounts = [
       {
         type: 'eip155:eoa',
-        caipAccountId: 'eip155:1:0x999',
+        address: '0x999',
+        scopes: ['eip155:59144'],
       },
     ];
     setupMockSelectors({ accounts: newAccounts });
@@ -232,7 +240,7 @@ describe('useCardholderCheck', () => {
     expect(mockDispatch).toHaveBeenCalledTimes(2);
     expect(mockDispatch).toHaveBeenLastCalledWith(
       loadCardholderAccounts({
-        caipAccountIds: ['eip155:1:0x999'],
+        caipAccountIds: ['eip155:0:0x999'],
         cardFeatureFlag: mockCardFeatureFlag,
       }),
     );

--- a/app/components/UI/Card/hooks/useCardholderCheck.ts
+++ b/app/components/UI/Card/hooks/useCardholderCheck.ts
@@ -1,7 +1,10 @@
 import { useCallback, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import useThunkDispatch from '../../../hooks/useThunkDispatch';
-import { selectCardFeatureFlag } from '../../../../selectors/featureFlagController/card';
+import {
+  CardFeatureFlag,
+  selectCardFeatureFlag,
+} from '../../../../selectors/featureFlagController/card';
 import { loadCardholderAccounts } from '../../../../core/redux/slices/card';
 import {
   selectAppServicesReady,
@@ -40,7 +43,7 @@ export const useCardholderCheck = () => {
     dispatch(
       loadCardholderAccounts({
         caipAccountIds,
-        cardFeatureFlag,
+        cardFeatureFlag: cardFeatureFlag as CardFeatureFlag,
       }),
     );
   }, [cardFeatureFlag, dispatch, internalAccounts]);

--- a/app/components/UI/Card/sdk/CardSDK.test.ts
+++ b/app/components/UI/Card/sdk/CardSDK.test.ts
@@ -525,43 +525,83 @@ describe('CardSDK', () => {
   });
 
   describe('getGeoLocation', () => {
-    it('should return geolocation on successful API call', async () => {
-      const mockGeolocation = 'US';
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: true,
-        text: jest.fn().mockResolvedValue(mockGeolocation),
-      });
+    const originalNodeEnv = process.env.NODE_ENV;
 
-      const result = await cardSDK.getGeoLocation();
-      expect(result).toBe(mockGeolocation);
-      expect(global.fetch).toHaveBeenCalledWith(
-        new URL(
-          'geolocation',
-          mockCardFeatureFlag.constants?.onRampApiUrl || '',
-        ),
-      );
+    afterEach(() => {
+      // Restore original NODE_ENV
+      if (originalNodeEnv === undefined) {
+        delete (process.env as { NODE_ENV?: string }).NODE_ENV;
+      } else {
+        (process.env as { NODE_ENV?: string }).NODE_ENV = originalNodeEnv;
+      }
+      jest.clearAllMocks();
     });
 
-    it('should handle API errors and return empty string', async () => {
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: false,
-      });
-
-      const result = await cardSDK.getGeoLocation();
-      expect(result).toBe('');
-      expect(Logger.log).toHaveBeenCalled();
-    });
-
-    it('should handle network errors and return empty string', async () => {
+    it('should return UNKNOWN when API call fails', async () => {
       const error = new Error('Network error');
-      (global.fetch as jest.Mock).mockRejectedValue(error);
+      (global.fetch as jest.Mock).mockRejectedValueOnce(error);
 
       const result = await cardSDK.getGeoLocation();
-      expect(result).toBe('');
+
+      expect(result).toBe('UNKNOWN');
       expect(Logger.log).toHaveBeenCalledWith(
         error,
         'CardSDK: Failed to get geolocation',
       );
+    });
+
+    it('should return UNKNOWN when fetch throws an error', async () => {
+      const fetchError = new Error('Fetch failed');
+      (global.fetch as jest.Mock).mockRejectedValueOnce(fetchError);
+
+      const result = await cardSDK.getGeoLocation();
+
+      expect(result).toBe('UNKNOWN');
+      expect(Logger.log).toHaveBeenCalledWith(
+        fetchError,
+        'CardSDK: Failed to get geolocation',
+      );
+    });
+
+    it('should return UNKNOWN when response.text() throws an error', async () => {
+      const textError = new Error('Failed to read response text');
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        text: jest.fn().mockRejectedValue(textError),
+      });
+
+      const result = await cardSDK.getGeoLocation();
+
+      expect(result).toBe('UNKNOWN');
+      expect(Logger.log).toHaveBeenCalledWith(
+        textError,
+        'CardSDK: Failed to get geolocation',
+      );
+    });
+
+    it('should handle different country codes correctly', async () => {
+      const countryCodes = ['US', 'GB', 'CA', 'DE', 'FR', 'UNKNOWN'];
+
+      for (const code of countryCodes) {
+        (global.fetch as jest.Mock).mockResolvedValueOnce({
+          ok: true,
+          text: jest.fn().mockResolvedValue(code),
+        });
+
+        const result = await cardSDK.getGeoLocation();
+        expect(result).toBe(code);
+      }
+    });
+
+    it('should handle empty string response from API', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        text: jest.fn().mockResolvedValue(''),
+      });
+
+      const result = await cardSDK.getGeoLocation();
+
+      expect(result).toBe('');
     });
   });
 

--- a/app/components/UI/Card/sdk/CardSDK.ts
+++ b/app/components/UI/Card/sdk/CardSDK.ts
@@ -121,16 +121,6 @@ export class CardSDK {
     );
   }
 
-  private get rampApiUrl() {
-    const onRampApi = this.cardFeatureFlag.constants?.onRampApiUrl;
-
-    if (!onRampApi) {
-      throw new Error('On Ramp API URL is not defined for the current chain');
-    }
-
-    return onRampApi;
-  }
-
   private get accountsApiUrl() {
     const accountsApi = this.cardFeatureFlag.constants?.accountsApiUrl;
 
@@ -264,17 +254,24 @@ export class CardSDK {
 
   getGeoLocation = async (): Promise<string> => {
     try {
-      const url = new URL('geolocation', this.rampApiUrl);
+      const env = process.env.NODE_ENV ?? 'production';
+      const environment = env === 'production' ? 'PROD' : 'DEV';
+
+      const GEOLOCATION_URLS = {
+        DEV: 'https://on-ramp.dev-api.cx.metamask.io/geolocation',
+        PROD: 'https://on-ramp.api.cx.metamask.io/geolocation',
+      };
+      const url = GEOLOCATION_URLS[environment];
       const response = await fetch(url);
 
       if (!response.ok) {
-        throw new Error('Failed to fetch geolocation');
+        throw new Error(`Failed to get geolocation: ${response.statusText}`);
       }
 
       return await response.text();
     } catch (error) {
       Logger.log(error as Error, 'CardSDK: Failed to get geolocation');
-      return '';
+      return 'UNKNOWN';
     }
   };
 

--- a/app/components/UI/Card/sdk/index.test.tsx
+++ b/app/components/UI/Card/sdk/index.test.tsx
@@ -18,7 +18,6 @@ import {
   SupportedToken,
   selectCardFeatureFlag,
 } from '../../../../selectors/featureFlagController/card';
-import { selectChainId } from '../../../../selectors/networkController';
 import { useCardholderCheck } from '../hooks/useCardholderCheck';
 import {
   getCardBaanxToken,
@@ -41,18 +40,24 @@ jest.mock('./CardSDK', () => ({
   })),
 }));
 
-jest.mock('../../../../selectors/networkController', () => ({
-  selectChainId: jest.fn(),
-}));
-
 jest.mock('../../../../selectors/featureFlagController/card', () => ({
   selectCardFeatureFlag: jest.fn(),
+  selectCardExperimentalSwitch: jest.fn(() => false),
+  selectCardSupportedCountries: jest.fn(() => []),
+  selectDisplayCardButtonFeatureFlag: jest.fn(() => false),
 }));
 
-// Mock react-redux hooks
+jest.mock('../../../../selectors/multichainAccounts/accounts', () => ({
+  selectSelectedInternalAccountByScope: jest.fn(() => () => null),
+}));
+
+// Create a stable mock dispatch function to prevent useEffect retriggering
+const mockDispatch = jest.fn();
+
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
   useSelector: jest.fn(),
+  useDispatch: jest.fn(() => mockDispatch),
 }));
 
 jest.mock('../hooks/useCardholderCheck', () => ({
@@ -72,7 +77,6 @@ jest.mock('../../../../util/Logger', () => ({
 describe('CardSDK Context', () => {
   const MockedCardholderSDK = jest.mocked(CardSDK);
   const mockUseSelector = jest.mocked(useSelector);
-  const mockSelectChainId = jest.mocked(selectChainId);
   const mockSelectCardFeatureFlag = jest.mocked(selectCardFeatureFlag);
   const mockUseCardholderCheck = jest.mocked(useCardholderCheck);
   const mockGetCardBaanxToken = jest.mocked(getCardBaanxToken);
@@ -102,29 +106,9 @@ describe('CardSDK Context', () => {
     },
   };
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-    MockedCardholderSDK.mockClear();
-    mockSelectChainId.mockClear();
-    mockSelectCardFeatureFlag.mockClear();
-    mockUseSelector.mockClear();
-    mockUseCardholderCheck.mockClear();
-    mockGetCardBaanxToken.mockClear();
-    mockStoreCardBaanxToken.mockClear();
-    mockRemoveCardBaanxToken.mockClear();
-    mockLogger.log.mockClear();
-
-    // Default successful token retrieval
-    mockGetCardBaanxToken.mockResolvedValue({
-      success: false,
-      error: 'No token found',
-    });
-    mockStoreCardBaanxToken.mockResolvedValue({ success: true });
-    mockRemoveCardBaanxToken.mockResolvedValue({ success: true });
-  });
-
+  // Helper: Setup feature flag selector
   const setupMockUseSelector = (
-    featureFlag: CardFeatureFlag | null | undefined,
+    featureFlag: CardFeatureFlag | null | undefined | Record<string, never>,
   ) => {
     mockUseSelector.mockImplementation((selector) => {
       if (selector === mockSelectCardFeatureFlag) {
@@ -134,49 +118,102 @@ describe('CardSDK Context', () => {
     });
   };
 
+  // Helper: Create mock SDK with custom properties
+  const createMockSDK = (
+    overrides: Partial<CardSDK> = {},
+  ): Partial<CardSDK> => ({
+    isCardEnabled: true,
+    isBaanxLoginEnabled: true,
+    supportedTokens: [],
+    isCardHolder: jest.fn(),
+    getGeoLocation: jest.fn(),
+    getSupportedTokensAllowances: jest.fn(),
+    getPriorityToken: jest.fn(),
+    refreshLocalToken: jest.fn().mockResolvedValue({
+      accessToken: 'new-access-token',
+      refreshToken: 'new-refresh-token',
+      expiresIn: 3600,
+    }),
+    ...overrides,
+  });
+
+  // Helper: Setup SDK mock
+  const setupMockSDK = (sdkProperties: Partial<CardSDK> = {}) => {
+    MockedCardholderSDK.mockImplementation(
+      () => createMockSDK(sdkProperties) as CardSDK,
+    );
+  };
+
+  // Helper: Create wrapper component
+  const createWrapper = ({ children }: { children: React.ReactNode }) => (
+    <CardSDKProvider>{children}</CardSDKProvider>
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    MockedCardholderSDK.mockClear();
+    mockSelectCardFeatureFlag.mockClear();
+    mockUseSelector.mockClear();
+    mockUseCardholderCheck.mockClear();
+    mockGetCardBaanxToken.mockClear();
+    mockStoreCardBaanxToken.mockClear();
+    mockRemoveCardBaanxToken.mockClear();
+    mockLogger.log.mockClear();
+    mockDispatch.mockClear();
+
+    // Default: no token found
+    mockGetCardBaanxToken.mockResolvedValue({
+      success: false,
+      error: 'No token found',
+    });
+    mockStoreCardBaanxToken.mockResolvedValue({ success: true });
+    mockRemoveCardBaanxToken.mockResolvedValue({ success: true });
+  });
+
   describe('CardSDKProvider', () => {
-    it('should render children without crashing', () => {
+    it('initializes SDK when feature flag is available', () => {
+      // Given: feature flag is configured
       setupMockUseSelector(mockCardFeatureFlag);
 
-      const TestComponent = () => <View>Test Child</View>;
-
+      // When: provider renders
       render(
         <CardSDKProvider>
-          <TestComponent />
+          <View>Test Child</View>
         </CardSDKProvider>,
       );
 
+      // Then: SDK should be created with feature flag
       expect(MockedCardholderSDK).toHaveBeenCalledWith({
         cardFeatureFlag: mockCardFeatureFlag,
       });
     });
 
-    it('should not initialize SDK when card feature flag is missing', () => {
+    it('does not initialize SDK when feature flag is missing', () => {
+      // Given: no feature flag
       setupMockUseSelector(null);
 
-      const TestComponent = () => <View>Test Child</View>;
-
+      // When: provider renders
       render(
         <CardSDKProvider>
-          <TestComponent />
+          <View>Test Child</View>
         </CardSDKProvider>,
       );
 
+      // Then: SDK should not be created
       expect(MockedCardholderSDK).not.toHaveBeenCalled();
     });
 
-    it('should use provided value prop when given', () => {
+    it('uses provided value prop when given', () => {
+      // Given: a custom context value
       setupMockUseSelector(mockCardFeatureFlag);
-
       const providedValue: ICardSDK = {
         sdk: null,
-        isAuthenticated: false,
-        setIsAuthenticated: jest.fn(),
         isLoading: false,
         logoutFromProvider: jest.fn(),
         userCardLocation: 'international' as const,
       };
 
+      // When: provider renders with custom value
       const TestComponent = () => {
         const context = useCardSDK();
         expect(context).toEqual(providedValue);
@@ -188,119 +225,49 @@ describe('CardSDK Context', () => {
           <TestComponent />
         </CardSDKProvider>,
       );
+
+      // Then: custom value is used (assertion in TestComponent)
     });
   });
 
   describe('useCardSDK', () => {
-    it('should return SDK context when used within provider', async () => {
+    it('returns SDK context when used within provider', async () => {
+      // Given: provider with feature flag
       setupMockUseSelector(mockCardFeatureFlag);
 
-      const wrapper = ({ children }: { children: React.ReactNode }) => (
-        <CardSDKProvider>{children}</CardSDKProvider>
-      );
+      // When: hook is called within provider
+      const { result } = renderHook(() => useCardSDK(), {
+        wrapper: createWrapper,
+      });
 
-      const { result } = renderHook(() => useCardSDK(), { wrapper });
-
+      // Then: should return valid context
       await waitFor(() => {
         expect(result.current.sdk).not.toBeNull();
       });
 
       expect(result.current).toEqual({
         sdk: expect.any(Object),
-        isAuthenticated: expect.any(Boolean),
-        setIsAuthenticated: expect.any(Function),
         isLoading: expect.any(Boolean),
         logoutFromProvider: expect.any(Function),
         userCardLocation: expect.stringMatching(/^(us|international)$/),
       });
-      expect(result.current.sdk).toHaveProperty('isCardEnabled', true);
-      expect(result.current.sdk).toHaveProperty('isBaanxLoginEnabled', true);
-      expect(result.current.sdk).toHaveProperty('supportedTokens', []);
-      expect(result.current.sdk).toHaveProperty('isCardHolder');
-      expect(result.current.sdk).toHaveProperty('getGeoLocation');
-      expect(result.current.sdk).toHaveProperty('getSupportedTokensAllowances');
-      expect(result.current.sdk).toHaveProperty('getPriorityToken');
-      expect(result.current.sdk).toHaveProperty('refreshLocalToken');
     });
 
-    it('should throw error when used outside of provider', () => {
+    it('throws error when used outside provider', () => {
+      // Given: no provider
       const consoleError = jest
         .spyOn(console, 'error')
         .mockImplementation(() => {
           // Suppress console error for test
         });
 
+      // When: hook is called without provider
+      // Then: should throw error
       expect(() => {
         renderHook(() => useCardSDK());
       }).toThrow('useCardSDK must be used within a CardSDKProvider');
 
       consoleError.mockRestore();
-    });
-  });
-
-  describe('CardSDK interface', () => {
-    it('should have correct interface structure', async () => {
-      setupMockUseSelector(mockCardFeatureFlag);
-
-      const wrapper = ({ children }: { children: React.ReactNode }) => (
-        <CardSDKProvider>{children}</CardSDKProvider>
-      );
-
-      const { result } = renderHook(() => useCardSDK(), { wrapper });
-
-      await waitFor(() => {
-        expect(result.current.sdk).not.toBeNull();
-      });
-
-      expect(result.current).toHaveProperty('sdk');
-      expect(
-        typeof result.current.sdk === 'object' || result.current.sdk === null,
-      ).toBe(true);
-
-      if (result.current.sdk) {
-        expect(result.current.sdk).toHaveProperty('isCardEnabled');
-        expect(result.current.sdk).toHaveProperty('isBaanxLoginEnabled');
-        expect(result.current.sdk).toHaveProperty('supportedTokens');
-        expect(result.current.sdk).toHaveProperty('isCardHolder');
-        expect(result.current.sdk).toHaveProperty('getGeoLocation');
-        expect(result.current.sdk).toHaveProperty(
-          'getSupportedTokensAllowances',
-        );
-        expect(result.current.sdk).toHaveProperty('getPriorityToken');
-        expect(result.current.sdk).toHaveProperty('refreshLocalToken');
-      }
-    });
-  });
-
-  describe('Edge cases', () => {
-    it('should handle undefined card feature flag gracefully', () => {
-      setupMockUseSelector(undefined);
-
-      const TestComponent = () => <View>Test Child</View>;
-
-      render(
-        <CardSDKProvider>
-          <TestComponent />
-        </CardSDKProvider>,
-      );
-
-      expect(MockedCardholderSDK).not.toHaveBeenCalled();
-    });
-
-    it('should handle empty card feature flag gracefully', () => {
-      setupMockUseSelector({});
-
-      const TestComponent = () => <View>Test Child</View>;
-
-      render(
-        <CardSDKProvider>
-          <TestComponent />
-        </CardSDKProvider>,
-      );
-
-      expect(MockedCardholderSDK).toHaveBeenCalledWith({
-        cardFeatureFlag: {},
-      });
     });
   });
 
@@ -319,42 +286,22 @@ describe('CardSDK Context', () => {
       location: 'us' as const,
     };
 
-    beforeEach(() => {
-      // Mock SDK with Baanx login enabled
-      MockedCardholderSDK.mockImplementation(
-        () =>
-          ({
-            isCardEnabled: true,
-            isBaanxLoginEnabled: true,
-            supportedTokens: [],
-            isCardHolder: jest.fn(),
-            getGeoLocation: jest.fn(),
-            getSupportedTokensAllowances: jest.fn(),
-            getPriorityToken: jest.fn(),
-            refreshLocalToken: jest.fn().mockResolvedValue({
-              accessToken: 'new-access-token',
-              refreshToken: 'new-refresh-token',
-              expiresIn: 3600,
-            }),
-          } as unknown as CardSDK),
-      );
-    });
-
-    it('should authenticate user with valid token', async () => {
+    it('authenticates user with valid token', async () => {
+      // Given: valid token available
+      setupMockSDK();
       setupMockUseSelector(mockCardFeatureFlag);
       mockGetCardBaanxToken.mockResolvedValue({
         success: true,
         tokenData: mockValidTokenData,
       });
 
-      const wrapper = ({ children }: { children: React.ReactNode }) => (
-        <CardSDKProvider>{children}</CardSDKProvider>
-      );
+      // When: provider initializes
+      const { result } = renderHook(() => useCardSDK(), {
+        wrapper: createWrapper,
+      });
 
-      const { result } = renderHook(() => useCardSDK(), { wrapper });
-
+      // Then: user should be authenticated
       await waitFor(() => {
-        expect(result.current.isAuthenticated).toBe(true);
         expect(result.current.userCardLocation).toBe('international');
         expect(result.current.isLoading).toBe(false);
       });
@@ -362,21 +309,22 @@ describe('CardSDK Context', () => {
       expect(mockGetCardBaanxToken).toHaveBeenCalled();
     });
 
-    it('should not authenticate user when token retrieval fails', async () => {
+    it('logs error when token retrieval fails', async () => {
+      // Given: token retrieval fails
+      setupMockSDK();
       setupMockUseSelector(mockCardFeatureFlag);
       mockGetCardBaanxToken.mockResolvedValue({
         success: false,
         error: 'Keychain error',
       });
 
-      const wrapper = ({ children }: { children: React.ReactNode }) => (
-        <CardSDKProvider>{children}</CardSDKProvider>
-      );
+      // When: provider initializes
+      const { result } = renderHook(() => useCardSDK(), {
+        wrapper: createWrapper,
+      });
 
-      const { result } = renderHook(() => useCardSDK(), { wrapper });
-
+      // Then: should log error and not authenticate
       await waitFor(() => {
-        expect(result.current.isAuthenticated).toBe(false);
         expect(result.current.isLoading).toBe(false);
       });
 
@@ -386,40 +334,42 @@ describe('CardSDK Context', () => {
       );
     });
 
-    it('should not authenticate user when no token data exists', async () => {
+    it('does not authenticate when token data is missing', async () => {
+      // Given: no token data
+      setupMockSDK();
       setupMockUseSelector(mockCardFeatureFlag);
       mockGetCardBaanxToken.mockResolvedValue({
         success: true,
         tokenData: undefined,
       });
 
-      const wrapper = ({ children }: { children: React.ReactNode }) => (
-        <CardSDKProvider>{children}</CardSDKProvider>
-      );
+      // When: provider initializes
+      const { result } = renderHook(() => useCardSDK(), {
+        wrapper: createWrapper,
+      });
 
-      const { result } = renderHook(() => useCardSDK(), { wrapper });
-
+      // Then: should not authenticate
       await waitFor(() => {
-        expect(result.current.isAuthenticated).toBe(false);
         expect(result.current.isLoading).toBe(false);
       });
     });
 
-    it('should refresh expired token successfully', async () => {
+    it('refreshes expired token successfully', async () => {
+      // Given: expired token available
+      setupMockSDK();
       setupMockUseSelector(mockCardFeatureFlag);
       mockGetCardBaanxToken.mockResolvedValue({
         success: true,
         tokenData: mockExpiredTokenData,
       });
 
-      const wrapper = ({ children }: { children: React.ReactNode }) => (
-        <CardSDKProvider>{children}</CardSDKProvider>
-      );
+      // When: provider initializes
+      const { result } = renderHook(() => useCardSDK(), {
+        wrapper: createWrapper,
+      });
 
-      const { result } = renderHook(() => useCardSDK(), { wrapper });
-
+      // Then: token should be refreshed and stored
       await waitFor(() => {
-        expect(result.current.isAuthenticated).toBe(true);
         expect(result.current.userCardLocation).toBe('us');
         expect(result.current.isLoading).toBe(false);
       });
@@ -432,38 +382,26 @@ describe('CardSDK Context', () => {
       });
     });
 
-    it('should handle token refresh failure', async () => {
+    it('logs error when token refresh fails', async () => {
+      // Given: expired token and refresh failure
+      setupMockSDK({
+        refreshLocalToken: jest
+          .fn()
+          .mockRejectedValue(new Error('Refresh failed')),
+      });
       setupMockUseSelector(mockCardFeatureFlag);
       mockGetCardBaanxToken.mockResolvedValue({
         success: true,
         tokenData: mockExpiredTokenData,
       });
 
-      // Mock refresh token failure
-      MockedCardholderSDK.mockImplementation(
-        () =>
-          ({
-            isCardEnabled: true,
-            isBaanxLoginEnabled: true,
-            supportedTokens: [],
-            isCardHolder: jest.fn(),
-            getGeoLocation: jest.fn(),
-            getSupportedTokensAllowances: jest.fn(),
-            getPriorityToken: jest.fn(),
-            refreshLocalToken: jest
-              .fn()
-              .mockRejectedValue(new Error('Refresh failed')),
-          } as unknown as CardSDK),
-      );
+      // When: provider initializes
+      const { result } = renderHook(() => useCardSDK(), {
+        wrapper: createWrapper,
+      });
 
-      const wrapper = ({ children }: { children: React.ReactNode }) => (
-        <CardSDKProvider>{children}</CardSDKProvider>
-      );
-
-      const { result } = renderHook(() => useCardSDK(), { wrapper });
-
+      // Then: should log error
       await waitFor(() => {
-        expect(result.current.isAuthenticated).toBe(false);
         expect(result.current.isLoading).toBe(false);
       });
 
@@ -473,49 +411,37 @@ describe('CardSDK Context', () => {
       );
     });
 
-    it('should skip authentication when Baanx login is disabled', async () => {
+    it('skips authentication when Baanx login is disabled', async () => {
+      // Given: Baanx login disabled
+      setupMockSDK({ isBaanxLoginEnabled: false });
       setupMockUseSelector(mockCardFeatureFlag);
-      // Mock SDK with Baanx login disabled
-      MockedCardholderSDK.mockImplementation(
-        () =>
-          ({
-            isCardEnabled: true,
-            isBaanxLoginEnabled: false,
-            supportedTokens: [],
-            isCardHolder: jest.fn(),
-            getGeoLocation: jest.fn(),
-            getSupportedTokensAllowances: jest.fn(),
-            getPriorityToken: jest.fn(),
-            refreshLocalToken: jest.fn(),
-          } as unknown as CardSDK),
-      );
 
-      const wrapper = ({ children }: { children: React.ReactNode }) => (
-        <CardSDKProvider>{children}</CardSDKProvider>
-      );
+      // When: provider initializes
+      const { result } = renderHook(() => useCardSDK(), {
+        wrapper: createWrapper,
+      });
 
-      const { result } = renderHook(() => useCardSDK(), { wrapper });
-
+      // Then: should not attempt authentication
       await waitFor(() => {
-        expect(result.current.isAuthenticated).toBe(false);
         expect(result.current.isLoading).toBe(false);
       });
 
       expect(mockGetCardBaanxToken).not.toHaveBeenCalled();
     });
 
-    it('should handle authentication errors gracefully', async () => {
+    it('handles authentication errors gracefully', async () => {
+      // Given: authentication throws error
+      setupMockSDK();
       setupMockUseSelector(mockCardFeatureFlag);
       mockGetCardBaanxToken.mockRejectedValue(new Error('Unexpected error'));
 
-      const wrapper = ({ children }: { children: React.ReactNode }) => (
-        <CardSDKProvider>{children}</CardSDKProvider>
-      );
+      // When: provider initializes
+      const { result } = renderHook(() => useCardSDK(), {
+        wrapper: createWrapper,
+      });
 
-      const { result } = renderHook(() => useCardSDK(), { wrapper });
-
+      // Then: should log error and complete loading
       await waitFor(() => {
-        expect(result.current.isAuthenticated).toBe(false);
         expect(result.current.isLoading).toBe(false);
       });
 
@@ -527,23 +453,9 @@ describe('CardSDK Context', () => {
   });
 
   describe('Logout Functionality', () => {
-    beforeEach(() => {
-      MockedCardholderSDK.mockImplementation(
-        () =>
-          ({
-            isCardEnabled: true,
-            isBaanxLoginEnabled: true,
-            supportedTokens: [],
-            isCardHolder: jest.fn(),
-            getGeoLocation: jest.fn(),
-            getSupportedTokensAllowances: jest.fn(),
-            getPriorityToken: jest.fn(),
-            refreshLocalToken: jest.fn(),
-          } as unknown as CardSDK),
-      );
-    });
-
-    it('should logout user successfully', async () => {
+    it('logs out user successfully', async () => {
+      // Given: authenticated user
+      setupMockSDK();
       setupMockUseSelector(mockCardFeatureFlag);
       mockGetCardBaanxToken.mockResolvedValue({
         success: true,
@@ -555,39 +467,37 @@ describe('CardSDK Context', () => {
         },
       });
 
-      const wrapper = ({ children }: { children: React.ReactNode }) => (
-        <CardSDKProvider>{children}</CardSDKProvider>
-      );
-
-      const { result } = renderHook(() => useCardSDK(), { wrapper });
-
-      // Wait for initial authentication
-      await waitFor(() => {
-        expect(result.current.isAuthenticated).toBe(true);
+      const { result } = renderHook(() => useCardSDK(), {
+        wrapper: createWrapper,
       });
 
-      // Perform logout
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // When: user logs out
       await act(async () => {
         await result.current.logoutFromProvider();
       });
 
-      expect(result.current.isAuthenticated).toBe(false);
+      // Then: token should be removed
       expect(mockRemoveCardBaanxToken).toHaveBeenCalled();
     });
 
-    it('should throw error when SDK is not available for logout', async () => {
-      setupMockUseSelector(null); // No feature flag = no SDK
+    it('throws error when SDK is unavailable for logout', async () => {
+      // Given: no SDK available
+      setupMockUseSelector(null);
 
-      const wrapper = ({ children }: { children: React.ReactNode }) => (
-        <CardSDKProvider>{children}</CardSDKProvider>
-      );
-
-      const { result } = renderHook(() => useCardSDK(), { wrapper });
+      const { result } = renderHook(() => useCardSDK(), {
+        wrapper: createWrapper,
+      });
 
       await waitFor(() => {
         expect(result.current.sdk).toBeNull();
       });
 
+      // When: attempting logout
+      // Then: should throw error
       await expect(result.current.logoutFromProvider()).rejects.toThrow(
         'SDK not available for logout',
       );
@@ -595,25 +505,10 @@ describe('CardSDK Context', () => {
   });
 
   describe('Loading States', () => {
-    beforeEach(() => {
-      MockedCardholderSDK.mockImplementation(
-        () =>
-          ({
-            isCardEnabled: true,
-            isBaanxLoginEnabled: true,
-            supportedTokens: [],
-            isCardHolder: jest.fn(),
-            getGeoLocation: jest.fn(),
-            getSupportedTokensAllowances: jest.fn(),
-            getPriorityToken: jest.fn(),
-            refreshLocalToken: jest.fn(),
-          } as unknown as CardSDK),
-      );
-    });
-
-    it('should show loading state during authentication', async () => {
+    it('shows loading state during authentication', async () => {
+      // Given: slow token retrieval
+      setupMockSDK();
       setupMockUseSelector(mockCardFeatureFlag);
-      // Delay token retrieval to capture loading state
       mockGetCardBaanxToken.mockImplementation(
         () =>
           new Promise((resolve) =>
@@ -633,74 +528,49 @@ describe('CardSDK Context', () => {
           ),
       );
 
-      const wrapper = ({ children }: { children: React.ReactNode }) => (
-        <CardSDKProvider>{children}</CardSDKProvider>
-      );
+      // When: provider initializes
+      const { result } = renderHook(() => useCardSDK(), {
+        wrapper: createWrapper,
+      });
 
-      const { result } = renderHook(() => useCardSDK(), { wrapper });
-
-      // Should start with loading state
+      // Then: should show loading initially
       expect(result.current.isLoading).toBe(true);
-      expect(result.current.isAuthenticated).toBe(false);
 
-      // Wait for authentication to complete
+      // And: loading should complete
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
-        expect(result.current.isAuthenticated).toBe(true);
       });
     });
 
-    it('should not show loading when Baanx login is disabled', async () => {
+    it('does not show loading when Baanx login is disabled', async () => {
+      // Given: Baanx login disabled
+      setupMockSDK({ isBaanxLoginEnabled: false });
       setupMockUseSelector(mockCardFeatureFlag);
-      // Mock SDK with Baanx login disabled
-      MockedCardholderSDK.mockImplementation(
-        () =>
-          ({
-            isCardEnabled: true,
-            isBaanxLoginEnabled: false,
-            supportedTokens: [],
-            isCardHolder: jest.fn(),
-            getGeoLocation: jest.fn(),
-            getSupportedTokensAllowances: jest.fn(),
-            getPriorityToken: jest.fn(),
-            refreshLocalToken: jest.fn(),
-          } as unknown as CardSDK),
-      );
 
-      const wrapper = ({ children }: { children: React.ReactNode }) => (
-        <CardSDKProvider>{children}</CardSDKProvider>
-      );
-
-      const { result } = renderHook(() => useCardSDK(), { wrapper });
-
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-        expect(result.current.isAuthenticated).toBe(false);
+      // When: provider initializes
+      const { result } = renderHook(() => useCardSDK(), {
+        wrapper: createWrapper,
       });
 
-      // Should never have been in loading state
+      // Then: should not be loading
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
       expect(mockGetCardBaanxToken).not.toHaveBeenCalled();
     });
   });
 
   describe('Token Refresh Edge Cases', () => {
-    beforeEach(() => {
-      MockedCardholderSDK.mockImplementation(
-        () =>
-          ({
-            isCardEnabled: true,
-            isBaanxLoginEnabled: true,
-            supportedTokens: [],
-            isCardHolder: jest.fn(),
-            getGeoLocation: jest.fn(),
-            getSupportedTokensAllowances: jest.fn(),
-            getPriorityToken: jest.fn(),
-            refreshLocalToken: jest.fn(),
-          } as unknown as CardSDK),
-      );
-    });
-
-    it('should handle invalid token response during refresh', async () => {
+    it('handles invalid token response during refresh', async () => {
+      // Given: expired token and invalid refresh response
+      setupMockSDK({
+        refreshLocalToken: jest.fn().mockResolvedValue({
+          accessToken: null, // Invalid response
+          refreshToken: 'new-refresh-token',
+          expiresIn: 3600,
+        }),
+      });
       setupMockUseSelector(mockCardFeatureFlag);
       mockGetCardBaanxToken.mockResolvedValue({
         success: true,
@@ -712,33 +582,13 @@ describe('CardSDK Context', () => {
         },
       });
 
-      // Mock invalid refresh response
-      MockedCardholderSDK.mockImplementation(
-        () =>
-          ({
-            isCardEnabled: true,
-            isBaanxLoginEnabled: true,
-            supportedTokens: [],
-            isCardHolder: jest.fn(),
-            getGeoLocation: jest.fn(),
-            getSupportedTokensAllowances: jest.fn(),
-            getPriorityToken: jest.fn(),
-            refreshLocalToken: jest.fn().mockResolvedValue({
-              accessToken: null, // Invalid response
-              refreshToken: 'new-refresh-token',
-              expiresIn: 3600,
-            }),
-          } as unknown as CardSDK),
-      );
+      // When: provider initializes
+      const { result } = renderHook(() => useCardSDK(), {
+        wrapper: createWrapper,
+      });
 
-      const wrapper = ({ children }: { children: React.ReactNode }) => (
-        <CardSDKProvider>{children}</CardSDKProvider>
-      );
-
-      const { result } = renderHook(() => useCardSDK(), { wrapper });
-
+      // Then: should log error and not store invalid token
       await waitFor(() => {
-        expect(result.current.isAuthenticated).toBe(false);
         expect(result.current.isLoading).toBe(false);
       });
 
@@ -748,75 +598,23 @@ describe('CardSDK Context', () => {
       );
       expect(mockStoreCardBaanxToken).not.toHaveBeenCalled();
     });
-
-    it('should handle SDK unavailable during token refresh', async () => {
-      setupMockUseSelector(mockCardFeatureFlag);
-      mockGetCardBaanxToken.mockResolvedValue({
-        success: true,
-        tokenData: {
-          accessToken: 'expired-access-token',
-          refreshToken: 'expired-refresh-token',
-          expiresAt: Date.now() - 3600000,
-          location: 'international' as const,
-        },
-      });
-
-      // Create provider but force SDK to be null during refresh
-      const wrapper = ({ children }: { children: React.ReactNode }) => (
-        <CardSDKProvider>{children}</CardSDKProvider>
-      );
-
-      const { result } = renderHook(() => useCardSDK(), { wrapper });
-
-      // Mock SDK becoming null during refresh (edge case)
-      const originalSdk = result.current.sdk;
-      if (originalSdk) {
-        (originalSdk as CardSDK).refreshLocalToken = jest
-          .fn()
-          .mockImplementation(() => {
-            // Simulate SDK becoming unavailable during refresh
-            throw new Error('SDK not available for token refresh');
-          });
-      }
-
-      await waitFor(() => {
-        expect(result.current.isAuthenticated).toBe(false);
-        expect(result.current.isLoading).toBe(false);
-      });
-    });
   });
 
   describe('CardVerification', () => {
-    beforeEach(() => {
-      mockUseCardholderCheck.mockClear();
-    });
-
-    it('should render without crashing', () => {
-      const result = render(<CardVerification />);
-      expect(result).toBeTruthy();
-    });
-
-    it('should call useCardholderCheck hook', () => {
+    it('calls useCardholderCheck hook', () => {
+      // When: component renders
       render(<CardVerification />);
+
+      // Then: should call cardholder check
       expect(mockUseCardholderCheck).toHaveBeenCalledTimes(1);
     });
 
-    it('should return null (render nothing)', () => {
+    it('renders nothing', () => {
+      // When: component renders
       const { toJSON } = render(<CardVerification />);
+
+      // Then: should return null
       expect(toJSON()).toBeNull();
-    });
-
-    it('should call useCardholderCheck on every render', () => {
-      const { rerender } = render(<CardVerification />);
-      expect(mockUseCardholderCheck).toHaveBeenCalledTimes(1);
-
-      rerender(<CardVerification />);
-      expect(mockUseCardholderCheck).toHaveBeenCalledTimes(2);
-    });
-
-    it('should be a functional component', () => {
-      expect(typeof CardVerification).toBe('function');
-      expect(CardVerification.prototype).toEqual({});
     });
   });
 });

--- a/app/components/UI/Card/util/getCardholder.test.ts
+++ b/app/components/UI/Card/util/getCardholder.test.ts
@@ -57,38 +57,47 @@ describe('getCardholder', () => {
 
     mockCardSDKInstance = {
       isCardHolder: jest.fn(),
+      getGeoLocation: jest.fn(),
     } as unknown as jest.Mocked<CardSDK>;
 
     MockedCardSDK.mockImplementation(() => mockCardSDKInstance);
 
     // Mock address utilities
     mockedIsValidHexAddress.mockReturnValue(true);
+
+    // Default mock for geolocation
+    mockCardSDKInstance.getGeoLocation.mockResolvedValue('US');
   });
 
   describe('successful scenarios', () => {
-    it('should return cardholder addresses when accounts are cardholders', async () => {
+    it('should return cardholder addresses and geolocation when accounts are cardholders', async () => {
       const mockResult = [
         'eip155:59144:0x1234567890abcdef1234567890abcdef12345678',
         'eip155:59144:0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
       ] as `${string}:${string}:${string}`[];
 
       mockCardSDKInstance.isCardHolder.mockResolvedValue(mockResult);
+      mockCardSDKInstance.getGeoLocation.mockResolvedValue('US');
 
       const result = await getCardholder({
         caipAccountIds: mockFormattedAccounts,
         cardFeatureFlag: mockCardFeatureFlag,
       });
 
-      expect(result).toEqual([
-        '0x1234567890abcdef1234567890abcdef12345678',
-        '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
-      ]);
+      expect(result).toEqual({
+        cardholderAddresses: [
+          '0x1234567890abcdef1234567890abcdef12345678',
+          '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+        ],
+        geoLocation: 'US',
+      });
       expect(MockedCardSDK).toHaveBeenCalledWith({
         cardFeatureFlag: mockCardFeatureFlag,
       });
       expect(mockCardSDKInstance.isCardHolder).toHaveBeenCalledWith(
         mockFormattedAccounts,
       );
+      expect(mockCardSDKInstance.getGeoLocation).toHaveBeenCalled();
     });
 
     it('should return only cardholder addresses from mixed results', async () => {
@@ -97,80 +106,103 @@ describe('getCardholder', () => {
       ] as `${string}:${string}:${string}`[];
 
       mockCardSDKInstance.isCardHolder.mockResolvedValue(mockResult);
+      mockCardSDKInstance.getGeoLocation.mockResolvedValue('GB');
 
       const result = await getCardholder({
         caipAccountIds: mockFormattedAccounts,
         cardFeatureFlag: mockCardFeatureFlag,
       });
 
-      expect(result).toEqual(['0x1234567890abcdef1234567890abcdef12345678']);
+      expect(result).toEqual({
+        cardholderAddresses: ['0x1234567890abcdef1234567890abcdef12345678'],
+        geoLocation: 'GB',
+      });
     });
 
-    it('should return empty array when no accounts are cardholders', async () => {
+    it('should return empty array and geolocation when no accounts are cardholders', async () => {
       mockCardSDKInstance.isCardHolder.mockResolvedValue([]);
+      mockCardSDKInstance.getGeoLocation.mockResolvedValue('CA');
 
       const result = await getCardholder({
         caipAccountIds: mockFormattedAccounts,
         cardFeatureFlag: mockCardFeatureFlag,
       });
 
-      expect(result).toEqual([]);
+      expect(result).toEqual({
+        cardholderAddresses: [],
+        geoLocation: 'CA',
+      });
     });
   });
 
   describe('early return scenarios', () => {
-    it('should return empty array when cardFeatureFlag is null', async () => {
+    it('should return empty array and UNKNOWN geolocation when cardFeatureFlag is null', async () => {
       const result = await getCardholder({
         caipAccountIds: mockFormattedAccounts,
         cardFeatureFlag: null as unknown as CardFeatureFlag,
       });
 
-      expect(result).toEqual([]);
+      expect(result).toEqual({
+        cardholderAddresses: [],
+        geoLocation: 'UNKNOWN',
+      });
       expect(MockedCardSDK).not.toHaveBeenCalled();
       expect(mockCardSDKInstance.isCardHolder).not.toHaveBeenCalled();
     });
 
-    it('should return empty array when cardFeatureFlag is undefined', async () => {
+    it('should return empty array and UNKNOWN geolocation when cardFeatureFlag is undefined', async () => {
       const result = await getCardholder({
         caipAccountIds: mockFormattedAccounts,
         cardFeatureFlag: undefined as unknown as CardFeatureFlag,
       });
 
-      expect(result).toEqual([]);
+      expect(result).toEqual({
+        cardholderAddresses: [],
+        geoLocation: 'UNKNOWN',
+      });
       expect(MockedCardSDK).not.toHaveBeenCalled();
       expect(mockCardSDKInstance.isCardHolder).not.toHaveBeenCalled();
     });
 
-    it('should return empty array when caipAccountIds is empty', async () => {
+    it('should return empty array and UNKNOWN geolocation when caipAccountIds is empty', async () => {
       const result = await getCardholder({
         caipAccountIds: [],
         cardFeatureFlag: mockCardFeatureFlag,
       });
 
-      expect(result).toEqual([]);
+      expect(result).toEqual({
+        cardholderAddresses: [],
+        geoLocation: 'UNKNOWN',
+      });
       expect(MockedCardSDK).not.toHaveBeenCalled();
       expect(mockCardSDKInstance.isCardHolder).not.toHaveBeenCalled();
     });
 
-    it('should return empty array when caipAccountIds is null', async () => {
+    it('should return empty array and UNKNOWN geolocation when caipAccountIds is null', async () => {
       const result = await getCardholder({
         caipAccountIds: null as unknown as `${string}:${string}:${string}`[],
         cardFeatureFlag: mockCardFeatureFlag,
       });
 
-      expect(result).toEqual([]);
+      expect(result).toEqual({
+        cardholderAddresses: [],
+        geoLocation: 'UNKNOWN',
+      });
       expect(MockedCardSDK).not.toHaveBeenCalled();
       expect(mockCardSDKInstance.isCardHolder).not.toHaveBeenCalled();
     });
 
-    it('should return empty array when caipAccountIds is undefined', async () => {
+    it('should return empty array and UNKNOWN geolocation when caipAccountIds is undefined', async () => {
       const result = await getCardholder({
         caipAccountIds:
           undefined as unknown as `${string}:${string}:${string}`[],
         cardFeatureFlag: mockCardFeatureFlag,
       });
 
-      expect(result).toEqual([]);
+      expect(result).toEqual({
+        cardholderAddresses: [],
+        geoLocation: 'UNKNOWN',
+      });
       expect(MockedCardSDK).not.toHaveBeenCalled();
       expect(mockCardSDKInstance.isCardHolder).not.toHaveBeenCalled();
     });
@@ -188,7 +220,10 @@ describe('getCardholder', () => {
         cardFeatureFlag: mockCardFeatureFlag,
       });
 
-      expect(result).toEqual([]);
+      expect(result).toEqual({
+        cardholderAddresses: [],
+        geoLocation: 'UNKNOWN',
+      });
       expect(mockedLogger.error).toHaveBeenCalledWith(
         mockError,
         'getCardholder::Error loading cardholder accounts',
@@ -204,7 +239,10 @@ describe('getCardholder', () => {
         cardFeatureFlag: mockCardFeatureFlag,
       });
 
-      expect(result).toEqual([]);
+      expect(result).toEqual({
+        cardholderAddresses: [],
+        geoLocation: 'UNKNOWN',
+      });
       expect(mockedLogger.error).toHaveBeenCalledWith(
         mockError,
         'getCardholder::Error loading cardholder accounts',
@@ -220,7 +258,10 @@ describe('getCardholder', () => {
         cardFeatureFlag: mockCardFeatureFlag,
       });
 
-      expect(result).toEqual([]);
+      expect(result).toEqual({
+        cardholderAddresses: [],
+        geoLocation: 'UNKNOWN',
+      });
       expect(mockedLogger.error).toHaveBeenCalledWith(
         new Error(mockErrorString),
         'getCardholder::Error loading cardholder accounts',
@@ -235,7 +276,10 @@ describe('getCardholder', () => {
         cardFeatureFlag: mockCardFeatureFlag,
       });
 
-      expect(result).toEqual([]);
+      expect(result).toEqual({
+        cardholderAddresses: [],
+        geoLocation: 'UNKNOWN',
+      });
       expect(mockedLogger.error).toHaveBeenCalledWith(
         new Error('null'),
         'getCardholder::Error loading cardholder accounts',
@@ -250,7 +294,10 @@ describe('getCardholder', () => {
         cardFeatureFlag: mockCardFeatureFlag,
       });
 
-      expect(result).toEqual([]);
+      expect(result).toEqual({
+        cardholderAddresses: [],
+        geoLocation: 'UNKNOWN',
+      });
       expect(mockedLogger.error).toHaveBeenCalledWith(
         new Error('undefined'),
         'getCardholder::Error loading cardholder accounts',
@@ -267,20 +314,24 @@ describe('getCardholder', () => {
       ] as `${string}:${string}:${string}`[];
 
       mockCardSDKInstance.isCardHolder.mockResolvedValue(mockResult);
+      mockCardSDKInstance.getGeoLocation.mockResolvedValue('DE');
 
       const result = await getCardholder({
         caipAccountIds: mockFormattedAccounts,
         cardFeatureFlag: mockCardFeatureFlag,
       });
 
-      expect(result).toEqual([
-        '0x1111111111111111111111111111111111111111',
-        '0x2222222222222222222222222222222222222222',
-        '0x3333333333333333333333333333333333333333',
-      ]);
+      expect(result).toEqual({
+        cardholderAddresses: [
+          '0x1111111111111111111111111111111111111111',
+          '0x2222222222222222222222222222222222222222',
+          '0x3333333333333333333333333333333333333333',
+        ],
+        geoLocation: 'DE',
+      });
     });
 
-    it('should handle invalid CAIP-10 format and log errors', async () => {
+    it('should handle invalid CAIP-10 format and filter them out', async () => {
       const mockResult = [
         'invalid:format',
         'eip155:59144:0x1111111111111111111111111111111111111111',
@@ -288,13 +339,17 @@ describe('getCardholder', () => {
       ] as `${string}:${string}:${string}`[];
 
       mockCardSDKInstance.isCardHolder.mockResolvedValue(mockResult);
+      mockCardSDKInstance.getGeoLocation.mockResolvedValue('FR');
 
       const result = await getCardholder({
         caipAccountIds: mockFormattedAccounts,
         cardFeatureFlag: mockCardFeatureFlag,
       });
 
-      expect(result).toEqual(['0x1111111111111111111111111111111111111111']);
+      expect(result).toEqual({
+        cardholderAddresses: ['0x1111111111111111111111111111111111111111'],
+        geoLocation: 'FR',
+      });
     });
 
     it('should filter out invalid hex addresses', async () => {
@@ -305,6 +360,7 @@ describe('getCardholder', () => {
       ] as `${string}:${string}:${string}`[];
 
       mockCardSDKInstance.isCardHolder.mockResolvedValue(mockResult);
+      mockCardSDKInstance.getGeoLocation.mockResolvedValue('ES');
       mockedIsValidHexAddress
         .mockReturnValueOnce(true)
         .mockReturnValueOnce(false)
@@ -315,11 +371,46 @@ describe('getCardholder', () => {
         cardFeatureFlag: mockCardFeatureFlag,
       });
 
-      expect(result).toEqual([
-        '0x1111111111111111111111111111111111111111',
-        '0x2222222222222222222222222222222222222222',
-      ]);
+      expect(result).toEqual({
+        cardholderAddresses: [
+          '0x1111111111111111111111111111111111111111',
+          '0x2222222222222222222222222222222222222222',
+        ],
+        geoLocation: 'ES',
+      });
       expect(mockedIsValidHexAddress).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('geolocation handling', () => {
+    it('should handle different geolocation values', async () => {
+      const geoLocations = ['US', 'GB', 'CA', 'DE', 'UNKNOWN'];
+
+      for (const geoLocation of geoLocations) {
+        mockCardSDKInstance.isCardHolder.mockResolvedValue([
+          'eip155:59144:0x1234567890abcdef1234567890abcdef12345678',
+        ] as `${string}:${string}:${string}`[]);
+        mockCardSDKInstance.getGeoLocation.mockResolvedValue(geoLocation);
+
+        const result = await getCardholder({
+          caipAccountIds: mockFormattedAccounts,
+          cardFeatureFlag: mockCardFeatureFlag,
+        });
+
+        expect(result.geoLocation).toBe(geoLocation);
+      }
+    });
+
+    it('should call getGeoLocation for each request', async () => {
+      mockCardSDKInstance.isCardHolder.mockResolvedValue([]);
+      mockCardSDKInstance.getGeoLocation.mockResolvedValue('US');
+
+      await getCardholder({
+        caipAccountIds: mockFormattedAccounts,
+        cardFeatureFlag: mockCardFeatureFlag,
+      });
+
+      expect(mockCardSDKInstance.getGeoLocation).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/app/components/UI/Card/util/getCardholder.ts
+++ b/app/components/UI/Card/util/getCardholder.ts
@@ -10,10 +10,16 @@ export const getCardholder = async ({
 }: {
   caipAccountIds: `${string}:${string}:${string}`[];
   cardFeatureFlag: CardFeatureFlag | null;
-}) => {
+}): Promise<{
+  cardholderAddresses: string[];
+  geoLocation: string;
+}> => {
   try {
     if (!cardFeatureFlag || !caipAccountIds?.length) {
-      return [];
+      return {
+        cardholderAddresses: [],
+        geoLocation: 'UNKNOWN',
+      };
     }
 
     const cardSDK = new CardSDK({
@@ -21,6 +27,7 @@ export const getCardholder = async ({
     });
 
     const cardCaipAccountIds = await cardSDK.isCardHolder(caipAccountIds);
+    const geoLocation = await cardSDK.getGeoLocation();
 
     const cardholderAddresses = cardCaipAccountIds.map((cardCaipAccountId) => {
       if (!isCaipAccountId(cardCaipAccountId)) return null;
@@ -32,12 +39,18 @@ export const getCardholder = async ({
       return address.toLowerCase();
     });
 
-    return cardholderAddresses.filter(Boolean) as string[];
+    return {
+      cardholderAddresses: cardholderAddresses.filter(Boolean) as string[],
+      geoLocation,
+    };
   } catch (error) {
     Logger.error(
       error instanceof Error ? error : new Error(String(error)),
       'getCardholder::Error loading cardholder accounts',
     );
-    return [];
+    return {
+      cardholderAddresses: [],
+      geoLocation: 'UNKNOWN',
+    };
   }
 };

--- a/app/components/Views/Settings/ExperimentalSettings/index.test.tsx
+++ b/app/components/Views/Settings/ExperimentalSettings/index.test.tsx
@@ -45,6 +45,20 @@ jest.mock('react-native-device-info', () => ({
   getBuildNumber: jest.fn(),
 }));
 
+jest.mock('../../../../selectors/featureFlagController/card', () => ({
+  selectCardExperimentalSwitch: jest.fn(() => false),
+}));
+
+jest.mock('../../../../core/redux/slices/card', () => ({
+  selectAlwaysShowCardButton: jest.fn(
+    (state) => state.card.alwaysShowCardButton,
+  ),
+  setAlwaysShowCardButton: jest.fn((value) => ({
+    type: 'card/setAlwaysShowCardButton',
+    payload: value,
+  })),
+}));
+
 const mockStore = configureMockStore();
 
 const initialState = {
@@ -63,6 +77,11 @@ const initialState = {
     },
     activeTraceBySessionId: {},
     isInitialized: true,
+  },
+  card: {
+    alwaysShowCardButton: false,
+    isAuthenticatedCard: false,
+    cardholderAccounts: [],
   },
   engine: {
     backgroundState,

--- a/app/components/Views/Settings/ExperimentalSettings/index.tsx
+++ b/app/components/Views/Settings/ExperimentalSettings/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { ScrollView, View } from 'react-native';
+import { ScrollView, Switch, View } from 'react-native';
 
 import { strings } from '../../../../../locales/i18n';
 import { useTheme } from '../../../../util/theme';
@@ -17,7 +17,7 @@ import Button, {
 } from '../../../../component-library/components/Buttons/Button';
 import Routes from '../../../../../app/constants/navigation/Routes';
 import { selectPerformanceMetrics } from '../../../../core/redux/slices/performance';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { isTest } from '../../../../util/test/utils';
 import ReactNativeBlobUtil from 'react-native-blob-util';
 import Share from 'react-native-share';
@@ -26,12 +26,20 @@ import {
   getVersion,
   getBuildNumber,
 } from 'react-native-device-info';
+import {
+  selectAlwaysShowCardButton,
+  setAlwaysShowCardButton,
+} from '../../../../core/redux/slices/card';
+import { selectCardExperimentalSwitch } from '../../../../selectors/featureFlagController/card';
 
 /**
  * Main view for app Experimental Settings
  */
 const ExperimentalSettings = ({ navigation, route }: Props) => {
+  const dispatch = useDispatch();
   const performanceMetrics = useSelector(selectPerformanceMetrics);
+  const cardExperimentalSwitch = useSelector(selectCardExperimentalSwitch);
+  const alwaysShowCardButton = useSelector(selectAlwaysShowCardButton);
 
   const isFullScreenModal = route?.params?.isFullScreenModal;
 
@@ -80,6 +88,30 @@ const ExperimentalSettings = ({ navigation, route }: Props) => {
         style={styles.accessory}
       />
     </>
+  );
+
+  const handleAlwaysShowCardButtonToggle = (value: boolean) => {
+    dispatch(setAlwaysShowCardButton(value));
+  };
+
+  const renderCardSettings = () => (
+    <View style={styles.heading}>
+      <Text color={TextColor.Default} variant={TextVariant.BodyLGMedium}>
+        {strings('experimental_settings.card_title')}
+      </Text>
+      <Text
+        color={TextColor.Alternative}
+        variant={TextVariant.BodyMD}
+        style={styles.desc}
+      >
+        {strings('experimental_settings.card_desc')}
+      </Text>
+      <Switch
+        value={alwaysShowCardButton}
+        onValueChange={handleAlwaysShowCardButtonToggle}
+        testID="always-show-card-button-switch"
+      />
+    </View>
   );
 
   const downloadPerformanceMetrics = async () => {
@@ -132,6 +164,7 @@ const ExperimentalSettings = ({ navigation, route }: Props) => {
   return (
     <ScrollView style={styles.wrapper}>
       {renderWalletConnectSettings()}
+      {cardExperimentalSwitch && renderCardSettings()}
       {isTest && renderPerformanceSettings()}
     </ScrollView>
   );

--- a/app/components/Views/Wallet/index.test.tsx
+++ b/app/components/Views/Wallet/index.test.tsx
@@ -34,6 +34,7 @@ jest.mock('../../UI/Perps/Views/PerpsTabView', () => ({
 // Mock remoteFeatureFlag util to ensure version check passes
 jest.mock('../../../util/remoteFeatureFlag', () => ({
   hasMinimumRequiredVersion: jest.fn(() => true),
+  validatedVersionGatedFeatureFlag: jest.fn(() => false),
 }));
 
 jest.mock(

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -158,7 +158,7 @@ import {
   IconColor,
   IconName,
 } from '../../../component-library/components/Icons/Icon';
-import { selectIsCardholder } from '../../../core/redux/slices/card';
+import { selectDisplayCardButton } from '../../../core/redux/slices/card';
 import { selectIsConnectionRemoved } from '../../../reducers/user';
 import { selectEVMEnabledNetworks } from '../../../selectors/networkEnablementController';
 import { selectSeedlessOnboardingLoginFlow } from '../../../selectors/seedlessOnboardingController';
@@ -1059,7 +1059,7 @@ const Wallet = ({
     [navigation, chainId, evmNetworkConfigurations],
   );
 
-  const isCardholder = useSelector(selectIsCardholder);
+  const shouldDisplayCardButton = useSelector(selectDisplayCardButton);
   const isRewardsEnabled = useSelector(selectRewardsEnabledFlag);
 
   useEffect(() => {
@@ -1078,7 +1078,7 @@ const Wallet = ({
         isBackupAndSyncEnabled,
         unreadNotificationCount,
         readNotificationCount,
-        isCardholder,
+        shouldDisplayCardButton,
         isRewardsEnabled,
       ),
     );
@@ -1094,7 +1094,7 @@ const Wallet = ({
     isBackupAndSyncEnabled,
     unreadNotificationCount,
     readNotificationCount,
-    isCardholder,
+    shouldDisplayCardButton,
     isRewardsEnabled,
   ]);
 

--- a/app/core/redux/slices/card/index.test.ts
+++ b/app/core/redux/slices/card/index.test.ts
@@ -13,6 +13,10 @@ import cardReducer, {
   initialState,
   setHasViewedCardButton,
   selectHasViewedCardButton,
+  selectCardGeoLocation,
+  selectDisplayCardButton,
+  selectAlwaysShowCardButton,
+  setAlwaysShowCardButton,
 } from '.';
 import {
   CardTokenAllowance,
@@ -30,8 +34,20 @@ jest.mock('../../../Multichain/utils', () => ({
   isEthAccount: jest.fn(),
 }));
 
+// Mock feature flag selectors
+jest.mock('../../../../selectors/featureFlagController/card', () => ({
+  selectCardExperimentalSwitch: jest.fn(),
+  selectCardSupportedCountries: jest.fn(),
+  selectDisplayCardButtonFeatureFlag: jest.fn(),
+}));
+
 import { selectSelectedInternalAccountByScope } from '../../../../selectors/multichainAccounts/accounts';
 import { isEthAccount } from '../../../Multichain/utils';
+import {
+  selectCardExperimentalSwitch,
+  selectCardSupportedCountries,
+  selectDisplayCardButtonFeatureFlag,
+} from '../../../../selectors/featureFlagController/card';
 
 const mockSelectSelectedInternalAccountByScope =
   selectSelectedInternalAccountByScope as jest.MockedFunction<
@@ -41,6 +57,21 @@ const mockSelectSelectedInternalAccountByScope =
 const mockIsEthAccount = isEthAccount as jest.MockedFunction<
   typeof isEthAccount
 >;
+
+const mockSelectCardExperimentalSwitch =
+  selectCardExperimentalSwitch as jest.MockedFunction<
+    typeof selectCardExperimentalSwitch
+  >;
+
+const mockSelectCardSupportedCountries =
+  selectCardSupportedCountries as jest.MockedFunction<
+    typeof selectCardSupportedCountries
+  >;
+
+const mockSelectDisplayCardButtonFeatureFlag =
+  selectDisplayCardButtonFeatureFlag as jest.MockedFunction<
+    typeof selectDisplayCardButtonFeatureFlag
+  >;
 
 const CARDHOLDER_ACCOUNTS_MOCK: string[] = [
   '0x1234567890123456789012345678901234567890',
@@ -70,6 +101,9 @@ const CARD_STATE_MOCK: CardSliceState = {
   },
   isLoaded: true,
   hasViewedCardButton: true,
+  alwaysShowCardButton: false,
+  geoLocation: 'US',
+  isAuthenticated: false,
 };
 
 const EMPTY_CARD_STATE_MOCK: CardSliceState = {
@@ -78,6 +112,9 @@ const EMPTY_CARD_STATE_MOCK: CardSliceState = {
   lastFetchedByAddress: {},
   isLoaded: false,
   hasViewedCardButton: false,
+  alwaysShowCardButton: false,
+  geoLocation: 'UNKNOWN',
+  isAuthenticated: false,
 };
 
 // Mock account object that matches the expected structure
@@ -131,6 +168,35 @@ describe('Card Selectors', () => {
       };
       const mockRootState = { card: stateWithFlag } as unknown as RootState;
       expect(selectHasViewedCardButton(mockRootState)).toBe(true);
+    });
+  });
+
+  describe('selectCardGeoLocation', () => {
+    it('returns UNKNOWN by default from initial state', () => {
+      const mockRootState = { card: initialState } as unknown as RootState;
+      expect(selectCardGeoLocation(mockRootState)).toBe('UNKNOWN');
+    });
+
+    it('returns the geolocation from the card state', () => {
+      const mockRootState = {
+        card: CARD_STATE_MOCK,
+      } as unknown as RootState;
+      expect(selectCardGeoLocation(mockRootState)).toBe('US');
+    });
+
+    it('returns different geolocation values correctly', () => {
+      const geoLocations = ['US', 'GB', 'CA', 'DE', 'FR', 'UNKNOWN'];
+
+      geoLocations.forEach((geoLocation) => {
+        const stateWithGeoLocation: CardSliceState = {
+          ...initialState,
+          geoLocation,
+        };
+        const mockRootState = {
+          card: stateWithGeoLocation,
+        } as unknown as RootState;
+        expect(selectCardGeoLocation(mockRootState)).toBe(geoLocation);
+      });
     });
   });
 
@@ -220,26 +286,51 @@ describe('Card Selectors', () => {
 describe('Card Reducer', () => {
   describe('extraReducers', () => {
     describe('loadCardholderAccounts', () => {
-      it('should set cardholder accounts and update state when fulfilled', () => {
-        const mockAccounts = ['0x123', '0x456'];
+      it('should set cardholder accounts, geolocation, and update state when fulfilled', () => {
+        const mockPayload = {
+          cardholderAddresses: ['0x123', '0x456'],
+          geoLocation: 'US',
+        };
         const action = {
           type: loadCardholderAccounts.fulfilled.type,
-          payload: mockAccounts,
+          payload: mockPayload,
         };
         const state = cardReducer(initialState, action);
 
-        expect(state.cardholderAccounts).toEqual(mockAccounts);
+        expect(state.cardholderAccounts).toEqual(['0x123', '0x456']);
+        expect(state.geoLocation).toBe('US');
         expect(state.isLoaded).toBe(true);
       });
 
-      it('should handle empty payload when fulfilled', () => {
+      it('should handle empty cardholderAddresses in payload when fulfilled', () => {
+        const mockPayload = {
+          cardholderAddresses: [],
+          geoLocation: 'GB',
+        };
         const action = {
           type: loadCardholderAccounts.fulfilled.type,
-          payload: null,
+          payload: mockPayload,
         };
         const state = cardReducer(initialState, action);
 
         expect(state.cardholderAccounts).toEqual([]);
+        expect(state.geoLocation).toBe('GB');
+        expect(state.isLoaded).toBe(true);
+      });
+
+      it('should handle null cardholderAddresses and fallback to UNKNOWN geolocation', () => {
+        const mockPayload = {
+          cardholderAddresses: null,
+          geoLocation: null,
+        };
+        const action = {
+          type: loadCardholderAccounts.fulfilled.type,
+          payload: mockPayload,
+        };
+        const state = cardReducer(initialState, action);
+
+        expect(state.cardholderAccounts).toEqual([]);
+        expect(state.geoLocation).toBe('UNKNOWN');
         expect(state.isLoaded).toBe(true);
       });
 
@@ -255,6 +346,25 @@ describe('Card Reducer', () => {
 
         expect(state.isLoaded).toBe(true);
         expect(state.cardholderAccounts).toEqual([]); // Should remain empty on error
+        expect(state.geoLocation).toBe('UNKNOWN'); // Should remain UNKNOWN on error
+      });
+
+      it('should handle different geolocation values', () => {
+        const geoLocations = ['US', 'GB', 'CA', 'DE', 'FR', 'UNKNOWN'];
+
+        geoLocations.forEach((geoLocation) => {
+          const mockPayload = {
+            cardholderAddresses: ['0x123'],
+            geoLocation,
+          };
+          const action = {
+            type: loadCardholderAccounts.fulfilled.type,
+            payload: mockPayload,
+          };
+          const state = cardReducer(initialState, action);
+
+          expect(state.geoLocation).toBe(geoLocation);
+        });
       });
     });
   });
@@ -271,11 +381,16 @@ describe('Card Reducer', () => {
         },
         isLoaded: true,
         hasViewedCardButton: true,
+        alwaysShowCardButton: true,
+        geoLocation: 'US',
+        isAuthenticated: false,
       };
 
       const state = cardReducer(currentState, resetCardState());
 
       expect(state).toEqual(initialState);
+      expect(state.geoLocation).toBe('UNKNOWN');
+      expect(state.alwaysShowCardButton).toBe(false);
     });
 
     describe('setHasViewedCardButton', () => {
@@ -750,6 +865,308 @@ describe('Card Caching Functionality', () => {
       expect(state.lastFetchedByAddress[testAddress.toLowerCase()]).toEqual(
         newTimestamp,
       );
+    });
+  });
+});
+
+describe('Card Button Display Selectors', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('selectAlwaysShowCardButton', () => {
+    it('should return false when experimental switch is disabled', () => {
+      mockSelectCardExperimentalSwitch.mockReturnValue(false);
+
+      const stateWithAlwaysShow: CardSliceState = {
+        ...initialState,
+        alwaysShowCardButton: true,
+      };
+
+      const mockRootState = {
+        card: stateWithAlwaysShow,
+      } as unknown as RootState;
+
+      expect(selectAlwaysShowCardButton(mockRootState)).toBe(false);
+    });
+
+    it('should return stored value when experimental switch is enabled', () => {
+      mockSelectCardExperimentalSwitch.mockReturnValue(true);
+
+      const stateWithAlwaysShow: CardSliceState = {
+        ...initialState,
+        alwaysShowCardButton: true,
+      };
+
+      const mockRootState = {
+        card: stateWithAlwaysShow,
+      } as unknown as RootState;
+
+      expect(selectAlwaysShowCardButton(mockRootState)).toBe(true);
+    });
+
+    it('should return false when experimental switch is enabled but stored value is false', () => {
+      mockSelectCardExperimentalSwitch.mockReturnValue(true);
+
+      const stateWithoutAlwaysShow: CardSliceState = {
+        ...initialState,
+        alwaysShowCardButton: false,
+      };
+
+      const mockRootState = {
+        card: stateWithoutAlwaysShow,
+      } as unknown as RootState;
+
+      expect(selectAlwaysShowCardButton(mockRootState)).toBe(false);
+    });
+
+    it('should return false by default with initial state', () => {
+      mockSelectCardExperimentalSwitch.mockReturnValue(false);
+
+      const mockRootState = {
+        card: initialState,
+      } as unknown as RootState;
+
+      expect(selectAlwaysShowCardButton(mockRootState)).toBe(false);
+    });
+  });
+
+  describe('setAlwaysShowCardButton', () => {
+    it('should set alwaysShowCardButton to true', () => {
+      const state = cardReducer(initialState, setAlwaysShowCardButton(true));
+      expect(state.alwaysShowCardButton).toBe(true);
+    });
+
+    it('should set alwaysShowCardButton to false', () => {
+      const currentState: CardSliceState = {
+        ...initialState,
+        alwaysShowCardButton: true,
+      };
+
+      const state = cardReducer(currentState, setAlwaysShowCardButton(false));
+      expect(state.alwaysShowCardButton).toBe(false);
+    });
+
+    it('should not affect other state properties', () => {
+      const state = cardReducer(initialState, setAlwaysShowCardButton(true));
+      expect(state.cardholderAccounts).toEqual(initialState.cardholderAccounts);
+      expect(state.geoLocation).toEqual(initialState.geoLocation);
+      expect(state.isLoaded).toEqual(initialState.isLoaded);
+    });
+  });
+
+  describe('selectDisplayCardButton', () => {
+    const mockAccountAddress = '0x1234567890123456789012345678901234567890';
+    const mockAccount = {
+      address: mockAccountAddress.toLowerCase(),
+      id: 'mock-id',
+      metadata: {
+        name: 'Mock Account',
+        importTime: Date.now(),
+        keyring: { type: 'HD Key Tree' },
+      },
+      options: {},
+      methods: [],
+      type: 'eip155:eoa' as const,
+      scopes: ['eip155:59144' as const],
+    };
+
+    beforeEach(() => {
+      // Reset all mocks to default false/empty values
+      mockSelectCardExperimentalSwitch.mockReturnValue(false);
+      mockSelectCardSupportedCountries.mockReturnValue({});
+      mockSelectDisplayCardButtonFeatureFlag.mockReturnValue(false);
+      mockSelectSelectedInternalAccountByScope.mockReturnValue(() => undefined);
+      mockIsEthAccount.mockReturnValue(false);
+    });
+
+    it('should return true when alwaysShowCardButton is true', () => {
+      mockSelectCardExperimentalSwitch.mockReturnValue(true);
+
+      const stateWithAlwaysShow: CardSliceState = {
+        ...initialState,
+        alwaysShowCardButton: true,
+        geoLocation: 'XX', // Unsupported country
+        cardholderAccounts: [], // Not a cardholder
+      };
+
+      const mockRootState = {
+        card: stateWithAlwaysShow,
+      } as unknown as RootState;
+
+      expect(selectDisplayCardButton(mockRootState)).toBe(true);
+    });
+
+    it('should return true when user is a cardholder', () => {
+      const stateWithCardholder: CardSliceState = {
+        ...initialState,
+        cardholderAccounts: [mockAccountAddress.toLowerCase()],
+        alwaysShowCardButton: false,
+        geoLocation: 'XX', // Unsupported country
+      };
+
+      mockSelectSelectedInternalAccountByScope.mockReturnValue(
+        () => mockAccount,
+      );
+      mockIsEthAccount.mockReturnValue(true);
+      mockSelectCardExperimentalSwitch.mockReturnValue(false);
+
+      const mockRootState = {
+        card: stateWithCardholder,
+      } as unknown as RootState;
+
+      expect(selectDisplayCardButton(mockRootState)).toBe(true);
+    });
+
+    it('should return true when in supported country with feature flag enabled', () => {
+      mockSelectCardSupportedCountries.mockReturnValue({ US: true });
+      mockSelectDisplayCardButtonFeatureFlag.mockReturnValue(true);
+
+      const stateWithGeoLocation: CardSliceState = {
+        ...initialState,
+        geoLocation: 'US',
+        cardholderAccounts: [],
+        alwaysShowCardButton: false,
+      };
+
+      const mockRootState = {
+        card: stateWithGeoLocation,
+      } as unknown as RootState;
+
+      expect(selectDisplayCardButton(mockRootState)).toBe(true);
+    });
+
+    it('should return false when in supported country but feature flag is disabled', () => {
+      mockSelectCardSupportedCountries.mockReturnValue({ US: true });
+      mockSelectDisplayCardButtonFeatureFlag.mockReturnValue(false);
+
+      const stateWithGeoLocation: CardSliceState = {
+        ...initialState,
+        geoLocation: 'US',
+        cardholderAccounts: [],
+        alwaysShowCardButton: false,
+      };
+
+      const mockRootState = {
+        card: stateWithGeoLocation,
+      } as unknown as RootState;
+
+      expect(selectDisplayCardButton(mockRootState)).toBe(false);
+    });
+
+    it('should return false when feature flag is enabled but country is not supported', () => {
+      mockSelectCardSupportedCountries.mockReturnValue({ US: true });
+      mockSelectDisplayCardButtonFeatureFlag.mockReturnValue(true);
+
+      const stateWithUnsupportedGeoLocation: CardSliceState = {
+        ...initialState,
+        geoLocation: 'CN', // Not in supported countries
+        cardholderAccounts: [],
+        alwaysShowCardButton: false,
+      };
+
+      const mockRootState = {
+        card: stateWithUnsupportedGeoLocation,
+      } as unknown as RootState;
+
+      expect(selectDisplayCardButton(mockRootState)).toBe(false);
+    });
+
+    it('should return false when no conditions are met', () => {
+      const mockRootState = {
+        card: initialState,
+      } as unknown as RootState;
+
+      expect(selectDisplayCardButton(mockRootState)).toBe(false);
+    });
+
+    it('should handle multiple supported countries', () => {
+      mockSelectCardSupportedCountries.mockReturnValue({
+        US: true,
+        GB: true,
+        CA: true,
+        DE: false, // Explicitly false
+      });
+      mockSelectDisplayCardButtonFeatureFlag.mockReturnValue(true);
+
+      // Test US
+      let state: CardSliceState = {
+        ...initialState,
+        geoLocation: 'US',
+        cardholderAccounts: [],
+        alwaysShowCardButton: false,
+      };
+      let mockRootState = { card: state } as unknown as RootState;
+      expect(selectDisplayCardButton(mockRootState)).toBe(true);
+
+      // Test GB
+      state = { ...state, geoLocation: 'GB' };
+      mockRootState = { card: state } as unknown as RootState;
+      expect(selectDisplayCardButton(mockRootState)).toBe(true);
+
+      // Test CA
+      state = { ...state, geoLocation: 'CA' };
+      mockRootState = { card: state } as unknown as RootState;
+      expect(selectDisplayCardButton(mockRootState)).toBe(true);
+
+      // Test DE (explicitly false)
+      state = { ...state, geoLocation: 'DE' };
+      mockRootState = { card: state } as unknown as RootState;
+      expect(selectDisplayCardButton(mockRootState)).toBe(false);
+    });
+
+    it('should prioritize alwaysShowCardButton over other conditions', () => {
+      mockSelectCardExperimentalSwitch.mockReturnValue(true);
+      mockSelectCardSupportedCountries.mockReturnValue({});
+      mockSelectDisplayCardButtonFeatureFlag.mockReturnValue(false);
+
+      const state: CardSliceState = {
+        ...initialState,
+        alwaysShowCardButton: true,
+        geoLocation: 'XX',
+        cardholderAccounts: [],
+      };
+
+      const mockRootState = { card: state } as unknown as RootState;
+
+      expect(selectDisplayCardButton(mockRootState)).toBe(true);
+    });
+
+    it('should handle UNKNOWN geolocation gracefully', () => {
+      mockSelectCardSupportedCountries.mockReturnValue({ US: true });
+      mockSelectDisplayCardButtonFeatureFlag.mockReturnValue(true);
+
+      const state: CardSliceState = {
+        ...initialState,
+        geoLocation: 'UNKNOWN',
+        cardholderAccounts: [],
+        alwaysShowCardButton: false,
+      };
+
+      const mockRootState = { card: state } as unknown as RootState;
+
+      expect(selectDisplayCardButton(mockRootState)).toBe(false);
+    });
+
+    it('should return true when all three conditions are true', () => {
+      mockSelectCardExperimentalSwitch.mockReturnValue(true);
+      mockSelectCardSupportedCountries.mockReturnValue({ US: true });
+      mockSelectDisplayCardButtonFeatureFlag.mockReturnValue(true);
+      mockSelectSelectedInternalAccountByScope.mockReturnValue(
+        () => mockAccount,
+      );
+      mockIsEthAccount.mockReturnValue(true);
+
+      const state: CardSliceState = {
+        ...initialState,
+        alwaysShowCardButton: true,
+        geoLocation: 'US',
+        cardholderAccounts: [mockAccountAddress.toLowerCase()],
+      };
+
+      const mockRootState = { card: state } as unknown as RootState;
+
+      expect(selectDisplayCardButton(mockRootState)).toBe(true);
     });
   });
 });

--- a/app/selectors/featureFlagController/card/index.test.ts
+++ b/app/selectors/featureFlagController/card/index.test.ts
@@ -1,20 +1,31 @@
 import {
   CardFeatureFlag,
+  CardSupportedCountries,
   SupportedChain,
   SupportedToken,
   selectCardFeatureFlag,
+  selectCardSupportedCountries,
+  selectDisplayCardButtonFeatureFlag,
+  selectCardExperimentalSwitch,
 } from '.';
 import mockedEngine from '../../../core/__mocks__/MockedEngine';
 import { mockedEmptyFlagsState, mockedUndefinedFlagsState } from '../mocks';
+import { validatedVersionGatedFeatureFlag } from '../../../util/remoteFeatureFlag';
 
 jest.mock('../../../core/Engine', () => ({
   init: () => mockedEngine.init(),
 }));
 
+jest.mock('../../../util/remoteFeatureFlag', () => ({
+  validatedVersionGatedFeatureFlag: jest.fn(),
+}));
+
 const originalEnv = process.env;
+
 beforeEach(() => {
   jest.resetModules();
   process.env = { ...originalEnv };
+  jest.clearAllMocks();
 });
 
 afterEach(() => {
@@ -94,20 +105,29 @@ const mockedStateWithPartialCardFeatureFlag = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } as any;
 
-describe('Card Feature Flag Selector', () => {
-  it('returns null when feature flag state is empty', () => {
-    const result = selectCardFeatureFlag(mockedEmptyFlagsState);
+describe('selectCardFeatureFlag', () => {
+  it('returns default card feature flag when feature flag state is empty', () => {
+    const result = selectCardFeatureFlag(
+      mockedEmptyFlagsState,
+    ) as CardFeatureFlag;
 
-    expect(result).toEqual(null);
+    expect(result).toBeDefined();
+    expect(result.constants).toBeDefined();
+    expect(result.chains).toBeDefined();
+    expect(result.isBaanxLoginEnabled).toBe(false);
   });
 
-  it('returns null when RemoteFeatureFlagController state is undefined', () => {
-    const result = selectCardFeatureFlag(mockedUndefinedFlagsState);
+  it('returns default card feature flag when RemoteFeatureFlagController state is undefined', () => {
+    const result = selectCardFeatureFlag(
+      mockedUndefinedFlagsState,
+    ) as CardFeatureFlag;
 
-    expect(result).toEqual(null);
+    expect(result).toBeDefined();
+    expect(result.constants).toBeDefined();
+    expect(result.chains).toBeDefined();
   });
 
-  it('returns null when cardFeature is null', () => {
+  it('returns default card feature flag when cardFeature is null', () => {
     const stateWithNullCardFlag = {
       engine: {
         backgroundState: {
@@ -121,9 +141,13 @@ describe('Card Feature Flag Selector', () => {
       },
     };
 
-    const result = selectCardFeatureFlag(stateWithNullCardFlag);
+    const result = selectCardFeatureFlag(
+      stateWithNullCardFlag,
+    ) as CardFeatureFlag;
 
-    expect(result).toBeNull();
+    expect(result).toBeDefined();
+    expect(result.constants).toBeDefined();
+    expect(result.chains).toBeDefined();
   });
 
   it('returns card feature flag when properly configured', () => {
@@ -219,11 +243,13 @@ describe('Card Feature Flag Selector', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
 
-    const result = selectCardFeatureFlag(stateWithMultipleTokens);
+    const result = selectCardFeatureFlag(
+      stateWithMultipleTokens,
+    ) as CardFeatureFlag;
 
-    expect(result?.chains?.['1']?.tokens).toHaveLength(2);
-    expect(result?.chains?.['1']?.tokens?.[0]).toEqual(mockedSupportedToken);
-    expect(result?.chains?.['1']?.tokens?.[1]).toEqual({
+    expect(result.chains?.['1']?.tokens).toHaveLength(2);
+    expect(result.chains?.['1']?.tokens?.[0]).toEqual(mockedSupportedToken);
+    expect(result.chains?.['1']?.tokens?.[1]).toEqual({
       address: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
       decimals: 6,
       enabled: false,
@@ -251,12 +277,312 @@ describe('Card Feature Flag Selector', () => {
           },
         },
       },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const result = selectCardFeatureFlag(
+      stateWithDisabledChain,
+    ) as CardFeatureFlag;
+
+    expect(result.chains?.['1']?.enabled).toBe(false);
+    expect(result.chains?.['1']?.tokens).toBeNull();
+  });
+});
+
+describe('selectCardSupportedCountries', () => {
+  it('returns default supported countries when feature flag state is empty', () => {
+    const result = selectCardSupportedCountries(
+      mockedEmptyFlagsState,
+    ) as CardSupportedCountries;
+
+    expect(result).toBeDefined();
+    expect(typeof result).toBe('object');
+    expect(result.GB).toBe(true);
+    expect(result.US).toBeUndefined();
+  });
+
+  it('returns default supported countries when RemoteFeatureFlagController state is undefined', () => {
+    const result = selectCardSupportedCountries(
+      mockedUndefinedFlagsState,
+    ) as CardSupportedCountries;
+
+    expect(result).toBeDefined();
+    expect(typeof result).toBe('object');
+  });
+
+  it('returns custom supported countries when defined in remote flags', () => {
+    const customCountries: CardSupportedCountries = {
+      US: true,
+      CA: true,
+      GB: false,
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result = selectCardFeatureFlag(stateWithDisabledChain as any);
+    const stateWithCustomCountries = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              cardSupportedCountries: customCountries,
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
 
-    expect(result?.chains?.['1']?.enabled).toBe(false);
-    expect(result?.chains?.['1']?.tokens).toBeNull();
+    const result = selectCardSupportedCountries(
+      stateWithCustomCountries,
+    ) as CardSupportedCountries;
+
+    expect(result).toEqual(customCountries);
+    expect(result.US).toBe(true);
+    expect(result.CA).toBe(true);
+    expect(result.GB).toBe(false);
+  });
+
+  it('handles null cardSupportedCountries by returning default', () => {
+    const stateWithNullCountries = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              cardSupportedCountries: null,
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const result = selectCardSupportedCountries(stateWithNullCountries);
+
+    expect(result).toBeDefined();
+    expect(typeof result).toBe('object');
+  });
+});
+
+describe('selectDisplayCardButtonFeatureFlag', () => {
+  const mockedValidatedVersionGatedFeatureFlag =
+    validatedVersionGatedFeatureFlag as jest.MockedFunction<
+      typeof validatedVersionGatedFeatureFlag
+    >;
+
+  it('returns false when feature flag state is empty', () => {
+    mockedValidatedVersionGatedFeatureFlag.mockReturnValue(undefined);
+
+    const result = selectDisplayCardButtonFeatureFlag(mockedEmptyFlagsState);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when RemoteFeatureFlagController state is undefined', () => {
+    mockedValidatedVersionGatedFeatureFlag.mockReturnValue(undefined);
+
+    const result = selectDisplayCardButtonFeatureFlag(
+      mockedUndefinedFlagsState,
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it('returns true when feature flag is enabled and version requirement is met', () => {
+    mockedValidatedVersionGatedFeatureFlag.mockReturnValue(true);
+
+    const stateWithDisplayCardButton = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              displayCardButton: {
+                enabled: true,
+                minimumVersion: '7.0.0',
+              },
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const result = selectDisplayCardButtonFeatureFlag(
+      stateWithDisplayCardButton,
+    );
+
+    expect(result).toBe(true);
+    expect(mockedValidatedVersionGatedFeatureFlag).toHaveBeenCalledWith({
+      enabled: true,
+      minimumVersion: '7.0.0',
+    });
+  });
+
+  it('returns false when feature flag is disabled', () => {
+    mockedValidatedVersionGatedFeatureFlag.mockReturnValue(false);
+
+    const stateWithDisabledFlag = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              displayCardButton: {
+                enabled: false,
+                minimumVersion: '7.0.0',
+              },
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const result = selectDisplayCardButtonFeatureFlag(stateWithDisabledFlag);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when version requirement is not met', () => {
+    mockedValidatedVersionGatedFeatureFlag.mockReturnValue(false);
+
+    const stateWithVersionGate = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              displayCardButton: {
+                enabled: true,
+                minimumVersion: '99.0.0',
+              },
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const result = selectDisplayCardButtonFeatureFlag(stateWithVersionGate);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when validatedVersionGatedFeatureFlag returns undefined', () => {
+    mockedValidatedVersionGatedFeatureFlag.mockReturnValue(undefined);
+
+    const stateWithMalformedFlag = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              displayCardButton: {
+                enabled: 'true', // Invalid type
+              },
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const result = selectDisplayCardButtonFeatureFlag(stateWithMalformedFlag);
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('selectCardExperimentalSwitch', () => {
+  it('returns false when feature flag state is empty', () => {
+    const result = selectCardExperimentalSwitch(mockedEmptyFlagsState);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when RemoteFeatureFlagController state is undefined', () => {
+    const result = selectCardExperimentalSwitch(mockedUndefinedFlagsState);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns true when cardExperimentalSwitch is enabled', () => {
+    const stateWithExperimentalSwitch = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              cardExperimentalSwitch: true,
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const result = selectCardExperimentalSwitch(stateWithExperimentalSwitch);
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false when cardExperimentalSwitch is disabled', () => {
+    const stateWithDisabledSwitch = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              cardExperimentalSwitch: false,
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const result = selectCardExperimentalSwitch(stateWithDisabledSwitch);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when cardExperimentalSwitch is null', () => {
+    const stateWithNullSwitch = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              cardExperimentalSwitch: null,
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const result = selectCardExperimentalSwitch(stateWithNullSwitch);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when cardExperimentalSwitch is undefined', () => {
+    const stateWithUndefinedSwitch = {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              cardExperimentalSwitch: undefined,
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const result = selectCardExperimentalSwitch(stateWithUndefinedSwitch);
+
+    expect(result).toBe(false);
   });
 });

--- a/app/selectors/featureFlagController/card/index.ts
+++ b/app/selectors/featureFlagController/card/index.ts
@@ -1,5 +1,159 @@
 import { createSelector } from 'reselect';
 import { selectRemoteFeatureFlags } from '..';
+import { validatedVersionGatedFeatureFlag } from '../../../util/remoteFeatureFlag';
+
+const defaultCardFeatureFlag: CardFeatureFlag = {
+  chains: {
+    'eip155:59144': {
+      balanceScannerAddress: '0xed9f04f2da1b42ae558d5e688fe2ef7080931c9a',
+      enabled: true,
+      foxConnectAddresses: {
+        global: '0x9dd23A4a0845f10d65D293776B792af1131c7B30',
+        us: '0xA90b298d05C2667dDC64e2A4e17111357c215dD2',
+      },
+      tokens: [
+        {
+          address: '0x176211869cA2b568f2A7D4EE941E073a821EE1ff',
+          decimals: 6,
+          enabled: true,
+          name: 'USD Coin',
+          symbol: 'USDC',
+        },
+        {
+          address: '0xA219439258ca9da29E9Cc4cE5596924745e12B93',
+          decimals: 6,
+          enabled: true,
+          name: 'Tether USD',
+          symbol: 'USDT',
+        },
+        {
+          address: '0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f',
+          decimals: 18,
+          enabled: true,
+          name: 'Wrapped Ether',
+          symbol: 'WETH',
+        },
+        {
+          address: '0x3ff47c5Bf409C86533FE1f4907524d304062428D',
+          decimals: 18,
+          enabled: true,
+          name: 'EURe',
+          symbol: 'EURe',
+        },
+        {
+          address: '0x3Bce82cf1A2bc357F956dd494713Fe11DC54780f',
+          decimals: 18,
+          enabled: true,
+          name: 'GBPe',
+          symbol: 'GBPe',
+        },
+        {
+          address: '0x374D7860c4f2f604De0191298dD393703Cce84f3',
+          decimals: 6,
+          enabled: true,
+          name: 'Aave USDC',
+          symbol: 'aUSDC',
+        },
+        {
+          address: '0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
+          decimals: 6,
+          enabled: true,
+          name: 'MetaMask USD',
+          symbol: 'mUSD',
+        },
+      ],
+    },
+    'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': {
+      enabled: true,
+      tokens: [
+        {
+          address: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+          decimals: 6,
+          enabled: true,
+          name: 'USDC',
+          symbol: 'USDC',
+        },
+        {
+          address: 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB',
+          decimals: 6,
+          enabled: true,
+          name: 'USDT',
+          symbol: 'USDT',
+        },
+      ],
+    },
+  },
+  constants: {
+    accountsApiUrl: 'https://accounts.api.cx.metamask.io',
+    onRampApiUrl: 'https://on-ramp.uat-api.cx.metamask.io',
+  },
+  isBaanxLoginEnabled: false,
+};
+
+const defaultCardSupportedCountries: CardSupportedCountries = {
+  GG: true,
+  DE: true,
+  NO: true,
+  'CA-QC': true,
+  GI: true,
+  AD: true,
+  BE: true,
+  FI: true,
+  'CA-NB': true,
+  SV: true,
+  IM: true,
+  'CA-MB': true,
+  'CA-PE': true,
+  PT: true,
+  UY: true,
+  BG: true,
+  CH: true,
+  DK: true,
+  MT: true,
+  'CA-SK': true,
+  LU: true,
+  HR: true,
+  IS: true,
+  'CA-YT': true,
+  GR: true,
+  IT: true,
+  MX: true,
+  CO: true,
+  FR: true,
+  GT: true,
+  HU: true,
+  'CA-NL': true,
+  ES: true,
+  'CA-ON': true,
+  'CA-BC': true,
+  BR: true,
+  'CA-AB': true,
+  AR: true,
+  PA: true,
+  SE: true,
+  AT: true,
+  'CA-NS': true,
+  'CA-NT': true,
+  CY: true,
+  'CA-NU': true,
+  SI: true,
+  UK: true,
+  SK: true,
+  GB: true,
+  JE: true,
+  IE: true,
+  PL: true,
+  LI: true,
+  RO: true,
+  NL: true,
+};
+
+export type CardSupportedCountries = Record<string, boolean>;
+
+export interface DisplayCardButtonFeatureFlag {
+  enabled: boolean;
+  minimumVersion: string;
+}
 
 export interface CardFeatureFlag {
   isBaanxLoginEnabled?: boolean;
@@ -25,10 +179,33 @@ export interface SupportedToken {
   symbol?: string | null;
 }
 
+export const selectCardSupportedCountries = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) =>
+    remoteFeatureFlags?.cardSupportedCountries ??
+    (defaultCardSupportedCountries as CardSupportedCountries),
+);
+
+export const selectDisplayCardButtonFeatureFlag = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) => {
+    const remoteFlag =
+      remoteFeatureFlags?.displayCardButton as unknown as DisplayCardButtonFeatureFlag;
+
+    return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
+  },
+);
+
+export const selectCardExperimentalSwitch = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) => remoteFeatureFlags?.cardExperimentalSwitch ?? false,
+);
+
 export const selectCardFeatureFlag = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags) => {
     const cardFeatureFlag = remoteFeatureFlags?.cardFeature;
-    return (cardFeatureFlag ?? null) as CardFeatureFlag | null;
+
+    return cardFeatureFlag ?? defaultCardFeatureFlag;
   },
 );

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3970,7 +3970,9 @@
     "wallet_connect_dapps_cta": "View sessions",
     "network_not_supported": "Current network not supported",
     "select_provider": "Select your preferred provider",
-    "switch_network": "Please switch to mainnet or sepolia"
+    "switch_network": "Please switch to mainnet or sepolia",
+    "card_title": "Always show MetaMask Card button",
+    "card_desc": "MetaMask Card is only available to residents of select countries"
   },
   "walletconnect_sessions": {
     "no_active_sessions": "You have no active sessions",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once. -->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution? -->

This PR introduces new logic for displaying the Card button on the Wallet Home screen.

Key Changes
- Added geolocation fetching and verification to determine if the user is in a supported region.
- Added new feature flags to control progressive rollout of the Card button.
- Introduced a new experimental setting within the Settings → Experimental section to always display the Card button (for internal testing).

Display Logic

The Card button is shown under the following conditions (in order of priority):
1. Experimental flag enabled → Always show the Card button.
2. Experimental flag disabled, but the user is a cardholder (on-chain data) → Show the Card button.
3. Experimental flag disabled, but the user is logged in with Baanx → Show the Card button.
4. Experimental flag disabled, user is in a supported region, and feature flag (progressive rollout) is enabled → Show the Card button.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs` `CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: New Enable Card Button section on Experimental Options

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding
Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds geolocation- and flag-gated display logic for the Card button, moves Card auth/display state into Redux, introduces an experimental “always show” toggle, and updates SDK geolocation and related tests.
> 
> - **Card feature (Redux/state)**:
>   - Add `geoLocation`, `isAuthenticated`, and `alwaysShowCardButton` to `card` slice; introduce selectors `selectDisplayCardButton`, `selectAlwaysShowCardButton`, `selectCardGeoLocation`, `selectIsAuthenticatedCard`.
>   - Change `loadCardholderAccounts` payload to `{ cardholderAddresses, geoLocation }` and update consumers.
> - **SDK and hooks**:
>   - Update `CardSDK.getGeoLocation` to environment-based endpoints; return `UNKNOWN` on failure and improve logging.
>   - Move auth state handling to Redux actions; update `CardSDKProvider` and `useCardProviderAuthentication` to dispatch `setIsAuthenticatedCard`.
>   - `getCardholder` now returns both cardholder addresses and geolocation.
> - **UI**:
>   - Wallet navbar uses `selectDisplayCardButton` (replaces direct cardholder check).
>   - Experimental Settings: add toggle to always show Card button (guarded by experimental flag).
>   - CardHome reads Redux `isAuthenticated` and minor test utilities cleanup.
> - **Feature flags/selectors**:
>   - Add card supported countries and version-gated flag for displaying Card button; provide default card feature flag.
> - **Localization/Tests**:
>   - Update English strings for Experimental Settings Card section.
>   - Extensive unit test updates to reflect new selectors, geolocation handling, and Redux-driven auth/display logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9107a0c1f2f35cd7f94f353c695dc528c1e5e45d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


