### PR TITLE
refactor: Simplify NPM fetching logic

### DIFF
--- a/app/core/Snaps/location/npm.test.ts
+++ b/app/core/Snaps/location/npm.test.ts
@@ -5,10 +5,15 @@ jest.mock('react-native-blob-util', () => ({
     fetch: jest.fn(() => ({
       flush: jest.fn(),
       data: '/document-dir/archive.tgz',
+      respInfo: {
+        status: 200,
+        headers: {
+          'content-length': 2000,
+        },
+      },
     })),
   })),
   fs: {
-    dirs: { DocumentDir: '/document-dir/' },
     unlink: jest.fn().mockResolvedValue(undefined),
     isDir: jest.fn((path) => path.endsWith('archive') || path.endsWith('dist')),
     ls: jest.fn((path) => {

--- a/app/core/Snaps/location/npm.ts
+++ b/app/core/Snaps/location/npm.ts
@@ -1,7 +1,7 @@
 /* eslint-disable import/prefer-default-export */
 ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
 import { VirtualFile } from '@metamask/snaps-utils';
-import { assert, getErrorMessage, stringToBytes } from '@metamask/utils';
+import { assert, getErrorMessage } from '@metamask/utils';
 import { NativeModules } from 'react-native';
 import ReactNativeBlobUtil, { FetchBlobResponse } from 'react-native-blob-util';
 import {
@@ -25,9 +25,7 @@ const findAllPaths = async (path: string): Promise<string[]> => {
 };
 
 const readAndParseAt = async (path: string) => {
-  const contents = stringToBytes(
-    await ReactNativeBlobUtil.fs.readFile(path, 'utf8'),
-  );
+  const contents = await ReactNativeBlobUtil.fs.readFile(path, 'utf8');
   return { path, contents };
 };
 

--- a/app/core/Snaps/location/npm.ts
+++ b/app/core/Snaps/location/npm.ts
@@ -6,6 +6,7 @@ import { NativeModules } from 'react-native';
 import ReactNativeBlobUtil, { FetchBlobResponse } from 'react-native-blob-util';
 import {
   BaseNpmLocation,
+  DetectSnapLocationOptions,
   getNpmCanonicalBasePath,
   TARBALL_SIZE_SAFETY_LIMIT,
 } from '@metamask/snaps-controllers';
@@ -29,19 +30,27 @@ const readAndParseAt = async (path: string) => {
   return { path, contents };
 };
 
-const { fetch: blobFetch } = ReactNativeBlobUtil.config({
-  fileCache: true,
-  appendExt: 'tgz',
-});
-
 export class NpmLocation extends BaseNpmLocation {
+  #blobFetch: ReactNativeBlobUtil['fetch'];
+
+  constructor(url: URL, opts: DetectSnapLocationOptions = {}) {
+    super(url, opts);
+
+    const { fetch: blobFetch } = ReactNativeBlobUtil.config({
+      fileCache: true,
+      appendExt: 'tgz',
+    });
+
+    this.#blobFetch = blobFetch;
+  }
+
   async fetchNpmTarball(
     tarballUrl: URL,
   ): Promise<Map<string, VirtualFile<unknown>>> {
     let response: FetchBlobResponse | null = null;
     let untarPath: string | null = null;
     try {
-      response = await blobFetch('GET', tarballUrl.toString());
+      response = await this.#blobFetch('GET', tarballUrl.toString());
 
       const responseInfo = response.respInfo;
 

--- a/app/core/Snaps/location/npm.ts
+++ b/app/core/Snaps/location/npm.ts
@@ -31,6 +31,11 @@ const readAndParseAt = async (path: string) => {
   return { path, contents };
 };
 
+const { fetch: blobFetch } = ReactNativeBlobUtil.config({
+  fileCache: true,
+  appendExt: 'tgz',
+});
+
 export class NpmLocation extends BaseNpmLocation {
   async fetchNpmTarball(
     tarballUrl: URL,
@@ -38,10 +43,7 @@ export class NpmLocation extends BaseNpmLocation {
     let response: FetchBlobResponse | null = null;
     let untarPath: string | null = null;
     try {
-      response = await ReactNativeBlobUtil.config({
-        fileCache: true,
-        appendExt: 'tgz',
-      }).fetch('GET', tarballUrl.toString());
+      response = await blobFetch('GET', tarballUrl.toString());
 
       const responseInfo = response.respInfo;
 

--- a/app/core/Snaps/location/npm.ts
+++ b/app/core/Snaps/location/npm.ts
@@ -1,7 +1,7 @@
 /* eslint-disable import/prefer-default-export */
 ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
 import { VirtualFile } from '@metamask/snaps-utils';
-import { assert, stringToBytes } from '@metamask/utils';
+import { assert, getErrorMessage, stringToBytes } from '@metamask/utils';
 import { NativeModules } from 'react-native';
 import ReactNativeBlobUtil, { FetchBlobResponse } from 'react-native-blob-util';
 import {
@@ -97,9 +97,11 @@ export class NpmLocation extends BaseNpmLocation {
       });
 
       return map;
-    } catch {
+    } catch (error) {
       throw new Error(
-        `Failed to fetch and unpack NPM tarball for "${this.meta.packageName}"`,
+        `Failed to fetch and unpack NPM tarball for "${
+          this.meta.packageName
+        }": ${getErrorMessage(error)}`,
       );
     } finally {
       response?.flush();

--- a/app/core/Snaps/location/npm.ts
+++ b/app/core/Snaps/location/npm.ts
@@ -55,7 +55,7 @@ export class NpmLocation extends BaseNpmLocation {
       );
 
       // We assume that NPM is a good actor and provides us with a valid `content-length` header.
-      const tarballSizeString = responseInfo.headers.get('content-length');
+      const tarballSizeString = responseInfo.headers['content-length'];
       assert(tarballSizeString, 'Snap tarball has invalid content-length');
       const tarballSize = parseInt(tarballSizeString, 10);
       assert(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Simplify the NPM fetching implementation to make it more readable, while also fixing a couple of issues:
- Use the cache directory for the app instead of a shared directory
- Re-use the cache key for the unpacked directory to allow for multiple installs at a time
- Properly clean up files on the filesystem after install
- Match error messages and states from the extension implementation

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Closes: https://github.com/MetaMask/snaps/issues/3617 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors NPM tarball fetching with direct blob fetch, status/size validation, improved error handling, and robust cleanup; updates tests to match.
> 
> - **Core (NPM fetch)**:
>   - Rewrite `NpmLocation.fetchNpmTarball` to use `ReactNativeBlobUtil.config({ appendExt: 'tgz' }).fetch` and `RNTar.unTar`.
>   - Add response validation: assert 404 not-found, require 200 OK, enforce `content-length` against `TARBALL_SIZE_SAFETY_LIMIT`.
>   - Improve errors using `getErrorMessage`; accept `DetectSnapLocationOptions` via constructor.
>   - Ensure cleanup in `finally`: `response.flush()` and `fs.unlink` of unpacked path.
>   - Read files as UTF-8 strings in `readAndParseAt`; remove `stringToBytes`.
>   - Remove helpers: `decompressFile`, `fetchAndStoreNPMPackage`, `cleanupFileSystem`; drop `SNAPS_NPM_LOG_TAG`.
> - **Tests**:
>   - Update mocks to include `respInfo` with `status` and `content-length`; adjust FS mocks; align with new fetch/untar flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46c1840b24153959f60b5d262f4b20edc434c982. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->