### PR TITLE
fix: Prevent relative paths in RNTar native modules

### DIFF
--- a/.github/workflows/needs-e2e-build.yml
+++ b/.github/workflows/needs-e2e-build.yml
@@ -109,6 +109,7 @@ jobs:
               - 'sonar-project.properties'         # SonarQube config
               - 'scripts/*'                        # Build/utility scripts
               - 'scripts/*/**'                     # Subdirectories in scripts/   
+              - '!scripts/build.sh'                # But NOT build.sh
               - 'patches/**'                       # Dependency patches
               - 'ppom/**'                          # PPOM sub-project
 

--- a/.github/workflows/needs-e2e-build.yml
+++ b/.github/workflows/needs-e2e-build.yml
@@ -109,7 +109,6 @@ jobs:
               - 'sonar-project.properties'         # SonarQube config
               - 'scripts/*'                        # Build/utility scripts
               - 'scripts/*/**'                     # Subdirectories in scripts/   
-              - '!scripts/build.sh'                # But NOT build.sh
               - 'patches/**'                       # Dependency patches
               - 'ppom/**'                          # PPOM sub-project
 

--- a/android/app/src/main/java/io/metamask/nativeModules/RNTar/RNTar.java
+++ b/android/app/src/main/java/io/metamask/nativeModules/RNTar/RNTar.java
@@ -78,7 +78,7 @@ public class RNTar extends ReactContextBaseJavaModule {
       }
 
       File outPathFile = new File(outputPath);
-      String outPathCanonical = outPathFile.getCanonicalPath() + File.seperator;
+      String outPathCanonical = outPathFile.getCanonicalPath() + File.separator;
 
       // Set up the input streams for reading the .tgz file
       try (FileInputStream fileInputStream = new FileInputStream(tgzPath);
@@ -91,7 +91,7 @@ public class RNTar extends ReactContextBaseJavaModule {
         while ((entry = (TarArchiveEntry) tarInputStream.getNextEntry()) != null) {
           File outputFile = new File(outputPath, entry.getName());
 
-          if (!outPathFile.getCanonicalPath().startsWith(outPathCanonical)) {
+          if (!outputFile.getCanonicalPath().startsWith(outPathCanonical)) {
             throw new IOException("Tarball failed to extract due to invalid paths.");
           }
 

--- a/android/app/src/main/java/io/metamask/nativeModules/RNTar/RNTar.java
+++ b/android/app/src/main/java/io/metamask/nativeModules/RNTar/RNTar.java
@@ -77,7 +77,7 @@ public class RNTar extends ReactContextBaseJavaModule {
         throw new IOException("The output directory is not readable and/or writable.");
       }
 
-      File outPathFile = new File(outPathFile);
+      File outPathFile = new File(outputPath);
       String outPathCanonical = outPathFile.getCanonicalPath() + File.seperator;
 
       // Set up the input streams for reading the .tgz file

--- a/android/app/src/main/java/io/metamask/nativeModules/RNTar/RNTar.java
+++ b/android/app/src/main/java/io/metamask/nativeModules/RNTar/RNTar.java
@@ -77,6 +77,9 @@ public class RNTar extends ReactContextBaseJavaModule {
         throw new IOException("The output directory is not readable and/or writable.");
       }
 
+      File outPathFile = new File(outPathFile);
+      String outPathCanonical = outPathFile.getCanonicalPath() + File.seperator;
+
       // Set up the input streams for reading the .tgz file
       try (FileInputStream fileInputStream = new FileInputStream(tgzPath);
            GZIPInputStream gzipInputStream = new GZIPInputStream(fileInputStream);
@@ -87,6 +90,10 @@ public class RNTar extends ReactContextBaseJavaModule {
         // Loop through the entries in the .tgz file
         while ((entry = (TarArchiveEntry) tarInputStream.getNextEntry()) != null) {
           File outputFile = new File(outputPath, entry.getName());
+
+          if (!outPathFile.getCanonicalPath().startsWith(outPathCanonical)) {
+            throw new IOException("Tarball failed to extract due to invalid paths.");
+          }
 
           // If it is a directory, create the output directory
           if (entry.isDirectory()) {

--- a/ios/Light-Swift-Untar-V2/Light-Swift-Untar.swift
+++ b/ios/Light-Swift-Untar-V2/Light-Swift-Untar.swift
@@ -15,10 +15,12 @@ public typealias Closure = (Double) -> Void
 enum UntarError: Error, LocalizedError {
   case notFound(file: String)
   case corruptFile(type: UnicodeScalar)
+  case invalidPaths()
   public var errorDescription: String? {
     switch self {
     case let .notFound(file: file): return "Source file \(file) not found"
     case let .corruptFile(type: type): return "Invalid block type \(type) found"
+    case let .invalidPaths(): return "Tarball failed to extract due to invalid paths"
     }
   }
 }
@@ -37,6 +39,7 @@ public extension FileManager {
   private func createFilesAndDirectories(path: String, tarObject: Any, size: UInt64,
                                          progress progressClosure: Closure?) throws -> Bool {
     try! createDirectory(atPath: path, withIntermediateDirectories: true, attributes: nil)
+    let rootPath = URL(fileURLWithPath: path).resolvingSymlinksInPath().path + "/"
     var location: UInt64 = 0
     while location < size {
       var blockCount: UInt64 = 1
@@ -46,7 +49,10 @@ public extension FileManager {
       switch type {
       case "0": // File
         let name = self.name(object: tarObject, offset: location)
-        let filePath = URL(fileURLWithPath: path).appendingPathComponent(name).path
+        let filePath = URL(fileURLWithPath: path).appendingPathComponent(name).resolvingSymlinksInPath().path
+        guard filePath.hasPrefix(rootPath) {
+          throw UntarError.invalidPaths()
+        }
         let size = self.size(object: tarObject, offset: location)
         if size == 0 { try "".write(toFile: filePath, atomically: true, encoding: .utf8) } else {
           blockCount += (size - 1) / FileManager.tarBlockSize + 1 // size / tarBlockSize rounded up
@@ -55,7 +61,10 @@ public extension FileManager {
         }
       case "5": // Directory
         let name = self.name(object: tarObject, offset: location)
-        let directoryPath = URL(fileURLWithPath: path).appendingPathComponent(name).path
+        let directoryPath = URL(fileURLWithPath: path).appendingPathComponent(name).resolvingSymlinksInPath().path
+        guard directoryPath.hasPrefix(rootPath) {
+          throw UntarError.invalidPaths()
+        }
         try createDirectory(atPath: directoryPath, withIntermediateDirectories: true,
                             attributes: nil)
       case "\0": break // Null block

--- a/ios/Light-Swift-Untar-V2/Light-Swift-Untar.swift
+++ b/ios/Light-Swift-Untar-V2/Light-Swift-Untar.swift
@@ -15,12 +15,12 @@ public typealias Closure = (Double) -> Void
 enum UntarError: Error, LocalizedError {
   case notFound(file: String)
   case corruptFile(type: UnicodeScalar)
-  case invalidPaths()
+  case invalidPaths
   public var errorDescription: String? {
     switch self {
     case let .notFound(file: file): return "Source file \(file) not found"
     case let .corruptFile(type: type): return "Invalid block type \(type) found"
-    case let .invalidPaths(): return "Tarball failed to extract due to invalid paths"
+    case .invalidPaths: return "Tarball failed to extract due to invalid paths"
     }
   }
 }
@@ -51,7 +51,7 @@ public extension FileManager {
         let name = self.name(object: tarObject, offset: location)
         let filePath = URL(fileURLWithPath: path).appendingPathComponent(name).resolvingSymlinksInPath().path
         guard filePath.hasPrefix(rootPath) else {
-          throw UntarError.invalidPaths()
+            throw UntarError.invalidPaths
         }
         let size = self.size(object: tarObject, offset: location)
         if size == 0 { try "".write(toFile: filePath, atomically: true, encoding: .utf8) } else {
@@ -63,7 +63,7 @@ public extension FileManager {
         let name = self.name(object: tarObject, offset: location)
         let directoryPath = URL(fileURLWithPath: path).appendingPathComponent(name).resolvingSymlinksInPath().path
         guard directoryPath.hasPrefix(rootPath) else {
-          throw UntarError.invalidPaths()
+            throw UntarError.invalidPaths
         }
         try createDirectory(atPath: directoryPath, withIntermediateDirectories: true,
                             attributes: nil)

--- a/ios/Light-Swift-Untar-V2/Light-Swift-Untar.swift
+++ b/ios/Light-Swift-Untar-V2/Light-Swift-Untar.swift
@@ -50,7 +50,7 @@ public extension FileManager {
       case "0": // File
         let name = self.name(object: tarObject, offset: location)
         let filePath = URL(fileURLWithPath: path).appendingPathComponent(name).resolvingSymlinksInPath().path
-        guard filePath.hasPrefix(rootPath) {
+        guard filePath.hasPrefix(rootPath) else {
           throw UntarError.invalidPaths()
         }
         let size = self.size(object: tarObject, offset: location)
@@ -62,7 +62,7 @@ public extension FileManager {
       case "5": // Directory
         let name = self.name(object: tarObject, offset: location)
         let directoryPath = URL(fileURLWithPath: path).appendingPathComponent(name).resolvingSymlinksInPath().path
-        guard directoryPath.hasPrefix(rootPath) {
+        guard directoryPath.hasPrefix(rootPath) else {
           throw UntarError.invalidPaths()
         }
         try createDirectory(atPath: directoryPath, withIntermediateDirectories: true,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Prevent unsafe unpacking of tarballs that use relative paths in both the iOS and Android native modules used for `RNTar.unTar`.

This was not abusable in production since the code path is not currently reachable, but since the code will be used in the near future this should be fixed.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Closes: https://github.com/MetaMask/metamask-mobile/issues/8096

Closes: https://github.com/MetaMask/metamask-mobile/issues/13765

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add path validation during tar extraction on Android and iOS to block entries escaping the output directory.
> 
> - **Security: Tar extraction hardening**
>   - **Android (`android/app/src/main/java/io/metamask/nativeModules/RNTar/RNTar.java`)**:
>     - Validate each entry with canonical paths; reject if `outputFile.getCanonicalPath()` does not start with the canonical `outputPath`.
>   - **iOS (`ios/Light-Swift-Untar-V2/Light-Swift-Untar.swift`)**:
>     - Resolve symlinks and validate extracted `filePath`/`directoryPath` stay under resolved root; throw `UntarError.invalidPaths` on violation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f08804a4af704909ec1d701ba2f4e00fbf40850. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->