### PR TITLE
fix: exit useLatestBalance early on undefined chain

### DIFF
--- a/app/components/UI/Bridge/hooks/useLatestBalance/index.ts
+++ b/app/components/UI/Bridge/hooks/useLatestBalance/index.ts
@@ -145,6 +145,13 @@ export const useLatestBalance = (token: {
   }, [token.address, token.decimals, chainId, selectedAddress, nonEvmTokens]);
 
   useEffect(() => {
+    // In case chainId is undefined, exit early to avoid
+    // calling handleFetchEvmAtomicBalance which will trigger an invalid address error
+    // when selectedAddress is a non-EVM chain.
+    if (!chainId) {
+      return;
+    }
+
     if (!isCaipChainId(chainId)) {
       handleFetchEvmAtomicBalance();
     }

--- a/app/components/UI/Bridge/hooks/useLatestBalance/index.ts
+++ b/app/components/UI/Bridge/hooks/useLatestBalance/index.ts
@@ -12,6 +12,7 @@ import usePrevious from '../../../../hooks/usePrevious';
 import { isNativeAddress, isNonEvmChainId } from '@metamask/bridge-controller';
 import { endTrace, trace, TraceName } from '../../../../../util/trace';
 import { useNonEvmTokensWithBalance } from '../useNonEvmTokensWithBalance';
+import { isEthAddress } from '../../../../../util/address';
 
 export async function fetchAtomicTokenBalance(
   address: string,
@@ -82,7 +83,8 @@ export const useLatestBalance = (token: {
       token.decimals &&
       chainId &&
       !isCaipChainId(chainId) &&
-      selectedAddress
+      selectedAddress &&
+      isEthAddress(selectedAddress)
     ) {
       // Create a unique UUID for this trace to prevent collisions
       const traceId = uuidv4();

--- a/app/components/UI/Bridge/hooks/useLatestBalance/useLatestBalance.test.tsx
+++ b/app/components/UI/Bridge/hooks/useLatestBalance/useLatestBalance.test.tsx
@@ -214,31 +214,6 @@ describe('useLatestBalance', () => {
     });
   });
 
-  it('does not call EVM balance fetch when Solana address is selected with hex chainId', async () => {
-    const state = cloneDeep(initialState);
-    state.engine.backgroundState.AccountsController.internalAccounts.selectedAccount =
-      solanaAccountId;
-
-    const { result } = renderHookWithProvider(
-      () =>
-        useLatestBalance({
-          address: solanaNativeTokenAddress,
-          decimals: 9,
-          chainId: '0x1' as Hex,
-          balance: '100.0',
-        }),
-      { state },
-    );
-
-    // When a Solana address is selected but chainId is hex (EVM),
-    // it should not attempt to call EVM balance methods with Solana address
-    // This would cause ethers.js to throw "invalid address" error
-    expect(result.current).toEqual({
-      displayBalance: '100.0',
-      atomicBalance: BigNumber.from('100000000000'),
-    });
-  });
-
   it('returns cached balance when EVM address is used with Solana CAIP chainId', async () => {
     const { result } = renderHookWithProvider(
       () =>
@@ -257,6 +232,158 @@ describe('useLatestBalance', () => {
     expect(result.current).toEqual({
       displayBalance: '50.0',
       atomicBalance: BigNumber.from('50000000000000000000'),
+    });
+  });
+
+  describe('Address type validation (race condition fix)', () => {
+    it('does not call EVM balance fetch when Solana address is selected with EVM hex chainId', async () => {
+      const state = cloneDeep(initialState);
+      state.engine.backgroundState.AccountsController.internalAccounts.selectedAccount =
+        solanaAccountId;
+
+      const { result } = renderHookWithProvider(
+        () =>
+          useLatestBalance({
+            address: '0x1234567890123456789012345678901234567890',
+            decimals: 18,
+            chainId: '0x1' as Hex,
+            balance: '100.0',
+          }),
+        { state },
+      );
+
+      // When Solana address is selected but chainId is EVM hex,
+      // isEthAddress(selectedAddress) returns false, preventing EVM balance fetch
+      expect(getProviderByChainId).not.toHaveBeenCalled();
+      expect(mockProvider.getBalance).not.toHaveBeenCalled();
+
+      // Returns cached balance instead of attempting to fetch
+      expect(result.current).toEqual({
+        displayBalance: '100.0',
+        atomicBalance: BigNumber.from('100000000000000000000'),
+      });
+    });
+
+    it('does not call EVM balance fetch when Solana address with native token has EVM chainId', async () => {
+      const state = cloneDeep(initialState);
+      state.engine.backgroundState.AccountsController.internalAccounts.selectedAccount =
+        solanaAccountId;
+
+      const { result } = renderHookWithProvider(
+        () =>
+          useLatestBalance({
+            address: constants.AddressZero,
+            decimals: 18,
+            chainId: '0x1' as Hex,
+            balance: '50.0',
+          }),
+        { state },
+      );
+
+      // Solana address with zero address token and EVM chainId
+      // should not attempt EVM balance fetch
+      expect(getProviderByChainId).not.toHaveBeenCalled();
+      expect(mockProvider.getBalance).not.toHaveBeenCalled();
+      expect(result.current).toEqual({
+        displayBalance: '50.0',
+        atomicBalance: BigNumber.from('50000000000000000000'),
+      });
+    });
+
+    it('fetches EVM balance when EVM address is selected with EVM chainId', async () => {
+      const { result } = renderHookWithProvider(
+        () =>
+          useLatestBalance({
+            address: '0x1234567890123456789012345678901234567890',
+            decimals: 6,
+            chainId: '0x1' as Hex,
+          }),
+        { state: initialState },
+      );
+
+      // EVM address with EVM chainId should fetch balance normally
+      await waitFor(() => {
+        expect(getProviderByChainId).toHaveBeenCalledWith('0x1');
+        expect(result.current).toEqual({
+          displayBalance: '1.0',
+          atomicBalance: BigNumber.from('1000000'),
+        });
+      });
+    });
+
+    it('returns cached balance when Bitcoin address is selected with EVM chainId', async () => {
+      const state = cloneDeep(initialState);
+      // Mock a Bitcoin account being selected
+      state.engine.backgroundState.AccountsController.internalAccounts.selectedAccount =
+        'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq'; // Bitcoin address format
+
+      const { result } = renderHookWithProvider(
+        () =>
+          useLatestBalance({
+            address: '0x1234567890123456789012345678901234567890',
+            decimals: 18,
+            chainId: '0x1' as Hex,
+            balance: '25.0',
+          }),
+        { state },
+      );
+
+      // Bitcoin address with EVM chainId should not attempt EVM balance fetch
+      expect(getProviderByChainId).not.toHaveBeenCalled();
+      expect(mockProvider.getBalance).not.toHaveBeenCalled();
+      expect(result.current).toEqual({
+        displayBalance: '25.0',
+        atomicBalance: BigNumber.from('25000000000000000000'),
+      });
+    });
+
+    it('handles rapid account switching from EVM to Solana gracefully', async () => {
+      const stateWithEvmAccount = cloneDeep(initialState);
+
+      renderHookWithProvider(
+        () =>
+          useLatestBalance({
+            address: '0x1234567890123456789012345678901234567890',
+            decimals: 18,
+            chainId: '0x1' as Hex,
+            balance: '10.0',
+          }),
+        { state: stateWithEvmAccount },
+      );
+
+      // Initially with EVM account, balance should be fetched
+      await waitFor(() => {
+        expect(getProviderByChainId).toHaveBeenCalledWith('0x1');
+      });
+
+      jest.clearAllMocks();
+
+      // Simulate switching to Solana account by rendering with updated state
+      const stateWithSolanaAccount = cloneDeep(initialState);
+      stateWithSolanaAccount.engine.backgroundState.AccountsController.internalAccounts.selectedAccount =
+        solanaAccountId;
+
+      const { result: resultAfterSwitch } = renderHookWithProvider(
+        () =>
+          useLatestBalance({
+            address: '0x1234567890123456789012345678901234567890',
+            decimals: 18,
+            chainId: '0x1' as Hex,
+            balance: '10.0',
+          }),
+        { state: stateWithSolanaAccount },
+      );
+
+      // After switching to Solana, EVM balance fetch should not be called
+      // even though chainId is still '0x1'
+      expect(getProviderByChainId).not.toHaveBeenCalled();
+      expect(mockProvider.getBalance).not.toHaveBeenCalled();
+
+      // Should return cached balance
+      expect(resultAfterSwitch.current).toEqual({
+        displayBalance: '10.0',
+        atomicBalance: BigNumber.from('10000000000000000000'),
+      });
     });
   });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR addresses [Sentry Issue #6619121420](https://metamask.sentry.io/issues/6619121420/?project=2299799&query=is%3Aunresolved%20assigned%3A%23team-swaps-bridge&referrer=issue-stream) where `useLatestBalance` incorrectly processes Solana addresses as EVM addresses when `chainId` is `undefined`, causing ethers.js to throw `Error: invalid address (argument="address", value="32P9tNY1MnS4DTQpP2yqtoroEKxzNWk8iJnv6wgwHfG3", code=INVALID_ARGUMENT, version=address/5.7.0)`. When users select a non-EVM address in the Bridge/Swap feature, React's concurrent updates can trigger `useLatestBalance` with an `undefined` chainId while `selectedAddress` contains a valid Solana address. Since `!isCaipChainId(undefined)` evaluates to `true`, the hook incorrectly calls `handleFetchEvmAtomicBalance()`, which passes the Solana address to ethers.js `getAddress()` function, causing it to fail. This bug was likely introduced in PR #14365 (Solana integration to Bridge), as the Sentry issue timeline aligns with this hypothesis. The fix adds an early exit guard when `chainId` is `undefined` to prevent calling `handleFetchEvmAtomicBalance` with Solana addresses.

**Update:** Cursor Bugbot reported a race codition where chain id can be EVM but address can still be solana. This is likely to happen, but we provided a guard to be more explicit as well as implemented the required tests.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3252

## **Manual testing steps**

```gherkin
Feature: Bridge balance fetching with multi-chain account support

  Scenario: User switches from EVM to Solana account
    Given user has an EVM account selected with Ethereum Mainnet
    And Bridge view is displaying ETH balance
    
    When user switches to a Solana account
    Then no "invalid address" error appears in console
    And cached balance displays for Solana account if available
    And app remains functional without crashes
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds early exits and EVM address validation in `useLatestBalance` to avoid invalid address fetches and introduces comprehensive tests for multi-chain scenarios.
> 
> - **Bridge hook (`useLatestBalance`)**:
>   - Add guard to only fetch EVM balances when `selectedAddress` is an EVM address (`isEthAddress`) and `chainId` is defined/non-CAIP.
>   - Early-return in effect when `chainId` is undefined to prevent erroneous EVM fetches.
> - **Tests (`useLatestBalance.test.tsx`)**:
>   - Add cases ensuring no EVM fetch on undefined `chainId` and when CAIP/Solana chain IDs are used.
>   - Validate behavior when address type and `chainId` mismatch (Solana/Bitcoin address with EVM `chainId`).
>   - Confirm normal fetch for EVM address with EVM `chainId` and cached-balance fallbacks.
>   - Add scenario covering rapid account switching from EVM to Solana.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1725296ec8656c648747cae2630272ce8981c3af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->