### PR TITLE
docs: fix broken link

### DIFF
--- a/docs/readme/metametrics-debugging.md
+++ b/docs/readme/metametrics-debugging.md
@@ -243,5 +243,5 @@ If you're still experiencing issues after following this guide, ask for help in 
 ## Related Documentation
 
 - [Analytics Module README](../../app/core/Analytics/README.md)
-- [Testing Guide](testing.md)
+- [E2E Testing Guide](e2e-testing.md)
 - [Environment Setup](environment.md)


### PR DESCRIPTION
- [Testing Guide](testing.md) - old version
- [E2E Testing Guide](e2e-testing.md) - new version

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace the Related Documentation link in `docs/readme/metametrics-debugging.md` from `testing.md` (Testing Guide) to `e2e-testing.md` (E2E Testing Guide).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08a793a0174f2e9875c3ae023200b2261c8b36b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->