### PR TITLE
perf: Increase Snap timeouts slightly

### DIFF
--- a/app/core/Engine/controllers/snaps/execution-service-init.test.ts
+++ b/app/core/Engine/controllers/snaps/execution-service-init.test.ts
@@ -42,6 +42,7 @@ describe('ExecutionServiceInit', () => {
     expect(controllerMock).toHaveBeenCalledWith({
       messenger: expect.any(Object),
       setupSnapProvider: expect.any(Function),
+      pingTimeout: expect.any(Number),
     });
   });
 

--- a/app/core/Engine/controllers/snaps/execution-service-init.ts
+++ b/app/core/Engine/controllers/snaps/execution-service-init.ts
@@ -8,6 +8,7 @@ import { createWebView, removeWebView } from '../../../../lib/snaps';
 import Logger from '../../../../util/Logger';
 import { SnapBridge } from '../../../Snaps';
 import getRpcMethodMiddleware from '../../../RPCMethods/RPCMethodMiddleware';
+import { Duration, inMilliseconds } from '@metamask/utils';
 
 /**
  * Initialize the Snaps execution service.
@@ -67,6 +68,7 @@ export const executionServiceInit: ControllerInitFunction<
       setupSnapProvider,
       createWebView,
       removeWebView,
+      pingTimeout: inMilliseconds(5, Duration.Second),
     }),
   };
 };

--- a/app/core/Engine/controllers/snaps/snap-controller-init.test.ts
+++ b/app/core/Engine/controllers/snaps/snap-controller-init.test.ts
@@ -69,6 +69,7 @@ describe('SnapControllerInit', () => {
       getFeatureFlags: expect.any(Function),
       getMnemonicSeed: expect.any(Function),
       maxIdleTime: expect.any(Number),
+      maxRequestTime: expect.any(Number),
       preinstalledSnaps: expect.any(Array),
       trackEvent: expect.any(Function),
     });

--- a/app/core/Engine/controllers/snaps/snap-controller-init.ts
+++ b/app/core/Engine/controllers/snaps/snap-controller-init.ts
@@ -103,6 +103,7 @@ export const snapControllerInit: ControllerInitFunction<
     // TODO: Look into the type mismatch.
     messenger: controllerMessenger,
     maxIdleTime: inMilliseconds(5, Duration.Minute),
+    maxRequestTime: inMilliseconds(2, Duration.Minute),
     featureFlags: {
       allowLocalSnaps,
       disableSnapInstallation,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When the app is under load messages between the app and Snaps may be delayed due to the JS thread being held up. To prevent this causing unnecessary failures we bump the timeouts slightly. With this PR, the ping timeout is now 5 seconds instead of 2 seconds and the execution timeout is doubled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps execution service ping timeout to 5s and adds a 2m max request time to SnapController, updating tests accordingly.
> 
> - **Snaps Execution Service (`app/core/Engine/controllers/snaps/execution-service-init.ts`)**
>   - Add `pingTimeout: inMilliseconds(5, Duration.Second)` to `WebViewExecutionService` options.
>   - Tests updated to assert `pingTimeout` argument.
> - **Snap Controller (`app/core/Engine/controllers/snaps/snap-controller-init.ts`)**
>   - Add `maxRequestTime: inMilliseconds(2, Duration.Minute)` to `SnapController` options.
>   - Tests updated to assert `maxRequestTime` argument.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de103a7b5aac3221021a94f200a8e2701eafbaa5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->