### PR TITLE
fix: prevent Android ramps modal double press navigation issue

### DIFF
--- a/app/components/UI/Ramp/Aggregator/components/FiatSelectorModal/FiatSelectorModal.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/FiatSelectorModal/FiatSelectorModal.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { View, useWindowDimensions } from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
 import Fuse from 'fuse.js';
+import { useNavigation } from '@react-navigation/native';
 import { strings } from '../../../../../../../locales/i18n';
 import { FiatCurrency } from '@consensys/on-ramp-sdk';
 import {
@@ -41,6 +42,7 @@ export const createFiatSelectorModalNavigationDetails =
 function FiatSelectorModal() {
   const sheetRef = useRef<BottomSheetRef>(null);
   const listRef = useRef<FlatList<FiatCurrency>>(null);
+  const navigation = useNavigation();
 
   const { currencies } = useParams<FiatSelectorModalNavigationDetails>();
   const [searchString, setSearchString] = useState('');
@@ -75,9 +77,11 @@ function FiatSelectorModal() {
   const handleSelectCurrency = useCallback(
     (currency: FiatCurrency) => {
       setSelectedFiatCurrencyId(currency?.id);
-      sheetRef.current?.onCloseBottomSheet();
+      sheetRef.current?.onCloseBottomSheet(() => {
+        navigation.goBack();
+      });
     },
-    [setSelectedFiatCurrencyId],
+    [setSelectedFiatCurrencyId, navigation],
   );
 
   const renderItem = useCallback(
@@ -134,8 +138,14 @@ function FiatSelectorModal() {
   );
 
   return (
-    <BottomSheet ref={sheetRef} shouldNavigateBack>
-      <BottomSheetHeader onClose={() => sheetRef.current?.onCloseBottomSheet()}>
+    <BottomSheet ref={sheetRef} shouldNavigateBack={false}>
+      <BottomSheetHeader
+        onClose={() =>
+          sheetRef.current?.onCloseBottomSheet(() => {
+            navigation.goBack();
+          })
+        }
+      >
         <Text variant={TextVariant.HeadingMD}>
           {strings('fiat_on_ramp_aggregator.select_region_currency')}
         </Text>

--- a/app/components/UI/Ramp/Aggregator/components/PaymentMethodSelectorModal/PaymentMethodSelectorModal.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/PaymentMethodSelectorModal/PaymentMethodSelectorModal.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useRef } from 'react';
 import { View, ScrollView, useWindowDimensions } from 'react-native';
 import { Payment } from '@consensys/on-ramp-sdk';
+import { useNavigation } from '@react-navigation/native';
 
 import Text, {
   TextVariant,
@@ -37,6 +38,7 @@ export const createPaymentMethodSelectorModalNavigationDetails =
 
 function PaymentMethodSelectorModal() {
   const sheetRef = useRef<BottomSheetRef>(null);
+  const navigation = useNavigation();
   const { paymentMethods, location } =
     useParams<PaymentMethodSelectorModalParams>();
 
@@ -78,9 +80,12 @@ function PaymentMethodSelectorModal() {
 
         sheetRef.current?.onCloseBottomSheet(() => {
           setSelectedPaymentMethodId(paymentMethodId);
+          navigation.goBack();
         });
       } else {
-        sheetRef.current?.onCloseBottomSheet();
+        sheetRef.current?.onCloseBottomSheet(() => {
+          navigation.goBack();
+        });
       }
     },
     [
@@ -91,6 +96,7 @@ function PaymentMethodSelectorModal() {
       selectedPaymentMethodId,
       selectedRegion?.id,
       trackEvent,
+      navigation,
     ],
   );
 
@@ -99,8 +105,14 @@ function PaymentMethodSelectorModal() {
   );
 
   return (
-    <BottomSheet ref={sheetRef} shouldNavigateBack>
-      <BottomSheetHeader onClose={() => sheetRef.current?.onCloseBottomSheet()}>
+    <BottomSheet ref={sheetRef} shouldNavigateBack={false}>
+      <BottomSheetHeader
+        onClose={() =>
+          sheetRef.current?.onCloseBottomSheet(() => {
+            navigation.goBack();
+          })
+        }
+      >
         <Text variant={TextVariant.HeadingMD}>{title}</Text>
       </BottomSheetHeader>
 

--- a/app/components/UI/Ramp/Aggregator/components/RegionSelectorModal/RegionSelectorModal.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/RegionSelectorModal/RegionSelectorModal.tsx
@@ -135,6 +135,13 @@ function RegionSelectorModal() {
     }
   }, []);
 
+  const closeBottomSheetAndNavigate = useCallback(
+    (navigateFunc: () => void) => {
+      sheetRef.current?.onCloseBottomSheet(navigateFunc);
+    },
+    [],
+  );
+
   const handleOnRegionPressCallback = useCallback(
     async (region: Region) => {
       if (region.states && region.states.length > 0) {
@@ -155,7 +162,7 @@ function RegionSelectorModal() {
       });
 
       setSelectedRegion(region);
-      sheetRef.current?.onCloseBottomSheet(() => {
+      closeBottomSheetAndNavigate(() => {
         navigation.goBack();
       });
     },
@@ -166,6 +173,7 @@ function RegionSelectorModal() {
       scrollToTop,
       isBuy,
       navigation,
+      closeBottomSheetAndNavigate,
     ],
   );
 
@@ -243,11 +251,16 @@ function RegionSelectorModal() {
     if (activeView === RegionViewType.STATE) {
       handleRegionBackButton();
     } else {
-      sheetRef.current?.onCloseBottomSheet(() => {
+      closeBottomSheetAndNavigate(() => {
         navigation.goBack();
       });
     }
-  }, [activeView, handleRegionBackButton, navigation]);
+  }, [
+    activeView,
+    handleRegionBackButton,
+    navigation,
+    closeBottomSheetAndNavigate,
+  ]);
 
   const onModalHide = useCallback(() => {
     setActiveView(RegionViewType.COUNTRY);

--- a/app/components/UI/Ramp/Aggregator/components/RegionSelectorModal/RegionSelectorModal.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/RegionSelectorModal/RegionSelectorModal.tsx
@@ -8,6 +8,7 @@ import React, {
 import { View, useWindowDimensions } from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
 import Fuse from 'fuse.js';
+import { useNavigation } from '@react-navigation/native';
 
 import Text, {
   TextColor,
@@ -58,6 +59,7 @@ export const createRegionSelectorModalNavigationDetails =
 function RegionSelectorModal() {
   const sheetRef = useRef<BottomSheetRef>(null);
   const listRef = useRef<FlatList<Region>>(null);
+  const navigation = useNavigation();
 
   const { selectedRegion, setSelectedRegion, isBuy } = useRampSDK();
   const { regions } = useParams<RegionSelectorModalParams>();
@@ -153,9 +155,18 @@ function RegionSelectorModal() {
       });
 
       setSelectedRegion(region);
-      sheetRef.current?.onCloseBottomSheet();
+      sheetRef.current?.onCloseBottomSheet(() => {
+        navigation.goBack();
+      });
     },
-    [setSelectedRegion, trackEvent, regionInTransit, scrollToTop, isBuy],
+    [
+      setSelectedRegion,
+      trackEvent,
+      regionInTransit,
+      scrollToTop,
+      isBuy,
+      navigation,
+    ],
   );
 
   const renderRegionItem = useCallback(
@@ -232,9 +243,11 @@ function RegionSelectorModal() {
     if (activeView === RegionViewType.STATE) {
       handleRegionBackButton();
     } else {
-      sheetRef.current?.onCloseBottomSheet();
+      sheetRef.current?.onCloseBottomSheet(() => {
+        navigation.goBack();
+      });
     }
-  }, [activeView, handleRegionBackButton]);
+  }, [activeView, handleRegionBackButton, navigation]);
 
   const onModalHide = useCallback(() => {
     setActiveView(RegionViewType.COUNTRY);
@@ -246,7 +259,7 @@ function RegionSelectorModal() {
   return (
     <BottomSheet
       ref={sheetRef}
-      shouldNavigateBack
+      shouldNavigateBack={false}
       onClose={onModalHide}
       keyboardAvoidingViewEnabled={false}
     >

--- a/app/components/UI/Ramp/Aggregator/components/TokenSelectModal/TokenSelectModal.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/TokenSelectModal/TokenSelectModal.tsx
@@ -3,6 +3,7 @@ import { View, useWindowDimensions } from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
 import Fuse from 'fuse.js';
 import { useSelector } from 'react-redux';
+import { useNavigation } from '@react-navigation/native';
 
 import Text, {
   TextVariant,
@@ -61,6 +62,7 @@ export const createTokenSelectModalNavigationDetails =
 function TokenSelectModal() {
   const sheetRef = useRef<BottomSheetRef>(null);
   const listRef = useRef<FlatList>(null);
+  const navigation = useNavigation();
 
   const { tokens } = useParams<TokenSelectModalNavigationDetails>();
   const [searchString, setSearchString] = useState('');
@@ -150,9 +152,11 @@ function TokenSelectModal() {
   const handleSelectTokenCallback = useCallback(
     (newAsset: CryptoCurrency) => {
       setSelectedAsset(newAsset);
-      sheetRef.current?.onCloseBottomSheet();
+      sheetRef.current?.onCloseBottomSheet(() => {
+        navigation.goBack();
+      });
     },
-    [setSelectedAsset],
+    [setSelectedAsset, navigation],
   );
 
   const scrollToTop = useCallback(() => {
@@ -243,8 +247,14 @@ function TokenSelectModal() {
   }, [tokens]);
 
   return (
-    <BottomSheet ref={sheetRef} shouldNavigateBack>
-      <BottomSheetHeader onClose={() => sheetRef.current?.onCloseBottomSheet()}>
+    <BottomSheet ref={sheetRef} shouldNavigateBack={false}>
+      <BottomSheetHeader
+        onClose={() =>
+          sheetRef.current?.onCloseBottomSheet(() => {
+            navigation.goBack();
+          })
+        }
+      >
         <Text variant={TextVariant.HeadingMD}>
           {strings('fiat_on_ramp_aggregator.select_a_cryptocurrency')}
         </Text>

--- a/app/components/UI/Ramp/Deposit/Views/Modals/PaymentMethodSelectorModal/PaymentMethodSelectorModal.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/PaymentMethodSelectorModal/PaymentMethodSelectorModal.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useRef } from 'react';
 import { View, useWindowDimensions } from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
+import { useNavigation } from '@react-navigation/native';
 import Text, {
   TextVariant,
 } from '../../../../../../../component-library/components/Texts/Text';
@@ -42,6 +43,7 @@ export const createPaymentMethodSelectorModalNavigationDetails =
 function PaymentMethodSelectorModal() {
   const sheetRef = useRef<BottomSheetRef>(null);
   const listRef = useRef<FlatList>(null);
+  const navigation = useNavigation();
   const { height: screenHeight } = useWindowDimensions();
   const { themeAppearance } = useTheme();
   const { styles } = useStyles(styleSheet, {
@@ -71,7 +73,9 @@ function PaymentMethodSelectorModal() {
         });
         setSelectedPaymentMethod(foundPaymentMethod);
       }
-      sheetRef.current?.onCloseBottomSheet();
+      sheetRef.current?.onCloseBottomSheet(() => {
+        navigation.goBack();
+      });
     },
     [
       paymentMethods,
@@ -79,6 +83,7 @@ function PaymentMethodSelectorModal() {
       selectedRegion?.isoCode,
       isAuthenticated,
       setSelectedPaymentMethod,
+      navigation,
     ],
   );
 
@@ -121,8 +126,14 @@ function PaymentMethodSelectorModal() {
   );
 
   return (
-    <BottomSheet ref={sheetRef} shouldNavigateBack>
-      <BottomSheetHeader onClose={() => sheetRef.current?.onCloseBottomSheet()}>
+    <BottomSheet ref={sheetRef} shouldNavigateBack={false}>
+      <BottomSheetHeader
+        onClose={() =>
+          sheetRef.current?.onCloseBottomSheet(() => {
+            navigation.goBack();
+          })
+        }
+      >
         <Text variant={TextVariant.HeadingMD}>
           {strings('deposit.payment_modal.select_a_payment_method')}
         </Text>

--- a/app/components/UI/Ramp/Deposit/Views/Modals/RegionSelectorModal/RegionSelectorModal.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/RegionSelectorModal/RegionSelectorModal.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { View, useWindowDimensions } from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
 import Fuse from 'fuse.js';
+import { useNavigation } from '@react-navigation/native';
 
 import Text, {
   TextVariant,
@@ -44,6 +45,7 @@ export const createRegionSelectorModalNavigationDetails =
 function RegionSelectorModal() {
   const sheetRef = useRef<BottomSheetRef>(null);
   const listRef = useRef<FlatList<DepositRegion>>(null);
+  const navigation = useNavigation();
 
   const { selectedRegion, setSelectedRegion, isAuthenticated } =
     useDepositSDK();
@@ -105,10 +107,12 @@ function RegionSelectorModal() {
         });
 
         setSelectedRegion(region);
-        sheetRef.current?.onCloseBottomSheet();
+        sheetRef.current?.onCloseBottomSheet(() => {
+          navigation.goBack();
+        });
       }
     },
-    [setSelectedRegion, isAuthenticated, trackEvent],
+    [setSelectedRegion, isAuthenticated, trackEvent, navigation],
   );
 
   const renderRegionItem = useCallback(
@@ -180,8 +184,14 @@ function RegionSelectorModal() {
   }, [scrollToTop]);
 
   return (
-    <BottomSheet ref={sheetRef} shouldNavigateBack>
-      <BottomSheetHeader onClose={() => sheetRef.current?.onCloseBottomSheet()}>
+    <BottomSheet ref={sheetRef} shouldNavigateBack={false}>
+      <BottomSheetHeader
+        onClose={() =>
+          sheetRef.current?.onCloseBottomSheet(() => {
+            navigation.goBack();
+          })
+        }
+      >
         <Text variant={TextVariant.HeadingMD}>
           {strings('deposit.region_modal.select_a_region')}
         </Text>

--- a/app/components/UI/Ramp/Deposit/Views/Modals/StateSelectorModal/StateSelectorModal.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/StateSelectorModal/StateSelectorModal.tsx
@@ -102,7 +102,9 @@ function StateSelectorModal() {
         });
       } else {
         onStateSelect(state.code);
-        sheetRef.current?.onCloseBottomSheet();
+        sheetRef.current?.onCloseBottomSheet(() => {
+          navigation.goBack();
+        });
       }
     },
     [navigation, onStateSelect],
@@ -155,8 +157,14 @@ function StateSelectorModal() {
   }, [scrollToTop]);
 
   return (
-    <BottomSheet ref={sheetRef} shouldNavigateBack>
-      <BottomSheetHeader onClose={() => sheetRef.current?.onCloseBottomSheet()}>
+    <BottomSheet ref={sheetRef} shouldNavigateBack={false}>
+      <BottomSheetHeader
+        onClose={() =>
+          sheetRef.current?.onCloseBottomSheet(() => {
+            navigation.goBack();
+          })
+        }
+      >
         <Text variant={TextVariant.HeadingMD}>
           {strings('deposit.state_modal.select_a_state')}
         </Text>

--- a/app/components/UI/Ramp/Deposit/Views/Modals/StateSelectorModal/StateSelectorModal.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/StateSelectorModal/StateSelectorModal.tsx
@@ -88,10 +88,17 @@ function StateSelectorModal() {
     }
   }, []);
 
+  const closeBottomSheetAndNavigate = useCallback(
+    (navigateFunc: () => void) => {
+      sheetRef.current?.onCloseBottomSheet(navigateFunc);
+    },
+    [],
+  );
+
   const handleOnStatePressCallback = useCallback(
     (state: { code: string; name: string }) => {
       if (state.code === 'NY') {
-        sheetRef.current?.onCloseBottomSheet(() => {
+        closeBottomSheetAndNavigate(() => {
           navigation.navigate(
             ...createUnsupportedStateModalNavigationDetails({
               stateCode: state.code,
@@ -102,12 +109,12 @@ function StateSelectorModal() {
         });
       } else {
         onStateSelect(state.code);
-        sheetRef.current?.onCloseBottomSheet(() => {
+        closeBottomSheetAndNavigate(() => {
           navigation.goBack();
         });
       }
     },
-    [navigation, onStateSelect],
+    [navigation, onStateSelect, closeBottomSheetAndNavigate],
   );
 
   const renderStateItem = useCallback(
@@ -160,7 +167,7 @@ function StateSelectorModal() {
     <BottomSheet ref={sheetRef} shouldNavigateBack={false}>
       <BottomSheetHeader
         onClose={() =>
-          sheetRef.current?.onCloseBottomSheet(() => {
+          closeBottomSheetAndNavigate(() => {
             navigation.goBack();
           })
         }

--- a/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/TokenSelectorModal.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/TokenSelectorModal.tsx
@@ -3,6 +3,7 @@ import { View, useWindowDimensions } from 'react-native';
 import { FlatList } from 'react-native-gesture-handler';
 import { useSelector } from 'react-redux';
 import { CaipChainId } from '@metamask/utils';
+import { useNavigation } from '@react-navigation/native';
 
 import NetworksFilterBar from '../../../components/NetworksFilterBar';
 import NetworksFilterSelector from '../../../components/NetworksFilterSelector/NetworksFilterSelector';
@@ -57,6 +58,7 @@ export const createTokenSelectorModalNavigationDetails =
 function TokenSelectorModal() {
   const sheetRef = useRef<BottomSheetRef>(null);
   const listRef = useRef<FlatList>(null);
+  const navigation = useNavigation();
   const [searchString, setSearchString] = useState('');
   const [networkFilter, setNetworkFilter] = useState<CaipChainId[] | null>(
     null,
@@ -105,7 +107,9 @@ function TokenSelectorModal() {
         });
         setSelectedCryptoCurrency(selectedToken);
       }
-      sheetRef.current?.onCloseBottomSheet();
+      sheetRef.current?.onCloseBottomSheet(() => {
+        navigation.goBack();
+      });
     },
     [
       supportedTokens,
@@ -114,6 +118,7 @@ function TokenSelectorModal() {
       selectedRegion?.currency,
       isAuthenticated,
       setSelectedCryptoCurrency,
+      navigation,
     ],
   );
 
@@ -209,8 +214,14 @@ function TokenSelectorModal() {
   }, [supportedTokens]);
 
   return (
-    <BottomSheet ref={sheetRef} shouldNavigateBack>
-      <BottomSheetHeader onClose={() => sheetRef.current?.onCloseBottomSheet()}>
+    <BottomSheet ref={sheetRef} shouldNavigateBack={false}>
+      <BottomSheetHeader
+        onClose={() =>
+          sheetRef.current?.onCloseBottomSheet(() => {
+            navigation.goBack();
+          })
+        }
+      >
         <Text variant={TextVariant.HeadingMD}>
           {isEditingNetworkFilter
             ? strings('deposit.networks_filter_selector.select_network')

--- a/app/components/UI/Ramp/Deposit/components/NetworksFilterSelector/NetworksFilterSelector.tsx
+++ b/app/components/UI/Ramp/Deposit/components/NetworksFilterSelector/NetworksFilterSelector.tsx
@@ -83,10 +83,7 @@ function NetworksFilterSelector({
         renderItem={({ item: chainId }) => (
           <ListItemSelect onPress={handleNetworkOnPress(chainId)}>
             <ListItemColumn>
-              <Checkbox
-                isChecked={networkFilter?.includes(chainId) ?? false}
-                onPress={handleNetworkOnPress(chainId)}
-              />
+              <Checkbox isChecked={networkFilter?.includes(chainId) ?? false} />
             </ListItemColumn>
             <ListItemColumn>
               <AvatarNetwork


### PR DESCRIPTION
## **Description**

This PR fixes an Android-specific issue where selecting a token, payment method, or region in ramps flows (deposit, buy, withdraw) would incorrectly navigate to the home screen instead of returning to the previous screen.

**Problem:**
On Android devices, when users selected an item in any ramps modal selector (token, payment method, region, state, fiat), the app would navigate to the home screen instead of returning to the BuildQuote screen. This was a critical regression affecting the entire ramps user experience on Android.

**Root Cause:**
A race condition occurred between:

1. BottomSheet's automatic `navigation.goBack()` call (via `shouldNavigateBack={true}`)
2. Manual navigation triggered when closing the sheet

Both navigation actions fired simultaneously on Android, causing the navigation stack to become confused and navigate to the wrong screen.

**Solution:**

- Disabled automatic navigation by setting `shouldNavigateBack={false}` on all ramps BottomSheet components
- Implemented BottomSheet's callback pattern: `onCloseBottomSheet(() => navigation.goBack())`
- This ensures navigation happens sequentially: sheet closes → animation completes → navigation occurs

This follows the intended BottomSheet usage pattern and eliminates the race condition.

**Files Modified:**

- `TokenSelectorModal.tsx` (Deposit)
- `PaymentMethodSelectorModal.tsx` (Deposit)
- `RegionSelectorModal.tsx` (Deposit)
- `StateSelectorModal.tsx` (Deposit)
- `TokenSelectModal.tsx` (Aggregator - Buy/Sell)
- `RegionSelectorModal.tsx` (Aggregator - Buy/Sell)
- `PaymentMethodSelectorModal.tsx` (Aggregator - Buy/Sell)
- `FiatSelectorModal.tsx` (Aggregator - Buy/Sell)

## **Changelog**

CHANGELOG entry: Fixed Android issue where ramps modal selection navigated to home screen

## **Related issues**

Fixes: #21350

## **Manual testing steps**

```gherkin
Feature: Ramps Token Selection on Android

  Scenario: user selects a token in deposit flow
    Given user is on Android device
    And user is on the deposit BuildQuote screen

    When user taps on the token selector
    And user selects a different token from the list
    Then the token selector modal closes
    And user returns to the BuildQuote screen with the new token selected
    And user does NOT navigate to the home screen

  Scenario: user selects a payment method in buy flow
    Given user is on Android device
    And user is on the buy BuildQuote screen

    When user taps on the payment method selector
    And user selects a payment method from the list
    Then the payment method modal closes
    And user returns to the BuildQuote screen
    And user does NOT navigate to the home screen

  Scenario: user selects a region in deposit flow
    Given user is on Android device
    And user is on the deposit BuildQuote screen

    When user taps on the region selector
    And user selects a region from the list
    Then the region modal closes
    And user returns to the BuildQuote screen
    And user does NOT navigate to the home screen
```

## **Screenshots/Recordings**

### **Before**

Issue as reported in #21350 - selecting token navigates to home screen on Android

### **After**

Expected behavior: selecting token closes modal and returns to BuildQuote screen

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable (no test changes needed - navigation already mocked)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Technical Details**

### Why This Fix Works

The BottomSheet component has a built-in callback system specifically designed for this use case:

```typescript
// Before (Broken):
<BottomSheet ref={sheetRef} shouldNavigateBack={true}>
  onPress={() => sheetRef.current?.onCloseBottomSheet()}
</BottomSheet>

// After (Fixed):
<BottomSheet ref={sheetRef} shouldNavigateBack={false}>
  onPress={() => sheetRef.current?.onCloseBottomSheet(() => navigation.goBack())}
</BottomSheet>
```

The callback ensures:

1. Sheet closing animation starts
2. Animation completes
3. Callback fires → `navigation.goBack()`
4. Single, clean navigation action at the right time

### Testing Impact

- No unit test updates required (navigation is already mocked via `renderScreen`)
- Manual testing on Android devices is critical
- iOS behavior remains unchanged
