### PR TITLE
chore: Update `build-utils`

### DIFF
--- a/package.json
+++ b/package.json
@@ -506,7 +506,7 @@
     "@lavamoat/git-safe-dependencies": "^0.2.1",
     "@metamask/abi-utils": "^3.0.0",
     "@metamask/browser-passworder": "^5.0.0",
-    "@metamask/build-utils": "^1.0.0",
+    "@metamask/build-utils": "^3.0.0",
     "@metamask/eslint-config-typescript": "^9.0.0",
     "@metamask/eslint-plugin-design-tokens": "^1.0.0",
     "@metamask/foundryup": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7117,13 +7117,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/build-utils@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@metamask/build-utils@npm:1.0.0"
+"@metamask/build-utils@npm:^3.0.0":
+  version: 3.0.4
+  resolution: "@metamask/build-utils@npm:3.0.4"
   dependencies:
-    "@metamask/utils": ^8.2.0
+    "@metamask/utils": ^11.8.1
     "@types/eslint": ^8.44.7
-  checksum: 3e70fc1b72948d0d5466b96e329fb80f2e08f70dcb801aa3cbb903bdc490245ed77e107ffa4da6c9ea6f6feb0551bb18f38da5d6467b1b35cc9de90e007ef451
+  checksum: bb9b25777c0b4f30a9f50de513000084b0d74b3961f0040f328c8a20751b96c567d90c9bf061ab584c23a2e9c97626f99849ced18caf42fef49f88708c3396c8
   languageName: node
   linkType: hard
 
@@ -34078,7 +34078,7 @@ __metadata:
     "@metamask/bridge-controller": ^50.0.0
     "@metamask/bridge-status-controller": ^50.0.0
     "@metamask/browser-passworder": ^5.0.0
-    "@metamask/build-utils": ^1.0.0
+    "@metamask/build-utils": ^3.0.0
     "@metamask/chain-agnostic-permission": ^1.1.0
     "@metamask/composable-controller": ^11.0.0
     "@metamask/controller-utils": ^11.11.0


### PR DESCRIPTION
## **Description**

Update `@metamask/build-utils` from v1 to v3. Breaking changes include updating the minimum Node.js version, and dropping support for sub-path exports (which are not used here anyway).

Changelog: https://github.com/MetaMask/core/blob/main/packages/build-utils/CHANGELOG.md#300

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps @metamask/build-utils from ^1.0.0 to ^3.0.0 and updates yarn.lock (resolving to 3.0.4 with newer @metamask/utils).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4593a44d1c1254f6ce55b148cda08091fa274b53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->