### PR TITLE
fix: fixed issue where button is cutt off and keyboard aware scroll d…

### DIFF
--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
@@ -1,20 +1,15 @@
 /* eslint-disable */
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import React, { PureComponent } from 'react';
 import {
-  StyleSheet,
   View,
   TextInput,
   SafeAreaView,
   Linking,
+  KeyboardAvoidingView,
 } from 'react-native';
-import { connect } from 'react-redux';
-import { typography } from '@metamask/design-tokens';
 import isUrl from 'is-url';
-import {
-  fontStyles,
-  colors as staticColors,
-} from '../../../../../styles/common';
 import { getNavigationOptionsTitle } from '../../../../UI/Navbar';
 import { strings } from '../../../../../../locales/i18n';
 import Networks, {
@@ -46,7 +41,6 @@ import sanitizeUrl, {
 } from '../../../../../util/sanitizeUrl';
 import onlyKeepHost from '../../../../../util/onlyKeepHost';
 import { themeAppearanceLight } from '../../../../../constants/storage';
-import { scale, moderateScale } from 'react-native-size-matters';
 import CustomNetwork from './CustomNetworkView/CustomNetwork';
 import Button, {
   ButtonVariants,
@@ -88,10 +82,8 @@ import ButtonPrimary from '../../../../../component-library/components/Buttons/B
 import { RpcEndpointType } from '@metamask/network-controller';
 import { AvatarVariant } from '../../../../../component-library/components/Avatars/Avatar';
 import ReusableModal from '../../../../../components/UI/ReusableModal';
-import Device from '../../../../../util/device';
 import { ScrollView } from 'react-native-gesture-handler';
 import Text, {
-  getFontFamily,
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
 import { DEFAULT_CELLBASE_AVATAR_TITLE_TEXTVARIANT } from '../../../../../component-library/components/Cells/Cell/foundation/CellBase/CellBase.constants';
@@ -106,303 +98,11 @@ import {
 } from '../../../../../util/metrics/MultichainAPI/networkMetricUtils';
 import { isRemoveGlobalNetworkSelectorEnabled } from '../../../../../util/networks';
 import { NETWORK_TO_NAME_MAP } from '../../../../../core/Engine/constants';
+import { createStyles } from './index.styles';
 
 const formatNetworkRpcUrl = (rpcUrl) => {
   return stripProtocol(stripKeyFromInfuraUrl(rpcUrl));
 };
-
-const createStyles = (colors) =>
-  StyleSheet.create({
-    baseAll: {
-      padding: 16,
-    },
-    addRpcButton: {
-      position: 'absolute',
-      alignSelf: 'center',
-    },
-    screen: {
-      flex: 1,
-      paddingHorizontal: 24,
-      paddingVertical: 16,
-      justifyContent: 'space-between',
-      alignItems: 'center',
-      backgroundColor: colors.background.default,
-    },
-    container: {
-      flex: 1,
-    },
-    headerText: {
-      fontSize: 18,
-      fontWeight: 'bold',
-    },
-    scrollViewContent: {
-      paddingBottom: 16,
-    },
-    scrollableBox: {
-      height: 164,
-      marginVertical: 10,
-      justifyContent: 'center',
-      alignItems: 'center',
-      alignSelf: 'center',
-      bottom: 64,
-    },
-    footer: {
-      height: 60,
-      justifyContent: 'center',
-      alignItems: 'center',
-      position: 'absolute',
-      bottom: 16,
-      left: 0,
-      right: 0,
-      zIndex: 10, // Ensures it stays on top of other components
-    },
-    content: {
-      justifyContent: 'center',
-      paddingHorizontal: 16,
-      flexGrow: 1,
-    },
-    addRpcNameButton: {
-      paddingTop: 32,
-      alignSelf: 'center',
-    },
-    sheet: {
-      flexDirection: 'column',
-      bottom: 0,
-      top: Device.getDeviceHeight() * 0.5,
-      backgroundColor: colors.background.default,
-      borderTopLeftRadius: 10,
-      borderTopRightRadius: 10,
-      height: Device.getDeviceHeight() * 0.5,
-    },
-    sheetSmall: {
-      position: 'absolute',
-      bottom: 0,
-      top: Device.getDeviceHeight() * 0.7,
-      backgroundColor: colors.background.default,
-      borderTopLeftRadius: 10,
-      borderTopRightRadius: 10,
-      height: Device.getDeviceHeight() * 0.3,
-    },
-    sheetRpcForm: {
-      position: 'absolute',
-      bottom: 0,
-      top: Device.getDeviceHeight() * 0.3,
-      backgroundColor: colors.background.default,
-      borderTopLeftRadius: 10,
-      borderTopRightRadius: 10,
-    },
-    notch: {
-      width: 48,
-      height: 5,
-      borderRadius: 4,
-      backgroundColor: colors.border.default,
-      marginTop: 4,
-      alignSelf: 'center',
-    },
-    rpcMenu: {
-      paddingHorizontal: 16,
-      flex: 1,
-    },
-    wrapper: {
-      backgroundColor: colors.background.default,
-      flexGrow: 1,
-      flexDirection: 'column',
-    },
-    informationWrapper: {
-      flex: 1,
-      paddingHorizontal: 16,
-    },
-    informationCustomWrapper: {},
-    scrollWrapper: {
-      flex: 1,
-      paddingVertical: 12,
-    },
-    scrollWrapperOverlay: {
-      flex: 1,
-      paddingVertical: 12,
-      opacity: 0.5,
-    },
-    onboardingInput: {
-      borderColor: staticColors.transparent,
-      padding: 0,
-    },
-    inputDisabled: {
-      borderColor: colors.border.muted,
-      color: colors.text.muted,
-    },
-    input: {
-      ...fontStyles.normal,
-      borderColor: colors.border.default,
-      borderRadius: 5,
-      borderWidth: 2,
-      padding: 10,
-      color: colors.text.default,
-    },
-    dropDownInput: {
-      borderColor: colors.border.default,
-      borderRadius: 5,
-      borderWidth: 2,
-    },
-    inputWithError: {
-      ...typography.sBodyMD,
-      fontFamily: getFontFamily(TextVariant.BodyMD),
-      borderColor: colors.error.default,
-      borderRadius: 5,
-      borderWidth: 1,
-      paddingTop: 2,
-      paddingBottom: 12,
-      paddingHorizontal: 12,
-      color: colors.text.default,
-    },
-    inputWithFocus: {
-      ...typography.sBodyMD,
-      fontFamily: getFontFamily(TextVariant.BodyMD),
-      borderColor: colors.primary.default,
-      borderRadius: 5,
-      borderWidth: 2,
-      paddingTop: 2,
-      paddingBottom: 12,
-      paddingHorizontal: 12,
-      color: colors.text.default,
-    },
-    warningText: {
-      ...fontStyles.normal,
-      color: colors.error.default,
-      marginTop: 4,
-      paddingLeft: 2,
-      paddingRight: 4,
-    },
-    warningContainer: {
-      marginTop: 16,
-      flexGrow: 1,
-      flexShrink: 1,
-    },
-    newWarningContainer: {
-      flexGrow: 1,
-      flexShrink: 1,
-    },
-    heading: {
-      fontSize: 16,
-      color: colors.text.default,
-      ...fontStyles.bold,
-    },
-    label: {
-      fontSize: 14,
-      paddingVertical: 12,
-      color: colors.text.default,
-      ...fontStyles.bold,
-    },
-    link: {
-      color: colors.primary.default,
-    },
-    title: {
-      fontSize: 20,
-      paddingVertical: 12,
-      color: colors.text.default,
-      ...fontStyles.bold,
-    },
-    desc: {
-      fontSize: 14,
-      color: colors.text.default,
-      ...fontStyles.normal,
-    },
-    messageWarning: {
-      paddingVertical: 2,
-      fontSize: 14,
-      color: colors.warning.default,
-      ...typography.sBodyMD,
-      fontFamily: getFontFamily(TextVariant.BodyMD),
-    },
-    suggestionButton: {
-      color: colors.text.default,
-      paddingLeft: 2,
-      paddingRight: 4,
-      marginTop: 4,
-    },
-    inlineWarning: {
-      paddingVertical: 2,
-      fontSize: 14,
-      color: colors.text.default,
-      ...typography.sBodyMD,
-      fontFamily: getFontFamily(TextVariant.BodyMD),
-    },
-    inlineWarningMessage: {
-      paddingVertical: 2,
-      color: colors.warning.default,
-      ...typography.sBodyMD,
-      fontFamily: getFontFamily(TextVariant.BodyMD),
-    },
-    buttonsWrapper: {
-      marginVertical: 12,
-      flexDirection: 'row',
-      alignSelf: 'flex-end',
-    },
-    buttonsContainer: {
-      flex: 1,
-      flexDirection: 'column',
-      alignSelf: 'flex-end',
-    },
-    editableButtonsContainer: {
-      flex: 1,
-      flexDirection: 'row',
-    },
-    networksWrapper: {
-      marginTop: 12,
-    },
-    popularNetwork: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      justifyContent: 'space-between',
-      marginVertical: 12,
-    },
-    tabUnderlineStyle: {
-      height: 2,
-      backgroundColor: colors.primary.default,
-    },
-    tabStyle: {
-      paddingVertical: 8,
-    },
-    textStyle: {
-      ...fontStyles.bold,
-      fontSize: 14,
-    },
-    popularNetworkImage: {
-      width: 20,
-      height: 20,
-      marginRight: 10,
-      borderRadius: 10,
-    },
-    popularWrapper: {
-      flexDirection: 'row',
-      alignItems: 'center',
-    },
-    icon: {
-      marginRight: moderateScale(12, 1.5),
-      marginTop: 4,
-    },
-    button: {
-      flex: 1,
-    },
-    disabledButton: {
-      backgroundColor: colors.primary.muted,
-    },
-    cancel: {
-      marginRight: 16,
-    },
-    blueText: {
-      color: colors.primary.default,
-      marginTop: 1,
-    },
-    bottomSection: {
-      flex: 1,
-      flexDirection: 'column',
-    },
-    rpcTitleWrapper: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      gap: 4,
-    },
-  });
 
 const allNetworks = getAllNetworks();
 
@@ -2201,22 +1901,26 @@ export class NetworkSettings extends PureComponent {
             shouldGoBack={false}
           >
             <View style={styles.notch} />
-            <BottomSheetHeader
-              onBack={() => {
-                this.closeAddRpcForm();
-                this.openRpcModal();
-              }}
-              style={styles.baseAll}
-            >
-              <Text style={styles.heading}>
-                {strings('app_settings.add_rpc_url')}
-              </Text>
-            </BottomSheetHeader>
-            <KeyboardAwareScrollView
-              enableOnAndroid
-              keyboardShouldPersistTaps="handled"
-            >
-              <SafeAreaView style={styles.rpcMenu}>
+            <View style={styles.container}>
+              {/* Sticky Header */}
+              <BottomSheetHeader
+                onBack={() => {
+                  this.closeAddRpcForm();
+                  this.openRpcModal();
+                }}
+                style={styles.baseAll}
+              >
+                <Text style={styles.heading}>
+                  {strings('app_settings.add_rpc_url')}
+                </Text>
+              </BottomSheetHeader>
+              {/* Keyboard Aware Scrollable Middle Content */}
+              <KeyboardAwareScrollView
+                enableOnAndroid
+                keyboardShouldPersistTaps="handled"
+                extraScrollHeight={80}
+              >
+                {/* URL Input */}
                 <Text style={styles.label}>
                   {strings('app_settings.network_rpc_url_label')}
                 </Text>
@@ -2239,6 +1943,7 @@ export class NetworkSettings extends PureComponent {
                     <Text style={styles.warningText}>{warningRpcUrl}</Text>
                   </View>
                 )}
+                {/* RPC Name Input */}
                 <Text style={styles.label}>
                   {strings('app_settings.network_rpc_name_label')}
                 </Text>
@@ -2255,7 +1960,8 @@ export class NetworkSettings extends PureComponent {
                   testID={NetworksViewSelectorsIDs.RPC_NAME_INPUT}
                   keyboardAppearance={themeAppearance}
                 />
-                <View style={styles.addRpcNameButton}>
+                {/* Add RPC Button */}
+                <View style={styles.scrollableBox}>
                   <ButtonPrimary
                     label={strings('app_settings.add_rpc_url')}
                     size={ButtonSize.Lg}
@@ -2268,8 +1974,8 @@ export class NetworkSettings extends PureComponent {
                     testID={NetworksViewSelectorsIDs.ADD_RPC_BUTTON}
                   />
                 </View>
-              </SafeAreaView>
-            </KeyboardAwareScrollView>
+              </KeyboardAwareScrollView>
+            </View>
           </ReusableModal>
         ) : null}
         {isNetworkUiRedesignEnabled() && showAddBlockExplorerForm.isVisible ? (

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.styles.js
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.styles.js
@@ -1,0 +1,241 @@
+import { typography } from '@metamask/design-tokens';
+import { StyleSheet } from 'react-native';
+import Device from '../../../../../util/device';
+import {
+  fontStyles,
+  colors as staticColors,
+} from '../../../../../styles/common';
+import {
+  getFontFamily,
+  TextVariant,
+} from '../../../../../component-library/components/Texts/Text';
+
+export const createStyles = (colors) =>
+  StyleSheet.create({
+    baseAll: {
+      padding: 16,
+    },
+    container: {
+      flex: 1,
+    },
+    scrollViewContent: {
+      height: '100%',
+    },
+    scrollableBox: {
+      marginTop: 24,
+      justifyContent: 'center',
+      alignItems: 'center',
+      alignSelf: 'center',
+    },
+    addRpcNameButton: {
+      paddingTop: 32,
+      alignSelf: 'center',
+    },
+    sheet: {
+      flexDirection: 'column',
+      bottom: 0,
+      top: Device.getDeviceHeight() * 0.5,
+      backgroundColor: colors.background.default,
+      borderTopLeftRadius: 10,
+      borderTopRightRadius: 10,
+      height: Device.getDeviceHeight() * 0.5,
+    },
+    sheetSmall: {
+      position: 'absolute',
+      bottom: 0,
+      top: Device.getDeviceHeight() * 0.7,
+      backgroundColor: colors.background.default,
+      borderTopLeftRadius: 10,
+      borderTopRightRadius: 10,
+      height: Device.getDeviceHeight() * 0.3,
+    },
+    sheetRpcForm: {
+      position: 'absolute',
+      bottom: 0,
+      top: Device.getDeviceHeight() * 0.3,
+      backgroundColor: colors.background.default,
+      borderTopLeftRadius: 10,
+      borderTopRightRadius: 10,
+      height: '100%',
+    },
+    notch: {
+      width: 48,
+      height: 5,
+      borderRadius: 4,
+      backgroundColor: colors.border.default,
+      marginTop: 4,
+      alignSelf: 'center',
+    },
+    rpcMenu: {
+      paddingHorizontal: 16,
+      flex: 1,
+    },
+    wrapper: {
+      backgroundColor: colors.background.default,
+      flexGrow: 1,
+      flexDirection: 'column',
+    },
+    informationWrapper: {
+      flex: 1,
+      paddingHorizontal: 16,
+    },
+    informationCustomWrapper: {},
+    scrollWrapper: {
+      flex: 1,
+      paddingVertical: 12,
+    },
+    scrollWrapperOverlay: {
+      flex: 1,
+      paddingVertical: 12,
+      opacity: 0.5,
+    },
+    onboardingInput: {
+      borderColor: staticColors.transparent,
+      padding: 0,
+    },
+    inputDisabled: {
+      borderColor: colors.border.muted,
+      color: colors.text.muted,
+    },
+    input: {
+      ...fontStyles.normal,
+      borderColor: colors.border.default,
+      borderRadius: 5,
+      borderWidth: 2,
+      padding: 10,
+      color: colors.text.default,
+    },
+    dropDownInput: {
+      borderColor: colors.border.default,
+      borderRadius: 5,
+      borderWidth: 2,
+    },
+    inputWithError: {
+      ...typography.sBodyMD,
+      fontFamily: getFontFamily(TextVariant.BodyMD),
+      borderColor: colors.error.default,
+      borderRadius: 5,
+      borderWidth: 1,
+      paddingTop: 2,
+      paddingBottom: 12,
+      paddingHorizontal: 12,
+      color: colors.text.default,
+    },
+    inputWithFocus: {
+      ...typography.sBodyMD,
+      fontFamily: getFontFamily(TextVariant.BodyMD),
+      borderColor: colors.primary.default,
+      borderRadius: 5,
+      borderWidth: 2,
+      paddingTop: 2,
+      paddingBottom: 12,
+      paddingHorizontal: 12,
+      color: colors.text.default,
+    },
+    warningText: {
+      ...fontStyles.normal,
+      color: colors.error.default,
+      marginTop: 4,
+      paddingLeft: 2,
+      paddingRight: 4,
+    },
+    warningContainer: {
+      marginTop: 16,
+      flexGrow: 1,
+      flexShrink: 1,
+    },
+    newWarningContainer: {
+      flexGrow: 1,
+      flexShrink: 1,
+    },
+    heading: {
+      fontSize: 16,
+      color: colors.text.default,
+      ...fontStyles.bold,
+    },
+    label: {
+      fontSize: 14,
+      paddingVertical: 12,
+      color: colors.text.default,
+      ...fontStyles.bold,
+    },
+    link: {
+      color: colors.primary.default,
+    },
+    title: {
+      fontSize: 20,
+      paddingVertical: 12,
+      color: colors.text.default,
+      ...fontStyles.bold,
+    },
+    desc: {
+      fontSize: 14,
+      color: colors.text.default,
+      ...fontStyles.normal,
+    },
+    messageWarning: {
+      paddingVertical: 2,
+      fontSize: 14,
+      color: colors.warning.default,
+      ...typography.sBodyMD,
+      fontFamily: getFontFamily(TextVariant.BodyMD),
+    },
+    inlineWarning: {
+      paddingVertical: 2,
+      fontSize: 14,
+      color: colors.text.default,
+      ...typography.sBodyMD,
+      fontFamily: getFontFamily(TextVariant.BodyMD),
+    },
+    inlineWarningMessage: {
+      paddingVertical: 2,
+      color: colors.warning.default,
+      ...typography.sBodyMD,
+      fontFamily: getFontFamily(TextVariant.BodyMD),
+    },
+    buttonsWrapper: {
+      marginVertical: 12,
+      flexDirection: 'row',
+      alignSelf: 'flex-end',
+    },
+    buttonsContainer: {
+      flex: 1,
+      flexDirection: 'column',
+      alignSelf: 'flex-end',
+    },
+    editableButtonsContainer: {
+      flex: 1,
+      flexDirection: 'row',
+    },
+    networksWrapper: {
+      marginTop: 12,
+    },
+    popularNetwork: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      marginVertical: 12,
+    },
+    button: {
+      flex: 1,
+    },
+    disabledButton: {
+      backgroundColor: colors.primary.muted,
+    },
+    cancel: {
+      marginRight: 16,
+    },
+    blueText: {
+      color: colors.primary.default,
+      marginTop: 1,
+    },
+    bottomSection: {
+      flex: 1,
+      flexDirection: 'column',
+    },
+    rpcTitleWrapper: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 4,
+    },
+  });


### PR DESCRIPTION
## **Description**

Problem: The submit form for new RPC urls has two bugs
- The submit button is hidden and the user has to scroll through the parent component to find the button
- When the keyboard is active and the input field is focused, the view doesn't focus on the actual input field

Solution: Improve composition of components

Other Notes:
- Refactored styles - removed unused style variables

## **Changelog**

CHANGELOG entry: Fixed an issue where the add RPC button doesn't show up when adding a custom network in settings

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/21305

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

`~`

### **Before**

https://github.com/user-attachments/assets/629c396f-b213-4fbe-aa50-411d96450cfe


### **After**

https://github.com/user-attachments/assets/bfbac45f-f874-4e5f-970e-9420c2803ab9


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents button cutoff by restructuring Add RPC/Block Explorer modals with sticky headers and keyboard-aware scrolling, and moves inline styles to a new styles file.
> 
> - **UI/Settings – `NetworkSettings`**:
>   - Restructures Add RPC modal: sticky header, keyboard-aware scroll (extraScrollHeight), and scrollable content so the action button isn’t cut off.
>   - Updates Add Block Explorer modal list to use scrollable content with selectable/deletable entries and an add button section.
> - **Styling**:
>   - Extracts inline `StyleSheet` into `index.styles.js` and imports `createStyles`.
>   - Adjusts sheet sizing (e.g., `sheetRpcForm` height) and adds layout helpers (`container`, `scrollViewContent`, `scrollableBox`).
> - **Cleanup**:
>   - Removes unused imports and consolidates style-related logic out of `index.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e39e367e638eb336464a6a6ef554199b093cbc5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->