### PR TITLE
fix(predict): small ui/ux fixes

### DIFF
--- a/app/components/UI/Predict/components/PredictKeypad/PredictKeypad.tsx
+++ b/app/components/UI/Predict/components/PredictKeypad/PredictKeypad.tsx
@@ -147,7 +147,7 @@ const PredictKeypad = forwardRef<PredictKeypadHandles, PredictKeypadProps>(
             style={tw.style('flex-1')}
           />
           <Button
-            variant={ButtonVariants.Secondary}
+            variant={ButtonVariants.Primary}
             size={ButtonSize.Md}
             label="Done"
             onPress={handleDonePress}

--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.test.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.test.tsx
@@ -470,9 +470,9 @@ describe('MarketsWonCard', () => {
     });
 
     it('formats available balance to 2 decimal places', () => {
-      setupMarketsWonCardTest({ availableBalance: 123.456 });
+      setupMarketsWonCardTest({ availableBalance: 123.4321 });
 
-      expect(screen.getByText('$123.456')).toBeOnTheScreen();
+      expect(screen.getByText('$123.43')).toBeOnTheScreen();
     });
 
     it('formats claimable amount to 2 decimal places', () => {

--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
@@ -202,7 +202,7 @@ const PredictPositionsHeader = forwardRef<PredictPositionsHeaderHandle>(
                       twClassName="text-primary mr-1"
                       testID="claimable-amount"
                     >
-                      {formatPrice(balance)}
+                      {formatPrice(balance, { maximumDecimals: 2 })}
                     </Text>
                     <Icon
                       name={IconName.ArrowRight}

--- a/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.test.tsx
@@ -403,9 +403,6 @@ describe('PredictBuyPreview', () => {
       });
 
       expect(mockDispatch).toHaveBeenCalledWith(StackActions.pop());
-      expect(mockDispatch).toHaveBeenCalledWith(
-        StackActions.replace('PredictMarketList'),
-      );
     });
 
     it('disables place bet button when loading', () => {

--- a/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
+++ b/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
@@ -26,7 +26,6 @@ import Text, {
   TextColor,
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
-import Routes from '../../../../../constants/navigation/Routes';
 import { usePredictPlaceOrder } from '../../hooks/usePredictPlaceOrder';
 import { usePredictOrderPreview } from '../../hooks/usePredictOrderPreview';
 import { Side } from '../../types';
@@ -87,7 +86,6 @@ const PredictBuyPreview = () => {
     });
     try {
       dispatch(StackActions.pop());
-      dispatch(StackActions.replace(Routes.PREDICT.MARKET_LIST));
     } catch (error) {
       // Navigation errors should not prevent the bet from being placed
       console.warn('Navigation error after placing bet:', error);

--- a/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.test.tsx
+++ b/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.test.tsx
@@ -430,9 +430,6 @@ describe('PredictSellPreview', () => {
       });
 
       expect(mockDispatch).toHaveBeenCalledWith(StackActions.pop());
-      expect(mockDispatch).toHaveBeenCalledWith(
-        StackActions.replace('PredictMarketList'),
-      );
     });
 
     it('disables cash out button when loading', () => {
@@ -511,9 +508,6 @@ describe('PredictSellPreview', () => {
       fireEvent.press(cashOutButton);
 
       expect(mockDispatch).toHaveBeenCalledWith(StackActions.pop());
-      expect(mockDispatch).toHaveBeenCalledWith(
-        StackActions.replace('PredictMarketList'),
-      );
     });
 
     it('uses correct route params', () => {

--- a/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.tsx
+++ b/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.tsx
@@ -16,7 +16,6 @@ import Text, {
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../../component-library/hooks/useStyles';
-import Routes from '../../../../../constants/navigation/Routes';
 import { useTheme } from '../../../../../util/theme';
 import { usePredictOrderPreview } from '../../hooks/usePredictOrderPreview';
 import { usePredictPlaceOrder } from '../../hooks/usePredictPlaceOrder';
@@ -44,10 +43,7 @@ const PredictSellPreview = () => {
   const { placeOrder, isLoading } = usePredictPlaceOrder({
     onComplete: () => {
       try {
-        // TODO: fix this logic. This only seems to pop the stack once, but does not
-        // navigate to the market details screen
         dispatch(StackActions.pop());
-        dispatch(StackActions.replace(Routes.PREDICT.MARKET_LIST));
       } catch (error) {
         // Navigation errors shouldn't prevent the order from being considered successful
         console.warn('Navigation error after successful cash out:', error);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
- fix PredictKeypad done button color
- after order confirmation, simply pop the stack (no redirects)
- adjust max decimas for predict balance

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes the keypad Done button primary, limits displayed balances to 2 decimals, and after placing orders only pops the navigation stack (no redirects).
> 
> - **Predict UI**:
>   - **Keypad**: `PredictKeypad` sets `"Done"` button to `Primary` variant.
>   - **Positions Header**: Formats available balance via `formatPrice(balance, { maximumDecimals: 2 })`; tests updated accordingly.
>   - **Buy/Sell Preview**:
>     - After placing orders, only dispatches `StackActions.pop()`; removes `StackActions.replace(Routes.PREDICT.MARKET_LIST)` and related imports/tests.
>     - Minor test adjustments to reflect new navigation behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 639e3c01c8bf50f877d378ca368e9fde56398afd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->