### PR TITLE
chore: New Crowdin translations by Github Action cp-7.57.0

### DIFF
--- a/locales/languages/de.json
+++ b/locales/languages/de.json
@@ -594,7 +594,9 @@
       "unexpectedError": "Ein unerwarteter Fehler ist aufgetreten.",
       "quoteFetchError": "Angebot konnte nicht abgerufen werden.",
       "kycFormsFetchError": "KYC-Formulare konnten nicht abgerufen werden.",
-      "title": "Einzahlung"
+      "title": "Einzahlung",
+      "limitExceeded": "This deposit would exceed your {{period}} limit. Your deposit including fees must be {{remaining}} or less.",
+      "limitError": "Failed to check your deposit limits. Please try again later."
     },
     "token_modal": {
       "select_a_token": "Token wählen",
@@ -892,7 +894,7 @@
     "withdraw": "Auszahlen",
     "refresh_balance": "Guthaben aktualisieren",
     "add_funds": "Gelder hinzufügen",
-    "deposit_in_progress": "Deposit in progress",
+    "deposit_in_progress": "Einzahlung im Gange",
     "your_positions": "Ihre Positionen",
     "loading_positions": "Positionen werden geladen ...",
     "refreshing_positions": "Positionen werden aktualisiert ...",
@@ -1277,6 +1279,7 @@
       "assetMappingFailed": "Erstellung des Asset-Mappings fehlgeschlagen",
       "depositFailed": "Einzahlung fehlgeschlagen",
       "orderLeverageReductionFailed": "Sie können Ihren Hebel nicht reduzieren",
+      "connectionTimeout": "Connection timed out. Please check your network and try again.",
       "connectionFailed": {
         "title": "Perps ist vorübergehend offline",
         "description": "Wir arbeiten daran, bald wieder online zu sein.",
@@ -1348,9 +1351,9 @@
         "error_message": "Marktdaten nicht gefunden. Bitte kehren Sie zurück und versuchen Sie es erneut."
       },
       "statistics": "Übersicht",
-      "24h_high": "24h high",
-      "24h_low": "24h low",
-      "24h_volume": "24h volume",
+      "24h_high": "24-Std.-Hoch",
+      "24h_low": "24-Std.-Tief",
+      "24h_volume": "24-Std.-Volumen",
       "open_interest": "Open Interest",
       "funding_rate": "Finanzierungsrate",
       "countdown": "Countdown",
@@ -1510,9 +1513,9 @@
         "metamask_fee": "MetaMask-Gebühr",
         "hyperliquid_fee": "Hyperliquid-Gebühr",
         "total_fee": "Gesamtgebühr",
-        "liquidated": "Liquidated",
-        "take_profit": "Take profit",
-        "stop_loss": "Stop loss"
+        "liquidated": "Liquidiert",
+        "take_profit": "Take-Profit",
+        "stop_loss": "Stop-Loss"
       },
       "funding": {
         "date": "Datum",
@@ -1555,11 +1558,11 @@
       "ready_to_trade": {
         "title": "Bereit zum Handeln?",
         "description": "Zahlen Sie ein beliebiges Token auf Ihr Perps-Konto ein und führen Sie innerhalb von Sekunden Ihren ersten Trade durch.",
-        "footer_text": "MetaMask swappt Ihre Gelder auf Arbitrum in USDC und zahlt sie ohne zusätzliche Gebühr auf HyperCore ein."
+        "footer_text": "MetaMask will swap your funds to USDC on Arbitrum, and deposit them onto HyperCore for no added fee."
       },
       "got_it": "Verstanden",
       "card": {
-        "title": "Learn the basics of perps"
+        "title": "Lernen Sie die Grundlagen von Perps"
       }
     },
     "points": "Punkte",
@@ -1576,10 +1579,10 @@
     "market_list": "Marktliste",
     "market_details": "Marktdetails",
     "tab": {
-      "no_predictions": "Noch keine Prognosen",
-      "no_predictions_description": "Öffnen Sie eine Prognose, um loszulegen.",
-      "explore": "Märkte erkunden",
-      "new_prediction": "Neue Prognose"
+      "no_predictions_description": "Your predictions will appear here, showing your stake and market movement.",
+      "explore": "Browse markets",
+      "new_prediction": "Neue Prognose",
+      "resolved_markets": "Resolved markets"
     },
     "sell_position": "Verkaufsposition",
     "cash_out": "Auszahlen",
@@ -1609,16 +1612,73 @@
     "claim_button": "Einfordern",
     "markets_won": "Gewonnene Märkte",
     "won_markets_text": "{{count}} Markt{{s}} gewonnen",
-    "won_markets_text_singular": "{{count}} Markt gewonnen",
-    "won_markets_text_plural": "{{count}} Märkte gewonnen",
+    "available_balance": "Available balance",
     "claim_amount_text": "{{amount}} $ einfordern",
     "unrealized_pnl_label": "Nicht realisierte GuV",
     "unrealized_pnl_value": "{{amount}} ({{percent}})",
+    "unrealized_pnl_error": "Unable to load",
     "unavailable": {
       "title": "Unavailable in your region",
       "description": "Predictions aren't available in your region due to legal restrictions.",
       "link": "See Polymarket terms",
       "button": "Got it"
+    },
+    "deposit": {
+      "in_progress": "Deposit in progress",
+      "adding_funds": "Adding funds",
+      "adding_your_funds": "Adding your funds",
+      "add_funds": "Add funds",
+      "withdraw": "Withdraw",
+      "estimated_processing_time": "Est. {{time}} seconds",
+      "account_ready": "Your account is ready",
+      "account_ready_description": "{{amount}} added to your balance",
+      "error_title": "Something went wrong",
+      "error_description": "Your account wasn't funded",
+      "try_again": "Try again"
+    },
+    "add_funds_sheet": {
+      "title": "Add funds",
+      "description": "You'll need to add funds to your Predictions account to get started. You can add any token and make your first prediction in seconds."
+    },
+    "transactions": {
+      "title": "Predictions",
+      "no_transactions": "No recent activity",
+      "buy_title": "Predicted",
+      "sell_title": "Cashed out",
+      "claim_title": "Claimed winnings",
+      "buy_detail": "Bought {{amountUsd}} on {{outcome}} · {{priceCents}} per share",
+      "sell_detail": "Sold at {{priceCents}} per share",
+      "claim_detail": "Claimed winnings",
+      "not_available": "N/A",
+      "date": "Date",
+      "market": "Market",
+      "outcome": "Outcome",
+      "predicted_amount": "Predicted amount",
+      "shares_bought": "Shares bought",
+      "shares_sold": "Shares sold",
+      "price_per_share": "Price per share",
+      "price_impact": "Price impact",
+      "net_pnl": "Net P&L",
+      "total_net_pnl": "Total Net P&L",
+      "market_net_pnl": "Market Net P&L",
+      "activity_details": "Activity details"
+    },
+    "claim": {
+      "toasts": {
+        "pending": {
+          "title": "Claiming {{amount}}",
+          "description": "Est. {{time}} seconds"
+        },
+        "confirmed": {
+          "title": "Claimed",
+          "description": "{{amount}} added to your balance"
+        },
+        "error": {
+          "title": "Something went wrong",
+          "description": "Failed to proceed with claim",
+          "try_again": "Try again"
+        }
+      }
     }
   },
   "receive": {
@@ -3093,6 +3153,7 @@
     "tx_review_lending_withdraw": "Kreditauszahlung",
     "tx_review_perps_deposit": "Perps-Konto finanziert",
     "tx_review_predict_deposit": "Funded Predict account",
+    "tx_review_predict_claim": "Claimed Predict winnings",
     "sent_ether": "Ether senden",
     "self_sent_ether": "Senden Sie sich selbst Ether",
     "received_ether": "Ether empfangen",
@@ -3939,7 +4000,9 @@
     "wallet_connect_dapps_cta": "Sitzungen anzeigen",
     "network_not_supported": "Aktuelles Netzwerk nicht unterstützt",
     "select_provider": "Wählen Sie Ihren bevorzugten Anbieter",
-    "switch_network": "Bitte wechseln Sie auf Mainnet oder Sepolia."
+    "switch_network": "Bitte wechseln Sie auf Mainnet oder Sepolia.",
+    "card_title": "Always show MetaMask Card button",
+    "card_desc": "MetaMask Card is only available to residents of select countries"
   },
   "walletconnect_sessions": {
     "no_active_sessions": "Sie haben keine aktiven Sitzungen",
@@ -5315,7 +5378,7 @@
     },
     "tooltip": {
       "perps_deposit": {
-        "transaction_fee": "Wir swappen Ihre Token gegen USDC auf HyperCore, dem von Perps verwendeten Netzwerk. Swap-Anbieter können eine Gebühr erheben, MetaMask jedoch nicht."
+        "transaction_fee": "We'll swap your tokens for USDC on HyperCore, the network used by Perps. Swap providers may charge a fee, but MetaMask won't."
       },
       "predict_deposit": {
         "transaction_fee": "We'll swap your tokens for USDC.e on Polygon, the network used by Predict. Swap providers may charge a fee, but MetaMask won't."
@@ -5407,6 +5470,12 @@
       "save": "Speichern",
       "title": "Genehmigungslimit bearbeiten"
     },
+    "predict_claim": {
+      "button_label": "Claim winnings",
+      "summary": "You won",
+      "footer_bottom": "Funds will be added to your available balance",
+      "footer_top": "Winnings from {{count}} markets"
+    },
     "unlimited": "Unbegrenzt",
     "all": "Alle",
     "none": "Keine",
@@ -5469,12 +5538,15 @@
     "points": "Geschätzte Punkte",
     "points_tooltip": "Punkte",
     "points_tooltip_content_1": "Points are how you earn MetaMask Rewards for completing transactions, like when you swap, bridge, or trade perps.",
-    "points_tooltip_content_2": "Keep in mind this value is an estimate and will be finalized once the transaction is complete. Points can take up to 1 hour to be confirmed in your Rewards balance.",
+    "points_tooltip_content_2": "Beachten Sie bitte, dass es sich bei diesem Wert um einen Schätzwert handelt, der erst bei Abschluss der Transaktion endgültig festgelegt wird. Es kann bis zu 1 Stunde dauern, bis die Punkte in Ihrem Belohnungsguthaben bestätigt werden.",
     "unable_to_load": "Laden nicht möglich",
     "points_error": "Wir können momentan keine Punkte laden",
-    "points_error_content": "You'll still earn any points for this transaction. We'll notify you once they've been added to your account. You can also check your rewards tab in about an hour.",
+    "points_error_content": "Sie erhalten für diese Transaktion weiterhin Punkte. Wir werden Sie benachrichtigen, sobald sie Ihrem Konto gutgeschrieben wurden. Sie können auch in etwa einer Stunde Ihre Registerkarte „Belohnungen“ überprüfen.",
     "see_other_quotes": "Andere Angebote sehen",
     "receive_at": "Empfangen bei",
+    "recipient": "Recipient",
+    "select_recipient": "Select recipient",
+    "external_account": "External account",
     "error_banner_description": "Diese Handelsroute ist derzeit nicht verfügbar. Versuchen Sie, den Betrag, das Netzwerk oder das Token zu ändern, und wir finden die beste Option.",
     "insufficient_funds": "Unzureichende Gelder",
     "insufficient_gas": "Unzureichendes Gas",
@@ -5775,6 +5847,12 @@
       "update_to_store_link": "Aktualisieren Sie auf die neueste Version von MetaMask",
       "well_take_you_to_right_place": " und wir bringen Sie an den richtigen Ort."
     },
+    "unsupported": {
+      "title": "This page is not supported in current version",
+      "description": "Update to the latest version to use this feature",
+      "update_to_store_link": "Update to the latest version of MetaMask",
+      "well_take_you_to_right_place": " and we'll take you to the right place."
+    },
     "go_to_home_button": "Zur Startseite gehen",
     "back_button": "Zurück",
     "continue_button": "Fortfahren"
@@ -5791,7 +5869,96 @@
     "card_onboarding": {
       "title": "Willkommen bei Karte",
       "description": "Um Kartenfunktionen nutzen zu können, müssen Sie Ihr Konto bei unserem Partner verifizieren.",
-      "verify_account_button": "Konto verifizieren"
+      "verify_account_button": "Konto verifizieren",
+      "sign_up": {
+        "title": "Sign-up",
+        "description": "Register your details with Crypto Life, the provider of MetaMask Card. You'll use this account to access and manage your card.",
+        "email_label": "Email",
+        "password_label": "Password",
+        "confirm_password_label": "Confirm password",
+        "country_label": "Country of Residence",
+        "email_placeholder": "Enter your email address",
+        "password_placeholder": "Enter your password",
+        "country_placeholder": "Select your country",
+        "password_mismatch": "Passwords do not match",
+        "invalid_email": "Invalid email address"
+      },
+      "confirm_email": {
+        "title": "Confirm your email",
+        "description": "We've sent a confirmation code to: {{email}}",
+        "confirm_code_label": "Confirmation code",
+        "confirm_code_placeholder": "Enter the confirmation code"
+      },
+      "set_phone_number": {
+        "title": "Phone number",
+        "description": "Enter your phone number",
+        "phone_number_label": "Phone number",
+        "phone_number_placeholder": "Enter your phone number",
+        "country_area_code_label": "Country area code",
+        "invalid_phone_number": "Invalid phone number",
+        "legal_terms": "By continuing, you agree to receiving SMS to verify your phone number."
+      },
+      "confirm_phone_number": {
+        "title": "Confirm your phone number",
+        "description": "We've sent a confirmation code to: {{phoneNumber}}",
+        "confirm_code_label": "Confirmation code"
+      },
+      "verify_identity": {
+        "title": "Verifying your identity to get your card",
+        "description": "To keep your account secure and comply with regulations, we need to verify your identity.\n\nYou'll need a government-issued ID and a proof of address (like a utility bill or bank statement).\n\nVerification usually takes 5-30 minutes, and we'll notify you as soon as it's complete.",
+        "verify_button": "Verify now with Veriff"
+      },
+      "validating_kyc": {
+        "title": "Validating your KYC..."
+      },
+      "kyc_failed": {
+        "title": "Rejected",
+        "description": "Your KYC was rejected. Please try again."
+      },
+      "personal_details": {
+        "title": "Personal details",
+        "description": "Enter your personal details",
+        "first_name_label": "First name",
+        "last_name_label": "Last name",
+        "date_of_birth_label": "Date of birth",
+        "nationality_label": "Country of Nationality",
+        "ssn_label": "Social Security Number",
+        "first_name_placeholder": "Enter your first name",
+        "last_name_placeholder": "Enter your last name",
+        "date_of_birth_placeholder": "Enter your date of birth",
+        "nationality_placeholder": "Select your nationality",
+        "ssn_placeholder": "Enter your SSN",
+        "invalid_ssn": "Invalid SSN",
+        "invalid_date_of_birth": "Invalid date of birth",
+        "invalid_date_of_birth_underage": "You must be at least 18 years old"
+      },
+      "physical_address": {
+        "title": "Physical address",
+        "description": "Please provide your physical address",
+        "address_line_1_label": "Address line 1",
+        "address_line_2_label": "Address line 2",
+        "city_label": "City",
+        "state_label": "State",
+        "zip_code_label": "ZIP code",
+        "address_line_1_placeholder": "Enter your address line 1",
+        "address_line_2_placeholder": "Enter your address line 2",
+        "city_placeholder": "Enter your city",
+        "state_placeholder": "Enter your state",
+        "zip_code_placeholder": "Enter your ZIP code",
+        "same_mailing_address_label": "Physical address is the same as mailing address",
+        "electronic_consent": "I agree to the E-Sign Act Consent and Disclosure and to receive all communictions electronically."
+      },
+      "mailing_address": {
+        "title": "Mailing address",
+        "description": "Please provide your mailing address"
+      },
+      "complete": {
+        "title": "Approved!",
+        "description": "Your KYC was approved. You can now use your Card."
+      },
+      "continue_button": "Next",
+      "confirm_button": "Confirm",
+      "retry_button": "Try again"
     },
     "card_home": {
       "error_title": "Daten können nicht abgerufen werden",
@@ -5799,9 +5966,36 @@
       "try_again": "Erneut versuchen",
       "limited_spending_warning": "Ihre tatsächliche Ausgabenkapazität ist möglicherweise begrenzt. Um Ihr Limit anzupassen, gehen Sie zu {{manageCard}}.",
       "add_funds": "Gelder hinzufügen",
+      "change_asset": "Change asset",
       "manage_card_options": {
+        "manage_spending_limit": "Manage spending limit",
+        "manage_spending_limit_description_restricted": "Restricted spending limit is on",
+        "manage_spending_limit_description_full": "Full spending access is on",
         "manage_card": "Karte verwalten",
-        "advanced_card_management_description": "Transaktionen einsehen, Karte sperren und mehr"
+        "advanced_card_management_description": "Detailed transactions, freeze card, and more"
+      }
+    },
+    "card_authentication": {
+      "title": "Log in to your Card account",
+      "location_button_text": "International",
+      "location_button_text_us": "US account",
+      "email_label": "Email",
+      "password_label": "Password",
+      "email_placeholder": "Enter your email address",
+      "password_placeholder": "Enter your password",
+      "login_button": "Log in",
+      "errors": {
+        "invalid_credentials": "Invalid login details",
+        "unknown_error": "Unknown error, please try again later",
+        "email_required": "Email is required",
+        "password_required": "Password is required",
+        "email_invalid": "Invalid email address",
+        "password_invalid": "Invalid password",
+        "invalid_email_or_password": "Invalid email or password, check your credentials and try again.",
+        "network_error": "Network error. Please check your connection and try again.",
+        "timeout_error": "Request timed out. Please check your connection and try again.",
+        "server_error": "Server error. Please try again later.",
+        "configuration_error": "Service is temporarily unavailable. Please try again later."
       }
     }
   },
@@ -5825,65 +6019,65 @@
     "close": "Schließen"
   },
   "rewards": {
-    "auth_fail_title": "Unknown Error.",
-    "auth_fail_description": "An unknown error occurred while authenticating this account with the rewards program. Please try again later.",
-    "failed_to_authenticate": "Failed to authenticate with rewards program",
+    "auth_fail_title": "Unbekannter Fehler.",
+    "auth_fail_description": "Bei der Authentifizierung dieses Kontos mit dem Belohnungsprogramm ist ein unbekannter Fehler aufgetreten. Bitte versuchen Sie es später erneut.",
+    "failed_to_authenticate": "Authentifizierung beim Belohnungsprogramm fehlgeschlagen",
     "not_implemented": "Demnächst verfügbar",
     "not_implemented_season_summary": "Zusammenfassung der Saison demnächst verfügbar",
     "optin_error": {
-      "title": "Opt-in failed",
-      "description": "Check your connection and try again."
+      "title": "Anmeldung fehlgeschlagen",
+      "description": "Überprüfen Sie Ihre Verbindung und versuchen Sie es erneut."
     },
     "season_status_error": {
-      "error_fetching_title": "Season balance couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Saisonbilanz konnte nicht geladen werden",
+      "error_fetching_description": "Überprüfen Sie Ihre Verbindung und versuchen Sie es erneut.",
+      "retry_button": "Erneut versuchen"
     },
     "active_boosts_error": {
-      "error_fetching_title": "Boosts couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Boosts konnten nicht geladen werden",
+      "error_fetching_description": "Überprüfen Sie Ihre Verbindung und versuchen Sie es erneut.",
+      "retry_button": "Erneut versuchen"
     },
     "unlocked_rewards_error": {
-      "error_fetching_title": "Rewards couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Belohnungen konnten nicht geladen werden",
+      "error_fetching_description": "Überprüfen Sie Ihre Verbindung und versuchen Sie es erneut.",
+      "retry_button": "Erneut versuchen"
     },
     "upcoming_rewards_error": {
-      "error_fetching_title": "Rewards couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Belohnungen konnten nicht geladen werden",
+      "error_fetching_description": "Überprüfen Sie Ihre Verbindung und versuchen Sie es erneut.",
+      "retry_button": "Erneut versuchen"
     },
     "referral_details_error": {
-      "error_fetching_title": "Referral details couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Empfehlungsdetails konnten nicht geladen werden",
+      "error_fetching_description": "Überprüfen Sie Ihre Verbindung und versuchen Sie es erneut.",
+      "retry_button": "Erneut versuchen"
     },
     "referral_validation_unknown_error": {
-      "title": "Referral code couldn’t be validated",
-      "description": "Check your connection and try again."
+      "title": "Empfehlungscode konnte nicht validiert werden",
+      "description": "Überprüfen Sie Ihre Verbindung und versuchen Sie es erneut."
     },
     "active_activity_error": {
-      "error_fetching_title": "Activity couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Aktivität konnte nicht geladen werden",
+      "error_fetching_description": "Überprüfen Sie Ihre Verbindung und versuchen Sie es erneut.",
+      "retry_button": "Erneut versuchen"
     },
-    "solana_signup_not_supported": "Signing in to Rewards with Solana accounts is not supported yet. Please use an Ethereum account instead.",
+    "solana_signup_not_supported": "Die Anmeldung zu Belohnungen mit Solana-Konten wird noch nicht unterstützt. Bitte verwenden Sie stattdessen ein Ethereum-Konto.",
     "error_messages": {
-      "unknown_error": "Unknown error occurred",
-      "something_went_wrong": "Something went wrong. Please try again shortly.",
-      "account_already_registered": "This account is already registered with another Rewards profile. Please switch account to continue.",
-      "request_rejected": "You rejected the request.",
-      "failed_to_claim_reward": "Failed to claim reward. Please try again shortly.",
-      "service_not_available": "Service is not available at the moment. Please try again shortly."
+      "unknown_error": "Ein unbekannter Fehler ist aufgetreten",
+      "something_went_wrong": "Etwas ist schiefgelaufen. Bitte versuchen Sie es in Kürze erneut.",
+      "account_already_registered": "Dieses Konto ist bereits mit einem anderen Belohnungsprofil registriert. Bitte wechseln Sie das Konto, um fortzufahren.",
+      "request_rejected": "Sie haben die Anfrage abgelehnt.",
+      "failed_to_claim_reward": "Einforderung der Belohnung fehlgeschlagen. Bitte versuchen Sie es in Kürze erneut.",
+      "service_not_available": "Der Dienst ist derzeit nicht verfügbar. Bitte versuchen Sie es in Kürze erneut."
     },
     "claim_reward_error": {
-      "title": "Failed to claim reward"
+      "title": "Einforderung der Belohnung fehlgeschlagen"
     },
     "accounts_opt_in_state_error": {
-      "error_fetching_title": "Accounts couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Konten konnten nicht geladen werden",
+      "error_fetching_description": "Überprüfen Sie Ihre Verbindung und versuchen Sie es erneut.",
+      "retry_button": "Erneut versuchen"
     },
     "referral_rewards_title": "Empfehlungen",
     "points": "Punkte",
@@ -5899,139 +6093,142 @@
     "tab_levels_title": "Stufen",
     "referral_stats_earned_from_referrals": "Durch Empfehlungen verdient",
     "referral_stats_referrals": "Empfehlungen",
-    "loading_activity": "Loading activity...",
-    "error_loading_activity": "Error loading activity",
-    "activity_empty_title": "No recent activity.",
-    "activity_empty_description": "Use MetaMask to earn points, level up, and unlock rewards.",
-    "activity_empty_link": "See ways to earn",
+    "loading_activity": "Aktivität wird geladen ...",
+    "error_loading_activity": "Fehler beim Laden der Aktivität",
+    "activity_empty_title": "Keine aktuelle Aktivität.",
+    "activity_empty_description": "Verwenden Sie MetaMask, um Punkte zu sammeln, hochzuleveln und Belohnungen freizuschalten.",
+    "activity_empty_link": "Siehe Möglichkeiten zum Verdienen",
     "events": {
-      "to": "to",
+      "to": "bis",
       "type": {
         "swap": "Swap",
         "perps": "Perps",
-        "referral": "Referral",
-        "referral_action": "Referral action",
-        "sign_up_bonus": "Sign up bonus",
-        "loyalty_bonus": "Loyalty bonus",
-        "one_time_bonus": "One-time bonus",
-        "open_position": "Opened position",
-        "close_position": "Closed position",
+        "card_spend": "Card spend",
+        "referral": "Empfehlung",
+        "referral_action": "Empfehlungsaktion",
+        "sign_up_bonus": "Anmeldebonus",
+        "loyalty_bonus": "Treuebonus",
+        "one_time_bonus": "Einmaliger Bonus",
+        "open_position": "Geöffnete Position",
+        "close_position": "Geschlossene Position",
         "take_profit": "TP/SL",
         "stop_loss": "TP/SL",
-        "uncategorized_event": "Uncategorized event"
+        "uncategorized_event": "Nicht kategorisiertes Ereignis"
       },
-      "date": "Date",
-      "account": "Account",
+      "date": "Datum",
+      "account": "Konto",
       "bonus": "Bonus",
       "details": "Details",
-      "points": "Points",
-      "points_base": "Base",
+      "points": "Punkte",
+      "points_base": "Basis",
       "points_boost": "Boost",
-      "points_total": "Total"
+      "points_total": "Insgesamt"
     },
     "onboarding": {
       "not_supported_region_title": "Region wird nicht unterstützt",
-      "not_supported_region_description": "Rewards are not supported in your region yet. We are working on expanding access, so check back later.",
-      "not_supported_hardware_account_title": "Account not supported",
-      "not_supported_hardware_account_description": "Hardware wallet accounts are not eligible to receive rewards yet. Please switch to a different account to proceed.",
-      "not_supported_account_type_title": "Account type not supported",
-      "not_supported_account_type_description": "Currently only internal Ethereum and Solana accounts can be opted into the Rewards program. Please switch to a different account to proceed.",
-      "not_supported_confirm_go_back": "Go back",
-      "not_supported_confirm_retry": "Retry",
-      "auth_fail_title": "Authentication Failed",
-      "auth_fail_description": "Unable to authenticate with the rewards program. Please check your connection and try again.",
-      "geo_check_fail_title": "Cannot determine opt-in eligibility",
-      "geo_check_fail_description": "We cannot determine if your country allows opting into the rewards program. Please check your connection and try again.",
+      "not_supported_region_description": "Belohnungen werden in Ihrer Region noch nicht unterstützt. Wir bemühen uns, den Zugang auszuweiten, also schauen Sie später wieder vorbei.",
+      "not_supported_hardware_account_title": "Konto wird nicht unterstützt",
+      "not_supported_hardware_account_description": "Hardware-Wallet-Konten sind noch nicht zum Empfang von Belohnungen berechtigt. Bitte wechseln Sie zu einem anderen Konto, um fortzufahren.",
+      "not_supported_account_type_title": "Kontotyp wird nicht unterstützt",
+      "not_supported_account_type_description": "Derzeit können nur interne Ethereum- und Solana-Konten für das Belohnungsprogramm ausgewählt werden. Bitte wechseln Sie zu einem anderen Konto, um fortzufahren.",
+      "not_supported_confirm_go_back": "Zurück",
+      "not_supported_confirm_retry": "Erneut versuchen",
+      "auth_fail_title": "Authentifizierung fehlgeschlagen",
+      "auth_fail_description": "Authentifizierung mit dem Belohnungsprogramm nicht möglich. Bitte überprüfen Sie Ihre Verbindung und versuchen Sie es erneut.",
+      "geo_check_fail_title": "Teilnahmeberechtigung kann nicht bestimmt werden",
+      "geo_check_fail_description": "Wir können nicht ermitteln, ob Ihr Land die Teilnahme am Belohnungsprogramm zulässt. Bitte überprüfen Sie Ihre Verbindung und versuchen Sie es erneut.",
       "gtm_title": "Belohnungen sind hier",
       "gtm_description": "Sammeln Sie Punkte für Ihre Aktivität. \nErklimmen Sie Level, um Belohnungen freizuschalten.",
       "gtm_confirm": "Erste Schritte",
       "intro_title": "Saison 1 \nist live",
-      "intro_description": "Earn points for your activity. \nAdvance through levels to unlock rewards.",
-      "intro_confirm": "Claim 250 points",
-      "intro_confirm_geo_loading": "Checking region...",
-      "checking_opt_in": "Checking accounts...",
-      "redirecting_to_dashboard": "Redirecting...",
+      "intro_description": "Sammeln Sie Punkte für Ihre Aktivität. \nErklimmen Sie Level, um Belohnungen freizuschalten.",
+      "intro_confirm": "250 Punkte einfordern",
+      "intro_confirm_geo_loading": "Region wird überprüft ...",
+      "checking_opt_in": "Konten werden überprüft ...",
+      "redirecting_to_dashboard": "Weiterleitung ...",
       "intro_skip": "Nicht jetzt",
       "step_confirm": "Weiter",
-      "step_skip": "Skip",
-      "step1_title": "Earn points on every trade",
+      "step_skip": "Überspringen",
+      "step1_title": "Verdienen Sie bei jedem Trade Punkte",
       "step1_description": "Jeder Swap und jeder Trade mit Perps, den Sie in MetaMask tätigen, bringt Sie den Belohnungen näher. Fügen Sie Ihre Konten hinzu und erleben Sie, wie sich Ihre Punkte summieren.",
-      "step2_title": "Level up for bigger perks",
+      "step2_title": "Leveln Sie für größere Vorteile hoch",
       "step2_description": "Erreichen Sie Punkte-Meilensteine, um Vorteile wie 50 % Ermäßigung auf die Perps-Gebühren, exklusive Tokens und eine kostenlose MetaMask-Metallkarte zu erhalten.",
-      "step3_title": "Exclusive seasonal rewards",
-      "step3_description": "Each season brings new perks. Join in, compete, and claim what you can before time runs out.",
-      "step4_title": "You'll earn 250 points when you sign up!",
-      "step4_title_referral_validating": "Validating referral code...",
-      "step4_referral_input_placeholder": "Referral code (optional)",
-      "step4_referral_input_error": "Invalid referral code",
-      "step4_confirm": "Claim points",
-      "step4_confirm_loading": "Claiming points...",
-      "step4_linking_accounts": "Adding accounts... ({{current}}/{{total}})",
-      "step4_linking_accounts_loading": "Adding additional accounts...",
-      "step4_success_description": "You have successfully signed up for MetaMask Rewards!",
-      "step4_legal_disclaimer_1": "By selecting 'Claim Points', you agree to the MetaMask Rewards",
-      "step4_legal_disclaimer_2": "Supplemental Terms of Use and Privacy Notice",
-      "step4_legal_disclaimer_3": ". We'll track onchain activity to reward you automatically –",
-      "step4_legal_disclaimer_4": "learn more"
+      "step3_title": "Exklusive saisonale Belohnungen",
+      "step3_description": "Jede Saison bringt neue Vorteile. Nehmen Sie teil, konkurrieren Sie und fordern Sie ein, was Sie kriegen können, bevor die Zeit abläuft.",
+      "step4_title": "Bei Ihrer Anmeldung erhalten Sie 250 Punkte!",
+      "step4_title_referral_bonus": "You'll earn 500 points when you sign up with this code!",
+      "step4_title_referral_validating": "Validierung des Empfehlungscodes ...",
+      "step4_referral_bonus_description": "Use a referral code to earn 250 more",
+      "step4_referral_input_placeholder": "Empfehlungscode (optional)",
+      "step4_referral_input_error": "Ungültiger Empfehlungscode",
+      "step4_confirm": "Punkte einfordern",
+      "step4_confirm_loading": "Punkte werden eingefordert ...",
+      "step4_linking_accounts": "Konten werden hinzufügen ... ({{current}}/{{total}})",
+      "step4_linking_accounts_loading": "Weitere Konten werden hinzugefügt ...",
+      "step4_success_description": "Sie haben sich erfolgreich für MetaMask-Belohnungen angemeldet!",
+      "step4_legal_disclaimer_1": "Indem Sie „Punkte einfordern“ wählen, stimmen Sie den MetaMask-Belohnungen zu",
+      "step4_legal_disclaimer_2": "Ergänzende Nutzungsbedingungen und Datenschutzhinweis",
+      "step4_legal_disclaimer_3": ". Wir verfolgen die Onchain-Aktivitäten und belohnen Sie automatisch –",
+      "step4_legal_disclaimer_4": "erfahren Sie mehr"
     },
     "settings": {
-      "title": "Rewards Settings",
-      "subtitle": "Accounts",
-      "description": "Add multiple accounts to combine your points and unlock rewards faster.",
-      "tab_linked_accounts": "Added ({{count}})",
-      "tab_unlinked_accounts": "Not added ({{count}})",
-      "no_linked_accounts": "No accounts opted in",
-      "all_accounts_linked_title": "All accounts opted in",
-      "all_accounts_linked_description": "You have added all your accounts to Rewards.",
-      "link_account_success_title": "{{accountName}} successfully added",
-      "link_account_error_title": "Failed to add account",
-      "link_account_button": "Add",
-      "link_account_failed_error": "Failed to link account",
-      "link_account_unknown_error": "Unknown error occurred"
+      "title": "Belohnungseinstellungen",
+      "subtitle": "Konten",
+      "description": "Fügen Sie mehrere Konten hinzu, um Ihre Punkte zu kombinieren und Belohnungen schneller freizuschalten.",
+      "tab_linked_accounts": "Hinzugefügt ({{count}})",
+      "tab_unlinked_accounts": "Nicht hinzugefügt ({{count}})",
+      "no_linked_accounts": "Keine Konten angemeldet",
+      "all_accounts_linked_title": "Alle Konten sind angemeldet",
+      "all_accounts_linked_description": "Sie haben nun alle Ihre Konten zu Belohnungen hinzugefügt.",
+      "link_account_success_title": "{{accountName}} erfolgreich hinzugefügt",
+      "link_account_error_title": "Hinzufügen des Kontos fehlgeschlagen",
+      "link_account_button": "Hinzufügen",
+      "link_account_failed_error": "Verknüpfen des Kontos fehlgeschlagen",
+      "link_account_unknown_error": "Ein unbekannter Fehler ist aufgetreten"
     },
     "optout": {
-      "title": "Opt out of Rewards",
-      "description": "This will remove your accounts from the Rewards program and erase your points and progress. You won't be able to undo this.",
-      "confirm": "Opt out",
+      "title": "Von Belohnungen abmelden",
+      "description": "Dadurch werden Ihre Konten aus dem Belohnungsprogramm entfernt und Ihre Punkte sowie Ihr Fortschritt werden gelöscht. Dieser Vorgang kann nicht rückgängig gemacht werden.",
+      "confirm": "Abmelden",
       "modal": {
-        "confirmation_title": "Are you sure?",
-        "confirmation_description": "This will remove all your progress, and can't be reversed. If you rejoin the Rewards program later, you'll start back at 0.",
-        "cancel": "Cancel",
-        "confirm": "Confirm",
-        "error_message": "Failed to opt out of Rewards. Please try again.",
-        "processing": "Processing..."
+        "confirmation_title": "Sind Sie sicher?",
+        "confirmation_description": "Dadurch wird Ihr gesamter Fortschritt gelöscht und kann nicht rückgängig gemacht werden. Wenn Sie später wieder am Belohnungsprogramm teilnehmen, beginnen Sie wieder bei 0.",
+        "cancel": "Stornieren",
+        "confirm": "Bestätigen",
+        "error_message": "Abmeldung von Belohnungen fehlgeschlagen. Bitte versuchen Sie es erneut.",
+        "processing": "Verarbeitung..."
       }
     },
-    "toast_dismiss": "Dismiss",
+    "toast_dismiss": "Verwerfen",
     "dashboard_modal_info": {
       "active_account": {
-        "title": "Don't miss out",
-        "description": "Add your account to start earning points from your activity.",
-        "confirm": "Add account"
+        "title": "Nicht verpassen",
+        "description": "Fügen Sie Ihr Konto hinzu und fangen Sie an, durch Ihre Aktivitäten Punkte zu sammeln.",
+        "confirm": "Konto hinzufügen"
       },
       "multiple_unlinked_accounts": {
-        "title": "Start earning points",
-        "description": "Add your accounts so you can track your rewards at a glance.",
-        "confirm": "Add accounts"
+        "title": "Beginnen Sie mit dem Sammeln von Punkten",
+        "description": "Fügen Sie Ihre Konten hinzu, damit Sie den Überblick über Ihre Belohnungen behalten.",
+        "confirm": "Konten hinzufügen"
       },
       "account_not_supported": {
-        "title": "Account not supported",
-        "description_hardware": "Hardware wallet accounts are not yet eligible to earn points. Please switch to a different account to proceed.",
-        "description_general": "Currently only non-hardware internal Ethereum and Solana accounts are eligible to earn points. Please switch to a different account to proceed.",
-        "confirm": "Go back"
+        "title": "Konto wird nicht unterstützt",
+        "description_hardware": "Mit Hardware-Wallet-Konten können noch keine Punkte gesammelt werden. Bitte wechseln Sie zu einem anderen Konto, um fortzufahren.",
+        "description_general": "Derzeit sind nur interne Ethereum- und Solana-Konten ohne Hardware zum Sammeln von Punkten berechtigt. Bitte wechseln Sie zu einem anderen Konto, um fortzufahren.",
+        "confirm": "Zurück"
       }
     },
     "ways_to_earn": {
-      "title": "Ways to earn",
-      "supported_networks": "Supported Networks",
+      "title": "Möglichkeiten zum Verdienen",
+      "supported_networks": "Unterstützte Netzwerke",
       "swap": {
         "title": "Swap",
-        "description": "80 points per $100",
+        "description": "80 Punkte pro 100 $",
         "sheet": {
-          "title": "Swap tokens",
-          "points": "80 points per $100",
-          "description": "Swap tokens on supported networks to earn points for every dollar you trade.",
-          "cta_label": "Start a swap"
+          "title": "Tokens tauschen",
+          "points": "80 Punkte pro 100 $",
+          "description": "Swappen Sie Token in unterstützten Netzwerken und verdienen Sie Punkte für jeden gehandelten Dollar.",
+          "cta_label": "Swap beginnen"
         }
       },
       "perps": {
@@ -6045,52 +6242,74 @@
         }
       },
       "referrals": {
-        "title": "Refer friends",
-        "description": "10 points per 50 from friends"
+        "title": "Freunden empfehlen",
+        "description": "10 Punkte pro 50 Punkte von Freunden",
+        "sheet": {
+          "title": "Refer a friend",
+          "points": "20 points per 100",
+          "cta_label": "Refer a friend"
+        }
       },
       "loyalty": {
-        "title": "Loyalty bonus",
-        "description": "Earn points from past trades",
+        "title": "Treuebonus",
+        "description": "Verdienen Sie Punkte aus vergangenen Trades",
         "sheet": {
-          "title": "Loyalty bonus",
-          "points": "250 points per $1250",
-          "description": "Add accounts with past swaps or bridges in MetaMask to earn loyalty bonuses. Each eligible account unlocks points in increments of 250, up to a total of 50,000. Bonuses appear shortly after you add an account.",
-          "cta_label": "Add accounts"
+          "title": "Treuebonus",
+          "points": "250 Punkte pro 1250 $",
+          "description": "Fügen Sie Konten mit vergangenen Swaps oder Bridges in MetaMask hinzu, um Treueboni zu verdienen. Für jedes teilnahmeberechtigte Konto werden Punkte in 250er-Schritten bis zu einer Gesamtzahl von 50.000 freigeschaltet. Die Boni erscheinen bereits kurz nach dem Hinzufügen eines Kontos.",
+          "cta_label": "Konten hinzufügen"
+        }
+      },
+      "card": {
+        "title": "MetaMask Card",
+        "description": "1 point per $1 spent",
+        "sheet": {
+          "title": "MetaMask Card",
+          "points": "1 point per $1 spent",
+          "description": "Earn points every time you use your MetaMask Card for purchases, plus 1% cash back (3% for Metal cardholders).",
+          "cta_label": "Manage Card"
         }
       }
     },
     "referral": {
-      "referral_code": "Referral code",
-      "referral_link": "Referral link",
+      "referral_code": "Empfehlungscode",
+      "referral_link": "Empfehlungslink",
       "actions": {
         "share_referral_link": "Einem Freund empfehlen",
         "share_referral_subject": "MetaMask-Belohnungen beitreten"
       },
       "info": {
         "title": "Teilen Sie Ihren Code und verdienen Sie mehr",
-        "description": "Your friends get a 2x sign up bonus. You get 10 points for every 50 they earn from trading."
+        "description": "Ihre Freunde erhalten einen 2-fachen Anmeldebonus. Sie erhalten 10 Punkte für jeweils 50 Punkte, die Ihre Freunde beim Trading verdienen."
       }
     },
-    "active_boosts_title": "Active boosts",
-    "season_1": "Season 1",
+    "link_account_group": {
+      "link_account": "Add account",
+      "tracked": "Tracked",
+      "untracked": "Untracked",
+      "link_account_success": "{{accountName}} added successfully",
+      "link_account_error": "Failed to add one or more addresses for {{accountName}}"
+    },
+    "active_boosts_title": "Aktive Boosts",
+    "season_1": "Saison 1",
     "upcoming_rewards": {
       "title": "Gesperrte Belohnungen",
-      "points_needed": "{{points}} points",
-      "cta_label": "Got it",
-      "alpha_fox_invite_input_placeholder": "Your Telegram handle"
+      "points_needed": "{{points}} Punkte",
+      "cta_label": "Verstanden",
+      "alpha_fox_invite_input_placeholder": "Ihr Telegramm-Handle"
     },
     "unlocked_rewards": {
-      "title": "Unlocked rewards",
-      "cta_label": "Claim now",
-      "cta_request_invite": "Request invite",
-      "claim_label": "Claim",
-      "claimed_label": "Claimed",
-      "reward_claimed": "Reward claimed",
+      "title": "Freigeschaltete Belohnungen",
+      "cta_label": "Jetzt einfordern",
+      "cta_request_invite": "Einladung anfordern",
+      "claim_label": "Einfordern",
+      "claimed_label": "Eingefordert",
+      "reward_claimed": "Belohnung eingefordert",
       "time_left": "verbleibend",
-      "expired": "Expired"
+      "expired": "Abgelaufen"
     },
     "animation": {
-      "could_not_load": "Couldn't load"
+      "could_not_load": "Laden fehlgeschlagen"
     }
   },
   "time": {
@@ -6099,7 +6318,7 @@
   },
   "transaction_details": {
     "title": {
-      "perps_deposit": "Funded Perps account",
+      "perps_deposit": "Perps-Konto finanziert",
       "predict_deposit": "Funded Predict account",
       "default": "Transaktionsdetails"
     },
@@ -6107,19 +6326,23 @@
       "bridge_fee": "Bridge-Gebühr",
       "network_fee": "Netzwerk-Gebühr",
       "paid_with": "Bezahlt mit",
+      "retry_button": "Try again",
       "total": "Insgesamt"
     },
     "summary_title": {
-      "bridge": "Bridge von {{sourceSymbol}} nach {{targetSymbol}}",
       "bridge_approval": "{{approveSymbol}} genehmigen",
       "bridge_approval_loading": "Genehmigen",
-      "bridge_loading": "Bridge",
+      "bridge_send": "Bridge {{sourceSymbol}} from {{sourceChain}}",
+      "bridge_send_loading": "Bridge Send",
+      "bridge_receive": "Receive {{targetSymbol}} on {{targetChain}}",
+      "bridge_receive_loading": "Bridge Receive",
       "default": "Transaktion",
       "perps_deposit": "Gelder hinzufügen",
       "predict_deposit": "Add funds",
       "swap": "Tokens tauschen",
       "swap_approval": "Tokens genehmigen"
-    }
+    },
+    "perps_deposit_solution": "You now have {{fiat}} of USDC on Arbitrum. Try your deposit again."
   },
   "sdk_connect_v2": {
     "show_loading": {

--- a/locales/languages/el.json
+++ b/locales/languages/el.json
@@ -594,7 +594,9 @@
       "unexpectedError": "Παρουσιάστηκε απρόσμενο σφάλμα.",
       "quoteFetchError": "Αποτυχία λήψης προσφοράς.",
       "kycFormsFetchError": "Αποτυχία λήψης της φόρμας KYC.",
-      "title": "Κατάθεση"
+      "title": "Κατάθεση",
+      "limitExceeded": "This deposit would exceed your {{period}} limit. Your deposit including fees must be {{remaining}} or less.",
+      "limitError": "Failed to check your deposit limits. Please try again later."
     },
     "token_modal": {
       "select_a_token": "Επιλέξτε ένα Token",
@@ -892,7 +894,7 @@
     "withdraw": "Ανάληψη",
     "refresh_balance": "Ανανέωση υπολοίπου",
     "add_funds": "Προσθήκη κεφαλαίων",
-    "deposit_in_progress": "Deposit in progress",
+    "deposit_in_progress": "Η κατάθεση είναι σε εξέλιξη",
     "your_positions": "Οι θέσεις σας",
     "loading_positions": "Φόρτωση θέσεων...",
     "refreshing_positions": "Ανανέωση θέσεων...",
@@ -1277,6 +1279,7 @@
       "assetMappingFailed": "Αποτυχία δημιουργίας χαρτογράφησης περιουσιακών στοιχείων",
       "depositFailed": "Η κατάθεση απέτυχε",
       "orderLeverageReductionFailed": "Δεν μπορείτε να μειώσετε τη μόχλευση",
+      "connectionTimeout": "Connection timed out. Please check your network and try again.",
       "connectionFailed": {
         "title": "Τα συμβόλαια αορίστου διάρκειας είναι προσωρινά εκτός λειτουργίας",
         "description": "Προσπαθούμε να τα επαναφέρουμε σύντομα σε λειτουργία.",
@@ -1348,9 +1351,9 @@
         "error_message": "Δεν βρέθηκαν δεδομένα αγοράς. Παρακαλώ επιστρέψτε και προσπαθήστε ξανά."
       },
       "statistics": "Επισκόπηση",
-      "24h_high": "24h high",
-      "24h_low": "24h low",
-      "24h_volume": "24h volume",
+      "24h_high": "Υψηλό 24ώρου",
+      "24h_low": "Χαμηλό 24ώρου",
+      "24h_volume": "Όγκος 24ώρου",
       "open_interest": "Ανοιχτό ενδιαφέρον",
       "funding_rate": "Χρέωση χρηματοδότησης",
       "countdown": "Χρονόμετρο αντίστροφης μέτρησης",
@@ -1510,9 +1513,9 @@
         "metamask_fee": "Χρεώσεις στο MetaMask",
         "hyperliquid_fee": "Χρεώσεις στο Hyperliquid",
         "total_fee": "Συνολικά τέλη",
-        "liquidated": "Liquidated",
-        "take_profit": "Take profit",
-        "stop_loss": "Stop loss"
+        "liquidated": "Ρευστοποιήθηκε",
+        "take_profit": "Λήψη κερδών",
+        "stop_loss": "Περιορισμός ζημιών"
       },
       "funding": {
         "date": "Ημερομηνία",
@@ -1555,11 +1558,11 @@
       "ready_to_trade": {
         "title": "Έτοιμοι να ξεκινήσετε τις συναλλαγές;",
         "description": "Χρηματοδοτήστε τον λογαριασμό σας για συμβόλαια αορίστου διάρκειας με οποιοδήποτε token και ξεκινήστε τις πρώτες σας συναλλαγές μέσα σε δευτερόλεπτα.",
-        "footer_text": "Το MetaMask θα μετατρέψει τα κεφάλαιά σας σε USDC στο δίκτυο Arbitrum και θα τα καταθέσει στο HyperCore χωρίς επιπλέον χρέωση."
+        "footer_text": "MetaMask will swap your funds to USDC on Arbitrum, and deposit them onto HyperCore for no added fee."
       },
       "got_it": "Κατανοητό",
       "card": {
-        "title": "Learn the basics of perps"
+        "title": "Μάθετε τα βασικά για τα perpetual συμβόλαια"
       }
     },
     "points": "Πόντοι",
@@ -1576,10 +1579,10 @@
     "market_list": "Λίστα αγορών",
     "market_details": "Λεπτομέρειες αγοράς",
     "tab": {
-      "no_predictions": "Δεν υπάρχουν ακόμη προβλέψεις",
-      "no_predictions_description": "Ανοίξτε μια πρόβλεψη για να ξεκινήσετε.",
-      "explore": "Εξερευνήστε αγορές",
-      "new_prediction": "Νέα πρόβλεψη"
+      "no_predictions_description": "Your predictions will appear here, showing your stake and market movement.",
+      "explore": "Browse markets",
+      "new_prediction": "Νέα πρόβλεψη",
+      "resolved_markets": "Resolved markets"
     },
     "sell_position": "Πώληση θέσης",
     "cash_out": "Ανάληψη",
@@ -1609,16 +1612,73 @@
     "claim_button": "Εξαργύρωση",
     "markets_won": "Αγορές που κερδήθηκαν",
     "won_markets_text": "Κερδίσατε {{count}} αγορά{{s}}",
-    "won_markets_text_singular": "Κερδίσατε {{count}} αγορά",
-    "won_markets_text_plural": "Κερδίσατε {{count}} αγορές",
+    "available_balance": "Available balance",
     "claim_amount_text": "Εξαργυρώστε ${{amount}}",
     "unrealized_pnl_label": "Μη οριστικοποιημένα κέρδη & ζημίες",
     "unrealized_pnl_value": "{{amount}} ({{percent}})",
+    "unrealized_pnl_error": "Unable to load",
     "unavailable": {
       "title": "Unavailable in your region",
       "description": "Predictions aren't available in your region due to legal restrictions.",
       "link": "See Polymarket terms",
       "button": "Got it"
+    },
+    "deposit": {
+      "in_progress": "Deposit in progress",
+      "adding_funds": "Adding funds",
+      "adding_your_funds": "Adding your funds",
+      "add_funds": "Add funds",
+      "withdraw": "Withdraw",
+      "estimated_processing_time": "Est. {{time}} seconds",
+      "account_ready": "Your account is ready",
+      "account_ready_description": "{{amount}} added to your balance",
+      "error_title": "Something went wrong",
+      "error_description": "Your account wasn't funded",
+      "try_again": "Try again"
+    },
+    "add_funds_sheet": {
+      "title": "Add funds",
+      "description": "You'll need to add funds to your Predictions account to get started. You can add any token and make your first prediction in seconds."
+    },
+    "transactions": {
+      "title": "Predictions",
+      "no_transactions": "No recent activity",
+      "buy_title": "Predicted",
+      "sell_title": "Cashed out",
+      "claim_title": "Claimed winnings",
+      "buy_detail": "Bought {{amountUsd}} on {{outcome}} · {{priceCents}} per share",
+      "sell_detail": "Sold at {{priceCents}} per share",
+      "claim_detail": "Claimed winnings",
+      "not_available": "N/A",
+      "date": "Date",
+      "market": "Market",
+      "outcome": "Outcome",
+      "predicted_amount": "Predicted amount",
+      "shares_bought": "Shares bought",
+      "shares_sold": "Shares sold",
+      "price_per_share": "Price per share",
+      "price_impact": "Price impact",
+      "net_pnl": "Net P&L",
+      "total_net_pnl": "Total Net P&L",
+      "market_net_pnl": "Market Net P&L",
+      "activity_details": "Activity details"
+    },
+    "claim": {
+      "toasts": {
+        "pending": {
+          "title": "Claiming {{amount}}",
+          "description": "Est. {{time}} seconds"
+        },
+        "confirmed": {
+          "title": "Claimed",
+          "description": "{{amount}} added to your balance"
+        },
+        "error": {
+          "title": "Something went wrong",
+          "description": "Failed to proceed with claim",
+          "try_again": "Try again"
+        }
+      }
     }
   },
   "receive": {
@@ -3093,6 +3153,7 @@
     "tx_review_lending_withdraw": "Ανάληψη Δανεισμού",
     "tx_review_perps_deposit": "Χρηματοδοτημένος λογαριασμός με συμβόλαια αορίστου διάρκειας",
     "tx_review_predict_deposit": "Funded Predict account",
+    "tx_review_predict_claim": "Claimed Predict winnings",
     "sent_ether": "Αποστολή Ether",
     "self_sent_ether": "Στείλτε Ether στον εαυτό σας",
     "received_ether": "Ληφθέντα Ether",
@@ -3939,7 +4000,9 @@
     "wallet_connect_dapps_cta": "Προβολή συνεδριών",
     "network_not_supported": "Το τρέχον δίκτυο δεν υποστηρίζεται",
     "select_provider": "Επιλέξτε τον πάροχο που προτιμάτε",
-    "switch_network": "Παρακαλούμε μεταβείτε στο mainnet ή το sepolia"
+    "switch_network": "Παρακαλούμε μεταβείτε στο mainnet ή το sepolia",
+    "card_title": "Always show MetaMask Card button",
+    "card_desc": "MetaMask Card is only available to residents of select countries"
   },
   "walletconnect_sessions": {
     "no_active_sessions": "Δεν έχετε ενεργές συνεδρίες",
@@ -5315,7 +5378,7 @@
     },
     "tooltip": {
       "perps_deposit": {
-        "transaction_fee": "Θα μετατρέψουμε τα tokens σας σε USDC στο HyperCore, το δίκτυο που χρησιμοποιούμε για συμβόλαια αορίστου διάρκειας (perps). Οι πάροχοι ανταλλαγών ενδέχεται να χρεώνουν προμήθεια, αλλά το MetaMask δεν χρεώνει."
+        "transaction_fee": "We'll swap your tokens for USDC on HyperCore, the network used by Perps. Swap providers may charge a fee, but MetaMask won't."
       },
       "predict_deposit": {
         "transaction_fee": "We'll swap your tokens for USDC.e on Polygon, the network used by Predict. Swap providers may charge a fee, but MetaMask won't."
@@ -5407,6 +5470,12 @@
       "save": "Αποθήκευση",
       "title": "Επεξεργασία ορίου έγκρισης"
     },
+    "predict_claim": {
+      "button_label": "Claim winnings",
+      "summary": "You won",
+      "footer_bottom": "Funds will be added to your available balance",
+      "footer_top": "Winnings from {{count}} markets"
+    },
     "unlimited": "Απεριόριστα",
     "all": "Όλα",
     "none": "Τίποτα",
@@ -5469,12 +5538,15 @@
     "points": "Εκτ. πόντοι",
     "points_tooltip": "Πόντοι",
     "points_tooltip_content_1": "Points are how you earn MetaMask Rewards for completing transactions, like when you swap, bridge, or trade perps.",
-    "points_tooltip_content_2": "Keep in mind this value is an estimate and will be finalized once the transaction is complete. Points can take up to 1 hour to be confirmed in your Rewards balance.",
+    "points_tooltip_content_2": "Λάβετε υπόψη ότι αυτή η τιμή είναι κατ' εκτίμηση και θα οριστικοποιηθεί με την ολοκλήρωση της συναλλαγής. Η επιβεβαίωση των πόντων στο υπόλοιπο ανταμοιβών σας μπορεί να διαρκέσει έως και 1 ώρα.",
     "unable_to_load": "Δεν ήταν δυνατή η φόρτωση",
     "points_error": "Δεν είναι δυνατή η φόρτωση πόντων αυτή τη στιγμή",
-    "points_error_content": "You'll still earn any points for this transaction. We'll notify you once they've been added to your account. You can also check your rewards tab in about an hour.",
+    "points_error_content": "Θα εξακολουθήσετε να κερδίζετε τους πόντους που αντιστοιχούν σε αυτήν τη συναλλαγή. Θα σας ειδοποιήσουμε μόλις προστεθούν στον λογαριασμό σας. Μπορείτε επίσης να ελέγξετε την καρτέλα ανταμοιβών σας σε περίπου μία ώρα.",
     "see_other_quotes": "Δείτε άλλες προσφορές",
     "receive_at": "Θα λάβετε στις",
+    "recipient": "Recipient",
+    "select_recipient": "Select recipient",
+    "external_account": "External account",
     "error_banner_description": "Αυτή η διαδρομή συναλλαγών δεν είναι διαθέσιμη προς το παρόν. Δοκιμάστε να αλλάξετε το ποσό, το δίκτυο ή το token και θα βρούμε την καλύτερη επιλογή.",
     "insufficient_funds": "Ανεπαρκές ποσό",
     "insufficient_gas": "Δεν έχετε αρκετά χρήματα για τα τέλη συναλλαγών",
@@ -5775,6 +5847,12 @@
       "update_to_store_link": "Ενημερώστε στην πιο πρόσφατη έκδοση του MetaMask",
       "well_take_you_to_right_place": " και θα σας κατευθύνουμε στο σωστό σημείο."
     },
+    "unsupported": {
+      "title": "This page is not supported in current version",
+      "description": "Update to the latest version to use this feature",
+      "update_to_store_link": "Update to the latest version of MetaMask",
+      "well_take_you_to_right_place": " and we'll take you to the right place."
+    },
     "go_to_home_button": "Μετάβαση στην αρχική σελίδα",
     "back_button": "Πίσω",
     "continue_button": "Συνεχίστε"
@@ -5791,7 +5869,96 @@
     "card_onboarding": {
       "title": "Καλώς ήρθατε στις Κάρτες",
       "description": "Για να χρησιμοποιήσετε τις λειτουργίες καρτών, θα χρειαστεί να επαληθεύσετε τον λογαριασμό σας μέσω του συνεργάτη μας.",
-      "verify_account_button": "Επαλήθευση λογαριασμού"
+      "verify_account_button": "Επαλήθευση λογαριασμού",
+      "sign_up": {
+        "title": "Sign-up",
+        "description": "Register your details with Crypto Life, the provider of MetaMask Card. You'll use this account to access and manage your card.",
+        "email_label": "Email",
+        "password_label": "Password",
+        "confirm_password_label": "Confirm password",
+        "country_label": "Country of Residence",
+        "email_placeholder": "Enter your email address",
+        "password_placeholder": "Enter your password",
+        "country_placeholder": "Select your country",
+        "password_mismatch": "Passwords do not match",
+        "invalid_email": "Invalid email address"
+      },
+      "confirm_email": {
+        "title": "Confirm your email",
+        "description": "We've sent a confirmation code to: {{email}}",
+        "confirm_code_label": "Confirmation code",
+        "confirm_code_placeholder": "Enter the confirmation code"
+      },
+      "set_phone_number": {
+        "title": "Phone number",
+        "description": "Enter your phone number",
+        "phone_number_label": "Phone number",
+        "phone_number_placeholder": "Enter your phone number",
+        "country_area_code_label": "Country area code",
+        "invalid_phone_number": "Invalid phone number",
+        "legal_terms": "By continuing, you agree to receiving SMS to verify your phone number."
+      },
+      "confirm_phone_number": {
+        "title": "Confirm your phone number",
+        "description": "We've sent a confirmation code to: {{phoneNumber}}",
+        "confirm_code_label": "Confirmation code"
+      },
+      "verify_identity": {
+        "title": "Verifying your identity to get your card",
+        "description": "To keep your account secure and comply with regulations, we need to verify your identity.\n\nYou'll need a government-issued ID and a proof of address (like a utility bill or bank statement).\n\nVerification usually takes 5-30 minutes, and we'll notify you as soon as it's complete.",
+        "verify_button": "Verify now with Veriff"
+      },
+      "validating_kyc": {
+        "title": "Validating your KYC..."
+      },
+      "kyc_failed": {
+        "title": "Rejected",
+        "description": "Your KYC was rejected. Please try again."
+      },
+      "personal_details": {
+        "title": "Personal details",
+        "description": "Enter your personal details",
+        "first_name_label": "First name",
+        "last_name_label": "Last name",
+        "date_of_birth_label": "Date of birth",
+        "nationality_label": "Country of Nationality",
+        "ssn_label": "Social Security Number",
+        "first_name_placeholder": "Enter your first name",
+        "last_name_placeholder": "Enter your last name",
+        "date_of_birth_placeholder": "Enter your date of birth",
+        "nationality_placeholder": "Select your nationality",
+        "ssn_placeholder": "Enter your SSN",
+        "invalid_ssn": "Invalid SSN",
+        "invalid_date_of_birth": "Invalid date of birth",
+        "invalid_date_of_birth_underage": "You must be at least 18 years old"
+      },
+      "physical_address": {
+        "title": "Physical address",
+        "description": "Please provide your physical address",
+        "address_line_1_label": "Address line 1",
+        "address_line_2_label": "Address line 2",
+        "city_label": "City",
+        "state_label": "State",
+        "zip_code_label": "ZIP code",
+        "address_line_1_placeholder": "Enter your address line 1",
+        "address_line_2_placeholder": "Enter your address line 2",
+        "city_placeholder": "Enter your city",
+        "state_placeholder": "Enter your state",
+        "zip_code_placeholder": "Enter your ZIP code",
+        "same_mailing_address_label": "Physical address is the same as mailing address",
+        "electronic_consent": "I agree to the E-Sign Act Consent and Disclosure and to receive all communictions electronically."
+      },
+      "mailing_address": {
+        "title": "Mailing address",
+        "description": "Please provide your mailing address"
+      },
+      "complete": {
+        "title": "Approved!",
+        "description": "Your KYC was approved. You can now use your Card."
+      },
+      "continue_button": "Next",
+      "confirm_button": "Confirm",
+      "retry_button": "Try again"
     },
     "card_home": {
       "error_title": "Δεν είναι δυνατή η ανάκτηση δεδομένων",
@@ -5799,9 +5966,36 @@
       "try_again": "Προσπαθήστε ξανά",
       "limited_spending_warning": "Η πραγματική δυνατότητα δαπανών σας ενδέχεται να είναι περιορισμένη. Για να προσαρμόσετε το όριό σας, μεταβείτε στη {{manageCard}}",
       "add_funds": "Προσθήκη κεφαλαίων",
+      "change_asset": "Change asset",
       "manage_card_options": {
+        "manage_spending_limit": "Manage spending limit",
+        "manage_spending_limit_description_restricted": "Restricted spending limit is on",
+        "manage_spending_limit_description_full": "Full spending access is on",
         "manage_card": "Διαχείριση κάρτας",
-        "advanced_card_management_description": "Δείτε τις συναλλαγές, απενεργοποιήστε προσωρινά την κάρτα και άλλα"
+        "advanced_card_management_description": "Detailed transactions, freeze card, and more"
+      }
+    },
+    "card_authentication": {
+      "title": "Log in to your Card account",
+      "location_button_text": "International",
+      "location_button_text_us": "US account",
+      "email_label": "Email",
+      "password_label": "Password",
+      "email_placeholder": "Enter your email address",
+      "password_placeholder": "Enter your password",
+      "login_button": "Log in",
+      "errors": {
+        "invalid_credentials": "Invalid login details",
+        "unknown_error": "Unknown error, please try again later",
+        "email_required": "Email is required",
+        "password_required": "Password is required",
+        "email_invalid": "Invalid email address",
+        "password_invalid": "Invalid password",
+        "invalid_email_or_password": "Invalid email or password, check your credentials and try again.",
+        "network_error": "Network error. Please check your connection and try again.",
+        "timeout_error": "Request timed out. Please check your connection and try again.",
+        "server_error": "Server error. Please try again later.",
+        "configuration_error": "Service is temporarily unavailable. Please try again later."
       }
     }
   },
@@ -5825,65 +6019,65 @@
     "close": "Κλείσιμο"
   },
   "rewards": {
-    "auth_fail_title": "Unknown Error.",
-    "auth_fail_description": "An unknown error occurred while authenticating this account with the rewards program. Please try again later.",
-    "failed_to_authenticate": "Failed to authenticate with rewards program",
+    "auth_fail_title": "Άγνωστο σφάλμα.",
+    "auth_fail_description": "Παρουσιάστηκε άγνωστο σφάλμα κατά την ταυτοποίηση του λογαριασμού με το πρόγραμμα ανταμοιβών. Προσπαθήστε ξανά αργότερα.",
+    "failed_to_authenticate": "Η ταυτοποίηση με το πρόγραμμα ανταμοιβών απέτυχε",
     "not_implemented": "Προσεχώς",
     "not_implemented_season_summary": "Η σύνοψη της σεζόν θα είναι διαθέσιμη σύντομα",
     "optin_error": {
-      "title": "Opt-in failed",
-      "description": "Check your connection and try again."
+      "title": "Αποτυχία συμμετοχής",
+      "description": "Ελέγξτε τη σύνδεσή σας και προσπαθήστε ξανά."
     },
     "season_status_error": {
-      "error_fetching_title": "Season balance couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Δεν ήταν δυνατή η φόρτωση του υπολοίπου της περιόδου",
+      "error_fetching_description": "Ελέγξτε τη σύνδεσή σας και προσπαθήστε ξανά.",
+      "retry_button": "Επανάληψη"
     },
     "active_boosts_error": {
-      "error_fetching_title": "Boosts couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Δεν ήταν δυνατή η φόρτωση των ενισχύσεων",
+      "error_fetching_description": "Ελέγξτε τη σύνδεσή σας και προσπαθήστε ξανά.",
+      "retry_button": "Επανάληψη"
     },
     "unlocked_rewards_error": {
-      "error_fetching_title": "Rewards couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Δεν ήταν δυνατή η φόρτωση των ανταμοιβών",
+      "error_fetching_description": "Ελέγξτε τη σύνδεσή σας και προσπαθήστε ξανά.",
+      "retry_button": "Επανάληψη"
     },
     "upcoming_rewards_error": {
-      "error_fetching_title": "Rewards couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Δεν ήταν δυνατή η φόρτωση των ανταμοιβών",
+      "error_fetching_description": "Ελέγξτε τη σύνδεσή σας και προσπαθήστε ξανά.",
+      "retry_button": "Επανάληψη"
     },
     "referral_details_error": {
-      "error_fetching_title": "Referral details couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Δεν ήταν δυνατή η φόρτωση των στοιχείων παραπομπής",
+      "error_fetching_description": "Ελέγξτε τη σύνδεσή σας και προσπαθήστε ξανά.",
+      "retry_button": "Επανάληψη"
     },
     "referral_validation_unknown_error": {
-      "title": "Referral code couldn’t be validated",
-      "description": "Check your connection and try again."
+      "title": "Ο κωδικός παραπομπής δεν ήταν δυνατό να επαληθευτεί",
+      "description": "Ελέγξτε τη σύνδεσή σας και προσπαθήστε ξανά."
     },
     "active_activity_error": {
-      "error_fetching_title": "Activity couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Δεν ήταν δυνατή η φόρτωση της δραστηριότητας",
+      "error_fetching_description": "Ελέγξτε τη σύνδεσή σας και προσπαθήστε ξανά.",
+      "retry_button": "Επανάληψη"
     },
-    "solana_signup_not_supported": "Signing in to Rewards with Solana accounts is not supported yet. Please use an Ethereum account instead.",
+    "solana_signup_not_supported": "Η σύνδεση στο πρόγραμμα Ανταμοιβών μέσω λογαριασμών Solana δεν υποστηρίζεται ακόμη. Παρακαλώ χρησιμοποιήστε λογαριασμό Ethereum.",
     "error_messages": {
-      "unknown_error": "Unknown error occurred",
-      "something_went_wrong": "Something went wrong. Please try again shortly.",
-      "account_already_registered": "This account is already registered with another Rewards profile. Please switch account to continue.",
-      "request_rejected": "You rejected the request.",
-      "failed_to_claim_reward": "Failed to claim reward. Please try again shortly.",
-      "service_not_available": "Service is not available at the moment. Please try again shortly."
+      "unknown_error": "Παρουσιάστηκε άγνωστο σφάλμα",
+      "something_went_wrong": "Κάτι πήγε στραβά. Παρακαλούμε προσπαθήστε ξανά σε λίγο.",
+      "account_already_registered": "Αυτός ο λογαριασμός είναι ήδη συνδεδεμένος με άλλο προφίλ Ανταμοιβών. Παρακαλούμε αλλάξτε λογαριασμό για να συνεχίσετε.",
+      "request_rejected": "Απορρίψατε το αίτημα.",
+      "failed_to_claim_reward": "Η ενεργοποίηση της ανταμοιβής απέτυχε. Προσπαθήστε ξανά σε λίγο.",
+      "service_not_available": "Η υπηρεσία δεν είναι διαθέσιμη αυτήν τη στιγμή. Παρακαλούμε προσπαθήστε ξανά σε λίγο."
     },
     "claim_reward_error": {
-      "title": "Failed to claim reward"
+      "title": "Η ενεργοποίηση της ανταμοιβής απέτυχε"
     },
     "accounts_opt_in_state_error": {
-      "error_fetching_title": "Accounts couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Δεν ήταν δυνατή η φόρτωση των λογαριασμών",
+      "error_fetching_description": "Ελέγξτε τη σύνδεσή σας και προσπαθήστε ξανά.",
+      "retry_button": "Επανάληψη"
     },
     "referral_rewards_title": "Συστάσεις",
     "points": "Πόντοι",
@@ -5899,139 +6093,142 @@
     "tab_levels_title": "Επίπεδα",
     "referral_stats_earned_from_referrals": "Κερδίσατε από συστάσεις",
     "referral_stats_referrals": "Συστάσεις",
-    "loading_activity": "Loading activity...",
-    "error_loading_activity": "Error loading activity",
-    "activity_empty_title": "No recent activity.",
-    "activity_empty_description": "Use MetaMask to earn points, level up, and unlock rewards.",
-    "activity_empty_link": "See ways to earn",
+    "loading_activity": "Φόρτωση δραστηριότητας…",
+    "error_loading_activity": "Σφάλμα κατά τη φόρτωση της δραστηριότητας",
+    "activity_empty_title": "Δεν υπάρχει πρόσφατη δραστηριότητα.",
+    "activity_empty_description": "Χρησιμοποιήστε το MetaMask για να κερδίζετε πόντους, να ανεβαίνετε επίπεδο και να ξεκλειδώνετε ανταμοιβές.",
+    "activity_empty_link": "Δείτε τρόπους για να κερδίσετε",
     "events": {
-      "to": "to",
+      "to": "προς",
       "type": {
         "swap": "Ανταλλαγή",
         "perps": "Συμβόλαια αορίστου διάρκειας",
-        "referral": "Referral",
-        "referral_action": "Referral action",
-        "sign_up_bonus": "Sign up bonus",
-        "loyalty_bonus": "Loyalty bonus",
-        "one_time_bonus": "One-time bonus",
-        "open_position": "Opened position",
-        "close_position": "Closed position",
-        "take_profit": "TP/SL",
-        "stop_loss": "TP/SL",
-        "uncategorized_event": "Uncategorized event"
+        "card_spend": "Card spend",
+        "referral": "Παραπομπές",
+        "referral_action": "Ενέργεια παραπομπής",
+        "sign_up_bonus": "Μπόνους εγγραφής",
+        "loyalty_bonus": "Μπόνους αφοσίωσης",
+        "one_time_bonus": "Μπόνους που παρέχεται μία φορά",
+        "open_position": "Ανοιχτή θέση",
+        "close_position": "Κλειστή θέση",
+        "take_profit": "ΛΚ/ΠΖ",
+        "stop_loss": "ΛΚ/ΠΖ",
+        "uncategorized_event": "Μη κατηγοριοποιημένο συμβάν"
       },
-      "date": "Date",
-      "account": "Account",
-      "bonus": "Bonus",
-      "details": "Details",
-      "points": "Points",
-      "points_base": "Base",
-      "points_boost": "Boost",
-      "points_total": "Total"
+      "date": "Ημερομηνία",
+      "account": "Λογαριασμός",
+      "bonus": "Μπόνους",
+      "details": "Λεπτομέρειες",
+      "points": "Πόντοι",
+      "points_base": "Βάση",
+      "points_boost": "Ενίσχυση",
+      "points_total": "Σύνολο"
     },
     "onboarding": {
       "not_supported_region_title": "Η περιοχή δεν υποστηρίζεται",
-      "not_supported_region_description": "Rewards are not supported in your region yet. We are working on expanding access, so check back later.",
-      "not_supported_hardware_account_title": "Account not supported",
-      "not_supported_hardware_account_description": "Hardware wallet accounts are not eligible to receive rewards yet. Please switch to a different account to proceed.",
-      "not_supported_account_type_title": "Account type not supported",
-      "not_supported_account_type_description": "Currently only internal Ethereum and Solana accounts can be opted into the Rewards program. Please switch to a different account to proceed.",
-      "not_supported_confirm_go_back": "Go back",
-      "not_supported_confirm_retry": "Retry",
-      "auth_fail_title": "Authentication Failed",
-      "auth_fail_description": "Unable to authenticate with the rewards program. Please check your connection and try again.",
-      "geo_check_fail_title": "Cannot determine opt-in eligibility",
-      "geo_check_fail_description": "We cannot determine if your country allows opting into the rewards program. Please check your connection and try again.",
+      "not_supported_region_description": "Οι ανταμοιβές δεν υποστηρίζονται ακόμη στην περιοχή σας. Προσπαθούμε να επεκτείνουμε την πρόσβαση, οπότε ελέγξτε ξανά αργότερα.",
+      "not_supported_hardware_account_title": "Ο λογαριασμός δεν υποστηρίζεται",
+      "not_supported_hardware_account_description": "Οι λογαριασμοί με πορτοφόλι υλικού δεν είναι ακόμη επιλέξιμοι για ανταμοιβές. Παρακαλούμε αλλάξτε λογαριασμό για να συνεχίσετε.",
+      "not_supported_account_type_title": "Ο τύπος λογαριασμού δεν υποστηρίζεται",
+      "not_supported_account_type_description": "Προς το παρόν, μόνο εσωτερικοί λογαριασμοί Ethereum και Solana μπορούν να ενταχθούν στο πρόγραμμα Ανταμοιβών. Παρακαλούμε αλλάξτε λογαριασμό για να συνεχίσετε.",
+      "not_supported_confirm_go_back": "Πίσω",
+      "not_supported_confirm_retry": "Επανάληψη",
+      "auth_fail_title": "Η ταυτοποίηση απέτυχε",
+      "auth_fail_description": "Δεν ήταν δυνατή η ταυτοποίηση με το πρόγραμμα ανταμοιβών. Παρακαλούμε ελέγξτε τη σύνδεσή σας και προσπαθήστε ξανά.",
+      "geo_check_fail_title": "Δεν είναι δυνατός ο προσδιορισμός επιλεξιμότητας για συμμετοχή",
+      "geo_check_fail_description": "Δεν είναι δυνατόν να προσδιορίσουμε το αν η χώρα σας επιτρέπει τη συμμετοχή στο πρόγραμμα ανταμοιβών. Παρακαλούμε ελέγξτε τη σύνδεσή σας και προσπαθήστε ξανά.",
       "gtm_title": "Οι ανταμοιβές είναι εδώ",
       "gtm_description": "Κερδίστε πόντους με τη δραστηριότητά σας. \nΑνεβείτε επίπεδα για να ξεκλειδώσετε ανταμοιβές.",
       "gtm_confirm": "Ξεκινήστε",
       "intro_title": "Η Σεζόν 1 \nξεκίνησε",
-      "intro_description": "Earn points for your activity. \nAdvance through levels to unlock rewards.",
-      "intro_confirm": "Claim 250 points",
-      "intro_confirm_geo_loading": "Checking region...",
-      "checking_opt_in": "Checking accounts...",
-      "redirecting_to_dashboard": "Redirecting...",
+      "intro_description": "Κερδίστε πόντους με τη δραστηριότητά σας. \nΑνεβείτε επίπεδα για να ξεκλειδώσετε ανταμοιβές.",
+      "intro_confirm": "Διεκδικήστε 250 πόντους",
+      "intro_confirm_geo_loading": "Έλεγχος περιοχής…",
+      "checking_opt_in": "Έλεγχος λογαριασμών…",
+      "redirecting_to_dashboard": "Ανακατεύθυνση…",
       "intro_skip": "Όχι τώρα",
       "step_confirm": "Επόμενο",
-      "step_skip": "Skip",
-      "step1_title": "Earn points on every trade",
+      "step_skip": "Παράλειψη",
+      "step1_title": "Κερδίστε πόντους σε κάθε συναλλαγή",
       "step1_description": "Κάθε ανταλλαγή και συναλλαγή σε perps που κάνετε στο MetaMask σας φέρνει πιο κοντά σε ανταμοιβές.\nΠροσθέστε τους λογαριασμούς σας και δείτε τους πόντους σας να αυξάνονται.",
-      "step2_title": "Level up for bigger perks",
+      "step2_title": "Ανεβείτε επίπεδο για περισσότερα προνόμια",
       "step2_description": "Επιτύχετε ορόσημα πόντων για να αποκτήσετε προνόμια όπως 50% έκπτωση σε χρεώσεις συμβολαίων αορίστου διάρκειας (perps), αποκλειστικά tokens και δωρεάν μια MetaMask Metal Card.",
-      "step3_title": "Exclusive seasonal rewards",
-      "step3_description": "Each season brings new perks. Join in, compete, and claim what you can before time runs out.",
-      "step4_title": "You'll earn 250 points when you sign up!",
-      "step4_title_referral_validating": "Validating referral code...",
-      "step4_referral_input_placeholder": "Referral code (optional)",
-      "step4_referral_input_error": "Invalid referral code",
-      "step4_confirm": "Claim points",
-      "step4_confirm_loading": "Claiming points...",
-      "step4_linking_accounts": "Adding accounts... ({{current}}/{{total}})",
-      "step4_linking_accounts_loading": "Adding additional accounts...",
-      "step4_success_description": "You have successfully signed up for MetaMask Rewards!",
-      "step4_legal_disclaimer_1": "By selecting 'Claim Points', you agree to the MetaMask Rewards",
-      "step4_legal_disclaimer_2": "Supplemental Terms of Use and Privacy Notice",
-      "step4_legal_disclaimer_3": ". We'll track onchain activity to reward you automatically –",
-      "step4_legal_disclaimer_4": "learn more"
+      "step3_title": "Αποκλειστικές ανταμοιβές ανά περίοδο",
+      "step3_description": "Κάθε περίοδος έχει νέα προνόμια. Συμμετάσχετε, ανταγωνιστείτε και διεκδικήστε όσα μπορείτε πριν λήξει ο χρόνος.",
+      "step4_title": "Θα κερδίσετε 250 πόντους με την εγγραφή σας!",
+      "step4_title_referral_bonus": "You'll earn 500 points when you sign up with this code!",
+      "step4_title_referral_validating": "Έλεγχος κωδικού παραπομπής…",
+      "step4_referral_bonus_description": "Use a referral code to earn 250 more",
+      "step4_referral_input_placeholder": "Κωδικός παραπομπής (προαιρετικά)",
+      "step4_referral_input_error": "Μη έγκυρος κωδικός παραπομπής",
+      "step4_confirm": "Διεκδίκηση πόντων",
+      "step4_confirm_loading": "Διεκδίκηση πόντων…",
+      "step4_linking_accounts": "Προσθήκη λογαριασμών… ({{current}}/{{total}})",
+      "step4_linking_accounts_loading": "Προσθήκη επιπλέον λογαριασμών…",
+      "step4_success_description": "Η εγγραφή σας στο MetaMask Rewards ολοκληρώθηκε με επιτυχία!",
+      "step4_legal_disclaimer_1": "Επιλέγοντας ‘Διεκδίκηση Πόντων’, αποδέχεστε τους όρους του MetaMask Rewards",
+      "step4_legal_disclaimer_2": "Συμπληρωματικοί Όροι Χρήσης και Δήλωση Απορρήτου",
+      "step4_legal_disclaimer_3": ". Θα παρακολουθούμε τη δραστηριότητά σας στο blockchain για να σας ανταμείβουμε αυτόματα --",
+      "step4_legal_disclaimer_4": "μάθετε περισσότερα"
     },
     "settings": {
-      "title": "Rewards Settings",
-      "subtitle": "Accounts",
-      "description": "Add multiple accounts to combine your points and unlock rewards faster.",
-      "tab_linked_accounts": "Added ({{count}})",
-      "tab_unlinked_accounts": "Not added ({{count}})",
-      "no_linked_accounts": "No accounts opted in",
-      "all_accounts_linked_title": "All accounts opted in",
-      "all_accounts_linked_description": "You have added all your accounts to Rewards.",
-      "link_account_success_title": "{{accountName}} successfully added",
-      "link_account_error_title": "Failed to add account",
-      "link_account_button": "Add",
-      "link_account_failed_error": "Failed to link account",
-      "link_account_unknown_error": "Unknown error occurred"
+      "title": "Ρυθμίσεις ανταμοιβών",
+      "subtitle": "Λογαριασμοί",
+      "description": "Προσθέστε πολλαπλούς λογαριασμούς για να συνδυάσετε τους πόντους σας και να ξεκλειδώσετε ανταμοιβές πιο γρήγορα.",
+      "tab_linked_accounts": "Προστέθηκαν ({{count}})",
+      "tab_unlinked_accounts": "Δεν προστέθηκαν ({{count}})",
+      "no_linked_accounts": "Κανένας λογαριασμός δεν συμμετέχει ακόμη",
+      "all_accounts_linked_title": "Όλοι οι λογαριασμοί συμμετέχουν",
+      "all_accounts_linked_description": "Έχετε προσθέσει όλους τους λογαριασμούς σας στο πρόγραμμα Ανταμοιβών.",
+      "link_account_success_title": "Ο λογαριασμός {{accountName}} προστέθηκε με επιτυχία",
+      "link_account_error_title": "Αποτυχία προσθήκης λογαριασμού",
+      "link_account_button": "Προσθήκη",
+      "link_account_failed_error": "Αποτυχία σύνδεσης λογαριασμού",
+      "link_account_unknown_error": "Παρουσιάστηκε άγνωστο σφάλμα"
     },
     "optout": {
-      "title": "Opt out of Rewards",
-      "description": "This will remove your accounts from the Rewards program and erase your points and progress. You won't be able to undo this.",
-      "confirm": "Opt out",
+      "title": "Αποχώρηση από το πρόγραμμα Ανταμοιβών",
+      "description": "Αυτό θα αφαιρέσει τους λογαριασμούς σας από το πρόγραμμα Ανταμοιβών και θα διαγράψει τους πόντους και την πρόοδό σας. Δεν θα μπορείτε να το αναιρέσετε.",
+      "confirm": "Αποχώρηση",
       "modal": {
-        "confirmation_title": "Are you sure?",
-        "confirmation_description": "This will remove all your progress, and can't be reversed. If you rejoin the Rewards program later, you'll start back at 0.",
-        "cancel": "Cancel",
-        "confirm": "Confirm",
-        "error_message": "Failed to opt out of Rewards. Please try again.",
-        "processing": "Processing..."
+        "confirmation_title": "Είστε σίγουροι;",
+        "confirmation_description": "Αυτό θα διαγράψει όλη την πρόοδό σας και δεν μπορεί να αναιρεθεί. Αν επανέλθετε αργότερα στο πρόγραμμα Ανταμοιβών, θα ξεκινήσετε από το 0.",
+        "cancel": "Άκυρο",
+        "confirm": "Επιβεβαίωση",
+        "error_message": "Αποτυχία αποχώρησης από το πρόγραμμα Ανταμοιβών. Παρακαλούμε προσπαθήστε ξανά.",
+        "processing": "Επεξεργασία..."
       }
     },
-    "toast_dismiss": "Dismiss",
+    "toast_dismiss": "Απόρριψη",
     "dashboard_modal_info": {
       "active_account": {
-        "title": "Don't miss out",
-        "description": "Add your account to start earning points from your activity.",
-        "confirm": "Add account"
+        "title": "Μην το χάσετε",
+        "description": "Προσθέστε τον λογαριασμό σας για να αρχίσετε να κερδίζετε πόντους από τη δραστηριότητά σας.",
+        "confirm": "Προσθήκη λογαριασμού"
       },
       "multiple_unlinked_accounts": {
-        "title": "Start earning points",
-        "description": "Add your accounts so you can track your rewards at a glance.",
-        "confirm": "Add accounts"
+        "title": "Ξεκινήστε να κερδίζετε πόντους",
+        "description": "Προσθέστε τους λογαριασμούς σας για να παρακολουθείτε τις ανταμοιβές σας με μια ματιά.",
+        "confirm": "Προσθήκη λογαριασμών"
       },
       "account_not_supported": {
-        "title": "Account not supported",
-        "description_hardware": "Hardware wallet accounts are not yet eligible to earn points. Please switch to a different account to proceed.",
-        "description_general": "Currently only non-hardware internal Ethereum and Solana accounts are eligible to earn points. Please switch to a different account to proceed.",
-        "confirm": "Go back"
+        "title": "Ο λογαριασμός δεν υποστηρίζεται",
+        "description_hardware": "Οι λογαριασμοί με πορτοφόλι υλικού δεν είναι ακόμη επιλέξιμοι για συγκέντρωση πόντων. Παρακαλούμε αλλάξτε λογαριασμό για να συνεχίσετε.",
+        "description_general": "Προς το παρόν, μόνο εσωτερικοί λογαριασμοί Ethereum και Solana που δεν βασίζονται σε πορτοφόλι υλικού είναι επιλέξιμοι για συγκέντρωση πόντων. Παρακαλούμε αλλάξτε λογαριασμό για να συνεχίσετε.",
+        "confirm": "Πίσω"
       }
     },
     "ways_to_earn": {
-      "title": "Ways to earn",
-      "supported_networks": "Supported Networks",
+      "title": "Τρόποι για να κερδίσετε",
+      "supported_networks": "Υποστηριζόμενα δίκτυα",
       "swap": {
-        "title": "Swap",
-        "description": "80 points per $100",
+        "title": "Ανταλλαγή",
+        "description": "80 πόντοι ανά $100",
         "sheet": {
-          "title": "Swap tokens",
-          "points": "80 points per $100",
-          "description": "Swap tokens on supported networks to earn points for every dollar you trade.",
-          "cta_label": "Start a swap"
+          "title": "Ανταλλαγή tokens",
+          "points": "80 πόντοι ανά $100",
+          "description": "Ανταλλάξτε tokens σε υποστηριζόμενα δίκτυα για να κερδίζετε πόντους για κάθε δολάριο σε συναλλαγές.",
+          "cta_label": "Ξεκινήστε μια ανταλλαγή"
         }
       },
       "perps": {
@@ -6045,52 +6242,74 @@
         }
       },
       "referrals": {
-        "title": "Refer friends",
-        "description": "10 points per 50 from friends"
+        "title": "Προσκαλέστε φίλους",
+        "description": "10 πόντοι για κάθε 50 που προέρχονται από φίλους",
+        "sheet": {
+          "title": "Refer a friend",
+          "points": "20 points per 100",
+          "cta_label": "Refer a friend"
+        }
       },
       "loyalty": {
-        "title": "Loyalty bonus",
-        "description": "Earn points from past trades",
+        "title": "Μπόνους αφοσίωσης",
+        "description": "Κερδίστε πόντους από προηγούμενες συναλλαγές",
         "sheet": {
-          "title": "Loyalty bonus",
-          "points": "250 points per $1250",
-          "description": "Add accounts with past swaps or bridges in MetaMask to earn loyalty bonuses. Each eligible account unlocks points in increments of 250, up to a total of 50,000. Bonuses appear shortly after you add an account.",
-          "cta_label": "Add accounts"
+          "title": "Μπόνους αφοσίωσης",
+          "points": "250 πόντοι ανά $1250",
+          "description": "Προσθέστε λογαριασμούς με προηγούμενες ανταλλαγές ή μεταφορές μέσω MetaMask για να κερδίσετε μπόνους αφοσίωσης. Κάθε επιλέξιμος λογαριασμός ξεκλειδώνει πόντους τμηματικά κατά 250, έως και συνολικά 50.000. Τα μπόνους εμφανίζονται λίγο μετά την προσθήκη του λογαριασμού.",
+          "cta_label": "Προσθήκη λογαριασμών"
+        }
+      },
+      "card": {
+        "title": "MetaMask Card",
+        "description": "1 point per $1 spent",
+        "sheet": {
+          "title": "MetaMask Card",
+          "points": "1 point per $1 spent",
+          "description": "Earn points every time you use your MetaMask Card for purchases, plus 1% cash back (3% for Metal cardholders).",
+          "cta_label": "Manage Card"
         }
       }
     },
     "referral": {
-      "referral_code": "Referral code",
-      "referral_link": "Referral link",
+      "referral_code": "Κωδικός παραπομπής",
+      "referral_link": "Σύνδεσμος παραπομπής",
       "actions": {
         "share_referral_link": "Συστήστε έναν φίλο",
         "share_referral_subject": "Συμμετάσχετε στο MetaMask Rewards"
       },
       "info": {
         "title": "Κοινοποιήστε τον κωδικό σας για να κερδίσετε περισσότερα",
-        "description": "Your friends get a 2x sign up bonus. You get 10 points for every 50 they earn from trading."
+        "description": "Οι φίλοι σας αποκτούν 2x μπόνους εγγραφής. Εσείς λαμβάνετε 10 πόντους για κάθε 50 που κερδίζουν από τις συναλλαγές τους."
       }
     },
-    "active_boosts_title": "Active boosts",
-    "season_1": "Season 1",
+    "link_account_group": {
+      "link_account": "Add account",
+      "tracked": "Tracked",
+      "untracked": "Untracked",
+      "link_account_success": "{{accountName}} added successfully",
+      "link_account_error": "Failed to add one or more addresses for {{accountName}}"
+    },
+    "active_boosts_title": "Ενεργές ενισχύσεις",
+    "season_1": "Περίοδος 1",
     "upcoming_rewards": {
       "title": "Κλειδωμένες ανταμοιβές",
-      "points_needed": "{{points}} points",
-      "cta_label": "Got it",
-      "alpha_fox_invite_input_placeholder": "Your Telegram handle"
+      "points_needed": "{{points}} πόντοι",
+      "cta_label": "Κατανοητό",
+      "alpha_fox_invite_input_placeholder": "Το όνομα χρήστη σας στο Telegram"
     },
     "unlocked_rewards": {
-      "title": "Unlocked rewards",
-      "cta_label": "Claim now",
-      "cta_request_invite": "Request invite",
-      "claim_label": "Claim",
-      "claimed_label": "Claimed",
-      "reward_claimed": "Reward claimed",
+      "title": "Ανταμοιβές που έχουν ενεργοποιηθεί",
+      "cta_label": "Διεκδικήστε τώρα",
+      "cta_request_invite": "Ζητήστε πρόσκληση",
+      "claim_label": "Εξαργύρωση",
+      "claimed_label": "Διεκδικήθηκε",
+      "reward_claimed": "Η ανταμοιβή εξαργυρώθηκε",
       "time_left": "απομένει",
-      "expired": "Expired"
+      "expired": "Έληξε"
     },
     "animation": {
-      "could_not_load": "Couldn't load"
+      "could_not_load": "Δεν ήταν δυνατή η φόρτωση"
     }
   },
   "time": {
@@ -6099,7 +6318,7 @@
   },
   "transaction_details": {
     "title": {
-      "perps_deposit": "Funded Perps account",
+      "perps_deposit": "Χρηματοδοτημένος λογαριασμός συμβολαίων Perps",
       "predict_deposit": "Funded Predict account",
       "default": "Λεπτομέρειες συναλλαγής"
     },
@@ -6107,19 +6326,23 @@
       "bridge_fee": "Τέλη διασύνδεσης",
       "network_fee": "Τέλη δικτύου",
       "paid_with": "Πληρώθηκε με",
+      "retry_button": "Try again",
       "total": "Σύνολο"
     },
     "summary_title": {
-      "bridge": "Διασύνδεση από το {{sourceSymbol}} προς το {{targetSymbol}}",
       "bridge_approval": "Έγκριση {{approveSymbol}}",
       "bridge_approval_loading": "Έγκριση",
-      "bridge_loading": "Μεταφορά",
+      "bridge_send": "Bridge {{sourceSymbol}} from {{sourceChain}}",
+      "bridge_send_loading": "Bridge Send",
+      "bridge_receive": "Receive {{targetSymbol}} on {{targetChain}}",
+      "bridge_receive_loading": "Bridge Receive",
       "default": "Συναλλαγή",
       "perps_deposit": "Προσθήκη κεφαλαίων",
       "predict_deposit": "Add funds",
       "swap": "Ανταλλαγή tokens",
       "swap_approval": "Έγκριση token"
-    }
+    },
+    "perps_deposit_solution": "You now have {{fiat}} of USDC on Arbitrum. Try your deposit again."
   },
   "sdk_connect_v2": {
     "show_loading": {

--- a/locales/languages/es.json
+++ b/locales/languages/es.json
@@ -594,7 +594,9 @@
       "unexpectedError": "Ocurrió un error inesperado.",
       "quoteFetchError": "No se pudo obtener la cotización.",
       "kycFormsFetchError": "No se pudieron obtener los formularios KYC.",
-      "title": "Depósito"
+      "title": "Depósito",
+      "limitExceeded": "This deposit would exceed your {{period}} limit. Your deposit including fees must be {{remaining}} or less.",
+      "limitError": "Failed to check your deposit limits. Please try again later."
     },
     "token_modal": {
       "select_a_token": "Selecciona un token",
@@ -892,7 +894,7 @@
     "withdraw": "Retirar",
     "refresh_balance": "Actualizar saldo",
     "add_funds": "Agregar fondos",
-    "deposit_in_progress": "Deposit in progress",
+    "deposit_in_progress": "Depósito en curso",
     "your_positions": "Tus posiciones",
     "loading_positions": "Cargando posiciones...",
     "refreshing_positions": "Actualizando posiciones...",
@@ -1277,6 +1279,7 @@
       "assetMappingFailed": "Error al crear el mapeo de activos",
       "depositFailed": "Depósito fallido",
       "orderLeverageReductionFailed": "No puedes reducir tu apalancamiento",
+      "connectionTimeout": "Connection timed out. Please check your network and try again.",
       "connectionFailed": {
         "title": "Los contratos perpetuos están temporalmente fuera de línea",
         "description": "Estamos trabajando para que vuelva a estar en línea pronto.",
@@ -1348,9 +1351,9 @@
         "error_message": "No se encontraron datos de mercado. Vuelve atrás e inténtalo de nuevo."
       },
       "statistics": "Resumen",
-      "24h_high": "24h high",
-      "24h_low": "24h low",
-      "24h_volume": "24h volume",
+      "24h_high": "Máximo de 24 h",
+      "24h_low": "Mínimo de 24 h",
+      "24h_volume": "Volumen de 24 h",
       "open_interest": "Interés abierto",
       "funding_rate": "Tasa de financiación",
       "countdown": "Cuenta regresiva",
@@ -1510,9 +1513,9 @@
         "metamask_fee": "Tarifa de MetaMask",
         "hyperliquid_fee": "Tarifa de Hyperliquid",
         "total_fee": "Tarifa total",
-        "liquidated": "Liquidated",
-        "take_profit": "Take profit",
-        "stop_loss": "Stop loss"
+        "liquidated": "Liquidada",
+        "take_profit": "Toma de ganancias",
+        "stop_loss": "Límite de pérdidas"
       },
       "funding": {
         "date": "Fecha",
@@ -1525,7 +1528,7 @@
         "history_will_appear": "Tu historial de trading aparecerá aquí"
       }
     },
-    "risk_disclaimer": "Perpetual contracts are very risky, and you could suddenly and without notice lose your entire investment. You trade entirely at your own risk. Market data provided by Hyperliquid. Price chart powered by",
+    "risk_disclaimer": "Perpetual contracts are very risky, and you could suddenly and without notice lose your entire investment. You trade entirely at your own risk. Market data provided by Hyperliquid. Price chart powered by",
     "tutorial": {
       "continue": "Continuar",
       "skip": "Omitir",
@@ -1555,11 +1558,11 @@
       "ready_to_trade": {
         "title": "¿Estás listo para operar?",
         "description": "Financia tu cuenta de contratos perpetuos con cualquier token y realiza tu primera operación en segundos.",
-        "footer_text": "MetaMask canjeará tus fondos a USDC en Arbitrum y los depositará en HyperCore sin cargo adicional."
+        "footer_text": "MetaMask will swap your funds to USDC on Arbitrum, and deposit them onto HyperCore for no added fee."
       },
       "got_it": "Entendido",
       "card": {
-        "title": "Learn the basics of perps"
+        "title": "Aprende los conceptos básicos de los contratos perpetuos"
       }
     },
     "points": "Puntos",
@@ -1576,10 +1579,10 @@
     "market_list": "Lista de mercados",
     "market_details": "Detalles del mercado",
     "tab": {
-      "no_predictions": "Aún no hay predicciones",
-      "no_predictions_description": "Abre una predicción para comenzar.",
-      "explore": "Explorar mercados",
-      "new_prediction": "Nueva predicción"
+      "no_predictions_description": "Your predictions will appear here, showing your stake and market movement.",
+      "explore": "Browse markets",
+      "new_prediction": "Nueva predicción",
+      "resolved_markets": "Resolved markets"
     },
     "sell_position": "Posición de venta",
     "cash_out": "Retiro de efectivo",
@@ -1609,16 +1612,73 @@
     "claim_button": "Reclamar",
     "markets_won": "Mercados que ganaron",
     "won_markets_text": "Ganaron {{count}} mercado{{s}}",
-    "won_markets_text_singular": "Ganó {{count}} mercado",
-    "won_markets_text_plural": "Ganaron {{count}} mercados",
+    "available_balance": "Available balance",
     "claim_amount_text": "Reclamar ${{amount}}",
     "unrealized_pnl_label": "P&L no realizado",
     "unrealized_pnl_value": "{{amount}} ({{percent}})",
+    "unrealized_pnl_error": "Unable to load",
     "unavailable": {
       "title": "Unavailable in your region",
       "description": "Predictions aren't available in your region due to legal restrictions.",
       "link": "See Polymarket terms",
       "button": "Got it"
+    },
+    "deposit": {
+      "in_progress": "Deposit in progress",
+      "adding_funds": "Adding funds",
+      "adding_your_funds": "Adding your funds",
+      "add_funds": "Add funds",
+      "withdraw": "Withdraw",
+      "estimated_processing_time": "Est. {{time}} seconds",
+      "account_ready": "Your account is ready",
+      "account_ready_description": "{{amount}} added to your balance",
+      "error_title": "Something went wrong",
+      "error_description": "Your account wasn't funded",
+      "try_again": "Try again"
+    },
+    "add_funds_sheet": {
+      "title": "Add funds",
+      "description": "You'll need to add funds to your Predictions account to get started. You can add any token and make your first prediction in seconds."
+    },
+    "transactions": {
+      "title": "Predictions",
+      "no_transactions": "No recent activity",
+      "buy_title": "Predicted",
+      "sell_title": "Cashed out",
+      "claim_title": "Claimed winnings",
+      "buy_detail": "Bought {{amountUsd}} on {{outcome}} · {{priceCents}} per share",
+      "sell_detail": "Sold at {{priceCents}} per share",
+      "claim_detail": "Claimed winnings",
+      "not_available": "N/A",
+      "date": "Date",
+      "market": "Market",
+      "outcome": "Outcome",
+      "predicted_amount": "Predicted amount",
+      "shares_bought": "Shares bought",
+      "shares_sold": "Shares sold",
+      "price_per_share": "Price per share",
+      "price_impact": "Price impact",
+      "net_pnl": "Net P&L",
+      "total_net_pnl": "Total Net P&L",
+      "market_net_pnl": "Market Net P&L",
+      "activity_details": "Activity details"
+    },
+    "claim": {
+      "toasts": {
+        "pending": {
+          "title": "Claiming {{amount}}",
+          "description": "Est. {{time}} seconds"
+        },
+        "confirmed": {
+          "title": "Claimed",
+          "description": "{{amount}} added to your balance"
+        },
+        "error": {
+          "title": "Something went wrong",
+          "description": "Failed to proceed with claim",
+          "try_again": "Try again"
+        }
+      }
     }
   },
   "receive": {
@@ -3093,6 +3153,7 @@
     "tx_review_lending_withdraw": "Retiro de préstamo",
     "tx_review_perps_deposit": "Cuenta financiada de contratos perpetuos",
     "tx_review_predict_deposit": "Funded Predict account",
+    "tx_review_predict_claim": "Claimed Predict winnings",
     "sent_ether": "Ether enviado",
     "self_sent_ether": "Ether enviado a usted mismo",
     "received_ether": "Ether recibido",
@@ -3939,7 +4000,9 @@
     "wallet_connect_dapps_cta": "Ver sesiones",
     "network_not_supported": "No se admite la red actual",
     "select_provider": "Seleccione su proveedor preferido",
-    "switch_network": "Cambie a la red principal o a Sepolia"
+    "switch_network": "Cambie a la red principal o a Sepolia",
+    "card_title": "Always show MetaMask Card button",
+    "card_desc": "MetaMask Card is only available to residents of select countries"
   },
   "walletconnect_sessions": {
     "no_active_sessions": "No tiene sesiones activas",
@@ -5315,8 +5378,7 @@
     },
     "tooltip": {
       "perps_deposit": {
-
-        "transaction_fee": "Canjearemos tus tokens por USDC en HyperCore, la red que usan los contratos perpetuos. Los proveedores de canje pueden cobrar una comisión, pero MetaMask no."
+        "transaction_fee": "We'll swap your tokens for USDC on HyperCore, the network used by Perps. Swap providers may charge a fee, but MetaMask won't."
       },
       "predict_deposit": {
         "transaction_fee": "We'll swap your tokens for USDC.e on Polygon, the network used by Predict. Swap providers may charge a fee, but MetaMask won't."
@@ -5408,6 +5470,12 @@
       "save": "Guardar",
       "title": "Editar límite de aprobación"
     },
+    "predict_claim": {
+      "button_label": "Claim winnings",
+      "summary": "You won",
+      "footer_bottom": "Funds will be added to your available balance",
+      "footer_top": "Winnings from {{count}} markets"
+    },
     "unlimited": "Ilimitado",
     "all": "Todo",
     "none": "Ninguno",
@@ -5470,12 +5538,15 @@
     "points": "Puntos estimados",
     "points_tooltip": "Puntos",
     "points_tooltip_content_1": "Los puntos son la forma de ganar recompensas de MetaMask por completar transacciones, como cuando canjeas, puenteas u operas con contratos perpetuos.",
-    "points_tooltip_content_2": "Keep in mind this value is an estimate and will be finalized once the transaction is complete. Points can take up to 1 hour to be confirmed in your Rewards balance.",
+    "points_tooltip_content_2": "Ten en cuenta que este valor es una estimación y se finalizará una vez que se complete la transacción. Los puntos pueden tardar hasta 1 hora en confirmarse en tu saldo de Recompensas.",
     "unable_to_load": "No se puede cargar",
     "points_error": "No podemos cargar puntos en este momento",
-    "points_error_content": "You'll still earn any points for this transaction. We'll notify you once they've been added to your account. You can also check your rewards tab in about an hour.",
+    "points_error_content": "Aún ganarás puntos por esta transacción. Te notificaremos una vez que se hayan agregado a tu cuenta. También puedes consultar la pestaña de recompensas en aproximadamente una hora.",
     "see_other_quotes": "Ver otras cotizaciones",
     "receive_at": "Recibir en",
+    "recipient": "Recipient",
+    "select_recipient": "Select recipient",
+    "external_account": "External account",
     "error_banner_description": "Esta ruta de operación no está disponible en este momento. Intente cambiar el monto, la red o el token y encontraremos la mejor opción.",
     "insufficient_funds": "Fondos insuficientes",
     "insufficient_gas": "Gas insuficiente",
@@ -5776,6 +5847,12 @@
       "update_to_store_link": "Actualiza a la última versión de MetaMask",
       "well_take_you_to_right_place": " y te llevaremos al lugar correcto."
     },
+    "unsupported": {
+      "title": "This page is not supported in current version",
+      "description": "Update to the latest version to use this feature",
+      "update_to_store_link": "Update to the latest version of MetaMask",
+      "well_take_you_to_right_place": " and we'll take you to the right place."
+    },
     "go_to_home_button": "Ir a la página de inicio",
     "back_button": "Volver",
     "continue_button": "Continuar"
@@ -5792,7 +5869,96 @@
     "card_onboarding": {
       "title": "Bienvenido a la tarjeta",
       "description": "Para utilizar las funciones de la tarjeta, deberás verificar tu cuenta con nuestro socio.",
-      "verify_account_button": "Verificar cuenta"
+      "verify_account_button": "Verificar cuenta",
+      "sign_up": {
+        "title": "Sign-up",
+        "description": "Register your details with Crypto Life, the provider of MetaMask Card. You'll use this account to access and manage your card.",
+        "email_label": "Email",
+        "password_label": "Password",
+        "confirm_password_label": "Confirm password",
+        "country_label": "Country of Residence",
+        "email_placeholder": "Enter your email address",
+        "password_placeholder": "Enter your password",
+        "country_placeholder": "Select your country",
+        "password_mismatch": "Passwords do not match",
+        "invalid_email": "Invalid email address"
+      },
+      "confirm_email": {
+        "title": "Confirm your email",
+        "description": "We've sent a confirmation code to: {{email}}",
+        "confirm_code_label": "Confirmation code",
+        "confirm_code_placeholder": "Enter the confirmation code"
+      },
+      "set_phone_number": {
+        "title": "Phone number",
+        "description": "Enter your phone number",
+        "phone_number_label": "Phone number",
+        "phone_number_placeholder": "Enter your phone number",
+        "country_area_code_label": "Country area code",
+        "invalid_phone_number": "Invalid phone number",
+        "legal_terms": "By continuing, you agree to receiving SMS to verify your phone number."
+      },
+      "confirm_phone_number": {
+        "title": "Confirm your phone number",
+        "description": "We've sent a confirmation code to: {{phoneNumber}}",
+        "confirm_code_label": "Confirmation code"
+      },
+      "verify_identity": {
+        "title": "Verifying your identity to get your card",
+        "description": "To keep your account secure and comply with regulations, we need to verify your identity.\n\nYou'll need a government-issued ID and a proof of address (like a utility bill or bank statement).\n\nVerification usually takes 5-30 minutes, and we'll notify you as soon as it's complete.",
+        "verify_button": "Verify now with Veriff"
+      },
+      "validating_kyc": {
+        "title": "Validating your KYC..."
+      },
+      "kyc_failed": {
+        "title": "Rejected",
+        "description": "Your KYC was rejected. Please try again."
+      },
+      "personal_details": {
+        "title": "Personal details",
+        "description": "Enter your personal details",
+        "first_name_label": "First name",
+        "last_name_label": "Last name",
+        "date_of_birth_label": "Date of birth",
+        "nationality_label": "Country of Nationality",
+        "ssn_label": "Social Security Number",
+        "first_name_placeholder": "Enter your first name",
+        "last_name_placeholder": "Enter your last name",
+        "date_of_birth_placeholder": "Enter your date of birth",
+        "nationality_placeholder": "Select your nationality",
+        "ssn_placeholder": "Enter your SSN",
+        "invalid_ssn": "Invalid SSN",
+        "invalid_date_of_birth": "Invalid date of birth",
+        "invalid_date_of_birth_underage": "You must be at least 18 years old"
+      },
+      "physical_address": {
+        "title": "Physical address",
+        "description": "Please provide your physical address",
+        "address_line_1_label": "Address line 1",
+        "address_line_2_label": "Address line 2",
+        "city_label": "City",
+        "state_label": "State",
+        "zip_code_label": "ZIP code",
+        "address_line_1_placeholder": "Enter your address line 1",
+        "address_line_2_placeholder": "Enter your address line 2",
+        "city_placeholder": "Enter your city",
+        "state_placeholder": "Enter your state",
+        "zip_code_placeholder": "Enter your ZIP code",
+        "same_mailing_address_label": "Physical address is the same as mailing address",
+        "electronic_consent": "I agree to the E-Sign Act Consent and Disclosure and to receive all communictions electronically."
+      },
+      "mailing_address": {
+        "title": "Mailing address",
+        "description": "Please provide your mailing address"
+      },
+      "complete": {
+        "title": "Approved!",
+        "description": "Your KYC was approved. You can now use your Card."
+      },
+      "continue_button": "Next",
+      "confirm_button": "Confirm",
+      "retry_button": "Try again"
     },
     "card_home": {
       "error_title": "No se pueden obtener los datos",
@@ -5800,9 +5966,36 @@
       "try_again": "Inténtalo de nuevo",
       "limited_spending_warning": "Tu capacidad de gasto real podría estar limitada. Para ajustar tu límite, visita {{manageCard}}",
       "add_funds": "Agregar fondos",
+      "change_asset": "Change asset",
       "manage_card_options": {
+        "manage_spending_limit": "Manage spending limit",
+        "manage_spending_limit_description_restricted": "Restricted spending limit is on",
+        "manage_spending_limit_description_full": "Full spending access is on",
         "manage_card": "Administrar tarjeta",
-        "advanced_card_management_description": "Consulta tus transacciones, congela la tarjeta y mucho más"
+        "advanced_card_management_description": "Detailed transactions, freeze card, and more"
+      }
+    },
+    "card_authentication": {
+      "title": "Log in to your Card account",
+      "location_button_text": "International",
+      "location_button_text_us": "US account",
+      "email_label": "Email",
+      "password_label": "Password",
+      "email_placeholder": "Enter your email address",
+      "password_placeholder": "Enter your password",
+      "login_button": "Log in",
+      "errors": {
+        "invalid_credentials": "Invalid login details",
+        "unknown_error": "Unknown error, please try again later",
+        "email_required": "Email is required",
+        "password_required": "Password is required",
+        "email_invalid": "Invalid email address",
+        "password_invalid": "Invalid password",
+        "invalid_email_or_password": "Invalid email or password, check your credentials and try again.",
+        "network_error": "Network error. Please check your connection and try again.",
+        "timeout_error": "Request timed out. Please check your connection and try again.",
+        "server_error": "Server error. Please try again later.",
+        "configuration_error": "Service is temporarily unavailable. Please try again later."
       }
     }
   },
@@ -5826,65 +6019,65 @@
     "close": "Cerrar"
   },
   "rewards": {
-    "auth_fail_title": "Unknown Error.",
-    "auth_fail_description": "An unknown error occurred while authenticating this account with the rewards program. Please try again later.",
-    "failed_to_authenticate": "Failed to authenticate with rewards program",
+    "auth_fail_title": "Error desconocido.",
+    "auth_fail_description": "Se produjo un error desconocido al autenticar esta cuenta con el programa de recompensas. Inténtalo de nuevo más tarde.",
+    "failed_to_authenticate": "Error al autenticar con el programa de recompensas",
     "not_implemented": "Próximamente",
     "not_implemented_season_summary": "Resumen de la temporada disponible en breve",
     "optin_error": {
-      "title": "Opt-in failed",
-      "description": "Check your connection and try again."
+      "title": "Error al registrarte",
+      "description": "Comprueba tu conexión y vuelve a intentarlo."
     },
     "season_status_error": {
-      "error_fetching_title": "Season balance couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "No se pudo cargar el saldo de la temporada",
+      "error_fetching_description": "Comprueba tu conexión y vuelve a intentarlo.",
+      "retry_button": "Reintentar"
     },
     "active_boosts_error": {
-      "error_fetching_title": "Boosts couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "No se pudieron cargar los potenciadores",
+      "error_fetching_description": "Comprueba tu conexión y vuelve a intentarlo.",
+      "retry_button": "Reintentar"
     },
     "unlocked_rewards_error": {
-      "error_fetching_title": "Rewards couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "No se pudieron cargar las recompensas",
+      "error_fetching_description": "Comprueba tu conexión y vuelve a intentarlo.",
+      "retry_button": "Reintentar"
     },
     "upcoming_rewards_error": {
-      "error_fetching_title": "Rewards couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "No se pudieron cargar las recompensas",
+      "error_fetching_description": "Comprueba tu conexión y vuelve a intentarlo.",
+      "retry_button": "Reintentar"
     },
     "referral_details_error": {
-      "error_fetching_title": "Referral details couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "No se pudieron cargar los detalles de recomendación",
+      "error_fetching_description": "Comprueba tu conexión y vuelve a intentarlo.",
+      "retry_button": "Reintentar"
     },
     "referral_validation_unknown_error": {
-      "title": "Referral code couldn’t be validated",
-      "description": "Check your connection and try again."
+      "title": "El código de recomendación no se pudo validar",
+      "description": "Comprueba tu conexión y vuelve a intentarlo."
     },
     "active_activity_error": {
-      "error_fetching_title": "Activity couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "No se pudo cargar la actividad",
+      "error_fetching_description": "Comprueba tu conexión y vuelve a intentarlo.",
+      "retry_button": "Reintentar"
     },
-    "solana_signup_not_supported": "Signing in to Rewards with Solana accounts is not supported yet. Please use an Ethereum account instead.",
+    "solana_signup_not_supported": "Aún no se admite el inicio de sesión en Recompensas con cuentas de Solana. Utiliza una cuenta Ethereum en su lugar.",
     "error_messages": {
-      "unknown_error": "Unknown error occurred",
-      "something_went_wrong": "Something went wrong. Please try again shortly.",
-      "account_already_registered": "This account is already registered with another Rewards profile. Please switch account to continue.",
-      "request_rejected": "You rejected the request.",
-      "failed_to_claim_reward": "Failed to claim reward. Please try again shortly.",
-      "service_not_available": "Service is not available at the moment. Please try again shortly."
+      "unknown_error": "Ocurrió un error desconocido",
+      "something_went_wrong": "Se produjo un error. Inténtalo de nuevo en breve.",
+      "account_already_registered": "Esta cuenta ya está registrada con otro perfil de Recompensas. Cambia de cuenta para continuar.",
+      "request_rejected": "Rechazaste la solicitud.",
+      "failed_to_claim_reward": "No se pudo reclamar la recompensa. Inténtalo de nuevo en breve.",
+      "service_not_available": "El servicio no está disponible en este momento. Inténtalo de nuevo en breve."
     },
     "claim_reward_error": {
-      "title": "Failed to claim reward"
+      "title": "No se pudo reclamar la recompensa"
     },
     "accounts_opt_in_state_error": {
-      "error_fetching_title": "Accounts couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "No se pudieron cargar las cuentas",
+      "error_fetching_description": "Comprueba tu conexión y vuelve a intentarlo.",
+      "retry_button": "Reintentar"
     },
     "referral_rewards_title": "Referidos",
     "points": "Puntos",
@@ -5900,139 +6093,142 @@
     "tab_levels_title": "Niveles",
     "referral_stats_earned_from_referrals": "Ganancias por referidos",
     "referral_stats_referrals": "Recomendados",
-    "loading_activity": "Loading activity...",
-    "error_loading_activity": "Error loading activity",
-    "activity_empty_title": "No recent activity.",
-    "activity_empty_description": "Use MetaMask to earn points, level up, and unlock rewards.",
-    "activity_empty_link": "See ways to earn",
+    "loading_activity": "Cargando actividad...",
+    "error_loading_activity": "Error al cargar actividad",
+    "activity_empty_title": "Ninguna actividad reciente.",
+    "activity_empty_description": "Utiliza MetaMask para ganar puntos, subir de nivel y desbloquear recompensas.",
+    "activity_empty_link": "Ver formas de ganar",
     "events": {
-      "to": "to",
+      "to": "para",
       "type": {
         "swap": "Canjear",
         "perps": "Perps",
-        "referral": "Referral",
-        "referral_action": "Referral action",
-        "sign_up_bonus": "Sign up bonus",
-        "loyalty_bonus": "Loyalty bonus",
-        "one_time_bonus": "One-time bonus",
-        "open_position": "Opened position",
-        "close_position": "Closed position",
-        "take_profit": "TP/SL",
-        "stop_loss": "TP/SL",
-        "uncategorized_event": "Uncategorized event"
+        "card_spend": "Card spend",
+        "referral": "Recomendación",
+        "referral_action": "Acción de recomendación",
+        "sign_up_bonus": "Bonificación de registro",
+        "loyalty_bonus": "Bonificación de lealtad",
+        "one_time_bonus": "Bonificación única",
+        "open_position": "Posición abierta",
+        "close_position": "Posición cerrada",
+        "take_profit": "TG/LP",
+        "stop_loss": "TG/LP",
+        "uncategorized_event": "Evento sin categoría"
       },
-      "date": "Date",
-      "account": "Account",
-      "bonus": "Bonus",
-      "details": "Details",
-      "points": "Points",
+      "date": "Fecha",
+      "account": "Cuenta",
+      "bonus": "Bonificación",
+      "details": "Detalles",
+      "points": "Puntos",
       "points_base": "Base",
-      "points_boost": "Boost",
+      "points_boost": "Potenciador",
       "points_total": "Total"
     },
     "onboarding": {
       "not_supported_region_title": "Región no admitida",
-      "not_supported_region_description": "Rewards are not supported in your region yet. We are working on expanding access, so check back later.",
-      "not_supported_hardware_account_title": "Account not supported",
-      "not_supported_hardware_account_description": "Hardware wallet accounts are not eligible to receive rewards yet. Please switch to a different account to proceed.",
-      "not_supported_account_type_title": "Account type not supported",
-      "not_supported_account_type_description": "Currently only internal Ethereum and Solana accounts can be opted into the Rewards program. Please switch to a different account to proceed.",
-      "not_supported_confirm_go_back": "Go back",
-      "not_supported_confirm_retry": "Retry",
-      "auth_fail_title": "Authentication Failed",
-      "auth_fail_description": "Unable to authenticate with the rewards program. Please check your connection and try again.",
-      "geo_check_fail_title": "Cannot determine opt-in eligibility",
-      "geo_check_fail_description": "We cannot determine if your country allows opting into the rewards program. Please check your connection and try again.",
+      "not_supported_region_description": "Las recompensas aún no son compatibles en tu región. Estamos trabajando para ampliar el acceso, así que vuelve a consultar más tarde.",
+      "not_supported_hardware_account_title": "Cuenta no admitida",
+      "not_supported_hardware_account_description": "Las cuentas de billeteras físicas aún no pueden recibir recompensas. Cambia a otra cuenta para continuar.",
+      "not_supported_account_type_title": "Tipo de cuenta no admitida",
+      "not_supported_account_type_description": "Actualmente, solo las cuentas internas de Ethereum y Solana pueden optar por participar en el programa de Recompensas. Cambia a otra cuenta para continuar.",
+      "not_supported_confirm_go_back": "Atrás",
+      "not_supported_confirm_retry": "Reintentar",
+      "auth_fail_title": "Error de autenticación",
+      "auth_fail_description": "No se puede autenticar con el programa de recompensas. Verifica tu conexión e inténtalo nuevamente.",
+      "geo_check_fail_title": "No se puede determinar la elegibilidad para participar",
+      "geo_check_fail_description": "No podemos determinar si tu país permite optar por el programa de recompensas. Verifica tu conexión e inténtalo nuevamente.",
       "gtm_title": "Las recompensas están aquí",
       "gtm_description": "Gana puntos por tu actividad. \nAvanza a través de los niveles para desbloquear recompensas.",
       "gtm_confirm": "Comenzar",
       "intro_title": "La Temporada 1 \nya está disponible",
-      "intro_description": "Earn points for your activity. \nAdvance through levels to unlock rewards.",
-      "intro_confirm": "Claim 250 points",
-      "intro_confirm_geo_loading": "Checking region...",
-      "checking_opt_in": "Checking accounts...",
-      "redirecting_to_dashboard": "Redirecting...",
+      "intro_description": "Gana puntos por tu actividad. \nAvanza a través de los niveles para desbloquear recompensas.",
+      "intro_confirm": "Reclama 250 puntos",
+      "intro_confirm_geo_loading": "Comprobando región...",
+      "checking_opt_in": "Comprobando cuentas...",
+      "redirecting_to_dashboard": "Redirigiendo...",
       "intro_skip": "Ahora no",
       "step_confirm": "Siguiente",
-      "step_skip": "Skip",
-      "step1_title": "Earn points on every trade",
+      "step_skip": "Omitir",
+      "step1_title": "Gana puntos en cada operación",
       "step1_description": "Cada canje y operación con contratos perpetuos que hagas en MetaMask te acerca a las recompensas. Añade tus cuentas y observa cómo acumulas puntos.",
-      "step2_title": "Level up for bigger perks",
+      "step2_title": "Sube de nivel para obtener mayores beneficios",
       "step2_description": "Consigue hitos de puntos para obtener beneficios como un 50 % de descuento en las tarifas de contratos perpetuos, tokens exclusivos y una tarjeta metálica MetaMask gratis.",
-      "step3_title": "Exclusive seasonal rewards",
-      "step3_description": "Each season brings new perks. Join in, compete, and claim what you can before time runs out.",
-      "step4_title": "You'll earn 250 points when you sign up!",
-      "step4_title_referral_validating": "Validating referral code...",
-      "step4_referral_input_placeholder": "Referral code (optional)",
-      "step4_referral_input_error": "Invalid referral code",
-      "step4_confirm": "Claim points",
-      "step4_confirm_loading": "Claiming points...",
-      "step4_linking_accounts": "Adding accounts... ({{current}}/{{total}})",
-      "step4_linking_accounts_loading": "Adding additional accounts...",
-      "step4_success_description": "You have successfully signed up for MetaMask Rewards!",
-      "step4_legal_disclaimer_1": "By selecting 'Claim Points', you agree to the MetaMask Rewards",
-      "step4_legal_disclaimer_2": "Supplemental Terms of Use and Privacy Notice",
-      "step4_legal_disclaimer_3": ". We'll track onchain activity to reward you automatically –",
-      "step4_legal_disclaimer_4": "learn more"
+      "step3_title": "Recompensas exclusivas de temporada",
+      "step3_description": "Cada temporada trae nuevas ventajas. Únete, compite y reclama lo que puedas antes de que se acabe el tiempo.",
+      "step4_title": "¡Ganarás 250 puntos al registrarte!",
+      "step4_title_referral_bonus": "You'll earn 500 points when you sign up with this code!",
+      "step4_title_referral_validating": "Validando código de recomendación...",
+      "step4_referral_bonus_description": "Use a referral code to earn 250 more",
+      "step4_referral_input_placeholder": "Código de recomendación (opcional)",
+      "step4_referral_input_error": "Código de recomendación no válido",
+      "step4_confirm": "Reclamar puntos",
+      "step4_confirm_loading": "Reclamando puntos...",
+      "step4_linking_accounts": "Agregando cuentas... ({{current}}/{{total}})",
+      "step4_linking_accounts_loading": "Agregando cuentas adicionales...",
+      "step4_success_description": "¡Te registraste correctamente en el programa de Recompensas de MetaMask!",
+      "step4_legal_disclaimer_1": "Al seleccionar \"Reclamar puntos\", aceptas los términos y condiciones de Recompensas de MetaMask",
+      "step4_legal_disclaimer_2": "Términos de uso complementarios y aviso de privacidad",
+      "step4_legal_disclaimer_3": ". Realizaremos un seguimiento de la actividad en la cadena para recompensarte automáticamente –",
+      "step4_legal_disclaimer_4": "conozca más"
     },
     "settings": {
-      "title": "Rewards Settings",
-      "subtitle": "Accounts",
-      "description": "Add multiple accounts to combine your points and unlock rewards faster.",
-      "tab_linked_accounts": "Added ({{count}})",
-      "tab_unlinked_accounts": "Not added ({{count}})",
-      "no_linked_accounts": "No accounts opted in",
-      "all_accounts_linked_title": "All accounts opted in",
-      "all_accounts_linked_description": "You have added all your accounts to Rewards.",
-      "link_account_success_title": "{{accountName}} successfully added",
-      "link_account_error_title": "Failed to add account",
-      "link_account_button": "Add",
-      "link_account_failed_error": "Failed to link account",
-      "link_account_unknown_error": "Unknown error occurred"
+      "title": "Configuración de recompensas",
+      "subtitle": "Cuentas",
+      "description": "Agrega varias cuentas para combinar tus puntos y desbloquear recompensas más rápido.",
+      "tab_linked_accounts": "({{count}}) agregada",
+      "tab_unlinked_accounts": "({{count}}) no agregada",
+      "no_linked_accounts": "No hay cuentas registradas",
+      "all_accounts_linked_title": "Todas las cuentas se registraron",
+      "all_accounts_linked_description": "Has agregado todas tus cuentas a Recompensas.",
+      "link_account_success_title": "{{accountName}} se agregó correctamente",
+      "link_account_error_title": "Error al agregar la cuenta",
+      "link_account_button": "Agregar",
+      "link_account_failed_error": "Error al vincular la cuenta",
+      "link_account_unknown_error": "Ocurrió un error desconocido"
     },
     "optout": {
-      "title": "Opt out of Rewards",
-      "description": "This will remove your accounts from the Rewards program and erase your points and progress. You won't be able to undo this.",
-      "confirm": "Opt out",
+      "title": "Excluirse del programa de Recompensas",
+      "description": "Esto eliminará tus cuentas del programa de Recompensas y borrará tus puntos y progreso. No podrás deshacer esta acción.",
+      "confirm": "Excluirse",
       "modal": {
-        "confirmation_title": "Are you sure?",
-        "confirmation_description": "This will remove all your progress, and can't be reversed. If you rejoin the Rewards program later, you'll start back at 0.",
-        "cancel": "Cancel",
-        "confirm": "Confirm",
-        "error_message": "Failed to opt out of Rewards. Please try again.",
-        "processing": "Processing..."
+        "confirmation_title": "¿Estás seguro?",
+        "confirmation_description": "Esto eliminará todo tu progreso y no se podrá revertir. Si te reincorporas al programa de Recompensas más adelante, comenzarás desde cero.",
+        "cancel": "Cancelar",
+        "confirm": "Confirmar",
+        "error_message": "Error al excluirse del programa de Recompensas. Inténtalo de nuevo.",
+        "processing": "Procesando..."
       }
     },
-    "toast_dismiss": "Dismiss",
+    "toast_dismiss": "Ignorar",
     "dashboard_modal_info": {
       "active_account": {
-        "title": "Don't miss out",
-        "description": "Add your account to start earning points from your activity.",
-        "confirm": "Add account"
+        "title": "No te lo pierdas",
+        "description": "Agrega tu cuenta para comenzar a ganar puntos por tu actividad.",
+        "confirm": "Agregar cuenta"
       },
       "multiple_unlinked_accounts": {
-        "title": "Start earning points",
-        "description": "Add your accounts so you can track your rewards at a glance.",
-        "confirm": "Add accounts"
+        "title": "Empieza a ganar puntos",
+        "description": "Agrega tus cuentas para que puedas realizar un seguimiento de tus recompensas de un vistazo.",
+        "confirm": "Agregar cuentas"
       },
       "account_not_supported": {
-        "title": "Account not supported",
-        "description_hardware": "Hardware wallet accounts are not yet eligible to earn points. Please switch to a different account to proceed.",
-        "description_general": "Currently only non-hardware internal Ethereum and Solana accounts are eligible to earn points. Please switch to a different account to proceed.",
-        "confirm": "Go back"
+        "title": "Cuenta no admitida",
+        "description_hardware": "Las cuentas de billeteras físicas aún no pueden ganar puntos. Cambia a otra cuenta para continuar.",
+        "description_general": "Actualmente, solo las cuentas internas de Ethereum y Solana que no sean físicas pueden ganar puntos. Cambia a otra cuenta para continuar.",
+        "confirm": "Atrás"
       }
     },
     "ways_to_earn": {
-      "title": "Ways to earn",
-      "supported_networks": "Supported Networks",
+      "title": "Formas de ganar",
+      "supported_networks": "Redes compatibles",
       "swap": {
-        "title": "Swap",
-        "description": "80 points per $100",
+        "title": "Intercambiar",
+        "description": "80 puntos cada $100",
         "sheet": {
-          "title": "Swap tokens",
-          "points": "80 points per $100",
-          "description": "Swap tokens on supported networks to earn points for every dollar you trade.",
-          "cta_label": "Start a swap"
+          "title": "Canjear tokens",
+          "points": "80 puntos cada $100",
+          "description": "Canjea tokens en redes compatibles para ganar puntos por cada dólar que canjees.",
+          "cta_label": "Iniciar un canje"
         }
       },
       "perps": {
@@ -6046,52 +6242,74 @@
         }
       },
       "referrals": {
-        "title": "Refer friends",
-        "description": "10 points per 50 from friends"
+        "title": "Recomendar amigos",
+        "description": "10 puntos por cada 50 de tus amigos",
+        "sheet": {
+          "title": "Refer a friend",
+          "points": "20 points per 100",
+          "cta_label": "Refer a friend"
+        }
       },
       "loyalty": {
-        "title": "Loyalty bonus",
-        "description": "Earn points from past trades",
+        "title": "Bonificación de lealtad",
+        "description": "Gana puntos de operaciones anteriores",
         "sheet": {
-          "title": "Loyalty bonus",
-          "points": "250 points per $1250",
-          "description": "Add accounts with past swaps or bridges in MetaMask to earn loyalty bonuses. Each eligible account unlocks points in increments of 250, up to a total of 50,000. Bonuses appear shortly after you add an account.",
-          "cta_label": "Add accounts"
+          "title": "Bonificación de lealtad",
+          "points": "250 puntos cada $1250",
+          "description": "Agrega cuentas con canjes o puentes anteriores en MetaMask para ganar bonificaciones de lealtad. Cada cuenta elegible desbloquea puntos en incrementos de 250, hasta un total de 50.000. Las bonificaciones aparecen poco después de agregar una cuenta.",
+          "cta_label": "Agregar cuentas"
+        }
+      },
+      "card": {
+        "title": "MetaMask Card",
+        "description": "1 point per $1 spent",
+        "sheet": {
+          "title": "MetaMask Card",
+          "points": "1 point per $1 spent",
+          "description": "Earn points every time you use your MetaMask Card for purchases, plus 1% cash back (3% for Metal cardholders).",
+          "cta_label": "Manage Card"
         }
       }
     },
     "referral": {
-      "referral_code": "Referral code",
-      "referral_link": "Referral link",
+      "referral_code": "Código de recomendación",
+      "referral_link": "Enlace de recomendación",
       "actions": {
         "share_referral_link": "Referir a un amigo",
         "share_referral_subject": "Únete a MetaMask Rewards"
       },
       "info": {
         "title": "Comparte tu código para ganar más",
-        "description": "Your friends get a 2x sign up bonus. You get 10 points for every 50 they earn from trading."
+        "description": "Tus amigos obtienen una bonificación de registro del doble. Obtienes 10 puntos por cada 50 que ganen al operar."
       }
     },
-    "active_boosts_title": "Active boosts",
-    "season_1": "Season 1",
+    "link_account_group": {
+      "link_account": "Add account",
+      "tracked": "Tracked",
+      "untracked": "Untracked",
+      "link_account_success": "{{accountName}} added successfully",
+      "link_account_error": "Failed to add one or more addresses for {{accountName}}"
+    },
+    "active_boosts_title": "Potenciadores activos",
+    "season_1": "Temporada 1",
     "upcoming_rewards": {
       "title": "Recompensas bloqueadas",
-      "points_needed": "{{points}} points",
+      "points_needed": "{{points}} puntos",
       "cta_label": "Entendido",
-      "alpha_fox_invite_input_placeholder": "Your Telegram handle"
+      "alpha_fox_invite_input_placeholder": "Tu nombre de usuario de Telegram"
     },
     "unlocked_rewards": {
-      "title": "Unlocked rewards",
-      "cta_label": "Claim now",
-      "cta_request_invite": "Request invite",
-      "claim_label": "Claim",
-      "claimed_label": "Claimed",
-      "reward_claimed": "Reward claimed",
+      "title": "Recompensas desbloqueadas",
+      "cta_label": "Reclamar ahora",
+      "cta_request_invite": "Solicitar invitación",
+      "claim_label": "Reclamar",
+      "claimed_label": "Reclamada",
+      "reward_claimed": "Recompensa reclamada",
       "time_left": "restantes",
-      "expired": "Expired"
+      "expired": "Vencida"
     },
     "animation": {
-      "could_not_load": "Couldn't load"
+      "could_not_load": "No se pudo cargar"
     }
   },
   "time": {
@@ -6100,7 +6318,7 @@
   },
   "transaction_details": {
     "title": {
-      "perps_deposit": "Funded Perps account",
+      "perps_deposit": "Cuenta financiada de contratos perpetuos",
       "predict_deposit": "Funded Predict account",
       "default": "Detalles de la transacción"
     },
@@ -6108,19 +6326,23 @@
       "bridge_fee": "Tarifa de puente",
       "network_fee": "Tarifa de red",
       "paid_with": "Pagado con",
+      "retry_button": "Try again",
       "total": "Total"
     },
     "summary_title": {
-      "bridge": "Puentear de {{sourceSymbol}} a {{targetSymbol}}",
       "bridge_approval": "Aprobar {{approveSymbol}}",
       "bridge_approval_loading": "Aprobar",
-      "bridge_loading": "Puentear",
+      "bridge_send": "Bridge {{sourceSymbol}} from {{sourceChain}}",
+      "bridge_send_loading": "Bridge Send",
+      "bridge_receive": "Receive {{targetSymbol}} on {{targetChain}}",
+      "bridge_receive_loading": "Bridge Receive",
       "default": "Transacción",
       "perps_deposit": "Agregar fondos",
       "predict_deposit": "Add funds",
       "swap": "Canjear tokens",
       "swap_approval": "Aprobar tokens"
-    }
+    },
+    "perps_deposit_solution": "You now have {{fiat}} of USDC on Arbitrum. Try your deposit again."
   },
   "sdk_connect_v2": {
     "show_loading": {

--- a/locales/languages/fr.json
+++ b/locales/languages/fr.json
@@ -594,7 +594,9 @@
       "unexpectedError": "Une erreur inattendue s’est produite.",
       "quoteFetchError": "Échec de la récupération de la cotation.",
       "kycFormsFetchError": "Échec de la récupération des formulaires KYC.",
-      "title": "Dépôt"
+      "title": "Dépôt",
+      "limitExceeded": "This deposit would exceed your {{period}} limit. Your deposit including fees must be {{remaining}} or less.",
+      "limitError": "Failed to check your deposit limits. Please try again later."
     },
     "token_modal": {
       "select_a_token": "Sélectionner un jeton",
@@ -892,7 +894,7 @@
     "withdraw": "Retirer",
     "refresh_balance": "Actualiser le solde",
     "add_funds": "Ajouter des fonds",
-    "deposit_in_progress": "Deposit in progress",
+    "deposit_in_progress": "Dépôt en cours",
     "your_positions": "Vos positions",
     "loading_positions": "Chargement des positions…",
     "refreshing_positions": "En train d’actualiser les positions…",
@@ -1277,6 +1279,7 @@
       "assetMappingFailed": "Échec de la création du mappage des actifs",
       "depositFailed": "Le dépôt a échoué",
       "orderLeverageReductionFailed": "Vous ne pouvez pas réduire votre effet de levier",
+      "connectionTimeout": "Connection timed out. Please check your network and try again.",
       "connectionFailed": {
         "title": "Les contrats à terme perpétuels (perps) sont hors ligne",
         "description": "Nous mettons tout en œuvre pour rétablir la connexion.",
@@ -1348,9 +1351,9 @@
         "error_message": "Données de marché introuvables. Veuillez revenir en arrière et réessayer."
       },
       "statistics": "Aperçu",
-      "24h_high": "24h high",
-      "24h_low": "24h low",
-      "24h_volume": "24h volume",
+      "24h_high": "Prix le plus élevé atteint au cours des 24 dernières heures",
+      "24h_low": "Prix le plus bas atteint au cours des 24 dernières heures",
+      "24h_volume": "Volume sur 24 heures",
       "open_interest": "Intérêts ouverts",
       "funding_rate": "Taux de financement",
       "countdown": "Compte à rebours",
@@ -1510,7 +1513,7 @@
         "metamask_fee": "Commission MetaMask",
         "hyperliquid_fee": "Commission Hyperliquid",
         "total_fee": "Montant total des frais",
-        "liquidated": "Liquidated",
+        "liquidated": "Liquidé",
         "take_profit": "Take profit",
         "stop_loss": "Stop loss"
       },
@@ -1555,11 +1558,11 @@
       "ready_to_trade": {
         "title": "Prêt à trader ?",
         "description": "Approvisionnez votre compte de trading de contrats à terme perpétuels avec n’importe quel jeton, puis ouvrez votre première position en quelques secondes.",
-        "footer_text": "MetaMask échangera vos fonds contre des USDC sur Arbitrum et les déposera sur HyperCore sans frais supplémentaires."
+        "footer_text": "MetaMask will swap your funds to USDC on Arbitrum, and deposit them onto HyperCore for no added fee."
       },
       "got_it": "J’ai compris",
       "card": {
-        "title": "Learn the basics of perps"
+        "title": "Apprenez les bases des contrats perpétuels"
       }
     },
     "points": "Points",
@@ -1576,10 +1579,10 @@
     "market_list": "Liste des marchés",
     "market_details": "Détails du marché",
     "tab": {
-      "no_predictions": "Aucune prédiction pour l’instant",
-      "no_predictions_description": "Ouvrez une prédiction pour commencer.",
-      "explore": "Explorer les marchés",
-      "new_prediction": "Nouvelle prédiction"
+      "no_predictions_description": "Your predictions will appear here, showing your stake and market movement.",
+      "explore": "Browse markets",
+      "new_prediction": "Nouvelle prédiction",
+      "resolved_markets": "Resolved markets"
     },
     "sell_position": "Position de vente",
     "cash_out": "Encaisser",
@@ -1609,16 +1612,73 @@
     "claim_button": "Réclamer",
     "markets_won": "Marchés gagnés",
     "won_markets_text": "{{count}} marché{{s}} gagné(s)",
-    "won_markets_text_singular": "{{count}} marché gagné",
-    "won_markets_text_plural": "{{count}} marchés gagnés",
+    "available_balance": "Available balance",
     "claim_amount_text": "Réclamer {{amount}} $",
     "unrealized_pnl_label": "Profits et pertes non réalisés",
     "unrealized_pnl_value": "{{amount}} ({{percent}})",
+    "unrealized_pnl_error": "Unable to load",
     "unavailable": {
       "title": "Unavailable in your region",
       "description": "Predictions aren't available in your region due to legal restrictions.",
       "link": "See Polymarket terms",
       "button": "Got it"
+    },
+    "deposit": {
+      "in_progress": "Deposit in progress",
+      "adding_funds": "Adding funds",
+      "adding_your_funds": "Adding your funds",
+      "add_funds": "Add funds",
+      "withdraw": "Withdraw",
+      "estimated_processing_time": "Est. {{time}} seconds",
+      "account_ready": "Your account is ready",
+      "account_ready_description": "{{amount}} added to your balance",
+      "error_title": "Something went wrong",
+      "error_description": "Your account wasn't funded",
+      "try_again": "Try again"
+    },
+    "add_funds_sheet": {
+      "title": "Add funds",
+      "description": "You'll need to add funds to your Predictions account to get started. You can add any token and make your first prediction in seconds."
+    },
+    "transactions": {
+      "title": "Predictions",
+      "no_transactions": "No recent activity",
+      "buy_title": "Predicted",
+      "sell_title": "Cashed out",
+      "claim_title": "Claimed winnings",
+      "buy_detail": "Bought {{amountUsd}} on {{outcome}} · {{priceCents}} per share",
+      "sell_detail": "Sold at {{priceCents}} per share",
+      "claim_detail": "Claimed winnings",
+      "not_available": "N/A",
+      "date": "Date",
+      "market": "Market",
+      "outcome": "Outcome",
+      "predicted_amount": "Predicted amount",
+      "shares_bought": "Shares bought",
+      "shares_sold": "Shares sold",
+      "price_per_share": "Price per share",
+      "price_impact": "Price impact",
+      "net_pnl": "Net P&L",
+      "total_net_pnl": "Total Net P&L",
+      "market_net_pnl": "Market Net P&L",
+      "activity_details": "Activity details"
+    },
+    "claim": {
+      "toasts": {
+        "pending": {
+          "title": "Claiming {{amount}}",
+          "description": "Est. {{time}} seconds"
+        },
+        "confirmed": {
+          "title": "Claimed",
+          "description": "{{amount}} added to your balance"
+        },
+        "error": {
+          "title": "Something went wrong",
+          "description": "Failed to proceed with claim",
+          "try_again": "Try again"
+        }
+      }
     }
   },
   "receive": {
@@ -3093,6 +3153,7 @@
     "tx_review_lending_withdraw": "Retrait de prêt",
     "tx_review_perps_deposit": "Compte approvisionné par des contrats à terme perpétuels (perps)",
     "tx_review_predict_deposit": "Funded Predict account",
+    "tx_review_predict_claim": "Claimed Predict winnings",
     "sent_ether": "Ether envoyé(s)",
     "self_sent_ether": "Ether envoyé(s) à vous-même",
     "received_ether": "Ether reçu(s)",
@@ -3939,7 +4000,9 @@
     "wallet_connect_dapps_cta": "Afficher les sessions",
     "network_not_supported": "Le réseau actuel n’est pas pris en charge",
     "select_provider": "Sélectionnez votre fournisseur préféré",
-    "switch_network": "Veuillez passer à Mainnet ou à Sepolia"
+    "switch_network": "Veuillez passer à Mainnet ou à Sepolia",
+    "card_title": "Always show MetaMask Card button",
+    "card_desc": "MetaMask Card is only available to residents of select countries"
   },
   "walletconnect_sessions": {
     "no_active_sessions": "Vous n’avez aucune session active",
@@ -5315,7 +5378,7 @@
     },
     "tooltip": {
       "perps_deposit": {
-        "transaction_fee": "Nous échangerons vos jetons contre des USDC sur HyperCore, le réseau utilisé par les contrats à terme perpétuels. Les fournisseurs de services d’échange peuvent facturer des frais, mais MetaMask ne le fera pas."
+        "transaction_fee": "We'll swap your tokens for USDC on HyperCore, the network used by Perps. Swap providers may charge a fee, but MetaMask won't."
       },
       "predict_deposit": {
         "transaction_fee": "We'll swap your tokens for USDC.e on Polygon, the network used by Predict. Swap providers may charge a fee, but MetaMask won't."
@@ -5407,6 +5470,12 @@
       "save": "Sauvegarder",
       "title": "Modifier la limite d’approbation"
     },
+    "predict_claim": {
+      "button_label": "Claim winnings",
+      "summary": "You won",
+      "footer_bottom": "Funds will be added to your available balance",
+      "footer_top": "Winnings from {{count}} markets"
+    },
     "unlimited": "Illimité",
     "all": "Tout",
     "none": "Aucun",
@@ -5469,12 +5538,15 @@
     "points": "Points estimés",
     "points_tooltip": "Points",
     "points_tooltip_content_1": "Les points vous permettent de gagner des récompenses MetaMask lorsque vous effectuez des transactions, par exemple lorsque vous échangez, transférez ou tradez des contrats à terme.",
-    "points_tooltip_content_2": "Keep in mind this value is an estimate and will be finalized once the transaction is complete. Points can take up to 1 hour to be confirmed in your Rewards balance.",
+    "points_tooltip_content_2": "Gardez à l’esprit que cette valeur est une estimation et que la valeur finale sera déterminée une fois la transaction terminée. La confirmation des points dans votre solde de récompenses peut prendre jusqu’à 1 heure.",
     "unable_to_load": "Impossible de charger",
     "points_error": "Nous ne pouvons pas charger les points pour le moment",
-    "points_error_content": "You'll still earn any points for this transaction. We'll notify you once they've been added to your account. You can also check your rewards tab in about an hour.",
+    "points_error_content": "Vous gagnerez tout de même des points pour cette transaction. Nous vous informerons dès qu’ils auront été ajoutés à votre compte. Vous pouvez également consulter votre onglet « Récompenses » dans environ une  heure.",
     "see_other_quotes": "Voir d’autres cotations",
     "receive_at": "Recevoir à",
+    "recipient": "Recipient",
+    "select_recipient": "Select recipient",
+    "external_account": "External account",
     "error_banner_description": "Cette voie d’échange n’est pas disponible pour le moment. Essayez de modifier le montant, le réseau ou le jeton, et nous trouverons la meilleure option.",
     "insufficient_funds": "Fonds insuffisants",
     "insufficient_gas": "Gaz insuffisant",
@@ -5775,6 +5847,12 @@
       "update_to_store_link": "Mettez à jour MetaMask vers la dernière version",
       "well_take_you_to_right_place": " et nous vous redirigerons vers la bonne page."
     },
+    "unsupported": {
+      "title": "This page is not supported in current version",
+      "description": "Update to the latest version to use this feature",
+      "update_to_store_link": "Update to the latest version of MetaMask",
+      "well_take_you_to_right_place": " and we'll take you to the right place."
+    },
     "go_to_home_button": "Accéder à la page d’accueil",
     "back_button": "Retour",
     "continue_button": "Continuer"
@@ -5791,7 +5869,96 @@
     "card_onboarding": {
       "title": "Bienvenue sur la carte",
       "description": "Pour utiliser les fonctionnalités de la carte, vous devez vérifier votre compte auprès de notre partenaire.",
-      "verify_account_button": "Vérifier le compte"
+      "verify_account_button": "Vérifier le compte",
+      "sign_up": {
+        "title": "Sign-up",
+        "description": "Register your details with Crypto Life, the provider of MetaMask Card. You'll use this account to access and manage your card.",
+        "email_label": "Email",
+        "password_label": "Password",
+        "confirm_password_label": "Confirm password",
+        "country_label": "Country of Residence",
+        "email_placeholder": "Enter your email address",
+        "password_placeholder": "Enter your password",
+        "country_placeholder": "Select your country",
+        "password_mismatch": "Passwords do not match",
+        "invalid_email": "Invalid email address"
+      },
+      "confirm_email": {
+        "title": "Confirm your email",
+        "description": "We've sent a confirmation code to: {{email}}",
+        "confirm_code_label": "Confirmation code",
+        "confirm_code_placeholder": "Enter the confirmation code"
+      },
+      "set_phone_number": {
+        "title": "Phone number",
+        "description": "Enter your phone number",
+        "phone_number_label": "Phone number",
+        "phone_number_placeholder": "Enter your phone number",
+        "country_area_code_label": "Country area code",
+        "invalid_phone_number": "Invalid phone number",
+        "legal_terms": "By continuing, you agree to receiving SMS to verify your phone number."
+      },
+      "confirm_phone_number": {
+        "title": "Confirm your phone number",
+        "description": "We've sent a confirmation code to: {{phoneNumber}}",
+        "confirm_code_label": "Confirmation code"
+      },
+      "verify_identity": {
+        "title": "Verifying your identity to get your card",
+        "description": "To keep your account secure and comply with regulations, we need to verify your identity.\n\nYou'll need a government-issued ID and a proof of address (like a utility bill or bank statement).\n\nVerification usually takes 5-30 minutes, and we'll notify you as soon as it's complete.",
+        "verify_button": "Verify now with Veriff"
+      },
+      "validating_kyc": {
+        "title": "Validating your KYC..."
+      },
+      "kyc_failed": {
+        "title": "Rejected",
+        "description": "Your KYC was rejected. Please try again."
+      },
+      "personal_details": {
+        "title": "Personal details",
+        "description": "Enter your personal details",
+        "first_name_label": "First name",
+        "last_name_label": "Last name",
+        "date_of_birth_label": "Date of birth",
+        "nationality_label": "Country of Nationality",
+        "ssn_label": "Social Security Number",
+        "first_name_placeholder": "Enter your first name",
+        "last_name_placeholder": "Enter your last name",
+        "date_of_birth_placeholder": "Enter your date of birth",
+        "nationality_placeholder": "Select your nationality",
+        "ssn_placeholder": "Enter your SSN",
+        "invalid_ssn": "Invalid SSN",
+        "invalid_date_of_birth": "Invalid date of birth",
+        "invalid_date_of_birth_underage": "You must be at least 18 years old"
+      },
+      "physical_address": {
+        "title": "Physical address",
+        "description": "Please provide your physical address",
+        "address_line_1_label": "Address line 1",
+        "address_line_2_label": "Address line 2",
+        "city_label": "City",
+        "state_label": "State",
+        "zip_code_label": "ZIP code",
+        "address_line_1_placeholder": "Enter your address line 1",
+        "address_line_2_placeholder": "Enter your address line 2",
+        "city_placeholder": "Enter your city",
+        "state_placeholder": "Enter your state",
+        "zip_code_placeholder": "Enter your ZIP code",
+        "same_mailing_address_label": "Physical address is the same as mailing address",
+        "electronic_consent": "I agree to the E-Sign Act Consent and Disclosure and to receive all communictions electronically."
+      },
+      "mailing_address": {
+        "title": "Mailing address",
+        "description": "Please provide your mailing address"
+      },
+      "complete": {
+        "title": "Approved!",
+        "description": "Your KYC was approved. You can now use your Card."
+      },
+      "continue_button": "Next",
+      "confirm_button": "Confirm",
+      "retry_button": "Try again"
     },
     "card_home": {
       "error_title": "Impossible de récupérer les données",
@@ -5799,9 +5966,36 @@
       "try_again": "Réessayez",
       "limited_spending_warning": "Votre capacité de dépense réelle pourrait être limitée. Pour ajuster votre limite, accédez à {{manageCard}}",
       "add_funds": "Ajouter des fonds",
+      "change_asset": "Change asset",
       "manage_card_options": {
+        "manage_spending_limit": "Manage spending limit",
+        "manage_spending_limit_description_restricted": "Restricted spending limit is on",
+        "manage_spending_limit_description_full": "Full spending access is on",
         "manage_card": "Gérer la carte",
-        "advanced_card_management_description": "Consulter les transactions, bloquer la carte, etc."
+        "advanced_card_management_description": "Detailed transactions, freeze card, and more"
+      }
+    },
+    "card_authentication": {
+      "title": "Log in to your Card account",
+      "location_button_text": "International",
+      "location_button_text_us": "US account",
+      "email_label": "Email",
+      "password_label": "Password",
+      "email_placeholder": "Enter your email address",
+      "password_placeholder": "Enter your password",
+      "login_button": "Log in",
+      "errors": {
+        "invalid_credentials": "Invalid login details",
+        "unknown_error": "Unknown error, please try again later",
+        "email_required": "Email is required",
+        "password_required": "Password is required",
+        "email_invalid": "Invalid email address",
+        "password_invalid": "Invalid password",
+        "invalid_email_or_password": "Invalid email or password, check your credentials and try again.",
+        "network_error": "Network error. Please check your connection and try again.",
+        "timeout_error": "Request timed out. Please check your connection and try again.",
+        "server_error": "Server error. Please try again later.",
+        "configuration_error": "Service is temporarily unavailable. Please try again later."
       }
     }
   },
@@ -5825,65 +6019,65 @@
     "close": "Fermer"
   },
   "rewards": {
-    "auth_fail_title": "Unknown Error.",
-    "auth_fail_description": "An unknown error occurred while authenticating this account with the rewards program. Please try again later.",
-    "failed_to_authenticate": "Failed to authenticate with rewards program",
+    "auth_fail_title": "Erreur inconnue.",
+    "auth_fail_description": "Une erreur inconnue s’est produite lors de l’authentification de ce compte auprès du programme de récompenses. Veuillez réessayer plus tard.",
+    "failed_to_authenticate": "Échec de l’authentification auprès du programme de récompenses",
     "not_implemented": "Bientôt disponible",
     "not_implemented_season_summary": "Récapitulatif de la période bientôt disponible",
     "optin_error": {
-      "title": "Opt-in failed",
-      "description": "Check your connection and try again."
+      "title": "Échec de l’inscription",
+      "description": "Vérifiez votre connexion et réessayez."
     },
     "season_status_error": {
-      "error_fetching_title": "Season balance couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Impossible de charger le solde de la saison",
+      "error_fetching_description": "Vérifiez votre connexion et réessayez.",
+      "retry_button": "Réessayer"
     },
     "active_boosts_error": {
-      "error_fetching_title": "Boosts couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Impossible de charger les boosts",
+      "error_fetching_description": "Vérifiez votre connexion et réessayez.",
+      "retry_button": "Réessayer"
     },
     "unlocked_rewards_error": {
-      "error_fetching_title": "Rewards couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Impossible de charger les récompenses",
+      "error_fetching_description": "Vérifiez votre connexion et réessayez.",
+      "retry_button": "Réessayer"
     },
     "upcoming_rewards_error": {
-      "error_fetching_title": "Rewards couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Impossible de charger les récompenses",
+      "error_fetching_description": "Vérifiez votre connexion et réessayez.",
+      "retry_button": "Réessayer"
     },
     "referral_details_error": {
-      "error_fetching_title": "Referral details couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Impossible de charger les détails du parrainage",
+      "error_fetching_description": "Vérifiez votre connexion et réessayez.",
+      "retry_button": "Réessayer"
     },
     "referral_validation_unknown_error": {
-      "title": "Referral code couldn’t be validated",
-      "description": "Check your connection and try again."
+      "title": "Impossible de valider le code de parrainage",
+      "description": "Vérifiez votre connexion et réessayez."
     },
     "active_activity_error": {
-      "error_fetching_title": "Activity couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Impossible de charger l’activité",
+      "error_fetching_description": "Vérifiez votre connexion et réessayez.",
+      "retry_button": "Réessayer"
     },
-    "solana_signup_not_supported": "Signing in to Rewards with Solana accounts is not supported yet. Please use an Ethereum account instead.",
+    "solana_signup_not_supported": "La connexion au programme de récompenses avec un compte Solana n’est pas encore prise en charge. Veuillez utiliser un compte Ethereum à la place.",
     "error_messages": {
-      "unknown_error": "Unknown error occurred",
-      "something_went_wrong": "Something went wrong. Please try again shortly.",
-      "account_already_registered": "This account is already registered with another Rewards profile. Please switch account to continue.",
-      "request_rejected": "You rejected the request.",
-      "failed_to_claim_reward": "Failed to claim reward. Please try again shortly.",
-      "service_not_available": "Service is not available at the moment. Please try again shortly."
+      "unknown_error": "Une erreur inconnue s’est produite",
+      "something_went_wrong": "Une erreur s’est produite. Veuillez réessayer dans quelques instants.",
+      "account_already_registered": "Ce compte est déjà enregistré avec un autre profil « Récompenses ». Veuillez changer de compte pour continuer.",
+      "request_rejected": "Vous avez rejeté la demande.",
+      "failed_to_claim_reward": "Impossible de réclamer la récompense. Veuillez réessayer dans quelques instants.",
+      "service_not_available": "Le service n’est pas disponible pour le moment. Veuillez réessayer dans quelques instants."
     },
     "claim_reward_error": {
-      "title": "Failed to claim reward"
+      "title": "Impossible de réclamer la récompense"
     },
     "accounts_opt_in_state_error": {
-      "error_fetching_title": "Accounts couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Impossible de charger les comptes",
+      "error_fetching_description": "Vérifiez votre connexion et réessayez.",
+      "retry_button": "Réessayer"
     },
     "referral_rewards_title": "Parrainages",
     "points": "Points",
@@ -5899,31 +6093,32 @@
     "tab_levels_title": "Niveaux",
     "referral_stats_earned_from_referrals": "Gagnés grâce aux parrainages",
     "referral_stats_referrals": "Parrainages",
-    "loading_activity": "Loading activity...",
-    "error_loading_activity": "Error loading activity",
-    "activity_empty_title": "No recent activity.",
-    "activity_empty_description": "Use MetaMask to earn points, level up, and unlock rewards.",
-    "activity_empty_link": "See ways to earn",
+    "loading_activity": "Chargement de l’activité…",
+    "error_loading_activity": "Une erreur s’est produite lors du chargement de l’activité",
+    "activity_empty_title": "Aucune activité récente.",
+    "activity_empty_description": "Utilisez MetaMask pour gagner des points, passer au niveau supérieur et débloquer des récompenses.",
+    "activity_empty_link": "Découvrez comment gagner des points",
     "events": {
-      "to": "to",
+      "to": "à",
       "type": {
         "swap": "Échanger",
         "perps": "Perps",
-        "referral": "Referral",
-        "referral_action": "Referral action",
-        "sign_up_bonus": "Sign up bonus",
-        "loyalty_bonus": "Loyalty bonus",
-        "one_time_bonus": "One-time bonus",
-        "open_position": "Opened position",
-        "close_position": "Closed position",
+        "card_spend": "Card spend",
+        "referral": "Parrainage",
+        "referral_action": "Action de parrainage",
+        "sign_up_bonus": "Bonus d’inscription",
+        "loyalty_bonus": "Bonus de fidélité",
+        "one_time_bonus": "Bonus unique",
+        "open_position": "Position ouverte",
+        "close_position": "Position fermée",
         "take_profit": "TP/SL",
         "stop_loss": "TP/SL",
-        "uncategorized_event": "Uncategorized event"
+        "uncategorized_event": "Événement non classé"
       },
       "date": "Date",
-      "account": "Account",
+      "account": "Compte",
       "bonus": "Bonus",
-      "details": "Details",
+      "details": "Détails",
       "points": "Points",
       "points_base": "Base",
       "points_boost": "Boost",
@@ -5931,107 +6126,109 @@
     },
     "onboarding": {
       "not_supported_region_title": "Région non prise en charge",
-      "not_supported_region_description": "Rewards are not supported in your region yet. We are working on expanding access, so check back later.",
-      "not_supported_hardware_account_title": "Account not supported",
-      "not_supported_hardware_account_description": "Hardware wallet accounts are not eligible to receive rewards yet. Please switch to a different account to proceed.",
-      "not_supported_account_type_title": "Account type not supported",
-      "not_supported_account_type_description": "Currently only internal Ethereum and Solana accounts can be opted into the Rewards program. Please switch to a different account to proceed.",
-      "not_supported_confirm_go_back": "Go back",
-      "not_supported_confirm_retry": "Retry",
-      "auth_fail_title": "Authentication Failed",
-      "auth_fail_description": "Unable to authenticate with the rewards program. Please check your connection and try again.",
-      "geo_check_fail_title": "Cannot determine opt-in eligibility",
-      "geo_check_fail_description": "We cannot determine if your country allows opting into the rewards program. Please check your connection and try again.",
+      "not_supported_region_description": "Les récompenses ne sont pas encore prises en charge dans votre région. Nous travaillons actuellement à l’élargissement de l’accès au programme des récompenses, veuillez donc revenir plus tard.",
+      "not_supported_hardware_account_title": "Compte non pris en charge",
+      "not_supported_hardware_account_description": "Les comptes de portefeuille matériel ne sont pas encore autorisés à recevoir des récompenses. Veuillez passer à un autre compte pour continuer.",
+      "not_supported_account_type_title": "Type de compte non pris en charge",
+      "not_supported_account_type_description": "Actuellement, seuls les comptes Ethereum et Solana internes peuvent participer au programme de récompenses. Veuillez passer à un autre compte pour continuer.",
+      "not_supported_confirm_go_back": "Retour",
+      "not_supported_confirm_retry": "Réessayer",
+      "auth_fail_title": "L’authentification a échoué",
+      "auth_fail_description": "Impossible d’authentifier le compte auprès du programme de récompenses. Veuillez vérifier votre connexion et réessayer.",
+      "geo_check_fail_title": "Impossible de déterminer l’éligibilité à l’adhésion",
+      "geo_check_fail_description": "Nous ne pouvons pas déterminer si votre pays autorise l’adhésion au programme de récompenses. Veuillez vérifier votre connexion et réessayer.",
       "gtm_title": "Les récompenses sont arrivées",
       "gtm_description": "Gagnez des points pour votre activité. \nProgressez à travers les niveaux pour débloquer des récompenses.",
       "gtm_confirm": "Commencer",
       "intro_title": "La saison 1 \nest lancée",
-      "intro_description": "Earn points for your activity. \nAdvance through levels to unlock rewards.",
-      "intro_confirm": "Claim 250 points",
-      "intro_confirm_geo_loading": "Checking region...",
-      "checking_opt_in": "Checking accounts...",
-      "redirecting_to_dashboard": "Redirecting...",
+      "intro_description": "Gagnez des points pour votre activité. \nProgressez à travers les niveaux pour débloquer des récompenses.",
+      "intro_confirm": "Réclamer 250 points",
+      "intro_confirm_geo_loading": "Vérification de la région…",
+      "checking_opt_in": "Vérification des comptes…",
+      "redirecting_to_dashboard": "Redirection…",
       "intro_skip": "Pas maintenant",
       "step_confirm": "Suivant",
-      "step_skip": "Skip",
-      "step1_title": "Earn points on every trade",
+      "step_skip": "Ignorer",
+      "step1_title": "Gagnez des points sur chaque transaction",
       "step1_description": "Chaque échange que vous effectuez et chaque contrat à terme perpétuel que vous tradez dans MetaMask vous rapproche des récompenses. Ajoutez vos comptes et regardez vos points s’accumuler.",
-      "step2_title": "Level up for bigger perks",
+      "step2_title": "Passez au niveau supérieur pour bénéficier d’avantages plus importants",
       "step2_description": "Atteignez des niveaux de points pour obtenir des avantages tels que 50 % de réduction sur les frais de trading de contrats à terme perpétuels, des jetons exclusifs et une carte MetaMask Metal gratuite.",
-      "step3_title": "Exclusive seasonal rewards",
-      "step3_description": "Each season brings new perks. Join in, compete, and claim what you can before time runs out.",
-      "step4_title": "You'll earn 250 points when you sign up!",
-      "step4_title_referral_validating": "Validating referral code...",
-      "step4_referral_input_placeholder": "Referral code (optional)",
-      "step4_referral_input_error": "Invalid referral code",
-      "step4_confirm": "Claim points",
-      "step4_confirm_loading": "Claiming points...",
-      "step4_linking_accounts": "Adding accounts... ({{current}}/{{total}})",
-      "step4_linking_accounts_loading": "Adding additional accounts...",
-      "step4_success_description": "You have successfully signed up for MetaMask Rewards!",
-      "step4_legal_disclaimer_1": "By selecting 'Claim Points', you agree to the MetaMask Rewards",
-      "step4_legal_disclaimer_2": "Supplemental Terms of Use and Privacy Notice",
-      "step4_legal_disclaimer_3": ". We'll track onchain activity to reward you automatically –",
-      "step4_legal_disclaimer_4": "learn more"
+      "step3_title": "Récompenses saisonnières exclusives",
+      "step3_description": "Chaque saison apporte de nouveaux avantages. Participez, rivalisez et réclamez ce que vous pouvez avant la fin du temps imparti.",
+      "step4_title": "Vous gagnerez 250 points quand vous vous inscrirez !",
+      "step4_title_referral_bonus": "You'll earn 500 points when you sign up with this code!",
+      "step4_title_referral_validating": "Validation du code de parrainage…",
+      "step4_referral_bonus_description": "Use a referral code to earn 250 more",
+      "step4_referral_input_placeholder": "Code de parrainage (facultatif)",
+      "step4_referral_input_error": "Code de parrainage non valide",
+      "step4_confirm": "Réclamer des points",
+      "step4_confirm_loading": "Réclamation des points…",
+      "step4_linking_accounts": "Ajout des comptes… ({{current}}/{{total}})",
+      "step4_linking_accounts_loading": "Ajout de comptes supplémentaires…",
+      "step4_success_description": "Vous vous êtes inscrit avec succès à MetaMask Rewards !",
+      "step4_legal_disclaimer_1": "En sélectionnant « Réclamer des points », vous acceptez les",
+      "step4_legal_disclaimer_2": "Conditions d’utilisation supplémentaires et avis de confidentialité de MetaMask Rewards",
+      "step4_legal_disclaimer_3": ". Nous suivrons votre activité sur la chaîne pour vous récompenser automatiquement –",
+      "step4_legal_disclaimer_4": "en savoir plus"
     },
     "settings": {
-      "title": "Rewards Settings",
-      "subtitle": "Accounts",
-      "description": "Add multiple accounts to combine your points and unlock rewards faster.",
-      "tab_linked_accounts": "Added ({{count}})",
-      "tab_unlinked_accounts": "Not added ({{count}})",
-      "no_linked_accounts": "No accounts opted in",
-      "all_accounts_linked_title": "All accounts opted in",
-      "all_accounts_linked_description": "You have added all your accounts to Rewards.",
-      "link_account_success_title": "{{accountName}} successfully added",
-      "link_account_error_title": "Failed to add account",
-      "link_account_button": "Add",
-      "link_account_failed_error": "Failed to link account",
-      "link_account_unknown_error": "Unknown error occurred"
+      "title": "Paramètres des récompenses",
+      "subtitle": "Comptes",
+      "description": "Ajoutez plusieurs comptes pour combiner vos points et débloquer des récompenses plus rapidement.",
+      "tab_linked_accounts": "Ajouté ({{count}})",
+      "tab_unlinked_accounts": "Non ajouté ({{count}})",
+      "no_linked_accounts": "Aucun compte inscrit",
+      "all_accounts_linked_title": "Tous les comptes sont inscrits",
+      "all_accounts_linked_description": "Vous avez ajouté tous vos comptes à Rewards.",
+      "link_account_success_title": "{{accountName}} ajouté avec succès",
+      "link_account_error_title": "Échec de l’ajout du compte",
+      "link_account_button": "Ajouter",
+      "link_account_failed_error": "Échec de la liaison du compte",
+      "link_account_unknown_error": "Une erreur inconnue s’est produite"
     },
     "optout": {
-      "title": "Opt out of Rewards",
-      "description": "This will remove your accounts from the Rewards program and erase your points and progress. You won't be able to undo this.",
-      "confirm": "Opt out",
+      "title": "Se désinscrire de Rewards",
+      "description": "Cela supprimera vos comptes du programme « Rewards », et effacera vos points et votre progression. Vous ne pourrez pas annuler cette action.",
+      "confirm": "Se désinscrire",
       "modal": {
-        "confirmation_title": "Are you sure?",
-        "confirmation_description": "This will remove all your progress, and can't be reversed. If you rejoin the Rewards program later, you'll start back at 0.",
-        "cancel": "Cancel",
-        "confirm": "Confirm",
-        "error_message": "Failed to opt out of Rewards. Please try again.",
-        "processing": "Processing..."
+        "confirmation_title": "En êtes-vous sûr(e) ?",
+        "confirmation_description": "Cette opération supprimera toute votre progression et ne pourra pas être annulée. Si vous rejoignez le programme « Rewards » ultérieurement, vous repartirez de zéro.",
+        "cancel": "Annuler",
+        "confirm": "Confirmer",
+        "error_message": "Échec de la désinscription du programme « Rewards ». Veuillez réessayer.",
+        "processing": "Traitement en cours..."
       }
     },
-    "toast_dismiss": "Dismiss",
+    "toast_dismiss": "Ignorer",
     "dashboard_modal_info": {
       "active_account": {
-        "title": "Don't miss out",
-        "description": "Add your account to start earning points from your activity.",
-        "confirm": "Add account"
+        "title": "Ne manquez pas cette occasion",
+        "description": "Ajoutez votre compte pour commencer à gagner des points grâce à votre activité.",
+        "confirm": "Ajouter un compte"
       },
       "multiple_unlinked_accounts": {
-        "title": "Start earning points",
-        "description": "Add your accounts so you can track your rewards at a glance.",
-        "confirm": "Add accounts"
+        "title": "Commencez à gagner des points",
+        "description": "Ajoutez vos comptes afin de pouvoir consulter vos récompenses en un coup d’œil.",
+        "confirm": "Ajouter les comptes"
       },
       "account_not_supported": {
-        "title": "Account not supported",
-        "description_hardware": "Hardware wallet accounts are not yet eligible to earn points. Please switch to a different account to proceed.",
-        "description_general": "Currently only non-hardware internal Ethereum and Solana accounts are eligible to earn points. Please switch to a different account to proceed.",
-        "confirm": "Go back"
+        "title": "Compte non pris en charge",
+        "description_hardware": "Les comptes de portefeuille matériel ne sont pas encore autorisés à gagner des points. Veuillez passer à un autre compte pour continuer.",
+        "description_general": "Actuellement, seuls les comptes Ethereum et Solana internes non matériels peuvent gagner des points. Veuillez passer à un autre compte pour continuer.",
+        "confirm": "Retour"
       }
     },
     "ways_to_earn": {
-      "title": "Ways to earn",
-      "supported_networks": "Supported Networks",
+      "title": "Façons de gagner des points",
+      "supported_networks": "Réseaux pris en charge",
       "swap": {
-        "title": "Swap",
-        "description": "80 points per $100",
+        "title": "Échanger",
+        "description": "80 points par tranche de 100 $",
         "sheet": {
-          "title": "Swap tokens",
-          "points": "80 points per $100",
-          "description": "Swap tokens on supported networks to earn points for every dollar you trade.",
-          "cta_label": "Start a swap"
+          "title": "Échanger des jetons",
+          "points": "80 points par tranche de 100 $",
+          "description": "Échangez des jetons sur les réseaux pris en charge pour gagner des points pour chaque dollar que vous échangez.",
+          "cta_label": "Commencer un swap"
         }
       },
       "perps": {
@@ -6045,52 +6242,74 @@
         }
       },
       "referrals": {
-        "title": "Refer friends",
-        "description": "10 points per 50 from friends"
+        "title": "Parrainez des amis",
+        "description": "10 points pour chaque tranche de 50 points gagnés par vos amis",
+        "sheet": {
+          "title": "Refer a friend",
+          "points": "20 points per 100",
+          "cta_label": "Refer a friend"
+        }
       },
       "loyalty": {
-        "title": "Loyalty bonus",
-        "description": "Earn points from past trades",
+        "title": "Bonus de fidélité",
+        "description": "Gagnez des points grâce à vos échanges passés",
         "sheet": {
-          "title": "Loyalty bonus",
-          "points": "250 points per $1250",
-          "description": "Add accounts with past swaps or bridges in MetaMask to earn loyalty bonuses. Each eligible account unlocks points in increments of 250, up to a total of 50,000. Bonuses appear shortly after you add an account.",
-          "cta_label": "Add accounts"
+          "title": "Bonus de fidélité",
+          "points": "250 points par tranche de 1250 $",
+          "description": "Ajoutez des comptes ayant effectué des échanges ou établis des passerelles dans MetaMask pour gagner des bonus de fidélité. Chaque compte admissible débloque des points par tranches de 250 points, jusqu’à un total de 50 000 points. Les bonus apparaissent peu après l’ajout d’un compte.",
+          "cta_label": "Ajouter des comptes"
+        }
+      },
+      "card": {
+        "title": "MetaMask Card",
+        "description": "1 point per $1 spent",
+        "sheet": {
+          "title": "MetaMask Card",
+          "points": "1 point per $1 spent",
+          "description": "Earn points every time you use your MetaMask Card for purchases, plus 1% cash back (3% for Metal cardholders).",
+          "cta_label": "Manage Card"
         }
       }
     },
     "referral": {
-      "referral_code": "Referral code",
-      "referral_link": "Referral link",
+      "referral_code": "Code de parrainage",
+      "referral_link": "Lien de parrainage",
       "actions": {
         "share_referral_link": "Parrainer un ami",
         "share_referral_subject": "Rejoignez MetaMask Rewards"
       },
       "info": {
         "title": "Partagez votre code pour gagner plus",
-        "description": "Your friends get a 2x sign up bonus. You get 10 points for every 50 they earn from trading."
+        "description": "Vos amis obtiennent un bonus d’inscription doublé. Vous obtenez 10 points pour chaque tranche de 50 points qu’ils gagnent grâce à leurs transactions."
       }
     },
-    "active_boosts_title": "Active boosts",
-    "season_1": "Season 1",
+    "link_account_group": {
+      "link_account": "Add account",
+      "tracked": "Tracked",
+      "untracked": "Untracked",
+      "link_account_success": "{{accountName}} added successfully",
+      "link_account_error": "Failed to add one or more addresses for {{accountName}}"
+    },
+    "active_boosts_title": "Boosts actifs",
+    "season_1": "Saison 1",
     "upcoming_rewards": {
       "title": "Récompenses verrouillées",
-      "points_needed": "{{points}} points",
+      "points_needed": "{{points}} points",
       "cta_label": "D’accord",
-      "alpha_fox_invite_input_placeholder": "Your Telegram handle"
+      "alpha_fox_invite_input_placeholder": "Votre identifiant Telegram"
     },
     "unlocked_rewards": {
-      "title": "Unlocked rewards",
-      "cta_label": "Claim now",
-      "cta_request_invite": "Request invite",
-      "claim_label": "Claim",
-      "claimed_label": "Claimed",
-      "reward_claimed": "Reward claimed",
+      "title": "Récompenses débloquées",
+      "cta_label": "Réclamer maintenant",
+      "cta_request_invite": "Demander une invitation",
+      "claim_label": "Réclamer",
+      "claimed_label": "Réclamé",
+      "reward_claimed": "Récompense réclamée",
       "time_left": "Il reste",
-      "expired": "Expired"
+      "expired": "Expiré"
     },
     "animation": {
-      "could_not_load": "Couldn't load"
+      "could_not_load": "Impossible de charger"
     }
   },
   "time": {
@@ -6099,7 +6318,7 @@
   },
   "transaction_details": {
     "title": {
-      "perps_deposit": "Funded Perps account",
+      "perps_deposit": "Compte de trading de contrats à terme financé",
       "predict_deposit": "Funded Predict account",
       "default": "Détails de la transaction"
     },
@@ -6107,19 +6326,23 @@
       "bridge_fee": "Frais de passerelle",
       "network_fee": "Frais de réseau",
       "paid_with": "Payé avec",
+      "retry_button": "Try again",
       "total": "Total"
     },
     "summary_title": {
-      "bridge": "Passerelle établie entre {{sourceSymbol}} et {{targetSymbol}}",
       "bridge_approval": "Approuver {{approveSymbol}}",
       "bridge_approval_loading": "Approuver",
-      "bridge_loading": "Établir une passerelle",
+      "bridge_send": "Bridge {{sourceSymbol}} from {{sourceChain}}",
+      "bridge_send_loading": "Bridge Send",
+      "bridge_receive": "Receive {{targetSymbol}} on {{targetChain}}",
+      "bridge_receive_loading": "Bridge Receive",
       "default": "Transaction",
       "perps_deposit": "Ajouter des fonds",
       "predict_deposit": "Add funds",
       "swap": "Échanger des jetons",
       "swap_approval": "Approuver les jetons"
-    }
+    },
+    "perps_deposit_solution": "You now have {{fiat}} of USDC on Arbitrum. Try your deposit again."
   },
   "sdk_connect_v2": {
     "show_loading": {

--- a/locales/languages/hi.json
+++ b/locales/languages/hi.json
@@ -594,7 +594,9 @@
       "unexpectedError": "एक अनपेक्षित गड़बड़ी हुई।",
       "quoteFetchError": "कोटेशन प्राप्त नहीं हो पाया।",
       "kycFormsFetchError": "KYC फॉर्म प्राप्त नहीं हो पाया।",
-      "title": "डिपॉज़िट करें"
+      "title": "डिपॉज़िट करें",
+      "limitExceeded": "This deposit would exceed your {{period}} limit. Your deposit including fees must be {{remaining}} or less.",
+      "limitError": "Failed to check your deposit limits. Please try again later."
     },
     "token_modal": {
       "select_a_token": "एक टोकन चुनें",
@@ -892,7 +894,7 @@
     "withdraw": "निकालें",
     "refresh_balance": "बैलेंस रीफ्रेश करें",
     "add_funds": "फंड जोड़ें",
-    "deposit_in_progress": "Deposit in progress",
+    "deposit_in_progress": "डिपॉज़िट प्रगति में है",
     "your_positions": "आपकी पोज़िशन्स",
     "loading_positions": "पोजीशन्स लोड हो रही है...",
     "refreshing_positions": "पोज़िशन्स को रीफ़्रेश किया जा रहा है…",
@@ -1277,6 +1279,7 @@
       "assetMappingFailed": "एसेट मैपिंग बनाना नहीं हो पाया",
       "depositFailed": "डिपॉज़िट नहीं हो पाया",
       "orderLeverageReductionFailed": "आप अपनी लीवरेज को कम नहीं कर सकते",
+      "connectionTimeout": "Connection timed out. Please check your network and try again.",
       "connectionFailed": {
         "title": "पर्प्स अस्थायी रूप से ऑफ़लाइन है",
         "description": "हम इसे जल्द ही ऑनलाइन लाने के लिए काम कर रहे हैं।",
@@ -1348,9 +1351,9 @@
         "error_message": "मार्केट डाटा नहीं मिला। कृपया वापस जाएँ और फिर से प्रयास करें।"
       },
       "statistics": "ओवरव्यू",
-      "24h_high": "24h high",
-      "24h_low": "24h low",
-      "24h_volume": "24h volume",
+      "24h_high": "24 घंटे का उच्च",
+      "24h_low": "24 घंटे का निम्न",
+      "24h_volume": "24 घंटे का वॉल्यूम",
       "open_interest": "ओपन इंटरेस्ट",
       "funding_rate": "फंडिंग रेट",
       "countdown": "उलटी गिनती",
@@ -1510,9 +1513,9 @@
         "metamask_fee": "MetaMask फीस",
         "hyperliquid_fee": "हाइपरलिक्विड फीस",
         "total_fee": "कुल फीस",
-        "liquidated": "Liquidated",
-        "take_profit": "Take profit",
-        "stop_loss": "Stop loss"
+        "liquidated": "लिक्विडेट किया गया",
+        "take_profit": "टेक प्रॉफ़िट",
+        "stop_loss": "स्टॉप लॉस"
       },
       "funding": {
         "date": "तिथि",
@@ -1525,7 +1528,7 @@
         "history_will_appear": "आपका ट्रेडिंग इतिहास यहां दिखाई देगा"
       }
     },
-    "risk_disclaimer": "Perpetual contracts are very risky, and you could suddenly and without notice lose your entire investment. You trade entirely at your own risk. Market data provided by Hyperliquid. Price chart powered by",
+    "risk_disclaimer": "Perpetual contracts are very risky, and you could suddenly and without notice lose your entire investment. You trade entirely at your own risk. Market data provided by Hyperliquid. Price chart powered by",
     "tutorial": {
       "continue": "जारी रखें",
       "skip": "छोड़ें",
@@ -1555,11 +1558,11 @@
       "ready_to_trade": {
         "title": "ट्रेड करने के लिए तैयार हैं?",
         "description": "अपने पर्प्स अकाउंट को किसी भी टोकन से फंड करें और सेकंडों में अपना पहला ट्रेड करें।",
-        "footer_text": "MetaMask आपके फंड को Arbitrum पर USDC में स्वैप करेगा और बिना किसी अतिरिक्त फीस के उन्हें HyperCore में डिपॉज़िट करेगा।"
+        "footer_text": "MetaMask will swap your funds to USDC on Arbitrum, and deposit them onto HyperCore for no added fee."
       },
       "got_it": "समझ गए",
       "card": {
-        "title": "Learn the basics of perps"
+        "title": "पर्प्स की मूल बातें सीखें"
       }
     },
     "points": "पॉइंट्स",
@@ -1576,10 +1579,10 @@
     "market_list": "मार्केट लिस्ट",
     "market_details": "मार्केट का विवरण",
     "tab": {
-      "no_predictions": "अभी तक कोई प्रेडिक्शन नहीं",
-      "no_predictions_description": "शुरू करने के लिए एक प्रेडिक्शन खोलें।",
-      "explore": "मार्केट एक्सप्लोर करें",
-      "new_prediction": "नया प्रेडिक्शन"
+      "no_predictions_description": "Your predictions will appear here, showing your stake and market movement.",
+      "explore": "Browse markets",
+      "new_prediction": "नया प्रेडिक्शन",
+      "resolved_markets": "Resolved markets"
     },
     "sell_position": "सेल पोज़िशन",
     "cash_out": "कैश आउट",
@@ -1609,16 +1612,73 @@
     "claim_button": "क्लेम करें",
     "markets_won": "मार्केट जीते",
     "won_markets_text": "{{count}} मार्केट{{s}} जीते",
-    "won_markets_text_singular": "{{count}} मार्केट जीते",
-    "won_markets_text_plural": "{{count}} मार्केट जीते",
+    "available_balance": "Available balance",
     "claim_amount_text": "${{amount}} क्लेम करें",
     "unrealized_pnl_label": "अनरियलाइज्ड P&L",
     "unrealized_pnl_value": "{{amount}} ({{percent}})",
+    "unrealized_pnl_error": "Unable to load",
     "unavailable": {
       "title": "Unavailable in your region",
       "description": "Predictions aren't available in your region due to legal restrictions.",
       "link": "See Polymarket terms",
       "button": "Got it"
+    },
+    "deposit": {
+      "in_progress": "Deposit in progress",
+      "adding_funds": "Adding funds",
+      "adding_your_funds": "Adding your funds",
+      "add_funds": "Add funds",
+      "withdraw": "Withdraw",
+      "estimated_processing_time": "Est. {{time}} seconds",
+      "account_ready": "Your account is ready",
+      "account_ready_description": "{{amount}} added to your balance",
+      "error_title": "Something went wrong",
+      "error_description": "Your account wasn't funded",
+      "try_again": "Try again"
+    },
+    "add_funds_sheet": {
+      "title": "Add funds",
+      "description": "You'll need to add funds to your Predictions account to get started. You can add any token and make your first prediction in seconds."
+    },
+    "transactions": {
+      "title": "Predictions",
+      "no_transactions": "No recent activity",
+      "buy_title": "Predicted",
+      "sell_title": "Cashed out",
+      "claim_title": "Claimed winnings",
+      "buy_detail": "Bought {{amountUsd}} on {{outcome}} · {{priceCents}} per share",
+      "sell_detail": "Sold at {{priceCents}} per share",
+      "claim_detail": "Claimed winnings",
+      "not_available": "N/A",
+      "date": "Date",
+      "market": "Market",
+      "outcome": "Outcome",
+      "predicted_amount": "Predicted amount",
+      "shares_bought": "Shares bought",
+      "shares_sold": "Shares sold",
+      "price_per_share": "Price per share",
+      "price_impact": "Price impact",
+      "net_pnl": "Net P&L",
+      "total_net_pnl": "Total Net P&L",
+      "market_net_pnl": "Market Net P&L",
+      "activity_details": "Activity details"
+    },
+    "claim": {
+      "toasts": {
+        "pending": {
+          "title": "Claiming {{amount}}",
+          "description": "Est. {{time}} seconds"
+        },
+        "confirmed": {
+          "title": "Claimed",
+          "description": "{{amount}} added to your balance"
+        },
+        "error": {
+          "title": "Something went wrong",
+          "description": "Failed to proceed with claim",
+          "try_again": "Try again"
+        }
+      }
     }
   },
   "receive": {
@@ -3093,6 +3153,7 @@
     "tx_review_lending_withdraw": "विदड्रॉवल उधार दिया जा रहा है",
     "tx_review_perps_deposit": "फंडेड पर्प्स अकाउंट",
     "tx_review_predict_deposit": "Funded Predict account",
+    "tx_review_predict_claim": "Claimed Predict winnings",
     "sent_ether": "Ether भेजे गए",
     "self_sent_ether": "खुद को Ether भेजें",
     "received_ether": "Ether प्राप्त किया",
@@ -3939,7 +4000,9 @@
     "wallet_connect_dapps_cta": "सेशन देखें",
     "network_not_supported": "वर्तमान नेटवर्क समर्थन नहीं करता",
     "select_provider": "अपना पसंदीदा प्रदाता चुनें",
-    "switch_network": "कृपया Mainnet या sepolia पर बदलें"
+    "switch_network": "कृपया Mainnet या sepolia पर बदलें",
+    "card_title": "Always show MetaMask Card button",
+    "card_desc": "MetaMask Card is only available to residents of select countries"
   },
   "walletconnect_sessions": {
     "no_active_sessions": "आपके पास सक्रिय सत्र नहीं हैं",
@@ -5315,7 +5378,7 @@
     },
     "tooltip": {
       "perps_deposit": {
-        "transaction_fee": "हम आपके टोकन को HyperCore पर USDC में स्वैप करेंगे, जो पर्प्स द्वारा इस्तेमाल होने वाला नेटवर्क है। स्वैप प्रदाता फीस ले सकते हैं, लेकिन MetaMask कोई फीस नहीं लेगा।"
+        "transaction_fee": "We'll swap your tokens for USDC on HyperCore, the network used by Perps. Swap providers may charge a fee, but MetaMask won't."
       },
       "predict_deposit": {
         "transaction_fee": "We'll swap your tokens for USDC.e on Polygon, the network used by Predict. Swap providers may charge a fee, but MetaMask won't."
@@ -5407,6 +5470,12 @@
       "save": "सेव करें",
       "title": "एप्रूवल लिमिट बदलें"
     },
+    "predict_claim": {
+      "button_label": "Claim winnings",
+      "summary": "You won",
+      "footer_bottom": "Funds will be added to your available balance",
+      "footer_top": "Winnings from {{count}} markets"
+    },
     "unlimited": "असीमित",
     "all": "सभी",
     "none": "कोई नहीं",
@@ -5469,12 +5538,15 @@
     "points": "अनुमानित पॉइंट्स",
     "points_tooltip": "पॉइंट्स",
     "points_tooltip_content_1": "Points are how you earn MetaMask Rewards for completing transactions, like when you swap, bridge, or trade perps.",
-    "points_tooltip_content_2": "Keep in mind this value is an estimate and will be finalized once the transaction is complete. Points can take up to 1 hour to be confirmed in your Rewards balance.",
+    "points_tooltip_content_2": "ध्यान रखें कि यह मूल्य केवल एक अनुमान है और ट्रांसेक्शन पूरा होने के बाद अंतिम रूप दिया जाएगा। आपके रिवॉर्ड्स बैलेंस में पॉइंट्स कन्फर्म होने में 1 घंटे तक का समय लग सकता है।",
     "unable_to_load": "लोड करने में असमर्थ",
     "points_error": "हम अभी पॉइंट्स लोड नहीं कर सकते",
-    "points_error_content": "You'll still earn any points for this transaction. We'll notify you once they've been added to your account. You can also check your rewards tab in about an hour.",
+    "points_error_content": "आप इस ट्रांसेक्शन के लिए अभी भी पॉइंट्स अर्जित करेंगे। जब ये आपके अकाउंट में जोड़ दिए जाएंगे, तब हम आपको सूचित करेंगे। आप लगभग एक घंटे में अपने रिवॉर्ड्स टैब में भी जांच सकते हैं।",
     "see_other_quotes": "अन्य कोटेशन देखें",
     "receive_at": "यहां प्राप्त करें",
+    "recipient": "Recipient",
+    "select_recipient": "Select recipient",
+    "external_account": "External account",
     "error_banner_description": "यह ट्रेड रूट अभी उपलब्ध नहीं है। राशि, नेटवर्क या टोकन बदलने का प्रयास करें और हम सबसे अच्छा विकल्प ढूँढ लेंगे।",
     "insufficient_funds": "अपर्याप्त फंड",
     "insufficient_gas": "अपर्याप्त गैस",
@@ -5775,6 +5847,12 @@
       "update_to_store_link": "MetaMask के लेटेस्ट वर्शन में अपडेट करें",
       "well_take_you_to_right_place": " और हम आपको सही स्थान पर ले चलेंगे।"
     },
+    "unsupported": {
+      "title": "This page is not supported in current version",
+      "description": "Update to the latest version to use this feature",
+      "update_to_store_link": "Update to the latest version of MetaMask",
+      "well_take_you_to_right_place": " and we'll take you to the right place."
+    },
     "go_to_home_button": "होम पेज पर जाएं",
     "back_button": "वापस",
     "continue_button": "जारी रखें"
@@ -5791,7 +5869,96 @@
     "card_onboarding": {
       "title": "कार्ड में आपका स्वागत है",
       "description": "कार्ड संबंधी फीचर्स का उपयोग करने के लिए, आपको हमारे पार्टनर के साथ अपना अकाउंट वेरिफ़ाई करना होगा।",
-      "verify_account_button": "अकाउंट वेरिफ़ाई करें"
+      "verify_account_button": "अकाउंट वेरिफ़ाई करें",
+      "sign_up": {
+        "title": "Sign-up",
+        "description": "Register your details with Crypto Life, the provider of MetaMask Card. You'll use this account to access and manage your card.",
+        "email_label": "Email",
+        "password_label": "Password",
+        "confirm_password_label": "Confirm password",
+        "country_label": "Country of Residence",
+        "email_placeholder": "Enter your email address",
+        "password_placeholder": "Enter your password",
+        "country_placeholder": "Select your country",
+        "password_mismatch": "Passwords do not match",
+        "invalid_email": "Invalid email address"
+      },
+      "confirm_email": {
+        "title": "Confirm your email",
+        "description": "We've sent a confirmation code to: {{email}}",
+        "confirm_code_label": "Confirmation code",
+        "confirm_code_placeholder": "Enter the confirmation code"
+      },
+      "set_phone_number": {
+        "title": "Phone number",
+        "description": "Enter your phone number",
+        "phone_number_label": "Phone number",
+        "phone_number_placeholder": "Enter your phone number",
+        "country_area_code_label": "Country area code",
+        "invalid_phone_number": "Invalid phone number",
+        "legal_terms": "By continuing, you agree to receiving SMS to verify your phone number."
+      },
+      "confirm_phone_number": {
+        "title": "Confirm your phone number",
+        "description": "We've sent a confirmation code to: {{phoneNumber}}",
+        "confirm_code_label": "Confirmation code"
+      },
+      "verify_identity": {
+        "title": "Verifying your identity to get your card",
+        "description": "To keep your account secure and comply with regulations, we need to verify your identity.\n\nYou'll need a government-issued ID and a proof of address (like a utility bill or bank statement).\n\nVerification usually takes 5-30 minutes, and we'll notify you as soon as it's complete.",
+        "verify_button": "Verify now with Veriff"
+      },
+      "validating_kyc": {
+        "title": "Validating your KYC..."
+      },
+      "kyc_failed": {
+        "title": "Rejected",
+        "description": "Your KYC was rejected. Please try again."
+      },
+      "personal_details": {
+        "title": "Personal details",
+        "description": "Enter your personal details",
+        "first_name_label": "First name",
+        "last_name_label": "Last name",
+        "date_of_birth_label": "Date of birth",
+        "nationality_label": "Country of Nationality",
+        "ssn_label": "Social Security Number",
+        "first_name_placeholder": "Enter your first name",
+        "last_name_placeholder": "Enter your last name",
+        "date_of_birth_placeholder": "Enter your date of birth",
+        "nationality_placeholder": "Select your nationality",
+        "ssn_placeholder": "Enter your SSN",
+        "invalid_ssn": "Invalid SSN",
+        "invalid_date_of_birth": "Invalid date of birth",
+        "invalid_date_of_birth_underage": "You must be at least 18 years old"
+      },
+      "physical_address": {
+        "title": "Physical address",
+        "description": "Please provide your physical address",
+        "address_line_1_label": "Address line 1",
+        "address_line_2_label": "Address line 2",
+        "city_label": "City",
+        "state_label": "State",
+        "zip_code_label": "ZIP code",
+        "address_line_1_placeholder": "Enter your address line 1",
+        "address_line_2_placeholder": "Enter your address line 2",
+        "city_placeholder": "Enter your city",
+        "state_placeholder": "Enter your state",
+        "zip_code_placeholder": "Enter your ZIP code",
+        "same_mailing_address_label": "Physical address is the same as mailing address",
+        "electronic_consent": "I agree to the E-Sign Act Consent and Disclosure and to receive all communictions electronically."
+      },
+      "mailing_address": {
+        "title": "Mailing address",
+        "description": "Please provide your mailing address"
+      },
+      "complete": {
+        "title": "Approved!",
+        "description": "Your KYC was approved. You can now use your Card."
+      },
+      "continue_button": "Next",
+      "confirm_button": "Confirm",
+      "retry_button": "Try again"
     },
     "card_home": {
       "error_title": "डेटा प्राप्त नहीं किया जा सकता",
@@ -5799,9 +5966,36 @@
       "try_again": "फिर से कोशिश करें",
       "limited_spending_warning": "आपकी वास्तविक खर्च करने की क्षमता सीमित हो सकती है। अपनी सीमा समायोजित करने के लिए, {{manageCard}} पर जाएँ",
       "add_funds": "फंड जोड़ें",
+      "change_asset": "Change asset",
       "manage_card_options": {
+        "manage_spending_limit": "Manage spending limit",
+        "manage_spending_limit_description_restricted": "Restricted spending limit is on",
+        "manage_spending_limit_description_full": "Full spending access is on",
         "manage_card": "कार्ड प्रबंधित करें",
-        "advanced_card_management_description": "ट्रांसेक्शन देखें, कार्ड फ़्रीज़ करें, और बहुत कुछ"
+        "advanced_card_management_description": "Detailed transactions, freeze card, and more"
+      }
+    },
+    "card_authentication": {
+      "title": "Log in to your Card account",
+      "location_button_text": "International",
+      "location_button_text_us": "US account",
+      "email_label": "Email",
+      "password_label": "Password",
+      "email_placeholder": "Enter your email address",
+      "password_placeholder": "Enter your password",
+      "login_button": "Log in",
+      "errors": {
+        "invalid_credentials": "Invalid login details",
+        "unknown_error": "Unknown error, please try again later",
+        "email_required": "Email is required",
+        "password_required": "Password is required",
+        "email_invalid": "Invalid email address",
+        "password_invalid": "Invalid password",
+        "invalid_email_or_password": "Invalid email or password, check your credentials and try again.",
+        "network_error": "Network error. Please check your connection and try again.",
+        "timeout_error": "Request timed out. Please check your connection and try again.",
+        "server_error": "Server error. Please try again later.",
+        "configuration_error": "Service is temporarily unavailable. Please try again later."
       }
     }
   },
@@ -5825,65 +6019,65 @@
     "close": "बंद करें"
   },
   "rewards": {
-    "auth_fail_title": "Unknown Error.",
-    "auth_fail_description": "An unknown error occurred while authenticating this account with the rewards program. Please try again later.",
-    "failed_to_authenticate": "Failed to authenticate with rewards program",
+    "auth_fail_title": "अज्ञात गड़बड़ी।",
+    "auth_fail_description": "इस अकाउंट को रिवॉर्ड्स प्रोग्राम के साथ प्रमाणित करते समय एक अज्ञात गड़बड़ी हुई। कृपया बाद में फिर से प्रयास करें।",
+    "failed_to_authenticate": "रिवॉर्ड्स प्रोग्राम के साथ प्रमाणीकरण नहीं हो पाया",
     "not_implemented": "जल्द आ रहा है",
     "not_implemented_season_summary": "सीज़न सारांश जल्द ही आ रहा है",
     "optin_error": {
-      "title": "Opt-in failed",
-      "description": "Check your connection and try again."
+      "title": "ऑप्ट-इन नहीं हो पाया",
+      "description": "अपना कनेक्शन जांचें और फिर से प्रयास करें।"
     },
     "season_status_error": {
-      "error_fetching_title": "Season balance couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "सीज़न बैलेंस लोड नहीं हो सका",
+      "error_fetching_description": "अपना कनेक्शन जांचें और फिर से प्रयास करें।",
+      "retry_button": "फिर से प्रयास करें"
     },
     "active_boosts_error": {
-      "error_fetching_title": "Boosts couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "बूस्ट्स लोड नहीं हो सके",
+      "error_fetching_description": "अपना कनेक्शन जांचें और फिर से प्रयास करें।",
+      "retry_button": "फिर से प्रयास करें"
     },
     "unlocked_rewards_error": {
-      "error_fetching_title": "Rewards couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "रिवॉर्ड्स लोड नहीं हो सके",
+      "error_fetching_description": "अपना कनेक्शन जांचें और फिर से प्रयास करें।",
+      "retry_button": "फिर से प्रयास करें"
     },
     "upcoming_rewards_error": {
-      "error_fetching_title": "Rewards couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "रिवॉर्ड्स लोड नहीं हो सके",
+      "error_fetching_description": "अपना कनेक्शन जांचें और फिर से प्रयास करें।",
+      "retry_button": "फिर से प्रयास करें"
     },
     "referral_details_error": {
-      "error_fetching_title": "Referral details couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "रेफरल विवरण लोड नहीं हो सके",
+      "error_fetching_description": "अपना कनेक्शन जांचें और फिर से प्रयास करें।",
+      "retry_button": "फिर से प्रयास करें"
     },
     "referral_validation_unknown_error": {
-      "title": "Referral code couldn’t be validated",
-      "description": "Check your connection and try again."
+      "title": "रेफरल कोड मान्य नहीं किया जा सका",
+      "description": "अपना कनेक्शन जांचें और फिर से प्रयास करें।"
     },
     "active_activity_error": {
-      "error_fetching_title": "Activity couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "गतिविधि लोड नहीं हो सकी",
+      "error_fetching_description": "अपना कनेक्शन जांचें और फिर से प्रयास करें।",
+      "retry_button": "फिर से प्रयास करें"
     },
-    "solana_signup_not_supported": "Signing in to Rewards with Solana accounts is not supported yet. Please use an Ethereum account instead.",
+    "solana_signup_not_supported": "Solana एकाउंट्स के साथ रिवॉर्ड्स में साइन इन करना अभी सपोर्टेड नहीं है। कृपया इसके बजाय Ethereum अकाउंट उपयोग करें।",
     "error_messages": {
-      "unknown_error": "Unknown error occurred",
-      "something_went_wrong": "Something went wrong. Please try again shortly.",
-      "account_already_registered": "This account is already registered with another Rewards profile. Please switch account to continue.",
-      "request_rejected": "You rejected the request.",
-      "failed_to_claim_reward": "Failed to claim reward. Please try again shortly.",
-      "service_not_available": "Service is not available at the moment. Please try again shortly."
+      "unknown_error": "अज्ञात गड़बड़ी हुई",
+      "something_went_wrong": "कुछ गलत हो गया। कृपया थोड़ी देर में फिर से कोशिश करें।",
+      "account_already_registered": "यह अकाउंट पहले ही किसी अन्य रिवॉर्ड्स प्रोफ़ाइल के साथ पंजीकृत है। जारी रखने के लिए कृपया अकाउंट बदलें।",
+      "request_rejected": "आपने अनुरोध रिजेक्ट कर दिया।",
+      "failed_to_claim_reward": "रिवॉर्ड क्लेम नहीं हो पाया। कृपया थोड़ी देर में फिर से प्रयास करें।",
+      "service_not_available": "सेवा इस समय उपलब्ध नहीं है। कृपया थोड़ी देर में फिर से प्रयास करें।"
     },
     "claim_reward_error": {
-      "title": "Failed to claim reward"
+      "title": "रिवॉर्ड क्लेम नहीं हो पाया"
     },
     "accounts_opt_in_state_error": {
-      "error_fetching_title": "Accounts couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "एकाउंट्स को लोड नहीं किया जा सका",
+      "error_fetching_description": "अपना कनेक्शन जांचें और फिर से प्रयास करें।",
+      "retry_button": "फिर से प्रयास करें"
     },
     "referral_rewards_title": "रेफरल",
     "points": "पॉइंट्स",
@@ -5899,139 +6093,142 @@
     "tab_levels_title": "लेवल",
     "referral_stats_earned_from_referrals": "रेफरल से अर्जित",
     "referral_stats_referrals": "रेफरल",
-    "loading_activity": "Loading activity...",
-    "error_loading_activity": "Error loading activity",
-    "activity_empty_title": "No recent activity.",
-    "activity_empty_description": "Use MetaMask to earn points, level up, and unlock rewards.",
-    "activity_empty_link": "See ways to earn",
+    "loading_activity": "गतिविधि लोड हो रही है…",
+    "error_loading_activity": "गतिविधि लोड करने में गड़बड़ी हुई",
+    "activity_empty_title": "हाल ही में कोई गतिविधि नहीं।",
+    "activity_empty_description": "पॉइंट्स कमाने, स्तर बढ़ाने, और रिवॉर्ड्स अनलॉक करने के लिए MetaMask का उपयोग करें।",
+    "activity_empty_link": "कमाने के तरीके देखें",
     "events": {
-      "to": "to",
+      "to": "प्रति",
       "type": {
         "swap": "स्वैप करें",
         "perps": "पर्प्स",
-        "referral": "Referral",
-        "referral_action": "Referral action",
-        "sign_up_bonus": "Sign up bonus",
-        "loyalty_bonus": "Loyalty bonus",
-        "one_time_bonus": "One-time bonus",
-        "open_position": "Opened position",
-        "close_position": "Closed position",
+        "card_spend": "Card spend",
+        "referral": "रेफरल",
+        "referral_action": "रेफरल क्रिया",
+        "sign_up_bonus": "साइन अप बोनस",
+        "loyalty_bonus": "लोयल्टी बोनस",
+        "one_time_bonus": "वन-टाइम बोनस",
+        "open_position": "खुली पोज़िशन",
+        "close_position": "बंद पोज़िशन",
         "take_profit": "TP/SL",
         "stop_loss": "TP/SL",
-        "uncategorized_event": "Uncategorized event"
+        "uncategorized_event": "अवर्गीकृत इवेंट"
       },
-      "date": "Date",
-      "account": "Account",
-      "bonus": "Bonus",
-      "details": "Details",
-      "points": "Points",
-      "points_base": "Base",
-      "points_boost": "Boost",
-      "points_total": "Total"
+      "date": "तिथि",
+      "account": "अकाउंट",
+      "bonus": "बोनस",
+      "details": "विवरण",
+      "points": "पॉइंट्स",
+      "points_base": "बेस",
+      "points_boost": "बूस्ट",
+      "points_total": "कुल"
     },
     "onboarding": {
       "not_supported_region_title": "क्षेत्र सपोर्टेड नहीं है",
-      "not_supported_region_description": "Rewards are not supported in your region yet. We are working on expanding access, so check back later.",
-      "not_supported_hardware_account_title": "Account not supported",
-      "not_supported_hardware_account_description": "Hardware wallet accounts are not eligible to receive rewards yet. Please switch to a different account to proceed.",
-      "not_supported_account_type_title": "Account type not supported",
-      "not_supported_account_type_description": "Currently only internal Ethereum and Solana accounts can be opted into the Rewards program. Please switch to a different account to proceed.",
-      "not_supported_confirm_go_back": "Go back",
-      "not_supported_confirm_retry": "Retry",
-      "auth_fail_title": "Authentication Failed",
-      "auth_fail_description": "Unable to authenticate with the rewards program. Please check your connection and try again.",
-      "geo_check_fail_title": "Cannot determine opt-in eligibility",
-      "geo_check_fail_description": "We cannot determine if your country allows opting into the rewards program. Please check your connection and try again.",
+      "not_supported_region_description": "आपके क्षेत्र में रिवॉर्ड्स अभी सपोर्टेड नहीं हैं। हम पहुंच बढ़ाने पर काम कर रहे हैं, इसलिए बाद में फिर से जाँच करें।",
+      "not_supported_hardware_account_title": "अकाउंट सपोर्टेड नहीं है",
+      "not_supported_hardware_account_description": "हार्डवेयर वॉलेट एकाउंट्स अभी रिवॉर्ड्स प्राप्त करने के लिए योग्य नहीं हैं। जारी रखने के लिए कृपया किसी अन्य अकाउंट का उपयोग करें।",
+      "not_supported_account_type_title": "अकाउंट प्रकार सपोर्टेड नहीं है",
+      "not_supported_account_type_description": "वर्तमान में केवल आंतरिक Ethereum और Solana एकाउंट्स को ही रिवॉर्ड्स प्रोग्राम में शामिल किया जा सकता है। जारी रखने के लिए कृपया किसी अन्य अकाउंट का उपयोग करें।",
+      "not_supported_confirm_go_back": "वापस जाएं",
+      "not_supported_confirm_retry": "फिर से प्रयास करें",
+      "auth_fail_title": "प्रमाणीकरण नहीं हो पाया",
+      "auth_fail_description": "रिवॉर्ड्स प्रोग्राम के साथ प्रमाणीकरण नहीं हो सका। कृपया अपना कनेक्शन जांचें और फिर से प्रयास करें।",
+      "geo_check_fail_title": "ऑप्ट-इन पात्रता निर्धारित नहीं की जा सकती",
+      "geo_check_fail_description": "हम यह निर्धारित नहीं कर सकते कि आपका देश रिवॉर्ड्स प्रोग्राम में ऑप्ट-इन की अनुमति देता है या नहीं। कृपया अपना कनेक्शन जांचें और फिर से कोशिश करें।",
       "gtm_title": "रिवॉर्ड्स उपलब्ध हैं",
       "gtm_description": "अपनी गतिविधि के लिए पॉइंट्स कमाएं। \nलेवल बढ़ाएं और रिवॉर्ड्स अनलॉक करें।",
       "gtm_confirm": "शुरू करें",
       "intro_title": "सीज़न 1 \nलाइव है",
-      "intro_description": "Earn points for your activity. \nAdvance through levels to unlock rewards.",
-      "intro_confirm": "Claim 250 points",
-      "intro_confirm_geo_loading": "Checking region...",
-      "checking_opt_in": "Checking accounts...",
-      "redirecting_to_dashboard": "Redirecting...",
+      "intro_description": "अपनी गतिविधि के लिए पॉइंट्स कमाएं। \nलेवल बढ़ाएं और रिवॉर्ड्स अनलॉक करें।",
+      "intro_confirm": "250 पॉइंट्स क्लेम करें",
+      "intro_confirm_geo_loading": "क्षेत्र की जांच की जा रही है…",
+      "checking_opt_in": "एकाउंट्स की जांच की जा रही है…",
+      "redirecting_to_dashboard": "रीडायरेक्ट किया जा रहा है...",
       "intro_skip": "अभी नहीं",
       "step_confirm": "आगे",
-      "step_skip": "Skip",
-      "step1_title": "Earn points on every trade",
+      "step_skip": "छोड़ें",
+      "step1_title": "हर ट्रेड पर पॉइंट्स कमाएं",
       "step1_description": "MetaMask में किया गया हर स्वैप और पर्प्स ट्रेड आपको रिवॉर्ड्स के करीब ले जाता है। अपने एकाउंट्स जोड़ें और अपने पॉइंट्स को बढ़ते हुए देखें।",
-      "step2_title": "Level up for bigger perks",
+      "step2_title": "बड़े पर्क्स के लिए स्तर बढ़ाएं",
       "step2_description": "पॉइंट्स माइलस्टोन हिट करें और ऐसे लाभ पाएं जैसे पर्प्स फीस में 50% की छूट, एक्सक्लूसिव टोकन और एक मुफ्त MetaMask मेटल कार्ड।",
-      "step3_title": "Exclusive seasonal rewards",
-      "step3_description": "Each season brings new perks. Join in, compete, and claim what you can before time runs out.",
-      "step4_title": "You'll earn 250 points when you sign up!",
-      "step4_title_referral_validating": "Validating referral code...",
-      "step4_referral_input_placeholder": "Referral code (optional)",
-      "step4_referral_input_error": "Invalid referral code",
-      "step4_confirm": "Claim points",
-      "step4_confirm_loading": "Claiming points...",
-      "step4_linking_accounts": "Adding accounts... ({{current}}/{{total}})",
-      "step4_linking_accounts_loading": "Adding additional accounts...",
-      "step4_success_description": "You have successfully signed up for MetaMask Rewards!",
-      "step4_legal_disclaimer_1": "By selecting 'Claim Points', you agree to the MetaMask Rewards",
-      "step4_legal_disclaimer_2": "Supplemental Terms of Use and Privacy Notice",
-      "step4_legal_disclaimer_3": ". We'll track onchain activity to reward you automatically –",
-      "step4_legal_disclaimer_4": "learn more"
+      "step3_title": "विशेष मौसमी रिवॉर्ड्स",
+      "step3_description": "हर सीज़न नए पर्क्स लाता है। इसमें शामिल हों, प्रतिस्पर्धा करें, और समय खत्म होने से पहले जितना हो सके क्लेम करें।",
+      "step4_title": "साइन अप करने पर आप 250 पॉइंट्स कमाएँगे!",
+      "step4_title_referral_bonus": "You'll earn 500 points when you sign up with this code!",
+      "step4_title_referral_validating": "रेफरल कोड मान्य किया जा रहा है…",
+      "step4_referral_bonus_description": "Use a referral code to earn 250 more",
+      "step4_referral_input_placeholder": "रेफरल कोड (वैकल्पिक)",
+      "step4_referral_input_error": "रेफरल कोड ग़लत है",
+      "step4_confirm": "पॉइंट्स क्लेम करें",
+      "step4_confirm_loading": "पॉइंट्स क्लेम किया जा रहा है...",
+      "step4_linking_accounts": "एकाउंट्स जोड़ा जा रहा है... ({{current}}/{{total}})",
+      "step4_linking_accounts_loading": "अतिरिक्त एकाउंट्स जोड़े जा रहे हैं...",
+      "step4_success_description": "आपने सफलतापूर्वक MetaMask रिवॉर्ड्स के लिए साइन अप कर लिया है!",
+      "step4_legal_disclaimer_1": "'पॉइंट्स क्लेम करें' चुनकर, आप MetaMask रिवॉर्ड्स",
+      "step4_legal_disclaimer_2": "के पूरक उपयोग की शर्तों और गोपनीयता नोटिस से सहमत होते हैं",
+      "step4_legal_disclaimer_3": "। हम ऑनचेन गतिविधि को ट्रैक करेंगे ताकि आपको स्वचालित रूप से रिवॉर्ड मिले –",
+      "step4_legal_disclaimer_4": "ज़्यादा जानें"
     },
     "settings": {
-      "title": "Rewards Settings",
-      "subtitle": "Accounts",
-      "description": "Add multiple accounts to combine your points and unlock rewards faster.",
-      "tab_linked_accounts": "Added ({{count}})",
-      "tab_unlinked_accounts": "Not added ({{count}})",
-      "no_linked_accounts": "No accounts opted in",
-      "all_accounts_linked_title": "All accounts opted in",
-      "all_accounts_linked_description": "You have added all your accounts to Rewards.",
-      "link_account_success_title": "{{accountName}} successfully added",
-      "link_account_error_title": "Failed to add account",
-      "link_account_button": "Add",
-      "link_account_failed_error": "Failed to link account",
-      "link_account_unknown_error": "Unknown error occurred"
+      "title": "रिवॉर्ड्स सेटिंग्स",
+      "subtitle": "एकाउंट्स",
+      "description": "कई एकाउंट्स जोड़ें ताकि आप अपने पॉइंट्स को मिलाकर तेजी से रिवॉर्ड्स अनलॉक कर सकें।",
+      "tab_linked_accounts": "जोड़ा गया ({{count}})",
+      "tab_unlinked_accounts": "नहीं जोड़ा गया ({{count}})",
+      "no_linked_accounts": "कोई अकाउंट ऑप्ट इन नहीं किया गया",
+      "all_accounts_linked_title": "सभी एकाउंट्स ऑप्ट इन किए गए",
+      "all_accounts_linked_description": "आपने अपने सभी एकाउंट्स रिवॉर्ड्स में जोड़ दिए हैं।",
+      "link_account_success_title": "{{accountName}} सफलतापूर्वक जोड़ा गया",
+      "link_account_error_title": "अकाउंट जोड़ना नहीं हो पाया",
+      "link_account_button": "जोड़ें",
+      "link_account_failed_error": "अकाउंट लिंक करना नहीं हो पाया",
+      "link_account_unknown_error": "अज्ञात गड़बड़ी हुई"
     },
     "optout": {
-      "title": "Opt out of Rewards",
-      "description": "This will remove your accounts from the Rewards program and erase your points and progress. You won't be able to undo this.",
-      "confirm": "Opt out",
+      "title": "रिवॉर्ड्स से ऑप्ट आउट करें",
+      "description": "यह आपके एकाउंट्स को रिवॉर्ड्स प्रोग्राम से हटा देगा और आपके पॉइंट्स और प्रगति को मिटा देगा। आप इसे वापस नहीं ला पाएंगे।",
+      "confirm": "ऑप्ट आउट करें",
       "modal": {
-        "confirmation_title": "Are you sure?",
-        "confirmation_description": "This will remove all your progress, and can't be reversed. If you rejoin the Rewards program later, you'll start back at 0.",
-        "cancel": "Cancel",
-        "confirm": "Confirm",
-        "error_message": "Failed to opt out of Rewards. Please try again.",
-        "processing": "Processing..."
+        "confirmation_title": "क्या आप सुनिश्चित हैं?",
+        "confirmation_description": "इससे आपकी सभी प्रगति हट जाएगी और इसे वापस नहीं लाया जा सकता। यदि आप बाद में रिवॉर्ड्स प्रोग्राम में फिर से शामिल होते हैं, तो आपकी शुरुआत फिर से 0 से होगी।",
+        "cancel": "कैंसिल करें",
+        "confirm": "कन्फर्म करें",
+        "error_message": "रिवॉर्ड्स से ऑप्ट आउट नहीं हो पाया। कृपया फिर से प्रयास करें।",
+        "processing": "प्रोसेस हो रहा है..."
       }
     },
-    "toast_dismiss": "Dismiss",
+    "toast_dismiss": "खारिज करें",
     "dashboard_modal_info": {
       "active_account": {
-        "title": "Don't miss out",
-        "description": "Add your account to start earning points from your activity.",
-        "confirm": "Add account"
+        "title": "चूकें नहीं",
+        "description": "अपना अकाउंट जोड़ें ताकि आप अपनी गतिविधियों से पॉइंट्स कमाना शुरू कर सकें।",
+        "confirm": "अकाउंट जोड़ें"
       },
       "multiple_unlinked_accounts": {
-        "title": "Start earning points",
-        "description": "Add your accounts so you can track your rewards at a glance.",
-        "confirm": "Add accounts"
+        "title": "पॉइंट्स कमाना शुरू करें",
+        "description": "अपने एकाउंट्स जोड़ें ताकि आप अपनी रिवॉर्ड्स को एक नजर में ट्रैक कर सकें।",
+        "confirm": "एकाउंट्स जोड़ें"
       },
       "account_not_supported": {
-        "title": "Account not supported",
-        "description_hardware": "Hardware wallet accounts are not yet eligible to earn points. Please switch to a different account to proceed.",
-        "description_general": "Currently only non-hardware internal Ethereum and Solana accounts are eligible to earn points. Please switch to a different account to proceed.",
-        "confirm": "Go back"
+        "title": "अकाउंट सपोर्टेड नहीं है",
+        "description_hardware": "हार्डवेयर वॉलेट एकाउंट्स अभी पॉइंट्स कमाने के लिए योग्य नहीं हैं। जारी रखने के लिए कृपया किसी अन्य अकाउंट का उपयोग करें।",
+        "description_general": "वर्तमान में केवल गैर-हार्डवेयर आंतरिक Ethereum और Solana एकाउंट्स ही पॉइंट्स कमाने के लिए योग्य हैं। जारी रखने के लिए कृपया किसी अन्य अकाउंट का उपयोग करें।",
+        "confirm": "वापस जाएं"
       }
     },
     "ways_to_earn": {
-      "title": "Ways to earn",
-      "supported_networks": "Supported Networks",
+      "title": "कमाने के तरीके",
+      "supported_networks": "सपोर्टेड नेटवर्क",
       "swap": {
-        "title": "Swap",
-        "description": "80 points per $100",
+        "title": "स्वैप करें",
+        "description": "प्रति $800 पर 10 पॉइंट्स",
         "sheet": {
-          "title": "Swap tokens",
-          "points": "80 points per $100",
-          "description": "Swap tokens on supported networks to earn points for every dollar you trade.",
-          "cta_label": "Start a swap"
+          "title": "टोकन स्वैप करें",
+          "points": "प्रति $800 पर 10 पॉइंट्स",
+          "description": "सपोर्टेड नेटवर्क पर टोकन स्वैप करें और हर डॉलर के ट्रेड पर पॉइंट्स कमाएं।",
+          "cta_label": "एक स्वैप शुरू करें"
         }
       },
       "perps": {
@@ -6045,52 +6242,74 @@
         }
       },
       "referrals": {
-        "title": "Refer friends",
-        "description": "10 points per 50 from friends"
+        "title": "दोस्तों को रेफर करें",
+        "description": "दोस्तों से हर 50 पर 10 पॉइंट्स",
+        "sheet": {
+          "title": "Refer a friend",
+          "points": "20 points per 100",
+          "cta_label": "Refer a friend"
+        }
       },
       "loyalty": {
-        "title": "Loyalty bonus",
-        "description": "Earn points from past trades",
+        "title": "लोयल्टी बोनस",
+        "description": "पिछले ट्रेड्स से पॉइंट्स कमाएं",
         "sheet": {
-          "title": "Loyalty bonus",
-          "points": "250 points per $1250",
-          "description": "Add accounts with past swaps or bridges in MetaMask to earn loyalty bonuses. Each eligible account unlocks points in increments of 250, up to a total of 50,000. Bonuses appear shortly after you add an account.",
-          "cta_label": "Add accounts"
+          "title": "लोयल्टी बोनस",
+          "points": "प्रति $1250 पर 250 पॉइंट्स",
+          "description": "MetaMask में पिछले स्वैप या ब्रिज वाले एकाउंट्स जोड़ें ताकि आप लोयल्टी बोनस कमाएं। प्रत्येक पात्र अकाउंट 250 पॉइंट्स की वृद्धि में पॉइंट्स अनलॉक करता है, कुल मिलाकर 50,000 तक। एक अकाउंट जोड़ने के तुरंत बाद बोनस दिखाई देते हैं।",
+          "cta_label": "एकाउंट्स जोड़ें"
+        }
+      },
+      "card": {
+        "title": "MetaMask Card",
+        "description": "1 point per $1 spent",
+        "sheet": {
+          "title": "MetaMask Card",
+          "points": "1 point per $1 spent",
+          "description": "Earn points every time you use your MetaMask Card for purchases, plus 1% cash back (3% for Metal cardholders).",
+          "cta_label": "Manage Card"
         }
       }
     },
     "referral": {
-      "referral_code": "Referral code",
-      "referral_link": "Referral link",
+      "referral_code": "रेफरल कोड",
+      "referral_link": "रेफरल लिंक",
       "actions": {
         "share_referral_link": "एक मित्र को रेफर करें",
         "share_referral_subject": "MetaMask पुरस्कार में शामिल हों"
       },
       "info": {
         "title": "अधिक कमाने के लिए अपना कोड साझा करें",
-        "description": "Your friends get a 2x sign up bonus. You get 10 points for every 50 they earn from trading."
+        "description": "आपके दोस्तों को 2x साइन अप बोनस मिलता है। आप उनके ट्रेडिंग से कमाए गए हर 50 पर 10 पॉइंट्स पाते हैं।"
       }
     },
-    "active_boosts_title": "Active boosts",
-    "season_1": "Season 1",
+    "link_account_group": {
+      "link_account": "Add account",
+      "tracked": "Tracked",
+      "untracked": "Untracked",
+      "link_account_success": "{{accountName}} added successfully",
+      "link_account_error": "Failed to add one or more addresses for {{accountName}}"
+    },
+    "active_boosts_title": "सक्रिय बूस्ट्स",
+    "season_1": "सीज़न 1",
     "upcoming_rewards": {
       "title": "लॉक किए हुए रिवॉर्ड्स",
-      "points_needed": "{{points}} points",
-      "cta_label": "Got it",
-      "alpha_fox_invite_input_placeholder": "Your Telegram handle"
+      "points_needed": "{{points}} पॉइंट्स",
+      "cta_label": "समझ गए",
+      "alpha_fox_invite_input_placeholder": "आपका Telegram हैंडल"
     },
     "unlocked_rewards": {
-      "title": "Unlocked rewards",
-      "cta_label": "Claim now",
-      "cta_request_invite": "Request invite",
-      "claim_label": "Claim",
-      "claimed_label": "Claimed",
-      "reward_claimed": "Reward claimed",
+      "title": "अनलॉक किए हुए रिवॉर्ड्स",
+      "cta_label": "अभी क्लेम करें",
+      "cta_request_invite": "निमंत्रण का अनुरोध करें",
+      "claim_label": "क्लेम करें",
+      "claimed_label": "क्लेम किया गया",
+      "reward_claimed": "रिवॉर्ड क्लेम किया गया",
       "time_left": "बचा है",
-      "expired": "Expired"
+      "expired": "एक्सपायर हो गया"
     },
     "animation": {
-      "could_not_load": "Couldn't load"
+      "could_not_load": "लोड नहीं हो सका"
     }
   },
   "time": {
@@ -6099,7 +6318,7 @@
   },
   "transaction_details": {
     "title": {
-      "perps_deposit": "Funded Perps account",
+      "perps_deposit": "फंडेड पर्प्स अकाउंट",
       "predict_deposit": "Funded Predict account",
       "default": "ट्रांसेक्शन संबंधी विवरण"
     },
@@ -6107,19 +6326,23 @@
       "bridge_fee": "ब्रिज फीस",
       "network_fee": "नेटवर्क फीस",
       "paid_with": "के साथ भुगतान किया गया",
+      "retry_button": "Try again",
       "total": "कुल"
     },
     "summary_title": {
-      "bridge": "{{sourceSymbol}} से {{targetSymbol}} पर ब्रिज करें",
       "bridge_approval": "{{approveSymbol}} एप्रूव करें",
       "bridge_approval_loading": "एप्रूव करें",
-      "bridge_loading": "ब्रिज करें",
+      "bridge_send": "Bridge {{sourceSymbol}} from {{sourceChain}}",
+      "bridge_send_loading": "Bridge Send",
+      "bridge_receive": "Receive {{targetSymbol}} on {{targetChain}}",
+      "bridge_receive_loading": "Bridge Receive",
       "default": "ट्रांसेक्शन",
       "perps_deposit": "फंड जोड़ें",
       "predict_deposit": "Add funds",
       "swap": "टोकन स्वैप करें",
       "swap_approval": "टोकन एप्रूव करें"
-    }
+    },
+    "perps_deposit_solution": "You now have {{fiat}} of USDC on Arbitrum. Try your deposit again."
   },
   "sdk_connect_v2": {
     "show_loading": {

--- a/locales/languages/id.json
+++ b/locales/languages/id.json
@@ -594,7 +594,9 @@
       "unexpectedError": "Terjadi kesalahan tidak terduga.",
       "quoteFetchError": "Gagal mengambil kuotasi.",
       "kycFormsFetchError": "Gagal mengambil formulir KYC.",
-      "title": "Deposit"
+      "title": "Deposit",
+      "limitExceeded": "This deposit would exceed your {{period}} limit. Your deposit including fees must be {{remaining}} or less.",
+      "limitError": "Failed to check your deposit limits. Please try again later."
     },
     "token_modal": {
       "select_a_token": "Pilih Token",
@@ -892,7 +894,7 @@
     "withdraw": "Tarik",
     "refresh_balance": "Segarkan Saldo",
     "add_funds": "Tambahkan dana",
-    "deposit_in_progress": "Deposit in progress",
+    "deposit_in_progress": "Deposit sedang diproses",
     "your_positions": "Posisi Anda",
     "loading_positions": "Memuat posisi...",
     "refreshing_positions": "Menyegarkan posisi...",
@@ -1277,6 +1279,7 @@
       "assetMappingFailed": "Gagal membuat pemetaan aset",
       "depositFailed": "Deposit gagal",
       "orderLeverageReductionFailed": "Anda tidak dapat mengurangi leverage",
+      "connectionTimeout": "Connection timed out. Please check your network and try again.",
       "connectionFailed": {
         "title": "Perp sedang offline untuk sementara",
         "description": "Kami sedang berupaya agar dapat segera kembali online.",
@@ -1348,9 +1351,9 @@
         "error_message": "Data pasar tidak ditemukan. Kembali dan coba lagi."
       },
       "statistics": "Ikhtisar",
-      "24h_high": "24h high",
-      "24h_low": "24h low",
-      "24h_volume": "24h volume",
+      "24h_high": "Tinggi 24 jam",
+      "24h_low": "Rendah 24 jam",
+      "24h_volume": "Volume 24 jam",
       "open_interest": "Kontrak terbuka",
       "funding_rate": "Tingkat pendanaan",
       "countdown": "Hitung mundur",
@@ -1510,7 +1513,7 @@
         "metamask_fee": "Biaya MetaMask",
         "hyperliquid_fee": "Biaya Hyperliquid",
         "total_fee": "Total biaya",
-        "liquidated": "Liquidated",
+        "liquidated": "Dilikuidasi",
         "take_profit": "Take profit",
         "stop_loss": "Stop loss"
       },
@@ -1525,7 +1528,7 @@
         "history_will_appear": "Riwayat perdagangan Anda akan muncul di sini"
       }
     },
-    "risk_disclaimer": "Perpetual contracts are very risky, and you could suddenly and without notice lose your entire investment. You trade entirely at your own risk. Market data provided by Hyperliquid. Price chart powered by",
+    "risk_disclaimer": "Perpetual contracts are very risky, and you could suddenly and without notice lose your entire investment. You trade entirely at your own risk. Market data provided by Hyperliquid. Price chart powered by",
     "tutorial": {
       "continue": "Lanjutkan",
       "skip": "Lewati",
@@ -1555,11 +1558,11 @@
       "ready_to_trade": {
         "title": "Siap untuk berdagang?",
         "description": "Danai akun perp Anda dengan token apa pun dan lakukan perdagangan pertama dalam hitungan detik.",
-        "footer_text": "MetaMask akan menukar dana Anda ke USDC di Arbitrum, dan mendepositkan ke HyperCore tanpa biaya tambahan."
+        "footer_text": "MetaMask will swap your funds to USDC on Arbitrum, and deposit them onto HyperCore for no added fee."
       },
       "got_it": "Mengerti",
       "card": {
-        "title": "Learn the basics of perps"
+        "title": "Pelajari dasar-dasar perp"
       }
     },
     "points": "Poin",
@@ -1576,10 +1579,10 @@
     "market_list": "Daftar Pasar",
     "market_details": "Detail Pasar",
     "tab": {
-      "no_predictions": "Belum ada prediksi",
-      "no_predictions_description": "Buka prediksi untuk memulai.",
-      "explore": "Jelajahi pasar",
-      "new_prediction": "Prediksi baru"
+      "no_predictions_description": "Your predictions will appear here, showing your stake and market movement.",
+      "explore": "Browse markets",
+      "new_prediction": "Prediksi baru",
+      "resolved_markets": "Resolved markets"
     },
     "sell_position": "Posisi Jual",
     "cash_out": "Uang Tunai",
@@ -1609,16 +1612,73 @@
     "claim_button": "Klaim",
     "markets_won": "Pasar menang",
     "won_markets_text": "Memenangkan {{count}} pasar{{s}}",
-    "won_markets_text_singular": "Memenangkan {{count}} pasar",
-    "won_markets_text_plural": "Memenangkan {{count}} pasar",
+    "available_balance": "Available balance",
     "claim_amount_text": "Klaim ${{amount}}",
     "unrealized_pnl_label": "P&L Belum Terealisasi",
     "unrealized_pnl_value": "{{amount}} ({{percent}})",
+    "unrealized_pnl_error": "Unable to load",
     "unavailable": {
       "title": "Unavailable in your region",
       "description": "Predictions aren't available in your region due to legal restrictions.",
       "link": "See Polymarket terms",
       "button": "Got it"
+    },
+    "deposit": {
+      "in_progress": "Deposit in progress",
+      "adding_funds": "Adding funds",
+      "adding_your_funds": "Adding your funds",
+      "add_funds": "Add funds",
+      "withdraw": "Withdraw",
+      "estimated_processing_time": "Est. {{time}} seconds",
+      "account_ready": "Your account is ready",
+      "account_ready_description": "{{amount}} added to your balance",
+      "error_title": "Something went wrong",
+      "error_description": "Your account wasn't funded",
+      "try_again": "Try again"
+    },
+    "add_funds_sheet": {
+      "title": "Add funds",
+      "description": "You'll need to add funds to your Predictions account to get started. You can add any token and make your first prediction in seconds."
+    },
+    "transactions": {
+      "title": "Predictions",
+      "no_transactions": "No recent activity",
+      "buy_title": "Predicted",
+      "sell_title": "Cashed out",
+      "claim_title": "Claimed winnings",
+      "buy_detail": "Bought {{amountUsd}} on {{outcome}} · {{priceCents}} per share",
+      "sell_detail": "Sold at {{priceCents}} per share",
+      "claim_detail": "Claimed winnings",
+      "not_available": "N/A",
+      "date": "Date",
+      "market": "Market",
+      "outcome": "Outcome",
+      "predicted_amount": "Predicted amount",
+      "shares_bought": "Shares bought",
+      "shares_sold": "Shares sold",
+      "price_per_share": "Price per share",
+      "price_impact": "Price impact",
+      "net_pnl": "Net P&L",
+      "total_net_pnl": "Total Net P&L",
+      "market_net_pnl": "Market Net P&L",
+      "activity_details": "Activity details"
+    },
+    "claim": {
+      "toasts": {
+        "pending": {
+          "title": "Claiming {{amount}}",
+          "description": "Est. {{time}} seconds"
+        },
+        "confirmed": {
+          "title": "Claimed",
+          "description": "{{amount}} added to your balance"
+        },
+        "error": {
+          "title": "Something went wrong",
+          "description": "Failed to proceed with claim",
+          "try_again": "Try again"
+        }
+      }
     }
   },
   "receive": {
@@ -3093,6 +3153,7 @@
     "tx_review_lending_withdraw": "Penarikan Pinjaman",
     "tx_review_perps_deposit": "Akun Perp yang didanai",
     "tx_review_predict_deposit": "Funded Predict account",
+    "tx_review_predict_claim": "Claimed Predict winnings",
     "sent_ether": "Mengirim Ether",
     "self_sent_ether": "Mengirim Ether ke Diri Sendiri",
     "received_ether": "Menerima Ether",
@@ -3939,7 +4000,9 @@
     "wallet_connect_dapps_cta": "Lihat sesi",
     "network_not_supported": "Tidak mendukung jaringan saat ini",
     "select_provider": "Pilih penyedia favorit Anda",
-    "switch_network": "Harap beralih ke mainnet atau sepolia"
+    "switch_network": "Harap beralih ke mainnet atau sepolia",
+    "card_title": "Always show MetaMask Card button",
+    "card_desc": "MetaMask Card is only available to residents of select countries"
   },
   "walletconnect_sessions": {
     "no_active_sessions": "Anda tidak memiliki sesi aktif",
@@ -5315,7 +5378,7 @@
     },
     "tooltip": {
       "perps_deposit": {
-        "transaction_fee": "Kami akan menukar token Anda dengan USDC di HyperCore, jaringan yang digunakan oleh Perp. Penyedia swap mungkin akan mengenakan biaya, tetapi MetaMask tidak."
+        "transaction_fee": "We'll swap your tokens for USDC on HyperCore, the network used by Perps. Swap providers may charge a fee, but MetaMask won't."
       },
       "predict_deposit": {
         "transaction_fee": "We'll swap your tokens for USDC.e on Polygon, the network used by Predict. Swap providers may charge a fee, but MetaMask won't."
@@ -5407,6 +5470,12 @@
       "save": "Simpan",
       "title": "Edit batas persetujuan"
     },
+    "predict_claim": {
+      "button_label": "Claim winnings",
+      "summary": "You won",
+      "footer_bottom": "Funds will be added to your available balance",
+      "footer_top": "Winnings from {{count}} markets"
+    },
     "unlimited": "Tak terbatas",
     "all": "Semua",
     "none": "Kosong",
@@ -5469,12 +5538,15 @@
     "points": "Estimasi poin",
     "points_tooltip": "Poin",
     "points_tooltip_content_1": "Points are how you earn MetaMask Rewards for completing transactions, like when you swap, bridge, or trade perps.",
-    "points_tooltip_content_2": "Keep in mind this value is an estimate and will be finalized once the transaction is complete. Points can take up to 1 hour to be confirmed in your Rewards balance.",
+    "points_tooltip_content_2": "Ingatlah bahwa nilai ini merupakan estimasi dan akan difinalisasi setelah transaksi selesai. Poin dapat membutuhkan waktu hingga 1 jam untuk dikonfirmasi di saldo Reward Anda.",
     "unable_to_load": "Tidak dapat memuat",
     "points_error": "Kami tidak dapat memuat poin saat ini",
-    "points_error_content": "You'll still earn any points for this transaction. We'll notify you once they've been added to your account. You can also check your rewards tab in about an hour.",
+    "points_error_content": "Anda tetap akan memperoleh poin untuk transaksi ini. Kami akan memberi tahu Anda setelah poin ditambahkan ke akun. Anda juga dapat memeriksa tab reward dalam waktu satu jam.",
     "see_other_quotes": "Lihat kuotasi lainnya",
     "receive_at": "Terima di",
+    "recipient": "Recipient",
+    "select_recipient": "Select recipient",
+    "external_account": "External account",
     "error_banner_description": "Rute perdagangan ini tidak tersedia untuk saat ini. Coba ubah jumlah, jaringan, atau token, dan kami akan mencari opsi terbaik.",
     "insufficient_funds": "Dana tidak cukup",
     "insufficient_gas": "Gas tidak cukup",
@@ -5775,6 +5847,12 @@
       "update_to_store_link": "Perbarui ke versi terkini MetaMask",
       "well_take_you_to_right_place": " dan kami akan membawa Anda ke tempat yang tepat."
     },
+    "unsupported": {
+      "title": "This page is not supported in current version",
+      "description": "Update to the latest version to use this feature",
+      "update_to_store_link": "Update to the latest version of MetaMask",
+      "well_take_you_to_right_place": " and we'll take you to the right place."
+    },
     "go_to_home_button": "Buka halaman beranda",
     "back_button": "Kembali",
     "continue_button": "Lanjutkan"
@@ -5791,7 +5869,96 @@
     "card_onboarding": {
       "title": "Selamat datang di Card",
       "description": "Untuk menggunakan fitur card, Anda perlu memverifikasi akun dengan mitra kami.",
-      "verify_account_button": "Verifikasikan akun"
+      "verify_account_button": "Verifikasikan akun",
+      "sign_up": {
+        "title": "Sign-up",
+        "description": "Register your details with Crypto Life, the provider of MetaMask Card. You'll use this account to access and manage your card.",
+        "email_label": "Email",
+        "password_label": "Password",
+        "confirm_password_label": "Confirm password",
+        "country_label": "Country of Residence",
+        "email_placeholder": "Enter your email address",
+        "password_placeholder": "Enter your password",
+        "country_placeholder": "Select your country",
+        "password_mismatch": "Passwords do not match",
+        "invalid_email": "Invalid email address"
+      },
+      "confirm_email": {
+        "title": "Confirm your email",
+        "description": "We've sent a confirmation code to: {{email}}",
+        "confirm_code_label": "Confirmation code",
+        "confirm_code_placeholder": "Enter the confirmation code"
+      },
+      "set_phone_number": {
+        "title": "Phone number",
+        "description": "Enter your phone number",
+        "phone_number_label": "Phone number",
+        "phone_number_placeholder": "Enter your phone number",
+        "country_area_code_label": "Country area code",
+        "invalid_phone_number": "Invalid phone number",
+        "legal_terms": "By continuing, you agree to receiving SMS to verify your phone number."
+      },
+      "confirm_phone_number": {
+        "title": "Confirm your phone number",
+        "description": "We've sent a confirmation code to: {{phoneNumber}}",
+        "confirm_code_label": "Confirmation code"
+      },
+      "verify_identity": {
+        "title": "Verifying your identity to get your card",
+        "description": "To keep your account secure and comply with regulations, we need to verify your identity.\n\nYou'll need a government-issued ID and a proof of address (like a utility bill or bank statement).\n\nVerification usually takes 5-30 minutes, and we'll notify you as soon as it's complete.",
+        "verify_button": "Verify now with Veriff"
+      },
+      "validating_kyc": {
+        "title": "Validating your KYC..."
+      },
+      "kyc_failed": {
+        "title": "Rejected",
+        "description": "Your KYC was rejected. Please try again."
+      },
+      "personal_details": {
+        "title": "Personal details",
+        "description": "Enter your personal details",
+        "first_name_label": "First name",
+        "last_name_label": "Last name",
+        "date_of_birth_label": "Date of birth",
+        "nationality_label": "Country of Nationality",
+        "ssn_label": "Social Security Number",
+        "first_name_placeholder": "Enter your first name",
+        "last_name_placeholder": "Enter your last name",
+        "date_of_birth_placeholder": "Enter your date of birth",
+        "nationality_placeholder": "Select your nationality",
+        "ssn_placeholder": "Enter your SSN",
+        "invalid_ssn": "Invalid SSN",
+        "invalid_date_of_birth": "Invalid date of birth",
+        "invalid_date_of_birth_underage": "You must be at least 18 years old"
+      },
+      "physical_address": {
+        "title": "Physical address",
+        "description": "Please provide your physical address",
+        "address_line_1_label": "Address line 1",
+        "address_line_2_label": "Address line 2",
+        "city_label": "City",
+        "state_label": "State",
+        "zip_code_label": "ZIP code",
+        "address_line_1_placeholder": "Enter your address line 1",
+        "address_line_2_placeholder": "Enter your address line 2",
+        "city_placeholder": "Enter your city",
+        "state_placeholder": "Enter your state",
+        "zip_code_placeholder": "Enter your ZIP code",
+        "same_mailing_address_label": "Physical address is the same as mailing address",
+        "electronic_consent": "I agree to the E-Sign Act Consent and Disclosure and to receive all communictions electronically."
+      },
+      "mailing_address": {
+        "title": "Mailing address",
+        "description": "Please provide your mailing address"
+      },
+      "complete": {
+        "title": "Approved!",
+        "description": "Your KYC was approved. You can now use your Card."
+      },
+      "continue_button": "Next",
+      "confirm_button": "Confirm",
+      "retry_button": "Try again"
     },
     "card_home": {
       "error_title": "Tidak dapat mengambil data",
@@ -5799,9 +5966,36 @@
       "try_again": "Coba lagi",
       "limited_spending_warning": "Kemampuan pemakaian Anda mungkin terbatas. Untuk menyesuaikan limit, buka {{manageCard}}",
       "add_funds": "Tambahkan dana",
+      "change_asset": "Change asset",
       "manage_card_options": {
+        "manage_spending_limit": "Manage spending limit",
+        "manage_spending_limit_description_restricted": "Restricted spending limit is on",
+        "manage_spending_limit_description_full": "Full spending access is on",
         "manage_card": "Kelola kartu",
-        "advanced_card_management_description": "Lihat transaksi, bekukan kartu, dan lainnya"
+        "advanced_card_management_description": "Detailed transactions, freeze card, and more"
+      }
+    },
+    "card_authentication": {
+      "title": "Log in to your Card account",
+      "location_button_text": "International",
+      "location_button_text_us": "US account",
+      "email_label": "Email",
+      "password_label": "Password",
+      "email_placeholder": "Enter your email address",
+      "password_placeholder": "Enter your password",
+      "login_button": "Log in",
+      "errors": {
+        "invalid_credentials": "Invalid login details",
+        "unknown_error": "Unknown error, please try again later",
+        "email_required": "Email is required",
+        "password_required": "Password is required",
+        "email_invalid": "Invalid email address",
+        "password_invalid": "Invalid password",
+        "invalid_email_or_password": "Invalid email or password, check your credentials and try again.",
+        "network_error": "Network error. Please check your connection and try again.",
+        "timeout_error": "Request timed out. Please check your connection and try again.",
+        "server_error": "Server error. Please try again later.",
+        "configuration_error": "Service is temporarily unavailable. Please try again later."
       }
     }
   },
@@ -5825,65 +6019,65 @@
     "close": "Tutup"
   },
   "rewards": {
-    "auth_fail_title": "Unknown Error.",
-    "auth_fail_description": "An unknown error occurred while authenticating this account with the rewards program. Please try again later.",
-    "failed_to_authenticate": "Failed to authenticate with rewards program",
+    "auth_fail_title": "Kesalahan Tidak Dikenal.",
+    "auth_fail_description": "Terjadi kesalahan tidak dikenal saat mengautentikasi akun ini dengan program reward. Coba lagi nanti.",
+    "failed_to_authenticate": "Gagal mengautentikasi dengan program reward",
     "not_implemented": "Segera hadir",
     "not_implemented_season_summary": "Ringkasan Musim Segera Hadir",
     "optin_error": {
-      "title": "Opt-in failed",
-      "description": "Check your connection and try again."
+      "title": "Gagal berpartisipasi",
+      "description": "Periksa koneksi Anda dan coba lagi."
     },
     "season_status_error": {
-      "error_fetching_title": "Season balance couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Saldo musim tidak dapat dimuat",
+      "error_fetching_description": "Periksa koneksi Anda dan coba lagi.",
+      "retry_button": "Coba lagi"
     },
     "active_boosts_error": {
-      "error_fetching_title": "Boosts couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Peningkatan tidak dapat dimuat",
+      "error_fetching_description": "Periksa koneksi Anda dan coba lagi.",
+      "retry_button": "Coba lagi"
     },
     "unlocked_rewards_error": {
-      "error_fetching_title": "Rewards couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Reward tidak dapat dimuat",
+      "error_fetching_description": "Periksa koneksi Anda dan coba lagi.",
+      "retry_button": "Coba lagi"
     },
     "upcoming_rewards_error": {
-      "error_fetching_title": "Rewards couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Reward tidak dapat dimuat",
+      "error_fetching_description": "Periksa koneksi Anda dan coba lagi.",
+      "retry_button": "Coba lagi"
     },
     "referral_details_error": {
-      "error_fetching_title": "Referral details couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Detail referensi tidak dapat dimuat",
+      "error_fetching_description": "Periksa koneksi Anda dan coba lagi.",
+      "retry_button": "Coba lagi"
     },
     "referral_validation_unknown_error": {
-      "title": "Referral code couldn’t be validated",
-      "description": "Check your connection and try again."
+      "title": "Kode referensi tidak dapat divalidasi",
+      "description": "Periksa koneksi Anda dan coba lagi."
     },
     "active_activity_error": {
-      "error_fetching_title": "Activity couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Aktivitas tidak dapat dimuat",
+      "error_fetching_description": "Periksa koneksi Anda dan coba lagi.",
+      "retry_button": "Coba lagi"
     },
-    "solana_signup_not_supported": "Signing in to Rewards with Solana accounts is not supported yet. Please use an Ethereum account instead.",
+    "solana_signup_not_supported": "Masuk ke Reward dengan akun Solana belum didukung. Gunakan akun Ethereum sebagai gantinya.",
     "error_messages": {
-      "unknown_error": "Unknown error occurred",
-      "something_went_wrong": "Something went wrong. Please try again shortly.",
-      "account_already_registered": "This account is already registered with another Rewards profile. Please switch account to continue.",
-      "request_rejected": "You rejected the request.",
-      "failed_to_claim_reward": "Failed to claim reward. Please try again shortly.",
-      "service_not_available": "Service is not available at the moment. Please try again shortly."
+      "unknown_error": "Terjadi kesalahan tidak dikenal",
+      "something_went_wrong": "Terjadi kesalahan. Coba lagi nanti.",
+      "account_already_registered": "Akun ini sudah terdaftar dengan profil Reward lain. Ganti akun untuk melanjutkan.",
+      "request_rejected": "Anda menolak permintaan tersebut.",
+      "failed_to_claim_reward": "Gagal mengklaim reward. Coba lagi nanti.",
+      "service_not_available": "Layanan tidak tersedia untuk saat ini. Coba lagi nanti."
     },
     "claim_reward_error": {
-      "title": "Failed to claim reward"
+      "title": "Gagal mengklaim reward"
     },
     "accounts_opt_in_state_error": {
-      "error_fetching_title": "Accounts couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Akun tidak dapat dimuat",
+      "error_fetching_description": "Periksa koneksi Anda dan coba lagi.",
+      "retry_button": "Coba lagi"
     },
     "referral_rewards_title": "Rujukan",
     "points": "Poin",
@@ -5899,139 +6093,142 @@
     "tab_levels_title": "Level",
     "referral_stats_earned_from_referrals": "Diperoleh dari rujukan",
     "referral_stats_referrals": "Rujukan",
-    "loading_activity": "Loading activity...",
-    "error_loading_activity": "Error loading activity",
-    "activity_empty_title": "No recent activity.",
-    "activity_empty_description": "Use MetaMask to earn points, level up, and unlock rewards.",
-    "activity_empty_link": "See ways to earn",
+    "loading_activity": "Memuat aktivitas...",
+    "error_loading_activity": "Terjadi kesalahan saat memuat aktivitas",
+    "activity_empty_title": "Tidak ada aktivitas terbaru.",
+    "activity_empty_description": "Gunakan MetaMask untuk memperoleh poin, naik level, dan membuka reward.",
+    "activity_empty_link": "Lihat cara memperolehnya",
     "events": {
-      "to": "to",
+      "to": "ke",
       "type": {
         "swap": "Swap",
         "perps": "Perp",
-        "referral": "Referral",
-        "referral_action": "Referral action",
-        "sign_up_bonus": "Sign up bonus",
-        "loyalty_bonus": "Loyalty bonus",
-        "one_time_bonus": "One-time bonus",
-        "open_position": "Opened position",
-        "close_position": "Closed position",
+        "card_spend": "Card spend",
+        "referral": "Referensi",
+        "referral_action": "Tindakan referensi",
+        "sign_up_bonus": "Bonus pendaftaran",
+        "loyalty_bonus": "Bonus loyalitas",
+        "one_time_bonus": "Bonus satu kali",
+        "open_position": "Posisi terbuka",
+        "close_position": "Posisi tertutup",
         "take_profit": "TP/SL",
         "stop_loss": "TP/SL",
-        "uncategorized_event": "Uncategorized event"
+        "uncategorized_event": "Acara yang tidak dikategorikan"
       },
-      "date": "Date",
-      "account": "Account",
+      "date": "Tanggal",
+      "account": "Akun",
       "bonus": "Bonus",
-      "details": "Details",
-      "points": "Points",
-      "points_base": "Base",
-      "points_boost": "Boost",
+      "details": "Detail",
+      "points": "Poin",
+      "points_base": "Dasar",
+      "points_boost": "Peningkatan",
       "points_total": "Total"
     },
     "onboarding": {
       "not_supported_region_title": "Wilayah tidak didukung",
-      "not_supported_region_description": "Rewards are not supported in your region yet. We are working on expanding access, so check back later.",
-      "not_supported_hardware_account_title": "Account not supported",
-      "not_supported_hardware_account_description": "Hardware wallet accounts are not eligible to receive rewards yet. Please switch to a different account to proceed.",
-      "not_supported_account_type_title": "Account type not supported",
-      "not_supported_account_type_description": "Currently only internal Ethereum and Solana accounts can be opted into the Rewards program. Please switch to a different account to proceed.",
-      "not_supported_confirm_go_back": "Go back",
-      "not_supported_confirm_retry": "Retry",
-      "auth_fail_title": "Authentication Failed",
-      "auth_fail_description": "Unable to authenticate with the rewards program. Please check your connection and try again.",
-      "geo_check_fail_title": "Cannot determine opt-in eligibility",
-      "geo_check_fail_description": "We cannot determine if your country allows opting into the rewards program. Please check your connection and try again.",
+      "not_supported_region_description": "Reward belum didukung di wilayah Anda. Kami sedang berupaya memperluas akses, jadi, periksa kembali nanti.",
+      "not_supported_hardware_account_title": "Akun tidak didukung",
+      "not_supported_hardware_account_description": "Akun dompet perangkat keras belum memenuhi syarat untuk menerima reward. Beralih ke akun lain untuk melanjutkan.",
+      "not_supported_account_type_title": "Jenis akun tidak didukung",
+      "not_supported_account_type_description": "Saat ini, hanya akun internal Ethereum dan Solana yang dapat berpartisipasi dalam program Reward. Beralih ke akun lain untuk melanjutkan.",
+      "not_supported_confirm_go_back": "Kembali",
+      "not_supported_confirm_retry": "Coba lagi",
+      "auth_fail_title": "Autentikasi Gagal",
+      "auth_fail_description": "Tidak dapat mengautentikasi dengan program reward. Periksa koneksi Anda dan coba lagi.",
+      "geo_check_fail_title": "Tidak dapat menentukan kelayakan berpartisipasi",
+      "geo_check_fail_description": "Kami tidak dapat memastikan jika negara Anda mengizinkan Anda untuk berpartisipasi dalam program reward. Periksa koneksi dan coba lagi.",
       "gtm_title": "Reward ada di sini",
       "gtm_description": "Dapatkan poin untuk aktivitas Anda. \nLewati level untuk membuka reward.",
       "gtm_confirm": "Mulai",
       "intro_title": "Musim 1 \nTayang",
-      "intro_description": "Earn points for your activity. \nAdvance through levels to unlock rewards.",
-      "intro_confirm": "Claim 250 points",
-      "intro_confirm_geo_loading": "Checking region...",
-      "checking_opt_in": "Checking accounts...",
-      "redirecting_to_dashboard": "Redirecting...",
+      "intro_description": "Dapatkan poin untuk aktivitas Anda. \nLewati level untuk membuka reward.",
+      "intro_confirm": "Klaim 250 poin",
+      "intro_confirm_geo_loading": "Memeriksa wilayah...",
+      "checking_opt_in": "Memeriksa akun...",
+      "redirecting_to_dashboard": "Mengalihkan...",
       "intro_skip": "Tidak sekarang",
       "step_confirm": "Berikutnya",
-      "step_skip": "Skip",
-      "step1_title": "Earn points on every trade",
+      "step_skip": "Lewati",
+      "step1_title": "Dapatkan poin pada setiap perdagangan",
       "step1_description": "Setiap swap dan perdagangan perp yang Anda lakukan di MetaMask makin mendekatkan Anda dengan reward. Tambahkan akun dan lihat poin Anda bertambah.",
-      "step2_title": "Level up for bigger perks",
+      "step2_title": "Naik level dan dapatkan keuntungan lebih besar",
       "step2_description": "Capai tonggak poin untuk memperoleh keuntungan seperti diskon 50% untuk biaya perp, token eksklusif, dan Kartu Metal MetaMask gratis.",
-      "step3_title": "Exclusive seasonal rewards",
-      "step3_description": "Each season brings new perks. Join in, compete, and claim what you can before time runs out.",
-      "step4_title": "You'll earn 250 points when you sign up!",
-      "step4_title_referral_validating": "Validating referral code...",
-      "step4_referral_input_placeholder": "Referral code (optional)",
-      "step4_referral_input_error": "Invalid referral code",
-      "step4_confirm": "Claim points",
-      "step4_confirm_loading": "Claiming points...",
-      "step4_linking_accounts": "Adding accounts... ({{current}}/{{total}})",
-      "step4_linking_accounts_loading": "Adding additional accounts...",
-      "step4_success_description": "You have successfully signed up for MetaMask Rewards!",
-      "step4_legal_disclaimer_1": "By selecting 'Claim Points', you agree to the MetaMask Rewards",
-      "step4_legal_disclaimer_2": "Supplemental Terms of Use and Privacy Notice",
-      "step4_legal_disclaimer_3": ". We'll track onchain activity to reward you automatically –",
-      "step4_legal_disclaimer_4": "learn more"
+      "step3_title": "Reward musiman eksklusif",
+      "step3_description": "Setiap musim menghadirkan keuntungan baru. Bergabunglah, berkompetisi, dan klaim semua yang Anda bisa sebelum waktu habis.",
+      "step4_title": "Anda akan memperoleh 250 poin saat mendaftar!",
+      "step4_title_referral_bonus": "You'll earn 500 points when you sign up with this code!",
+      "step4_title_referral_validating": "Memvalidasi kode referensi...",
+      "step4_referral_bonus_description": "Use a referral code to earn 250 more",
+      "step4_referral_input_placeholder": "Kode referensi (opsional)",
+      "step4_referral_input_error": "Kode referensi tidak valid",
+      "step4_confirm": "Klaim poin",
+      "step4_confirm_loading": "Mengklaim poin...",
+      "step4_linking_accounts": "Menambahkan akun... ({{current}}/{{total}})",
+      "step4_linking_accounts_loading": "Menambahkan akun tambahan...",
+      "step4_success_description": "Anda telah berhasil mendaftar untuk Reward MetaMask!",
+      "step4_legal_disclaimer_1": "Dengan memilih 'Klaim Poin', Anda menyetujui Reward MetaMask",
+      "step4_legal_disclaimer_2": "Ketentuan Penggunaan dan Pemberitahuan Privasi Tambahan",
+      "step4_legal_disclaimer_3": ". Kami akan melacak aktivitas onchain untuk memberikan reward secara otomatis –",
+      "step4_legal_disclaimer_4": "selengkapnya"
     },
     "settings": {
-      "title": "Rewards Settings",
-      "subtitle": "Accounts",
-      "description": "Add multiple accounts to combine your points and unlock rewards faster.",
-      "tab_linked_accounts": "Added ({{count}})",
-      "tab_unlinked_accounts": "Not added ({{count}})",
-      "no_linked_accounts": "No accounts opted in",
-      "all_accounts_linked_title": "All accounts opted in",
-      "all_accounts_linked_description": "You have added all your accounts to Rewards.",
-      "link_account_success_title": "{{accountName}} successfully added",
-      "link_account_error_title": "Failed to add account",
-      "link_account_button": "Add",
-      "link_account_failed_error": "Failed to link account",
-      "link_account_unknown_error": "Unknown error occurred"
+      "title": "Pengaturan Reward",
+      "subtitle": "Akun",
+      "description": "Tambahkan beberapa akun untuk menggabungkan poin Anda dan membuka reward lebih cepat.",
+      "tab_linked_accounts": "Ditambahkan ({{count}})",
+      "tab_unlinked_accounts": "Belum ditambahkan ({{count}})",
+      "no_linked_accounts": "Tidak ada akun yang berpartisipasi",
+      "all_accounts_linked_title": "Semua akun berpartisipasi",
+      "all_accounts_linked_description": "Anda telah menambahkan semua akun ke Reward.",
+      "link_account_success_title": "{{accountName}} berhasil ditambahkan",
+      "link_account_error_title": "Gagal menambahkan akun",
+      "link_account_button": "Tambah",
+      "link_account_failed_error": "Gagal menautkan akun",
+      "link_account_unknown_error": "Terjadi kesalahan tidak dikenal"
     },
     "optout": {
-      "title": "Opt out of Rewards",
-      "description": "This will remove your accounts from the Rewards program and erase your points and progress. You won't be able to undo this.",
-      "confirm": "Opt out",
+      "title": "Keluar dari Reward",
+      "description": "Tindakan ini akan menghapus akun Anda dari program Reward dan menghapus poin serta progres Anda. Tindakan ini tidak dapat dibatalkan.",
+      "confirm": "Keluar",
       "modal": {
-        "confirmation_title": "Are you sure?",
-        "confirmation_description": "This will remove all your progress, and can't be reversed. If you rejoin the Rewards program later, you'll start back at 0.",
-        "cancel": "Cancel",
-        "confirm": "Confirm",
-        "error_message": "Failed to opt out of Rewards. Please try again.",
-        "processing": "Processing..."
+        "confirmation_title": "Anda yakin?",
+        "confirmation_description": "Tindakan ini akan menghapus semua progres Anda dan tidak dapat dibatalkan. Jika bergabung kembali dengan program Reward nanti, Anda akan memulai dari 0.",
+        "cancel": "Batal",
+        "confirm": "Konfirmasikan",
+        "error_message": "Gagal keluar dari Reward. Coba lagi.",
+        "processing": "Memproses..."
       }
     },
-    "toast_dismiss": "Dismiss",
+    "toast_dismiss": "Lewatkan",
     "dashboard_modal_info": {
       "active_account": {
-        "title": "Don't miss out",
-        "description": "Add your account to start earning points from your activity.",
-        "confirm": "Add account"
+        "title": "Jangan lewatkan",
+        "description": "Tambahkan akun untuk mulai memperoleh poin dari aktivitas Anda.",
+        "confirm": "Tambah akun"
       },
       "multiple_unlinked_accounts": {
-        "title": "Start earning points",
-        "description": "Add your accounts so you can track your rewards at a glance.",
-        "confirm": "Add accounts"
+        "title": "Mulai memperoleh poin",
+        "description": "Tambahkan akun Anda untuk melacak reward dengan cepat.",
+        "confirm": "Tambah akun"
       },
       "account_not_supported": {
-        "title": "Account not supported",
-        "description_hardware": "Hardware wallet accounts are not yet eligible to earn points. Please switch to a different account to proceed.",
-        "description_general": "Currently only non-hardware internal Ethereum and Solana accounts are eligible to earn points. Please switch to a different account to proceed.",
-        "confirm": "Go back"
+        "title": "Akun tidak didukung",
+        "description_hardware": "Akun dompet perangkat keras belum memenuhi syarat untuk memperoleh poin. Beralih ke akun lain untuk melanjutkan.",
+        "description_general": "Saat ini, hanya akun internal Ethereum dan Solana non-perangkat keras yang memenuhi syarat untuk memperoleh poin. Beralih ke akun lain untuk melanjutkan.",
+        "confirm": "Kembali"
       }
     },
     "ways_to_earn": {
-      "title": "Ways to earn",
-      "supported_networks": "Supported Networks",
+      "title": "Cara memperoleh",
+      "supported_networks": "Jaringan yang Didukung",
       "swap": {
         "title": "Swap",
-        "description": "80 points per $100",
+        "description": "80 poin per $100",
         "sheet": {
-          "title": "Swap tokens",
-          "points": "80 points per $100",
-          "description": "Swap tokens on supported networks to earn points for every dollar you trade.",
-          "cta_label": "Start a swap"
+          "title": "Tukar token",
+          "points": "80 poin per $100",
+          "description": "Swap token pada jaringan yang didukung untuk memperoleh poin dari setiap dolar yang Anda perdagangkan.",
+          "cta_label": "Mulai swap"
         }
       },
       "perps": {
@@ -6045,52 +6242,74 @@
         }
       },
       "referrals": {
-        "title": "Refer friends",
-        "description": "10 points per 50 from friends"
+        "title": "Rekomendasikan ke teman",
+        "description": "10 poin per 50 dari teman",
+        "sheet": {
+          "title": "Refer a friend",
+          "points": "20 points per 100",
+          "cta_label": "Refer a friend"
+        }
       },
       "loyalty": {
-        "title": "Loyalty bonus",
-        "description": "Earn points from past trades",
+        "title": "Bonus loyalitas",
+        "description": "Dapatkan poin dari perdagangan sebelumnya",
         "sheet": {
-          "title": "Loyalty bonus",
-          "points": "250 points per $1250",
-          "description": "Add accounts with past swaps or bridges in MetaMask to earn loyalty bonuses. Each eligible account unlocks points in increments of 250, up to a total of 50,000. Bonuses appear shortly after you add an account.",
-          "cta_label": "Add accounts"
+          "title": "Bonus loyalitas",
+          "points": "250 poin per $1250",
+          "description": "Tambahkan akun dengan swap atau bridge sebelumnya di MetaMask untuk memperoleh bonus loyalitas. Setiap akun yang memenuhi syarat akan membuka poin dengan kelipatan 250, hingga total 50.000. Bonus akan muncul segera setelah Anda menambahkan akun.",
+          "cta_label": "Tambah akun"
+        }
+      },
+      "card": {
+        "title": "MetaMask Card",
+        "description": "1 point per $1 spent",
+        "sheet": {
+          "title": "MetaMask Card",
+          "points": "1 point per $1 spent",
+          "description": "Earn points every time you use your MetaMask Card for purchases, plus 1% cash back (3% for Metal cardholders).",
+          "cta_label": "Manage Card"
         }
       }
     },
     "referral": {
-      "referral_code": "Referral code",
-      "referral_link": "Referral link",
+      "referral_code": "Kode referensi",
+      "referral_link": "Tautan referensi",
       "actions": {
         "share_referral_link": "Rekomendasikan ke teman",
         "share_referral_subject": "Gabung dengan MetaMask Rewards"
       },
       "info": {
         "title": "Bagikan kode Anda untuk mendapatkan lebih banyak",
-        "description": "Your friends get a 2x sign up bonus. You get 10 points for every 50 they earn from trading."
+        "description": "Teman Anda mendapatkan bonus pendaftaran 2x lipat. Anda mendapatkan 10 poin untuk setiap 50 poin yang mereka peroleh dari perdagangan."
       }
     },
-    "active_boosts_title": "Active boosts",
-    "season_1": "Season 1",
+    "link_account_group": {
+      "link_account": "Add account",
+      "tracked": "Tracked",
+      "untracked": "Untracked",
+      "link_account_success": "{{accountName}} added successfully",
+      "link_account_error": "Failed to add one or more addresses for {{accountName}}"
+    },
+    "active_boosts_title": "Peningkatan aktif",
+    "season_1": "Musim 1",
     "upcoming_rewards": {
       "title": "Reward terkunci",
-      "points_needed": "{{points}} points",
-      "cta_label": "Got it",
-      "alpha_fox_invite_input_placeholder": "Your Telegram handle"
+      "points_needed": "{{points}} poin",
+      "cta_label": "Mengerti",
+      "alpha_fox_invite_input_placeholder": "Nama pengguna Telegram Anda"
     },
     "unlocked_rewards": {
-      "title": "Unlocked rewards",
-      "cta_label": "Claim now",
-      "cta_request_invite": "Request invite",
-      "claim_label": "Claim",
-      "claimed_label": "Claimed",
-      "reward_claimed": "Reward claimed",
+      "title": "Reward yang terbuka",
+      "cta_label": "Klaim sekarang",
+      "cta_request_invite": "Minta undangan",
+      "claim_label": "Klaim",
+      "claimed_label": "Diklaim",
+      "reward_claimed": "Reward diklaim",
       "time_left": "tersisa",
-      "expired": "Expired"
+      "expired": "Kedaluwarsa"
     },
     "animation": {
-      "could_not_load": "Couldn't load"
+      "could_not_load": "Tidak dapat memuat"
     }
   },
   "time": {
@@ -6099,7 +6318,7 @@
   },
   "transaction_details": {
     "title": {
-      "perps_deposit": "Funded Perps account",
+      "perps_deposit": "Akun Perp yang didanai",
       "predict_deposit": "Funded Predict account",
       "default": "Detail transaksi"
     },
@@ -6107,19 +6326,23 @@
       "bridge_fee": "Biaya bridge",
       "network_fee": "Biaya jaringan",
       "paid_with": "Dibayar dengan",
+      "retry_button": "Try again",
       "total": "Total"
     },
     "summary_title": {
-      "bridge": "Bridge dari {{sourceSymbol}} ke {{targetSymbol}}",
       "bridge_approval": "Setujui {{approveSymbol}}",
       "bridge_approval_loading": "Setujui",
-      "bridge_loading": "Bridge",
+      "bridge_send": "Bridge {{sourceSymbol}} from {{sourceChain}}",
+      "bridge_send_loading": "Bridge Send",
+      "bridge_receive": "Receive {{targetSymbol}} on {{targetChain}}",
+      "bridge_receive_loading": "Bridge Receive",
       "default": "Transaksi",
       "perps_deposit": "Tambahkan dana",
       "predict_deposit": "Add funds",
       "swap": "Tukar token",
       "swap_approval": "Setujui token"
-    }
+    },
+    "perps_deposit_solution": "You now have {{fiat}} of USDC on Arbitrum. Try your deposit again."
   },
   "sdk_connect_v2": {
     "show_loading": {

--- a/locales/languages/ja.json
+++ b/locales/languages/ja.json
@@ -594,7 +594,9 @@
       "unexpectedError": "予期せぬエラーが発生しました。",
       "quoteFetchError": "クォートを取得できませんでした。",
       "kycFormsFetchError": "KYCフォームを取得できませんでした。",
-      "title": "入金する"
+      "title": "入金する",
+      "limitExceeded": "This deposit would exceed your {{period}} limit. Your deposit including fees must be {{remaining}} or less.",
+      "limitError": "Failed to check your deposit limits. Please try again later."
     },
     "token_modal": {
       "select_a_token": "トークンを選択",
@@ -892,7 +894,7 @@
     "withdraw": "出金",
     "refresh_balance": "残高を更新",
     "add_funds": "資金を追加",
-    "deposit_in_progress": "Deposit in progress",
+    "deposit_in_progress": "デポジット処理中",
     "your_positions": "保有ポジション",
     "loading_positions": "ポジションを読み込み中...",
     "refreshing_positions": "ポジションを更新中...",
@@ -1277,6 +1279,7 @@
       "assetMappingFailed": "資産マッピングを構築できませんでした",
       "depositFailed": "デポジット失敗",
       "orderLeverageReductionFailed": "レバレッジを下げることはできません",
+      "connectionTimeout": "Connection timed out. Please check your network and try again.",
       "connectionFailed": {
         "title": "パーペチュアルが一時的にオフラインです",
         "description": "すぐにオンラインに戻せるように対応しています",
@@ -1348,9 +1351,9 @@
         "error_message": "市場データが見つかりません。前の画面に戻り、もう一度お試しください。"
       },
       "statistics": "概要",
-      "24h_high": "24h high",
-      "24h_low": "24h low",
-      "24h_volume": "24h volume",
+      "24h_high": "24時間の最高値",
+      "24h_low": "24時間の最安値",
+      "24h_volume": "24時間の取引高",
       "open_interest": "取組高",
       "funding_rate": "資金調達率",
       "countdown": "カウントダウン",
@@ -1510,9 +1513,9 @@
         "metamask_fee": "MetaMaskの手数料",
         "hyperliquid_fee": "Hyperliquidの手数料",
         "total_fee": "合計手数料",
-        "liquidated": "Liquidated",
-        "take_profit": "Take profit",
-        "stop_loss": "Stop loss"
+        "liquidated": "清算",
+        "take_profit": "利益確定",
+        "stop_loss": "ストップロス"
       },
       "funding": {
         "date": "日付",
@@ -1525,7 +1528,7 @@
         "history_will_appear": "ここに取引履歴が表示されます"
       }
     },
-    "risk_disclaimer": "Perpetual contracts are very risky, and you could suddenly and without notice lose your entire investment. You trade entirely at your own risk. Market data provided by Hyperliquid. Price chart powered by",
+    "risk_disclaimer": "Perpetual contracts are very risky, and you could suddenly and without notice lose your entire investment. You trade entirely at your own risk. Market data provided by Hyperliquid. Price chart powered by",
     "tutorial": {
       "continue": "続行",
       "skip": "スキップ",
@@ -1555,11 +1558,11 @@
       "ready_to_trade": {
         "title": "取引の準備はできましたか？",
         "description": "任意のトークンでパーペチュアルアカウントに入金すれば、数秒で最初の取引ができます。",
-        "footer_text": "MetaMaskはArbitrum上で資金をUSDCに交換し、これを追加手数料なしでHyperCoreに入金します。"
+        "footer_text": "MetaMask will swap your funds to USDC on Arbitrum, and deposit them onto HyperCore for no added fee."
       },
       "got_it": "了解",
       "card": {
-        "title": "Learn the basics of perps"
+        "title": "パーペチュアルの基本"
       }
     },
     "points": "ポイント",
@@ -1576,10 +1579,10 @@
     "market_list": "市場リスト",
     "market_details": "市場の詳細",
     "tab": {
-      "no_predictions": "まだ予測はありません",
-      "no_predictions_description": "予測を開いて始めましょう。",
-      "explore": "市場を探索",
-      "new_prediction": "新しい予測"
+      "no_predictions_description": "Your predictions will appear here, showing your stake and market movement.",
+      "explore": "Browse markets",
+      "new_prediction": "新しい予測",
+      "resolved_markets": "Resolved markets"
     },
     "sell_position": "売りポジション",
     "cash_out": "キャッシュアウト",
@@ -1609,16 +1612,73 @@
     "claim_button": "請求",
     "markets_won": "的中した市場",
     "won_markets_text": "{{count}}件の市場{{s}}で的中",
-    "won_markets_text_singular": "{{count}}件の市場で的中",
-    "won_markets_text_plural": "{{count}}件の市場で的中",
+    "available_balance": "Available balance",
     "claim_amount_text": "請求額 ${{amount}}",
     "unrealized_pnl_label": "含み損益",
     "unrealized_pnl_value": "{{amount}} ({{percent}})",
+    "unrealized_pnl_error": "Unable to load",
     "unavailable": {
       "title": "Unavailable in your region",
       "description": "Predictions aren't available in your region due to legal restrictions.",
       "link": "See Polymarket terms",
       "button": "Got it"
+    },
+    "deposit": {
+      "in_progress": "Deposit in progress",
+      "adding_funds": "Adding funds",
+      "adding_your_funds": "Adding your funds",
+      "add_funds": "Add funds",
+      "withdraw": "Withdraw",
+      "estimated_processing_time": "Est. {{time}} seconds",
+      "account_ready": "Your account is ready",
+      "account_ready_description": "{{amount}} added to your balance",
+      "error_title": "Something went wrong",
+      "error_description": "Your account wasn't funded",
+      "try_again": "Try again"
+    },
+    "add_funds_sheet": {
+      "title": "Add funds",
+      "description": "You'll need to add funds to your Predictions account to get started. You can add any token and make your first prediction in seconds."
+    },
+    "transactions": {
+      "title": "Predictions",
+      "no_transactions": "No recent activity",
+      "buy_title": "Predicted",
+      "sell_title": "Cashed out",
+      "claim_title": "Claimed winnings",
+      "buy_detail": "Bought {{amountUsd}} on {{outcome}} · {{priceCents}} per share",
+      "sell_detail": "Sold at {{priceCents}} per share",
+      "claim_detail": "Claimed winnings",
+      "not_available": "N/A",
+      "date": "Date",
+      "market": "Market",
+      "outcome": "Outcome",
+      "predicted_amount": "Predicted amount",
+      "shares_bought": "Shares bought",
+      "shares_sold": "Shares sold",
+      "price_per_share": "Price per share",
+      "price_impact": "Price impact",
+      "net_pnl": "Net P&L",
+      "total_net_pnl": "Total Net P&L",
+      "market_net_pnl": "Market Net P&L",
+      "activity_details": "Activity details"
+    },
+    "claim": {
+      "toasts": {
+        "pending": {
+          "title": "Claiming {{amount}}",
+          "description": "Est. {{time}} seconds"
+        },
+        "confirmed": {
+          "title": "Claimed",
+          "description": "{{amount}} added to your balance"
+        },
+        "error": {
+          "title": "Something went wrong",
+          "description": "Failed to proceed with claim",
+          "try_again": "Try again"
+        }
+      }
     }
   },
   "receive": {
@@ -3093,6 +3153,7 @@
     "tx_review_lending_withdraw": "貸付金の引き出し",
     "tx_review_perps_deposit": "パーペチュアルアカウントに入金しました",
     "tx_review_predict_deposit": "Funded Predict account",
+    "tx_review_predict_claim": "Claimed Predict winnings",
     "sent_ether": "送信されたイーサ",
     "self_sent_ether": "自分に送信されたイーサ",
     "received_ether": "受け取ったイーサ",
@@ -3939,7 +4000,9 @@
     "wallet_connect_dapps_cta": "セッションを表示",
     "network_not_supported": "現在のネットワークはサポートされていません",
     "select_provider": "希望のプロバイダーを選択してください",
-    "switch_network": "メインネットまたはSepoliaに切り替えてください"
+    "switch_network": "メインネットまたはSepoliaに切り替えてください",
+    "card_title": "Always show MetaMask Card button",
+    "card_desc": "MetaMask Card is only available to residents of select countries"
   },
   "walletconnect_sessions": {
     "no_active_sessions": "アクティブなセッションがありません",
@@ -5315,7 +5378,7 @@
     },
     "tooltip": {
       "perps_deposit": {
-        "transaction_fee": "Metamaskは、HyperCore (パーペチュアル取引で使用されるネットワーク) 上でトークンをUSDCに交換します。スワッププロバイダーは手数料を請求することがありますが、MetaMaskなら無料です。"
+        "transaction_fee": "We'll swap your tokens for USDC on HyperCore, the network used by Perps. Swap providers may charge a fee, but MetaMask won't."
       },
       "predict_deposit": {
         "transaction_fee": "We'll swap your tokens for USDC.e on Polygon, the network used by Predict. Swap providers may charge a fee, but MetaMask won't."
@@ -5407,6 +5470,12 @@
       "save": "保存",
       "title": "承認限度額を編集"
     },
+    "predict_claim": {
+      "button_label": "Claim winnings",
+      "summary": "You won",
+      "footer_bottom": "Funds will be added to your available balance",
+      "footer_top": "Winnings from {{count}} markets"
+    },
     "unlimited": "無制限",
     "all": "すべて",
     "none": "なし",
@@ -5469,12 +5538,15 @@
     "points": "推定ポイント数",
     "points_tooltip": "ポイント",
     "points_tooltip_content_1": "Points are how you earn MetaMask Rewards for completing transactions, like when you swap, bridge, or trade perps.",
-    "points_tooltip_content_2": "Keep in mind this value is an estimate and will be finalized once the transaction is complete. Points can take up to 1 hour to be confirmed in your Rewards balance.",
+    "points_tooltip_content_2": "この金額は見積もりであり、トランザクション完了後に確定されることをご留意ください。ポイントがリワード残高で確定されるまでに最長1時間かかる場合があります。",
     "unable_to_load": "読み込めません",
     "points_error": "現在、ポイントを読み込めません",
-    "points_error_content": "You'll still earn any points for this transaction. We'll notify you once they've been added to your account. You can also check your rewards tab in about an hour.",
+    "points_error_content": "このトランザクションで引き続きポイントを獲得できます。ポイントがアカウントに追加され次第、お知らせいたします。約1時間後に「リワード」タブにてご確認いただくことも可能です。",
     "see_other_quotes": "他のクォートを表示",
     "receive_at": "受取先:",
+    "recipient": "Recipient",
+    "select_recipient": "Select recipient",
+    "external_account": "External account",
     "error_banner_description": "この取引ルートは現在使用できません。金額、ネットワーク、またはトークンを変更してみてください。最善のオプションを探します。",
     "insufficient_funds": "資金不足",
     "insufficient_gas": "ガス不足",
@@ -5775,6 +5847,12 @@
       "update_to_store_link": "MetaMaskを最新バージョンにアップデートしてください。",
       "well_take_you_to_right_place": "その後、該当するページにご案内いたします。"
     },
+    "unsupported": {
+      "title": "This page is not supported in current version",
+      "description": "Update to the latest version to use this feature",
+      "update_to_store_link": "Update to the latest version of MetaMask",
+      "well_take_you_to_right_place": " and we'll take you to the right place."
+    },
     "go_to_home_button": "ホームページに移動",
     "back_button": "戻る",
     "continue_button": "続行"
@@ -5791,7 +5869,96 @@
     "card_onboarding": {
       "title": "カードへようこそ",
       "description": "カードの機能を使用するには、当社のパートナーとアカウントを検証する必要があります。",
-      "verify_account_button": "アカウントを検証"
+      "verify_account_button": "アカウントを検証",
+      "sign_up": {
+        "title": "Sign-up",
+        "description": "Register your details with Crypto Life, the provider of MetaMask Card. You'll use this account to access and manage your card.",
+        "email_label": "Email",
+        "password_label": "Password",
+        "confirm_password_label": "Confirm password",
+        "country_label": "Country of Residence",
+        "email_placeholder": "Enter your email address",
+        "password_placeholder": "Enter your password",
+        "country_placeholder": "Select your country",
+        "password_mismatch": "Passwords do not match",
+        "invalid_email": "Invalid email address"
+      },
+      "confirm_email": {
+        "title": "Confirm your email",
+        "description": "We've sent a confirmation code to: {{email}}",
+        "confirm_code_label": "Confirmation code",
+        "confirm_code_placeholder": "Enter the confirmation code"
+      },
+      "set_phone_number": {
+        "title": "Phone number",
+        "description": "Enter your phone number",
+        "phone_number_label": "Phone number",
+        "phone_number_placeholder": "Enter your phone number",
+        "country_area_code_label": "Country area code",
+        "invalid_phone_number": "Invalid phone number",
+        "legal_terms": "By continuing, you agree to receiving SMS to verify your phone number."
+      },
+      "confirm_phone_number": {
+        "title": "Confirm your phone number",
+        "description": "We've sent a confirmation code to: {{phoneNumber}}",
+        "confirm_code_label": "Confirmation code"
+      },
+      "verify_identity": {
+        "title": "Verifying your identity to get your card",
+        "description": "To keep your account secure and comply with regulations, we need to verify your identity.\n\nYou'll need a government-issued ID and a proof of address (like a utility bill or bank statement).\n\nVerification usually takes 5-30 minutes, and we'll notify you as soon as it's complete.",
+        "verify_button": "Verify now with Veriff"
+      },
+      "validating_kyc": {
+        "title": "Validating your KYC..."
+      },
+      "kyc_failed": {
+        "title": "Rejected",
+        "description": "Your KYC was rejected. Please try again."
+      },
+      "personal_details": {
+        "title": "Personal details",
+        "description": "Enter your personal details",
+        "first_name_label": "First name",
+        "last_name_label": "Last name",
+        "date_of_birth_label": "Date of birth",
+        "nationality_label": "Country of Nationality",
+        "ssn_label": "Social Security Number",
+        "first_name_placeholder": "Enter your first name",
+        "last_name_placeholder": "Enter your last name",
+        "date_of_birth_placeholder": "Enter your date of birth",
+        "nationality_placeholder": "Select your nationality",
+        "ssn_placeholder": "Enter your SSN",
+        "invalid_ssn": "Invalid SSN",
+        "invalid_date_of_birth": "Invalid date of birth",
+        "invalid_date_of_birth_underage": "You must be at least 18 years old"
+      },
+      "physical_address": {
+        "title": "Physical address",
+        "description": "Please provide your physical address",
+        "address_line_1_label": "Address line 1",
+        "address_line_2_label": "Address line 2",
+        "city_label": "City",
+        "state_label": "State",
+        "zip_code_label": "ZIP code",
+        "address_line_1_placeholder": "Enter your address line 1",
+        "address_line_2_placeholder": "Enter your address line 2",
+        "city_placeholder": "Enter your city",
+        "state_placeholder": "Enter your state",
+        "zip_code_placeholder": "Enter your ZIP code",
+        "same_mailing_address_label": "Physical address is the same as mailing address",
+        "electronic_consent": "I agree to the E-Sign Act Consent and Disclosure and to receive all communictions electronically."
+      },
+      "mailing_address": {
+        "title": "Mailing address",
+        "description": "Please provide your mailing address"
+      },
+      "complete": {
+        "title": "Approved!",
+        "description": "Your KYC was approved. You can now use your Card."
+      },
+      "continue_button": "Next",
+      "confirm_button": "Confirm",
+      "retry_button": "Try again"
     },
     "card_home": {
       "error_title": "データを取得できません",
@@ -5799,9 +5966,36 @@
       "try_again": "再試行してください",
       "limited_spending_warning": "実際の利用可能額は制限されている可能性があります。制限を調整するには、{{manageCard}}に移動してください。",
       "add_funds": "資金を追加",
+      "change_asset": "Change asset",
       "manage_card_options": {
+        "manage_spending_limit": "Manage spending limit",
+        "manage_spending_limit_description_restricted": "Restricted spending limit is on",
+        "manage_spending_limit_description_full": "Full spending access is on",
         "manage_card": "カードの管理",
-        "advanced_card_management_description": "トランザクションの表示、カードの凍結などを行います"
+        "advanced_card_management_description": "Detailed transactions, freeze card, and more"
+      }
+    },
+    "card_authentication": {
+      "title": "Log in to your Card account",
+      "location_button_text": "International",
+      "location_button_text_us": "US account",
+      "email_label": "Email",
+      "password_label": "Password",
+      "email_placeholder": "Enter your email address",
+      "password_placeholder": "Enter your password",
+      "login_button": "Log in",
+      "errors": {
+        "invalid_credentials": "Invalid login details",
+        "unknown_error": "Unknown error, please try again later",
+        "email_required": "Email is required",
+        "password_required": "Password is required",
+        "email_invalid": "Invalid email address",
+        "password_invalid": "Invalid password",
+        "invalid_email_or_password": "Invalid email or password, check your credentials and try again.",
+        "network_error": "Network error. Please check your connection and try again.",
+        "timeout_error": "Request timed out. Please check your connection and try again.",
+        "server_error": "Server error. Please try again later.",
+        "configuration_error": "Service is temporarily unavailable. Please try again later."
       }
     }
   },
@@ -5825,65 +6019,65 @@
     "close": "閉じる"
   },
   "rewards": {
-    "auth_fail_title": "Unknown Error.",
-    "auth_fail_description": "An unknown error occurred while authenticating this account with the rewards program. Please try again later.",
-    "failed_to_authenticate": "Failed to authenticate with rewards program",
+    "auth_fail_title": "不明なエラーです。",
+    "auth_fail_description": "このアカウントをリワードプログラムで認証中に不明なエラーが発生しました。後でもう一度お試しください。",
+    "failed_to_authenticate": "リワードプログラムの認証に失敗しました",
     "not_implemented": "近日追加予定",
     "not_implemented_season_summary": "セッションサマリーが近日利用可能になります",
     "optin_error": {
-      "title": "Opt-in failed",
-      "description": "Check your connection and try again."
+      "title": "オプトインに失敗しました",
+      "description": "接続を確認して、もう一度お試しください。"
     },
     "season_status_error": {
-      "error_fetching_title": "Season balance couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "シーズン残高を読み込めませんでした",
+      "error_fetching_description": "接続を確認して、もう一度お試しください。",
+      "retry_button": "再試行"
     },
     "active_boosts_error": {
-      "error_fetching_title": "Boosts couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "ブーストを読み込めませんでした",
+      "error_fetching_description": "接続を確認して、もう一度お試しください。",
+      "retry_button": "再試行"
     },
     "unlocked_rewards_error": {
-      "error_fetching_title": "Rewards couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "リワードを読み込めませんでした",
+      "error_fetching_description": "接続を確認して、もう一度お試しください。",
+      "retry_button": "再試行"
     },
     "upcoming_rewards_error": {
-      "error_fetching_title": "Rewards couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "リワードを読み込めませんでした",
+      "error_fetching_description": "接続を確認して、もう一度お試しください。",
+      "retry_button": "再試行"
     },
     "referral_details_error": {
-      "error_fetching_title": "Referral details couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "紹介の詳細を読み込めませんでした",
+      "error_fetching_description": "接続を確認して、もう一度お試しください。",
+      "retry_button": "再試行"
     },
     "referral_validation_unknown_error": {
-      "title": "Referral code couldn’t be validated",
-      "description": "Check your connection and try again."
+      "title": "紹介コードを検証できませんでした",
+      "description": "接続を確認して、もう一度お試しください。"
     },
     "active_activity_error": {
-      "error_fetching_title": "Activity couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "アクティビティを読み込めませんでした",
+      "error_fetching_description": "接続を確認して、もう一度お試しください。",
+      "retry_button": "再試行"
     },
-    "solana_signup_not_supported": "Signing in to Rewards with Solana accounts is not supported yet. Please use an Ethereum account instead.",
+    "solana_signup_not_supported": "Solanaアカウントでのリワードへのサインインは、まだサポートされていません。代わりにイーサリアムアカウントをご利用ください。",
     "error_messages": {
-      "unknown_error": "Unknown error occurred",
-      "something_went_wrong": "Something went wrong. Please try again shortly.",
-      "account_already_registered": "This account is already registered with another Rewards profile. Please switch account to continue.",
-      "request_rejected": "You rejected the request.",
-      "failed_to_claim_reward": "Failed to claim reward. Please try again shortly.",
-      "service_not_available": "Service is not available at the moment. Please try again shortly."
+      "unknown_error": "不明なエラーが発生しました",
+      "something_went_wrong": "問題が発生しました。しばらくしてからもう一度お試しください。",
+      "account_already_registered": "このアカウントは別のリワードプロファイルにすでに登録されています。続行するにはアカウントを切り替えてください。",
+      "request_rejected": "リクエストを拒否しました。",
+      "failed_to_claim_reward": "リワードの請求に失敗しました。しばらくしてからもう一度お試しください。",
+      "service_not_available": "現在サービスをご利用いただけません。しばらくしてからもう一度お試しください。"
     },
     "claim_reward_error": {
-      "title": "Failed to claim reward"
+      "title": "リワードの請求に失敗しました"
     },
     "accounts_opt_in_state_error": {
-      "error_fetching_title": "Accounts couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "アカウントを読み込めませんでした",
+      "error_fetching_description": "接続を確認して、もう一度お試しください。",
+      "retry_button": "再試行"
     },
     "referral_rewards_title": "紹介",
     "points": "ポイント",
@@ -5899,139 +6093,142 @@
     "tab_levels_title": "レベル",
     "referral_stats_earned_from_referrals": "紹介して報酬を獲得",
     "referral_stats_referrals": "紹介",
-    "loading_activity": "Loading activity...",
-    "error_loading_activity": "Error loading activity",
-    "activity_empty_title": "No recent activity.",
-    "activity_empty_description": "Use MetaMask to earn points, level up, and unlock rewards.",
-    "activity_empty_link": "See ways to earn",
+    "loading_activity": "アクティビティを読み込み中...",
+    "error_loading_activity": "アクティビティの読み込みエラー",
+    "activity_empty_title": "最近のアクティビティはありません。",
+    "activity_empty_description": "MetaMaskを使ってポイントを獲得し、レベルアップして、リワードのロックを解除しましょう。",
+    "activity_empty_link": "獲得方法を見る",
     "events": {
-      "to": "to",
+      "to": "送り先",
       "type": {
         "swap": "スワップ",
         "perps": "パーペチュアル",
-        "referral": "Referral",
-        "referral_action": "Referral action",
-        "sign_up_bonus": "Sign up bonus",
-        "loyalty_bonus": "Loyalty bonus",
-        "one_time_bonus": "One-time bonus",
-        "open_position": "Opened position",
-        "close_position": "Closed position",
+        "card_spend": "Card spend",
+        "referral": "紹介",
+        "referral_action": "紹介アクション",
+        "sign_up_bonus": "サインアップボーナス",
+        "loyalty_bonus": "ロイヤルティボーナス",
+        "one_time_bonus": "ワンタイムボーナス",
+        "open_position": "ポジションをオープン",
+        "close_position": "ポジションをクローズ",
         "take_profit": "TP/SL",
         "stop_loss": "TP/SL",
-        "uncategorized_event": "Uncategorized event"
+        "uncategorized_event": "未分類のイベント"
       },
-      "date": "Date",
-      "account": "Account",
-      "bonus": "Bonus",
-      "details": "Details",
-      "points": "Points",
-      "points_base": "Base",
-      "points_boost": "Boost",
-      "points_total": "Total"
+      "date": "日付",
+      "account": "アカウント",
+      "bonus": "ボーナス",
+      "details": "詳細",
+      "points": "ポイント",
+      "points_base": "ベース",
+      "points_boost": "ブースト",
+      "points_total": "合計"
     },
     "onboarding": {
       "not_supported_region_title": "未対応の地域です",
-      "not_supported_region_description": "Rewards are not supported in your region yet. We are working on expanding access, so check back later.",
-      "not_supported_hardware_account_title": "Account not supported",
-      "not_supported_hardware_account_description": "Hardware wallet accounts are not eligible to receive rewards yet. Please switch to a different account to proceed.",
-      "not_supported_account_type_title": "Account type not supported",
-      "not_supported_account_type_description": "Currently only internal Ethereum and Solana accounts can be opted into the Rewards program. Please switch to a different account to proceed.",
-      "not_supported_confirm_go_back": "Go back",
-      "not_supported_confirm_retry": "Retry",
-      "auth_fail_title": "Authentication Failed",
-      "auth_fail_description": "Unable to authenticate with the rewards program. Please check your connection and try again.",
-      "geo_check_fail_title": "Cannot determine opt-in eligibility",
-      "geo_check_fail_description": "We cannot determine if your country allows opting into the rewards program. Please check your connection and try again.",
+      "not_supported_region_description": "現在、お住まいの地域ではリワードをご利用いただけません。対象地域を拡大中ですので、後日再度ご確認ください。",
+      "not_supported_hardware_account_title": "サポートされていないアカウントです",
+      "not_supported_hardware_account_description": "ハードウェアウォレットのアカウントは、現時点ではリワードを受け取ることはできません。別のアカウントに切り替えてください。",
+      "not_supported_account_type_title": "サポートされていないアカウントタイプです",
+      "not_supported_account_type_description": "現在、リワードプログラムは内部のイーサリアムおよびSolanaアカウントのみがオプトイン可能です。続行するには、別のアカウントに切り替えてください。",
+      "not_supported_confirm_go_back": "戻る",
+      "not_supported_confirm_retry": "再試行",
+      "auth_fail_title": "認証に失敗しました",
+      "auth_fail_description": "リワードプログラムに認証できませんでした。接続状況を確認して、もう一度お試しください。",
+      "geo_check_fail_title": "オプトインの資格を確認できません",
+      "geo_check_fail_description": "お住いの国でリワードプログラムへのオプトインが許可されているかを確認できません。接続を確認して、もう一度お試しください。",
       "gtm_title": "リワードのご紹介",
       "gtm_description": "アクティビティに対してポイントを獲得できます。\nレベルを上げてリワードのロックを解除しましょう。",
       "gtm_confirm": "開始",
       "intro_title": "シーズン1\n開催中",
-      "intro_description": "Earn points for your activity. \nAdvance through levels to unlock rewards.",
-      "intro_confirm": "Claim 250 points",
-      "intro_confirm_geo_loading": "Checking region...",
-      "checking_opt_in": "Checking accounts...",
-      "redirecting_to_dashboard": "Redirecting...",
+      "intro_description": "アクティビティに対してポイントを獲得できます。\nレベルを上げてリワードのロックを解除しましょう。",
+      "intro_confirm": "250ポイントを請求する",
+      "intro_confirm_geo_loading": "地域を確認中…",
+      "checking_opt_in": "アカウントを確認中…",
+      "redirecting_to_dashboard": "リダイレクト中…",
       "intro_skip": "後で",
       "step_confirm": "次へ",
-      "step_skip": "Skip",
-      "step1_title": "Earn points on every trade",
+      "step_skip": "スキップ",
+      "step1_title": "すべての取引でポイントを獲得",
       "step1_description": "MetaMaskでスワップやパーペチュアル取引を行うたびに、リワード獲得のチャンスが近づきます。アカウントを追加して、ポイントが貯まる様子をご覧ください。",
-      "step2_title": "Level up for bigger perks",
+      "step2_title": "レベルアップして特典を増やそう",
       "step2_description": "ポイント数のマイルストーンに達すると、パーペチュアル手数料50%オフ、限定トークン、無料のMetaMaskメタルカードといった特典を獲得できます。",
-      "step3_title": "Exclusive seasonal rewards",
-      "step3_description": "Each season brings new perks. Join in, compete, and claim what you can before time runs out.",
-      "step4_title": "You'll earn 250 points when you sign up!",
-      "step4_title_referral_validating": "Validating referral code...",
-      "step4_referral_input_placeholder": "Referral code (optional)",
-      "step4_referral_input_error": "Invalid referral code",
-      "step4_confirm": "Claim points",
-      "step4_confirm_loading": "Claiming points...",
-      "step4_linking_accounts": "Adding accounts... ({{current}}/{{total}})",
-      "step4_linking_accounts_loading": "Adding additional accounts...",
-      "step4_success_description": "You have successfully signed up for MetaMask Rewards!",
-      "step4_legal_disclaimer_1": "By selecting 'Claim Points', you agree to the MetaMask Rewards",
-      "step4_legal_disclaimer_2": "Supplemental Terms of Use and Privacy Notice",
-      "step4_legal_disclaimer_3": ". We'll track onchain activity to reward you automatically –",
-      "step4_legal_disclaimer_4": "learn more"
+      "step3_title": "限定シーズンリワード",
+      "step3_description": "シーズンごとに新しい特典が登場します。参加して競争し、期間終了までにリワードを請求しましょう。",
+      "step4_title": "サインアップすると250ポイントを獲得できます！",
+      "step4_title_referral_bonus": "You'll earn 500 points when you sign up with this code!",
+      "step4_title_referral_validating": "紹介コードを検証中...",
+      "step4_referral_bonus_description": "Use a referral code to earn 250 more",
+      "step4_referral_input_placeholder": "紹介コード（オプション）",
+      "step4_referral_input_error": "無効な紹介コード",
+      "step4_confirm": "ポイントを請求する",
+      "step4_confirm_loading": "ポイントを請求中…",
+      "step4_linking_accounts": "アカウントを追加中… ({{current}}/{{total}})",
+      "step4_linking_accounts_loading": "追加アカウントを追加中…",
+      "step4_success_description": "MetaMaskリワードへの登録が完了しました！",
+      "step4_legal_disclaimer_1": "「ポイントを請求」を選択することで、MetaMaskリワードに関する以下の規約に同意したものとみなされます",
+      "step4_legal_disclaimer_2": "補足利用規約およびプライバシー通知",
+      "step4_legal_disclaimer_3": "オンチェーンアクティビティを自動的に追跡し、リワードを付与します –",
+      "step4_legal_disclaimer_4": "詳細"
     },
     "settings": {
-      "title": "Rewards Settings",
-      "subtitle": "Accounts",
-      "description": "Add multiple accounts to combine your points and unlock rewards faster.",
-      "tab_linked_accounts": "Added ({{count}})",
-      "tab_unlinked_accounts": "Not added ({{count}})",
-      "no_linked_accounts": "No accounts opted in",
-      "all_accounts_linked_title": "All accounts opted in",
-      "all_accounts_linked_description": "You have added all your accounts to Rewards.",
-      "link_account_success_title": "{{accountName}} successfully added",
-      "link_account_error_title": "Failed to add account",
-      "link_account_button": "Add",
-      "link_account_failed_error": "Failed to link account",
-      "link_account_unknown_error": "Unknown error occurred"
+      "title": "リワード設定",
+      "subtitle": "アカウント",
+      "description": "複数のアカウントを追加して、ポイントを合算し、より早くリワードのロックを解除しましょう。",
+      "tab_linked_accounts": "追加: ({{count}})",
+      "tab_unlinked_accounts": "未追加: ({{count}})",
+      "no_linked_accounts": "オプトイン済みのアカウントはありません",
+      "all_accounts_linked_title": "すべてのアカウントがオプトイン済みです",
+      "all_accounts_linked_description": "すべてのアカウントをリワードに追加しました。",
+      "link_account_success_title": "{{accountName}}を追加しました",
+      "link_account_error_title": "アカウントの追加に失敗しました",
+      "link_account_button": "追加",
+      "link_account_failed_error": "アカウントのリンクに失敗しました",
+      "link_account_unknown_error": "不明なエラーが発生しました"
     },
     "optout": {
-      "title": "Opt out of Rewards",
-      "description": "This will remove your accounts from the Rewards program and erase your points and progress. You won't be able to undo this.",
-      "confirm": "Opt out",
+      "title": "リワードをオプトアウトする",
+      "description": "これにより、リワードプログラムからアカウントが削除され、ポイントと進行状況がすべて消去されます。この操作は元に戻せません。",
+      "confirm": "オプトアウトする",
       "modal": {
-        "confirmation_title": "Are you sure?",
-        "confirmation_description": "This will remove all your progress, and can't be reversed. If you rejoin the Rewards program later, you'll start back at 0.",
-        "cancel": "Cancel",
-        "confirm": "Confirm",
-        "error_message": "Failed to opt out of Rewards. Please try again.",
-        "processing": "Processing..."
+        "confirmation_title": "よろしいですか？",
+        "confirmation_description": "これにより、進行状況はすべて削除され、元には戻せません。リワードプログラムに後で再び参加した場合は、最初から始めることになります。",
+        "cancel": "キャンセル",
+        "confirm": "選択すると、",
+        "error_message": "リワードのオプトアウトに失敗しました。もう一度お試しください。",
+        "processing": "処理中..."
       }
     },
-    "toast_dismiss": "Dismiss",
+    "toast_dismiss": "閉じる",
     "dashboard_modal_info": {
       "active_account": {
-        "title": "Don't miss out",
-        "description": "Add your account to start earning points from your activity.",
-        "confirm": "Add account"
+        "title": "お見逃しなく",
+        "description": "アクティビティからポイントを獲得するには、アカウントを追加してください。",
+        "confirm": "アカウントを追加"
       },
       "multiple_unlinked_accounts": {
-        "title": "Start earning points",
-        "description": "Add your accounts so you can track your rewards at a glance.",
-        "confirm": "Add accounts"
+        "title": "ポイントの獲得を開始しましょう",
+        "description": "アカウントを追加すると、リワードを一目で確認できるようになります。",
+        "confirm": "アカウントを追加する"
       },
       "account_not_supported": {
-        "title": "Account not supported",
-        "description_hardware": "Hardware wallet accounts are not yet eligible to earn points. Please switch to a different account to proceed.",
-        "description_general": "Currently only non-hardware internal Ethereum and Solana accounts are eligible to earn points. Please switch to a different account to proceed.",
-        "confirm": "Go back"
+        "title": "サポートされていないアカウントです",
+        "description_hardware": "ハードウェアウォレットのアカウントは、現時点ではポイントを受け取ることはできません。別のアカウントに切り替えてください。",
+        "description_general": "現在、非ハードウェアの内部イーサリアムおよびSolanaアカウントのみがポイントを獲得できます。続行するには、別のアカウントに切り替えてください。",
+        "confirm": "戻る"
       }
     },
     "ways_to_earn": {
-      "title": "Ways to earn",
-      "supported_networks": "Supported Networks",
+      "title": "獲得方法",
+      "supported_networks": "サポートされているネットワーク",
       "swap": {
-        "title": "Swap",
-        "description": "80 points per $100",
+        "title": "スワップ",
+        "description": "$800ごとに10ポイント",
         "sheet": {
-          "title": "Swap tokens",
-          "points": "80 points per $100",
-          "description": "Swap tokens on supported networks to earn points for every dollar you trade.",
-          "cta_label": "Start a swap"
+          "title": "トークンをスワップ",
+          "points": "$800ごとに10ポイント",
+          "description": "サポートされているネットワークでトークンをスワップすると、1ドル取引するごとにポイントを獲得できます。",
+          "cta_label": "スワップを開始"
         }
       },
       "perps": {
@@ -6045,52 +6242,74 @@
         }
       },
       "referrals": {
-        "title": "Refer friends",
-        "description": "10 points per 50 from friends"
+        "title": "友達を紹介",
+        "description": "友達が50ポイント獲得するごとに10ポイント",
+        "sheet": {
+          "title": "Refer a friend",
+          "points": "20 points per 100",
+          "cta_label": "Refer a friend"
+        }
       },
       "loyalty": {
-        "title": "Loyalty bonus",
-        "description": "Earn points from past trades",
+        "title": "ロイヤルティボーナス",
+        "description": "過去の取引からポイントを獲得",
         "sheet": {
-          "title": "Loyalty bonus",
-          "points": "250 points per $1250",
-          "description": "Add accounts with past swaps or bridges in MetaMask to earn loyalty bonuses. Each eligible account unlocks points in increments of 250, up to a total of 50,000. Bonuses appear shortly after you add an account.",
-          "cta_label": "Add accounts"
+          "title": "ロイヤルティボーナス",
+          "points": "1250ドルごとに250ポイント",
+          "description": "MetaMaskで過去にスワップまたはブリッジを行ったアカウントを追加して、ロイヤルティボーナスを獲得しましょう。対象となるアカウントごとに、250ポイントずつ、最大50,000ポイントのロックを解除できます。ボーナスは、アカウントを追加するとすぐに反映されます。",
+          "cta_label": "アカウントを追加"
+        }
+      },
+      "card": {
+        "title": "MetaMask Card",
+        "description": "1 point per $1 spent",
+        "sheet": {
+          "title": "MetaMask Card",
+          "points": "1 point per $1 spent",
+          "description": "Earn points every time you use your MetaMask Card for purchases, plus 1% cash back (3% for Metal cardholders).",
+          "cta_label": "Manage Card"
         }
       }
     },
     "referral": {
-      "referral_code": "Referral code",
-      "referral_link": "Referral link",
+      "referral_code": "紹介コード",
+      "referral_link": "紹介リンク",
       "actions": {
         "share_referral_link": "友達を紹介",
         "share_referral_subject": "MetaMaskリワードにご参加ください"
       },
       "info": {
         "title": "コードを共有してさらに収入を得ましょう",
-        "description": "Your friends get a 2x sign up bonus. You get 10 points for every 50 they earn from trading."
+        "description": "友達はサインアップ時に2倍のボーナスを獲得できます。お客様は友達が取引で50ポイント獲得するごとに10ポイント獲得できます。"
       }
     },
-    "active_boosts_title": "Active boosts",
-    "season_1": "Season 1",
+    "link_account_group": {
+      "link_account": "Add account",
+      "tracked": "Tracked",
+      "untracked": "Untracked",
+      "link_account_success": "{{accountName}} added successfully",
+      "link_account_error": "Failed to add one or more addresses for {{accountName}}"
+    },
+    "active_boosts_title": "有効なブースト",
+    "season_1": "シーズン1",
     "upcoming_rewards": {
       "title": "ロックされているリワード",
-      "points_needed": "{{points}} points",
-      "cta_label": "Got it",
-      "alpha_fox_invite_input_placeholder": "Your Telegram handle"
+      "points_needed": "{{points}}ポイント",
+      "cta_label": "了解",
+      "alpha_fox_invite_input_placeholder": "Telegramのハンドルネーム"
     },
     "unlocked_rewards": {
-      "title": "Unlocked rewards",
-      "cta_label": "Claim now",
-      "cta_request_invite": "Request invite",
-      "claim_label": "Claim",
-      "claimed_label": "Claimed",
-      "reward_claimed": "Reward claimed",
+      "title": "ロックが解除されたリワード",
+      "cta_label": "今すぐ請求",
+      "cta_request_invite": "招待をリクエスト",
+      "claim_label": "請求",
+      "claimed_label": "請求済み",
+      "reward_claimed": "リワードを請求しました",
       "time_left": "残り",
-      "expired": "Expired"
+      "expired": "期限切れ"
     },
     "animation": {
-      "could_not_load": "Couldn't load"
+      "could_not_load": "読み込ませんでした"
     }
   },
   "time": {
@@ -6099,7 +6318,7 @@
   },
   "transaction_details": {
     "title": {
-      "perps_deposit": "Funded Perps account",
+      "perps_deposit": "パーペチュアルアカウントに入金しました",
       "predict_deposit": "Funded Predict account",
       "default": "トランザクションの詳細"
     },
@@ -6107,19 +6326,23 @@
       "bridge_fee": "ブリッジ手数料",
       "network_fee": "ネットワーク手数料",
       "paid_with": "支払方法:",
+      "retry_button": "Try again",
       "total": "合計"
     },
     "summary_title": {
-      "bridge": "{{sourceSymbol}}から{{targetSymbol}}にブリッジ",
       "bridge_approval": "{{approveSymbol}}を承認",
       "bridge_approval_loading": "承認",
-      "bridge_loading": "ブリッジ",
+      "bridge_send": "Bridge {{sourceSymbol}} from {{sourceChain}}",
+      "bridge_send_loading": "Bridge Send",
+      "bridge_receive": "Receive {{targetSymbol}} on {{targetChain}}",
+      "bridge_receive_loading": "Bridge Receive",
       "default": "トランザクション",
       "perps_deposit": "資金を追加",
       "predict_deposit": "Add funds",
       "swap": "トークンをスワップ",
       "swap_approval": "トークンを承認"
-    }
+    },
+    "perps_deposit_solution": "You now have {{fiat}} of USDC on Arbitrum. Try your deposit again."
   },
   "sdk_connect_v2": {
     "show_loading": {

--- a/locales/languages/ko.json
+++ b/locales/languages/ko.json
@@ -594,7 +594,9 @@
       "unexpectedError": "예기치 않은 오류가 발생했습니다.",
       "quoteFetchError": "견적을 불러오지 못했습니다.",
       "kycFormsFetchError": "KYC 양식을 불러오지 못했습니다.",
-      "title": "예치"
+      "title": "예치",
+      "limitExceeded": "This deposit would exceed your {{period}} limit. Your deposit including fees must be {{remaining}} or less.",
+      "limitError": "Failed to check your deposit limits. Please try again later."
     },
     "token_modal": {
       "select_a_token": "토큰 선택",
@@ -892,7 +894,7 @@
     "withdraw": "출금",
     "refresh_balance": "잔액 새로고침",
     "add_funds": "자금 추가",
-    "deposit_in_progress": "Deposit in progress",
+    "deposit_in_progress": "예치 진행 중",
     "your_positions": "내 포지션",
     "loading_positions": "포지션 불러오는 중...",
     "refreshing_positions": "포지션 새로고침 중...",
@@ -1277,6 +1279,7 @@
       "assetMappingFailed": "자산 매핑 구축에 실패했습니다",
       "depositFailed": "예치 실패",
       "orderLeverageReductionFailed": "레버리지를 줄일 수 없습니다",
+      "connectionTimeout": "Connection timed out. Please check your network and try again.",
       "connectionFailed": {
         "title": "무기한 선물이 일시적으로 중단되었습니다",
         "description": "곧 다시 온라인으로 이용할 수 있도록 작업 중입니다.",
@@ -1348,9 +1351,9 @@
         "error_message": "시장 데이터를 찾을 수 없습니다. 뒤로 가서 다시 시도해 보세요."
       },
       "statistics": "개요",
-      "24h_high": "24h high",
-      "24h_low": "24h low",
-      "24h_volume": "24h volume",
+      "24h_high": "24시간 최고가",
+      "24h_low": "24시간 최저가",
+      "24h_volume": "24시간 거래량",
       "open_interest": "미결제 약정",
       "funding_rate": "펀딩 비율",
       "countdown": "카운트다운",
@@ -1510,9 +1513,9 @@
         "metamask_fee": "MetaMask 수수료",
         "hyperliquid_fee": "Hyperliquid 수수료",
         "total_fee": "총 수수료",
-        "liquidated": "Liquidated",
-        "take_profit": "Take profit",
-        "stop_loss": "Stop loss"
+        "liquidated": "강제 청산됨",
+        "take_profit": "익절",
+        "stop_loss": "손절"
       },
       "funding": {
         "date": "날짜",
@@ -1525,7 +1528,7 @@
         "history_will_appear": "회원님의 거래 내역이 여기에 표시됩니다"
       }
     },
-    "risk_disclaimer": "Perpetual contracts are very risky, and you could suddenly and without notice lose your entire investment. You trade entirely at your own risk. Market data provided by Hyperliquid. Price chart powered by",
+    "risk_disclaimer": "Perpetual contracts are very risky, and you could suddenly and without notice lose your entire investment. You trade entirely at your own risk. Market data provided by Hyperliquid. Price chart powered by",
     "tutorial": {
       "continue": "계속",
       "skip": "건너뛰기",
@@ -1555,11 +1558,11 @@
       "ready_to_trade": {
         "title": "거래할 준비가 되셨나요?",
         "description": "원하는 토큰으로 무기한 선물 계정에 입금하고, 바로 첫 거래를 시작하세요.",
-        "footer_text": "MetaMask가 자금을 Arbitrum의 USDC로 스왑하고 추가 수수료 없이 HyperCore에 입금합니다."
+        "footer_text": "MetaMask will swap your funds to USDC on Arbitrum, and deposit them onto HyperCore for no added fee."
       },
       "got_it": "확인",
       "card": {
-        "title": "Learn the basics of perps"
+        "title": "무기한 선물 기초 배우기"
       }
     },
     "points": "포인트",
@@ -1576,10 +1579,10 @@
     "market_list": "시장 목록",
     "market_details": "시장 상세 정보",
     "tab": {
-      "no_predictions": "아직 예측이 없습니다",
-      "no_predictions_description": "예측을 만들어 시작해 보세요.",
-      "explore": "시장 살펴보기",
-      "new_prediction": "새 예측"
+      "no_predictions_description": "Your predictions will appear here, showing your stake and market movement.",
+      "explore": "Browse markets",
+      "new_prediction": "새 예측",
+      "resolved_markets": "Resolved markets"
     },
     "sell_position": "포지션 매도",
     "cash_out": "출금",
@@ -1609,16 +1612,73 @@
     "claim_button": "청구",
     "markets_won": "수익을 낸 시장",
     "won_markets_text": "{{count}}개 시장{{s}} 승리",
-    "won_markets_text_singular": "{{count}}개 시장에서 수익을 냄",
-    "won_markets_text_plural": "{{count}}개 시장에서 수익을 냄",
+    "available_balance": "Available balance",
     "claim_amount_text": "${{amount}} 수령",
     "unrealized_pnl_label": "미실현 손익",
     "unrealized_pnl_value": "{{amount}}({{percent}})",
+    "unrealized_pnl_error": "Unable to load",
     "unavailable": {
       "title": "Unavailable in your region",
       "description": "Predictions aren't available in your region due to legal restrictions.",
       "link": "See Polymarket terms",
       "button": "Got it"
+    },
+    "deposit": {
+      "in_progress": "Deposit in progress",
+      "adding_funds": "Adding funds",
+      "adding_your_funds": "Adding your funds",
+      "add_funds": "Add funds",
+      "withdraw": "Withdraw",
+      "estimated_processing_time": "Est. {{time}} seconds",
+      "account_ready": "Your account is ready",
+      "account_ready_description": "{{amount}} added to your balance",
+      "error_title": "Something went wrong",
+      "error_description": "Your account wasn't funded",
+      "try_again": "Try again"
+    },
+    "add_funds_sheet": {
+      "title": "Add funds",
+      "description": "You'll need to add funds to your Predictions account to get started. You can add any token and make your first prediction in seconds."
+    },
+    "transactions": {
+      "title": "Predictions",
+      "no_transactions": "No recent activity",
+      "buy_title": "Predicted",
+      "sell_title": "Cashed out",
+      "claim_title": "Claimed winnings",
+      "buy_detail": "Bought {{amountUsd}} on {{outcome}} · {{priceCents}} per share",
+      "sell_detail": "Sold at {{priceCents}} per share",
+      "claim_detail": "Claimed winnings",
+      "not_available": "N/A",
+      "date": "Date",
+      "market": "Market",
+      "outcome": "Outcome",
+      "predicted_amount": "Predicted amount",
+      "shares_bought": "Shares bought",
+      "shares_sold": "Shares sold",
+      "price_per_share": "Price per share",
+      "price_impact": "Price impact",
+      "net_pnl": "Net P&L",
+      "total_net_pnl": "Total Net P&L",
+      "market_net_pnl": "Market Net P&L",
+      "activity_details": "Activity details"
+    },
+    "claim": {
+      "toasts": {
+        "pending": {
+          "title": "Claiming {{amount}}",
+          "description": "Est. {{time}} seconds"
+        },
+        "confirmed": {
+          "title": "Claimed",
+          "description": "{{amount}} added to your balance"
+        },
+        "error": {
+          "title": "Something went wrong",
+          "description": "Failed to proceed with claim",
+          "try_again": "Try again"
+        }
+      }
     }
   },
   "receive": {
@@ -3093,6 +3153,7 @@
     "tx_review_lending_withdraw": "대출 출금",
     "tx_review_perps_deposit": "자금이 입금된 무기한 선물 계정",
     "tx_review_predict_deposit": "Funded Predict account",
+    "tx_review_predict_claim": "Claimed Predict winnings",
     "sent_ether": "보낸 이더",
     "self_sent_ether": "나에게 보낸 이더",
     "received_ether": "받은 이더",
@@ -3939,7 +4000,9 @@
     "wallet_connect_dapps_cta": "세션 보기",
     "network_not_supported": "현재 네트워크는 지원하지 않음",
     "select_provider": "선호하는 공급업체 선택",
-    "switch_network": "메인넷이나 세폴리아로 전환하세요"
+    "switch_network": "메인넷이나 세폴리아로 전환하세요",
+    "card_title": "Always show MetaMask Card button",
+    "card_desc": "MetaMask Card is only available to residents of select countries"
   },
   "walletconnect_sessions": {
     "no_active_sessions": "현재 활성화된 세션이 없습니다",
@@ -5315,7 +5378,7 @@
     },
     "tooltip": {
       "perps_deposit": {
-        "transaction_fee": "무기한 선물에서 사용하는 네트워크인 HyperCore에서 토큰을 USDC로 스왑합니다. 스왑 제공업체가 수수료를 부과할 수 있지만 MetaMask에서 부과하는 수수료는 없습니다."
+        "transaction_fee": "We'll swap your tokens for USDC on HyperCore, the network used by Perps. Swap providers may charge a fee, but MetaMask won't."
       },
       "predict_deposit": {
         "transaction_fee": "We'll swap your tokens for USDC.e on Polygon, the network used by Predict. Swap providers may charge a fee, but MetaMask won't."
@@ -5407,6 +5470,12 @@
       "save": "저장",
       "title": "승인 한도 편집"
     },
+    "predict_claim": {
+      "button_label": "Claim winnings",
+      "summary": "You won",
+      "footer_bottom": "Funds will be added to your available balance",
+      "footer_top": "Winnings from {{count}} markets"
+    },
     "unlimited": "무제한",
     "all": "모두",
     "none": "없음",
@@ -5469,12 +5538,15 @@
     "points": "예상 포인트",
     "points_tooltip": "포인트",
     "points_tooltip_content_1": "Points are how you earn MetaMask Rewards for completing transactions, like when you swap, bridge, or trade perps.",
-    "points_tooltip_content_2": "Keep in mind this value is an estimate and will be finalized once the transaction is complete. Points can take up to 1 hour to be confirmed in your Rewards balance.",
+    "points_tooltip_content_2": "이 값은 추정치이며, 거래가 완료되면 최종적으로 확정됩니다. 포인트는 보상 잔액에 반영되기까지 최대 1시간이 걸릴 수 있습니다.",
     "unable_to_load": "불러올 수 없습니다",
     "points_error": "지금 포인트를 불러올 수 없습니다",
-    "points_error_content": "You'll still earn any points for this transaction. We'll notify you once they've been added to your account. You can also check your rewards tab in about an hour.",
+    "points_error_content": "이 트랜잭션에 대해서도 포인트가 적립됩니다. 포인트가 계정에 추가되면 알려드립니다. 약 한 시간이 지나면 보상 탭에서도 확인할 수 있습니다.",
     "see_other_quotes": "다른 견적 보기",
     "receive_at": "수령 주소:",
+    "recipient": "Recipient",
+    "select_recipient": "Select recipient",
+    "external_account": "External account",
     "error_banner_description": "현재 이 거래 경로를 이용할 수 없습니다. 금액이나 네트워크, 토큰을 변경해 보세요. 최적의 옵션을 찾아드리겠습니다.",
     "insufficient_funds": "자금 부족",
     "insufficient_gas": "가스 부족",
@@ -5775,6 +5847,12 @@
       "update_to_store_link": "MetaMask 최신 버전으로 업데이트하세요",
       "well_take_you_to_right_place": " 그러면 적절하게 안내해 드리겠습니다."
     },
+    "unsupported": {
+      "title": "This page is not supported in current version",
+      "description": "Update to the latest version to use this feature",
+      "update_to_store_link": "Update to the latest version of MetaMask",
+      "well_take_you_to_right_place": " and we'll take you to the right place."
+    },
     "go_to_home_button": "홈페이지로 가기",
     "back_button": "뒤로",
     "continue_button": "계속"
@@ -5791,7 +5869,96 @@
     "card_onboarding": {
       "title": "카드에 오신 걸 환영합니다",
       "description": "카드 기능을 사용하려면 MetaMask의 파트너사를 통해 계정을 인증해야 합니다.",
-      "verify_account_button": "계정 인증"
+      "verify_account_button": "계정 인증",
+      "sign_up": {
+        "title": "Sign-up",
+        "description": "Register your details with Crypto Life, the provider of MetaMask Card. You'll use this account to access and manage your card.",
+        "email_label": "Email",
+        "password_label": "Password",
+        "confirm_password_label": "Confirm password",
+        "country_label": "Country of Residence",
+        "email_placeholder": "Enter your email address",
+        "password_placeholder": "Enter your password",
+        "country_placeholder": "Select your country",
+        "password_mismatch": "Passwords do not match",
+        "invalid_email": "Invalid email address"
+      },
+      "confirm_email": {
+        "title": "Confirm your email",
+        "description": "We've sent a confirmation code to: {{email}}",
+        "confirm_code_label": "Confirmation code",
+        "confirm_code_placeholder": "Enter the confirmation code"
+      },
+      "set_phone_number": {
+        "title": "Phone number",
+        "description": "Enter your phone number",
+        "phone_number_label": "Phone number",
+        "phone_number_placeholder": "Enter your phone number",
+        "country_area_code_label": "Country area code",
+        "invalid_phone_number": "Invalid phone number",
+        "legal_terms": "By continuing, you agree to receiving SMS to verify your phone number."
+      },
+      "confirm_phone_number": {
+        "title": "Confirm your phone number",
+        "description": "We've sent a confirmation code to: {{phoneNumber}}",
+        "confirm_code_label": "Confirmation code"
+      },
+      "verify_identity": {
+        "title": "Verifying your identity to get your card",
+        "description": "To keep your account secure and comply with regulations, we need to verify your identity.\n\nYou'll need a government-issued ID and a proof of address (like a utility bill or bank statement).\n\nVerification usually takes 5-30 minutes, and we'll notify you as soon as it's complete.",
+        "verify_button": "Verify now with Veriff"
+      },
+      "validating_kyc": {
+        "title": "Validating your KYC..."
+      },
+      "kyc_failed": {
+        "title": "Rejected",
+        "description": "Your KYC was rejected. Please try again."
+      },
+      "personal_details": {
+        "title": "Personal details",
+        "description": "Enter your personal details",
+        "first_name_label": "First name",
+        "last_name_label": "Last name",
+        "date_of_birth_label": "Date of birth",
+        "nationality_label": "Country of Nationality",
+        "ssn_label": "Social Security Number",
+        "first_name_placeholder": "Enter your first name",
+        "last_name_placeholder": "Enter your last name",
+        "date_of_birth_placeholder": "Enter your date of birth",
+        "nationality_placeholder": "Select your nationality",
+        "ssn_placeholder": "Enter your SSN",
+        "invalid_ssn": "Invalid SSN",
+        "invalid_date_of_birth": "Invalid date of birth",
+        "invalid_date_of_birth_underage": "You must be at least 18 years old"
+      },
+      "physical_address": {
+        "title": "Physical address",
+        "description": "Please provide your physical address",
+        "address_line_1_label": "Address line 1",
+        "address_line_2_label": "Address line 2",
+        "city_label": "City",
+        "state_label": "State",
+        "zip_code_label": "ZIP code",
+        "address_line_1_placeholder": "Enter your address line 1",
+        "address_line_2_placeholder": "Enter your address line 2",
+        "city_placeholder": "Enter your city",
+        "state_placeholder": "Enter your state",
+        "zip_code_placeholder": "Enter your ZIP code",
+        "same_mailing_address_label": "Physical address is the same as mailing address",
+        "electronic_consent": "I agree to the E-Sign Act Consent and Disclosure and to receive all communictions electronically."
+      },
+      "mailing_address": {
+        "title": "Mailing address",
+        "description": "Please provide your mailing address"
+      },
+      "complete": {
+        "title": "Approved!",
+        "description": "Your KYC was approved. You can now use your Card."
+      },
+      "continue_button": "Next",
+      "confirm_button": "Confirm",
+      "retry_button": "Try again"
     },
     "card_home": {
       "error_title": "데이터를 불러올 수 없습니다",
@@ -5799,9 +5966,36 @@
       "try_again": "다시 시도",
       "limited_spending_warning": "실제 사용 가능 금액이 제한될 수 있습니다. 한도를 조정하려면 {{manageCard}}(으)로 이동하세요",
       "add_funds": "자금 추가",
+      "change_asset": "Change asset",
       "manage_card_options": {
+        "manage_spending_limit": "Manage spending limit",
+        "manage_spending_limit_description_restricted": "Restricted spending limit is on",
+        "manage_spending_limit_description_full": "Full spending access is on",
         "manage_card": "카드 관리",
-        "advanced_card_management_description": "트랜잭션 내역, 카드 동결 등 확인"
+        "advanced_card_management_description": "Detailed transactions, freeze card, and more"
+      }
+    },
+    "card_authentication": {
+      "title": "Log in to your Card account",
+      "location_button_text": "International",
+      "location_button_text_us": "US account",
+      "email_label": "Email",
+      "password_label": "Password",
+      "email_placeholder": "Enter your email address",
+      "password_placeholder": "Enter your password",
+      "login_button": "Log in",
+      "errors": {
+        "invalid_credentials": "Invalid login details",
+        "unknown_error": "Unknown error, please try again later",
+        "email_required": "Email is required",
+        "password_required": "Password is required",
+        "email_invalid": "Invalid email address",
+        "password_invalid": "Invalid password",
+        "invalid_email_or_password": "Invalid email or password, check your credentials and try again.",
+        "network_error": "Network error. Please check your connection and try again.",
+        "timeout_error": "Request timed out. Please check your connection and try again.",
+        "server_error": "Server error. Please try again later.",
+        "configuration_error": "Service is temporarily unavailable. Please try again later."
       }
     }
   },
@@ -5825,65 +6019,65 @@
     "close": "종료"
   },
   "rewards": {
-    "auth_fail_title": "Unknown Error.",
-    "auth_fail_description": "An unknown error occurred while authenticating this account with the rewards program. Please try again later.",
-    "failed_to_authenticate": "Failed to authenticate with rewards program",
+    "auth_fail_title": "알 수 없는 오류입니다.",
+    "auth_fail_description": "보상 프로그램에 대한 계정 인증 중 알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.",
+    "failed_to_authenticate": "보상 프로그램 인증에 실패했습니다",
     "not_implemented": "곧 추가 예정",
     "not_implemented_season_summary": "시즌 요약이 곧 추가될 예정입니다",
     "optin_error": {
-      "title": "Opt-in failed",
-      "description": "Check your connection and try again."
+      "title": "참여 실패",
+      "description": "연결 상태를 확인하고 다시 시도하세요."
     },
     "season_status_error": {
-      "error_fetching_title": "Season balance couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "시즌 잔액을 불러올 수 없습니다",
+      "error_fetching_description": "연결 상태를 확인하고 다시 시도하세요.",
+      "retry_button": "다시 시도"
     },
     "active_boosts_error": {
-      "error_fetching_title": "Boosts couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "부스트를 불러올 수 없습니다",
+      "error_fetching_description": "연결 상태를 확인하고 다시 시도하세요.",
+      "retry_button": "다시 시도"
     },
     "unlocked_rewards_error": {
-      "error_fetching_title": "Rewards couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "보상을 불러올 수 없습니다",
+      "error_fetching_description": "연결 상태를 확인하고 다시 시도하세요.",
+      "retry_button": "다시 시도"
     },
     "upcoming_rewards_error": {
-      "error_fetching_title": "Rewards couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "보상을 불러올 수 없습니다",
+      "error_fetching_description": "연결 상태를 확인하고 다시 시도하세요.",
+      "retry_button": "다시 시도"
     },
     "referral_details_error": {
-      "error_fetching_title": "Referral details couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "추천 정보를 불러올 수 없습니다",
+      "error_fetching_description": "연결 상태를 확인하고 다시 시도하세요.",
+      "retry_button": "다시 시도"
     },
     "referral_validation_unknown_error": {
-      "title": "Referral code couldn’t be validated",
-      "description": "Check your connection and try again."
+      "title": "추천 코드를 확인할 수 없습니다",
+      "description": "연결 상태를 확인하고 다시 시도하세요."
     },
     "active_activity_error": {
-      "error_fetching_title": "Activity couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "활동 정보를 불러올 수 없습니다",
+      "error_fetching_description": "연결 상태를 확인하고 다시 시도하세요.",
+      "retry_button": "다시 시도"
     },
-    "solana_signup_not_supported": "Signing in to Rewards with Solana accounts is not supported yet. Please use an Ethereum account instead.",
+    "solana_signup_not_supported": "솔라나 계정으로 보상에 로그인하는 기능은 아직 지원되지 않습니다. 이더리움 계정을 대신 사용해 주세요.",
     "error_messages": {
-      "unknown_error": "Unknown error occurred",
-      "something_went_wrong": "Something went wrong. Please try again shortly.",
-      "account_already_registered": "This account is already registered with another Rewards profile. Please switch account to continue.",
-      "request_rejected": "You rejected the request.",
-      "failed_to_claim_reward": "Failed to claim reward. Please try again shortly.",
-      "service_not_available": "Service is not available at the moment. Please try again shortly."
+      "unknown_error": "알 수 없는 오류가 발생했습니다",
+      "something_went_wrong": "알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.",
+      "account_already_registered": "이 계정은 이미 다른 보상 프로필에 등록되어 있습니다. 계정을 변경한 후 계속 진행하세요.",
+      "request_rejected": "요청을 거부하셨습니다.",
+      "failed_to_claim_reward": "보상을 수령할 수 없습니다. 잠시 후 다시 시도해 주세요.",
+      "service_not_available": "현재 서비스를 이용할 수 없습니다. 잠시 후 다시 시도해 주세요."
     },
     "claim_reward_error": {
-      "title": "Failed to claim reward"
+      "title": "보상을 수령할 수 없습니다"
     },
     "accounts_opt_in_state_error": {
-      "error_fetching_title": "Accounts couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "계정을 불러올 수 없습니다",
+      "error_fetching_description": "연결 상태를 확인하고 다시 시도하세요.",
+      "retry_button": "다시 시도"
     },
     "referral_rewards_title": "추천",
     "points": "포인트",
@@ -5899,139 +6093,142 @@
     "tab_levels_title": "레벨",
     "referral_stats_earned_from_referrals": "추천을 통해 적립",
     "referral_stats_referrals": "추천",
-    "loading_activity": "Loading activity...",
-    "error_loading_activity": "Error loading activity",
-    "activity_empty_title": "No recent activity.",
-    "activity_empty_description": "Use MetaMask to earn points, level up, and unlock rewards.",
-    "activity_empty_link": "See ways to earn",
+    "loading_activity": "활동 정보를 불러오는 중...",
+    "error_loading_activity": "활동 정보를 불러올 수 없습니다",
+    "activity_empty_title": "최근 활동이 없습니다.",
+    "activity_empty_description": "MetaMask로 포인트를 획득하고 보상을 잠금 해제하세요.",
+    "activity_empty_link": "포인트 적립 방법 보기",
     "events": {
-      "to": "to",
+      "to": "수신:",
       "type": {
         "swap": "스왑",
         "perps": "무기한 선물",
-        "referral": "Referral",
-        "referral_action": "Referral action",
-        "sign_up_bonus": "Sign up bonus",
-        "loyalty_bonus": "Loyalty bonus",
-        "one_time_bonus": "One-time bonus",
-        "open_position": "Opened position",
-        "close_position": "Closed position",
-        "take_profit": "TP/SL",
-        "stop_loss": "TP/SL",
-        "uncategorized_event": "Uncategorized event"
+        "card_spend": "Card spend",
+        "referral": "추천",
+        "referral_action": "추천 활동",
+        "sign_up_bonus": "가입 보너스",
+        "loyalty_bonus": "로열티 보너스",
+        "one_time_bonus": "일회성 보너스",
+        "open_position": "포지션 진입",
+        "close_position": "포지션 청산",
+        "take_profit": "익절/손절",
+        "stop_loss": "익절/손절",
+        "uncategorized_event": "미분류 이벤트"
       },
-      "date": "Date",
-      "account": "Account",
-      "bonus": "Bonus",
-      "details": "Details",
-      "points": "Points",
-      "points_base": "Base",
-      "points_boost": "Boost",
-      "points_total": "Total"
+      "date": "날짜",
+      "account": "계정",
+      "bonus": "보너스",
+      "details": "세부 정보",
+      "points": "포인트",
+      "points_base": "기본",
+      "points_boost": "부스트",
+      "points_total": "총액"
     },
     "onboarding": {
       "not_supported_region_title": "지원되지 않는 지역입니다",
-      "not_supported_region_description": "Rewards are not supported in your region yet. We are working on expanding access, so check back later.",
-      "not_supported_hardware_account_title": "Account not supported",
-      "not_supported_hardware_account_description": "Hardware wallet accounts are not eligible to receive rewards yet. Please switch to a different account to proceed.",
-      "not_supported_account_type_title": "Account type not supported",
-      "not_supported_account_type_description": "Currently only internal Ethereum and Solana accounts can be opted into the Rewards program. Please switch to a different account to proceed.",
-      "not_supported_confirm_go_back": "Go back",
-      "not_supported_confirm_retry": "Retry",
-      "auth_fail_title": "Authentication Failed",
-      "auth_fail_description": "Unable to authenticate with the rewards program. Please check your connection and try again.",
-      "geo_check_fail_title": "Cannot determine opt-in eligibility",
-      "geo_check_fail_description": "We cannot determine if your country allows opting into the rewards program. Please check your connection and try again.",
+      "not_supported_region_description": "회원님의 지역에서는 보상 프로그램이 아직 지원되지 않습니다. 현재 대상 지역을 확대 중이니, 나중에 다시 확인해 주세요.",
+      "not_supported_hardware_account_title": "지원되지 않는 계정입니다",
+      "not_supported_hardware_account_description": "아직은 하드웨어 지갑 계정으로 보상을 받을 수 없습니다. 다른 계정으로 변경하여 계속 진행하세요.",
+      "not_supported_account_type_title": "지원되지 않는 계정 유형입니다",
+      "not_supported_account_type_description": "현재는 내부 이더리움 및 솔라나 계정으로만 보상 프로그램에 참여할 수 있습니다. 다른 계정으로 변경하여 계속 진행해 주세요.",
+      "not_supported_confirm_go_back": "뒤로 가기",
+      "not_supported_confirm_retry": "다시 시도",
+      "auth_fail_title": "인증 실패",
+      "auth_fail_description": "보상 프로그램 인증을 할 수 없습니다. 연결 상태를 확인하고 다시 시도하세요.",
+      "geo_check_fail_title": "참여할 자격이 있는지 확인할 수 없습니다",
+      "geo_check_fail_description": "현재 사용자의 국가에서 보상 프로그램에 참여할 수 있는지 확인할 수 없습니다. 인터넷 연결 상태를 확인하고 다시 시도해 주세요.",
       "gtm_title": "리워드를 받으세요",
       "gtm_description": "활동에 대한 포인트를 획득하세요. \n레벨을 올려 리워드를 잠금 해제하세요.",
       "gtm_confirm": "시작하기",
       "intro_title": "시즌 1이 \n시작되었습니다",
-      "intro_description": "Earn points for your activity. \nAdvance through levels to unlock rewards.",
-      "intro_confirm": "Claim 250 points",
-      "intro_confirm_geo_loading": "Checking region...",
-      "checking_opt_in": "Checking accounts...",
-      "redirecting_to_dashboard": "Redirecting...",
+      "intro_description": "활동에 대한 포인트를 획득하세요. \n레벨을 올려 리워드를 잠금 해제하세요.",
+      "intro_confirm": "250포인트 수령",
+      "intro_confirm_geo_loading": "지역 확인 중...",
+      "checking_opt_in": "계정 확인 중...",
+      "redirecting_to_dashboard": "다른 페이지로 이동 중...",
       "intro_skip": "나중에",
       "step_confirm": "다음",
-      "step_skip": "Skip",
-      "step1_title": "Earn points on every trade",
+      "step_skip": "건너뛰기",
+      "step1_title": "거래할 때마다 포인트를 획득하세요",
       "step1_description": "MetaMask에서 스왑과 무기한 선물 거래를 할 때마다 보상 포인트가 적립됩니다. 계정을 추가하고 포인트가 쌓이는 것을 확인하세요.",
-      "step2_title": "Level up for bigger perks",
+      "step2_title": "레벨을 높여 더 많은 특전을 받으세요",
       "step2_description": "포인트 마일스톤을 달성하면 무기한 선물 수수료 50% 할인, 독점 토큰, 무료 MetaMask 메탈 카드와 같은 특전을 받을 수 있습니다.",
-      "step3_title": "Exclusive seasonal rewards",
-      "step3_description": "Each season brings new perks. Join in, compete, and claim what you can before time runs out.",
-      "step4_title": "You'll earn 250 points when you sign up!",
-      "step4_title_referral_validating": "Validating referral code...",
-      "step4_referral_input_placeholder": "Referral code (optional)",
-      "step4_referral_input_error": "Invalid referral code",
-      "step4_confirm": "Claim points",
-      "step4_confirm_loading": "Claiming points...",
-      "step4_linking_accounts": "Adding accounts... ({{current}}/{{total}})",
-      "step4_linking_accounts_loading": "Adding additional accounts...",
-      "step4_success_description": "You have successfully signed up for MetaMask Rewards!",
-      "step4_legal_disclaimer_1": "By selecting 'Claim Points', you agree to the MetaMask Rewards",
-      "step4_legal_disclaimer_2": "Supplemental Terms of Use and Privacy Notice",
-      "step4_legal_disclaimer_3": ". We'll track onchain activity to reward you automatically –",
-      "step4_legal_disclaimer_4": "learn more"
+      "step3_title": "특별한 시즌 보상",
+      "step3_description": "시즌마다 새로운 특전이 기다립니다. 시즌이 끝나기 전에 참여하고 경쟁하여 보상을 받으세요.",
+      "step4_title": "가입하면 250포인트를 획득할 수 있습니다!",
+      "step4_title_referral_bonus": "You'll earn 500 points when you sign up with this code!",
+      "step4_title_referral_validating": "추천 코드 확인 중...",
+      "step4_referral_bonus_description": "Use a referral code to earn 250 more",
+      "step4_referral_input_placeholder": "추천 코드(선택 사항)",
+      "step4_referral_input_error": "잘못된 추천 코드",
+      "step4_confirm": "포인트 수령",
+      "step4_confirm_loading": "포인트 수령 중...",
+      "step4_linking_accounts": "계정 추가 중...({{current}}/{{total}})",
+      "step4_linking_accounts_loading": "다른 계정 추가 중...",
+      "step4_success_description": "MetaMask 보상 프로그램에 성공적으로 등록하셨습니다!",
+      "step4_legal_disclaimer_1": "'포인트 수령'을 선택하면 MetaMask 보상 프로그램",
+      "step4_legal_disclaimer_2": "추가 이용 약관 및 개인정보 처리방침에 동의하는 것이 됩니다",
+      "step4_legal_disclaimer_3": ". 당사는 온체인 활동을 추척하여 사용자에게 자동으로 보상을 제공합니다 -",
+      "step4_legal_disclaimer_4": "자세히 알아보세요"
     },
     "settings": {
-      "title": "Rewards Settings",
-      "subtitle": "Accounts",
-      "description": "Add multiple accounts to combine your points and unlock rewards faster.",
-      "tab_linked_accounts": "Added ({{count}})",
-      "tab_unlinked_accounts": "Not added ({{count}})",
-      "no_linked_accounts": "No accounts opted in",
-      "all_accounts_linked_title": "All accounts opted in",
-      "all_accounts_linked_description": "You have added all your accounts to Rewards.",
-      "link_account_success_title": "{{accountName}} successfully added",
-      "link_account_error_title": "Failed to add account",
-      "link_account_button": "Add",
-      "link_account_failed_error": "Failed to link account",
-      "link_account_unknown_error": "Unknown error occurred"
+      "title": "보상 설정",
+      "subtitle": "계정",
+      "description": "여러 계정을 추가하면 포인트를 합쳐 보상을 더 빨리 잠금 해제할 수 있습니다.",
+      "tab_linked_accounts": "추가됨({{count}})",
+      "tab_unlinked_accounts": "추가되지 않음({{count}})",
+      "no_linked_accounts": "참여한 계정 없음",
+      "all_accounts_linked_title": "모든 계정 참여함",
+      "all_accounts_linked_description": "모든 계정을 보상 프로그램에 추가했습니다.",
+      "link_account_success_title": "{{accountName}} 추가 성공",
+      "link_account_error_title": "계정 추가 실패",
+      "link_account_button": "추가",
+      "link_account_failed_error": "계정 연결 실패",
+      "link_account_unknown_error": "알 수 없는 오류가 발생했습니다"
     },
     "optout": {
-      "title": "Opt out of Rewards",
-      "description": "This will remove your accounts from the Rewards program and erase your points and progress. You won't be able to undo this.",
-      "confirm": "Opt out",
+      "title": "보상 프로그램 탈퇴",
+      "description": "이 작업을 수행하면 보상 프로그램에서 계정이 제거되며, 모든 포인트와 진행 상황이 삭제됩니다. 이 작업은 되돌릴 수 없습니다.",
+      "confirm": "탈퇴",
       "modal": {
-        "confirmation_title": "Are you sure?",
-        "confirmation_description": "This will remove all your progress, and can't be reversed. If you rejoin the Rewards program later, you'll start back at 0.",
-        "cancel": "Cancel",
-        "confirm": "Confirm",
-        "error_message": "Failed to opt out of Rewards. Please try again.",
-        "processing": "Processing..."
+        "confirmation_title": "진행하시겠습니까?",
+        "confirmation_description": "이 작업을 수행하면 모든 진행 상황이 제거되며 복원할 수 없습니다. 보상 프로그램에 다시 참여할 경우 처음부터 다시 시작해야 합니다.",
+        "cancel": "취소",
+        "confirm": "컨펌",
+        "error_message": "보상 프로그램을 탈퇴할 수 없습니다. 다시 시도해 보세요.",
+        "processing": "처리 중..."
       }
     },
-    "toast_dismiss": "Dismiss",
+    "toast_dismiss": "닫기",
     "dashboard_modal_info": {
       "active_account": {
-        "title": "Don't miss out",
-        "description": "Add your account to start earning points from your activity.",
-        "confirm": "Add account"
+        "title": "기회를 놓치지 마세요",
+        "description": "계정을 추가하면 활동 포인트를 획득할 수 있습니다.",
+        "confirm": "계정 추가"
       },
       "multiple_unlinked_accounts": {
-        "title": "Start earning points",
-        "description": "Add your accounts so you can track your rewards at a glance.",
-        "confirm": "Add accounts"
+        "title": "포인트 획득 시작하기",
+        "description": "계정을 추가하면 한눈에 보상 상황을 추적할 수 있습니다.",
+        "confirm": "계정 추가"
       },
       "account_not_supported": {
-        "title": "Account not supported",
-        "description_hardware": "Hardware wallet accounts are not yet eligible to earn points. Please switch to a different account to proceed.",
-        "description_general": "Currently only non-hardware internal Ethereum and Solana accounts are eligible to earn points. Please switch to a different account to proceed.",
-        "confirm": "Go back"
+        "title": "지원되지 않는 계정입니다",
+        "description_hardware": "아직은 하드웨어 지갑 계정으로 포인트를 획득할 수 없습니다. 다른 계정으로 변경하여 계속 진행하세요.",
+        "description_general": "현재는 하드웨어 지갑 계정이 아닌 내부 이더리움 및 솔라나 계정으로만 포인트를 획득할 수 있습니다. 다른 계정으로 변경하여 계속 진행해 주세요.",
+        "confirm": "뒤로 가기"
       }
     },
     "ways_to_earn": {
-      "title": "Ways to earn",
-      "supported_networks": "Supported Networks",
+      "title": "포인트를 획득하는 방법",
+      "supported_networks": "지원 네트워크",
       "swap": {
-        "title": "Swap",
-        "description": "80 points per $100",
+        "title": "스왑",
+        "description": "$800당 10포인트",
         "sheet": {
-          "title": "Swap tokens",
-          "points": "80 points per $100",
-          "description": "Swap tokens on supported networks to earn points for every dollar you trade.",
-          "cta_label": "Start a swap"
+          "title": "토큰 스왑",
+          "points": "$800당 10포인트",
+          "description": "지원되는 네트워크에서 토큰을 스왑하면 거래 금액에 비례하여 포인트를 획득할 수 있습니다.",
+          "cta_label": "스왑 시작"
         }
       },
       "perps": {
@@ -6045,52 +6242,74 @@
         }
       },
       "referrals": {
-        "title": "Refer friends",
-        "description": "10 points per 50 from friends"
+        "title": "친구 추천",
+        "description": "친구가 50포인트를 획득할 때마다 10포인트를 받습니다",
+        "sheet": {
+          "title": "Refer a friend",
+          "points": "20 points per 100",
+          "cta_label": "Refer a friend"
+        }
       },
       "loyalty": {
-        "title": "Loyalty bonus",
-        "description": "Earn points from past trades",
+        "title": "로열티 보너스",
+        "description": "지난 거래에서 포인트를 획득합니다",
         "sheet": {
-          "title": "Loyalty bonus",
-          "points": "250 points per $1250",
-          "description": "Add accounts with past swaps or bridges in MetaMask to earn loyalty bonuses. Each eligible account unlocks points in increments of 250, up to a total of 50,000. Bonuses appear shortly after you add an account.",
-          "cta_label": "Add accounts"
+          "title": "로열티 보너스",
+          "points": "1,250달러당 250포인트",
+          "description": "MetaMask에서 스왑 또는 브릿지 거래 내역이 있는 계정을 추가하면 로열티 보너스를 받을 수 있습니다. 조건을 충족하는 계정당 250포인트씩 적립되며, 최대 총 50,000포인트까지 획득할 수 있습니다. 보너스는 계정 추가 직후 지급됩니다.",
+          "cta_label": "계정 추가"
+        }
+      },
+      "card": {
+        "title": "MetaMask Card",
+        "description": "1 point per $1 spent",
+        "sheet": {
+          "title": "MetaMask Card",
+          "points": "1 point per $1 spent",
+          "description": "Earn points every time you use your MetaMask Card for purchases, plus 1% cash back (3% for Metal cardholders).",
+          "cta_label": "Manage Card"
         }
       }
     },
     "referral": {
-      "referral_code": "Referral code",
-      "referral_link": "Referral link",
+      "referral_code": "추천 코드",
+      "referral_link": "추천 링크",
       "actions": {
         "share_referral_link": "친구 추천",
         "share_referral_subject": "MetaMask 보상 프로그램 가입"
       },
       "info": {
         "title": "코드를 공유하고 더 많이 적립하세요",
-        "description": "Your friends get a 2x sign up bonus. You get 10 points for every 50 they earn from trading."
+        "description": "친구는 두 배의 가입 보너스를 받을 수 있습니다. 친구가 거래로 50포인트를 획득할 때마다 사용자는 10포인트를 적립할 수 있습니다."
       }
     },
-    "active_boosts_title": "Active boosts",
-    "season_1": "Season 1",
+    "link_account_group": {
+      "link_account": "Add account",
+      "tracked": "Tracked",
+      "untracked": "Untracked",
+      "link_account_success": "{{accountName}} added successfully",
+      "link_account_error": "Failed to add one or more addresses for {{accountName}}"
+    },
+    "active_boosts_title": "적용 중인 부스트",
+    "season_1": "시즌 1",
     "upcoming_rewards": {
       "title": "잠긴 리워드",
-      "points_needed": "{{points}} points",
-      "cta_label": "Got it",
-      "alpha_fox_invite_input_placeholder": "Your Telegram handle"
+      "points_needed": "{{points}}포인트",
+      "cta_label": "컨펌",
+      "alpha_fox_invite_input_placeholder": "내 Telegram 아이디"
     },
     "unlocked_rewards": {
-      "title": "Unlocked rewards",
-      "cta_label": "Claim now",
-      "cta_request_invite": "Request invite",
-      "claim_label": "Claim",
-      "claimed_label": "Claimed",
-      "reward_claimed": "Reward claimed",
+      "title": "잠금 해제된 보상",
+      "cta_label": "지금 받기",
+      "cta_request_invite": "초대 요청",
+      "claim_label": "청구",
+      "claimed_label": "받음",
+      "reward_claimed": "보상받음",
       "time_left": "남음",
-      "expired": "Expired"
+      "expired": "만료됨"
     },
     "animation": {
-      "could_not_load": "Couldn't load"
+      "could_not_load": "불러올 수 없음"
     }
   },
   "time": {
@@ -6099,7 +6318,7 @@
   },
   "transaction_details": {
     "title": {
-      "perps_deposit": "Funded Perps account",
+      "perps_deposit": "무기한 선물 계정에 입금 완료",
       "predict_deposit": "Funded Predict account",
       "default": "트랜잭션 세부 사항"
     },
@@ -6107,19 +6326,23 @@
       "bridge_fee": "브릿지 수수료",
       "network_fee": "네트워크 수수료",
       "paid_with": "결제 수단:",
+      "retry_button": "Try again",
       "total": "총액"
     },
     "summary_title": {
-      "bridge": "{{sourceSymbol}}에서 {{targetSymbol}}(으)로 브릿지",
       "bridge_approval": "{{approveSymbol}} 승인",
       "bridge_approval_loading": "승인",
-      "bridge_loading": "브릿지",
+      "bridge_send": "Bridge {{sourceSymbol}} from {{sourceChain}}",
+      "bridge_send_loading": "Bridge Send",
+      "bridge_receive": "Receive {{targetSymbol}} on {{targetChain}}",
+      "bridge_receive_loading": "Bridge Receive",
       "default": "트랜잭션",
       "perps_deposit": "자금 추가",
       "predict_deposit": "Add funds",
       "swap": "토큰 스왑",
       "swap_approval": "토큰 승인"
-    }
+    },
+    "perps_deposit_solution": "You now have {{fiat}} of USDC on Arbitrum. Try your deposit again."
   },
   "sdk_connect_v2": {
     "show_loading": {

--- a/locales/languages/pt.json
+++ b/locales/languages/pt.json
@@ -594,7 +594,9 @@
       "unexpectedError": "Ocorreu um erro inesperado.",
       "quoteFetchError": "Falha ao buscar cotação.",
       "kycFormsFetchError": "Falha ao buscar formulários KYC.",
-      "title": "Depositar"
+      "title": "Depositar",
+      "limitExceeded": "This deposit would exceed your {{period}} limit. Your deposit including fees must be {{remaining}} or less.",
+      "limitError": "Failed to check your deposit limits. Please try again later."
     },
     "token_modal": {
       "select_a_token": "Selecione um token",
@@ -892,7 +894,7 @@
     "withdraw": "Sacar",
     "refresh_balance": "Atualizar saldo",
     "add_funds": "Adicionar fundos",
-    "deposit_in_progress": "Deposit in progress",
+    "deposit_in_progress": "Depósito em andamento",
     "your_positions": "Suas posições",
     "loading_positions": "Carregando posições...",
     "refreshing_positions": "Atualizando posições...",
@@ -1277,6 +1279,7 @@
       "assetMappingFailed": "Falha ao criar mapeamento de ativos",
       "depositFailed": "Falha no depósito",
       "orderLeverageReductionFailed": "Você não pode reduzir sua alavancagem",
+      "connectionTimeout": "Connection timed out. Please check your network and try again.",
       "connectionFailed": {
         "title": "Perps está temporariamente off-line",
         "description": "Estamos trabalhando para colocá-lo on-line novamente em breve.",
@@ -1348,9 +1351,9 @@
         "error_message": "Dados de mercado não encontrados. Volte e tente novamente."
       },
       "statistics": "Visão geral",
-      "24h_high": "24h high",
-      "24h_low": "24h low",
-      "24h_volume": "24h volume",
+      "24h_high": "Máxima em 24h",
+      "24h_low": "Mínima em 24h",
+      "24h_volume": "Volume em 24 horas",
       "open_interest": "Contratos em aberto",
       "funding_rate": "Taxa de depósito de fundos",
       "countdown": "Contagem regressiva",
@@ -1510,7 +1513,7 @@
         "metamask_fee": "Taxa da MetaMask",
         "hyperliquid_fee": "Taxa da Hyperliquid",
         "total_fee": "Taxa total",
-        "liquidated": "Liquidated",
+        "liquidated": "Liquidado",
         "take_profit": "Take profit",
         "stop_loss": "Stop loss"
       },
@@ -1525,7 +1528,7 @@
         "history_will_appear": "Seu histórico de negociação aparecerá aqui"
       }
     },
-    "risk_disclaimer": "Perpetual contracts are very risky, and you could suddenly and without notice lose your entire investment. You trade entirely at your own risk. Market data provided by Hyperliquid. Price chart powered by",
+    "risk_disclaimer": "Perpetual contracts are very risky, and you could suddenly and without notice lose your entire investment. You trade entirely at your own risk. Market data provided by Hyperliquid. Price chart powered by",
     "tutorial": {
       "continue": "Continuar",
       "skip": "Pular",
@@ -1555,11 +1558,11 @@
       "ready_to_trade": {
         "title": "Pronto para negociar?",
         "description": "Deposite fundos em sua conta perps com qualquer token e faça sua primeira negociação em segundos.",
-        "footer_text": "A MetaMask trocará seus fundos para USDC na Arbitrum e os depositará na HyperCore sem nenhuma taxa adicional."
+        "footer_text": "MetaMask will swap your funds to USDC on Arbitrum, and deposit them onto HyperCore for no added fee."
       },
       "got_it": "Entendi",
       "card": {
-        "title": "Learn the basics of perps"
+        "title": "Aprenda o básico sobre perps"
       }
     },
     "points": "Pontos",
@@ -1576,10 +1579,10 @@
     "market_list": "Lista de mercado",
     "market_details": "Detalhes do mercado",
     "tab": {
-      "no_predictions": "Nenhuma previsão ainda",
-      "no_predictions_description": "Abra uma previsão para começar.",
-      "explore": "Explorar mercados",
-      "new_prediction": "Nova previsão"
+      "no_predictions_description": "Your predictions will appear here, showing your stake and market movement.",
+      "explore": "Browse markets",
+      "new_prediction": "Nova previsão",
+      "resolved_markets": "Resolved markets"
     },
     "sell_position": "Posição de venda",
     "cash_out": "Sacar",
@@ -1609,16 +1612,73 @@
     "claim_button": "Resgatar",
     "markets_won": "Mercados ganhos",
     "won_markets_text": "Ganhou {{count}} mercado{{s}}",
-    "won_markets_text_singular": "Ganhou {{count}} mercado",
-    "won_markets_text_plural": "Ganhou {{count}} mercados",
+    "available_balance": "Available balance",
     "claim_amount_text": "Resgatar $ {{amount}}",
     "unrealized_pnl_label": "P&L não realizados",
     "unrealized_pnl_value": "{{amount}} ({{percent}})",
+    "unrealized_pnl_error": "Unable to load",
     "unavailable": {
       "title": "Unavailable in your region",
       "description": "Predictions aren't available in your region due to legal restrictions.",
       "link": "See Polymarket terms",
       "button": "Got it"
+    },
+    "deposit": {
+      "in_progress": "Deposit in progress",
+      "adding_funds": "Adding funds",
+      "adding_your_funds": "Adding your funds",
+      "add_funds": "Add funds",
+      "withdraw": "Withdraw",
+      "estimated_processing_time": "Est. {{time}} seconds",
+      "account_ready": "Your account is ready",
+      "account_ready_description": "{{amount}} added to your balance",
+      "error_title": "Something went wrong",
+      "error_description": "Your account wasn't funded",
+      "try_again": "Try again"
+    },
+    "add_funds_sheet": {
+      "title": "Add funds",
+      "description": "You'll need to add funds to your Predictions account to get started. You can add any token and make your first prediction in seconds."
+    },
+    "transactions": {
+      "title": "Predictions",
+      "no_transactions": "No recent activity",
+      "buy_title": "Predicted",
+      "sell_title": "Cashed out",
+      "claim_title": "Claimed winnings",
+      "buy_detail": "Bought {{amountUsd}} on {{outcome}} · {{priceCents}} per share",
+      "sell_detail": "Sold at {{priceCents}} per share",
+      "claim_detail": "Claimed winnings",
+      "not_available": "N/A",
+      "date": "Date",
+      "market": "Market",
+      "outcome": "Outcome",
+      "predicted_amount": "Predicted amount",
+      "shares_bought": "Shares bought",
+      "shares_sold": "Shares sold",
+      "price_per_share": "Price per share",
+      "price_impact": "Price impact",
+      "net_pnl": "Net P&L",
+      "total_net_pnl": "Total Net P&L",
+      "market_net_pnl": "Market Net P&L",
+      "activity_details": "Activity details"
+    },
+    "claim": {
+      "toasts": {
+        "pending": {
+          "title": "Claiming {{amount}}",
+          "description": "Est. {{time}} seconds"
+        },
+        "confirmed": {
+          "title": "Claimed",
+          "description": "{{amount}} added to your balance"
+        },
+        "error": {
+          "title": "Something went wrong",
+          "description": "Failed to proceed with claim",
+          "try_again": "Try again"
+        }
+      }
     }
   },
   "receive": {
@@ -3093,6 +3153,7 @@
     "tx_review_lending_withdraw": "Saque de empréstimo",
     "tx_review_perps_deposit": "Depósito de fundos na conta de perps",
     "tx_review_predict_deposit": "Funded Predict account",
+    "tx_review_predict_claim": "Claimed Predict winnings",
     "sent_ether": "Ethers enviados",
     "self_sent_ether": "Ethers enviados a si mesmo",
     "received_ether": "Ethers recebidos",
@@ -3939,7 +4000,9 @@
     "wallet_connect_dapps_cta": "Ver sessões",
     "network_not_supported": "Rede atual não compatível",
     "select_provider": "Selecione seu provedor de preferência",
-    "switch_network": "Alterne para a Mainnet ou Sepolia"
+    "switch_network": "Alterne para a Mainnet ou Sepolia",
+    "card_title": "Always show MetaMask Card button",
+    "card_desc": "MetaMask Card is only available to residents of select countries"
   },
   "walletconnect_sessions": {
     "no_active_sessions": "Você não tem nenhuma sessão ativa",
@@ -5315,7 +5378,7 @@
     },
     "tooltip": {
       "perps_deposit": {
-        "transaction_fee": "Trocaremos seus tokens por USDC na HyperCore, a rede usada pelos perps. Os provedores de troca podem cobrar uma taxa, mas a MetaMask não cobra."
+        "transaction_fee": "We'll swap your tokens for USDC on HyperCore, the network used by Perps. Swap providers may charge a fee, but MetaMask won't."
       },
       "predict_deposit": {
         "transaction_fee": "We'll swap your tokens for USDC.e on Polygon, the network used by Predict. Swap providers may charge a fee, but MetaMask won't."
@@ -5407,6 +5470,12 @@
       "save": "Salvar",
       "title": "Editar limite de aprovação"
     },
+    "predict_claim": {
+      "button_label": "Claim winnings",
+      "summary": "You won",
+      "footer_bottom": "Funds will be added to your available balance",
+      "footer_top": "Winnings from {{count}} markets"
+    },
     "unlimited": "Ilimitado",
     "all": "Tudo",
     "none": "Nenhum",
@@ -5469,12 +5538,15 @@
     "points": "Est. de pontos",
     "points_tooltip": "Pontos",
     "points_tooltip_content_1": "Points are how you earn MetaMask Rewards for completing transactions, like when you swap, bridge, or trade perps.",
-    "points_tooltip_content_2": "Keep in mind this value is an estimate and will be finalized once the transaction is complete. Points can take up to 1 hour to be confirmed in your Rewards balance.",
+    "points_tooltip_content_2": "Lembre-se de que este valor é uma estimativa e será finalizado após a conclusão da transação. Os pontos podem levar até 1 hora para serem confirmados no seu saldo de recompensas.",
     "unable_to_load": "Não foi possível carregar",
     "points_error": "Não é possível carregar pontos neste momento",
-    "points_error_content": "You'll still earn any points for this transaction. We'll notify you once they've been added to your account. You can also check your rewards tab in about an hour.",
+    "points_error_content": "Você ainda ganhará os pontos por essa transação. Notificaremos você assim que eles forem adicionados à sua conta. Você também poderá conferir sua guia de recompensas em cerca de uma hora.",
     "see_other_quotes": "Ver outras cotações",
     "receive_at": "Receber em",
+    "recipient": "Recipient",
+    "select_recipient": "Select recipient",
+    "external_account": "External account",
     "error_banner_description": "Esta rota comercial não está disponível no momento. Experimente mudar o valor, a rede ou o token e encontraremos a melhor opção.",
     "insufficient_funds": "Fundos insuficientes",
     "insufficient_gas": "Gás insuficiente",
@@ -5775,6 +5847,12 @@
       "update_to_store_link": "Atualize para a versão mais recente da MetaMask",
       "well_take_you_to_right_place": " e nós levaremos você ao lugar certo."
     },
+    "unsupported": {
+      "title": "This page is not supported in current version",
+      "description": "Update to the latest version to use this feature",
+      "update_to_store_link": "Update to the latest version of MetaMask",
+      "well_take_you_to_right_place": " and we'll take you to the right place."
+    },
     "go_to_home_button": "Ir para a página inicial",
     "back_button": "Voltar",
     "continue_button": "Continuar"
@@ -5791,7 +5869,96 @@
     "card_onboarding": {
       "title": "Bem-vindo ao cartão",
       "description": "Para usar os recursos do cartão, será necessário verificar sua conta com o nosso parceiro.",
-      "verify_account_button": "Verificar conta"
+      "verify_account_button": "Verificar conta",
+      "sign_up": {
+        "title": "Sign-up",
+        "description": "Register your details with Crypto Life, the provider of MetaMask Card. You'll use this account to access and manage your card.",
+        "email_label": "Email",
+        "password_label": "Password",
+        "confirm_password_label": "Confirm password",
+        "country_label": "Country of Residence",
+        "email_placeholder": "Enter your email address",
+        "password_placeholder": "Enter your password",
+        "country_placeholder": "Select your country",
+        "password_mismatch": "Passwords do not match",
+        "invalid_email": "Invalid email address"
+      },
+      "confirm_email": {
+        "title": "Confirm your email",
+        "description": "We've sent a confirmation code to: {{email}}",
+        "confirm_code_label": "Confirmation code",
+        "confirm_code_placeholder": "Enter the confirmation code"
+      },
+      "set_phone_number": {
+        "title": "Phone number",
+        "description": "Enter your phone number",
+        "phone_number_label": "Phone number",
+        "phone_number_placeholder": "Enter your phone number",
+        "country_area_code_label": "Country area code",
+        "invalid_phone_number": "Invalid phone number",
+        "legal_terms": "By continuing, you agree to receiving SMS to verify your phone number."
+      },
+      "confirm_phone_number": {
+        "title": "Confirm your phone number",
+        "description": "We've sent a confirmation code to: {{phoneNumber}}",
+        "confirm_code_label": "Confirmation code"
+      },
+      "verify_identity": {
+        "title": "Verifying your identity to get your card",
+        "description": "To keep your account secure and comply with regulations, we need to verify your identity.\n\nYou'll need a government-issued ID and a proof of address (like a utility bill or bank statement).\n\nVerification usually takes 5-30 minutes, and we'll notify you as soon as it's complete.",
+        "verify_button": "Verify now with Veriff"
+      },
+      "validating_kyc": {
+        "title": "Validating your KYC..."
+      },
+      "kyc_failed": {
+        "title": "Rejected",
+        "description": "Your KYC was rejected. Please try again."
+      },
+      "personal_details": {
+        "title": "Personal details",
+        "description": "Enter your personal details",
+        "first_name_label": "First name",
+        "last_name_label": "Last name",
+        "date_of_birth_label": "Date of birth",
+        "nationality_label": "Country of Nationality",
+        "ssn_label": "Social Security Number",
+        "first_name_placeholder": "Enter your first name",
+        "last_name_placeholder": "Enter your last name",
+        "date_of_birth_placeholder": "Enter your date of birth",
+        "nationality_placeholder": "Select your nationality",
+        "ssn_placeholder": "Enter your SSN",
+        "invalid_ssn": "Invalid SSN",
+        "invalid_date_of_birth": "Invalid date of birth",
+        "invalid_date_of_birth_underage": "You must be at least 18 years old"
+      },
+      "physical_address": {
+        "title": "Physical address",
+        "description": "Please provide your physical address",
+        "address_line_1_label": "Address line 1",
+        "address_line_2_label": "Address line 2",
+        "city_label": "City",
+        "state_label": "State",
+        "zip_code_label": "ZIP code",
+        "address_line_1_placeholder": "Enter your address line 1",
+        "address_line_2_placeholder": "Enter your address line 2",
+        "city_placeholder": "Enter your city",
+        "state_placeholder": "Enter your state",
+        "zip_code_placeholder": "Enter your ZIP code",
+        "same_mailing_address_label": "Physical address is the same as mailing address",
+        "electronic_consent": "I agree to the E-Sign Act Consent and Disclosure and to receive all communictions electronically."
+      },
+      "mailing_address": {
+        "title": "Mailing address",
+        "description": "Please provide your mailing address"
+      },
+      "complete": {
+        "title": "Approved!",
+        "description": "Your KYC was approved. You can now use your Card."
+      },
+      "continue_button": "Next",
+      "confirm_button": "Confirm",
+      "retry_button": "Try again"
     },
     "card_home": {
       "error_title": "Não é possível obter os dados",
@@ -5799,9 +5966,36 @@
       "try_again": "Tentar novamente",
       "limited_spending_warning": "Sua capacidade real de gastos pode estar limitada. Para ajustar seu limite, acesse {{manageCard}}",
       "add_funds": "Adicionar fundos",
+      "change_asset": "Change asset",
       "manage_card_options": {
+        "manage_spending_limit": "Manage spending limit",
+        "manage_spending_limit_description_restricted": "Restricted spending limit is on",
+        "manage_spending_limit_description_full": "Full spending access is on",
         "manage_card": "Gerenciar cartão",
-        "advanced_card_management_description": "Veja transações, congele o cartão e muito mais"
+        "advanced_card_management_description": "Detailed transactions, freeze card, and more"
+      }
+    },
+    "card_authentication": {
+      "title": "Log in to your Card account",
+      "location_button_text": "International",
+      "location_button_text_us": "US account",
+      "email_label": "Email",
+      "password_label": "Password",
+      "email_placeholder": "Enter your email address",
+      "password_placeholder": "Enter your password",
+      "login_button": "Log in",
+      "errors": {
+        "invalid_credentials": "Invalid login details",
+        "unknown_error": "Unknown error, please try again later",
+        "email_required": "Email is required",
+        "password_required": "Password is required",
+        "email_invalid": "Invalid email address",
+        "password_invalid": "Invalid password",
+        "invalid_email_or_password": "Invalid email or password, check your credentials and try again.",
+        "network_error": "Network error. Please check your connection and try again.",
+        "timeout_error": "Request timed out. Please check your connection and try again.",
+        "server_error": "Server error. Please try again later.",
+        "configuration_error": "Service is temporarily unavailable. Please try again later."
       }
     }
   },
@@ -5825,65 +6019,65 @@
     "close": "Fechar"
   },
   "rewards": {
-    "auth_fail_title": "Unknown Error.",
-    "auth_fail_description": "An unknown error occurred while authenticating this account with the rewards program. Please try again later.",
-    "failed_to_authenticate": "Failed to authenticate with rewards program",
+    "auth_fail_title": "Erro desconhecido.",
+    "auth_fail_description": "Ocorreu um erro desconhecido ao autenticar esta conta no programa de recompensas. Tente novamente mais tarde.",
+    "failed_to_authenticate": "Falha em autenticar no programa de recompensas",
     "not_implemented": "Em breve",
     "not_implemented_season_summary": "O resumo da temporada será publicado em breve",
     "optin_error": {
-      "title": "Opt-in failed",
-      "description": "Check your connection and try again."
+      "title": "A participação falhou",
+      "description": "Verifique sua conexão e tente novamente."
     },
     "season_status_error": {
-      "error_fetching_title": "Season balance couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Não foi possível carregar o saldo da temporada",
+      "error_fetching_description": "Verifique sua conexão e tente novamente.",
+      "retry_button": "Tentar novamente"
     },
     "active_boosts_error": {
-      "error_fetching_title": "Boosts couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Não foi possível carregar os incrementos",
+      "error_fetching_description": "Verifique sua conexão e tente novamente.",
+      "retry_button": "Tentar novamente"
     },
     "unlocked_rewards_error": {
-      "error_fetching_title": "Rewards couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Não foi possível carregar as recompensas",
+      "error_fetching_description": "Verifique sua conexão e tente novamente.",
+      "retry_button": "Tentar novamente"
     },
     "upcoming_rewards_error": {
-      "error_fetching_title": "Rewards couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Não foi possível carregar as recompensas",
+      "error_fetching_description": "Verifique sua conexão e tente novamente.",
+      "retry_button": "Tentar novamente"
     },
     "referral_details_error": {
-      "error_fetching_title": "Referral details couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Não foi possível carregar os detalhes da indicação",
+      "error_fetching_description": "Verifique sua conexão e tente novamente.",
+      "retry_button": "Tentar novamente"
     },
     "referral_validation_unknown_error": {
-      "title": "Referral code couldn’t be validated",
-      "description": "Check your connection and try again."
+      "title": "Não foi possível validar o código de indicação",
+      "description": "Verifique sua conexão e tente novamente."
     },
     "active_activity_error": {
-      "error_fetching_title": "Activity couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Não foi possível carregar a atividade",
+      "error_fetching_description": "Verifique sua conexão e tente novamente.",
+      "retry_button": "Tentar novamente"
     },
-    "solana_signup_not_supported": "Signing in to Rewards with Solana accounts is not supported yet. Please use an Ethereum account instead.",
+    "solana_signup_not_supported": "Ainda não é possível acessar o programa de recompensas com contas Solana. Em vez disso, use uma conta Ethereum.",
     "error_messages": {
-      "unknown_error": "Unknown error occurred",
-      "something_went_wrong": "Something went wrong. Please try again shortly.",
-      "account_already_registered": "This account is already registered with another Rewards profile. Please switch account to continue.",
-      "request_rejected": "You rejected the request.",
-      "failed_to_claim_reward": "Failed to claim reward. Please try again shortly.",
-      "service_not_available": "Service is not available at the moment. Please try again shortly."
+      "unknown_error": "Ocorreu um erro desconhecido",
+      "something_went_wrong": "Algo deu errado. Tente novamente em instantes.",
+      "account_already_registered": "Esta conta já está cadastrada em outro perfil do programa de recompensas. Troque de conta para continuar.",
+      "request_rejected": "Você recusou a solicitação.",
+      "failed_to_claim_reward": "Falha ao resgatar a recompensa. Tente novamente em instantes.",
+      "service_not_available": "Serviço não disponível no momento. Tente novamente em instantes."
     },
     "claim_reward_error": {
-      "title": "Failed to claim reward"
+      "title": "Falha ao resgatar a recompensa"
     },
     "accounts_opt_in_state_error": {
-      "error_fetching_title": "Accounts couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Não foi possível carregar as contas",
+      "error_fetching_description": "Verifique sua conexão e tente novamente.",
+      "retry_button": "Tentar novamente"
     },
     "referral_rewards_title": "Indicações",
     "points": "Pontos",
@@ -5899,139 +6093,142 @@
     "tab_levels_title": "Níveis",
     "referral_stats_earned_from_referrals": "Ganho por meio de indicações",
     "referral_stats_referrals": "Indicações",
-    "loading_activity": "Loading activity...",
-    "error_loading_activity": "Error loading activity",
-    "activity_empty_title": "No recent activity.",
-    "activity_empty_description": "Use MetaMask to earn points, level up, and unlock rewards.",
-    "activity_empty_link": "See ways to earn",
+    "loading_activity": "Carregando atividade...",
+    "error_loading_activity": "Erro ao carregar atividade",
+    "activity_empty_title": "Nenhuma atividade recente.",
+    "activity_empty_description": "Use a MetaMask para ganhar pontos, subir de nível e desbloquear recompensas.",
+    "activity_empty_link": "Veja maneiras de ganhar",
     "events": {
-      "to": "to",
+      "to": "para",
       "type": {
         "swap": "Swap",
         "perps": "Perps",
-        "referral": "Referral",
-        "referral_action": "Referral action",
-        "sign_up_bonus": "Sign up bonus",
-        "loyalty_bonus": "Loyalty bonus",
-        "one_time_bonus": "One-time bonus",
-        "open_position": "Opened position",
-        "close_position": "Closed position",
+        "card_spend": "Card spend",
+        "referral": "Indicação",
+        "referral_action": "Ação de indicação",
+        "sign_up_bonus": "Bônus de inscrição",
+        "loyalty_bonus": "Bônus de fidelidade",
+        "one_time_bonus": "Bônus único",
+        "open_position": "Posição aberta",
+        "close_position": "Posição encerrada",
         "take_profit": "TP/SL",
         "stop_loss": "TP/SL",
-        "uncategorized_event": "Uncategorized event"
+        "uncategorized_event": "Evento não categorizado"
       },
-      "date": "Date",
-      "account": "Account",
-      "bonus": "Bonus",
-      "details": "Details",
-      "points": "Points",
+      "date": "Data",
+      "account": "Conta",
+      "bonus": "Bônus",
+      "details": "Detalhes",
+      "points": "Pontos",
       "points_base": "Base",
-      "points_boost": "Boost",
+      "points_boost": "Incremento",
       "points_total": "Total"
     },
     "onboarding": {
       "not_supported_region_title": "Não há suporte a essa região",
-      "not_supported_region_description": "Rewards are not supported in your region yet. We are working on expanding access, so check back later.",
-      "not_supported_hardware_account_title": "Account not supported",
-      "not_supported_hardware_account_description": "Hardware wallet accounts are not eligible to receive rewards yet. Please switch to a different account to proceed.",
-      "not_supported_account_type_title": "Account type not supported",
-      "not_supported_account_type_description": "Currently only internal Ethereum and Solana accounts can be opted into the Rewards program. Please switch to a different account to proceed.",
-      "not_supported_confirm_go_back": "Go back",
-      "not_supported_confirm_retry": "Retry",
-      "auth_fail_title": "Authentication Failed",
-      "auth_fail_description": "Unable to authenticate with the rewards program. Please check your connection and try again.",
-      "geo_check_fail_title": "Cannot determine opt-in eligibility",
-      "geo_check_fail_description": "We cannot determine if your country allows opting into the rewards program. Please check your connection and try again.",
+      "not_supported_region_description": "Ainda não oferecemos suporte às recompensas em sua região. Estamos trabalhando para expandir o acesso. Volte mais tarde.",
+      "not_supported_hardware_account_title": "Não há suporte para esta conta",
+      "not_supported_hardware_account_description": "Contas de carteira de hardware ainda não são qualificadas para receber recompensas. Mude para uma conta diferente para continuar.",
+      "not_supported_account_type_title": "Não há suporte para este tipo de conta",
+      "not_supported_account_type_description": "Atualmente, apenas contas internas Ethereum e Solana podem participar do programa de recompensas. Mude para uma conta diferente para continuar.",
+      "not_supported_confirm_go_back": "Voltar",
+      "not_supported_confirm_retry": "Tentar novamente",
+      "auth_fail_title": "Falha na autenticação",
+      "auth_fail_description": "Não foi possível autenticar no programa de recompensas. Verifique sua conexão e tente novamente.",
+      "geo_check_fail_title": "Não foi possível determinar a qualificação para participação",
+      "geo_check_fail_description": "Não foi possível determinar se o seu país permite a participação no programa de recompensas. Verifique sua conexão e tente novamente.",
       "gtm_title": "As recompensas chegaram",
       "gtm_description": "Ganhe pontos por sua atividade. \nSuba de nível para desbloquear recompensas.",
       "gtm_confirm": "Comece já",
       "intro_title": "A Temporada 1 \nestá ativa",
-      "intro_description": "Earn points for your activity. \nAdvance through levels to unlock rewards.",
-      "intro_confirm": "Claim 250 points",
-      "intro_confirm_geo_loading": "Checking region...",
-      "checking_opt_in": "Checking accounts...",
-      "redirecting_to_dashboard": "Redirecting...",
+      "intro_description": "Ganhe pontos por sua atividade. \nSuba de nível para desbloquear recompensas.",
+      "intro_confirm": "Resgatar 250 pontos",
+      "intro_confirm_geo_loading": "Verificando região...",
+      "checking_opt_in": "Verificando contas...",
+      "redirecting_to_dashboard": "Redirecionando...",
       "intro_skip": "Agora não",
       "step_confirm": "Avançar",
-      "step_skip": "Skip",
-      "step1_title": "Earn points on every trade",
+      "step_skip": "Pular",
+      "step1_title": "Ganhe pontos a cada negociação",
       "step1_description": "Cada troca e negociação de perps que você faz na MetaMask te deixa mais perto das recompensas. Adicione suas contas e veja seus pontos acumularem.",
-      "step2_title": "Level up for bigger perks",
+      "step2_title": "Suba de nível para obter mais vantagens",
       "step2_description": "Atinja marcos de pontos para obter vantagens como 50% de desconto nas taxas de perps, tokens exclusivos e um Cartão MetaMask Metal grátis.",
-      "step3_title": "Exclusive seasonal rewards",
-      "step3_description": "Each season brings new perks. Join in, compete, and claim what you can before time runs out.",
-      "step4_title": "You'll earn 250 points when you sign up!",
-      "step4_title_referral_validating": "Validating referral code...",
-      "step4_referral_input_placeholder": "Referral code (optional)",
-      "step4_referral_input_error": "Invalid referral code",
-      "step4_confirm": "Claim points",
-      "step4_confirm_loading": "Claiming points...",
-      "step4_linking_accounts": "Adding accounts... ({{current}}/{{total}})",
-      "step4_linking_accounts_loading": "Adding additional accounts...",
-      "step4_success_description": "You have successfully signed up for MetaMask Rewards!",
-      "step4_legal_disclaimer_1": "By selecting 'Claim Points', you agree to the MetaMask Rewards",
-      "step4_legal_disclaimer_2": "Supplemental Terms of Use and Privacy Notice",
-      "step4_legal_disclaimer_3": ". We'll track onchain activity to reward you automatically –",
-      "step4_legal_disclaimer_4": "learn more"
+      "step3_title": "Recompensas exclusivas por temporada",
+      "step3_description": "Cada temporada traz novas vantagens. Participe, dispute e resgate o que puder antes que o tempo se esgote.",
+      "step4_title": "Você ganhará 250 pontos ao se inscrever!",
+      "step4_title_referral_bonus": "You'll earn 500 points when you sign up with this code!",
+      "step4_title_referral_validating": "Validando código de indicação...",
+      "step4_referral_bonus_description": "Use a referral code to earn 250 more",
+      "step4_referral_input_placeholder": "Código de indicação (opcional)",
+      "step4_referral_input_error": "Código de indicação inválido",
+      "step4_confirm": "Resgatar pontos",
+      "step4_confirm_loading": "Resgatando pontos...",
+      "step4_linking_accounts": "Adicionando contas... ({{current}}/{{total}})",
+      "step4_linking_accounts_loading": "Adicionando mais contas...",
+      "step4_success_description": "Você se inscreveu com sucesso no programa MetaMask Rewards!",
+      "step4_legal_disclaimer_1": "Ao selecionar \"Resgatar pontos\", você concorda com o programa MetaMask Rewards",
+      "step4_legal_disclaimer_2": "Termos de uso suplementares e aviso de privacidade",
+      "step4_legal_disclaimer_3": ". Rastrearemos a atividade onchain para recompensar você automaticamente –",
+      "step4_legal_disclaimer_4": "saiba mais"
     },
     "settings": {
-      "title": "Rewards Settings",
-      "subtitle": "Accounts",
-      "description": "Add multiple accounts to combine your points and unlock rewards faster.",
-      "tab_linked_accounts": "Added ({{count}})",
-      "tab_unlinked_accounts": "Not added ({{count}})",
-      "no_linked_accounts": "No accounts opted in",
-      "all_accounts_linked_title": "All accounts opted in",
-      "all_accounts_linked_description": "You have added all your accounts to Rewards.",
-      "link_account_success_title": "{{accountName}} successfully added",
-      "link_account_error_title": "Failed to add account",
-      "link_account_button": "Add",
-      "link_account_failed_error": "Failed to link account",
-      "link_account_unknown_error": "Unknown error occurred"
+      "title": "Configurações de recompensa",
+      "subtitle": "Contas",
+      "description": "Adicione várias contas para combinar seus pontos e desbloquear recompensas mais rapidamente.",
+      "tab_linked_accounts": "Adicionadas ({{count}})",
+      "tab_unlinked_accounts": "Não adicionadas ({{count}})",
+      "no_linked_accounts": "Nenhuma conta participante",
+      "all_accounts_linked_title": "Todas as contas estão participando",
+      "all_accounts_linked_description": "Você adicionou todas as suas contas ao programa de recompensas.",
+      "link_account_success_title": "{{accountName}} adicionada com sucesso",
+      "link_account_error_title": "Falha ao adicionar a conta",
+      "link_account_button": "Adicionar",
+      "link_account_failed_error": "Falha ao vincular a conta",
+      "link_account_unknown_error": "Ocorreu um erro desconhecido"
     },
     "optout": {
-      "title": "Opt out of Rewards",
-      "description": "This will remove your accounts from the Rewards program and erase your points and progress. You won't be able to undo this.",
-      "confirm": "Opt out",
+      "title": "Sair do Rewards",
+      "description": "Isso removerá suas contas do programa de recompensas e apagará seus pontos e progresso. Essa ação não poderá ser desfeita.",
+      "confirm": "Cancelar participação",
       "modal": {
-        "confirmation_title": "Are you sure?",
-        "confirmation_description": "This will remove all your progress, and can't be reversed. If you rejoin the Rewards program later, you'll start back at 0.",
-        "cancel": "Cancel",
-        "confirm": "Confirm",
-        "error_message": "Failed to opt out of Rewards. Please try again.",
-        "processing": "Processing..."
+        "confirmation_title": "Tem certeza?",
+        "confirmation_description": "Essa ação removerá todo o seu progresso e não poderá ser revertida. Se você voltar a participar do programa de recompensas mais tarde, começará do zero.",
+        "cancel": "Cancelar",
+        "confirm": "Confirmar",
+        "error_message": "Falha ao cancelar a participação no programa de recompensas. Tente novamente.",
+        "processing": "Em processamento..."
       }
     },
-    "toast_dismiss": "Dismiss",
+    "toast_dismiss": "Ignorar",
     "dashboard_modal_info": {
       "active_account": {
-        "title": "Don't miss out",
-        "description": "Add your account to start earning points from your activity.",
-        "confirm": "Add account"
+        "title": "Não perca",
+        "description": "Adicione sua conta para começar a ganhar pontos com sua atividade.",
+        "confirm": "Adicionar conta"
       },
       "multiple_unlinked_accounts": {
-        "title": "Start earning points",
-        "description": "Add your accounts so you can track your rewards at a glance.",
-        "confirm": "Add accounts"
+        "title": "Comece a ganhar pontos",
+        "description": "Adicione suas contas para acompanhar suas recompensas de forma rápida e fácil.",
+        "confirm": "Adicionar contas"
       },
       "account_not_supported": {
-        "title": "Account not supported",
-        "description_hardware": "Hardware wallet accounts are not yet eligible to earn points. Please switch to a different account to proceed.",
-        "description_general": "Currently only non-hardware internal Ethereum and Solana accounts are eligible to earn points. Please switch to a different account to proceed.",
-        "confirm": "Go back"
+        "title": "Não há suporte para esta conta",
+        "description_hardware": "Contas de carteira de hardware ainda não são qualificadas para ganhar pontos. Mude para uma conta diferente para continuar.",
+        "description_general": "Atualmente, apenas contas internas Ethereum e Solana que não sejam de hardware estão qualificadas para ganhar pontos. Mude para uma conta diferente para continuar.",
+        "confirm": "Voltar"
       }
     },
     "ways_to_earn": {
-      "title": "Ways to earn",
-      "supported_networks": "Supported Networks",
+      "title": "Formas de ganhar",
+      "supported_networks": "Redes compatíveis",
       "swap": {
         "title": "Swap",
-        "description": "80 points per $100",
+        "description": "80 pontos a cada US$ 100",
         "sheet": {
-          "title": "Swap tokens",
-          "points": "80 points per $100",
-          "description": "Swap tokens on supported networks to earn points for every dollar you trade.",
-          "cta_label": "Start a swap"
+          "title": "Trocar tokens",
+          "points": "80 pontos a cada US$ 100",
+          "description": "Troque tokens em redes compatíveis para ganhar pontos a cada dólar negociado.",
+          "cta_label": "Iniciar uma troca"
         }
       },
       "perps": {
@@ -6045,52 +6242,74 @@
         }
       },
       "referrals": {
-        "title": "Refer friends",
-        "description": "10 points per 50 from friends"
+        "title": "Indicar amigos",
+        "description": "10 pontos a cada 50 pontos de seus amigos",
+        "sheet": {
+          "title": "Refer a friend",
+          "points": "20 points per 100",
+          "cta_label": "Refer a friend"
+        }
       },
       "loyalty": {
-        "title": "Loyalty bonus",
-        "description": "Earn points from past trades",
+        "title": "Bônus de fidelidade",
+        "description": "Ganhe pontos por negociações passadas",
         "sheet": {
-          "title": "Loyalty bonus",
-          "points": "250 points per $1250",
-          "description": "Add accounts with past swaps or bridges in MetaMask to earn loyalty bonuses. Each eligible account unlocks points in increments of 250, up to a total of 50,000. Bonuses appear shortly after you add an account.",
-          "cta_label": "Add accounts"
+          "title": "Bônus de fidelidade",
+          "points": "250 pontos a cada US$ 1250",
+          "description": "Adicione contas com trocas ou pontes passadas na MetaMask para ganhar bônus de fidelidade. Cada conta qualificada desbloqueia pontos em incrementos de 250, até um total de 50.000. Os bônus aparecem logo após você adicionar uma conta.",
+          "cta_label": "Adicionar contas"
+        }
+      },
+      "card": {
+        "title": "MetaMask Card",
+        "description": "1 point per $1 spent",
+        "sheet": {
+          "title": "MetaMask Card",
+          "points": "1 point per $1 spent",
+          "description": "Earn points every time you use your MetaMask Card for purchases, plus 1% cash back (3% for Metal cardholders).",
+          "cta_label": "Manage Card"
         }
       }
     },
     "referral": {
-      "referral_code": "Referral code",
-      "referral_link": "Referral link",
+      "referral_code": "Código de indicação",
+      "referral_link": "Link de indicação",
       "actions": {
         "share_referral_link": "Indique um amigo",
         "share_referral_subject": "Junte-se ao MetaMask Rewards"
       },
       "info": {
         "title": "Compartilhe seu código para ganhar mais",
-        "description": "Your friends get a 2x sign up bonus. You get 10 points for every 50 they earn from trading."
+        "description": "Seus amigos ganham um bônus de inscrição x2. Você ganha 10 pontos para cada 50 que eles ganharem com negociações."
       }
     },
-    "active_boosts_title": "Active boosts",
-    "season_1": "Season 1",
+    "link_account_group": {
+      "link_account": "Add account",
+      "tracked": "Tracked",
+      "untracked": "Untracked",
+      "link_account_success": "{{accountName}} added successfully",
+      "link_account_error": "Failed to add one or more addresses for {{accountName}}"
+    },
+    "active_boosts_title": "Incrementos ativos",
+    "season_1": "Temporada 1",
     "upcoming_rewards": {
       "title": "Recompensas bloqueadas",
-      "points_needed": "{{points}} points",
-      "cta_label": "Got it",
-      "alpha_fox_invite_input_placeholder": "Your Telegram handle"
+      "points_needed": "{{points}} pontos",
+      "cta_label": "Entendi",
+      "alpha_fox_invite_input_placeholder": "Seu nome de usuário do Telegram"
     },
     "unlocked_rewards": {
-      "title": "Unlocked rewards",
-      "cta_label": "Claim now",
-      "cta_request_invite": "Request invite",
-      "claim_label": "Claim",
-      "claimed_label": "Claimed",
-      "reward_claimed": "Reward claimed",
+      "title": "Recompensas desbloqueadas",
+      "cta_label": "Resgatar agora",
+      "cta_request_invite": "Solicitar convite",
+      "claim_label": "Resgatar",
+      "claimed_label": "Resgatada",
+      "reward_claimed": "Recompensa resgatada",
       "time_left": "restante",
-      "expired": "Expired"
+      "expired": "Expirada"
     },
     "animation": {
-      "could_not_load": "Couldn't load"
+      "could_not_load": "Não foi possível carregar"
     }
   },
   "time": {
@@ -6099,7 +6318,7 @@
   },
   "transaction_details": {
     "title": {
-      "perps_deposit": "Funded Perps account",
+      "perps_deposit": "Conta de perps creditada",
       "predict_deposit": "Funded Predict account",
       "default": "Dados da transação"
     },
@@ -6107,19 +6326,23 @@
       "bridge_fee": "Taxa de ponte",
       "network_fee": "Taxa de rede",
       "paid_with": "Paga com",
+      "retry_button": "Try again",
       "total": "Total"
     },
     "summary_title": {
-      "bridge": "Ponte de {{sourceSymbol}} para {{targetSymbol}}",
       "bridge_approval": "Aprovar {{approveSymbol}}",
       "bridge_approval_loading": "Aprovar",
-      "bridge_loading": "Ponte",
+      "bridge_send": "Bridge {{sourceSymbol}} from {{sourceChain}}",
+      "bridge_send_loading": "Bridge Send",
+      "bridge_receive": "Receive {{targetSymbol}} on {{targetChain}}",
+      "bridge_receive_loading": "Bridge Receive",
       "default": "Transação",
       "perps_deposit": "Adicionar fundos",
       "predict_deposit": "Add funds",
       "swap": "Trocar tokens",
       "swap_approval": "Aprovar tokens"
-    }
+    },
+    "perps_deposit_solution": "You now have {{fiat}} of USDC on Arbitrum. Try your deposit again."
   },
   "sdk_connect_v2": {
     "show_loading": {

--- a/locales/languages/ru.json
+++ b/locales/languages/ru.json
@@ -594,7 +594,9 @@
       "unexpectedError": "Произошла неожиданная ошибка.",
       "quoteFetchError": "Не удалось получить котировку.",
       "kycFormsFetchError": "Не удалось получить формы ЗСК.",
-      "title": "Внести депозит"
+      "title": "Внести депозит",
+      "limitExceeded": "This deposit would exceed your {{period}} limit. Your deposit including fees must be {{remaining}} or less.",
+      "limitError": "Failed to check your deposit limits. Please try again later."
     },
     "token_modal": {
       "select_a_token": "Выбрать токен",
@@ -892,7 +894,7 @@
     "withdraw": "Вывести средства",
     "refresh_balance": "Обновить баланс",
     "add_funds": "Внести средства",
-    "deposit_in_progress": "Deposit in progress",
+    "deposit_in_progress": "Выполняется внесение депозита",
     "your_positions": "Ваши позиции",
     "loading_positions": "Загрузка позиций...",
     "refreshing_positions": "Обновление позиций...",
@@ -1277,6 +1279,7 @@
       "assetMappingFailed": "Не удалось создать карту сопоставления активов",
       "depositFailed": "Ошибка депозита",
       "orderLeverageReductionFailed": "Вы не можете уменьшить свое кредитное плечо",
+      "connectionTimeout": "Connection timed out. Please check your network and try again.",
       "connectionFailed": {
         "title": "Бессрочные фьючерсы временно не в сети",
         "description": "Мы работаем над тем, чтобы скоро снова предоставить доступ к ним.",
@@ -1348,9 +1351,9 @@
         "error_message": "Рыночные данные не найдены. Вернитесь и повторите попытку."
       },
       "statistics": "Обзор",
-      "24h_high": "24h high",
-      "24h_low": "24h low",
-      "24h_volume": "24h volume",
+      "24h_high": "Максимум за 24 ч",
+      "24h_low": "Минимум за 24 часа",
+      "24h_volume": "Объем за 24 ч",
       "open_interest": "Открытый процент",
       "funding_rate": "Ставка финансирования",
       "countdown": "Обратный отсчет",
@@ -1510,9 +1513,9 @@
         "metamask_fee": "Комиссия MetaMask",
         "hyperliquid_fee": "Комиссия Hyperliquid",
         "total_fee": "Итого комиссий",
-        "liquidated": "Liquidated",
-        "take_profit": "Take profit",
-        "stop_loss": "Stop loss"
+        "liquidated": "Ликвидировано",
+        "take_profit": "Тейк-профит",
+        "stop_loss": "Стоп-лосс"
       },
       "funding": {
         "date": "Дата",
@@ -1555,11 +1558,11 @@
       "ready_to_trade": {
         "title": "Готовы к торговле?",
         "description": "Пополните свой счет бессрочных фьючерсов любыми токенами и совершите первую сделку за считанные секунды.",
-        "footer_text": "MetaMask обменяет ваши средства на USDC на Arbitrum и внесет их на HyperCore без дополнительной комиссии."
+        "footer_text": "MetaMask will swap your funds to USDC on Arbitrum, and deposit them onto HyperCore for no added fee."
       },
       "got_it": "Понятно",
       "card": {
-        "title": "Learn the basics of perps"
+        "title": "Изучите основы перпов"
       }
     },
     "points": "Баллы",
@@ -1576,10 +1579,10 @@
     "market_list": "Список рынков",
     "market_details": "Сведения о рынке",
     "tab": {
-      "no_predictions": "Пока нет прогнозов",
-      "no_predictions_description": "Чтобы начать, откройте прогноз.",
-      "explore": "Обзор рынков",
-      "new_prediction": "Новый прогноз"
+      "no_predictions_description": "Your predictions will appear here, showing your stake and market movement.",
+      "explore": "Browse markets",
+      "new_prediction": "Новый прогноз",
+      "resolved_markets": "Resolved markets"
     },
     "sell_position": "Продать позицию",
     "cash_out": "Вывести деньги",
@@ -1609,16 +1612,73 @@
     "claim_button": "Получить",
     "markets_won": "Выигранные рынки",
     "won_markets_text": "Выигран {{count}} рынок{{s}}",
-    "won_markets_text_singular": "Выигран {{count}} рынок",
-    "won_markets_text_plural": "Выиграны {{count}} рынка(-ов)",
+    "available_balance": "Available balance",
     "claim_amount_text": "Получить {{amount}} $",
     "unrealized_pnl_label": "Нереализованные П/У",
     "unrealized_pnl_value": "{{amount}} ({{percent}})",
+    "unrealized_pnl_error": "Unable to load",
     "unavailable": {
       "title": "Unavailable in your region",
       "description": "Predictions aren't available in your region due to legal restrictions.",
       "link": "See Polymarket terms",
       "button": "Got it"
+    },
+    "deposit": {
+      "in_progress": "Deposit in progress",
+      "adding_funds": "Adding funds",
+      "adding_your_funds": "Adding your funds",
+      "add_funds": "Add funds",
+      "withdraw": "Withdraw",
+      "estimated_processing_time": "Est. {{time}} seconds",
+      "account_ready": "Your account is ready",
+      "account_ready_description": "{{amount}} added to your balance",
+      "error_title": "Something went wrong",
+      "error_description": "Your account wasn't funded",
+      "try_again": "Try again"
+    },
+    "add_funds_sheet": {
+      "title": "Add funds",
+      "description": "You'll need to add funds to your Predictions account to get started. You can add any token and make your first prediction in seconds."
+    },
+    "transactions": {
+      "title": "Predictions",
+      "no_transactions": "No recent activity",
+      "buy_title": "Predicted",
+      "sell_title": "Cashed out",
+      "claim_title": "Claimed winnings",
+      "buy_detail": "Bought {{amountUsd}} on {{outcome}} · {{priceCents}} per share",
+      "sell_detail": "Sold at {{priceCents}} per share",
+      "claim_detail": "Claimed winnings",
+      "not_available": "N/A",
+      "date": "Date",
+      "market": "Market",
+      "outcome": "Outcome",
+      "predicted_amount": "Predicted amount",
+      "shares_bought": "Shares bought",
+      "shares_sold": "Shares sold",
+      "price_per_share": "Price per share",
+      "price_impact": "Price impact",
+      "net_pnl": "Net P&L",
+      "total_net_pnl": "Total Net P&L",
+      "market_net_pnl": "Market Net P&L",
+      "activity_details": "Activity details"
+    },
+    "claim": {
+      "toasts": {
+        "pending": {
+          "title": "Claiming {{amount}}",
+          "description": "Est. {{time}} seconds"
+        },
+        "confirmed": {
+          "title": "Claimed",
+          "description": "{{amount}} added to your balance"
+        },
+        "error": {
+          "title": "Something went wrong",
+          "description": "Failed to proceed with claim",
+          "try_again": "Try again"
+        }
+      }
     }
   },
   "receive": {
@@ -3093,6 +3153,7 @@
     "tx_review_lending_withdraw": "Кредитование вывода средств",
     "tx_review_perps_deposit": "Счет бессрочных фьючерсов пополнен",
     "tx_review_predict_deposit": "Funded Predict account",
+    "tx_review_predict_claim": "Claimed Predict winnings",
     "sent_ether": "Отправлен эфир",
     "self_sent_ether": "Отправил(-а) себе эфир",
     "received_ether": "Получен эфир",
@@ -3939,7 +4000,9 @@
     "wallet_connect_dapps_cta": "Просмотр сеансов",
     "network_not_supported": "Текущая сеть не поддерживается",
     "select_provider": "Выберите предпочитаемого поставщика",
-    "switch_network": "Переключитесь на мейн-нет или Sepolia"
+    "switch_network": "Переключитесь на мейн-нет или Sepolia",
+    "card_title": "Always show MetaMask Card button",
+    "card_desc": "MetaMask Card is only available to residents of select countries"
   },
   "walletconnect_sessions": {
     "no_active_sessions": "У вас нет активных сеансов",
@@ -5315,7 +5378,7 @@
     },
     "tooltip": {
       "perps_deposit": {
-        "transaction_fee": "Мы обменяем ваши токены на USDC в HyperCore, сети, используемой Перами. Поставщики услуг свопов могут взимать комиссию, но MetaMask не взимает ее."
+        "transaction_fee": "We'll swap your tokens for USDC on HyperCore, the network used by Perps. Swap providers may charge a fee, but MetaMask won't."
       },
       "predict_deposit": {
         "transaction_fee": "We'll swap your tokens for USDC.e on Polygon, the network used by Predict. Swap providers may charge a fee, but MetaMask won't."
@@ -5407,6 +5470,12 @@
       "save": "Сохранить",
       "title": "Изменить лимит одобрения"
     },
+    "predict_claim": {
+      "button_label": "Claim winnings",
+      "summary": "You won",
+      "footer_bottom": "Funds will be added to your available balance",
+      "footer_top": "Winnings from {{count}} markets"
+    },
     "unlimited": "Неограничено",
     "all": "Все",
     "none": "Нет",
@@ -5469,12 +5538,15 @@
     "points": "Прим. баллов",
     "points_tooltip": "Баллы",
     "points_tooltip_content_1": "Points are how you earn MetaMask Rewards for completing transactions, like when you swap, bridge, or trade perps.",
-    "points_tooltip_content_2": "Keep in mind this value is an estimate and will be finalized once the transaction is complete. Points can take up to 1 hour to be confirmed in your Rewards balance.",
+    "points_tooltip_content_2": "Имейте в виду, что это приблизительное значение, которое будет окончательно подтверждено после завершения транзакции. Подтверждение начисления баллов на ваш баланс вознаграждений может занять до 1 часа.",
     "unable_to_load": "Не удалось загрузить",
     "points_error": "Мы не можем загрузить баллы сейчас",
-    "points_error_content": "You'll still earn any points for this transaction. We'll notify you once they've been added to your account. You can also check your rewards tab in about an hour.",
+    "points_error_content": "Вы все равно получите баллы за эту транзакцию. Мы уведомим вас, как только они будут зачислены на ваш счет. Вы также сможете увидеть их на вкладке «Вознаграждения» примерно через час.",
     "see_other_quotes": "Смотреть другие котировки",
     "receive_at": "Получить в",
+    "recipient": "Recipient",
+    "select_recipient": "Select recipient",
+    "external_account": "External account",
     "error_banner_description": "Этот торговый маршрут сейчас недоступен. Попробуйте изменить сумму, сеть или токен, и мы найдем лучший вариант.",
     "insufficient_funds": "Недостаточно средств",
     "insufficient_gas": "Недостаточно газа",
@@ -5775,6 +5847,12 @@
       "update_to_store_link": "Обновите до последней версии MetaMask,",
       "well_take_you_to_right_place": " и мы доставим вас в нужное место."
     },
+    "unsupported": {
+      "title": "This page is not supported in current version",
+      "description": "Update to the latest version to use this feature",
+      "update_to_store_link": "Update to the latest version of MetaMask",
+      "well_take_you_to_right_place": " and we'll take you to the right place."
+    },
     "go_to_home_button": "Перейти на главную страницу",
     "back_button": "Назад",
     "continue_button": "Продолжить"
@@ -5791,7 +5869,96 @@
     "card_onboarding": {
       "title": "Добро пожаловать в Карту",
       "description": "Чтобы воспользоваться функциями карты, необходимо подтвердить свой счет у нашего партнера.",
-      "verify_account_button": "Подтвердить счет"
+      "verify_account_button": "Подтвердить счет",
+      "sign_up": {
+        "title": "Sign-up",
+        "description": "Register your details with Crypto Life, the provider of MetaMask Card. You'll use this account to access and manage your card.",
+        "email_label": "Email",
+        "password_label": "Password",
+        "confirm_password_label": "Confirm password",
+        "country_label": "Country of Residence",
+        "email_placeholder": "Enter your email address",
+        "password_placeholder": "Enter your password",
+        "country_placeholder": "Select your country",
+        "password_mismatch": "Passwords do not match",
+        "invalid_email": "Invalid email address"
+      },
+      "confirm_email": {
+        "title": "Confirm your email",
+        "description": "We've sent a confirmation code to: {{email}}",
+        "confirm_code_label": "Confirmation code",
+        "confirm_code_placeholder": "Enter the confirmation code"
+      },
+      "set_phone_number": {
+        "title": "Phone number",
+        "description": "Enter your phone number",
+        "phone_number_label": "Phone number",
+        "phone_number_placeholder": "Enter your phone number",
+        "country_area_code_label": "Country area code",
+        "invalid_phone_number": "Invalid phone number",
+        "legal_terms": "By continuing, you agree to receiving SMS to verify your phone number."
+      },
+      "confirm_phone_number": {
+        "title": "Confirm your phone number",
+        "description": "We've sent a confirmation code to: {{phoneNumber}}",
+        "confirm_code_label": "Confirmation code"
+      },
+      "verify_identity": {
+        "title": "Verifying your identity to get your card",
+        "description": "To keep your account secure and comply with regulations, we need to verify your identity.\n\nYou'll need a government-issued ID and a proof of address (like a utility bill or bank statement).\n\nVerification usually takes 5-30 minutes, and we'll notify you as soon as it's complete.",
+        "verify_button": "Verify now with Veriff"
+      },
+      "validating_kyc": {
+        "title": "Validating your KYC..."
+      },
+      "kyc_failed": {
+        "title": "Rejected",
+        "description": "Your KYC was rejected. Please try again."
+      },
+      "personal_details": {
+        "title": "Personal details",
+        "description": "Enter your personal details",
+        "first_name_label": "First name",
+        "last_name_label": "Last name",
+        "date_of_birth_label": "Date of birth",
+        "nationality_label": "Country of Nationality",
+        "ssn_label": "Social Security Number",
+        "first_name_placeholder": "Enter your first name",
+        "last_name_placeholder": "Enter your last name",
+        "date_of_birth_placeholder": "Enter your date of birth",
+        "nationality_placeholder": "Select your nationality",
+        "ssn_placeholder": "Enter your SSN",
+        "invalid_ssn": "Invalid SSN",
+        "invalid_date_of_birth": "Invalid date of birth",
+        "invalid_date_of_birth_underage": "You must be at least 18 years old"
+      },
+      "physical_address": {
+        "title": "Physical address",
+        "description": "Please provide your physical address",
+        "address_line_1_label": "Address line 1",
+        "address_line_2_label": "Address line 2",
+        "city_label": "City",
+        "state_label": "State",
+        "zip_code_label": "ZIP code",
+        "address_line_1_placeholder": "Enter your address line 1",
+        "address_line_2_placeholder": "Enter your address line 2",
+        "city_placeholder": "Enter your city",
+        "state_placeholder": "Enter your state",
+        "zip_code_placeholder": "Enter your ZIP code",
+        "same_mailing_address_label": "Physical address is the same as mailing address",
+        "electronic_consent": "I agree to the E-Sign Act Consent and Disclosure and to receive all communictions electronically."
+      },
+      "mailing_address": {
+        "title": "Mailing address",
+        "description": "Please provide your mailing address"
+      },
+      "complete": {
+        "title": "Approved!",
+        "description": "Your KYC was approved. You can now use your Card."
+      },
+      "continue_button": "Next",
+      "confirm_button": "Confirm",
+      "retry_button": "Try again"
     },
     "card_home": {
       "error_title": "Невозможно получить данные",
@@ -5799,9 +5966,36 @@
       "try_again": "Повторить попытку",
       "limited_spending_warning": "Ваши фактические расходы могут быть ограничены. Чтобы изменить лимит, перейдите в раздел «{{manageCard}}»",
       "add_funds": "Внести средства",
+      "change_asset": "Change asset",
       "manage_card_options": {
+        "manage_spending_limit": "Manage spending limit",
+        "manage_spending_limit_description_restricted": "Restricted spending limit is on",
+        "manage_spending_limit_description_full": "Full spending access is on",
         "manage_card": "Управление картой",
-        "advanced_card_management_description": "Просматривайте транзакций, блокируйте карту и делайте многое другое"
+        "advanced_card_management_description": "Detailed transactions, freeze card, and more"
+      }
+    },
+    "card_authentication": {
+      "title": "Log in to your Card account",
+      "location_button_text": "International",
+      "location_button_text_us": "US account",
+      "email_label": "Email",
+      "password_label": "Password",
+      "email_placeholder": "Enter your email address",
+      "password_placeholder": "Enter your password",
+      "login_button": "Log in",
+      "errors": {
+        "invalid_credentials": "Invalid login details",
+        "unknown_error": "Unknown error, please try again later",
+        "email_required": "Email is required",
+        "password_required": "Password is required",
+        "email_invalid": "Invalid email address",
+        "password_invalid": "Invalid password",
+        "invalid_email_or_password": "Invalid email or password, check your credentials and try again.",
+        "network_error": "Network error. Please check your connection and try again.",
+        "timeout_error": "Request timed out. Please check your connection and try again.",
+        "server_error": "Server error. Please try again later.",
+        "configuration_error": "Service is temporarily unavailable. Please try again later."
       }
     }
   },
@@ -5825,65 +6019,65 @@
     "close": "Закрыть"
   },
   "rewards": {
-    "auth_fail_title": "Unknown Error.",
-    "auth_fail_description": "An unknown error occurred while authenticating this account with the rewards program. Please try again later.",
-    "failed_to_authenticate": "Failed to authenticate with rewards program",
+    "auth_fail_title": "Неизвестная ошибка.",
+    "auth_fail_description": "При аутентификации этого счета в программе вознаграждений произошла неизвестная ошибка. Повторите попытку позже.",
+    "failed_to_authenticate": "Не удалось аутентифицироваться в программе вознаграждений",
     "not_implemented": "Скоро появятся",
     "not_implemented_season_summary": "Скоро будут подведены итоги сезона",
     "optin_error": {
-      "title": "Opt-in failed",
-      "description": "Check your connection and try again."
+      "title": "Не удалось согласиться",
+      "description": "Проверьте соединение и повторите попытку."
     },
     "season_status_error": {
-      "error_fetching_title": "Season balance couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Не удалось загрузить баланс сезона",
+      "error_fetching_description": "Проверьте соединение и повторите попытку.",
+      "retry_button": "Повтор"
     },
     "active_boosts_error": {
-      "error_fetching_title": "Boosts couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Не удалось загрузить повышающие коэффициенты",
+      "error_fetching_description": "Проверьте соединение и повторите попытку.",
+      "retry_button": "Повтор"
     },
     "unlocked_rewards_error": {
-      "error_fetching_title": "Rewards couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Не удалось загрузить вознаграждения",
+      "error_fetching_description": "Проверьте соединение и повторите попытку.",
+      "retry_button": "Повтор"
     },
     "upcoming_rewards_error": {
-      "error_fetching_title": "Rewards couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Не удалось загрузить вознаграждения",
+      "error_fetching_description": "Проверьте соединение и повторите попытку.",
+      "retry_button": "Повтор"
     },
     "referral_details_error": {
-      "error_fetching_title": "Referral details couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Не удалось загрузить данные о реферале",
+      "error_fetching_description": "Проверьте соединение и повторите попытку.",
+      "retry_button": "Повтор"
     },
     "referral_validation_unknown_error": {
-      "title": "Referral code couldn’t be validated",
-      "description": "Check your connection and try again."
+      "title": "Не удалось проверить реферальный код",
+      "description": "Проверьте соединение и повторите попытку."
     },
     "active_activity_error": {
-      "error_fetching_title": "Activity couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Не удалось загрузить активность",
+      "error_fetching_description": "Проверьте соединение и повторите попытку.",
+      "retry_button": "Повтор"
     },
-    "solana_signup_not_supported": "Signing in to Rewards with Solana accounts is not supported yet. Please use an Ethereum account instead.",
+    "solana_signup_not_supported": "Вход в «Вознаграждения» с помощью счетов Solana пока не поддерживается. Используйте вместо этого счет Ethereum.",
     "error_messages": {
-      "unknown_error": "Unknown error occurred",
-      "something_went_wrong": "Something went wrong. Please try again shortly.",
-      "account_already_registered": "This account is already registered with another Rewards profile. Please switch account to continue.",
-      "request_rejected": "You rejected the request.",
-      "failed_to_claim_reward": "Failed to claim reward. Please try again shortly.",
-      "service_not_available": "Service is not available at the moment. Please try again shortly."
+      "unknown_error": "Произошла неизвестная ошибка",
+      "something_went_wrong": "Возникла ошибка. Повторите попытку позже.",
+      "account_already_registered": "Этот счет уже зарегистрирован в другом профиле вознаграждений. Смените счет, чтобы продолжить.",
+      "request_rejected": "Вы отклонили запрос.",
+      "failed_to_claim_reward": "Не удалось получить вознаграждение. Повторите попытку позже.",
+      "service_not_available": "В данный момент сервис недоступен. Повторите попытку позже."
     },
     "claim_reward_error": {
-      "title": "Failed to claim reward"
+      "title": "Не удалось получить вознаграждение"
     },
     "accounts_opt_in_state_error": {
-      "error_fetching_title": "Accounts couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Не удалось загрузить счета",
+      "error_fetching_description": "Проверьте соединение и повторите попытку.",
+      "retry_button": "Повтор"
     },
     "referral_rewards_title": "Рефералы",
     "points": "Баллы",
@@ -5899,139 +6093,142 @@
     "tab_levels_title": "Уровни",
     "referral_stats_earned_from_referrals": "Заработано на рефералах",
     "referral_stats_referrals": "Рефералы",
-    "loading_activity": "Loading activity...",
-    "error_loading_activity": "Error loading activity",
-    "activity_empty_title": "No recent activity.",
-    "activity_empty_description": "Use MetaMask to earn points, level up, and unlock rewards.",
-    "activity_empty_link": "See ways to earn",
+    "loading_activity": "Загрузка активности...",
+    "error_loading_activity": "Ошибка загрузки активности",
+    "activity_empty_title": "Нет недавней активности.",
+    "activity_empty_description": "Используйте MetaMask, чтобы зарабатывать баллы, повышать уровень и получать вознаграждения.",
+    "activity_empty_link": "Посмотрите способы заработка",
     "events": {
-      "to": "to",
+      "to": "место назначения",
       "type": {
         "swap": "Обменять",
         "perps": "Бессрочные фьючерсы",
-        "referral": "Referral",
-        "referral_action": "Referral action",
-        "sign_up_bonus": "Sign up bonus",
-        "loyalty_bonus": "Loyalty bonus",
-        "one_time_bonus": "One-time bonus",
-        "open_position": "Opened position",
-        "close_position": "Closed position",
-        "take_profit": "TP/SL",
-        "stop_loss": "TP/SL",
-        "uncategorized_event": "Uncategorized event"
+        "card_spend": "Card spend",
+        "referral": "Реферал",
+        "referral_action": "Действие реферала",
+        "sign_up_bonus": "Бонус за регистрацию",
+        "loyalty_bonus": "Бонус за лояльность",
+        "one_time_bonus": "Однократный бонус",
+        "open_position": "Открытая позиция",
+        "close_position": "Закрытая позиция",
+        "take_profit": "ТП/СЛ",
+        "stop_loss": "ТП/СЛ",
+        "uncategorized_event": "Событие без категории"
       },
-      "date": "Date",
-      "account": "Account",
-      "bonus": "Bonus",
-      "details": "Details",
-      "points": "Points",
-      "points_base": "Base",
-      "points_boost": "Boost",
-      "points_total": "Total"
+      "date": "Дата",
+      "account": "Счет",
+      "bonus": "Бонус",
+      "details": "Подробности",
+      "points": "Баллы",
+      "points_base": "Основа",
+      "points_boost": "Повышающий коэффициент",
+      "points_total": "Итого"
     },
     "onboarding": {
       "not_supported_region_title": "Регион не поддерживается",
-      "not_supported_region_description": "Rewards are not supported in your region yet. We are working on expanding access, so check back later.",
-      "not_supported_hardware_account_title": "Account not supported",
-      "not_supported_hardware_account_description": "Hardware wallet accounts are not eligible to receive rewards yet. Please switch to a different account to proceed.",
-      "not_supported_account_type_title": "Account type not supported",
-      "not_supported_account_type_description": "Currently only internal Ethereum and Solana accounts can be opted into the Rewards program. Please switch to a different account to proceed.",
-      "not_supported_confirm_go_back": "Go back",
-      "not_supported_confirm_retry": "Retry",
-      "auth_fail_title": "Authentication Failed",
-      "auth_fail_description": "Unable to authenticate with the rewards program. Please check your connection and try again.",
-      "geo_check_fail_title": "Cannot determine opt-in eligibility",
-      "geo_check_fail_description": "We cannot determine if your country allows opting into the rewards program. Please check your connection and try again.",
+      "not_supported_region_description": "Вознаграждения пока не поддерживаются в вашем регионе. Мы работаем над расширением доступа, поэтому зайдите позже.",
+      "not_supported_hardware_account_title": "Счет не поддерживается",
+      "not_supported_hardware_account_description": "Счета аппаратных кошельков пока не могут быть использованы для получения вознаграждений. Чтобы продолжить, перейдите в другой счет.",
+      "not_supported_account_type_title": "Тип счета не поддерживается",
+      "not_supported_account_type_description": "В настоящее время к программе вознаграждений можно подключить только внутренние счета Ethereum и Solana. Для продолжения перейдите в другой счет.",
+      "not_supported_confirm_go_back": "Назад",
+      "not_supported_confirm_retry": "Повтор",
+      "auth_fail_title": "Ошибка аутентификации",
+      "auth_fail_description": "Не удалось авторизоваться в программе вознаграждений. Проверьте подключение и повторите попытку.",
+      "geo_check_fail_title": "Невозможно определить право на участие",
+      "geo_check_fail_description": "Мы не можем определить, разрешено ли участие в программе вознаграждений в вашей стране. Проверьте подключение и повторите попытку.",
       "gtm_title": "Награды здесь",
       "gtm_description": "Зарабатывайте баллы за активность.\nПроходите уровни, чтобы разблокировать награды.",
       "gtm_confirm": "С чего начать",
       "intro_title": "Сезон 1\nуже идет",
-      "intro_description": "Earn points for your activity. \nAdvance through levels to unlock rewards.",
-      "intro_confirm": "Claim 250 points",
-      "intro_confirm_geo_loading": "Checking region...",
-      "checking_opt_in": "Checking accounts...",
-      "redirecting_to_dashboard": "Redirecting...",
+      "intro_description": "Зарабатывайте баллы за активность.\nПроходите уровни, чтобы разблокировать награды.",
+      "intro_confirm": "Получите 250 баллов",
+      "intro_confirm_geo_loading": "Проверка региона...",
+      "checking_opt_in": "Проверка счетов...",
+      "redirecting_to_dashboard": "Перенаправление...",
       "intro_skip": "Не сейчас",
       "step_confirm": "Далее",
-      "step_skip": "Skip",
-      "step1_title": "Earn points on every trade",
+      "step_skip": "Пропустить",
+      "step1_title": "Зарабатывайте баллы за каждую сделку",
       "step1_description": "Каждый своп и сделка с перпами в MetaMask приближает вас к вознаграждениям. Добавьте свои счета и наблюдайте за ростом количества ваших баллов.",
-      "step2_title": "Level up for bigger perks",
+      "step2_title": "Повышайте уровень для получения больших преимуществ",
       "step2_description": "Достигайте контрольных уровней, чтобы получить такие привилегии, как скидка 50% на комиссию на первы, эксклюзивные токены и бесплатную карту MetaMask Metal.",
-      "step3_title": "Exclusive seasonal rewards",
-      "step3_description": "Each season brings new perks. Join in, compete, and claim what you can before time runs out.",
-      "step4_title": "You'll earn 250 points when you sign up!",
-      "step4_title_referral_validating": "Validating referral code...",
-      "step4_referral_input_placeholder": "Referral code (optional)",
-      "step4_referral_input_error": "Invalid referral code",
-      "step4_confirm": "Claim points",
-      "step4_confirm_loading": "Claiming points...",
-      "step4_linking_accounts": "Adding accounts... ({{current}}/{{total}})",
-      "step4_linking_accounts_loading": "Adding additional accounts...",
-      "step4_success_description": "You have successfully signed up for MetaMask Rewards!",
-      "step4_legal_disclaimer_1": "By selecting 'Claim Points', you agree to the MetaMask Rewards",
-      "step4_legal_disclaimer_2": "Supplemental Terms of Use and Privacy Notice",
-      "step4_legal_disclaimer_3": ". We'll track onchain activity to reward you automatically –",
-      "step4_legal_disclaimer_4": "learn more"
+      "step3_title": "Эксклюзивные сезонные вознаграждения",
+      "step3_description": "Каждый сезон приносит новые преимущества. Присоединяйтесь, соревнуйтесь и получайте все, что сможете, пока не истечет время.",
+      "step4_title": "Вы получите 250 баллов за регистрацию!",
+      "step4_title_referral_bonus": "You'll earn 500 points when you sign up with this code!",
+      "step4_title_referral_validating": "Проверка реферального кода...",
+      "step4_referral_bonus_description": "Use a referral code to earn 250 more",
+      "step4_referral_input_placeholder": "Реферальный код (необязательно)",
+      "step4_referral_input_error": "Недействительный реферальный код",
+      "step4_confirm": "Получить баллы",
+      "step4_confirm_loading": "Получение баллов...",
+      "step4_linking_accounts": "Добавляются счета... ({{current}} из {{total}})",
+      "step4_linking_accounts_loading": "Добавление дополнительных счетов...",
+      "step4_success_description": "Вы успешно зарегистрировались в программе MetaMask Rewards!",
+      "step4_legal_disclaimer_1": "Выбирая «Получить баллы», вы соглашаетесь с условиями программы вознаграждений MetaMask Rewards",
+      "step4_legal_disclaimer_2": "Дополнительные условия использования и уведомление о конфиденциальности",
+      "step4_legal_disclaimer_3": ". Мы будем отслеживать активность в сети, чтобы автоматически начислять вам вознаграждения –",
+      "step4_legal_disclaimer_4": "узнайте подробнее"
     },
     "settings": {
-      "title": "Rewards Settings",
-      "subtitle": "Accounts",
-      "description": "Add multiple accounts to combine your points and unlock rewards faster.",
-      "tab_linked_accounts": "Added ({{count}})",
-      "tab_unlinked_accounts": "Not added ({{count}})",
-      "no_linked_accounts": "No accounts opted in",
-      "all_accounts_linked_title": "All accounts opted in",
-      "all_accounts_linked_description": "You have added all your accounts to Rewards.",
-      "link_account_success_title": "{{accountName}} successfully added",
-      "link_account_error_title": "Failed to add account",
-      "link_account_button": "Add",
-      "link_account_failed_error": "Failed to link account",
-      "link_account_unknown_error": "Unknown error occurred"
+      "title": "Настройки вознаграждений",
+      "subtitle": "Счета",
+      "description": "Добавьте несколько счетов, чтобы объединять баллы и быстрее получать вознаграждения.",
+      "tab_linked_accounts": "Добавлено ({{count}})",
+      "tab_unlinked_accounts": "Не добавлено ({{count}})",
+      "no_linked_accounts": "Ни один счет не выбран",
+      "all_accounts_linked_title": "Выбраны все счета",
+      "all_accounts_linked_description": "Вы добавили все свои аккаунты в программу вознаграждений.",
+      "link_account_success_title": "{{accountName}} успешно добавлен",
+      "link_account_error_title": "Не удалось добавить счет",
+      "link_account_button": "Добавить",
+      "link_account_failed_error": "Не удалось привязать счет",
+      "link_account_unknown_error": "Произошла неизвестная ошибка"
     },
     "optout": {
-      "title": "Opt out of Rewards",
-      "description": "This will remove your accounts from the Rewards program and erase your points and progress. You won't be able to undo this.",
-      "confirm": "Opt out",
+      "title": "Отказаться от участия в программе вознаграждений",
+      "description": "Это приведет к удалению ваших счетов из программы вознаграждений, а также к потере баллов и прогресса. Отменить это действие будет невозможно.",
+      "confirm": "Отказаться",
       "modal": {
-        "confirmation_title": "Are you sure?",
-        "confirmation_description": "This will remove all your progress, and can't be reversed. If you rejoin the Rewards program later, you'll start back at 0.",
-        "cancel": "Cancel",
-        "confirm": "Confirm",
-        "error_message": "Failed to opt out of Rewards. Please try again.",
-        "processing": "Processing..."
+        "confirmation_title": "Вы уверены?",
+        "confirmation_description": "Это удалит весь ваш прогресс, и его нельзя будет восстановить. Если вы снова присоединитесь к Программе вознаграждений позже, вы начнете с нуля.",
+        "cancel": "Отмена",
+        "confirm": "Подтвердить",
+        "error_message": "Не удалось отказаться от участия в Программе вознаграждений. Попробуйте еще раз.",
+        "processing": "Обработка..."
       }
     },
-    "toast_dismiss": "Dismiss",
+    "toast_dismiss": "Отклонить",
     "dashboard_modal_info": {
       "active_account": {
-        "title": "Don't miss out",
-        "description": "Add your account to start earning points from your activity.",
-        "confirm": "Add account"
+        "title": "Не пропустите",
+        "description": "Добавьте свой счет, чтобы начать зарабатывать баллы за свою активность.",
+        "confirm": "Добавить аккаунт"
       },
       "multiple_unlinked_accounts": {
-        "title": "Start earning points",
-        "description": "Add your accounts so you can track your rewards at a glance.",
-        "confirm": "Add accounts"
+        "title": "Начните зарабатывать баллы",
+        "description": "Добавьте свои счета, чтобы вы могли мгновенно отслеживать вознаграждения.",
+        "confirm": "Добавить счета"
       },
       "account_not_supported": {
-        "title": "Account not supported",
-        "description_hardware": "Hardware wallet accounts are not yet eligible to earn points. Please switch to a different account to proceed.",
-        "description_general": "Currently only non-hardware internal Ethereum and Solana accounts are eligible to earn points. Please switch to a different account to proceed.",
-        "confirm": "Go back"
+        "title": "Счет не поддерживается",
+        "description_hardware": "Счета аппаратных кошельков пока не позволяют зарабатывать баллы. Чтобы продолжить, перейдите в другой счет.",
+        "description_general": "В настоящее время баллы начисляются только по внутренним счетам Ethereum и Solana, не использующим аппаратные кошельки. Чтобы продолжить, перейдите в другой счет.",
+        "confirm": "Назад"
       }
     },
     "ways_to_earn": {
-      "title": "Ways to earn",
-      "supported_networks": "Supported Networks",
+      "title": "Способы заработка",
+      "supported_networks": "Поддерживаемые сети",
       "swap": {
-        "title": "Swap",
-        "description": "80 points per $100",
+        "title": "Своп",
+        "description": "80 баллов за 100 $",
         "sheet": {
-          "title": "Swap tokens",
-          "points": "80 points per $100",
-          "description": "Swap tokens on supported networks to earn points for every dollar you trade.",
-          "cta_label": "Start a swap"
+          "title": "Обменять токены",
+          "points": "80 баллов за 100 $",
+          "description": "Обменивайте токены в поддерживаемых сетях, чтобы зарабатывать баллы за каждый доллар потраченный на торговлю.",
+          "cta_label": "Начать своп"
         }
       },
       "perps": {
@@ -6045,52 +6242,74 @@
         }
       },
       "referrals": {
-        "title": "Refer friends",
-        "description": "10 points per 50 from friends"
+        "title": "Порекомендуйте друзьям",
+        "description": "10 баллов за каждые 50 от друзей",
+        "sheet": {
+          "title": "Refer a friend",
+          "points": "20 points per 100",
+          "cta_label": "Refer a friend"
+        }
       },
       "loyalty": {
-        "title": "Loyalty bonus",
-        "description": "Earn points from past trades",
+        "title": "Бонус за лояльность",
+        "description": "Зарабатывайте баллы за прошлые сделки",
         "sheet": {
-          "title": "Loyalty bonus",
-          "points": "250 points per $1250",
-          "description": "Add accounts with past swaps or bridges in MetaMask to earn loyalty bonuses. Each eligible account unlocks points in increments of 250, up to a total of 50,000. Bonuses appear shortly after you add an account.",
-          "cta_label": "Add accounts"
+          "title": "Бонус за лояльность",
+          "points": "250 баллов за 1250 $",
+          "description": "Добавляйте счета с прошлыми свопами или мостами в MetaMask, чтобы получать бонусы за лояльность. Каждый соответствующий условиям счет разблокирует баллы с шагом в 250, вплоть до 50 000. Бонусы появляются вскоре после добавления счета.",
+          "cta_label": "Добавить счета"
+        }
+      },
+      "card": {
+        "title": "MetaMask Card",
+        "description": "1 point per $1 spent",
+        "sheet": {
+          "title": "MetaMask Card",
+          "points": "1 point per $1 spent",
+          "description": "Earn points every time you use your MetaMask Card for purchases, plus 1% cash back (3% for Metal cardholders).",
+          "cta_label": "Manage Card"
         }
       }
     },
     "referral": {
-      "referral_code": "Referral code",
-      "referral_link": "Referral link",
+      "referral_code": "Реферальный код",
+      "referral_link": "Реферальная ссылка",
       "actions": {
         "share_referral_link": "Приведите друга",
         "share_referral_subject": "Присоединяйтесь к MetaMask Rewards"
       },
       "info": {
         "title": "Поделитесь своим кодом, чтобы заработать больше",
-        "description": "Your friends get a 2x sign up bonus. You get 10 points for every 50 they earn from trading."
+        "description": "Ваши друзья получат двойной бонус за регистрацию. Вы получите 10 баллов за каждые 50, заработанные друзьями на торговле."
       }
     },
-    "active_boosts_title": "Active boosts",
-    "season_1": "Season 1",
+    "link_account_group": {
+      "link_account": "Add account",
+      "tracked": "Tracked",
+      "untracked": "Untracked",
+      "link_account_success": "{{accountName}} added successfully",
+      "link_account_error": "Failed to add one or more addresses for {{accountName}}"
+    },
+    "active_boosts_title": "Активные повышающие коэффициенты",
+    "season_1": "Сезон 1",
     "upcoming_rewards": {
       "title": "Заблокированные награды",
-      "points_needed": "{{points}} points",
-      "cta_label": "Got it",
-      "alpha_fox_invite_input_placeholder": "Your Telegram handle"
+      "points_needed": "{{points}} балла(-ов)",
+      "cta_label": "Понятно",
+      "alpha_fox_invite_input_placeholder": "Ваш ник в Telegram"
     },
     "unlocked_rewards": {
-      "title": "Unlocked rewards",
-      "cta_label": "Claim now",
-      "cta_request_invite": "Request invite",
-      "claim_label": "Claim",
-      "claimed_label": "Claimed",
-      "reward_claimed": "Reward claimed",
+      "title": "Разблокированные вознаграждения",
+      "cta_label": "Получить сейчас",
+      "cta_request_invite": "Запросить приглашение",
+      "claim_label": "Получить",
+      "claimed_label": "Получено",
+      "reward_claimed": "Вознаграждение получено",
       "time_left": "осталось",
-      "expired": "Expired"
+      "expired": "Просрочено"
     },
     "animation": {
-      "could_not_load": "Couldn't load"
+      "could_not_load": "Ошибка загрузки"
     }
   },
   "time": {
@@ -6099,7 +6318,7 @@
   },
   "transaction_details": {
     "title": {
-      "perps_deposit": "Funded Perps account",
+      "perps_deposit": "Счет перпов пополнен",
       "predict_deposit": "Funded Predict account",
       "default": "Сведения о транзакции"
     },
@@ -6107,19 +6326,23 @@
       "bridge_fee": "Комиссия моста",
       "network_fee": "Комиссия сети",
       "paid_with": "Оплачено с помощью",
+      "retry_button": "Try again",
       "total": "Итого"
     },
     "summary_title": {
-      "bridge": "Мост от {{sourceSymbol}} к {{targetSymbol}}",
       "bridge_approval": "Одобрить {{approveSymbol}}",
       "bridge_approval_loading": "Одобрить",
-      "bridge_loading": "Мост",
+      "bridge_send": "Bridge {{sourceSymbol}} from {{sourceChain}}",
+      "bridge_send_loading": "Bridge Send",
+      "bridge_receive": "Receive {{targetSymbol}} on {{targetChain}}",
+      "bridge_receive_loading": "Bridge Receive",
       "default": "Транзакция",
       "perps_deposit": "Внести средства",
       "predict_deposit": "Add funds",
       "swap": "Обменять токены",
       "swap_approval": "Одобрить токены"
-    }
+    },
+    "perps_deposit_solution": "You now have {{fiat}} of USDC on Arbitrum. Try your deposit again."
   },
   "sdk_connect_v2": {
     "show_loading": {

--- a/locales/languages/tl.json
+++ b/locales/languages/tl.json
@@ -594,7 +594,9 @@
       "unexpectedError": "Nagkaroon ng hindi inaasahang error.",
       "quoteFetchError": "Nabigong kunin ang quote.",
       "kycFormsFetchError": "Nabigong kunin ang mga KYC form.",
-      "title": "Magdeposito"
+      "title": "Magdeposito",
+      "limitExceeded": "This deposit would exceed your {{period}} limit. Your deposit including fees must be {{remaining}} or less.",
+      "limitError": "Failed to check your deposit limits. Please try again later."
     },
     "token_modal": {
       "select_a_token": "Pumili ng Token",
@@ -892,7 +894,7 @@
     "withdraw": "I-withdraw",
     "refresh_balance": "I-refresh ang Balanse",
     "add_funds": "Magdagdag ng mga pondo",
-    "deposit_in_progress": "Deposit in progress",
+    "deposit_in_progress": "Kasalukuyang nagdedeposito",
     "your_positions": "Mga position mo",
     "loading_positions": "Inilo-load ang mga posisyon...",
     "refreshing_positions": "Nire-refresh ang mga posisyon mo...",
@@ -1277,6 +1279,7 @@
       "assetMappingFailed": "Hindi nakabuo ng pagmamapa ng asset",
       "depositFailed": "Nabigo ang pagdeposito",
       "orderLeverageReductionFailed": "Hindi mo mababawasan ang iyong leverage",
+      "connectionTimeout": "Connection timed out. Please check your network and try again.",
       "connectionFailed": {
         "title": "Pansamantalang offline ang perps",
         "description": "Nagsisikap kaming maibalik ito online sa lalong madaling panahon.",
@@ -1510,7 +1513,7 @@
         "metamask_fee": "Bayad sa MetaMask",
         "hyperliquid_fee": "Bayad sa HyperLiquid",
         "total_fee": "Kabuuang bayarin",
-        "liquidated": "Liquidated",
+        "liquidated": "Na-liquidate",
         "take_profit": "Take profit",
         "stop_loss": "Stop loss"
       },
@@ -1525,7 +1528,7 @@
         "history_will_appear": "Lalabas dito ang history ng pag-trade mo"
       }
     },
-    "risk_disclaimer": "Perpetual contracts are very risky, and you could suddenly and without notice lose your entire investment. You trade entirely at your own risk. Market data provided by Hyperliquid. Price chart powered by",
+    "risk_disclaimer": "Perpetual contracts are very risky, and you could suddenly and without notice lose your entire investment. You trade entirely at your own risk. Market data provided by Hyperliquid. Price chart powered by",
     "tutorial": {
       "continue": "Magpatuloy",
       "skip": "Laktawan",
@@ -1555,11 +1558,11 @@
       "ready_to_trade": {
         "title": "Handa nang mag-trade?",
         "description": "Pondohan ang perps account mo gamit ang anumang token at isagawa ang una mong trade sa ilang segundo.",
-        "footer_text": "Isu-swap ng MetaMask ang iyong mga pondo sa USDC sa Arbitrum, at idedeposito ang mga iyon sa HyperCore nang walang dagdag na bayad."
+        "footer_text": "MetaMask will swap your funds to USDC on Arbitrum, and deposit them onto HyperCore for no added fee."
       },
       "got_it": "Nakuha ko",
       "card": {
-        "title": "Learn the basics of perps"
+        "title": "Matutunan ang mga pangunahing kaalaman tungkol sa perps"
       }
     },
     "points": "Mga Point",
@@ -1576,10 +1579,10 @@
     "market_list": "Listahan ng Market",
     "market_details": "Mga Detalye ng Market",
     "tab": {
-      "no_predictions": "Wala pang mga hula",
-      "no_predictions_description": "Buksan ang hula para magsimula.",
-      "explore": "Suriin ang mga market",
-      "new_prediction": "Bagong hula"
+      "no_predictions_description": "Your predictions will appear here, showing your stake and market movement.",
+      "explore": "Browse markets",
+      "new_prediction": "Bagong hula",
+      "resolved_markets": "Resolved markets"
     },
     "sell_position": "Posisyon sa Pagbenta",
     "cash_out": "Mag-cash Out",
@@ -1609,16 +1612,73 @@
     "claim_button": "I-claim",
     "markets_won": "Nanalo ang mga market",
     "won_markets_text": "Nanalo ang {{count}} market{{s}}",
-    "won_markets_text_singular": "Nanalo ang {{count}} market",
-    "won_markets_text_plural": "Nanalo ang {{count}} na market",
+    "available_balance": "Available balance",
     "claim_amount_text": "I-claim ang ${{amount}}",
     "unrealized_pnl_label": "Unrealized P&L",
     "unrealized_pnl_value": "{{amount}} ({{percent}})",
+    "unrealized_pnl_error": "Unable to load",
     "unavailable": {
       "title": "Unavailable in your region",
       "description": "Predictions aren't available in your region due to legal restrictions.",
       "link": "See Polymarket terms",
       "button": "Got it"
+    },
+    "deposit": {
+      "in_progress": "Deposit in progress",
+      "adding_funds": "Adding funds",
+      "adding_your_funds": "Adding your funds",
+      "add_funds": "Add funds",
+      "withdraw": "Withdraw",
+      "estimated_processing_time": "Est. {{time}} seconds",
+      "account_ready": "Your account is ready",
+      "account_ready_description": "{{amount}} added to your balance",
+      "error_title": "Something went wrong",
+      "error_description": "Your account wasn't funded",
+      "try_again": "Try again"
+    },
+    "add_funds_sheet": {
+      "title": "Add funds",
+      "description": "You'll need to add funds to your Predictions account to get started. You can add any token and make your first prediction in seconds."
+    },
+    "transactions": {
+      "title": "Predictions",
+      "no_transactions": "No recent activity",
+      "buy_title": "Predicted",
+      "sell_title": "Cashed out",
+      "claim_title": "Claimed winnings",
+      "buy_detail": "Bought {{amountUsd}} on {{outcome}} · {{priceCents}} per share",
+      "sell_detail": "Sold at {{priceCents}} per share",
+      "claim_detail": "Claimed winnings",
+      "not_available": "N/A",
+      "date": "Date",
+      "market": "Market",
+      "outcome": "Outcome",
+      "predicted_amount": "Predicted amount",
+      "shares_bought": "Shares bought",
+      "shares_sold": "Shares sold",
+      "price_per_share": "Price per share",
+      "price_impact": "Price impact",
+      "net_pnl": "Net P&L",
+      "total_net_pnl": "Total Net P&L",
+      "market_net_pnl": "Market Net P&L",
+      "activity_details": "Activity details"
+    },
+    "claim": {
+      "toasts": {
+        "pending": {
+          "title": "Claiming {{amount}}",
+          "description": "Est. {{time}} seconds"
+        },
+        "confirmed": {
+          "title": "Claimed",
+          "description": "{{amount}} added to your balance"
+        },
+        "error": {
+          "title": "Something went wrong",
+          "description": "Failed to proceed with claim",
+          "try_again": "Try again"
+        }
+      }
     }
   },
   "receive": {
@@ -3093,6 +3153,7 @@
     "tx_review_lending_withdraw": "Pag-withdraw sa Pagpapautang",
     "tx_review_perps_deposit": "Pinondohang Perps account",
     "tx_review_predict_deposit": "Funded Predict account",
+    "tx_review_predict_claim": "Claimed Predict winnings",
     "sent_ether": "Nagpadala ng Ether",
     "self_sent_ether": "Nagpadala ka sa sarili mo ng Ether",
     "received_ether": "Nakatanggap ng Ether",
@@ -3939,7 +4000,9 @@
     "wallet_connect_dapps_cta": "Tingnan ang mga sesyon",
     "network_not_supported": "Hindi sinusuportahan ang kasalukuyang network",
     "select_provider": "Piliin ang iyong mas gustong provider",
-    "switch_network": "Mangyaring lumipat sa mainnet o sepolia"
+    "switch_network": "Mangyaring lumipat sa mainnet o sepolia",
+    "card_title": "Always show MetaMask Card button",
+    "card_desc": "MetaMask Card is only available to residents of select countries"
   },
   "walletconnect_sessions": {
     "no_active_sessions": "Wala kang aktibong session",
@@ -5315,7 +5378,7 @@
     },
     "tooltip": {
       "perps_deposit": {
-        "transaction_fee": "Isu-swap namin ang iyong mga token para maging USDC sa HyperCore, ang network na ginagamit ng Perps. Maaaring maningil ang mga swap provider, ngunit hindi ang MetaMask."
+        "transaction_fee": "We'll swap your tokens for USDC on HyperCore, the network used by Perps. Swap providers may charge a fee, but MetaMask won't."
       },
       "predict_deposit": {
         "transaction_fee": "We'll swap your tokens for USDC.e on Polygon, the network used by Predict. Swap providers may charge a fee, but MetaMask won't."
@@ -5407,6 +5470,12 @@
       "save": "I-save",
       "title": "I-edit ang limit ng pag-apruba"
     },
+    "predict_claim": {
+      "button_label": "Claim winnings",
+      "summary": "You won",
+      "footer_bottom": "Funds will be added to your available balance",
+      "footer_top": "Winnings from {{count}} markets"
+    },
     "unlimited": "Walang limitasyon",
     "all": "Lahat",
     "none": "Wala",
@@ -5469,12 +5538,15 @@
     "points": "Tinatayang mga point",
     "points_tooltip": "Mga Point",
     "points_tooltip_content_1": "Points are how you earn MetaMask Rewards for completing transactions, like when you swap, bridge, or trade perps.",
-    "points_tooltip_content_2": "Keep in mind this value is an estimate and will be finalized once the transaction is complete. Points can take up to 1 hour to be confirmed in your Rewards balance.",
+    "points_tooltip_content_2": "Tandaan na ang halagang ito ay isang pagtatantya lamang at magiging pinal lamang kapag natapos na ang transaksyon. Maaaring umabot ng hanggang 1 oras bago makumpirma ang mga point sa iyong balanse ng mga Reward.",
     "unable_to_load": "Hindi mai-load",
     "points_error": "Hindi namin mai-load ang mga point sa ngayon",
-    "points_error_content": "You'll still earn any points for this transaction. We'll notify you once they've been added to your account. You can also check your rewards tab in about an hour.",
+    "points_error_content": "Makakaipon ka pa rin ng mga point para sa transaksyong ito. Aabisuhan ka namin kapag naidagdag na ang mga ito sa iyong account. Maaari mo rin itong tingnan sa iyong rewards tab makalipas ang humigit-kumulang isang oras.",
     "see_other_quotes": "Tingnan ang ibang mga quote",
     "receive_at": "Natanggap sa",
+    "recipient": "Recipient",
+    "select_recipient": "Select recipient",
+    "external_account": "External account",
     "error_banner_description": "Hindi available ang ruta ng trade na ito sa ngayon. Subukang baguhin ang halaga, network, o token at hahanapin namin ang pinakamainam na solusyon.",
     "insufficient_funds": "Hindi sapat ang pondo",
     "insufficient_gas": "Hindi sapat ang gas",
@@ -5775,6 +5847,12 @@
       "update_to_store_link": "I-update ang pinakabagong bersyon ng MetaMask",
       "well_take_you_to_right_place": " at dadalhin ka namin sa tamang lugar."
     },
+    "unsupported": {
+      "title": "This page is not supported in current version",
+      "description": "Update to the latest version to use this feature",
+      "update_to_store_link": "Update to the latest version of MetaMask",
+      "well_take_you_to_right_place": " and we'll take you to the right place."
+    },
     "go_to_home_button": "Pumunta sa home page",
     "back_button": "Bumalik",
     "continue_button": "Magpatuloy"
@@ -5791,7 +5869,96 @@
     "card_onboarding": {
       "title": "Welcome sa Card",
       "description": "Para gamitin ang mga feature ng card, kakailanganin mong i-veify ang account mo sa aming ka-partner.",
-      "verify_account_button": "I-verify ang account"
+      "verify_account_button": "I-verify ang account",
+      "sign_up": {
+        "title": "Sign-up",
+        "description": "Register your details with Crypto Life, the provider of MetaMask Card. You'll use this account to access and manage your card.",
+        "email_label": "Email",
+        "password_label": "Password",
+        "confirm_password_label": "Confirm password",
+        "country_label": "Country of Residence",
+        "email_placeholder": "Enter your email address",
+        "password_placeholder": "Enter your password",
+        "country_placeholder": "Select your country",
+        "password_mismatch": "Passwords do not match",
+        "invalid_email": "Invalid email address"
+      },
+      "confirm_email": {
+        "title": "Confirm your email",
+        "description": "We've sent a confirmation code to: {{email}}",
+        "confirm_code_label": "Confirmation code",
+        "confirm_code_placeholder": "Enter the confirmation code"
+      },
+      "set_phone_number": {
+        "title": "Phone number",
+        "description": "Enter your phone number",
+        "phone_number_label": "Phone number",
+        "phone_number_placeholder": "Enter your phone number",
+        "country_area_code_label": "Country area code",
+        "invalid_phone_number": "Invalid phone number",
+        "legal_terms": "By continuing, you agree to receiving SMS to verify your phone number."
+      },
+      "confirm_phone_number": {
+        "title": "Confirm your phone number",
+        "description": "We've sent a confirmation code to: {{phoneNumber}}",
+        "confirm_code_label": "Confirmation code"
+      },
+      "verify_identity": {
+        "title": "Verifying your identity to get your card",
+        "description": "To keep your account secure and comply with regulations, we need to verify your identity.\n\nYou'll need a government-issued ID and a proof of address (like a utility bill or bank statement).\n\nVerification usually takes 5-30 minutes, and we'll notify you as soon as it's complete.",
+        "verify_button": "Verify now with Veriff"
+      },
+      "validating_kyc": {
+        "title": "Validating your KYC..."
+      },
+      "kyc_failed": {
+        "title": "Rejected",
+        "description": "Your KYC was rejected. Please try again."
+      },
+      "personal_details": {
+        "title": "Personal details",
+        "description": "Enter your personal details",
+        "first_name_label": "First name",
+        "last_name_label": "Last name",
+        "date_of_birth_label": "Date of birth",
+        "nationality_label": "Country of Nationality",
+        "ssn_label": "Social Security Number",
+        "first_name_placeholder": "Enter your first name",
+        "last_name_placeholder": "Enter your last name",
+        "date_of_birth_placeholder": "Enter your date of birth",
+        "nationality_placeholder": "Select your nationality",
+        "ssn_placeholder": "Enter your SSN",
+        "invalid_ssn": "Invalid SSN",
+        "invalid_date_of_birth": "Invalid date of birth",
+        "invalid_date_of_birth_underage": "You must be at least 18 years old"
+      },
+      "physical_address": {
+        "title": "Physical address",
+        "description": "Please provide your physical address",
+        "address_line_1_label": "Address line 1",
+        "address_line_2_label": "Address line 2",
+        "city_label": "City",
+        "state_label": "State",
+        "zip_code_label": "ZIP code",
+        "address_line_1_placeholder": "Enter your address line 1",
+        "address_line_2_placeholder": "Enter your address line 2",
+        "city_placeholder": "Enter your city",
+        "state_placeholder": "Enter your state",
+        "zip_code_placeholder": "Enter your ZIP code",
+        "same_mailing_address_label": "Physical address is the same as mailing address",
+        "electronic_consent": "I agree to the E-Sign Act Consent and Disclosure and to receive all communictions electronically."
+      },
+      "mailing_address": {
+        "title": "Mailing address",
+        "description": "Please provide your mailing address"
+      },
+      "complete": {
+        "title": "Approved!",
+        "description": "Your KYC was approved. You can now use your Card."
+      },
+      "continue_button": "Next",
+      "confirm_button": "Confirm",
+      "retry_button": "Try again"
     },
     "card_home": {
       "error_title": "Hindi makuha ang data",
@@ -5799,9 +5966,36 @@
       "try_again": "Subukang muli",
       "limited_spending_warning": "Posibleng limitado ang aktwal na kakayahan mong gumastos. Para ayusin ang limitasyon mo, pumunta sa {{manageCard}}",
       "add_funds": "Magdagdag ng mga pondo",
+      "change_asset": "Change asset",
       "manage_card_options": {
+        "manage_spending_limit": "Manage spending limit",
+        "manage_spending_limit_description_restricted": "Restricted spending limit is on",
+        "manage_spending_limit_description_full": "Full spending access is on",
         "manage_card": "Pamahalaan ang card",
-        "advanced_card_management_description": "Tingnan ang mga transaksyon, freeze card, at higit pa"
+        "advanced_card_management_description": "Detailed transactions, freeze card, and more"
+      }
+    },
+    "card_authentication": {
+      "title": "Log in to your Card account",
+      "location_button_text": "International",
+      "location_button_text_us": "US account",
+      "email_label": "Email",
+      "password_label": "Password",
+      "email_placeholder": "Enter your email address",
+      "password_placeholder": "Enter your password",
+      "login_button": "Log in",
+      "errors": {
+        "invalid_credentials": "Invalid login details",
+        "unknown_error": "Unknown error, please try again later",
+        "email_required": "Email is required",
+        "password_required": "Password is required",
+        "email_invalid": "Invalid email address",
+        "password_invalid": "Invalid password",
+        "invalid_email_or_password": "Invalid email or password, check your credentials and try again.",
+        "network_error": "Network error. Please check your connection and try again.",
+        "timeout_error": "Request timed out. Please check your connection and try again.",
+        "server_error": "Server error. Please try again later.",
+        "configuration_error": "Service is temporarily unavailable. Please try again later."
       }
     }
   },
@@ -5825,65 +6019,65 @@
     "close": "Isara"
   },
   "rewards": {
-    "auth_fail_title": "Unknown Error.",
-    "auth_fail_description": "An unknown error occurred while authenticating this account with the rewards program. Please try again later.",
-    "failed_to_authenticate": "Failed to authenticate with rewards program",
+    "auth_fail_title": "Hindi nakikilalang Error.",
+    "auth_fail_description": "May naganap na hindi nakikilalang error habang ina-authenticate ang account na ito gamit ang programa ng mga reward. Pakisubukang muli mamaya.",
+    "failed_to_authenticate": "Nabigong ma-authenticate gamit ang programa ng mga reward",
     "not_implemented": "Paparating na",
     "not_implemented_season_summary": "Paparating na ang Buod ng Season",
     "optin_error": {
-      "title": "Opt-in failed",
-      "description": "Check your connection and try again."
+      "title": "Nabigong mag-opt-in",
+      "description": "Suriin ang iyong koneksyon at subukang muli."
     },
     "season_status_error": {
-      "error_fetching_title": "Season balance couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Hindi mai-load ang balanse ng season",
+      "error_fetching_description": "Suriin ang iyong koneksyon at subukang muli.",
+      "retry_button": "Subukang muli"
     },
     "active_boosts_error": {
-      "error_fetching_title": "Boosts couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Hindi mai-load ang mga boost",
+      "error_fetching_description": "Suriin ang iyong koneksyon at subukang muli.",
+      "retry_button": "Subukang muli"
     },
     "unlocked_rewards_error": {
-      "error_fetching_title": "Rewards couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Hindi mai--load ang rewards",
+      "error_fetching_description": "Suriin ang iyong koneksyon at subukang muli.",
+      "retry_button": "Subukang muli"
     },
     "upcoming_rewards_error": {
-      "error_fetching_title": "Rewards couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Hindi mai--load ang rewards",
+      "error_fetching_description": "Suriin ang iyong koneksyon at subukang muli.",
+      "retry_button": "Subukang muli"
     },
     "referral_details_error": {
-      "error_fetching_title": "Referral details couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Hindi mai-load ang mga detalye ng referral",
+      "error_fetching_description": "Suriin ang iyong koneksyon at subukang muli.",
+      "retry_button": "Subukang muli"
     },
     "referral_validation_unknown_error": {
-      "title": "Referral code couldn’t be validated",
-      "description": "Check your connection and try again."
+      "title": "Hindi ma-validate ang referral code",
+      "description": "Suriin ang iyong koneksyon at subukang muli."
     },
     "active_activity_error": {
-      "error_fetching_title": "Activity couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Hindi mai-load ang aktibidad",
+      "error_fetching_description": "Suriin ang iyong koneksyon at subukang muli.",
+      "retry_button": "Subukang muli"
     },
-    "solana_signup_not_supported": "Signing in to Rewards with Solana accounts is not supported yet. Please use an Ethereum account instead.",
+    "solana_signup_not_supported": "Hindi pa sinusuportahan ang pag-sign in sa Rewards gamit ang Solana account. Pakigamitin na lamang ang Ethereum account.",
     "error_messages": {
-      "unknown_error": "Unknown error occurred",
-      "something_went_wrong": "Something went wrong. Please try again shortly.",
-      "account_already_registered": "This account is already registered with another Rewards profile. Please switch account to continue.",
-      "request_rejected": "You rejected the request.",
-      "failed_to_claim_reward": "Failed to claim reward. Please try again shortly.",
-      "service_not_available": "Service is not available at the moment. Please try again shortly."
+      "unknown_error": "Nagkaroon ng hindi kilalang error",
+      "something_went_wrong": "Nagkaproblema. Subukang muli maya-maya.",
+      "account_already_registered": "Nakarehistro na ang account na ito gamit ang ibang profile ng Rewards. Pakilipat ang account para magpatuloy.",
+      "request_rejected": "Tinanggihan mo ang kahilingan.",
+      "failed_to_claim_reward": "Nabigong ma-claim ang reward. Pakisubukang muli maya-maya.",
+      "service_not_available": "Hindi available sa sandaling ito ang serbisyo. Pakisubukang muli maya-maya."
     },
     "claim_reward_error": {
-      "title": "Failed to claim reward"
+      "title": "Nabigong ma-claim ang reward"
     },
     "accounts_opt_in_state_error": {
-      "error_fetching_title": "Accounts couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Hindi mai-load ang mga account",
+      "error_fetching_description": "Suriin ang iyong koneksyon at subukang muli.",
+      "retry_button": "Subukang muli"
     },
     "referral_rewards_title": "Mga Referral",
     "points": "Mga Point",
@@ -5899,139 +6093,142 @@
     "tab_levels_title": "Mga Antas",
     "referral_stats_earned_from_referrals": "Nakuha mula sa mga referral",
     "referral_stats_referrals": "Mga Referral",
-    "loading_activity": "Loading activity...",
-    "error_loading_activity": "Error loading activity",
-    "activity_empty_title": "No recent activity.",
-    "activity_empty_description": "Use MetaMask to earn points, level up, and unlock rewards.",
-    "activity_empty_link": "See ways to earn",
+    "loading_activity": "Naglo-load ng aktibidad...",
+    "error_loading_activity": "Error sa paglo-load ng aktibidad",
+    "activity_empty_title": "Walang kamakailang aktibidad.",
+    "activity_empty_description": "Gamitin ang MetaMask para makaipon ng point, mag-level-up, at ma-unlock ang mga reward.",
+    "activity_empty_link": "Tingnan ang mga paraan para kumita",
     "events": {
-      "to": "to",
+      "to": "sa/Kay",
       "type": {
         "swap": "Mag-swap",
         "perps": "Perps",
+        "card_spend": "Card spend",
         "referral": "Referral",
-        "referral_action": "Referral action",
+        "referral_action": "Aksyon ng referral",
         "sign_up_bonus": "Sign up bonus",
         "loyalty_bonus": "Loyalty bonus",
-        "one_time_bonus": "One-time bonus",
-        "open_position": "Opened position",
-        "close_position": "Closed position",
+        "one_time_bonus": "One-time na bonus",
+        "open_position": "Bukas na posisyon",
+        "close_position": "Nakasarang posisyon",
         "take_profit": "TP/SL",
         "stop_loss": "TP/SL",
-        "uncategorized_event": "Uncategorized event"
+        "uncategorized_event": "Hindi nakakategoryang event"
       },
-      "date": "Date",
+      "date": "Petsa",
       "account": "Account",
       "bonus": "Bonus",
-      "details": "Details",
-      "points": "Points",
+      "details": "Mga detalye",
+      "points": "Mga Point",
       "points_base": "Base",
       "points_boost": "Boost",
-      "points_total": "Total"
+      "points_total": "Kabuuan"
     },
     "onboarding": {
       "not_supported_region_title": "Hindi sinusuportahan ang rehiyon",
-      "not_supported_region_description": "Rewards are not supported in your region yet. We are working on expanding access, so check back later.",
-      "not_supported_hardware_account_title": "Account not supported",
-      "not_supported_hardware_account_description": "Hardware wallet accounts are not eligible to receive rewards yet. Please switch to a different account to proceed.",
-      "not_supported_account_type_title": "Account type not supported",
-      "not_supported_account_type_description": "Currently only internal Ethereum and Solana accounts can be opted into the Rewards program. Please switch to a different account to proceed.",
-      "not_supported_confirm_go_back": "Go back",
-      "not_supported_confirm_retry": "Retry",
-      "auth_fail_title": "Authentication Failed",
-      "auth_fail_description": "Unable to authenticate with the rewards program. Please check your connection and try again.",
-      "geo_check_fail_title": "Cannot determine opt-in eligibility",
-      "geo_check_fail_description": "We cannot determine if your country allows opting into the rewards program. Please check your connection and try again.",
+      "not_supported_region_description": "Hindi pa sinusuportahan ang mga reward sa iyong rehiyon. Nagsisikap kaming palawakin ang access, kaya mangyaring bumalik muli sa ibang pagkakataon.",
+      "not_supported_hardware_account_title": "Hindi sinusuportahan ang account",
+      "not_supported_hardware_account_description": "Ang mga account na hardware wallet ay hindi pa kwalipikadong tumanggap ng mga reward. Lumipat sa ibang account upang magpatuloy.",
+      "not_supported_account_type_title": "Hindi sinusuportahan ang uri ng account",
+      "not_supported_account_type_description": "Sa kasalukuyan, tanging mga internal Ethereum at Solana account lamang ang maaaring sumali sa programa ng mga Reward. Lumipat sa ibang account upang magpatuloy.",
+      "not_supported_confirm_go_back": "Bumalik",
+      "not_supported_confirm_retry": "Subukang muli",
+      "auth_fail_title": "Nabigo ang pag-authenticate",
+      "auth_fail_description": "Hindi ma-authenticate ang programa ng mga reward. Pakisuriin ang koneksyon mo at subukang muli.",
+      "geo_check_fail_title": "Hindi matukoy ang pagiging kwalipikado sa pag-opt-in",
+      "geo_check_fail_description": "Hindi namin matukoy kung pinapayagan ng iyong bansa na mag-opt in sa programa ng mga reward. Suriin ang iyong koneksyon at subukang muli.",
       "gtm_title": "Narito na ang mga reward",
       "gtm_description": "Mag-ipon ng points mula sa aktibidad mo. \nMagpatuloy sa mas mataas na antas upang ma-unlock ang mga reward.",
       "gtm_confirm": "Magsimula",
       "intro_title": "Ang Season 1 \nay Live",
-      "intro_description": "Earn points for your activity. \nAdvance through levels to unlock rewards.",
-      "intro_confirm": "Claim 250 points",
-      "intro_confirm_geo_loading": "Checking region...",
-      "checking_opt_in": "Checking accounts...",
-      "redirecting_to_dashboard": "Redirecting...",
+      "intro_description": "Mag-ipon ng points mula sa aktibidad mo. \nMagpatuloy sa mas mataas na antas upang ma-unlock ang mga reward.",
+      "intro_confirm": "I-claim ang 250 point",
+      "intro_confirm_geo_loading": "Sinusuri ang rehiyon...",
+      "checking_opt_in": "Sinusuri ang mga account...",
+      "redirecting_to_dashboard": "Nagre-redirect...",
       "intro_skip": "Hindi sa ngayon",
       "step_confirm": "Susunod",
-      "step_skip": "Skip",
-      "step1_title": "Earn points on every trade",
+      "step_skip": "Laktawan",
+      "step1_title": "Makakakuha ng mga point sa bawat pag-trade",
       "step1_description": "Ang bawat pag-swap at pag-trade sa perps na isinasagawa mo sa MetaMask ay nagpapalapit sa iyo sa mga reward. Idagdag ang iyong mga account at makikita mong nadaragdagan ang iyong mga point.",
-      "step2_title": "Level up for bigger perks",
+      "step2_title": "Mag-level up para sa mas malalaking perk",
       "step2_description": "Abutin ang milestones ng mga point para makuha ang perks gaya ng 50% off na bayad sa perps, mga eksklusibong token, at libreng MetaMask Metal Card.",
-      "step3_title": "Exclusive seasonal rewards",
-      "step3_description": "Each season brings new perks. Join in, compete, and claim what you can before time runs out.",
-      "step4_title": "You'll earn 250 points when you sign up!",
-      "step4_title_referral_validating": "Validating referral code...",
-      "step4_referral_input_placeholder": "Referral code (optional)",
-      "step4_referral_input_error": "Invalid referral code",
-      "step4_confirm": "Claim points",
-      "step4_confirm_loading": "Claiming points...",
-      "step4_linking_accounts": "Adding accounts... ({{current}}/{{total}})",
-      "step4_linking_accounts_loading": "Adding additional accounts...",
-      "step4_success_description": "You have successfully signed up for MetaMask Rewards!",
-      "step4_legal_disclaimer_1": "By selecting 'Claim Points', you agree to the MetaMask Rewards",
-      "step4_legal_disclaimer_2": "Supplemental Terms of Use and Privacy Notice",
-      "step4_legal_disclaimer_3": ". We'll track onchain activity to reward you automatically –",
-      "step4_legal_disclaimer_4": "learn more"
+      "step3_title": "Eksklusibong mga seasonal reward",
+      "step3_description": "Ang bawat season ay nagdadala ng mga bagong perk. Sumali, makipagpaligsahan, at mag-claim ng kaya mo bago maubos ang oras.",
+      "step4_title": "Makakaipon ka ng 250 point kapag nag-sign up ka!",
+      "step4_title_referral_bonus": "You'll earn 500 points when you sign up with this code!",
+      "step4_title_referral_validating": "Bina-validate ang referral code...",
+      "step4_referral_bonus_description": "Use a referral code to earn 250 more",
+      "step4_referral_input_placeholder": "Referral code (opsyonal)",
+      "step4_referral_input_error": "Hindi valid na referral code",
+      "step4_confirm": "I-claim ang mga point",
+      "step4_confirm_loading": "Kini-claim ang mga point...",
+      "step4_linking_accounts": "Idinadagdag ang mga account... ({{current}}/{{total}})",
+      "step4_linking_accounts_loading": "Idinadagdag ang mga karagdagang account...",
+      "step4_success_description": "Matagumpay kang nakapag-sign up para sa MetaMask Rewards!",
+      "step4_legal_disclaimer_1": "Sa pamamagitan ng pagpili sa 'I-claim ang mga Point', sumasang-ayon ka sa MetaMask Rewards",
+      "step4_legal_disclaimer_2": "Karagdagang Mga Tuntunin ng Paggamit at Abiso sa Privacy",
+      "step4_legal_disclaimer_3": ". Susubaybayan namin ang aktibidad sa onchain para agad kang mabigyan ng reward –",
+      "step4_legal_disclaimer_4": "matuto pa"
     },
     "settings": {
-      "title": "Rewards Settings",
-      "subtitle": "Accounts",
-      "description": "Add multiple accounts to combine your points and unlock rewards faster.",
-      "tab_linked_accounts": "Added ({{count}})",
-      "tab_unlinked_accounts": "Not added ({{count}})",
-      "no_linked_accounts": "No accounts opted in",
-      "all_accounts_linked_title": "All accounts opted in",
-      "all_accounts_linked_description": "You have added all your accounts to Rewards.",
-      "link_account_success_title": "{{accountName}} successfully added",
-      "link_account_error_title": "Failed to add account",
-      "link_account_button": "Add",
-      "link_account_failed_error": "Failed to link account",
-      "link_account_unknown_error": "Unknown error occurred"
+      "title": "Settings ng Rewards",
+      "subtitle": "Mga Account",
+      "description": "Magdagdag ng maraming account para pagsama-samahin ang mga point mo at ma-unlock nang mas mabilis ang mga reward.",
+      "tab_linked_accounts": "Idinagdag ang ({{count}})",
+      "tab_unlinked_accounts": "Hindi idinagdag ang ({{count}})",
+      "no_linked_accounts": "Walang na-opt in na mga account",
+      "all_accounts_linked_title": "Na-opt in ang lahat ng account",
+      "all_accounts_linked_description": "Naidagdag mo ang lahat ng account mo sa Rewards.",
+      "link_account_success_title": "Matagumpay na naidagdag ang {{accountName}}",
+      "link_account_error_title": "Bigong maidagdag ang account",
+      "link_account_button": "Idagdag",
+      "link_account_failed_error": "Bigong mai-link ang account",
+      "link_account_unknown_error": "Nagkaroon ng hindi kilalang error"
     },
     "optout": {
-      "title": "Opt out of Rewards",
-      "description": "This will remove your accounts from the Rewards program and erase your points and progress. You won't be able to undo this.",
-      "confirm": "Opt out",
+      "title": "Opt out ng mga Reward",
+      "description": "Aalisin nito ang iyong mga account mula sa programa ng mga Reward at buburahin ang iyong mga point at progreso. Hindi mo na ito maibabalik.",
+      "confirm": "Mag-opt out",
       "modal": {
-        "confirmation_title": "Are you sure?",
-        "confirmation_description": "This will remove all your progress, and can't be reversed. If you rejoin the Rewards program later, you'll start back at 0.",
-        "cancel": "Cancel",
-        "confirm": "Confirm",
-        "error_message": "Failed to opt out of Rewards. Please try again.",
-        "processing": "Processing..."
+        "confirmation_title": "Sigurado ka ba?",
+        "confirmation_description": "Aalisin nito ang lahat ng iyong progreso at hindi na ito maibabalik. Kung muli kang sasali sa programa ng mga Reward sa hinaharap, magsisimula ka muli sa 0.",
+        "cancel": "Kanselahin",
+        "confirm": "Kumpirmahin",
+        "error_message": "Nabigong mag-opt-out sa mga Reward. Pakisubukang muli.",
+        "processing": "Pinoproseso..."
       }
     },
-    "toast_dismiss": "Dismiss",
+    "toast_dismiss": "I-dismiss",
     "dashboard_modal_info": {
       "active_account": {
-        "title": "Don't miss out",
-        "description": "Add your account to start earning points from your activity.",
-        "confirm": "Add account"
+        "title": "Huwag palampasin",
+        "description": "Idagdag ang iyong account para simulang makaipon ng puntos mula sa iyong aktibidad.",
+        "confirm": "Magdagdag ng account"
       },
       "multiple_unlinked_accounts": {
-        "title": "Start earning points",
-        "description": "Add your accounts so you can track your rewards at a glance.",
-        "confirm": "Add accounts"
+        "title": "Simulang makaipon ng mga point",
+        "description": "Idagdag ang iyong mga account upang madali mong masubaybayan ang iyong mga reward sa isang tingin.",
+        "confirm": "Magdagdag ng mga account"
       },
       "account_not_supported": {
-        "title": "Account not supported",
-        "description_hardware": "Hardware wallet accounts are not yet eligible to earn points. Please switch to a different account to proceed.",
-        "description_general": "Currently only non-hardware internal Ethereum and Solana accounts are eligible to earn points. Please switch to a different account to proceed.",
-        "confirm": "Go back"
+        "title": "Hindi sinusuportahan ang account",
+        "description_hardware": "Ang mga account na hardware wallet ay hindi pa kwalipikadong makaipon ng mga point. Mangyaring lumipat sa ibang account upang magpatuloy.",
+        "description_general": "Sa kasalukuyan, tanging mga internal Ethereum at Solana account na hindi hardware wallet ang kwalipikadong makaipon ng mga point. Mangyaring lumipat sa ibang account upang magpatuloy.",
+        "confirm": "Bumalik"
       }
     },
     "ways_to_earn": {
-      "title": "Ways to earn",
-      "supported_networks": "Supported Networks",
+      "title": "Mga paraan para makaipon",
+      "supported_networks": "Mga Sinusuportahang Network",
       "swap": {
-        "title": "Swap",
-        "description": "80 points per $100",
+        "title": "Mag-swap",
+        "description": "80 point kada $100",
         "sheet": {
-          "title": "Swap tokens",
-          "points": "80 points per $100",
-          "description": "Swap tokens on supported networks to earn points for every dollar you trade.",
-          "cta_label": "Start a swap"
+          "title": "Ipagpalit ang mga token",
+          "points": "80 point kada $100",
+          "description": "Mag-swap ng mga token sa mga sinusuportahang network para makaipon ng mga point para sa bawat dolyar na tini-trade mo.",
+          "cta_label": "Simulan ang pag-swap"
         }
       },
       "perps": {
@@ -6045,17 +6242,32 @@
         }
       },
       "referrals": {
-        "title": "Refer friends",
-        "description": "10 points per 50 from friends"
+        "title": "Mag-refer ng mga kaibigan",
+        "description": "10 point sa bawat 50 mula sa mga kaibigan",
+        "sheet": {
+          "title": "Refer a friend",
+          "points": "20 points per 100",
+          "cta_label": "Refer a friend"
+        }
       },
       "loyalty": {
         "title": "Loyalty bonus",
-        "description": "Earn points from past trades",
+        "description": "Mag-ipon ng mga point mula sa mga naunang trade",
         "sheet": {
           "title": "Loyalty bonus",
-          "points": "250 points per $1250",
-          "description": "Add accounts with past swaps or bridges in MetaMask to earn loyalty bonuses. Each eligible account unlocks points in increments of 250, up to a total of 50,000. Bonuses appear shortly after you add an account.",
-          "cta_label": "Add accounts"
+          "points": "250 point kada $1250",
+          "description": "Idagdag ang mga account na may nakaraang pag-swap o pag-bridge sa MetaMask upang makakuha ng mga loyalty bonus. Bawat kwalipikadong account ay nagbubukas ng mga point sa mga pagdagdag na tig-250, hanggang sa kabuuang 50,000. Lalabas ang mga bonus ilang sandali matapos mong idagdag ang isang account.",
+          "cta_label": "Magdagdag ng mga account"
+        }
+      },
+      "card": {
+        "title": "MetaMask Card",
+        "description": "1 point per $1 spent",
+        "sheet": {
+          "title": "MetaMask Card",
+          "points": "1 point per $1 spent",
+          "description": "Earn points every time you use your MetaMask Card for purchases, plus 1% cash back (3% for Metal cardholders).",
+          "cta_label": "Manage Card"
         }
       }
     },
@@ -6068,29 +6280,36 @@
       },
       "info": {
         "title": "Ibahagi ang iyong code para kumita pa",
-        "description": "Your friends get a 2x sign up bonus. You get 10 points for every 50 they earn from trading."
+        "description": "Makakakuha ang mga kaibigan mo ng 2x na sign up bonus. Makakakuha ka ng 10 point para sa bawat 50 na naiipon nila mula sa pagti-trade."
       }
     },
-    "active_boosts_title": "Active boosts",
+    "link_account_group": {
+      "link_account": "Add account",
+      "tracked": "Tracked",
+      "untracked": "Untracked",
+      "link_account_success": "{{accountName}} added successfully",
+      "link_account_error": "Failed to add one or more addresses for {{accountName}}"
+    },
+    "active_boosts_title": "Mga active boost",
     "season_1": "Season 1",
     "upcoming_rewards": {
       "title": "Naka-lock na mga reward",
-      "points_needed": "{{points}} points",
-      "cta_label": "Got it",
-      "alpha_fox_invite_input_placeholder": "Your Telegram handle"
+      "points_needed": "{{points}} (na) point",
+      "cta_label": "Nakuha ko",
+      "alpha_fox_invite_input_placeholder": "Ang ginagamit mong Telegram"
     },
     "unlocked_rewards": {
-      "title": "Unlocked rewards",
-      "cta_label": "Claim now",
-      "cta_request_invite": "Request invite",
-      "claim_label": "Claim",
-      "claimed_label": "Claimed",
-      "reward_claimed": "Reward claimed",
+      "title": "Na-unlock na mga reward",
+      "cta_label": "I-claim ngayon",
+      "cta_request_invite": "Humiling na imbitahan",
+      "claim_label": "I-claim",
+      "claimed_label": "Na-claim",
+      "reward_claimed": "Na-claim na reward",
       "time_left": "natitira",
-      "expired": "Expired"
+      "expired": "Nag-expire"
     },
     "animation": {
-      "could_not_load": "Couldn't load"
+      "could_not_load": "Hindi mai-load"
     }
   },
   "time": {
@@ -6099,7 +6318,7 @@
   },
   "transaction_details": {
     "title": {
-      "perps_deposit": "Funded Perps account",
+      "perps_deposit": "Pinondohang Perps account",
       "predict_deposit": "Funded Predict account",
       "default": "Mga detalye ng transaksyon"
     },
@@ -6107,19 +6326,23 @@
       "bridge_fee": "Bayad sa bridge",
       "network_fee": "Bayad sa network",
       "paid_with": "Magbayad gamit ang",
+      "retry_button": "Try again",
       "total": "Kabuuan"
     },
     "summary_title": {
-      "bridge": "Bridge mula {{sourceSymbol}} papuntang {{targetSymbol}}",
       "bridge_approval": "Aprubahan ang {{approveSymbol}}",
       "bridge_approval_loading": "Aprubahan",
-      "bridge_loading": "Mag-bridge",
+      "bridge_send": "Bridge {{sourceSymbol}} from {{sourceChain}}",
+      "bridge_send_loading": "Bridge Send",
+      "bridge_receive": "Receive {{targetSymbol}} on {{targetChain}}",
+      "bridge_receive_loading": "Bridge Receive",
       "default": "Transaksyon",
       "perps_deposit": "Magdagdag ng pondo",
       "predict_deposit": "Add funds",
       "swap": "Ipagpalit ang mga token",
       "swap_approval": "Aprubahan ang mga token"
-    }
+    },
+    "perps_deposit_solution": "You now have {{fiat}} of USDC on Arbitrum. Try your deposit again."
   },
   "sdk_connect_v2": {
     "show_loading": {

--- a/locales/languages/tr.json
+++ b/locales/languages/tr.json
@@ -594,7 +594,9 @@
       "unexpectedError": "Beklenmedik bir hata oluştu.",
       "quoteFetchError": "Teklif alınamadı.",
       "kycFormsFetchError": "KYC formları alınamadı.",
-      "title": "Para Yatır"
+      "title": "Para Yatır",
+      "limitExceeded": "This deposit would exceed your {{period}} limit. Your deposit including fees must be {{remaining}} or less.",
+      "limitError": "Failed to check your deposit limits. Please try again later."
     },
     "token_modal": {
       "select_a_token": "Bir Token seçin",
@@ -892,7 +894,7 @@
     "withdraw": "Çek",
     "refresh_balance": "Bakiyeyi Yenile",
     "add_funds": "Para ekle",
-    "deposit_in_progress": "Deposit in progress",
+    "deposit_in_progress": "Para yatırma işlemi devam ediyor",
     "your_positions": "Pozisyonlarınız",
     "loading_positions": "Pozisyonlar yükleniyor...",
     "refreshing_positions": "Pozisyonlar yenileniyor...",
@@ -1277,6 +1279,7 @@
       "assetMappingFailed": "Varlık eşleştirmesi oluşturulamadı",
       "depositFailed": "Para yatırma işlemi başarısız oldu",
       "orderLeverageReductionFailed": "Kaldıracınızı düşüremezsiniz",
+      "connectionTimeout": "Connection timed out. Please check your network and try again.",
       "connectionFailed": {
         "title": "Sürekli vadeli geçici olarak çevrimdışı",
         "description": "En kısa sürede çevrimiçi olması için çalışıyoruz.",
@@ -1348,9 +1351,9 @@
         "error_message": "Piyasa verileri bulunamadı. Lütfen geri dönüp tekrar deneyin."
       },
       "statistics": "Genel Bakış",
-      "24h_high": "24h high",
-      "24h_low": "24h low",
-      "24h_volume": "24h volume",
+      "24h_high": "24 saatlik en yüksek",
+      "24h_low": "24 saatlik en düşük",
+      "24h_volume": "24 saatlik hacim",
       "open_interest": "Açık faiz",
       "funding_rate": "Fonlama oranı",
       "countdown": "Geri sayım",
@@ -1510,9 +1513,9 @@
         "metamask_fee": "MetaMask ücreti",
         "hyperliquid_fee": "Hyperliquid ücreti",
         "total_fee": "Toplam ücret",
-        "liquidated": "Liquidated",
-        "take_profit": "Take profit",
-        "stop_loss": "Stop loss"
+        "liquidated": "Likide edildi",
+        "take_profit": "Kazancı al",
+        "stop_loss": "Zararda durdur"
       },
       "funding": {
         "date": "Tarih",
@@ -1555,11 +1558,11 @@
       "ready_to_trade": {
         "title": "İşlem yapmaya hazır mısınız?",
         "description": "Sürekli vadeli işlem sözleşmeleri hesabınıza herhangi bir token ile fonlama gerçekleştirin ve saniyeler içinde ilk işleminizi yapın.",
-        "footer_text": "MetaMask, fonlarınızı Arbitrum üzerinde USDC'ye takas eder ve ek ücret olmadan HyperCore'e yatırır."
+        "footer_text": "MetaMask will swap your funds to USDC on Arbitrum, and deposit them onto HyperCore for no added fee."
       },
       "got_it": "Anladım",
       "card": {
-        "title": "Learn the basics of perps"
+        "title": "Sürekli vadeli işlem sözleşmeleri hakkındaki temel bilgileri öğrenin"
       }
     },
     "points": "Puan",
@@ -1576,10 +1579,10 @@
     "market_list": "Piyasa Listesi",
     "market_details": "Piyasa Bilgileri",
     "tab": {
-      "no_predictions": "Henüz tahmin yok",
-      "no_predictions_description": "Başlamak için bir tahmini açın.",
-      "explore": "Piyasaları keşfet",
-      "new_prediction": "Yeni tahmin"
+      "no_predictions_description": "Your predictions will appear here, showing your stake and market movement.",
+      "explore": "Browse markets",
+      "new_prediction": "Yeni tahmin",
+      "resolved_markets": "Resolved markets"
     },
     "sell_position": "Sat Pozisyonu",
     "cash_out": "Paraya Çevir",
@@ -1609,16 +1612,73 @@
     "claim_button": "Al",
     "markets_won": "Kazandıran piyasalar",
     "won_markets_text": "{{count}} piyasada kazanıldı",
-    "won_markets_text_singular": "{{count}} piyasada kazanıldı",
-    "won_markets_text_plural": "{{count}} piyasada kazanıldı",
+    "available_balance": "Available balance",
     "claim_amount_text": "{{amount}}$ al",
     "unrealized_pnl_label": "Gerçekleşmemiş K&Z",
     "unrealized_pnl_value": "({{percent}}) {{amount}}",
+    "unrealized_pnl_error": "Unable to load",
     "unavailable": {
       "title": "Unavailable in your region",
       "description": "Predictions aren't available in your region due to legal restrictions.",
       "link": "See Polymarket terms",
       "button": "Got it"
+    },
+    "deposit": {
+      "in_progress": "Deposit in progress",
+      "adding_funds": "Adding funds",
+      "adding_your_funds": "Adding your funds",
+      "add_funds": "Add funds",
+      "withdraw": "Withdraw",
+      "estimated_processing_time": "Est. {{time}} seconds",
+      "account_ready": "Your account is ready",
+      "account_ready_description": "{{amount}} added to your balance",
+      "error_title": "Something went wrong",
+      "error_description": "Your account wasn't funded",
+      "try_again": "Try again"
+    },
+    "add_funds_sheet": {
+      "title": "Add funds",
+      "description": "You'll need to add funds to your Predictions account to get started. You can add any token and make your first prediction in seconds."
+    },
+    "transactions": {
+      "title": "Predictions",
+      "no_transactions": "No recent activity",
+      "buy_title": "Predicted",
+      "sell_title": "Cashed out",
+      "claim_title": "Claimed winnings",
+      "buy_detail": "Bought {{amountUsd}} on {{outcome}} · {{priceCents}} per share",
+      "sell_detail": "Sold at {{priceCents}} per share",
+      "claim_detail": "Claimed winnings",
+      "not_available": "N/A",
+      "date": "Date",
+      "market": "Market",
+      "outcome": "Outcome",
+      "predicted_amount": "Predicted amount",
+      "shares_bought": "Shares bought",
+      "shares_sold": "Shares sold",
+      "price_per_share": "Price per share",
+      "price_impact": "Price impact",
+      "net_pnl": "Net P&L",
+      "total_net_pnl": "Total Net P&L",
+      "market_net_pnl": "Market Net P&L",
+      "activity_details": "Activity details"
+    },
+    "claim": {
+      "toasts": {
+        "pending": {
+          "title": "Claiming {{amount}}",
+          "description": "Est. {{time}} seconds"
+        },
+        "confirmed": {
+          "title": "Claimed",
+          "description": "{{amount}} added to your balance"
+        },
+        "error": {
+          "title": "Something went wrong",
+          "description": "Failed to proceed with claim",
+          "try_again": "Try again"
+        }
+      }
     }
   },
   "receive": {
@@ -3093,6 +3153,7 @@
     "tx_review_lending_withdraw": "Borç Verme Para Çekme İşlemi",
     "tx_review_perps_deposit": "Fonlanmış Sürekli Vadeli İşlem Sözleşmeleri hesabı",
     "tx_review_predict_deposit": "Funded Predict account",
+    "tx_review_predict_claim": "Claimed Predict winnings",
     "sent_ether": "Ether Gönderdi",
     "self_sent_ether": "Sana Ether Gönderdi",
     "received_ether": "Ether Aldı",
@@ -3939,7 +4000,9 @@
     "wallet_connect_dapps_cta": "Oturumları görüntüle",
     "network_not_supported": "Geçerli ağ desteklenmiyor",
     "select_provider": "Tercih ettiğiniz sağlayıcıyı seçin",
-    "switch_network": "Lütfen ana ağa veya sepolia ağına geçin"
+    "switch_network": "Lütfen ana ağa veya sepolia ağına geçin",
+    "card_title": "Always show MetaMask Card button",
+    "card_desc": "MetaMask Card is only available to residents of select countries"
   },
   "walletconnect_sessions": {
     "no_active_sessions": "Aktif oturumunuz yok",
@@ -5315,7 +5378,7 @@
     },
     "tooltip": {
       "perps_deposit": {
-        "transaction_fee": "HyperCore, Sürekli Vadeli İşlem Sözleşmeleri için kullanılan ağdır ve token’larınızı burada USDC’ye çevireceğiz. Takas sağlayıcıları ücret alabilir, fakat MetaMask ek ücret talep etmez."
+        "transaction_fee": "We'll swap your tokens for USDC on HyperCore, the network used by Perps. Swap providers may charge a fee, but MetaMask won't."
       },
       "predict_deposit": {
         "transaction_fee": "We'll swap your tokens for USDC.e on Polygon, the network used by Predict. Swap providers may charge a fee, but MetaMask won't."
@@ -5407,6 +5470,12 @@
       "save": "Kaydet",
       "title": "Onay limitini düzenle"
     },
+    "predict_claim": {
+      "button_label": "Claim winnings",
+      "summary": "You won",
+      "footer_bottom": "Funds will be added to your available balance",
+      "footer_top": "Winnings from {{count}} markets"
+    },
     "unlimited": "Sınırsız",
     "all": "Tümü",
     "none": "Hiçbiri",
@@ -5469,12 +5538,15 @@
     "points": "Tah. puanlar",
     "points_tooltip": "Puan",
     "points_tooltip_content_1": "Takas, köprü ve sürekli vadeli işlem sözleşmeleri gibi işlemleri tamamladığınızda puan toplar ve MetaMask Ödülleri kazanırsınız.",
-    "points_tooltip_content_2": "Keep in mind this value is an estimate and will be finalized once the transaction is complete. Points can take up to 1 hour to be confirmed in your Rewards balance.",
+    "points_tooltip_content_2": "Bu değerin bir tahmin olduğunu ve işlem tamamlandığında kesinleşeceğini unutmayın. Puanların Ödüller bakiyenizde onaylanması 1 saate kadar sürebilir.",
     "unable_to_load": "Yüklenemiyor",
     "points_error": "Şu anda puanları yükleyemiyoruz",
-    "points_error_content": "You'll still earn any points for this transaction. We'll notify you once they've been added to your account. You can also check your rewards tab in about an hour.",
+    "points_error_content": "Bu işlem için puan kazanmaya devam edeceksiniz. Hesabınıza eklendiğinde sizi bilgilendireceğiz. Ayrıca yaklaşık bir saat içinde ödüller sekmenizi kontrol edebilirsiniz.",
     "see_other_quotes": "Diğer teklifleri gör",
     "receive_at": "Şurada alınacak:",
+    "recipient": "Recipient",
+    "select_recipient": "Select recipient",
+    "external_account": "External account",
     "error_banner_description": "Bu işlem rotası şu anda kullanılamıyor. Tutarı, ağı veya token'ı değiştirmeyi deneyin ve sizin için en iyi seçeneği bulalım.",
     "insufficient_funds": "Para yetersiz",
     "insufficient_gas": "Yetersiz gaz",
@@ -5775,6 +5847,12 @@
       "update_to_store_link": "MetaMask'i en son sürümüne güncelleyin",
       "well_take_you_to_right_place": " ve sizi doğru yere götürelim."
     },
+    "unsupported": {
+      "title": "This page is not supported in current version",
+      "description": "Update to the latest version to use this feature",
+      "update_to_store_link": "Update to the latest version of MetaMask",
+      "well_take_you_to_right_place": " and we'll take you to the right place."
+    },
     "go_to_home_button": "Ana sayfaya git",
     "back_button": "Geri",
     "continue_button": "Devam et"
@@ -5791,7 +5869,96 @@
     "card_onboarding": {
       "title": "Karta Hoş Geldiniz",
       "description": "Kart özelliklerini kullanmak için iş ortağımızla hesabınızı doğrulamanız gerekecek.",
-      "verify_account_button": "Hesabı doğrula"
+      "verify_account_button": "Hesabı doğrula",
+      "sign_up": {
+        "title": "Sign-up",
+        "description": "Register your details with Crypto Life, the provider of MetaMask Card. You'll use this account to access and manage your card.",
+        "email_label": "Email",
+        "password_label": "Password",
+        "confirm_password_label": "Confirm password",
+        "country_label": "Country of Residence",
+        "email_placeholder": "Enter your email address",
+        "password_placeholder": "Enter your password",
+        "country_placeholder": "Select your country",
+        "password_mismatch": "Passwords do not match",
+        "invalid_email": "Invalid email address"
+      },
+      "confirm_email": {
+        "title": "Confirm your email",
+        "description": "We've sent a confirmation code to: {{email}}",
+        "confirm_code_label": "Confirmation code",
+        "confirm_code_placeholder": "Enter the confirmation code"
+      },
+      "set_phone_number": {
+        "title": "Phone number",
+        "description": "Enter your phone number",
+        "phone_number_label": "Phone number",
+        "phone_number_placeholder": "Enter your phone number",
+        "country_area_code_label": "Country area code",
+        "invalid_phone_number": "Invalid phone number",
+        "legal_terms": "By continuing, you agree to receiving SMS to verify your phone number."
+      },
+      "confirm_phone_number": {
+        "title": "Confirm your phone number",
+        "description": "We've sent a confirmation code to: {{phoneNumber}}",
+        "confirm_code_label": "Confirmation code"
+      },
+      "verify_identity": {
+        "title": "Verifying your identity to get your card",
+        "description": "To keep your account secure and comply with regulations, we need to verify your identity.\n\nYou'll need a government-issued ID and a proof of address (like a utility bill or bank statement).\n\nVerification usually takes 5-30 minutes, and we'll notify you as soon as it's complete.",
+        "verify_button": "Verify now with Veriff"
+      },
+      "validating_kyc": {
+        "title": "Validating your KYC..."
+      },
+      "kyc_failed": {
+        "title": "Rejected",
+        "description": "Your KYC was rejected. Please try again."
+      },
+      "personal_details": {
+        "title": "Personal details",
+        "description": "Enter your personal details",
+        "first_name_label": "First name",
+        "last_name_label": "Last name",
+        "date_of_birth_label": "Date of birth",
+        "nationality_label": "Country of Nationality",
+        "ssn_label": "Social Security Number",
+        "first_name_placeholder": "Enter your first name",
+        "last_name_placeholder": "Enter your last name",
+        "date_of_birth_placeholder": "Enter your date of birth",
+        "nationality_placeholder": "Select your nationality",
+        "ssn_placeholder": "Enter your SSN",
+        "invalid_ssn": "Invalid SSN",
+        "invalid_date_of_birth": "Invalid date of birth",
+        "invalid_date_of_birth_underage": "You must be at least 18 years old"
+      },
+      "physical_address": {
+        "title": "Physical address",
+        "description": "Please provide your physical address",
+        "address_line_1_label": "Address line 1",
+        "address_line_2_label": "Address line 2",
+        "city_label": "City",
+        "state_label": "State",
+        "zip_code_label": "ZIP code",
+        "address_line_1_placeholder": "Enter your address line 1",
+        "address_line_2_placeholder": "Enter your address line 2",
+        "city_placeholder": "Enter your city",
+        "state_placeholder": "Enter your state",
+        "zip_code_placeholder": "Enter your ZIP code",
+        "same_mailing_address_label": "Physical address is the same as mailing address",
+        "electronic_consent": "I agree to the E-Sign Act Consent and Disclosure and to receive all communictions electronically."
+      },
+      "mailing_address": {
+        "title": "Mailing address",
+        "description": "Please provide your mailing address"
+      },
+      "complete": {
+        "title": "Approved!",
+        "description": "Your KYC was approved. You can now use your Card."
+      },
+      "continue_button": "Next",
+      "confirm_button": "Confirm",
+      "retry_button": "Try again"
     },
     "card_home": {
       "error_title": "Veriler alınamıyor",
@@ -5799,9 +5966,36 @@
       "try_again": "Tekrar dene",
       "limited_spending_warning": "Gerçek harcama kapasiteniz sınırlı olabilir. Limitinizi ayarlamak için {{manageCard}} alanına gidin",
       "add_funds": "Para ekle",
+      "change_asset": "Change asset",
       "manage_card_options": {
+        "manage_spending_limit": "Manage spending limit",
+        "manage_spending_limit_description_restricted": "Restricted spending limit is on",
+        "manage_spending_limit_description_full": "Full spending access is on",
         "manage_card": "Kartı yönet",
-        "advanced_card_management_description": "İşlemleri görüntüleyin, kartı dondurun ve daha fazlasını yapın"
+        "advanced_card_management_description": "Detailed transactions, freeze card, and more"
+      }
+    },
+    "card_authentication": {
+      "title": "Log in to your Card account",
+      "location_button_text": "International",
+      "location_button_text_us": "US account",
+      "email_label": "Email",
+      "password_label": "Password",
+      "email_placeholder": "Enter your email address",
+      "password_placeholder": "Enter your password",
+      "login_button": "Log in",
+      "errors": {
+        "invalid_credentials": "Invalid login details",
+        "unknown_error": "Unknown error, please try again later",
+        "email_required": "Email is required",
+        "password_required": "Password is required",
+        "email_invalid": "Invalid email address",
+        "password_invalid": "Invalid password",
+        "invalid_email_or_password": "Invalid email or password, check your credentials and try again.",
+        "network_error": "Network error. Please check your connection and try again.",
+        "timeout_error": "Request timed out. Please check your connection and try again.",
+        "server_error": "Server error. Please try again later.",
+        "configuration_error": "Service is temporarily unavailable. Please try again later."
       }
     }
   },
@@ -5825,65 +6019,65 @@
     "close": "Kapat"
   },
   "rewards": {
-    "auth_fail_title": "Unknown Error.",
-    "auth_fail_description": "An unknown error occurred while authenticating this account with the rewards program. Please try again later.",
-    "failed_to_authenticate": "Failed to authenticate with rewards program",
+    "auth_fail_title": "Bilinmeyen Hata.",
+    "auth_fail_description": "Bu hesabın ödüller programıyla doğrulanması sırasında bilinmeyen bir hata oluştu. Lütfen daha sonra tekrar deneyin.",
+    "failed_to_authenticate": "Ödüller programıyla doğrulanamadı",
     "not_implemented": "Çok yakında",
     "not_implemented_season_summary": "Sezon Özeti Çok Yakında",
     "optin_error": {
-      "title": "Opt-in failed",
-      "description": "Check your connection and try again."
+      "title": "Katılım başarısız oldu",
+      "description": "Bağlantınızı kontrol edin ve tekrar deneyin."
     },
     "season_status_error": {
-      "error_fetching_title": "Season balance couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Sezon bakiyesi yüklenemedi",
+      "error_fetching_description": "Bağlantınızı kontrol edin ve tekrar deneyin.",
+      "retry_button": "Tekrar Dene"
     },
     "active_boosts_error": {
-      "error_fetching_title": "Boosts couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Yükseltmeler yüklenemedi",
+      "error_fetching_description": "Bağlantınızı kontrol edin ve tekrar deneyin.",
+      "retry_button": "Tekrar Dene"
     },
     "unlocked_rewards_error": {
-      "error_fetching_title": "Rewards couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Ödüller yüklenemedi",
+      "error_fetching_description": "Bağlantınızı kontrol edin ve tekrar deneyin.",
+      "retry_button": "Tekrar Dene"
     },
     "upcoming_rewards_error": {
-      "error_fetching_title": "Rewards couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Ödüller yüklenemedi",
+      "error_fetching_description": "Bağlantınızı kontrol edin ve tekrar deneyin.",
+      "retry_button": "Tekrar Dene"
     },
     "referral_details_error": {
-      "error_fetching_title": "Referral details couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Referans bilgileri yüklenemedi",
+      "error_fetching_description": "Bağlantınızı kontrol edin ve tekrar deneyin.",
+      "retry_button": "Tekrar Dene"
     },
     "referral_validation_unknown_error": {
-      "title": "Referral code couldn’t be validated",
-      "description": "Check your connection and try again."
+      "title": "Referans kodu doğrulanamadı",
+      "description": "Bağlantınızı kontrol edin ve tekrar deneyin."
     },
     "active_activity_error": {
-      "error_fetching_title": "Activity couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Aktivite yüklenemedi",
+      "error_fetching_description": "Bağlantınızı kontrol edin ve tekrar deneyin.",
+      "retry_button": "Tekrar Dene"
     },
-    "solana_signup_not_supported": "Signing in to Rewards with Solana accounts is not supported yet. Please use an Ethereum account instead.",
+    "solana_signup_not_supported": "Solana hesaplarıyla Ödüller’e giriş henüz desteklenmiyor. Lütfen bunun yerine bir Ethereum hesabı kullanın.",
     "error_messages": {
-      "unknown_error": "Unknown error occurred",
-      "something_went_wrong": "Something went wrong. Please try again shortly.",
-      "account_already_registered": "This account is already registered with another Rewards profile. Please switch account to continue.",
-      "request_rejected": "You rejected the request.",
-      "failed_to_claim_reward": "Failed to claim reward. Please try again shortly.",
-      "service_not_available": "Service is not available at the moment. Please try again shortly."
+      "unknown_error": "Bilinmeyen bir hata oluştu",
+      "something_went_wrong": "Bir hata oluştu. Lütfen kısa süre sonra tekrar deneyin.",
+      "account_already_registered": "Bu hesap zaten başka bir Ödüller profili ile kayıtlı. Devam etmek için lütfen hesap değiştirin.",
+      "request_rejected": "Talebi reddettiniz.",
+      "failed_to_claim_reward": "Ödül alınamadı. Lütfen kısa süre sonra tekrar deneyin.",
+      "service_not_available": "Hizmet şu anda kullanılamıyor. Lütfen kısa süre sonra tekrar deneyin."
     },
     "claim_reward_error": {
-      "title": "Failed to claim reward"
+      "title": "Ödül alınamadı"
     },
     "accounts_opt_in_state_error": {
-      "error_fetching_title": "Accounts couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Hesaplar yüklenemedi",
+      "error_fetching_description": "Bağlantınızı kontrol edin ve tekrar deneyin.",
+      "retry_button": "Tekrar Dene"
     },
     "referral_rewards_title": "Referanslar",
     "points": "Puan",
@@ -5899,139 +6093,142 @@
     "tab_levels_title": "Seviyeler",
     "referral_stats_earned_from_referrals": "Referanslardan kazanılan",
     "referral_stats_referrals": "Referanslar",
-    "loading_activity": "Loading activity...",
-    "error_loading_activity": "Error loading activity",
-    "activity_empty_title": "No recent activity.",
-    "activity_empty_description": "Use MetaMask to earn points, level up, and unlock rewards.",
-    "activity_empty_link": "See ways to earn",
+    "loading_activity": "Aktivite yükleniyor...",
+    "error_loading_activity": "Aktivite yüklenirken hata",
+    "activity_empty_title": "Son aktivite yok.",
+    "activity_empty_description": "MetaMask'i kullanarak ödül kazanın, seviye yükseltin ve ödüllerin kilidini açın.",
+    "activity_empty_link": "Kazanmanın yollarını gör",
     "events": {
-      "to": "to",
+      "to": "alıcı",
       "type": {
         "swap": "Kaydır",
         "perps": "Sürekli Vadeli İşlem Sözleşmeleri",
-        "referral": "Referral",
-        "referral_action": "Referral action",
-        "sign_up_bonus": "Sign up bonus",
-        "loyalty_bonus": "Loyalty bonus",
-        "one_time_bonus": "One-time bonus",
-        "open_position": "Opened position",
-        "close_position": "Closed position",
-        "take_profit": "TP/SL",
-        "stop_loss": "TP/SL",
-        "uncategorized_event": "Uncategorized event"
+        "card_spend": "Card spend",
+        "referral": "Referans",
+        "referral_action": "Referans işlemi",
+        "sign_up_bonus": "Kaydolma bonusu",
+        "loyalty_bonus": "Sadakat bonusu",
+        "one_time_bonus": "Tek seferlik bonus",
+        "open_position": "Açılmış pozisyon",
+        "close_position": "Kapalı pozisyon",
+        "take_profit": "KA/ZD",
+        "stop_loss": "KA/ZD",
+        "uncategorized_event": "Kategorize edilmemiş etkinlik"
       },
-      "date": "Date",
-      "account": "Account",
+      "date": "Tarih",
+      "account": "Hesap",
       "bonus": "Bonus",
-      "details": "Details",
-      "points": "Points",
-      "points_base": "Base",
-      "points_boost": "Boost",
-      "points_total": "Total"
+      "details": "Ayrıntılar",
+      "points": "Puan",
+      "points_base": "Baz",
+      "points_boost": "Yükseltme",
+      "points_total": "Toplam"
     },
     "onboarding": {
       "not_supported_region_title": "Bölge desteklenmiyor",
-      "not_supported_region_description": "Rewards are not supported in your region yet. We are working on expanding access, so check back later.",
-      "not_supported_hardware_account_title": "Account not supported",
-      "not_supported_hardware_account_description": "Hardware wallet accounts are not eligible to receive rewards yet. Please switch to a different account to proceed.",
-      "not_supported_account_type_title": "Account type not supported",
-      "not_supported_account_type_description": "Currently only internal Ethereum and Solana accounts can be opted into the Rewards program. Please switch to a different account to proceed.",
-      "not_supported_confirm_go_back": "Go back",
-      "not_supported_confirm_retry": "Retry",
-      "auth_fail_title": "Authentication Failed",
-      "auth_fail_description": "Unable to authenticate with the rewards program. Please check your connection and try again.",
-      "geo_check_fail_title": "Cannot determine opt-in eligibility",
-      "geo_check_fail_description": "We cannot determine if your country allows opting into the rewards program. Please check your connection and try again.",
+      "not_supported_region_description": "Ödüller henüz bölgenizde desteklenmiyor. Erişimi genişletmek için çalışıyoruz, bu yüzden daha sonra tekrar kontrol edin.",
+      "not_supported_hardware_account_title": "Hesap desteklenmiyor",
+      "not_supported_hardware_account_description": "Donanım cüzdanı hesapları henüz ödül almaya uygun değil. Devam etmek için lütfen farklı bir hesaba geçin.",
+      "not_supported_account_type_title": "Hesap türü desteklenmiyor",
+      "not_supported_account_type_description": "Şu anda yalnızca dahili Ethereum ve Solana hesaplarıyla Ödüller programına katılım sağlanabilir. Devam etmek için lütfen farklı bir hesaba geçin.",
+      "not_supported_confirm_go_back": "Geri git",
+      "not_supported_confirm_retry": "Tekrar Dene",
+      "auth_fail_title": "Doğrulama Başarısız",
+      "auth_fail_description": "Ödüller programıyla doğrulama gerçekleştirilemedi. Lütfen bağlantınızı kontrol edin ve tekrar deneyin.",
+      "geo_check_fail_title": "Katılım uygunluğu belirlenemiyor",
+      "geo_check_fail_description": "Ülkenizin ödüller programına katılıma izin verip vermediğini belirleyemiyoruz. Lütfen bağlantınızı kontrol edin ve tekrar deneyin.",
       "gtm_title": "Ödüller burada",
       "gtm_description": "Aktivitelerinizden puan kazanın. \nSeviyelerde ilerleyerek ödüllerin kilidini açın.",
       "gtm_confirm": "Başlarken",
       "intro_title": "Sezon 1 \nBaşladı",
-      "intro_description": "Earn points for your activity. \nAdvance through levels to unlock rewards.",
-      "intro_confirm": "Claim 250 points",
-      "intro_confirm_geo_loading": "Checking region...",
-      "checking_opt_in": "Checking accounts...",
-      "redirecting_to_dashboard": "Redirecting...",
+      "intro_description": "Aktivitelerinizden puan kazanın. \nSeviyelerde ilerleyerek ödüllerin kilidini açın.",
+      "intro_confirm": "250 puan al",
+      "intro_confirm_geo_loading": "Bölge kontrol ediliyor...",
+      "checking_opt_in": "Hesaplar kontrol ediliyor...",
+      "redirecting_to_dashboard": "Yönlendiriliyor...",
       "intro_skip": "Şimdi değil",
       "step_confirm": "Sonraki",
-      "step_skip": "Skip",
-      "step1_title": "Earn points on every trade",
+      "step_skip": "Atla",
+      "step1_title": "Her işlemde puan kazanın",
       "step1_description": "MetaMask'te yaptığınız her takas ve sürekli vadeli işlem sizi ödüllere yaklaştırır. Hesaplarınızı ekleyin ve puanlarınızı takip edin.",
-      "step2_title": "Level up for bigger perks",
+      "step2_title": "Daha büyük avantajlar için seviye yükseltin",
       "step2_description": "Belirli puanlara ulaştığınızda, sürekli vadeli işlem ücretlerinde %50 indirim, özel token’lar ve ücretsiz MetaMask Metal Kart gibi avantajlar kazanabilirsiniz.",
-      "step3_title": "Exclusive seasonal rewards",
-      "step3_description": "Each season brings new perks. Join in, compete, and claim what you can before time runs out.",
-      "step4_title": "You'll earn 250 points when you sign up!",
-      "step4_title_referral_validating": "Validating referral code...",
-      "step4_referral_input_placeholder": "Referral code (optional)",
-      "step4_referral_input_error": "Invalid referral code",
-      "step4_confirm": "Claim points",
-      "step4_confirm_loading": "Claiming points...",
-      "step4_linking_accounts": "Adding accounts... ({{current}}/{{total}})",
-      "step4_linking_accounts_loading": "Adding additional accounts...",
-      "step4_success_description": "You have successfully signed up for MetaMask Rewards!",
-      "step4_legal_disclaimer_1": "By selecting 'Claim Points', you agree to the MetaMask Rewards",
-      "step4_legal_disclaimer_2": "Supplemental Terms of Use and Privacy Notice",
-      "step4_legal_disclaimer_3": ". We'll track onchain activity to reward you automatically –",
-      "step4_legal_disclaimer_4": "learn more"
+      "step3_title": "Özel sezonluk ödüller",
+      "step3_description": "Her sezon yeni avantajlar getirir. Katılın, yarışın ve süre dolmadan alabildiklerinizi alın.",
+      "step4_title": "Kaydolduğunuzda 250 puan kazanırsınız!",
+      "step4_title_referral_bonus": "You'll earn 500 points when you sign up with this code!",
+      "step4_title_referral_validating": "Referans kodu doğrulanıyor...",
+      "step4_referral_bonus_description": "Use a referral code to earn 250 more",
+      "step4_referral_input_placeholder": "Referans kodu (isteğe bağlı)",
+      "step4_referral_input_error": "Geçersiz referans kodu",
+      "step4_confirm": "Puanları al",
+      "step4_confirm_loading": "Puanlar alınıyor...",
+      "step4_linking_accounts": "Hesaplar ekleniyor... ({{current}}/{{total}})",
+      "step4_linking_accounts_loading": "Ek hesaplar ekleniyor...",
+      "step4_success_description": "MetaMask Ödüller’e başarıyla kaydoldunuz!",
+      "step4_legal_disclaimer_1": "‘Puanları Al’ı seçerek MetaMask Ödülleri kabul etmiş olursunuz",
+      "step4_legal_disclaimer_2": "Ek Kullanım Şartları ve Gizlilik Bildirimi",
+      "step4_legal_disclaimer_3": ". Sizi otomatik olarak ödüllendirmek için zincir üzeri etkinliğinizi takip edeceğiz –",
+      "step4_legal_disclaimer_4": "daha fazla bilgi edin"
     },
     "settings": {
-      "title": "Rewards Settings",
-      "subtitle": "Accounts",
-      "description": "Add multiple accounts to combine your points and unlock rewards faster.",
-      "tab_linked_accounts": "Added ({{count}})",
-      "tab_unlinked_accounts": "Not added ({{count}})",
-      "no_linked_accounts": "No accounts opted in",
-      "all_accounts_linked_title": "All accounts opted in",
-      "all_accounts_linked_description": "You have added all your accounts to Rewards.",
-      "link_account_success_title": "{{accountName}} successfully added",
-      "link_account_error_title": "Failed to add account",
-      "link_account_button": "Add",
-      "link_account_failed_error": "Failed to link account",
-      "link_account_unknown_error": "Unknown error occurred"
+      "title": "Ödüller Ayarları",
+      "subtitle": "Hesaplar",
+      "description": "Birden fazla hesap ekleyerek puanlarınızı birleştirin ve ödüllerin kilidini daha hızlı açın.",
+      "tab_linked_accounts": "Eklendi ({{count}})",
+      "tab_unlinked_accounts": "Eklenmedi ({{count}})",
+      "no_linked_accounts": "Hiçbir hesap katılım sağlamadı",
+      "all_accounts_linked_title": "Tüm hesaplar katılım sağladı",
+      "all_accounts_linked_description": "Tüm hesaplarınızı Ödüller programına eklediniz.",
+      "link_account_success_title": "{{accountName}} başarıyla eklendi",
+      "link_account_error_title": "Hesap eklenemedi",
+      "link_account_button": "Ekle",
+      "link_account_failed_error": "Hesap bağlanamadı",
+      "link_account_unknown_error": "Bilinmeyen bir hata oluştu"
     },
     "optout": {
-      "title": "Opt out of Rewards",
-      "description": "This will remove your accounts from the Rewards program and erase your points and progress. You won't be able to undo this.",
-      "confirm": "Opt out",
+      "title": "Ödüllerden Ayrıl",
+      "description": "Bu işlem hesaplarınızı Ödüller programından kaldırır ve puanlarınızı ve ilerlemenizi siler. Bu işlemi geri alamazsınız.",
+      "confirm": "Ayrıl",
       "modal": {
-        "confirmation_title": "Are you sure?",
-        "confirmation_description": "This will remove all your progress, and can't be reversed. If you rejoin the Rewards program later, you'll start back at 0.",
-        "cancel": "Cancel",
-        "confirm": "Confirm",
-        "error_message": "Failed to opt out of Rewards. Please try again.",
-        "processing": "Processing..."
+        "confirmation_title": "Emin misiniz?",
+        "confirmation_description": "Bu işlem tüm ilerlemenizi kaldırır ve geri alınamaz. Ödüller programına daha sonra tekrar katılırsanız 0'dan başlayacaksınız.",
+        "cancel": "İptal",
+        "confirm": "Onayla",
+        "error_message": "Ödüllerden ayrılma başarısız oldu. Lütfen tekrar deneyin.",
+        "processing": "Gerçekleştiriliyor..."
       }
     },
-    "toast_dismiss": "Dismiss",
+    "toast_dismiss": "Yok say",
     "dashboard_modal_info": {
       "active_account": {
-        "title": "Don't miss out",
-        "description": "Add your account to start earning points from your activity.",
-        "confirm": "Add account"
+        "title": "Kaçırmayın",
+        "description": "Aktivitenizden puan kazanmaya başlamak için hesabınızı ekleyin.",
+        "confirm": "Hesap ekleyin"
       },
       "multiple_unlinked_accounts": {
-        "title": "Start earning points",
-        "description": "Add your accounts so you can track your rewards at a glance.",
-        "confirm": "Add accounts"
+        "title": "Puan kazanmaya başla",
+        "description": "Ödüllerinizi bir bakışta takip edebilmek için hesaplarınızı ekleyin.",
+        "confirm": "Hesaplar ekle"
       },
       "account_not_supported": {
-        "title": "Account not supported",
-        "description_hardware": "Hardware wallet accounts are not yet eligible to earn points. Please switch to a different account to proceed.",
-        "description_general": "Currently only non-hardware internal Ethereum and Solana accounts are eligible to earn points. Please switch to a different account to proceed.",
-        "confirm": "Go back"
+        "title": "Hesap desteklenmiyor",
+        "description_hardware": "Donanım cüzdanı hesapları henüz puan kazanmaya uygun değil. Devam etmek için lütfen farklı bir hesaba geçin.",
+        "description_general": "Şu anda yalnızca donanım cüzdanı olmayan dahili Ethereum ve Solana hesapları puan kazanmaya uygundur. Devam etmek için lütfen farklı bir hesaba geçin.",
+        "confirm": "Geri git"
       }
     },
     "ways_to_earn": {
-      "title": "Ways to earn",
-      "supported_networks": "Supported Networks",
+      "title": "Kazanmanın yolları",
+      "supported_networks": "Desteklenen Ağlar",
       "swap": {
-        "title": "Swap",
-        "description": "80 points per $100",
+        "title": "Swap Yap",
+        "description": "Her 800$ için 10 puan",
         "sheet": {
-          "title": "Swap tokens",
-          "points": "80 points per $100",
-          "description": "Swap tokens on supported networks to earn points for every dollar you trade.",
-          "cta_label": "Start a swap"
+          "title": "Token swap işlemi yapın",
+          "points": "Her 800$ için 10 puan",
+          "description": "İşlem yaptığınız her bir dolarla puan kazanmak için desteklenen ağlarda token takas işlemi yapın.",
+          "cta_label": "Takas yapmaya başla"
         }
       },
       "perps": {
@@ -6045,52 +6242,74 @@
         }
       },
       "referrals": {
-        "title": "Refer friends",
-        "description": "10 points per 50 from friends"
+        "title": "Arkadaşlara öner",
+        "description": "Arkadaşlardan her 50 için 10 puan",
+        "sheet": {
+          "title": "Refer a friend",
+          "points": "20 points per 100",
+          "cta_label": "Refer a friend"
+        }
       },
       "loyalty": {
-        "title": "Loyalty bonus",
-        "description": "Earn points from past trades",
+        "title": "Sadakat bonusu",
+        "description": "Geçmiş işlemlerden puan kazanın",
         "sheet": {
-          "title": "Loyalty bonus",
-          "points": "250 points per $1250",
-          "description": "Add accounts with past swaps or bridges in MetaMask to earn loyalty bonuses. Each eligible account unlocks points in increments of 250, up to a total of 50,000. Bonuses appear shortly after you add an account.",
-          "cta_label": "Add accounts"
+          "title": "Sadakat bonusu",
+          "points": "Her 1250$’a 250 puan",
+          "description": "MetaMask'te geçmiş takas veya köprü işlemleri bulunan hesapları ekleyerek sadakat bonusları kazanın. Her uygun hesap, toplam 50.000 puana kadar olmak üzere 250'şer puanlık artışlarla puanların kilidini açar. Bonuslar hesap ekledikten kısa süre sonra görünür.",
+          "cta_label": "Hesap ekle"
+        }
+      },
+      "card": {
+        "title": "MetaMask Card",
+        "description": "1 point per $1 spent",
+        "sheet": {
+          "title": "MetaMask Card",
+          "points": "1 point per $1 spent",
+          "description": "Earn points every time you use your MetaMask Card for purchases, plus 1% cash back (3% for Metal cardholders).",
+          "cta_label": "Manage Card"
         }
       }
     },
     "referral": {
-      "referral_code": "Referral code",
-      "referral_link": "Referral link",
+      "referral_code": "Referans kodu",
+      "referral_link": "Referans bağlantısı",
       "actions": {
         "share_referral_link": "Bir arkadaşına öner",
         "share_referral_subject": "MetaMask Ödüllerine katıl"
       },
       "info": {
         "title": "Daha fazla kazanmak için kodunuzu paylaşın",
-        "description": "Your friends get a 2x sign up bonus. You get 10 points for every 50 they earn from trading."
+        "description": "Arkadaşlarınız 2 kat kayıt bonusu alır. Onların işlemlerden kazandığı her 50 puan için 10 puan alırsınız."
       }
     },
-    "active_boosts_title": "Active boosts",
-    "season_1": "Season 1",
+    "link_account_group": {
+      "link_account": "Add account",
+      "tracked": "Tracked",
+      "untracked": "Untracked",
+      "link_account_success": "{{accountName}} added successfully",
+      "link_account_error": "Failed to add one or more addresses for {{accountName}}"
+    },
+    "active_boosts_title": "Aktif yükseltmeler",
+    "season_1": "Sezon 1",
     "upcoming_rewards": {
       "title": "Kilitli ödüller",
-      "points_needed": "{{points}} points",
-      "cta_label": "Got it",
-      "alpha_fox_invite_input_placeholder": "Your Telegram handle"
+      "points_needed": "{{points}} puan",
+      "cta_label": "Anladım",
+      "alpha_fox_invite_input_placeholder": "Telegram kullanıcı adınız"
     },
     "unlocked_rewards": {
-      "title": "Unlocked rewards",
-      "cta_label": "Claim now",
-      "cta_request_invite": "Request invite",
-      "claim_label": "Claim",
-      "claimed_label": "Claimed",
-      "reward_claimed": "Reward claimed",
+      "title": "Kilidi açılan ödüller",
+      "cta_label": "Hemen al",
+      "cta_request_invite": "Davet talep et",
+      "claim_label": "Al",
+      "claimed_label": "Alındı",
+      "reward_claimed": "Ödül alındı",
       "time_left": "kaldı",
-      "expired": "Expired"
+      "expired": "Süresi doldu"
     },
     "animation": {
-      "could_not_load": "Couldn't load"
+      "could_not_load": "Yüklenemedi"
     }
   },
   "time": {
@@ -6099,7 +6318,7 @@
   },
   "transaction_details": {
     "title": {
-      "perps_deposit": "Funded Perps account",
+      "perps_deposit": "Fonlanmış Sürekli Vadeli İşlem Sözleşmeleri hesabı",
       "predict_deposit": "Funded Predict account",
       "default": "İşlem bilgileri"
     },
@@ -6107,19 +6326,23 @@
       "bridge_fee": "Köprü ücreti",
       "network_fee": "Ağ ücreti",
       "paid_with": "Ödeme aracı",
+      "retry_button": "Try again",
       "total": "Toplam"
     },
     "summary_title": {
-      "bridge": "{{sourceSymbol}} - {{targetSymbol}} köprüle",
       "bridge_approval": "{{approveSymbol}} onayla",
       "bridge_approval_loading": "Onayla",
-      "bridge_loading": "Köprü",
+      "bridge_send": "Bridge {{sourceSymbol}} from {{sourceChain}}",
+      "bridge_send_loading": "Bridge Send",
+      "bridge_receive": "Receive {{targetSymbol}} on {{targetChain}}",
+      "bridge_receive_loading": "Bridge Receive",
       "default": "İşlem",
       "perps_deposit": "Fon ekle",
       "predict_deposit": "Add funds",
       "swap": "Token swap işlemi yapın",
       "swap_approval": "Token'leri onayla"
-    }
+    },
+    "perps_deposit_solution": "You now have {{fiat}} of USDC on Arbitrum. Try your deposit again."
   },
   "sdk_connect_v2": {
     "show_loading": {

--- a/locales/languages/vi.json
+++ b/locales/languages/vi.json
@@ -594,7 +594,9 @@
       "unexpectedError": "Đã xảy ra lỗi không mong muốn.",
       "quoteFetchError": "Tìm nạp báo giá không thành công.",
       "kycFormsFetchError": "Tìm nạp biểu mẫu KYC không thành công.",
-      "title": "Nạp tiền"
+      "title": "Nạp tiền",
+      "limitExceeded": "This deposit would exceed your {{period}} limit. Your deposit including fees must be {{remaining}} or less.",
+      "limitError": "Failed to check your deposit limits. Please try again later."
     },
     "token_modal": {
       "select_a_token": "Chọn Token",
@@ -892,7 +894,7 @@
     "withdraw": "Rút tiền",
     "refresh_balance": "Làm mới số dư",
     "add_funds": "Thêm tiền",
-    "deposit_in_progress": "Deposit in progress",
+    "deposit_in_progress": "Đang nạp tiền",
     "your_positions": "Vị thế của bạn",
     "loading_positions": "Đang tải vị thế...",
     "refreshing_positions": "Đang làm mới vị thế...",
@@ -1277,6 +1279,7 @@
       "assetMappingFailed": "Không thể lập bản đồ tài sản",
       "depositFailed": "Nạp tiền thất bại",
       "orderLeverageReductionFailed": "Bạn không thể giảm đòn bẩy",
+      "connectionTimeout": "Connection timed out. Please check your network and try again.",
       "connectionFailed": {
         "title": "Hợp đồng vĩnh cửu tạm thời ngoại tuyến",
         "description": "Chúng tôi đang nỗ lực khôi phục sớm nhất có thể.",
@@ -1348,9 +1351,9 @@
         "error_message": "Không tìm thấy dữ liệu thị trường. Vui lòng quay lại và thử lại."
       },
       "statistics": "Tổng quan",
-      "24h_high": "24h high",
-      "24h_low": "24h low",
-      "24h_volume": "24h volume",
+      "24h_high": "Đỉnh 24 giờ",
+      "24h_low": "Đáy 24 giờ",
+      "24h_volume": "Khối lượng 24 giờ",
       "open_interest": "Lãi suất mở",
       "funding_rate": "Tỷ lệ tài trợ",
       "countdown": "Đếm ngược",
@@ -1510,9 +1513,9 @@
         "metamask_fee": "Phí MetaMask",
         "hyperliquid_fee": "Phí Hyperliquid",
         "total_fee": "Tổng phí",
-        "liquidated": "Liquidated",
-        "take_profit": "Take profit",
-        "stop_loss": "Stop loss"
+        "liquidated": "Đã bị thanh lý",
+        "take_profit": "Chốt lời",
+        "stop_loss": "Cắt lỗ"
       },
       "funding": {
         "date": "Ngày",
@@ -1525,7 +1528,7 @@
         "history_will_appear": "Lịch sử giao dịch của bạn sẽ hiển thị tại đây"
       }
     },
-    "risk_disclaimer": "Perpetual contracts are very risky, and you could suddenly and without notice lose your entire investment. You trade entirely at your own risk. Market data provided by Hyperliquid. Price chart powered by",
+    "risk_disclaimer": "Perpetual contracts are very risky, and you could suddenly and without notice lose your entire investment. You trade entirely at your own risk. Market data provided by Hyperliquid. Price chart powered by",
     "tutorial": {
       "continue": "Tiếp tục",
       "skip": "Bỏ qua",
@@ -1555,11 +1558,11 @@
       "ready_to_trade": {
         "title": "Sẵn sàng giao dịch?",
         "description": "Nạp tiền vào tài khoản hợp đồng vĩnh cửu bằng bất kỳ token nào và thực hiện giao dịch đầu tiên trong vài giây.",
-        "footer_text": "MetaMask sẽ hoán đổi tiền của bạn sang USDC trên Arbitrum và nạp vào HyperCore mà không tính thêm phí."
+        "footer_text": "MetaMask will swap your funds to USDC on Arbitrum, and deposit them onto HyperCore for no added fee."
       },
       "got_it": "Đã hiểu",
       "card": {
-        "title": "Learn the basics of perps"
+        "title": "Tìm hiểu những kiến thức cơ bản về hợp đồng vĩnh cửu"
       }
     },
     "points": "Điểm",
@@ -1576,10 +1579,10 @@
     "market_list": "Danh sách thị trường",
     "market_details": "Chi tiết thị trường",
     "tab": {
-      "no_predictions": "Chưa có dự đoán nào",
-      "no_predictions_description": "Mở một dự đoán để bắt đầu.",
-      "explore": "Khám phá thị trường",
-      "new_prediction": "Dự đoán mới"
+      "no_predictions_description": "Your predictions will appear here, showing your stake and market movement.",
+      "explore": "Browse markets",
+      "new_prediction": "Dự đoán mới",
+      "resolved_markets": "Resolved markets"
     },
     "sell_position": "Vị thế bán",
     "cash_out": "Rút tiền",
@@ -1609,16 +1612,73 @@
     "claim_button": "Nhận",
     "markets_won": "Thị trường đã thắng",
     "won_markets_text": "Đã thắng {{count}} thị trường{{s}}",
-    "won_markets_text_singular": "Đã thắng {{count}} thị trường",
-    "won_markets_text_plural": "Đã thắng {{count}} thị trường",
+    "available_balance": "Available balance",
     "claim_amount_text": "Nhận ${{amount}}",
     "unrealized_pnl_label": "Lãi/Lỗ chưa thực hiện",
     "unrealized_pnl_value": "{{amount}} ({{percent}})",
+    "unrealized_pnl_error": "Unable to load",
     "unavailable": {
       "title": "Unavailable in your region",
       "description": "Predictions aren't available in your region due to legal restrictions.",
       "link": "See Polymarket terms",
       "button": "Got it"
+    },
+    "deposit": {
+      "in_progress": "Deposit in progress",
+      "adding_funds": "Adding funds",
+      "adding_your_funds": "Adding your funds",
+      "add_funds": "Add funds",
+      "withdraw": "Withdraw",
+      "estimated_processing_time": "Est. {{time}} seconds",
+      "account_ready": "Your account is ready",
+      "account_ready_description": "{{amount}} added to your balance",
+      "error_title": "Something went wrong",
+      "error_description": "Your account wasn't funded",
+      "try_again": "Try again"
+    },
+    "add_funds_sheet": {
+      "title": "Add funds",
+      "description": "You'll need to add funds to your Predictions account to get started. You can add any token and make your first prediction in seconds."
+    },
+    "transactions": {
+      "title": "Predictions",
+      "no_transactions": "No recent activity",
+      "buy_title": "Predicted",
+      "sell_title": "Cashed out",
+      "claim_title": "Claimed winnings",
+      "buy_detail": "Bought {{amountUsd}} on {{outcome}} · {{priceCents}} per share",
+      "sell_detail": "Sold at {{priceCents}} per share",
+      "claim_detail": "Claimed winnings",
+      "not_available": "N/A",
+      "date": "Date",
+      "market": "Market",
+      "outcome": "Outcome",
+      "predicted_amount": "Predicted amount",
+      "shares_bought": "Shares bought",
+      "shares_sold": "Shares sold",
+      "price_per_share": "Price per share",
+      "price_impact": "Price impact",
+      "net_pnl": "Net P&L",
+      "total_net_pnl": "Total Net P&L",
+      "market_net_pnl": "Market Net P&L",
+      "activity_details": "Activity details"
+    },
+    "claim": {
+      "toasts": {
+        "pending": {
+          "title": "Claiming {{amount}}",
+          "description": "Est. {{time}} seconds"
+        },
+        "confirmed": {
+          "title": "Claimed",
+          "description": "{{amount}} added to your balance"
+        },
+        "error": {
+          "title": "Something went wrong",
+          "description": "Failed to proceed with claim",
+          "try_again": "Try again"
+        }
+      }
     }
   },
   "receive": {
@@ -3093,6 +3153,7 @@
     "tx_review_lending_withdraw": "Rút tiền cho vay",
     "tx_review_perps_deposit": "Tài khoản hợp đồng vĩnh cửu đã được nạp tiền",
     "tx_review_predict_deposit": "Funded Predict account",
+    "tx_review_predict_claim": "Claimed Predict winnings",
     "sent_ether": "Đã gửi Ether",
     "self_sent_ether": "Đã gửi Ether cho chính bạn",
     "received_ether": "Đã nhận Ether",
@@ -3939,7 +4000,9 @@
     "wallet_connect_dapps_cta": "Xem phiên",
     "network_not_supported": "Không hỗ trợ mạng hiện tại",
     "select_provider": "Chọn nhà cung cấp ưu tiên của bạn",
-    "switch_network": "Vui lòng chuyển qua mạng chính hoặc sepolia"
+    "switch_network": "Vui lòng chuyển qua mạng chính hoặc sepolia",
+    "card_title": "Always show MetaMask Card button",
+    "card_desc": "MetaMask Card is only available to residents of select countries"
   },
   "walletconnect_sessions": {
     "no_active_sessions": "Bạn không có phiên đang hoạt động nào",
@@ -5315,7 +5378,7 @@
     },
     "tooltip": {
       "perps_deposit": {
-        "transaction_fee": "Chúng tôi sẽ hoán đổi token của bạn sang USDC trên HyperCore, mạng được Hợp đồng vĩnh cửu sử dụng. Các nhà cung cấp dịch vụ hoán đổi có thể tính phí, nhưng MetaMask thì không."
+        "transaction_fee": "We'll swap your tokens for USDC on HyperCore, the network used by Perps. Swap providers may charge a fee, but MetaMask won't."
       },
       "predict_deposit": {
         "transaction_fee": "We'll swap your tokens for USDC.e on Polygon, the network used by Predict. Swap providers may charge a fee, but MetaMask won't."
@@ -5407,6 +5470,12 @@
       "save": "Lưu",
       "title": "Chỉnh sửa hạn mức phê duyệt"
     },
+    "predict_claim": {
+      "button_label": "Claim winnings",
+      "summary": "You won",
+      "footer_bottom": "Funds will be added to your available balance",
+      "footer_top": "Winnings from {{count}} markets"
+    },
     "unlimited": "Không giới hạn",
     "all": "Tất cả",
     "none": "Không có",
@@ -5469,12 +5538,15 @@
     "points": "Điểm ước tính",
     "points_tooltip": "Điểm",
     "points_tooltip_content_1": "Points are how you earn MetaMask Rewards for completing transactions, like when you swap, bridge, or trade perps.",
-    "points_tooltip_content_2": "Keep in mind this value is an estimate and will be finalized once the transaction is complete. Points can take up to 1 hour to be confirmed in your Rewards balance.",
+    "points_tooltip_content_2": "Lưu ý rằng giá trị này chỉ là ước tính và sẽ được xác nhận sau khi giao dịch hoàn tất. Điểm có thể mất đến 1 giờ để được xác nhận trong số dư Phần thưởng.",
     "unable_to_load": "Không thể tải",
     "points_error": "Chúng tôi không thể tải điểm ngay bây giờ",
-    "points_error_content": "You'll still earn any points for this transaction. We'll notify you once they've been added to your account. You can also check your rewards tab in about an hour.",
+    "points_error_content": "Bạn vẫn sẽ nhận được điểm cho giao dịch này. Chúng tôi sẽ thông báo cho bạn sau khi điểm đã được cộng vào tài khoản. Bạn cũng có thể kiểm tra tab Phần thưởng sau khoảng một giờ.",
     "see_other_quotes": "Xem các báo giá khác",
     "receive_at": "Nhận tại",
+    "recipient": "Recipient",
+    "select_recipient": "Select recipient",
+    "external_account": "External account",
     "error_banner_description": "Lộ trình giao dịch này hiện không khả dụng. Hãy thử thay đổi số lượng, mạng hoặc token và chúng tôi sẽ tìm phương án tốt nhất.",
     "insufficient_funds": "Không đủ tiền",
     "insufficient_gas": "Không đủ gas",
@@ -5775,6 +5847,12 @@
       "update_to_store_link": "Cập nhật lên phiên bản MetaMask mới nhất",
       "well_take_you_to_right_place": " và chúng tôi sẽ đưa bạn đến đúng nơi."
     },
+    "unsupported": {
+      "title": "This page is not supported in current version",
+      "description": "Update to the latest version to use this feature",
+      "update_to_store_link": "Update to the latest version of MetaMask",
+      "well_take_you_to_right_place": " and we'll take you to the right place."
+    },
     "go_to_home_button": "Đến trang chủ",
     "back_button": "Quay lại",
     "continue_button": "Tiếp tục"
@@ -5791,7 +5869,96 @@
     "card_onboarding": {
       "title": "Chào mừng đến với Thẻ",
       "description": "Để sử dụng các tính năng của thẻ, bạn cần xác minh tài khoản với đối tác của chúng tôi.",
-      "verify_account_button": "Xác minh tài khoản"
+      "verify_account_button": "Xác minh tài khoản",
+      "sign_up": {
+        "title": "Sign-up",
+        "description": "Register your details with Crypto Life, the provider of MetaMask Card. You'll use this account to access and manage your card.",
+        "email_label": "Email",
+        "password_label": "Password",
+        "confirm_password_label": "Confirm password",
+        "country_label": "Country of Residence",
+        "email_placeholder": "Enter your email address",
+        "password_placeholder": "Enter your password",
+        "country_placeholder": "Select your country",
+        "password_mismatch": "Passwords do not match",
+        "invalid_email": "Invalid email address"
+      },
+      "confirm_email": {
+        "title": "Confirm your email",
+        "description": "We've sent a confirmation code to: {{email}}",
+        "confirm_code_label": "Confirmation code",
+        "confirm_code_placeholder": "Enter the confirmation code"
+      },
+      "set_phone_number": {
+        "title": "Phone number",
+        "description": "Enter your phone number",
+        "phone_number_label": "Phone number",
+        "phone_number_placeholder": "Enter your phone number",
+        "country_area_code_label": "Country area code",
+        "invalid_phone_number": "Invalid phone number",
+        "legal_terms": "By continuing, you agree to receiving SMS to verify your phone number."
+      },
+      "confirm_phone_number": {
+        "title": "Confirm your phone number",
+        "description": "We've sent a confirmation code to: {{phoneNumber}}",
+        "confirm_code_label": "Confirmation code"
+      },
+      "verify_identity": {
+        "title": "Verifying your identity to get your card",
+        "description": "To keep your account secure and comply with regulations, we need to verify your identity.\n\nYou'll need a government-issued ID and a proof of address (like a utility bill or bank statement).\n\nVerification usually takes 5-30 minutes, and we'll notify you as soon as it's complete.",
+        "verify_button": "Verify now with Veriff"
+      },
+      "validating_kyc": {
+        "title": "Validating your KYC..."
+      },
+      "kyc_failed": {
+        "title": "Rejected",
+        "description": "Your KYC was rejected. Please try again."
+      },
+      "personal_details": {
+        "title": "Personal details",
+        "description": "Enter your personal details",
+        "first_name_label": "First name",
+        "last_name_label": "Last name",
+        "date_of_birth_label": "Date of birth",
+        "nationality_label": "Country of Nationality",
+        "ssn_label": "Social Security Number",
+        "first_name_placeholder": "Enter your first name",
+        "last_name_placeholder": "Enter your last name",
+        "date_of_birth_placeholder": "Enter your date of birth",
+        "nationality_placeholder": "Select your nationality",
+        "ssn_placeholder": "Enter your SSN",
+        "invalid_ssn": "Invalid SSN",
+        "invalid_date_of_birth": "Invalid date of birth",
+        "invalid_date_of_birth_underage": "You must be at least 18 years old"
+      },
+      "physical_address": {
+        "title": "Physical address",
+        "description": "Please provide your physical address",
+        "address_line_1_label": "Address line 1",
+        "address_line_2_label": "Address line 2",
+        "city_label": "City",
+        "state_label": "State",
+        "zip_code_label": "ZIP code",
+        "address_line_1_placeholder": "Enter your address line 1",
+        "address_line_2_placeholder": "Enter your address line 2",
+        "city_placeholder": "Enter your city",
+        "state_placeholder": "Enter your state",
+        "zip_code_placeholder": "Enter your ZIP code",
+        "same_mailing_address_label": "Physical address is the same as mailing address",
+        "electronic_consent": "I agree to the E-Sign Act Consent and Disclosure and to receive all communictions electronically."
+      },
+      "mailing_address": {
+        "title": "Mailing address",
+        "description": "Please provide your mailing address"
+      },
+      "complete": {
+        "title": "Approved!",
+        "description": "Your KYC was approved. You can now use your Card."
+      },
+      "continue_button": "Next",
+      "confirm_button": "Confirm",
+      "retry_button": "Try again"
     },
     "card_home": {
       "error_title": "Không thể tìm nạp dữ liệu",
@@ -5799,9 +5966,36 @@
       "try_again": "Thử lại",
       "limited_spending_warning": "Khả năng chi tiêu thực tế của bạn có thể bị giới hạn. Để điều chỉnh hạn mức, hãy vào {{manageCard}}",
       "add_funds": "Thêm tiền",
+      "change_asset": "Change asset",
       "manage_card_options": {
+        "manage_spending_limit": "Manage spending limit",
+        "manage_spending_limit_description_restricted": "Restricted spending limit is on",
+        "manage_spending_limit_description_full": "Full spending access is on",
         "manage_card": "Quản lý thẻ",
-        "advanced_card_management_description": "Xem giao dịch, đóng băng thẻ và nhiều hơn nữa"
+        "advanced_card_management_description": "Detailed transactions, freeze card, and more"
+      }
+    },
+    "card_authentication": {
+      "title": "Log in to your Card account",
+      "location_button_text": "International",
+      "location_button_text_us": "US account",
+      "email_label": "Email",
+      "password_label": "Password",
+      "email_placeholder": "Enter your email address",
+      "password_placeholder": "Enter your password",
+      "login_button": "Log in",
+      "errors": {
+        "invalid_credentials": "Invalid login details",
+        "unknown_error": "Unknown error, please try again later",
+        "email_required": "Email is required",
+        "password_required": "Password is required",
+        "email_invalid": "Invalid email address",
+        "password_invalid": "Invalid password",
+        "invalid_email_or_password": "Invalid email or password, check your credentials and try again.",
+        "network_error": "Network error. Please check your connection and try again.",
+        "timeout_error": "Request timed out. Please check your connection and try again.",
+        "server_error": "Server error. Please try again later.",
+        "configuration_error": "Service is temporarily unavailable. Please try again later."
       }
     }
   },
@@ -5825,65 +6019,65 @@
     "close": "Đóng"
   },
   "rewards": {
-    "auth_fail_title": "Unknown Error.",
-    "auth_fail_description": "An unknown error occurred while authenticating this account with the rewards program. Please try again later.",
-    "failed_to_authenticate": "Failed to authenticate with rewards program",
+    "auth_fail_title": "Lỗi không xác định.",
+    "auth_fail_description": "Đã xảy ra lỗi không xác định khi xác thực tài khoản này với chương trình phần thưởng. Vui lòng thử lại sau.",
+    "failed_to_authenticate": "Không thể xác thực với chương trình phần thưởng",
     "not_implemented": "Sắp ra mắt",
     "not_implemented_season_summary": "Tổng kết mùa giải sắp ra mắt",
     "optin_error": {
-      "title": "Opt-in failed",
-      "description": "Check your connection and try again."
+      "title": "Đăng ký tham gia thất bại",
+      "description": "Kiểm tra kết nối của bạn và thử lại."
     },
     "season_status_error": {
-      "error_fetching_title": "Season balance couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Không thể tải số dư mùa",
+      "error_fetching_description": "Kiểm tra kết nối của bạn và thử lại.",
+      "retry_button": "Thử lại"
     },
     "active_boosts_error": {
-      "error_fetching_title": "Boosts couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Không thể tải tính năng tăng cường",
+      "error_fetching_description": "Kiểm tra kết nối của bạn và thử lại.",
+      "retry_button": "Thử lại"
     },
     "unlocked_rewards_error": {
-      "error_fetching_title": "Rewards couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Không thể tải phần thưởng",
+      "error_fetching_description": "Kiểm tra kết nối của bạn và thử lại.",
+      "retry_button": "Thử lại"
     },
     "upcoming_rewards_error": {
-      "error_fetching_title": "Rewards couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Không thể tải phần thưởng",
+      "error_fetching_description": "Kiểm tra kết nối của bạn và thử lại.",
+      "retry_button": "Thử lại"
     },
     "referral_details_error": {
-      "error_fetching_title": "Referral details couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Không thể tải chi tiết giới thiệu",
+      "error_fetching_description": "Kiểm tra kết nối của bạn và thử lại.",
+      "retry_button": "Thử lại"
     },
     "referral_validation_unknown_error": {
-      "title": "Referral code couldn’t be validated",
-      "description": "Check your connection and try again."
+      "title": "Không thể xác minh mã giới thiệu",
+      "description": "Kiểm tra kết nối của bạn và thử lại."
     },
     "active_activity_error": {
-      "error_fetching_title": "Activity couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Không thể tải hoạt động",
+      "error_fetching_description": "Kiểm tra kết nối của bạn và thử lại.",
+      "retry_button": "Thử lại"
     },
-    "solana_signup_not_supported": "Signing in to Rewards with Solana accounts is not supported yet. Please use an Ethereum account instead.",
+    "solana_signup_not_supported": "Hiện tại chưa hỗ trợ đăng nhập Phần thưởng bằng tài khoản Solana. Vui lòng sử dụng tài khoản Ethereum.",
     "error_messages": {
-      "unknown_error": "Unknown error occurred",
-      "something_went_wrong": "Something went wrong. Please try again shortly.",
-      "account_already_registered": "This account is already registered with another Rewards profile. Please switch account to continue.",
-      "request_rejected": "You rejected the request.",
-      "failed_to_claim_reward": "Failed to claim reward. Please try again shortly.",
-      "service_not_available": "Service is not available at the moment. Please try again shortly."
+      "unknown_error": "Đã xảy ra lỗi không xác định",
+      "something_went_wrong": "Đã xảy ra lỗi. Vui lòng thử lại sau giây lát.",
+      "account_already_registered": "Tài khoản này đã được đăng ký với hồ sơ Phần thưởng khác. Vui lòng chuyển tài khoản để tiếp tục.",
+      "request_rejected": "Bạn đã từ chối yêu cầu.",
+      "failed_to_claim_reward": "Không thể nhận phần thưởng. Vui lòng thử lại sau giây lát.",
+      "service_not_available": "Dịch vụ hiện không khả dụng. Vui lòng thử lại sau giây lát."
     },
     "claim_reward_error": {
-      "title": "Failed to claim reward"
+      "title": "Không thể nhận phần thưởng"
     },
     "accounts_opt_in_state_error": {
-      "error_fetching_title": "Accounts couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "Không thể tải tài khoản",
+      "error_fetching_description": "Kiểm tra kết nối của bạn và thử lại.",
+      "retry_button": "Thử lại"
     },
     "referral_rewards_title": "Giới thiệu",
     "points": "Điểm",
@@ -5899,139 +6093,142 @@
     "tab_levels_title": "Cấp độ",
     "referral_stats_earned_from_referrals": "Nhận được từ giới thiệu",
     "referral_stats_referrals": "Giới thiệu",
-    "loading_activity": "Loading activity...",
-    "error_loading_activity": "Error loading activity",
-    "activity_empty_title": "No recent activity.",
-    "activity_empty_description": "Use MetaMask to earn points, level up, and unlock rewards.",
-    "activity_empty_link": "See ways to earn",
+    "loading_activity": "Đang tải hoạt động...",
+    "error_loading_activity": "Lỗi khi tải hoạt động",
+    "activity_empty_title": "Không có hoạt động gần đây.",
+    "activity_empty_description": "Sử dụng MetaMask để kiếm điểm, thăng cấp và mở khóa phần thưởng.",
+    "activity_empty_link": "Xem các cách để kiếm điểm",
     "events": {
-      "to": "to",
+      "to": "đến",
       "type": {
         "swap": "Hoán đổi",
         "perps": "Hợp đồng vĩnh cửu",
-        "referral": "Referral",
-        "referral_action": "Referral action",
-        "sign_up_bonus": "Sign up bonus",
-        "loyalty_bonus": "Loyalty bonus",
-        "one_time_bonus": "One-time bonus",
-        "open_position": "Opened position",
-        "close_position": "Closed position",
-        "take_profit": "TP/SL",
-        "stop_loss": "TP/SL",
-        "uncategorized_event": "Uncategorized event"
+        "card_spend": "Card spend",
+        "referral": "Giới thiệu",
+        "referral_action": "Hành động giới thiệu",
+        "sign_up_bonus": "Thưởng đăng ký",
+        "loyalty_bonus": "Thưởng cho khách hàng thân thiết",
+        "one_time_bonus": "Thưởng một lần",
+        "open_position": "Vị thế đã mở",
+        "close_position": "Vị thế đã đóng",
+        "take_profit": "Chốt lời/Cắt lỗ",
+        "stop_loss": "Chốt lời/Cắt lỗ",
+        "uncategorized_event": "Sự kiện chưa được phân loại"
       },
-      "date": "Date",
-      "account": "Account",
-      "bonus": "Bonus",
-      "details": "Details",
-      "points": "Points",
-      "points_base": "Base",
-      "points_boost": "Boost",
-      "points_total": "Total"
+      "date": "Ngày",
+      "account": "Tài khoản",
+      "bonus": "Thưởng",
+      "details": "Chi tiết",
+      "points": "Điểm",
+      "points_base": "Cơ bản",
+      "points_boost": "Tăng cường",
+      "points_total": "Tổng cộng"
     },
     "onboarding": {
       "not_supported_region_title": "Khu vực không được hỗ trợ",
-      "not_supported_region_description": "Rewards are not supported in your region yet. We are working on expanding access, so check back later.",
-      "not_supported_hardware_account_title": "Account not supported",
-      "not_supported_hardware_account_description": "Hardware wallet accounts are not eligible to receive rewards yet. Please switch to a different account to proceed.",
-      "not_supported_account_type_title": "Account type not supported",
-      "not_supported_account_type_description": "Currently only internal Ethereum and Solana accounts can be opted into the Rewards program. Please switch to a different account to proceed.",
-      "not_supported_confirm_go_back": "Go back",
-      "not_supported_confirm_retry": "Retry",
-      "auth_fail_title": "Authentication Failed",
-      "auth_fail_description": "Unable to authenticate with the rewards program. Please check your connection and try again.",
-      "geo_check_fail_title": "Cannot determine opt-in eligibility",
-      "geo_check_fail_description": "We cannot determine if your country allows opting into the rewards program. Please check your connection and try again.",
+      "not_supported_region_description": "Phần thưởng hiện chưa được hỗ trợ tại khu vực của bạn. Chúng tôi đang mở rộng phạm vi truy cập, vui lòng kiểm tra lại sau.",
+      "not_supported_hardware_account_title": "Tài khoản không được hỗ trợ",
+      "not_supported_hardware_account_description": "Tài khoản ví cứng hiện chưa đủ điều kiện nhận phần thưởng. Vui lòng chuyển sang tài khoản khác để tiếp tục.",
+      "not_supported_account_type_title": "Loại tài khoản không được hỗ trợ",
+      "not_supported_account_type_description": "Hiện tại, chỉ các tài khoản Ethereum và Solana nội bộ mới có thể tham gia chương trình Phần thưởng. Vui lòng chuyển sang tài khoản khác để tiếp tục.",
+      "not_supported_confirm_go_back": "Quay lại",
+      "not_supported_confirm_retry": "Thử lại",
+      "auth_fail_title": "Xác thực thất bại",
+      "auth_fail_description": "Không thể xác thực với chương trình phần thưởng. Vui lòng kiểm tra kết nối và thử lại.",
+      "geo_check_fail_title": "Không thể xác định tư cách đủ điều kiện tham gia",
+      "geo_check_fail_description": "Chúng tôi không thể xác định liệu quốc gia của bạn có cho phép tham gia chương trình phần thưởng hay không. Vui lòng kiểm tra kết nối và thử lại.",
       "gtm_title": "Phần thưởng đã sẵn sàng",
       "gtm_description": "Nhận điểm cho các hoạt động của bạn. \nThăng cấp để mở khóa phần thưởng.",
       "gtm_confirm": "Bắt đầu",
       "intro_title": "Mùa 1 \nđã bắt đầu",
-      "intro_description": "Earn points for your activity. \nAdvance through levels to unlock rewards.",
-      "intro_confirm": "Claim 250 points",
-      "intro_confirm_geo_loading": "Checking region...",
-      "checking_opt_in": "Checking accounts...",
-      "redirecting_to_dashboard": "Redirecting...",
+      "intro_description": "Nhận điểm cho các hoạt động của bạn. \nThăng cấp để mở khóa phần thưởng.",
+      "intro_confirm": "Nhận 250 điểm",
+      "intro_confirm_geo_loading": "Đang kiểm tra khu vực...",
+      "checking_opt_in": "Đang kiểm tra tài khoản...",
+      "redirecting_to_dashboard": "Đang chuyển hướng...",
       "intro_skip": "Không phải bây giờ",
       "step_confirm": "Tiếp theo",
-      "step_skip": "Skip",
-      "step1_title": "Earn points on every trade",
+      "step_skip": "Bỏ qua",
+      "step1_title": "Kiếm điểm với mỗi giao dịch",
       "step1_description": "Mỗi lần hoán đổi và giao dịch hợp đồng vĩnh cửu mà bạn thực hiện trong MetaMask sẽ giúp bạn tiến gần hơn đến phần thưởng. Hãy thêm tài khoản và xem điểm của bạn tăng lên.",
-      "step2_title": "Level up for bigger perks",
+      "step2_title": "Thăng cấp để nhận đặc quyền lớn hơn",
       "step2_description": "Đạt các mốc điểm để nhận những đặc quyền như giảm 50% phí hợp đồng vĩnh cửu, token độc quyền và Thẻ MetaMask Metal miễn phí.",
-      "step3_title": "Exclusive seasonal rewards",
-      "step3_description": "Each season brings new perks. Join in, compete, and claim what you can before time runs out.",
-      "step4_title": "You'll earn 250 points when you sign up!",
-      "step4_title_referral_validating": "Validating referral code...",
-      "step4_referral_input_placeholder": "Referral code (optional)",
-      "step4_referral_input_error": "Invalid referral code",
-      "step4_confirm": "Claim points",
-      "step4_confirm_loading": "Claiming points...",
-      "step4_linking_accounts": "Adding accounts... ({{current}}/{{total}})",
-      "step4_linking_accounts_loading": "Adding additional accounts...",
-      "step4_success_description": "You have successfully signed up for MetaMask Rewards!",
-      "step4_legal_disclaimer_1": "By selecting 'Claim Points', you agree to the MetaMask Rewards",
-      "step4_legal_disclaimer_2": "Supplemental Terms of Use and Privacy Notice",
-      "step4_legal_disclaimer_3": ". We'll track onchain activity to reward you automatically –",
-      "step4_legal_disclaimer_4": "learn more"
+      "step3_title": "Phần thưởng theo mùa độc quyền",
+      "step3_description": "Mỗi mùa sẽ mang đến những đặc quyền mới. Hãy tham gia, tranh tài và nhận phần thưởng trước khi thời gian kết thúc.",
+      "step4_title": "Bạn sẽ nhận được 250 điểm khi đăng ký!",
+      "step4_title_referral_bonus": "You'll earn 500 points when you sign up with this code!",
+      "step4_title_referral_validating": "Đang xác minh mã giới thiệu...",
+      "step4_referral_bonus_description": "Use a referral code to earn 250 more",
+      "step4_referral_input_placeholder": "Mã giới thiệu (không bắt buộc)",
+      "step4_referral_input_error": "Mã giới thiệu không hợp lệ",
+      "step4_confirm": "Nhận điểm",
+      "step4_confirm_loading": "Đang nhận điểm...",
+      "step4_linking_accounts": "Đang thêm tài khoản... ({{current}}/{{total}})",
+      "step4_linking_accounts_loading": "Đang thêm tài khoản bổ sung...",
+      "step4_success_description": "Bạn đã đăng ký thành công Phần thưởng MetaMask!",
+      "step4_legal_disclaimer_1": "Bằng cách chọn \"Nhận điểm\", bạn đồng ý với",
+      "step4_legal_disclaimer_2": "Điều khoản sử dụng bổ sung và Thông báo quyền riêng tư",
+      "step4_legal_disclaimer_3": "của Phần thưởng MetaMask. Chúng tôi sẽ theo dõi hoạt động trên chuỗi để tự động tặng thưởng cho bạn –",
+      "step4_legal_disclaimer_4": "tìm hiểu thêm"
     },
     "settings": {
-      "title": "Rewards Settings",
-      "subtitle": "Accounts",
-      "description": "Add multiple accounts to combine your points and unlock rewards faster.",
-      "tab_linked_accounts": "Added ({{count}})",
-      "tab_unlinked_accounts": "Not added ({{count}})",
-      "no_linked_accounts": "No accounts opted in",
-      "all_accounts_linked_title": "All accounts opted in",
-      "all_accounts_linked_description": "You have added all your accounts to Rewards.",
-      "link_account_success_title": "{{accountName}} successfully added",
-      "link_account_error_title": "Failed to add account",
-      "link_account_button": "Add",
-      "link_account_failed_error": "Failed to link account",
-      "link_account_unknown_error": "Unknown error occurred"
+      "title": "Cài đặt Phần thưởng",
+      "subtitle": "Tài khoản",
+      "description": "Thêm nhiều tài khoản để gộp điểm và mở khóa phần thưởng nhanh hơn.",
+      "tab_linked_accounts": "Đã thêm ({{count}})",
+      "tab_unlinked_accounts": "Chưa thêm ({{count}})",
+      "no_linked_accounts": "Không có tài khoản nào đã tham gia",
+      "all_accounts_linked_title": "Tất cả các tài khoản đã tham gia",
+      "all_accounts_linked_description": "Bạn đã thêm tất cả tài khoản của mình vào chương trình Phần thưởng.",
+      "link_account_success_title": "{{accountName}} đã được thêm thành công",
+      "link_account_error_title": "Thêm tài khoản không thành công",
+      "link_account_button": "Thêm",
+      "link_account_failed_error": "Liên kết tài khoản không thành công",
+      "link_account_unknown_error": "Đã xảy ra lỗi không xác định"
     },
     "optout": {
-      "title": "Opt out of Rewards",
-      "description": "This will remove your accounts from the Rewards program and erase your points and progress. You won't be able to undo this.",
-      "confirm": "Opt out",
+      "title": "Rút khỏi chương trình Phần thưởng",
+      "description": "Hành động này sẽ xóa các tài khoản của bạn khỏi chương trình Phần thưởng cũng như xóa toàn bộ điểm và tiến trình của bạn. Bạn sẽ không thể hoàn tác hành động này.",
+      "confirm": "Rút khỏi",
       "modal": {
-        "confirmation_title": "Are you sure?",
-        "confirmation_description": "This will remove all your progress, and can't be reversed. If you rejoin the Rewards program later, you'll start back at 0.",
-        "cancel": "Cancel",
-        "confirm": "Confirm",
-        "error_message": "Failed to opt out of Rewards. Please try again.",
-        "processing": "Processing..."
+        "confirmation_title": "Bạn có chắc chắn không?",
+        "confirmation_description": "Hành động này sẽ xóa toàn bộ tiến trình của bạn và không thể đảo ngược. Nếu bạn tham gia lại chương trình Phần thưởng sau này, bạn sẽ bắt đầu lại từ 0.",
+        "cancel": "Hủy",
+        "confirm": "Xác nhận",
+        "error_message": "Không thể rút khỏi chương trình Phần thưởng. Vui lòng thử lại.",
+        "processing": "Đang xử lý..."
       }
     },
-    "toast_dismiss": "Dismiss",
+    "toast_dismiss": "Đóng",
     "dashboard_modal_info": {
       "active_account": {
-        "title": "Don't miss out",
-        "description": "Add your account to start earning points from your activity.",
-        "confirm": "Add account"
+        "title": "Đừng bỏ lỡ cơ hội",
+        "description": "Thêm tài khoản để bắt đầu kiếm điểm từ hoạt động của bạn.",
+        "confirm": "Thêm tài khoản"
       },
       "multiple_unlinked_accounts": {
-        "title": "Start earning points",
-        "description": "Add your accounts so you can track your rewards at a glance.",
-        "confirm": "Add accounts"
+        "title": "Bắt đầu kiếm điểm",
+        "description": "Thêm các tài khoản của bạn để có thể theo dõi phần thưởng dễ dàng hơn.",
+        "confirm": "Thêm tài khoản"
       },
       "account_not_supported": {
-        "title": "Account not supported",
-        "description_hardware": "Hardware wallet accounts are not yet eligible to earn points. Please switch to a different account to proceed.",
-        "description_general": "Currently only non-hardware internal Ethereum and Solana accounts are eligible to earn points. Please switch to a different account to proceed.",
-        "confirm": "Go back"
+        "title": "Tài khoản không được hỗ trợ",
+        "description_hardware": "Tài khoản ví cứng hiện chưa đủ điều kiện để kiếm điểm. Vui lòng chuyển sang tài khoản khác để tiếp tục.",
+        "description_general": "Hiện tại, chỉ các tài khoản Ethereum và Solana nội bộ không phải ví cứng mới đủ điều kiện để kiếm điểm. Vui lòng chuyển sang tài khoản khác để tiếp tục.",
+        "confirm": "Quay lại"
       }
     },
     "ways_to_earn": {
-      "title": "Ways to earn",
-      "supported_networks": "Supported Networks",
+      "title": "Cách kiếm điểm",
+      "supported_networks": "Mạng được hỗ trợ",
       "swap": {
-        "title": "Swap",
-        "description": "80 points per $100",
+        "title": "Hoán đổi",
+        "description": "80 điểm cho mỗi $100",
         "sheet": {
-          "title": "Swap tokens",
-          "points": "80 points per $100",
-          "description": "Swap tokens on supported networks to earn points for every dollar you trade.",
-          "cta_label": "Start a swap"
+          "title": "Hoán đổi token",
+          "points": "80 điểm cho mỗi $100",
+          "description": "Hoán đổi token trên các mạng được hỗ trợ để kiếm điểm cho mỗi đô-la mà bạn giao dịch.",
+          "cta_label": "Bắt đầu hoán đổi"
         }
       },
       "perps": {
@@ -6045,52 +6242,74 @@
         }
       },
       "referrals": {
-        "title": "Refer friends",
-        "description": "10 points per 50 from friends"
+        "title": "Giới thiệu bạn bè",
+        "description": "10 điểm cho mỗi 50 điểm từ bạn bè",
+        "sheet": {
+          "title": "Refer a friend",
+          "points": "20 points per 100",
+          "cta_label": "Refer a friend"
+        }
       },
       "loyalty": {
-        "title": "Loyalty bonus",
-        "description": "Earn points from past trades",
+        "title": "Thưởng trung thành",
+        "description": "Kiếm điểm từ các giao dịch trước đây",
         "sheet": {
-          "title": "Loyalty bonus",
-          "points": "250 points per $1250",
-          "description": "Add accounts with past swaps or bridges in MetaMask to earn loyalty bonuses. Each eligible account unlocks points in increments of 250, up to a total of 50,000. Bonuses appear shortly after you add an account.",
-          "cta_label": "Add accounts"
+          "title": "Thưởng cho khách hàng thân thiết",
+          "points": "250 điểm cho mỗi $1250",
+          "description": "Thêm các tài khoản có giao dịch hoán đổi hoặc cầu nối trước đây trong MetaMask để nhận thưởng cho khách hàng thân thiết. Mỗi tài khoản đủ điều kiện sẽ mở khóa điểm theo bội số của 250, tối đa tổng cộng 50.000 điểm. Điểm thưởng sẽ xuất hiện ngay sau khi bạn thêm tài khoản.",
+          "cta_label": "Thêm tài khoản"
+        }
+      },
+      "card": {
+        "title": "MetaMask Card",
+        "description": "1 point per $1 spent",
+        "sheet": {
+          "title": "MetaMask Card",
+          "points": "1 point per $1 spent",
+          "description": "Earn points every time you use your MetaMask Card for purchases, plus 1% cash back (3% for Metal cardholders).",
+          "cta_label": "Manage Card"
         }
       }
     },
     "referral": {
-      "referral_code": "Referral code",
-      "referral_link": "Referral link",
+      "referral_code": "Mã giới thiệu",
+      "referral_link": "Liên kết giới thiệu",
       "actions": {
         "share_referral_link": "Giới thiệu bạn bè",
         "share_referral_subject": "Tham gia MetaMask Phần thưởng"
       },
       "info": {
         "title": "Chia sẻ mã của bạn để nhận thêm điểm",
-        "description": "Your friends get a 2x sign up bonus. You get 10 points for every 50 they earn from trading."
+        "description": "Bạn bè của bạn sẽ nhận 2x điểm thưởng khi đăng ký. Bạn sẽ nhận được 10 điểm cho mỗi 50 điểm mà bạn bè kiếm được từ giao dịch."
       }
     },
-    "active_boosts_title": "Active boosts",
-    "season_1": "Season 1",
+    "link_account_group": {
+      "link_account": "Add account",
+      "tracked": "Tracked",
+      "untracked": "Untracked",
+      "link_account_success": "{{accountName}} added successfully",
+      "link_account_error": "Failed to add one or more addresses for {{accountName}}"
+    },
+    "active_boosts_title": "Tính năng tăng cường đang hoạt động",
+    "season_1": "Mùa 1",
     "upcoming_rewards": {
       "title": "Phần thưởng bị khóa",
-      "points_needed": "{{points}} points",
-      "cta_label": "Got it",
-      "alpha_fox_invite_input_placeholder": "Your Telegram handle"
+      "points_needed": "{{points}} điểm",
+      "cta_label": "Tôi đã hiểu",
+      "alpha_fox_invite_input_placeholder": "Tên người dùng Telegram của bạn"
     },
     "unlocked_rewards": {
-      "title": "Unlocked rewards",
-      "cta_label": "Claim now",
-      "cta_request_invite": "Request invite",
-      "claim_label": "Claim",
-      "claimed_label": "Claimed",
-      "reward_claimed": "Reward claimed",
+      "title": "Phần thưởng đã mở khóa",
+      "cta_label": "Nhận ngay",
+      "cta_request_invite": "Yêu cầu lời mời",
+      "claim_label": "Nhận",
+      "claimed_label": "Đã nhận",
+      "reward_claimed": "Phần thưởng đã nhận",
       "time_left": "còn lại",
-      "expired": "Expired"
+      "expired": "Đã hết hạn"
     },
     "animation": {
-      "could_not_load": "Couldn't load"
+      "could_not_load": "Không thể tải"
     }
   },
   "time": {
@@ -6099,7 +6318,7 @@
   },
   "transaction_details": {
     "title": {
-      "perps_deposit": "Funded Perps account",
+      "perps_deposit": "Tài khoản hợp đồng vĩnh cửu đã được nạp tiền",
       "predict_deposit": "Funded Predict account",
       "default": "Chi tiết giao dịch"
     },
@@ -6107,19 +6326,23 @@
       "bridge_fee": "Phí cầu nối",
       "network_fee": "Phí mạng",
       "paid_with": "Đã thanh toán bằng",
+      "retry_button": "Try again",
       "total": "Tổng cộng"
     },
     "summary_title": {
-      "bridge": "Cầu nối từ {{sourceSymbol}} sang {{targetSymbol}}",
       "bridge_approval": "Phê duyệt {{approveSymbol}}",
       "bridge_approval_loading": "Phê duyệt",
-      "bridge_loading": "Cầu nối",
+      "bridge_send": "Bridge {{sourceSymbol}} from {{sourceChain}}",
+      "bridge_send_loading": "Bridge Send",
+      "bridge_receive": "Receive {{targetSymbol}} on {{targetChain}}",
+      "bridge_receive_loading": "Bridge Receive",
       "default": "Giao dịch",
       "perps_deposit": "Nạp tiền",
       "predict_deposit": "Add funds",
       "swap": "Hoán đổi token",
       "swap_approval": "Phê duyệt token"
-    }
+    },
+    "perps_deposit_solution": "You now have {{fiat}} of USDC on Arbitrum. Try your deposit again."
   },
   "sdk_connect_v2": {
     "show_loading": {

--- a/locales/languages/zh.json
+++ b/locales/languages/zh.json
@@ -594,7 +594,9 @@
       "unexpectedError": "发生意外错误。",
       "quoteFetchError": "获取报价失败。",
       "kycFormsFetchError": "获取 KYC（实名认证）表格失败。",
-      "title": "保证金"
+      "title": "保证金",
+      "limitExceeded": "This deposit would exceed your {{period}} limit. Your deposit including fees must be {{remaining}} or less.",
+      "limitError": "Failed to check your deposit limits. Please try again later."
     },
     "token_modal": {
       "select_a_token": "选择代币",
@@ -892,7 +894,7 @@
     "withdraw": "提取",
     "refresh_balance": "刷新余额",
     "add_funds": "充值",
-    "deposit_in_progress": "Deposit in progress",
+    "deposit_in_progress": "存款进行中",
     "your_positions": "您的仓位",
     "loading_positions": "正在加载头寸……",
     "refreshing_positions": "正在刷新仓位...",
@@ -1277,6 +1279,7 @@
       "assetMappingFailed": "构建资产映射失败",
       "depositFailed": "存款失败",
       "orderLeverageReductionFailed": "无法降低杠杆",
+      "connectionTimeout": "Connection timed out. Please check your network and try again.",
       "connectionFailed": {
         "title": "永续合约暂时离线",
         "description": "我们正在努力让它尽快重新上线。",
@@ -1348,9 +1351,9 @@
         "error_message": "未找到市场数据。请返回并重试。"
       },
       "statistics": "概览",
-      "24h_high": "24h high",
-      "24h_low": "24h low",
-      "24h_volume": "24h volume",
+      "24h_high": "24 小时最高价",
+      "24h_low": "24 小时最低价",
+      "24h_volume": "24 小时交易量",
       "open_interest": "未平仓合约量",
       "funding_rate": "资金费率",
       "countdown": "倒计时",
@@ -1510,9 +1513,9 @@
         "metamask_fee": "MetaMask 费用",
         "hyperliquid_fee": "Hyperliquid 费用",
         "total_fee": "总费用",
-        "liquidated": "Liquidated",
-        "take_profit": "Take profit",
-        "stop_loss": "Stop loss"
+        "liquidated": "已清算",
+        "take_profit": "止盈",
+        "stop_loss": "止损"
       },
       "funding": {
         "date": "日期",
@@ -1525,7 +1528,7 @@
         "history_will_appear": "您的交易历史将在此处显示"
       }
     },
-    "risk_disclaimer": "Perpetual contracts are very risky, and you could suddenly and without notice lose your entire investment. You trade entirely at your own risk. Market data provided by Hyperliquid. Price chart powered by",
+    "risk_disclaimer": "Perpetual contracts are very risky, and you could suddenly and without notice lose your entire investment. You trade entirely at your own risk. Market data provided by Hyperliquid. Price chart powered by",
     "tutorial": {
       "continue": "继续",
       "skip": "跳过",
@@ -1555,11 +1558,11 @@
       "ready_to_trade": {
         "title": "准备好交易了吗？",
         "description": "可使用任意代币为永续合约账户注资，极速完成首笔交易。",
-        "footer_text": "MetaMask 将在 Arbitrum 网络上将您的资金兑换为 USDC，并存入 HyperCore，无需任何额外费用。"
+        "footer_text": "MetaMask will swap your funds to USDC on Arbitrum, and deposit them onto HyperCore for no added fee."
       },
       "got_it": "知道了",
       "card": {
-        "title": "Learn the basics of perps"
+        "title": "了解永续合约的基础知识"
       }
     },
     "points": "积分",
@@ -1576,10 +1579,10 @@
     "market_list": "市场列表",
     "market_details": "市场详情",
     "tab": {
-      "no_predictions": "暂无预测",
-      "no_predictions_description": "开启一项预测即可开始。",
-      "explore": "探索市场",
-      "new_prediction": "新预测"
+      "no_predictions_description": "Your predictions will appear here, showing your stake and market movement.",
+      "explore": "Browse markets",
+      "new_prediction": "新预测",
+      "resolved_markets": "Resolved markets"
     },
     "sell_position": "卖出仓位",
     "cash_out": "提现",
@@ -1609,16 +1612,73 @@
     "claim_button": "领取",
     "markets_won": "已赢取的市场",
     "won_markets_text": "已赢取 {{count}} 个市场{{s}}",
-    "won_markets_text_singular": "已赢取 {{count}} 个市场",
-    "won_markets_text_plural": "已赢取 {{count}} 个市场",
+    "available_balance": "Available balance",
     "claim_amount_text": "领取 ${{amount}}",
     "unrealized_pnl_label": "未实现盈亏",
     "unrealized_pnl_value": "{{amount}}（{{percent}}）",
+    "unrealized_pnl_error": "Unable to load",
     "unavailable": {
       "title": "Unavailable in your region",
       "description": "Predictions aren't available in your region due to legal restrictions.",
       "link": "See Polymarket terms",
       "button": "Got it"
+    },
+    "deposit": {
+      "in_progress": "Deposit in progress",
+      "adding_funds": "Adding funds",
+      "adding_your_funds": "Adding your funds",
+      "add_funds": "Add funds",
+      "withdraw": "Withdraw",
+      "estimated_processing_time": "Est. {{time}} seconds",
+      "account_ready": "Your account is ready",
+      "account_ready_description": "{{amount}} added to your balance",
+      "error_title": "Something went wrong",
+      "error_description": "Your account wasn't funded",
+      "try_again": "Try again"
+    },
+    "add_funds_sheet": {
+      "title": "Add funds",
+      "description": "You'll need to add funds to your Predictions account to get started. You can add any token and make your first prediction in seconds."
+    },
+    "transactions": {
+      "title": "Predictions",
+      "no_transactions": "No recent activity",
+      "buy_title": "Predicted",
+      "sell_title": "Cashed out",
+      "claim_title": "Claimed winnings",
+      "buy_detail": "Bought {{amountUsd}} on {{outcome}} · {{priceCents}} per share",
+      "sell_detail": "Sold at {{priceCents}} per share",
+      "claim_detail": "Claimed winnings",
+      "not_available": "N/A",
+      "date": "Date",
+      "market": "Market",
+      "outcome": "Outcome",
+      "predicted_amount": "Predicted amount",
+      "shares_bought": "Shares bought",
+      "shares_sold": "Shares sold",
+      "price_per_share": "Price per share",
+      "price_impact": "Price impact",
+      "net_pnl": "Net P&L",
+      "total_net_pnl": "Total Net P&L",
+      "market_net_pnl": "Market Net P&L",
+      "activity_details": "Activity details"
+    },
+    "claim": {
+      "toasts": {
+        "pending": {
+          "title": "Claiming {{amount}}",
+          "description": "Est. {{time}} seconds"
+        },
+        "confirmed": {
+          "title": "Claimed",
+          "description": "{{amount}} added to your balance"
+        },
+        "error": {
+          "title": "Something went wrong",
+          "description": "Failed to proceed with claim",
+          "try_again": "Try again"
+        }
+      }
     }
   },
   "receive": {
@@ -3093,6 +3153,7 @@
     "tx_review_lending_withdraw": "出借提款",
     "tx_review_perps_deposit": "已注资的永续合约账户",
     "tx_review_predict_deposit": "Funded Predict account",
+    "tx_review_predict_claim": "Claimed Predict winnings",
     "sent_ether": "已发送以太币",
     "self_sent_ether": "已向自己发送以太币",
     "received_ether": "已接收以太币",
@@ -3939,7 +4000,9 @@
     "wallet_connect_dapps_cta": "查看会话",
     "network_not_supported": "不支持当前网络",
     "select_provider": "选择您的首选提供商",
-    "switch_network": "请切换为 mainnet 或 sepolia"
+    "switch_network": "请切换为 mainnet 或 sepolia",
+    "card_title": "Always show MetaMask Card button",
+    "card_desc": "MetaMask Card is only available to residents of select countries"
   },
   "walletconnect_sessions": {
     "no_active_sessions": "您没有活动会话",
@@ -5315,7 +5378,7 @@
     },
     "tooltip": {
       "perps_deposit": {
-        "transaction_fee": "我们将在永续合约所用的 HyperCore 网络上将您的代币兑换为 USDC。兑换服务商可能收取费用，但 MetaMask 不另收费。"
+        "transaction_fee": "We'll swap your tokens for USDC on HyperCore, the network used by Perps. Swap providers may charge a fee, but MetaMask won't."
       },
       "predict_deposit": {
         "transaction_fee": "We'll swap your tokens for USDC.e on Polygon, the network used by Predict. Swap providers may charge a fee, but MetaMask won't."
@@ -5407,6 +5470,12 @@
       "save": "保存",
       "title": "编辑授权额度"
     },
+    "predict_claim": {
+      "button_label": "Claim winnings",
+      "summary": "You won",
+      "footer_bottom": "Funds will be added to your available balance",
+      "footer_top": "Winnings from {{count}} markets"
+    },
     "unlimited": "无限制",
     "all": "所有",
     "none": "无",
@@ -5469,12 +5538,15 @@
     "points": "预计积分",
     "points_tooltip": "积分",
     "points_tooltip_content_1": "Points are how you earn MetaMask Rewards for completing transactions, like when you swap, bridge, or trade perps.",
-    "points_tooltip_content_2": "Keep in mind this value is an estimate and will be finalized once the transaction is complete. Points can take up to 1 hour to be confirmed in your Rewards balance.",
+    "points_tooltip_content_2": "请知悉，这一数值为估算值，将在交易完成后最终确定。积分最多可能需要 1 小时才能确认并存入您的奖励余额。",
     "unable_to_load": "无法加载",
     "points_error": "当前无法加载积分",
-    "points_error_content": "You'll still earn any points for this transaction. We'll notify you once they've been added to your account. You can also check your rewards tab in about an hour.",
+    "points_error_content": "您仍会获得这笔交易的所有积分。积分到账后我们将通知您。您也可以约一小时后在奖励选项卡中查看。",
     "see_other_quotes": "查看其他报价",
     "receive_at": "接收地址：",
+    "recipient": "Recipient",
+    "select_recipient": "Select recipient",
+    "external_account": "External account",
     "error_banner_description": "目前该交易路线不可用。请调整交易金额、切换网络或更换代币类型，我们将为您自动匹配最优通道。",
     "insufficient_funds": "资金不足",
     "insufficient_gas": "燃料不足",
@@ -5775,6 +5847,12 @@
       "update_to_store_link": "更新至 MetaMask 最新版本",
       "well_take_you_to_right_place": " 即可为您呈现对应界面。"
     },
+    "unsupported": {
+      "title": "This page is not supported in current version",
+      "description": "Update to the latest version to use this feature",
+      "update_to_store_link": "Update to the latest version of MetaMask",
+      "well_take_you_to_right_place": " and we'll take you to the right place."
+    },
     "go_to_home_button": "前往主页",
     "back_button": "返回",
     "continue_button": "继续"
@@ -5791,7 +5869,96 @@
     "card_onboarding": {
       "title": "欢迎使用卡片功能",
       "description": "要使用卡片功能，您需要通过我们的合作伙伴完成账户验证。",
-      "verify_account_button": "验证账户"
+      "verify_account_button": "验证账户",
+      "sign_up": {
+        "title": "Sign-up",
+        "description": "Register your details with Crypto Life, the provider of MetaMask Card. You'll use this account to access and manage your card.",
+        "email_label": "Email",
+        "password_label": "Password",
+        "confirm_password_label": "Confirm password",
+        "country_label": "Country of Residence",
+        "email_placeholder": "Enter your email address",
+        "password_placeholder": "Enter your password",
+        "country_placeholder": "Select your country",
+        "password_mismatch": "Passwords do not match",
+        "invalid_email": "Invalid email address"
+      },
+      "confirm_email": {
+        "title": "Confirm your email",
+        "description": "We've sent a confirmation code to: {{email}}",
+        "confirm_code_label": "Confirmation code",
+        "confirm_code_placeholder": "Enter the confirmation code"
+      },
+      "set_phone_number": {
+        "title": "Phone number",
+        "description": "Enter your phone number",
+        "phone_number_label": "Phone number",
+        "phone_number_placeholder": "Enter your phone number",
+        "country_area_code_label": "Country area code",
+        "invalid_phone_number": "Invalid phone number",
+        "legal_terms": "By continuing, you agree to receiving SMS to verify your phone number."
+      },
+      "confirm_phone_number": {
+        "title": "Confirm your phone number",
+        "description": "We've sent a confirmation code to: {{phoneNumber}}",
+        "confirm_code_label": "Confirmation code"
+      },
+      "verify_identity": {
+        "title": "Verifying your identity to get your card",
+        "description": "To keep your account secure and comply with regulations, we need to verify your identity.\n\nYou'll need a government-issued ID and a proof of address (like a utility bill or bank statement).\n\nVerification usually takes 5-30 minutes, and we'll notify you as soon as it's complete.",
+        "verify_button": "Verify now with Veriff"
+      },
+      "validating_kyc": {
+        "title": "Validating your KYC..."
+      },
+      "kyc_failed": {
+        "title": "Rejected",
+        "description": "Your KYC was rejected. Please try again."
+      },
+      "personal_details": {
+        "title": "Personal details",
+        "description": "Enter your personal details",
+        "first_name_label": "First name",
+        "last_name_label": "Last name",
+        "date_of_birth_label": "Date of birth",
+        "nationality_label": "Country of Nationality",
+        "ssn_label": "Social Security Number",
+        "first_name_placeholder": "Enter your first name",
+        "last_name_placeholder": "Enter your last name",
+        "date_of_birth_placeholder": "Enter your date of birth",
+        "nationality_placeholder": "Select your nationality",
+        "ssn_placeholder": "Enter your SSN",
+        "invalid_ssn": "Invalid SSN",
+        "invalid_date_of_birth": "Invalid date of birth",
+        "invalid_date_of_birth_underage": "You must be at least 18 years old"
+      },
+      "physical_address": {
+        "title": "Physical address",
+        "description": "Please provide your physical address",
+        "address_line_1_label": "Address line 1",
+        "address_line_2_label": "Address line 2",
+        "city_label": "City",
+        "state_label": "State",
+        "zip_code_label": "ZIP code",
+        "address_line_1_placeholder": "Enter your address line 1",
+        "address_line_2_placeholder": "Enter your address line 2",
+        "city_placeholder": "Enter your city",
+        "state_placeholder": "Enter your state",
+        "zip_code_placeholder": "Enter your ZIP code",
+        "same_mailing_address_label": "Physical address is the same as mailing address",
+        "electronic_consent": "I agree to the E-Sign Act Consent and Disclosure and to receive all communictions electronically."
+      },
+      "mailing_address": {
+        "title": "Mailing address",
+        "description": "Please provide your mailing address"
+      },
+      "complete": {
+        "title": "Approved!",
+        "description": "Your KYC was approved. You can now use your Card."
+      },
+      "continue_button": "Next",
+      "confirm_button": "Confirm",
+      "retry_button": "Try again"
     },
     "card_home": {
       "error_title": "无法获取数据",
@@ -5799,9 +5966,36 @@
       "try_again": "请重试",
       "limited_spending_warning": "您的实际消费额度可能受限。请前往 {{manageCard}} 调整限额",
       "add_funds": "充值",
+      "change_asset": "Change asset",
       "manage_card_options": {
+        "manage_spending_limit": "Manage spending limit",
+        "manage_spending_limit_description_restricted": "Restricted spending limit is on",
+        "manage_spending_limit_description_full": "Full spending access is on",
         "manage_card": "管理卡片",
-        "advanced_card_management_description": "查看交易记录、冻结卡片等操作"
+        "advanced_card_management_description": "Detailed transactions, freeze card, and more"
+      }
+    },
+    "card_authentication": {
+      "title": "Log in to your Card account",
+      "location_button_text": "International",
+      "location_button_text_us": "US account",
+      "email_label": "Email",
+      "password_label": "Password",
+      "email_placeholder": "Enter your email address",
+      "password_placeholder": "Enter your password",
+      "login_button": "Log in",
+      "errors": {
+        "invalid_credentials": "Invalid login details",
+        "unknown_error": "Unknown error, please try again later",
+        "email_required": "Email is required",
+        "password_required": "Password is required",
+        "email_invalid": "Invalid email address",
+        "password_invalid": "Invalid password",
+        "invalid_email_or_password": "Invalid email or password, check your credentials and try again.",
+        "network_error": "Network error. Please check your connection and try again.",
+        "timeout_error": "Request timed out. Please check your connection and try again.",
+        "server_error": "Server error. Please try again later.",
+        "configuration_error": "Service is temporarily unavailable. Please try again later."
       }
     }
   },
@@ -5825,65 +6019,65 @@
     "close": "关闭"
   },
   "rewards": {
-    "auth_fail_title": "Unknown Error.",
-    "auth_fail_description": "An unknown error occurred while authenticating this account with the rewards program. Please try again later.",
-    "failed_to_authenticate": "Failed to authenticate with rewards program",
+    "auth_fail_title": "未知错误。",
+    "auth_fail_description": "为此账户进行奖励计划认证时发生未知错误。请稍后再试。",
+    "failed_to_authenticate": "奖励计划认证失败",
     "not_implemented": "即将推出",
     "not_implemented_season_summary": "赛季总结即将推出",
     "optin_error": {
-      "title": "Opt-in failed",
-      "description": "Check your connection and try again."
+      "title": "参与失败",
+      "description": "请检查连接后重试。"
     },
     "season_status_error": {
-      "error_fetching_title": "Season balance couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "赛季余额加载失败",
+      "error_fetching_description": "请检查连接后重试。",
+      "retry_button": "重试"
     },
     "active_boosts_error": {
-      "error_fetching_title": "Boosts couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "加成无法加载",
+      "error_fetching_description": "请检查连接后重试。",
+      "retry_button": "重试"
     },
     "unlocked_rewards_error": {
-      "error_fetching_title": "Rewards couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "奖励加载失败",
+      "error_fetching_description": "请检查连接后重试。",
+      "retry_button": "重试"
     },
     "upcoming_rewards_error": {
-      "error_fetching_title": "Rewards couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "奖励加载失败",
+      "error_fetching_description": "请检查连接后重试。",
+      "retry_button": "重试"
     },
     "referral_details_error": {
-      "error_fetching_title": "Referral details couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "推荐详情加载失败",
+      "error_fetching_description": "请检查连接后重试。",
+      "retry_button": "重试"
     },
     "referral_validation_unknown_error": {
-      "title": "Referral code couldn’t be validated",
-      "description": "Check your connection and try again."
+      "title": "推荐码验证失败",
+      "description": "请检查连接后重试。"
     },
     "active_activity_error": {
-      "error_fetching_title": "Activity couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "活动加载失败",
+      "error_fetching_description": "请检查连接后重试。",
+      "retry_button": "重试"
     },
-    "solana_signup_not_supported": "Signing in to Rewards with Solana accounts is not supported yet. Please use an Ethereum account instead.",
+    "solana_signup_not_supported": "暂不支持使用 Solana 账户登录奖励计划。请改用以太坊账户。",
     "error_messages": {
-      "unknown_error": "Unknown error occurred",
-      "something_went_wrong": "Something went wrong. Please try again shortly.",
-      "account_already_registered": "This account is already registered with another Rewards profile. Please switch account to continue.",
-      "request_rejected": "You rejected the request.",
-      "failed_to_claim_reward": "Failed to claim reward. Please try again shortly.",
-      "service_not_available": "Service is not available at the moment. Please try again shortly."
+      "unknown_error": "发生未知错误",
+      "something_went_wrong": "出错了。请稍后重试。",
+      "account_already_registered": "该账户已关联其他奖励档案。请切换账户继续操作。",
+      "request_rejected": "您已拒绝该请求。",
+      "failed_to_claim_reward": "领取奖励失败。请稍后再试。",
+      "service_not_available": "服务暂不可用。请稍后再试。"
     },
     "claim_reward_error": {
-      "title": "Failed to claim reward"
+      "title": "领取奖励失败"
     },
     "accounts_opt_in_state_error": {
-      "error_fetching_title": "Accounts couldn’t be loaded",
-      "error_fetching_description": "Check your connection and try again.",
-      "retry_button": "Retry"
+      "error_fetching_title": "账户加载失败",
+      "error_fetching_description": "请检查连接后重试。",
+      "retry_button": "重试"
     },
     "referral_rewards_title": "推荐",
     "points": "积分",
@@ -5899,139 +6093,142 @@
     "tab_levels_title": "等级",
     "referral_stats_earned_from_referrals": "通过推荐所获奖励",
     "referral_stats_referrals": "推荐",
-    "loading_activity": "Loading activity...",
-    "error_loading_activity": "Error loading activity",
-    "activity_empty_title": "No recent activity.",
-    "activity_empty_description": "Use MetaMask to earn points, level up, and unlock rewards.",
-    "activity_empty_link": "See ways to earn",
+    "loading_activity": "正在加载活动……",
+    "error_loading_activity": "加载活动出错",
+    "activity_empty_title": "暂无近期活动。",
+    "activity_empty_description": "使用 MetaMask 赚取积分、升级并解锁奖励。",
+    "activity_empty_link": "查看赚取方式",
     "events": {
-      "to": "to",
+      "to": "至",
       "type": {
         "swap": "交换",
         "perps": "永续合约",
-        "referral": "Referral",
-        "referral_action": "Referral action",
-        "sign_up_bonus": "Sign up bonus",
-        "loyalty_bonus": "Loyalty bonus",
-        "one_time_bonus": "One-time bonus",
-        "open_position": "Opened position",
-        "close_position": "Closed position",
-        "take_profit": "TP/SL",
-        "stop_loss": "TP/SL",
-        "uncategorized_event": "Uncategorized event"
+        "card_spend": "Card spend",
+        "referral": "推荐",
+        "referral_action": "推荐行动",
+        "sign_up_bonus": "注册奖励",
+        "loyalty_bonus": "忠诚奖励",
+        "one_time_bonus": "一次性奖励",
+        "open_position": "已开立仓位",
+        "close_position": "已平仓位",
+        "take_profit": "止盈/止损",
+        "stop_loss": "止盈/止损",
+        "uncategorized_event": "未归类事件"
       },
-      "date": "Date",
-      "account": "Account",
-      "bonus": "Bonus",
-      "details": "Details",
-      "points": "Points",
-      "points_base": "Base",
-      "points_boost": "Boost",
-      "points_total": "Total"
+      "date": "日期",
+      "account": "账户",
+      "bonus": "奖励",
+      "details": "详情",
+      "points": "积分",
+      "points_base": "基数",
+      "points_boost": "加成",
+      "points_total": "总额"
     },
     "onboarding": {
       "not_supported_region_title": "不支持此地区",
-      "not_supported_region_description": "Rewards are not supported in your region yet. We are working on expanding access, so check back later.",
-      "not_supported_hardware_account_title": "Account not supported",
-      "not_supported_hardware_account_description": "Hardware wallet accounts are not eligible to receive rewards yet. Please switch to a different account to proceed.",
-      "not_supported_account_type_title": "Account type not supported",
-      "not_supported_account_type_description": "Currently only internal Ethereum and Solana accounts can be opted into the Rewards program. Please switch to a different account to proceed.",
-      "not_supported_confirm_go_back": "Go back",
-      "not_supported_confirm_retry": "Retry",
-      "auth_fail_title": "Authentication Failed",
-      "auth_fail_description": "Unable to authenticate with the rewards program. Please check your connection and try again.",
-      "geo_check_fail_title": "Cannot determine opt-in eligibility",
-      "geo_check_fail_description": "We cannot determine if your country allows opting into the rewards program. Please check your connection and try again.",
+      "not_supported_region_description": "您所在地区暂不支持奖励计划。我们正在努力拓展覆盖范围，敬请期待后续更新。",
+      "not_supported_hardware_account_title": "账户不受支持",
+      "not_supported_hardware_account_description": "硬件钱包账户暂不符合奖励领取资格。请切换至其他账户继续操作。",
+      "not_supported_account_type_title": "账户类型不受支持",
+      "not_supported_account_type_description": "目前仅限内部以太坊及 Solana 账户可参与奖励计划。请切换至其他账户继续操作。",
+      "not_supported_confirm_go_back": "返回",
+      "not_supported_confirm_retry": "重试",
+      "auth_fail_title": "认证失败",
+      "auth_fail_description": "奖励计划认证失败。请检查连接后重试。",
+      "geo_check_fail_title": "无法确定参与资格",
+      "geo_check_fail_description": "我们暂时无法确定您所在国家/地区是否允许参与奖励计划。请检查连接后重试。",
       "gtm_title": "奖励已到",
       "gtm_description": "通过活动赚取积分。 \n提升等级即可解锁奖励。",
       "gtm_confirm": "开始",
       "intro_title": "第 1 季\n已上线",
-      "intro_description": "Earn points for your activity. \nAdvance through levels to unlock rewards.",
-      "intro_confirm": "Claim 250 points",
-      "intro_confirm_geo_loading": "Checking region...",
-      "checking_opt_in": "Checking accounts...",
-      "redirecting_to_dashboard": "Redirecting...",
+      "intro_description": "通过活动赚取积分。 \n提升等级即可解锁奖励。",
+      "intro_confirm": "领取 250 积分",
+      "intro_confirm_geo_loading": "正在检查地区……",
+      "checking_opt_in": "正在检查账户……",
+      "redirecting_to_dashboard": "正在重定向……",
       "intro_skip": "暂时不",
       "step_confirm": "下一步",
-      "step_skip": "Skip",
-      "step1_title": "Earn points on every trade",
+      "step_skip": "跳过",
+      "step1_title": "每笔交易均可赚取积分",
       "step1_description": "您在 MetaMask 进行的每次兑换和永续合约交易都将助您加速解锁奖励。添加您的账户，见证积分不断累积。",
-      "step2_title": "Level up for bigger perks",
+      "step2_title": "升级以获取更多福利",
       "step2_description": "达成积分里程碑可享专属福利：永续合约手续费5折优惠、独家代币及免费 MetaMask Metal Card 等。",
-      "step3_title": "Exclusive seasonal rewards",
-      "step3_description": "Each season brings new perks. Join in, compete, and claim what you can before time runs out.",
-      "step4_title": "You'll earn 250 points when you sign up!",
-      "step4_title_referral_validating": "Validating referral code...",
-      "step4_referral_input_placeholder": "Referral code (optional)",
-      "step4_referral_input_error": "Invalid referral code",
-      "step4_confirm": "Claim points",
-      "step4_confirm_loading": "Claiming points...",
-      "step4_linking_accounts": "Adding accounts... ({{current}}/{{total}})",
-      "step4_linking_accounts_loading": "Adding additional accounts...",
-      "step4_success_description": "You have successfully signed up for MetaMask Rewards!",
-      "step4_legal_disclaimer_1": "By selecting 'Claim Points', you agree to the MetaMask Rewards",
-      "step4_legal_disclaimer_2": "Supplemental Terms of Use and Privacy Notice",
-      "step4_legal_disclaimer_3": ". We'll track onchain activity to reward you automatically –",
-      "step4_legal_disclaimer_4": "learn more"
+      "step3_title": "专属赛季奖励",
+      "step3_description": "每季都有全新福利。立即参与，展开竞争，在活动结束前将属于您的奖励收入囊中。",
+      "step4_title": "注册即可赚取 250 积分！",
+      "step4_title_referral_bonus": "You'll earn 500 points when you sign up with this code!",
+      "step4_title_referral_validating": "正在验证推荐码……",
+      "step4_referral_bonus_description": "Use a referral code to earn 250 more",
+      "step4_referral_input_placeholder": "推荐码（可选）",
+      "step4_referral_input_error": "推荐码无效",
+      "step4_confirm": "领取积分",
+      "step4_confirm_loading": "正在领取积分……",
+      "step4_linking_accounts": "正在添加账户……({{current}}/{{total}})",
+      "step4_linking_accounts_loading": "正在添加额外账户……",
+      "step4_success_description": "您已成功注册 MetaMask 奖励计划！",
+      "step4_legal_disclaimer_1": "选择“领取积分”即表示您同意 MetaMask 奖励计划",
+      "step4_legal_disclaimer_2": "补充使用条款及隐私声明",
+      "step4_legal_disclaimer_3": "。我们将通过追踪链上活动为您自动发放奖励——",
+      "step4_legal_disclaimer_4": "了解详情"
     },
     "settings": {
-      "title": "Rewards Settings",
-      "subtitle": "Accounts",
-      "description": "Add multiple accounts to combine your points and unlock rewards faster.",
-      "tab_linked_accounts": "Added ({{count}})",
-      "tab_unlinked_accounts": "Not added ({{count}})",
-      "no_linked_accounts": "No accounts opted in",
-      "all_accounts_linked_title": "All accounts opted in",
-      "all_accounts_linked_description": "You have added all your accounts to Rewards.",
-      "link_account_success_title": "{{accountName}} successfully added",
-      "link_account_error_title": "Failed to add account",
-      "link_account_button": "Add",
-      "link_account_failed_error": "Failed to link account",
-      "link_account_unknown_error": "Unknown error occurred"
+      "title": "奖励计划设置",
+      "subtitle": "账户",
+      "description": "添加多个账户即可合并积分并加速解锁奖励。",
+      "tab_linked_accounts": "已添加（{{count}}）",
+      "tab_unlinked_accounts": "未添加（{{count}}）",
+      "no_linked_accounts": "暂无账户参与",
+      "all_accounts_linked_title": "所有账户均已加入",
+      "all_accounts_linked_description": "您已将所有账户添加至奖励计划。",
+      "link_account_success_title": "{{accountName}} 已成功添加",
+      "link_account_error_title": "添加账户失败",
+      "link_account_button": "添加",
+      "link_account_failed_error": "关联账户失败",
+      "link_account_unknown_error": "发生未知错误"
     },
     "optout": {
-      "title": "Opt out of Rewards",
-      "description": "This will remove your accounts from the Rewards program and erase your points and progress. You won't be able to undo this.",
-      "confirm": "Opt out",
+      "title": "退出奖励计划",
+      "description": "此操作将从奖励计划中移除您的账户，并清空您的积分与进度记录。此操作无法撤销。",
+      "confirm": "退出",
       "modal": {
-        "confirmation_title": "Are you sure?",
-        "confirmation_description": "This will remove all your progress, and can't be reversed. If you rejoin the Rewards program later, you'll start back at 0.",
-        "cancel": "Cancel",
-        "confirm": "Confirm",
-        "error_message": "Failed to opt out of Rewards. Please try again.",
-        "processing": "Processing..."
+        "confirmation_title": "您确定吗？",
+        "confirmation_description": "此操作将清除您所有的进度，且无法撤销。若您日后重新加入奖励计划，将从 0 开始累积。",
+        "cancel": "取消",
+        "confirm": "确认",
+        "error_message": "退出奖励计划失败。请重试。",
+        "processing": "处理中..."
       }
     },
-    "toast_dismiss": "Dismiss",
+    "toast_dismiss": "忽略",
     "dashboard_modal_info": {
       "active_account": {
-        "title": "Don't miss out",
-        "description": "Add your account to start earning points from your activity.",
-        "confirm": "Add account"
+        "title": "切勿错过",
+        "description": "添加您的账户，即可开始通过活动赚取积分。",
+        "confirm": "添加账户"
       },
       "multiple_unlinked_accounts": {
-        "title": "Start earning points",
-        "description": "Add your accounts so you can track your rewards at a glance.",
-        "confirm": "Add accounts"
+        "title": "开始赚取积分",
+        "description": "添加您的账户，即可一目了然地追踪奖励。",
+        "confirm": "添加账户"
       },
       "account_not_supported": {
-        "title": "Account not supported",
-        "description_hardware": "Hardware wallet accounts are not yet eligible to earn points. Please switch to a different account to proceed.",
-        "description_general": "Currently only non-hardware internal Ethereum and Solana accounts are eligible to earn points. Please switch to a different account to proceed.",
-        "confirm": "Go back"
+        "title": "账户不受支持",
+        "description_hardware": "硬件钱包账户暂不符合赚取积分资格。请切换至其他账户继续操作。",
+        "description_general": "目前仅限非硬件内部以太坊及 Solana 账户可赚取积分。请切换至其他账户继续操作。",
+        "confirm": "返回"
       }
     },
     "ways_to_earn": {
-      "title": "Ways to earn",
-      "supported_networks": "Supported Networks",
+      "title": "赚取方式",
+      "supported_networks": "支持的网络",
       "swap": {
-        "title": "Swap",
-        "description": "80 points per $100",
+        "title": "兑换",
+        "description": "每 800 美元 10 积分",
         "sheet": {
-          "title": "Swap tokens",
-          "points": "80 points per $100",
-          "description": "Swap tokens on supported networks to earn points for every dollar you trade.",
-          "cta_label": "Start a swap"
+          "title": "兑换代币",
+          "points": "每 800 美元 10 积分",
+          "description": "在支持的网络上兑换代币，每交易一美元即可赚取积分。",
+          "cta_label": "开始兑换"
         }
       },
       "perps": {
@@ -6045,52 +6242,74 @@
         }
       },
       "referrals": {
-        "title": "Refer friends",
-        "description": "10 points per 50 from friends"
+        "title": "推荐好友",
+        "description": "好友每获得 50 积分，您可获 10 积分",
+        "sheet": {
+          "title": "Refer a friend",
+          "points": "20 points per 100",
+          "cta_label": "Refer a friend"
+        }
       },
       "loyalty": {
-        "title": "Loyalty bonus",
-        "description": "Earn points from past trades",
+        "title": "忠诚奖励",
+        "description": "从历史交易赚取积分",
         "sheet": {
-          "title": "Loyalty bonus",
-          "points": "250 points per $1250",
-          "description": "Add accounts with past swaps or bridges in MetaMask to earn loyalty bonuses. Each eligible account unlocks points in increments of 250, up to a total of 50,000. Bonuses appear shortly after you add an account.",
-          "cta_label": "Add accounts"
+          "title": "忠诚奖励",
+          "points": "每 1250 美元 250 积分",
+          "description": "添加在 MetaMask 中进行过兑换或跨链桥操作的账户，即可获取忠诚奖励。每个符合条件的账户将以 250 积分为单位递增解锁奖励，累计最高可达 50000 积分。奖励将在添加账户稍后显示。",
+          "cta_label": "添加账户"
+        }
+      },
+      "card": {
+        "title": "MetaMask Card",
+        "description": "1 point per $1 spent",
+        "sheet": {
+          "title": "MetaMask Card",
+          "points": "1 point per $1 spent",
+          "description": "Earn points every time you use your MetaMask Card for purchases, plus 1% cash back (3% for Metal cardholders).",
+          "cta_label": "Manage Card"
         }
       }
     },
     "referral": {
-      "referral_code": "Referral code",
-      "referral_link": "Referral link",
+      "referral_code": "推荐码",
+      "referral_link": "推荐链接",
       "actions": {
         "share_referral_link": "推荐好友",
         "share_referral_subject": "加入 MetaMask Rewards"
       },
       "info": {
         "title": "分享您的邀请码以赚取更多",
-        "description": "Your friends get a 2x sign up bonus. You get 10 points for every 50 they earn from trading."
+        "description": "您的好友可获得双倍注册奖励。他们通过交易每赚取 50 积分，您可同步获得 10 积分。"
       }
     },
-    "active_boosts_title": "Active boosts",
-    "season_1": "Season 1",
+    "link_account_group": {
+      "link_account": "Add account",
+      "tracked": "Tracked",
+      "untracked": "Untracked",
+      "link_account_success": "{{accountName}} added successfully",
+      "link_account_error": "Failed to add one or more addresses for {{accountName}}"
+    },
+    "active_boosts_title": "活跃加成",
+    "season_1": "第 1 季",
     "upcoming_rewards": {
       "title": "锁定的奖励",
-      "points_needed": "{{points}} points",
+      "points_needed": "{{points}} 积分",
       "cta_label": "知道了",
-      "alpha_fox_invite_input_placeholder": "Your Telegram handle"
+      "alpha_fox_invite_input_placeholder": "您的 Telegram 用户名"
     },
     "unlocked_rewards": {
-      "title": "Unlocked rewards",
-      "cta_label": "Claim now",
-      "cta_request_invite": "Request invite",
-      "claim_label": "Claim",
-      "claimed_label": "Claimed",
-      "reward_claimed": "Reward claimed",
+      "title": "已解锁奖励",
+      "cta_label": "立即领取",
+      "cta_request_invite": "请求邀请",
+      "claim_label": "领取",
+      "claimed_label": "已领取",
+      "reward_claimed": "已领取奖励",
       "time_left": "剩余时间",
-      "expired": "Expired"
+      "expired": "已过期"
     },
     "animation": {
-      "could_not_load": "Couldn't load"
+      "could_not_load": "无法加载"
     }
   },
   "time": {
@@ -6099,7 +6318,7 @@
   },
   "transaction_details": {
     "title": {
-      "perps_deposit": "Funded Perps account",
+      "perps_deposit": "已注资的永续合约账户",
       "predict_deposit": "Funded Predict account",
       "default": "交易详情"
     },
@@ -6107,19 +6326,23 @@
       "bridge_fee": "跨链桥费用",
       "network_fee": "网络费",
       "paid_with": "已使用以下支付方式付款：",
+      "retry_button": "Try again",
       "total": "总额"
     },
     "summary_title": {
-      "bridge": "从 {{sourceSymbol}} 桥接至 {{targetSymbol}}",
       "bridge_approval": "批准 {{approveSymbol}}",
       "bridge_approval_loading": "批准",
-      "bridge_loading": "桥接",
+      "bridge_send": "Bridge {{sourceSymbol}} from {{sourceChain}}",
+      "bridge_send_loading": "Bridge Send",
+      "bridge_receive": "Receive {{targetSymbol}} on {{targetChain}}",
+      "bridge_receive_loading": "Bridge Receive",
       "default": "交易",
       "perps_deposit": "充值",
       "predict_deposit": "Add funds",
       "swap": "兑换代币",
       "swap_approval": "批准代币"
-    }
+    },
+    "perps_deposit_solution": "You now have {{fiat}} of USDC on Arbitrum. Try your deposit again."
   },
   "sdk_connect_v2": {
     "show_loading": {


### PR DESCRIPTION

CHANGELOG entry: chore: New Crowdin translations by Github Action (https://github.com/MetaMask/metamask-mobile/pull/21379)

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates many locale files with new and corrected strings for deposit limits, Predict flows (deposit/claims/transactions), Rewards screens, Card onboarding/auth, tooltips, market stats, and transaction details.
> 
> - **Internationalization (multiple languages)**
>   - Add/adjust strings for: deposit limits (`limitExceeded`, `limitError`), connection timeout, and in-progress states.
>   - Expand **Predict**: deposit flow, add-funds sheet, transactions list, claim toasts, and `predict_claim` UI.
>   - Update **Rewards**: error messages, onboarding flows, settings/opt-out, events, ways-to-earn, and account linking.
>   - Add **Card**: onboarding KYC flows, address forms, auth/login errors, manage spending limit texts, and “Always show MetaMask Card” experimental setting.
>   - Improve **Markets/Perps**: 24h stats labels, order history terms (liquidated/TP/SL), tutorial footers/tooltips, and points tooltips.
>   - Enhance **Transaction details**: bridge send/receive titles, retry button, `perps_deposit_solution`, and title translations.
>   - Add **Unsupported page** texts and various small translation fixes across locales.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae627d1ee1b49e9f12781b508e713f6f9ec4980e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->