### PR TITLE
fix: cp-7.57.0 deeplink for rewards populates referral code

### DIFF
--- a/app/components/UI/Rewards/OnboardingNavigator.tsx
+++ b/app/components/UI/Rewards/OnboardingNavigator.tsx
@@ -10,7 +10,6 @@ import OnboardingStep2 from './components/Onboarding/OnboardingStep2';
 import OnboardingStep3 from './components/Onboarding/OnboardingStep3';
 import OnboardingStep4 from './components/Onboarding/OnboardingStep4';
 import UnmountOnBlur from '../../Views/UnmountOnBlur';
-import { useParams } from '../../../util/navigation/navUtils';
 import { strings } from '../../../../locales/i18n';
 import RewardsIntroModal from './components/Onboarding/RewardsIntroModal';
 
@@ -18,7 +17,6 @@ const Stack = createStackNavigator();
 
 const OnboardingNavigator: React.FC = () => {
   const activeStep = useSelector(selectOnboardingActiveStep);
-  const urlParams = useParams<{ isFromDeeplink: boolean; referral?: string }>();
 
   const getInitialRoute = useCallback(() => {
     switch (activeStep) {
@@ -79,7 +77,6 @@ const OnboardingNavigator: React.FC = () => {
           name={Routes.REWARDS_ONBOARDING_4}
           component={OnboardingStep4}
           options={{ headerShown: false }}
-          initialParams={{ ...urlParams }}
         />
       </Stack.Navigator>
     </UnmountOnBlur>

--- a/app/components/UI/Rewards/RewardsNavigator.tsx
+++ b/app/components/UI/Rewards/RewardsNavigator.tsx
@@ -9,14 +9,12 @@ import { useSelector } from 'react-redux';
 import { selectRewardsSubscriptionId } from '../../../selectors/rewards';
 import { useCandidateSubscriptionId } from './hooks/useCandidateSubscriptionId';
 import { useNavigation } from '@react-navigation/native';
-import { useParams } from '../../../util/navigation/navUtils';
 import { useSeasonStatus } from './hooks/useSeasonStatus';
 const Stack = createStackNavigator();
 
 const RewardsNavigator: React.FC = () => {
   const subscriptionId = useSelector(selectRewardsSubscriptionId);
   const navigation = useNavigation();
-  const urlParams = useParams<{ isFromDeeplink: boolean; referral?: string }>();
 
   // Set candidate subscription ID in Redux state when component mounts and account changes
   useCandidateSubscriptionId();
@@ -49,7 +47,6 @@ const RewardsNavigator: React.FC = () => {
         name={Routes.REWARDS_ONBOARDING_FLOW}
         component={OnboardingNavigator}
         options={{ headerShown: false }}
-        initialParams={{ ...urlParams }}
       />
       {subscriptionId ? (
         <>

--- a/app/components/UI/Rewards/components/Onboarding/OnboardingStep4.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/OnboardingStep4.tsx
@@ -23,6 +23,7 @@ import TextField, {
 import { strings } from '../../../../../../locales/i18n';
 import OnboardingStepComponent from './OnboardingStep';
 import { selectRewardsSubscriptionId } from '../../../../../selectors/rewards';
+import { selectOnboardingReferralCode } from '../../../../../reducers/rewards/selectors';
 import RewardsErrorBanner from '../RewardsErrorBanner';
 import {
   REWARDS_ONBOARD_OPTIN_LEGAL_LEARN_MORE_URL,
@@ -30,14 +31,14 @@ import {
 } from './constants';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import Routes from '../../../../../constants/navigation/Routes';
-import { useParams } from '../../../../../util/navigation/navUtils';
 
 const OnboardingStep4: React.FC = () => {
   const tw = useTailwind();
   const subscriptionId = useSelector(selectRewardsSubscriptionId);
+  const onboardingReferralCode = useSelector(selectOnboardingReferralCode);
   const navigation = useNavigation();
   const { optin, optinError, optinLoading } = useOptin();
-  const urlParams = useParams<{ isFromDeeplink: boolean; referral?: string }>();
+
   const {
     referralCode,
     setReferralCode: handleReferralCodeChange,
@@ -45,14 +46,12 @@ const OnboardingStep4: React.FC = () => {
     isValid: referralCodeIsValid,
     isUnknownError: isUnknownErrorReferralCode,
   } = useValidateReferralCode(
-    urlParams?.isFromDeeplink && urlParams?.referral
-      ? urlParams.referral.trim().toUpperCase()
+    onboardingReferralCode
+      ? onboardingReferralCode.trim().toUpperCase()
       : undefined,
   );
 
-  const isPrefilledReferral = Boolean(
-    urlParams?.isFromDeeplink && urlParams?.referral,
-  );
+  const isPrefilledReferral = Boolean(onboardingReferralCode);
 
   const handleNext = useCallback(() => {
     optin({ referralCode, isPrefilled: isPrefilledReferral });

--- a/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingStep4.test.tsx
+++ b/app/components/UI/Rewards/components/Onboarding/__tests__/OnboardingStep4.test.tsx
@@ -5,12 +5,17 @@ import OnboardingStep4 from '../OnboardingStep4';
 
 // Mock navigation
 const mockNavigate = jest.fn();
-jest.mock('@react-navigation/native', () => ({
-  useNavigation: () => ({
-    navigate: mockNavigate,
-  }),
-  useFocusEffect: jest.fn(),
-}));
+
+jest.mock('@react-navigation/native', () => {
+  const actualNav = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualNav,
+    useNavigation: () => ({
+      navigate: mockNavigate,
+    }),
+    useFocusEffect: jest.fn(),
+  };
+});
 
 // Mock route params
 jest.mock('../../../../../../util/navigation/navUtils', () => ({
@@ -221,6 +226,10 @@ jest.mock('../../../../../../selectors/rewards', () => ({
   selectRewardsSubscriptionId: jest.fn(() => null),
 }));
 
+jest.mock('../../../../../../reducers/rewards/selectors', () => ({
+  selectOnboardingReferralCode: jest.fn(() => null),
+}));
+
 // Mock OnboardingStepComponent
 jest.mock('../OnboardingStep', () => {
   const ReactActual = jest.requireActual('react');
@@ -248,11 +257,21 @@ jest.mock('../OnboardingStep', () => {
 
 import { useOptin } from '../../../hooks/useOptIn';
 import { useValidateReferralCode } from '../../../hooks/useValidateReferralCode';
+import { selectRewardsSubscriptionId } from '../../../../../../selectors/rewards';
+import { selectOnboardingReferralCode } from '../../../../../../reducers/rewards/selectors';
 
 const mockUseOptin = useOptin as jest.MockedFunction<typeof useOptin>;
 const mockUseValidateReferralCode =
   useValidateReferralCode as jest.MockedFunction<
     typeof useValidateReferralCode
+  >;
+const mockSelectRewardsSubscriptionId =
+  selectRewardsSubscriptionId as jest.MockedFunction<
+    typeof selectRewardsSubscriptionId
+  >;
+const mockSelectOnboardingReferralCode =
+  selectOnboardingReferralCode as jest.MockedFunction<
+    typeof selectOnboardingReferralCode
   >;
 
 describe('OnboardingStep4', () => {
@@ -261,7 +280,7 @@ describe('OnboardingStep4', () => {
   });
 
   describe('rendering', () => {
-    it('should render step content with title and description', () => {
+    it('renders step content with title and description', () => {
       renderWithProviders(<OnboardingStep4 />);
 
       // Since mock has isValid: true, it shows the referral bonus title
@@ -272,8 +291,7 @@ describe('OnboardingStep4', () => {
       ).toBeDefined();
     });
 
-    it('should render regular title when referral code is invalid', () => {
-      // Mock referral code as invalid for this test
+    it('renders regular title when referral code is invalid', () => {
       mockUseValidateReferralCode.mockReturnValueOnce({
         referralCode: 'INVALID',
         setReferralCode: jest.fn(),
@@ -290,7 +308,7 @@ describe('OnboardingStep4', () => {
       ).toBeDefined();
     });
 
-    it('should render referral bonus description and input placeholder', () => {
+    it('renders referral bonus description and input placeholder', () => {
       renderWithProviders(<OnboardingStep4 />);
 
       // Check that referral_bonus_description is rendered
@@ -308,13 +326,13 @@ describe('OnboardingStep4', () => {
       ).toBeDefined();
     });
 
-    it('should render step image', () => {
+    it('renders step image', () => {
       renderWithProviders(<OnboardingStep4 />);
 
       expect(screen.getByTestId('step-4-image')).toBeDefined();
     });
 
-    it('should render navigation buttons', () => {
+    it('renders navigation buttons', () => {
       renderWithProviders(<OnboardingStep4 />);
 
       // Verify that navigation buttons are rendered in the component
@@ -323,8 +341,7 @@ describe('OnboardingStep4', () => {
   });
 
   describe('error states', () => {
-    it('should show error banner when optin fails', () => {
-      // Arrange: Mock an optin error
+    it('displays error banner when optin fails', () => {
       mockUseOptin.mockReturnValue({
         optin: jest.fn(),
         optinError: 'Network error',
@@ -341,17 +358,14 @@ describe('OnboardingStep4', () => {
         validateCode: jest.fn(),
       });
 
-      // Act
       renderWithProviders(<OnboardingStep4 />);
 
-      // Assert
       expect(screen.getByTestId('rewards-error-banner')).toBeDefined();
       expect(screen.getByTestId('error-title')).toBeDefined();
       expect(screen.getByTestId('error-description')).toBeDefined();
     });
 
-    it('should not show error banner when no optin error', () => {
-      // Arrange: Mock no optin error
+    it('hides error banner when no optin error exists', () => {
       mockUseOptin.mockReturnValue({
         optin: jest.fn(),
         optinError: null,
@@ -368,15 +382,12 @@ describe('OnboardingStep4', () => {
         validateCode: jest.fn(),
       });
 
-      // Act
       renderWithProviders(<OnboardingStep4 />);
 
-      // Assert
       expect(screen.queryByTestId('rewards-error-banner')).toBeNull();
     });
 
-    it('should show unknown error banner when referral validation has unknown error', () => {
-      // Arrange: Mock unknown error in referral validation
+    it('displays unknown error banner when referral validation encounters unknown error', () => {
       mockUseOptin.mockReturnValue({
         optin: jest.fn(),
         optinError: null,
@@ -393,10 +404,8 @@ describe('OnboardingStep4', () => {
         validateCode: jest.fn(),
       });
 
-      // Act
       renderWithProviders(<OnboardingStep4 />);
 
-      // Assert
       expect(screen.getByTestId('rewards-error-banner')).toBeDefined();
       expect(screen.getByTestId('error-title')).toBeDefined();
       expect(screen.getByTestId('error-description')).toBeDefined();
@@ -413,8 +422,7 @@ describe('OnboardingStep4', () => {
       ).toBeDefined();
     });
 
-    it('should not show unknown error banner when referral validation has no unknown error', () => {
-      // Arrange: Mock no unknown error in referral validation
+    it('hides unknown error banner when referral validation has no unknown error', () => {
       mockUseOptin.mockReturnValue({
         optin: jest.fn(),
         optinError: null,
@@ -431,10 +439,8 @@ describe('OnboardingStep4', () => {
         validateCode: jest.fn(),
       });
 
-      // Act
       renderWithProviders(<OnboardingStep4 />);
 
-      // Assert - Should not show the unknown error banner
       expect(
         screen.queryByText(
           'mocked_rewards.referral_validation_unknown_error.title',
@@ -449,7 +455,7 @@ describe('OnboardingStep4', () => {
   });
 
   describe('referral code input', () => {
-    it('should handle referral code input changes', () => {
+    it('updates referral code when input changes', () => {
       const mockSetReferralCode = jest.fn();
 
       mockUseValidateReferralCode.mockReturnValue({
@@ -467,13 +473,12 @@ describe('OnboardingStep4', () => {
         'mocked_rewards.onboarding.step4_referral_input_placeholder',
       );
 
-      // Simulate typing in the input
       input.props.onChangeText('ABC123');
 
       expect(mockSetReferralCode).toHaveBeenCalledWith('ABC123');
     });
 
-    it('should show error message for invalid referral code', () => {
+    it('displays error message for invalid referral code with six or more characters', () => {
       mockUseValidateReferralCode.mockReturnValue({
         referralCode: 'INVALID123',
         setReferralCode: jest.fn(),
@@ -492,7 +497,7 @@ describe('OnboardingStep4', () => {
       ).toBeDefined();
     });
 
-    it('should not show error message for short codes', () => {
+    it('hides error message for codes shorter than six characters', () => {
       mockUseValidateReferralCode.mockReturnValue({
         referralCode: 'ABC',
         setReferralCode: jest.fn(),
@@ -513,7 +518,7 @@ describe('OnboardingStep4', () => {
   });
 
   describe('icon states', () => {
-    it('should show success icon when referral code is valid', () => {
+    it('displays success icon when referral code is valid', () => {
       mockUseValidateReferralCode.mockReturnValue({
         referralCode: 'VALID123',
         setReferralCode: jest.fn(),
@@ -528,7 +533,7 @@ describe('OnboardingStep4', () => {
       expect(screen.getByTestId('confirmation-icon')).toBeDefined();
     });
 
-    it('should show error icon when referral code is invalid and long enough', () => {
+    it('displays error icon when referral code is invalid and has six or more characters', () => {
       mockUseValidateReferralCode.mockReturnValue({
         referralCode: 'INVALID123',
         setReferralCode: jest.fn(),
@@ -543,7 +548,7 @@ describe('OnboardingStep4', () => {
       expect(screen.getByTestId('error-icon')).toBeDefined();
     });
 
-    it('should show no icon for short codes', () => {
+    it('displays no icon for codes shorter than six characters', () => {
       mockUseValidateReferralCode.mockReturnValue({
         referralCode: 'ABC',
         setReferralCode: jest.fn(),
@@ -562,7 +567,7 @@ describe('OnboardingStep4', () => {
   });
 
   describe('button states', () => {
-    it('should disable next button when referral code is invalid', () => {
+    it('disables next button when referral code is invalid', () => {
       mockUseValidateReferralCode.mockReturnValue({
         referralCode: 'INVALID123',
         setReferralCode: jest.fn(),
@@ -579,7 +584,7 @@ describe('OnboardingStep4', () => {
       // Button disabled state is passed to OnboardingStepComponent
     });
 
-    it('should disable next button when unknown error occurs', () => {
+    it('disables next button when unknown error occurs', () => {
       mockUseValidateReferralCode.mockReturnValue({
         referralCode: 'ERROR123',
         setReferralCode: jest.fn(),
@@ -595,7 +600,7 @@ describe('OnboardingStep4', () => {
       expect(container).toBeDefined();
     });
 
-    it('should show loading text when optin is loading', () => {
+    it('displays loading text when optin is in progress', () => {
       mockUseOptin.mockReturnValue({
         optin: jest.fn(),
         optinError: null,
@@ -610,7 +615,7 @@ describe('OnboardingStep4', () => {
       expect(container).toBeDefined();
     });
 
-    it('should show validating text when validating referral code', () => {
+    it('displays validating text when validating referral code', () => {
       mockUseValidateReferralCode.mockReturnValue({
         referralCode: 'TEST123',
         setReferralCode: jest.fn(),
@@ -628,7 +633,7 @@ describe('OnboardingStep4', () => {
   });
 
   describe('legal disclaimer', () => {
-    it('should render legal disclaimer text', () => {
+    it('renders legal disclaimer text', () => {
       renderWithProviders(<OnboardingStep4 />);
 
       expect(
@@ -639,7 +644,7 @@ describe('OnboardingStep4', () => {
       ).toBeDefined();
     });
 
-    it('should handle terms of use link press', () => {
+    it('opens terms of use URL when link is pressed', () => {
       const { Linking } = jest.requireActual('react-native');
       const mockOpenURL = Linking.openURL;
 
@@ -655,7 +660,7 @@ describe('OnboardingStep4', () => {
       }
     });
 
-    it('should handle learn more link press', () => {
+    it('opens learn more URL when link is pressed', () => {
       const { Linking } = jest.requireActual('react-native');
       const mockOpenURL = Linking.openURL;
 
@@ -673,7 +678,7 @@ describe('OnboardingStep4', () => {
   });
 
   describe('next button interaction', () => {
-    it('should call optin with referral code when next button is pressed', () => {
+    it('prepares optin call with referral code when next button is ready to be pressed', () => {
       const mockOptin = jest.fn();
 
       mockUseOptin.mockReturnValue({
@@ -704,7 +709,7 @@ describe('OnboardingStep4', () => {
       expect(mockOptin).toBeDefined();
     });
 
-    it('should call optin with empty referral code when no code is entered', () => {
+    it('prepares optin call with empty referral code when no code is entered', () => {
       const mockOptin = jest.fn();
 
       mockUseOptin.mockReturnValue({
@@ -733,12 +738,133 @@ describe('OnboardingStep4', () => {
   });
 
   describe('integration', () => {
-    it('should integrate with navigation and dispatch functions', () => {
+    it('integrates with navigation and dispatch functions', () => {
       renderWithProviders(<OnboardingStep4 />);
 
       // Verify navigation and dispatch functions are available
       expect(mockDispatch).toBeDefined();
       expect(mockNavigate).toBeDefined();
+    });
+  });
+
+  describe('prefilled referral code', () => {
+    it('initializes with prefilled referral code from selector', () => {
+      mockSelectOnboardingReferralCode.mockReturnValue('REFER123');
+
+      mockUseValidateReferralCode.mockImplementation((initialCode) => ({
+        referralCode: initialCode || '',
+        setReferralCode: jest.fn(),
+        isValidating: false,
+        isValid: true,
+        isUnknownError: false,
+        validateCode: jest.fn(),
+      }));
+
+      renderWithProviders(<OnboardingStep4 />);
+
+      // Verify the hook was called with the trimmed and uppercased code
+      expect(mockUseValidateReferralCode).toHaveBeenCalledWith('REFER123');
+    });
+
+    it('trims and uppercases prefilled referral code', () => {
+      mockSelectOnboardingReferralCode.mockReturnValue('  refer123  ');
+
+      mockUseValidateReferralCode.mockImplementation((initialCode) => ({
+        referralCode: initialCode || '',
+        setReferralCode: jest.fn(),
+        isValidating: false,
+        isValid: true,
+        isUnknownError: false,
+        validateCode: jest.fn(),
+      }));
+
+      renderWithProviders(<OnboardingStep4 />);
+
+      // Verify the hook was called with trimmed and uppercased version
+      expect(mockUseValidateReferralCode).toHaveBeenCalledWith('REFER123');
+    });
+
+    it('calls optin with isPrefilled true when referral code is prefilled', () => {
+      mockSelectOnboardingReferralCode.mockReturnValue('PREFILLED');
+
+      const mockOptin = jest.fn();
+      mockUseOptin.mockReturnValue({
+        optin: mockOptin,
+        optinError: null,
+        optinLoading: false,
+        clearOptinError: jest.fn(),
+      });
+
+      mockUseValidateReferralCode.mockReturnValue({
+        referralCode: 'PREFILLED',
+        setReferralCode: jest.fn(),
+        isValidating: false,
+        isValid: true,
+        isUnknownError: false,
+        validateCode: jest.fn(),
+      });
+
+      const { getByTestId } = renderWithProviders(<OnboardingStep4 />);
+      const container = getByTestId('onboarding-step-container');
+
+      // Verify component rendered
+      expect(container).toBeDefined();
+      // The optin function is ready to be called with isPrefilled: true
+      expect(mockOptin).toBeDefined();
+    });
+
+    it('calls optin with isPrefilled false when referral code is not prefilled', () => {
+      mockSelectOnboardingReferralCode.mockReturnValue(null);
+
+      const mockOptin = jest.fn();
+      mockUseOptin.mockReturnValue({
+        optin: mockOptin,
+        optinError: null,
+        optinLoading: false,
+        clearOptinError: jest.fn(),
+      });
+
+      mockUseValidateReferralCode.mockReturnValue({
+        referralCode: 'MANUAL123',
+        setReferralCode: jest.fn(),
+        isValidating: false,
+        isValid: true,
+        isUnknownError: false,
+        validateCode: jest.fn(),
+      });
+
+      const { getByTestId } = renderWithProviders(<OnboardingStep4 />);
+      const container = getByTestId('onboarding-step-container');
+
+      // Verify component rendered
+      expect(container).toBeDefined();
+      // The optin function is ready to be called with isPrefilled: false
+      expect(mockOptin).toBeDefined();
+    });
+  });
+
+  describe('auto-redirect to dashboard', () => {
+    beforeEach(() => {
+      mockNavigate.mockClear();
+    });
+
+    it('disables next button when subscriptionId exists', () => {
+      mockSelectRewardsSubscriptionId.mockReturnValue('sub-123');
+
+      mockUseValidateReferralCode.mockReturnValue({
+        referralCode: '',
+        setReferralCode: jest.fn(),
+        isValidating: false,
+        isValid: true,
+        isUnknownError: false,
+        validateCode: jest.fn(),
+      });
+
+      const { getByTestId } = renderWithProviders(<OnboardingStep4 />);
+      const container = getByTestId('onboarding-step-container');
+
+      // Verify the container has the onNextDisabled prop set
+      expect(container.props.onNextDisabled).toBe(true);
     });
   });
 });

--- a/app/core/DeeplinkManager/Handlers/handleRewardsUrl.test.ts
+++ b/app/core/DeeplinkManager/Handlers/handleRewardsUrl.test.ts
@@ -2,17 +2,32 @@ import { handleRewardsUrl } from './handleRewardsUrl';
 import NavigationService from '../../NavigationService';
 import Routes from '../../../constants/navigation/Routes';
 import DevLogger from '../../SDKConnect/utils/DevLogger';
+import Logger from '../../../util/Logger';
+import { store } from '../../../store';
+import { setOnboardingReferralCode } from '../../../reducers/rewards';
 
 // Mock dependencies
 jest.mock('../../NavigationService');
 jest.mock('../../SDKConnect/utils/DevLogger');
+jest.mock('../../../util/Logger');
+jest.mock('../../../store', () => ({
+  store: {
+    dispatch: jest.fn(),
+  },
+}));
+jest.mock('../../../reducers/rewards', () => ({
+  setOnboardingReferralCode: jest.fn((code: string | null) => ({
+    type: 'SET_ONBOARDING_REFERRAL_CODE',
+    payload: code,
+  })),
+}));
 
 describe('handleRewardsUrl', () => {
   let mockNavigate: jest.Mock;
+  let mockDispatch: jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.useFakeTimers();
 
     // Setup navigation mocks
     mockNavigate = jest.fn();
@@ -20,41 +35,88 @@ describe('handleRewardsUrl', () => {
       navigate: mockNavigate,
     } as unknown as typeof NavigationService.navigation;
 
-    // Mock DevLogger
+    // Setup store mock
+    mockDispatch = store.dispatch as jest.Mock;
+
+    // Mock loggers
     (DevLogger.log as jest.Mock) = jest.fn();
+    (Logger.log as jest.Mock) = jest.fn();
   });
 
-  afterEach(() => {
-    jest.runOnlyPendingTimers();
-    jest.useRealTimers();
-  });
-
-  describe('handleRewardsUrl', () => {
-    it('should navigate to rewards view with referral code', async () => {
+  describe('with referral code', () => {
+    it('dispatches referral code and navigates to rewards view', async () => {
       await handleRewardsUrl({ rewardsPath: '?referral=code123' });
 
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_VIEW, {
-        screen: Routes.REWARDS_VIEW,
-        params: {
-          isFromDeeplink: true,
-          referral: 'code123',
-        },
+      expect(setOnboardingReferralCode).toHaveBeenCalledWith('code123');
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SET_ONBOARDING_REFERRAL_CODE',
+        payload: 'code123',
       });
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_VIEW);
     });
 
-    it('should navigate to rewards view without referral code', async () => {
+    it('extracts referral code from full URL path', async () => {
+      await handleRewardsUrl({ rewardsPath: 'rewards?referral=abc456' });
+
+      expect(setOnboardingReferralCode).toHaveBeenCalledWith('abc456');
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SET_ONBOARDING_REFERRAL_CODE',
+        payload: 'abc456',
+      });
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_VIEW);
+    });
+
+    it('handles multiple URL parameters', async () => {
+      await handleRewardsUrl({
+        rewardsPath: '?referral=xyz789&other=param',
+      });
+
+      expect(setOnboardingReferralCode).toHaveBeenCalledWith('xyz789');
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SET_ONBOARDING_REFERRAL_CODE',
+        payload: 'xyz789',
+      });
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_VIEW);
+    });
+  });
+
+  describe('without referral code', () => {
+    it('clears referral code and navigates to rewards view', async () => {
       await handleRewardsUrl({ rewardsPath: '' });
 
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_VIEW, {
-        screen: Routes.REWARDS_VIEW,
-        params: {
-          isFromDeeplink: true,
-        },
+      expect(setOnboardingReferralCode).toHaveBeenCalledWith(null);
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SET_ONBOARDING_REFERRAL_CODE',
+        payload: null,
       });
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_VIEW);
     });
 
-    it('should fallback to wallet view on error', async () => {
-      // Mock error in navigation
+    it('clears referral code when URL has no parameters', async () => {
+      await handleRewardsUrl({ rewardsPath: 'rewards' });
+
+      expect(setOnboardingReferralCode).toHaveBeenCalledWith(null);
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SET_ONBOARDING_REFERRAL_CODE',
+        payload: null,
+      });
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_VIEW);
+    });
+
+    it('clears referral code when referral parameter is empty', async () => {
+      await handleRewardsUrl({ rewardsPath: '?referral=' });
+
+      expect(setOnboardingReferralCode).toHaveBeenCalledWith(null);
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'SET_ONBOARDING_REFERRAL_CODE',
+        payload: null,
+      });
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_VIEW);
+    });
+  });
+
+  describe('error handling', () => {
+    it('falls back to wallet view when navigation fails', async () => {
       mockNavigate.mockImplementationOnce(() => {
         throw new Error('Navigation error');
       });
@@ -65,6 +127,32 @@ describe('handleRewardsUrl', () => {
       expect(mockNavigate).toHaveBeenLastCalledWith(Routes.WALLET_VIEW, {
         screen: Routes.WALLET_VIEW,
       });
+    });
+
+    it('falls back to wallet view when dispatch fails', async () => {
+      mockDispatch.mockImplementationOnce(() => {
+        throw new Error('Dispatch error');
+      });
+
+      await handleRewardsUrl({ rewardsPath: '?referral=code123' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET_VIEW, {
+        screen: Routes.WALLET_VIEW,
+      });
+    });
+
+    it('logs error details when handling fails', async () => {
+      const testError = new Error('Test error');
+      mockNavigate.mockImplementationOnce(() => {
+        throw testError;
+      });
+
+      await handleRewardsUrl({ rewardsPath: '?referral=code123' });
+
+      expect(DevLogger.log).toHaveBeenCalledWith(
+        'Failed to handle rewards deeplink:',
+        testError,
+      );
     });
   });
 });

--- a/app/core/DeeplinkManager/Handlers/handleRewardsUrl.ts
+++ b/app/core/DeeplinkManager/Handlers/handleRewardsUrl.ts
@@ -2,6 +2,8 @@ import NavigationService from '../../NavigationService';
 import Routes from '../../../constants/navigation/Routes';
 import DevLogger from '../../SDKConnect/utils/DevLogger';
 import Logger from '../../../util/Logger';
+import { store } from '../../../store';
+import { setOnboardingReferralCode } from '../../../reducers/rewards';
 
 interface HandleRewardsUrlParams {
   rewardsPath: string;
@@ -49,6 +51,7 @@ export const handleRewardsUrl = async ({
     '[handleRewardsUrl] Starting rewards deeplink handling with path:',
     rewardsPath,
   );
+  Logger.log(`[handleRewardsUrl] Raw rewardsPath received: "${rewardsPath}"`);
 
   try {
     // Parse navigation parameters from URL
@@ -56,27 +59,12 @@ export const handleRewardsUrl = async ({
     DevLogger.log('[handleRewardsUrl] Parsed URL parameters:', urlParams);
 
     if (urlParams.referral && urlParams.referral.length > 0) {
-      Logger.log(
-        '[handleRewardsUrl] Navigating to rewards view with referral code',
-      );
-      NavigationService.navigation.navigate(Routes.REWARDS_VIEW, {
-        screen: Routes.REWARDS_VIEW,
-        params: {
-          isFromDeeplink: true,
-          referral: urlParams.referral,
-        },
-      });
+      store.dispatch(setOnboardingReferralCode(urlParams.referral));
     } else {
-      DevLogger.log(
-        '[handleRewardsUrl] No referral code parameter, defaulting to rewards view without referral code',
-      );
-      NavigationService.navigation.navigate(Routes.REWARDS_VIEW, {
-        screen: Routes.REWARDS_VIEW,
-        params: {
-          isFromDeeplink: true,
-        },
-      });
+      // Clear any existing referral code
+      store.dispatch(setOnboardingReferralCode(null));
     }
+    NavigationService.navigation.navigate(Routes.REWARDS_VIEW);
   } catch (error) {
     DevLogger.log('Failed to handle rewards deeplink:', error);
     // Fallback to wallet home on error

--- a/app/reducers/rewards/index.ts
+++ b/app/reducers/rewards/index.ts
@@ -45,6 +45,7 @@ export interface RewardsState {
 
   // Onboarding state
   onboardingActiveStep: OnboardingStep;
+  onboardingReferralCode: string | null;
 
   // Candidate subscription state
   candidateSubscriptionId: string | 'pending' | 'error' | 'retry' | null;
@@ -98,6 +99,7 @@ export const initialState: RewardsState = {
   balanceUpdatedAt: null,
 
   onboardingActiveStep: OnboardingStep.INTRO,
+  onboardingReferralCode: null,
   candidateSubscriptionId: 'pending',
   geoLocation: null,
   optinAllowedForGeo: null,
@@ -222,6 +224,14 @@ const rewardsSlice = createSlice({
 
     resetOnboarding: (state) => {
       state.onboardingActiveStep = OnboardingStep.INTRO;
+      state.onboardingReferralCode = null;
+    },
+
+    setOnboardingReferralCode: (
+      state,
+      action: PayloadAction<string | null>,
+    ) => {
+      state.onboardingReferralCode = action.payload;
     },
 
     setCandidateSubscriptionId: (
@@ -394,6 +404,7 @@ export const {
   resetRewardsState,
   setOnboardingActiveStep,
   resetOnboarding,
+  setOnboardingReferralCode,
   setCandidateSubscriptionId,
   setGeoRewardsMetadata,
   setGeoRewardsMetadataLoading,

--- a/app/reducers/rewards/selectors.test.ts
+++ b/app/reducers/rewards/selectors.test.ts
@@ -18,10 +18,13 @@ import {
   selectSeasonEndDate,
   selectSeasonTiers,
   selectOnboardingActiveStep,
+  selectOnboardingReferralCode,
   selectGeoLocation,
   selectOptinAllowedForGeo,
   selectOptinAllowedForGeoLoading,
+  selectOptinAllowedForGeoError,
   selectReferralDetailsLoading,
+  selectReferralDetailsError,
   selectCandidateSubscriptionId,
   selectHideUnlinkedAccountsBanner,
   selectHideCurrentAccountNotOptedInBannerArray,
@@ -580,6 +583,58 @@ describe('Rewards selectors', () => {
     });
   });
 
+  describe('selectOnboardingReferralCode', () => {
+    it('returns null when onboarding referral code is not set', () => {
+      const mockState = { rewards: { onboardingReferralCode: null } };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result } = renderHook(() =>
+        useSelector(selectOnboardingReferralCode),
+      );
+      expect(result.current).toBeNull();
+    });
+
+    it('returns onboarding referral code when set', () => {
+      const mockState = { rewards: { onboardingReferralCode: 'ONBOARD123' } };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result } = renderHook(() =>
+        useSelector(selectOnboardingReferralCode),
+      );
+      expect(result.current).toBe('ONBOARD123');
+    });
+
+    it('returns empty string when onboarding referral code is empty', () => {
+      const mockState = { rewards: { onboardingReferralCode: '' } };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result } = renderHook(() =>
+        useSelector(selectOnboardingReferralCode),
+      );
+      expect(result.current).toBe('');
+    });
+
+    it('handles state changes correctly', () => {
+      const mockState = { rewards: { onboardingReferralCode: null } };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result, rerender } = renderHook(() =>
+        useSelector(selectOnboardingReferralCode),
+      );
+      expect(result.current).toBeNull();
+
+      // Simulate state change: update onboardingReferralCode to a string
+      const updatedState = {
+        rewards: { onboardingReferralCode: 'UPDATED456' },
+      };
+      mockedUseSelector.mockImplementation((selector) =>
+        selector(updatedState),
+      );
+      rerender();
+      expect(result.current).toBe('UPDATED456');
+    });
+  });
+
   describe('selectGeoLocation', () => {
     it('returns null when geo location is not set', () => {
       const mockState = { rewards: { geoLocation: null } };
@@ -642,6 +697,48 @@ describe('Rewards selectors', () => {
     });
   });
 
+  describe('selectOptinAllowedForGeoError', () => {
+    it('returns false when there is no geo error', () => {
+      const mockState = { rewards: { optinAllowedForGeoError: false } };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result } = renderHook(() =>
+        useSelector(selectOptinAllowedForGeoError),
+      );
+      expect(result.current).toBe(false);
+    });
+
+    it('returns true when there is a geo error', () => {
+      const mockState = { rewards: { optinAllowedForGeoError: true } };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result } = renderHook(() =>
+        useSelector(selectOptinAllowedForGeoError),
+      );
+      expect(result.current).toBe(true);
+    });
+
+    it('handles error state changes correctly', () => {
+      let mockState = { rewards: { optinAllowedForGeoError: false } };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result, rerender } = renderHook(() =>
+        useSelector(selectOptinAllowedForGeoError),
+      );
+      expect(result.current).toBe(false);
+
+      mockState = { rewards: { optinAllowedForGeoError: true } };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+      rerender();
+      expect(result.current).toBe(true);
+
+      mockState = { rewards: { optinAllowedForGeoError: false } };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+      rerender();
+      expect(result.current).toBe(false);
+    });
+  });
+
   describe('selectReferralDetailsLoading', () => {
     it('returns false when referral details are not loading', () => {
       const mockState = { rewards: { referralDetailsLoading: false } };
@@ -661,6 +758,48 @@ describe('Rewards selectors', () => {
         useSelector(selectReferralDetailsLoading),
       );
       expect(result.current).toBe(true);
+    });
+  });
+
+  describe('selectReferralDetailsError', () => {
+    it('returns false when there is no referral details error', () => {
+      const mockState = { rewards: { referralDetailsError: false } };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result } = renderHook(() =>
+        useSelector(selectReferralDetailsError),
+      );
+      expect(result.current).toBe(false);
+    });
+
+    it('returns true when there is a referral details error', () => {
+      const mockState = { rewards: { referralDetailsError: true } };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result } = renderHook(() =>
+        useSelector(selectReferralDetailsError),
+      );
+      expect(result.current).toBe(true);
+    });
+
+    it('handles error state changes correctly', () => {
+      let mockState = { rewards: { referralDetailsError: false } };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+
+      const { result, rerender } = renderHook(() =>
+        useSelector(selectReferralDetailsError),
+      );
+      expect(result.current).toBe(false);
+
+      mockState = { rewards: { referralDetailsError: true } };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+      rerender();
+      expect(result.current).toBe(true);
+
+      mockState = { rewards: { referralDetailsError: false } };
+      mockedUseSelector.mockImplementation((selector) => selector(mockState));
+      rerender();
+      expect(result.current).toBe(false);
     });
   });
 

--- a/app/reducers/rewards/selectors.ts
+++ b/app/reducers/rewards/selectors.ts
@@ -49,6 +49,9 @@ export const selectSeasonTiers = (state: RootState) =>
 export const selectOnboardingActiveStep = (state: RootState): OnboardingStep =>
   state.rewards.onboardingActiveStep;
 
+export const selectOnboardingReferralCode = (state: RootState) =>
+  state.rewards.onboardingReferralCode;
+
 export const selectGeoLocation = (state: RootState) =>
   state.rewards.geoLocation;
 


### PR DESCRIPTION
## **Description**

When scanning a rewards deeplink URI via metamask QR scanner, the referral code wasn't being populated in the onboarding flow due to url params not being passed through. We are now using the store ui state to populate the onboarding referral input.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/21402

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Routes rewards deeplink referral codes through Redux to prefill onboarding, removes navigation params, updates handler/state/selectors, and adjusts tests.
> 
> - **Navigation/Flows**:
>   - Remove `useParams` and `initialParams` from `RewardsNavigator` and `OnboardingNavigator`.
> - **Onboarding Step 4 (`components/Onboarding/OnboardingStep4.tsx`)**:
>   - Use `selectOnboardingReferralCode` to prefill and validate referral codes (trim/uppercase).
>   - Compute `isPrefilledReferral` from store; disable Next when invalid/unknown error or already subscribed.
>   - Minor UX: retain validation/loading icon handling and auto-redirect to dashboard if `subscriptionId` exists.
> - **State/Selectors (`reducers/rewards`)**:
>   - Add `onboardingReferralCode` to state; actions: `setOnboardingReferralCode`, `resetOnboarding` clears it.
>   - Add selector `selectOnboardingReferralCode` and extra selectors for geo/referral errors.
>   - Persist/rehydrate logic clarified to avoid persisting onboarding fields.
> - **Deeplink Handling (`handleRewardsUrl.ts`)**:
>   - Parse `referral` and dispatch `setOnboardingReferralCode(referral|null)`; navigate to `REWARDS_VIEW` without params.
>   - Add logging and fallback error handling.
> - **Tests**:
>   - Update/add tests for new state, selectors, deeplink dispatch, and prefilled referral behavior; adjust navigation mocks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 727fc65588c004fa0bc2e3e4a7932acb375d317c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->