### PR TITLE
fix(predict): order toasts

### DIFF
--- a/app/components/UI/Predict/hooks/usePredictPlaceOrder.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictPlaceOrder.test.ts
@@ -17,9 +17,17 @@ jest.mock('./usePredictBalance');
 jest.mock('../../../../../locales/i18n', () => ({
   strings: (key: string, options?: Record<string, unknown>) => {
     const translations: Record<string, string> = {
-      'predict.prediction_placed': 'Prediction placed',
-      'predict.cashed_out': 'Cashed out',
-      'predict.cashed_out_subtitle': `You claimed $${options?.amount || '0'}`,
+      'predict.order.placing_prediction': 'Placing a prediction',
+      'predict.order.prediction_placed': 'Prediction placed',
+      'predict.order.cashed_out': 'Cashed out',
+      'predict.order.cashed_out_subtitle': `${
+        options?.amount || '0'
+      } added to your balance`,
+      'predict.order.cashing_out': `Cashing out ${options?.amount || '0'}`,
+      'predict.order.cashing_out_subtitle': `Estimated ${
+        options?.time || 5
+      } seconds`,
+      'predict.order.order_failed': 'Order failed',
     };
     return translations[key] || key;
   },
@@ -147,7 +155,22 @@ describe('usePredictPlaceOrder', () => {
         await result.current.placeOrder(mockOrderParams);
       });
 
-      expect(mockToastRef.current?.showToast).toHaveBeenCalledWith(
+      expect(mockToastRef.current?.showToast).toHaveBeenCalledTimes(2);
+
+      // First call - loading toast
+      expect(mockToastRef.current?.showToast).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          variant: ToastVariants.Icon,
+          iconName: IconName.Loading,
+          labelOptions: [{ label: 'Placing a prediction' }],
+          hasNoTimeout: false,
+        }),
+      );
+
+      // Second call - success toast
+      expect(mockToastRef.current?.showToast).toHaveBeenNthCalledWith(
+        2,
         expect.objectContaining({
           variant: ToastVariants.Icon,
           iconName: IconName.Check,
@@ -179,7 +202,27 @@ describe('usePredictPlaceOrder', () => {
         await result.current.placeOrder(sellOrderParams);
       });
 
-      expect(mockToastRef.current?.showToast).toHaveBeenCalledWith(
+      expect(mockToastRef.current?.showToast).toHaveBeenCalledTimes(2);
+
+      // First call - loading toast
+      expect(mockToastRef.current?.showToast).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          variant: ToastVariants.Icon,
+          iconName: IconName.Loading,
+          labelOptions: expect.arrayContaining([
+            expect.objectContaining({
+              label: expect.stringContaining('Cashing out'),
+              isBold: true,
+            }),
+          ]),
+          hasNoTimeout: false,
+        }),
+      );
+
+      // Second call - success toast
+      expect(mockToastRef.current?.showToast).toHaveBeenNthCalledWith(
+        2,
         expect.objectContaining({
           variant: ToastVariants.Icon,
           iconName: IconName.Check,
@@ -300,7 +343,20 @@ describe('usePredictPlaceOrder', () => {
         await result.current.placeOrder(mockOrderParams);
       });
 
-      expect(mockToastRef.current?.showToast).toHaveBeenCalledWith({
+      expect(mockToastRef.current?.showToast).toHaveBeenCalledTimes(2);
+
+      // First call - loading toast
+      expect(mockToastRef.current?.showToast).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          variant: ToastVariants.Icon,
+          iconName: IconName.Loading,
+          hasNoTimeout: false,
+        }),
+      );
+
+      // Second call - failure toast
+      expect(mockToastRef.current?.showToast).toHaveBeenNthCalledWith(2, {
         variant: ToastVariants.Icon,
         iconName: IconName.Loading,
         labelOptions: [{ label: 'Order failed' }],

--- a/app/components/UI/Predict/hooks/usePredictPlaceOrder.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictPlaceOrder.test.ts
@@ -186,6 +186,7 @@ describe('usePredictPlaceOrder', () => {
     });
 
     it('shows cashed out toast when SELL order is placed successfully', async () => {
+      jest.useFakeTimers();
       mockPlaceOrder.mockResolvedValue(mockSuccessResult);
 
       const sellOrderParams = {
@@ -202,7 +203,7 @@ describe('usePredictPlaceOrder', () => {
         await result.current.placeOrder(sellOrderParams);
       });
 
-      expect(mockToastRef.current?.showToast).toHaveBeenCalledTimes(2);
+      expect(mockToastRef.current?.showToast).toHaveBeenCalledTimes(1);
 
       // First call - loading toast
       expect(mockToastRef.current?.showToast).toHaveBeenNthCalledWith(
@@ -220,7 +221,13 @@ describe('usePredictPlaceOrder', () => {
         }),
       );
 
-      // Second call - success toast
+      await act(async () => {
+        jest.advanceTimersByTime(2000);
+      });
+
+      expect(mockToastRef.current?.showToast).toHaveBeenCalledTimes(2);
+
+      // Second call - success toast (after delay)
       expect(mockToastRef.current?.showToast).toHaveBeenNthCalledWith(
         2,
         expect.objectContaining({
@@ -235,6 +242,8 @@ describe('usePredictPlaceOrder', () => {
           hasNoTimeout: false,
         }),
       );
+
+      jest.useRealTimers();
     });
 
     it('reloads balance after successful order placement', async () => {

--- a/app/components/UI/Predict/hooks/usePredictPlaceOrder.ts
+++ b/app/components/UI/Predict/hooks/usePredictPlaceOrder.ts
@@ -111,7 +111,9 @@ export function usePredictPlaceOrder(
             labelOptions: [
               {
                 label: strings('predict.order.cashing_out', {
-                  amount: formatPrice(minAmountReceived),
+                  amount: formatPrice(minAmountReceived, {
+                    maximumDecimals: 2,
+                  }),
                 }),
                 isBold: true,
               },
@@ -150,7 +152,9 @@ export function usePredictPlaceOrder(
         if (side === Side.BUY) {
           showOrderPlacedToast();
         } else {
-          showCashedOutToast(formatPrice(minAmountReceived));
+          showCashedOutToast(
+            formatPrice(minAmountReceived, { maximumDecimals: 2 }),
+          );
         }
 
         await loadBalance({ isRefresh: true });

--- a/app/components/UI/Predict/hooks/usePredictPlaceOrder.ts
+++ b/app/components/UI/Predict/hooks/usePredictPlaceOrder.ts
@@ -48,22 +48,27 @@ export function usePredictPlaceOrder(
   const { toastRef } = useContext(ToastContext);
 
   const showCashedOutToast = useCallback(
-    (amount: string) =>
-      toastRef?.current?.showToast({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Check,
-        labelOptions: [
-          { label: strings('predict.order.cashed_out'), isBold: true },
-          { label: '\n', isBold: false },
-          {
-            label: strings('predict.order.cashed_out_subtitle', {
-              amount,
-            }),
-            isBold: false,
-          },
-        ],
-        hasNoTimeout: false,
-      }),
+    (amount: string) => {
+      // NOTE: When cashing out happens fast, stacking toasts messes the UX.
+      // Figure out how toast behavior can be improved to avoid this.
+      setTimeout(() => {
+        toastRef?.current?.showToast({
+          variant: ToastVariants.Icon,
+          iconName: IconName.Check,
+          labelOptions: [
+            { label: strings('predict.order.cashed_out'), isBold: true },
+            { label: '\n', isBold: false },
+            {
+              label: strings('predict.order.cashed_out_subtitle', {
+                amount,
+              }),
+              isBold: false,
+            },
+          ],
+          hasNoTimeout: false,
+        });
+      }, 2000);
+    },
     [toastRef],
   );
 

--- a/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.test.tsx
@@ -821,12 +821,16 @@ describe('PredictBuyPreview', () => {
 
       const placeBetButton = getByText('Yes • 50¢');
 
-      // Even though navigation fails, placeOrder should still be called
+      // The dispatch now throws and is not caught, so expect the error
       expect(() => {
         fireEvent.press(placeBetButton);
-      }).not.toThrow();
+      }).toThrow('Navigation error');
 
+      // PlaceOrder should still be called before dispatch throws
       expect(mockPlaceOrder).toHaveBeenCalled();
+
+      // Dispatch should have been attempted
+      expect(mockDispatch).toHaveBeenCalledWith(StackActions.pop());
     });
   });
 });

--- a/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
+++ b/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
@@ -77,19 +77,14 @@ const PredictBuyPreview = () => {
     preview?.sharePrice ?? outcomeToken?.price ?? 0,
   )}`;
 
-  const onPlaceBet = async () => {
+  const onPlaceBet = () => {
     if (!preview) return;
 
-    await placeOrder({
+    placeOrder({
       providerId: outcome.providerId,
       preview,
     });
-    try {
-      dispatch(StackActions.pop());
-    } catch (error) {
-      // Navigation errors should not prevent the bet from being placed
-      console.warn('Navigation error after placing bet:', error);
-    }
+    dispatch(StackActions.pop());
   };
 
   const renderHeader = () => (

--- a/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.test.tsx
+++ b/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.test.tsx
@@ -485,12 +485,16 @@ describe('PredictSellPreview', () => {
 
       const cashOutButton = getByTestId('button-secondary');
 
-      // Even though navigation fails, placeOrder should still be called and no error should be thrown
+      // The dispatch now throws and is not caught, so expect the error
       expect(() => {
         fireEvent.press(cashOutButton);
-      }).not.toThrow();
+      }).toThrow('Navigation error');
 
+      // PlaceOrder should still be called before dispatch throws
       expect(mockPlaceOrder).toHaveBeenCalled();
+
+      // Dispatch should have been attempted
+      expect(mockDispatch).toHaveBeenCalledWith(StackActions.pop());
     });
   });
 

--- a/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.test.tsx
+++ b/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.test.tsx
@@ -118,7 +118,7 @@ const mockFormatPrice = jest.fn();
 const mockFormatPercentage = jest.fn();
 
 jest.mock('../../utils/format', () => ({
-  formatPrice: (value: number, options?: { minimumDecimals?: number }) =>
+  formatPrice: (value: number, options?: { maximumDecimals?: number }) =>
     mockFormatPrice(value, options),
   formatPercentage: (value: number) => mockFormatPercentage(value),
 }));
@@ -314,7 +314,7 @@ describe('PredictSellPreview', () => {
     });
 
     mockFormatPrice.mockImplementation((value, options) => {
-      if (options?.minimumDecimals === 2) {
+      if (options?.maximumDecimals === 2) {
         return `$${value.toFixed(2)}`;
       }
       return `$${value}`;
@@ -346,7 +346,7 @@ describe('PredictSellPreview', () => {
       });
 
       // Component uses preview.minAmountReceived for current value
-      expect(mockFormatPrice).toHaveBeenCalledWith(60, { minimumDecimals: 2 });
+      expect(mockFormatPrice).toHaveBeenCalledWith(60, { maximumDecimals: 2 });
       // PnL is calculated from position data, not preview
       expect(mockFormatPercentage).toHaveBeenCalledWith(20);
     });

--- a/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.tsx
+++ b/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.tsx
@@ -6,7 +6,7 @@ import {
   useRoute,
 } from '@react-navigation/native';
 import React, { useMemo } from 'react';
-import { Alert, Image, View } from 'react-native';
+import { Image, View } from 'react-native';
 import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
 import Button, {
   ButtonVariants,
@@ -75,14 +75,14 @@ const PredictSellPreview = () => {
       <View style={styles.container}>
         <View style={styles.cashOutContainer}>
           <Text style={styles.currentValue}>
-            {formatPrice(currentValue, { minimumDecimals: 2 })}
+            {formatPrice(currentValue, { maximumDecimals: 2 })}
           </Text>
           <Text
             style={styles.percentPnl}
             color={percentPnl > 0 ? TextColor.Success : TextColor.Error}
           >
             {`${signal}${formatPrice(Math.abs(cashPnl), {
-              minimumDecimals: 2,
+              maximumDecimals: 2,
             })} (${formatPercentage(percentPnl)})`}
           </Text>
         </View>
@@ -104,7 +104,7 @@ const PredictSellPreview = () => {
                 ellipsizeMode="tail"
                 style={styles.detailsResolves}
               >
-                {formatPrice(initialValue, { minimumDecimals: 2 })} on{' '}
+                {formatPrice(initialValue, { maximumDecimals: 2 })} on{' '}
                 {outcomeSideText}
               </Text>
             </View>

--- a/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.tsx
+++ b/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.tsx
@@ -40,19 +40,7 @@ const PredictSellPreview = () => {
 
   const outcomeTitle = title;
 
-  const { placeOrder, isLoading } = usePredictPlaceOrder({
-    onComplete: () => {
-      try {
-        dispatch(StackActions.pop());
-      } catch (error) {
-        // Navigation errors shouldn't prevent the order from being considered successful
-        console.warn('Navigation error after successful cash out:', error);
-      }
-    },
-    onError: (error) => {
-      Alert.alert('Order failed', error);
-    },
-  });
+  const { placeOrder, isLoading } = usePredictPlaceOrder();
 
   const { preview, isCalculating } = usePredictOrderPreview({
     providerId: position.providerId,
@@ -76,6 +64,7 @@ const PredictSellPreview = () => {
       providerId: position.providerId,
       preview,
     });
+    dispatch(StackActions.pop());
   };
 
   return (

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1679,6 +1679,15 @@
           "try_again": "Try again"
         }
       }
+    },
+    "order": {
+      "cashed_out": "Cashed out",
+      "cashed_out_subtitle": "{{amount}} added to your balance",
+      "cashing_out": "Cashing out {{amount}}",
+      "cashing_out_subtitle": "Estimated {{time}} seconds",
+      "placing_prediction": "Placing a prediction",
+      "prediction_placed": "Prediction placed",
+      "order_failed": "Order failed"
     }
   },
   "receive": {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Fixes for toasts during order placement.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/9de659a9-996d-4403-b47e-bf54938b87a1



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds loading/success toasts and new i18n keys for Predict orders, delays cash-out success, updates price formatting, and simplifies navigation by letting dispatch errors surface; tests updated.
> 
> - **Predict Order Hook (`usePredictPlaceOrder`)**:
>   - Adds loading toasts for BUY/SELL; shows success "prediction placed" or delayed "cashed out" toasts (2s) with new i18n keys under `predict.order`.
>   - Uses `strings('predict.order.*')` and `formatPrice(..., { maximumDecimals: 2 })`; failure toast uses `order_failed` key.
> - **Views**:
>   - `PredictBuyPreview`: call `placeOrder` then immediately `dispatch(StackActions.pop())`; remove try/catch; onPlaceBet no longer `async`.
>   - `PredictSellPreview`: same dispatch-after-placeOrder change; remove Alert usage; switch price formatting to `{ maximumDecimals: 2 }`.
> - **i18n (`locales/languages/en.json`)**:
>   - Adds `predict.order` namespace: `placing_prediction`, `prediction_placed`, `cashing_out`, `cashing_out_subtitle`, `cashed_out`, `cashed_out_subtitle`, `order_failed`.
> - **Tests**:
>   - Update to expect loading + success/failure toast sequences and delayed cash-out success.
>   - Adjust navigation tests to expect thrown dispatch errors while still calling `placeOrder`.
>   - Update formatting expectations to `maximumDecimals: 2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c141634d078090a6b483824a37aa28ec23e01716. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->