### PR TITLE
test: Add more predict e2e locators

### DIFF
--- a/app/components/UI/Predict/components/PredictPosition/PredictPosition.tsx
+++ b/app/components/UI/Predict/components/PredictPosition/PredictPosition.tsx
@@ -33,7 +33,6 @@ const PredictPosition: React.FC<PredictPositionProps> = ({
   return (
     <TouchableOpacity
       testID={getPredictPositionSelector.currentPositionCard(
-        position.marketId,
         position.outcomeIndex,
       )}
       style={styles.positionContainer}

--- a/app/components/UI/Predict/components/PredictPosition/PredictPosition.tsx
+++ b/app/components/UI/Predict/components/PredictPosition/PredictPosition.tsx
@@ -8,6 +8,7 @@ import { useStyles } from '../../../../../component-library/hooks';
 import { PredictPosition as PredictPositionType } from '../../types';
 import { formatPercentage, formatPrice } from '../../utils/format';
 import styleSheet from './PredictPosition.styles';
+import { getPredictPositionSelector } from '../../../../../../e2e/selectors/Predict/Predict.selectors';
 
 interface PredictPositionProps {
   position: PredictPositionType;
@@ -31,6 +32,10 @@ const PredictPosition: React.FC<PredictPositionProps> = ({
 
   return (
     <TouchableOpacity
+      testID={getPredictPositionSelector.currentPositionCard(
+        position.marketId,
+        position.outcomeIndex,
+      )}
       style={styles.positionContainer}
       onPress={() => onPress?.(position)}
     >

--- a/app/components/UI/Predict/components/PredictPositionResolved/PredictPositionResolved.tsx
+++ b/app/components/UI/Predict/components/PredictPositionResolved/PredictPositionResolved.tsx
@@ -10,6 +10,7 @@ import { useStyles } from '../../../../../component-library/hooks';
 import { PredictPosition as PredictPositionType } from '../../types';
 import { formatPrice } from '../../utils/format';
 import styleSheet from './PredictPositionResolved.styles';
+import { getPredictPositionSelector } from '../../../../../../e2e/selectors/Predict/Predict.selectors';
 
 dayjs.extend(relativeTime);
 
@@ -45,6 +46,9 @@ const PredictPositionResolved: React.FC<PredictPositionResolvedProps> = ({
 
   return (
     <TouchableOpacity
+      testID={getPredictPositionSelector.resolvedPositionCard(
+        position.outcomeIndex,
+      )}
       style={styles.positionContainer}
       onPress={() => onPress?.(position)}
     >

--- a/app/components/UI/Predict/components/PredictPositions/PredictPositions.test.tsx
+++ b/app/components/UI/Predict/components/PredictPositions/PredictPositions.test.tsx
@@ -130,10 +130,12 @@ describe('PredictPositions', () => {
     renderWithProvider(<PredictPositions />);
 
     // Assert - FlashList should be rendered
-    expect(screen.getByTestId('active-positions-list')).toBeOnTheScreen();
+    expect(
+      screen.getByTestId('predict-active-positions-list'),
+    ).toBeOnTheScreen();
     // Claimable list should not be rendered when there are no claimable positions
     expect(
-      screen.queryByTestId('claimable-positions-list'),
+      screen.queryByTestId('predict-claimable-positions-list'),
     ).not.toBeOnTheScreen();
   });
 
@@ -153,10 +155,12 @@ describe('PredictPositions', () => {
     renderWithProvider(<PredictPositions />);
 
     // Assert
-    expect(screen.getByTestId('active-positions-list')).toBeOnTheScreen();
+    expect(
+      screen.getByTestId('predict-active-positions-list'),
+    ).toBeOnTheScreen();
     // Claimable list should not be rendered when there are no claimable positions
     expect(
-      screen.queryByTestId('claimable-positions-list'),
+      screen.queryByTestId('predict-claimable-positions-list'),
     ).not.toBeOnTheScreen();
   });
 
@@ -183,8 +187,12 @@ describe('PredictPositions', () => {
     renderWithProvider(<PredictPositions />);
 
     // Assert
-    expect(screen.getByTestId('active-positions-list')).toBeOnTheScreen();
-    expect(screen.getByTestId('claimable-positions-list')).toBeOnTheScreen();
+    expect(
+      screen.getByTestId('predict-active-positions-list'),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByTestId('predict-claimable-positions-list'),
+    ).toBeOnTheScreen();
   });
 
   it('exposes refresh method via ref', () => {

--- a/app/components/UI/Predict/components/PredictPositions/PredictPositions.tsx
+++ b/app/components/UI/Predict/components/PredictPositions/PredictPositions.tsx
@@ -20,6 +20,7 @@ import PredictNewButton from '../PredictNewButton';
 import PredictPosition from '../PredictPosition/PredictPosition';
 import PredictPositionEmpty from '../PredictPositionEmpty';
 import PredictPositionResolved from '../PredictPositionResolved/PredictPositionResolved';
+import { PredictPositionsSelectorsIDs } from '../../../../../../e2e/selectors/Predict/Predict.selectors';
 
 export interface PredictPositionsHandle {
   refresh: () => Promise<void>;
@@ -107,7 +108,7 @@ const PredictPositions = forwardRef<PredictPositionsHandle>((_props, ref) => {
   return (
     <>
       <FlashList
-        testID="active-positions-list"
+        testID={PredictPositionsSelectorsIDs.ACTIVE_POSITIONS_LIST}
         ref={listRef}
         data={positions.sort((a, b) => b.percentPnl - a.percentPnl)}
         renderItem={renderPosition}
@@ -129,7 +130,7 @@ const PredictPositions = forwardRef<PredictPositionsHandle>((_props, ref) => {
             </Text>
           </Box>
           <FlashList
-            testID="claimable-positions-list"
+            testID={PredictPositionsSelectorsIDs.CLAIMABLE_POSITIONS_LIST}
             data={claimablePositions.sort(
               (a, b) =>
                 new Date(b.endDate).getTime() - new Date(a.endDate).getTime(),

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -25,10 +25,7 @@ import Routes from '../../../../../constants/navigation/Routes';
 import { useTheme } from '../../../../../util/theme';
 import { PredictNavigationParamList } from '../../types/navigation';
 import { formatPrice, formatVolume, formatAddress } from '../../utils/format';
-import {
-  PredictCashOutSelectorsIDs,
-  PredictMarketDetailsSelectorsIDs,
-} from '../../../../../../e2e/selectors/Predict/Predict.selectors';
+import { PredictMarketDetailsSelectorsIDs } from '../../../../../../e2e/selectors/Predict/Predict.selectors';
 import {
   Box,
   BoxFlexDirection,
@@ -394,7 +391,9 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
             </Box>
           </Box>
           <Button
-            testID={PredictCashOutSelectorsIDs.CASH_OUT_BUTTON}
+            testID={
+              PredictMarketDetailsSelectorsIDs.MARKET_DETAILS_CASH_OUT_BUTTON
+            }
             variant={ButtonVariants.Primary}
             size={ButtonSize.Lg}
             width={ButtonWidthTypes.Full}
@@ -581,7 +580,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
     <SafeAreaView
       style={tw.style('flex-1 bg-default')}
       edges={['left', 'right', 'bottom']}
-      testID="predict-market-details-screen"
+      testID={PredictMarketDetailsSelectorsIDs.SCREEN}
     >
       <Box twClassName="flex-1">
         <Box twClassName="px-3 gap-4" style={{ paddingTop: insets.top + 12 }}>
@@ -597,7 +596,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
           />
         </Box>
         <ScrollableTabView
-          testID={PredictMarketDetailsSelectorsIDs.SCREEN}
+          testID={PredictMarketDetailsSelectorsIDs.SCROLLABLE_TAB_VIEW}
           renderTabBar={() => (
             <TabBar
               textStyle={tw.style('text-base font-bold text-center')}

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -26,6 +26,10 @@ import { useTheme } from '../../../../../util/theme';
 import { PredictNavigationParamList } from '../../types/navigation';
 import { formatPrice, formatVolume, formatAddress } from '../../utils/format';
 import {
+  PredictCashOutSelectorsIDs,
+  PredictMarketDetailsSelectorsIDs,
+} from '../../../../../../e2e/selectors/Predict/Predict.selectors';
+import {
   Box,
   BoxFlexDirection,
   BoxAlignItems,
@@ -44,7 +48,6 @@ import { usePredictPriceHistory } from '../../hooks/usePredictPriceHistory';
 import { PredictPosition, PredictPriceHistoryInterval } from '../../types';
 import PredictMarketOutcome from '../../components/PredictMarketOutcome';
 import TabBar from '../../../../Base/TabBar';
-import { PredictMarketDetailsSelectorsIDs } from '../../../../../../e2e/selectors/Predict/Predict.selectors';
 import { usePredictPositions } from '../../hooks/usePredictPositions';
 import { usePredictBalance } from '../../hooks/usePredictBalance';
 
@@ -391,6 +394,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
             </Box>
           </Box>
           <Button
+            testID={PredictCashOutSelectorsIDs.CASH_OUT_BUTTON}
             variant={ButtonVariants.Primary}
             size={ButtonSize.Lg}
             width={ButtonWidthTypes.Full}
@@ -593,6 +597,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
           />
         </Box>
         <ScrollableTabView
+          testID={PredictMarketDetailsSelectorsIDs.SCREEN}
           renderTabBar={() => (
             <TabBar
               textStyle={tw.style('text-base font-bold text-center')}

--- a/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.test.tsx
+++ b/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.test.tsx
@@ -415,7 +415,7 @@ describe('PredictSellPreview', () => {
         state: initialState,
       });
 
-      const cashOutButton = getByTestId('predict-cash-out-button');
+      const cashOutButton = getByTestId('predict-sell-preview-cash-out-button');
       fireEvent.press(cashOutButton);
 
       expect(mockPlaceOrder).toHaveBeenCalledWith({
@@ -439,7 +439,7 @@ describe('PredictSellPreview', () => {
         state: initialState,
       });
 
-      const cashOutButton = getByTestId('predict-cash-out-button');
+      const cashOutButton = getByTestId('predict-sell-preview-cash-out-button');
       expect(cashOutButton.props['data-disabled']).toBe(true);
 
       // Reset loading state for other tests
@@ -453,7 +453,7 @@ describe('PredictSellPreview', () => {
         state: initialState,
       });
 
-      const cashOutButton = getByTestId('predict-cash-out-button');
+      const cashOutButton = getByTestId('predict-sell-preview-cash-out-button');
       expect(cashOutButton.props['data-disabled']).toBe(true);
 
       // Reset loading state for other tests
@@ -483,7 +483,7 @@ describe('PredictSellPreview', () => {
         state: initialState,
       });
 
-      const cashOutButton = getByTestId('predict-cash-out-button');
+      const cashOutButton = getByTestId('predict-sell-preview-cash-out-button');
 
       // The dispatch now throws and is not caught, so expect the error
       expect(() => {
@@ -508,7 +508,7 @@ describe('PredictSellPreview', () => {
         state: initialState,
       });
 
-      const cashOutButton = getByTestId('predict-cash-out-button');
+      const cashOutButton = getByTestId('predict-sell-preview-cash-out-button');
       fireEvent.press(cashOutButton);
 
       expect(mockDispatch).toHaveBeenCalledWith(StackActions.pop());
@@ -531,7 +531,7 @@ describe('PredictSellPreview', () => {
         state: initialState,
       });
 
-      const cashOutButton = getByTestId('predict-cash-out-button');
+      const cashOutButton = getByTestId('predict-sell-preview-cash-out-button');
       // Button should have the primary color background
       expect(cashOutButton.props.style).toBeDefined();
     });

--- a/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.test.tsx
+++ b/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.test.tsx
@@ -415,7 +415,7 @@ describe('PredictSellPreview', () => {
         state: initialState,
       });
 
-      const cashOutButton = getByTestId('button-secondary');
+      const cashOutButton = getByTestId('predict-cash-out-button');
       fireEvent.press(cashOutButton);
 
       expect(mockPlaceOrder).toHaveBeenCalledWith({
@@ -439,7 +439,7 @@ describe('PredictSellPreview', () => {
         state: initialState,
       });
 
-      const cashOutButton = getByTestId('button-secondary');
+      const cashOutButton = getByTestId('predict-cash-out-button');
       expect(cashOutButton.props['data-disabled']).toBe(true);
 
       // Reset loading state for other tests
@@ -453,7 +453,7 @@ describe('PredictSellPreview', () => {
         state: initialState,
       });
 
-      const cashOutButton = getByTestId('button-secondary');
+      const cashOutButton = getByTestId('predict-cash-out-button');
       expect(cashOutButton.props['data-disabled']).toBe(true);
 
       // Reset loading state for other tests
@@ -483,7 +483,7 @@ describe('PredictSellPreview', () => {
         state: initialState,
       });
 
-      const cashOutButton = getByTestId('button-secondary');
+      const cashOutButton = getByTestId('predict-cash-out-button');
 
       // The dispatch now throws and is not caught, so expect the error
       expect(() => {
@@ -508,7 +508,7 @@ describe('PredictSellPreview', () => {
         state: initialState,
       });
 
-      const cashOutButton = getByTestId('button-secondary');
+      const cashOutButton = getByTestId('predict-cash-out-button');
       fireEvent.press(cashOutButton);
 
       expect(mockDispatch).toHaveBeenCalledWith(StackActions.pop());
@@ -531,7 +531,7 @@ describe('PredictSellPreview', () => {
         state: initialState,
       });
 
-      const cashOutButton = getByTestId('button-secondary');
+      const cashOutButton = getByTestId('predict-cash-out-button');
       // Button should have the primary color background
       expect(cashOutButton.props.style).toBeDefined();
     });

--- a/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.tsx
+++ b/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.tsx
@@ -115,7 +115,7 @@ const PredictSellPreview = () => {
           </View>
           <View style={styles.cashOutButtonContainer}>
             <Button
-              testID={PredictCashOutSelectorsIDs.CASH_OUT_BUTTON}
+              testID={PredictCashOutSelectorsIDs.SELL_PREVIEW_CASH_OUT_BUTTON}
               label="Cash out"
               variant={ButtonVariants.Secondary}
               disabled={!preview || isCalculating || isLoading}

--- a/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.tsx
+++ b/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.tsx
@@ -25,6 +25,7 @@ import { formatPercentage, formatPrice } from '../../utils/format';
 import styleSheet from './PredictSellPreview.styles';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { PredictCashOutSelectorsIDs } from '../../../../../../e2e/selectors/Predict/Predict.selectors';
 
 const PredictSellPreview = () => {
   const tw = useTailwind();
@@ -72,7 +73,10 @@ const PredictSellPreview = () => {
       <BottomSheetHeader onClose={() => goBack()}>
         <Text variant={TextVariant.HeadingMD}>Cash Out</Text>
       </BottomSheetHeader>
-      <View style={styles.container}>
+      <View
+        testID={PredictCashOutSelectorsIDs.CONTAINER}
+        style={styles.container}
+      >
         <View style={styles.cashOutContainer}>
           <Text style={styles.currentValue}>
             {formatPrice(currentValue, { maximumDecimals: 2 })}
@@ -111,6 +115,7 @@ const PredictSellPreview = () => {
           </View>
           <View style={styles.cashOutButtonContainer}>
             <Button
+              testID={PredictCashOutSelectorsIDs.CASH_OUT_BUTTON}
               label="Cash out"
               variant={ButtonVariants.Secondary}
               disabled={!preview || isCalculating || isLoading}

--- a/app/components/UI/Predict/views/PredictTabView/PredictTabView.tsx
+++ b/app/components/UI/Predict/views/PredictTabView/PredictTabView.tsx
@@ -10,6 +10,7 @@ import PredictPositions, {
 import PredictAddFundsSheet from '../../components/PredictAddFundsSheet/PredictAddFundsSheet';
 import { usePredictDepositToasts } from '../../hooks/usePredictDepositToasts';
 import { usePredictClaimToasts } from '../../hooks/usePredictClaimToasts';
+import { PredictTabViewSelectorsIDs } from '../../../../../../e2e/selectors/Predict/Predict.selectors';
 
 interface PredictTabViewProps {}
 
@@ -38,6 +39,7 @@ const PredictTabView: React.FC<PredictTabViewProps> = () => {
   return (
     <View style={tw.style('flex-1 bg-default')}>
       <ScrollView
+        testID={PredictTabViewSelectorsIDs.SCROLL_VIEW}
         refreshControl={
           <RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} />
         }

--- a/e2e/selectors/Predict/Predict.selectors.ts
+++ b/e2e/selectors/Predict/Predict.selectors.ts
@@ -6,6 +6,9 @@ export const PredictTabViewSelectorsIDs = {
   // Main container
   CONTAINER: 'predict-tab-view-container',
 
+  // Scroll view
+  SCROLL_VIEW: 'predict-tab-view-scroll-view',
+
   // FlashList
   FLASH_LIST: 'predict-tab-view-flash-list',
 } as const;
@@ -54,3 +57,24 @@ export const PredictMarketDetailsSelectorsIDs = {
   POSITIONS_TAB: 'predict-market-details-positions-tab',
   OUTCOMES_TAB: 'predict-market-details-outcomes-tab',
 } as const;
+
+// ========================================
+// PREDICT POSITIONS SELECTORS
+// ========================================
+
+export const PredictPositionsSelectorsIDs = {
+  // Lists
+  ACTIVE_POSITIONS_LIST: 'predict-active-positions-list',
+  CLAIMABLE_POSITIONS_LIST: 'predict-claimable-positions-list',
+
+  // Section headers
+  RESOLVED_MARKETS_HEADER: 'predict-resolved-markets-header',
+} as const;
+
+// Helper functions for dynamic position selectors
+export const getPredictPositionSelector = {
+  currentPositionCard: (marketId: string, outcomeIndex: number) =>
+    `predict-current-position-card-${marketId}-${outcomeIndex}`,
+  resolvedPositionCard: (marketId: string, outcomeIndex: number) =>
+    `predict-resolved-position-card-${marketId}-${outcomeIndex}`,
+};

--- a/e2e/selectors/Predict/Predict.selectors.ts
+++ b/e2e/selectors/Predict/Predict.selectors.ts
@@ -47,6 +47,7 @@ export const getPredictMarketListSelector = {
 export const PredictMarketDetailsSelectorsIDs = {
   // Main screen
   SCREEN: 'predict-market-details-screen',
+  SCROLLABLE_TAB_VIEW: 'predict-market-details-scrollable-tab-view',
 
   // Header
   BACK_BUTTON: 'predict-market-details-back-button',
@@ -101,5 +102,5 @@ export const PredictCashOutSelectorsIDs = {
   CONTAINER: 'predict-cash-out-container',
 
   // Cash out buttons
-  CASH_OUT_BUTTON: 'predict-cash-out-button',
+  SELL_PREVIEW_CASH_OUT_BUTTON: 'predict-sell-preview-cash-out-button',
 } as const;

--- a/e2e/selectors/Predict/Predict.selectors.ts
+++ b/e2e/selectors/Predict/Predict.selectors.ts
@@ -56,6 +56,19 @@ export const PredictMarketDetailsSelectorsIDs = {
   ABOUT_TAB: 'predict-market-details-about-tab',
   POSITIONS_TAB: 'predict-market-details-positions-tab',
   OUTCOMES_TAB: 'predict-market-details-outcomes-tab',
+
+  // Tab content containers
+  ABOUT_TAB_CONTENT: 'about-tab-content',
+  POSITIONS_TAB_CONTENT: 'positions-tab-content',
+  OUTCOMES_TAB_CONTENT: 'outcomes-tab-content',
+  MARKET_DETAILS_CASH_OUT_BUTTON: 'predict-market-details-cash-out-button',
+} as const;
+
+export const PredictMarketDetailsSelectorsText = {
+  // Tab content containers
+  ABOUT_TAB_TEXT: 'About',
+  POSITIONS_TAB_TEXT: 'Positions',
+  OUTCOMES_TAB_TEXT: 'Outcomes',
 } as const;
 
 // ========================================
@@ -71,10 +84,22 @@ export const PredictPositionsSelectorsIDs = {
   RESOLVED_MARKETS_HEADER: 'predict-resolved-markets-header',
 } as const;
 
-// Helper functions for dynamic position selectors
+// Helper functions for position selectors with index
 export const getPredictPositionSelector = {
-  currentPositionCard: (marketId: string, outcomeIndex: number) =>
-    `predict-current-position-card-${marketId}-${outcomeIndex}`,
-  resolvedPositionCard: (marketId: string, outcomeIndex: number) =>
-    `predict-resolved-position-card-${marketId}-${outcomeIndex}`,
+  currentPositionCard: (outcomeIndex: number) =>
+    `predict-current-position-card-${outcomeIndex}`,
+  resolvedPositionCard: (outcomeIndex: number) =>
+    `predict-resolved-position-card-${outcomeIndex}`,
 };
+
+// ========================================
+// PREDICT CASH OUT SELECTORS
+// ========================================
+
+export const PredictCashOutSelectorsIDs = {
+  // Container
+  CONTAINER: 'predict-cash-out-container',
+
+  // Cash out buttons
+  CASH_OUT_BUTTON: 'predict-cash-out-button',
+} as const;

--- a/e2e/selectors/wallet/WalletView.selectors.ts
+++ b/e2e/selectors/wallet/WalletView.selectors.ts
@@ -96,6 +96,7 @@ export const WalletViewSelectorsText = {
   PERMISSIONS_SUMMARY_TAB: 'Permissions',
   ACCOUNTS_SUMMARY_TAB: 'Accounts',
   DEFI_TAB: enContent.wallet.defi,
+  PREDICTIONS_TAB: enContent.wallet.predict,
   DEFI_EMPTY_STATE_DESCRIPTION:
     enContent.defi_positions.empty_state.description,
   DEFI_EMPTY_STATE_EXPLORE_BUTTON:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The purpose of this PR is to add more testIDs to the various prediction components so it is easier to continue building the e2e tests. 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds standardized e2e selectors and applies corresponding testIDs across Predict components (positions, market details, sell preview, tab view), updating tests accordingly.
> 
> - **E2E Selectors**:
>   - Expand `e2e/selectors/Predict/Predict.selectors.ts` with IDs for tab view, market details (screen, scrollable tab view, cash-out button), positions lists, dynamic position cards, and cash-out flow.
>   - Add `PREDICTIONS_TAB` text selector in `e2e/selectors/wallet/WalletView.selectors.ts`.
> - **Predict UI**:
>   - `PredictPositions.tsx`: Use `PredictPositionsSelectorsIDs` for `FlashList` testIDs; keep resolved section header; no UI logic changes.
>   - `PredictPosition.tsx` and `PredictPositionResolved.tsx`: Add per-card `testID` via `getPredictPositionSelector` (by `outcomeIndex`).
>   - `PredictMarketDetails.tsx`: Add `testID`s for screen, scrollable tab view, and cash-out button; minor import tidy.
>   - `PredictSellPreview.tsx`: Add container and cash-out button `testID`s via `PredictCashOutSelectorsIDs`.
>   - `PredictTabView.tsx`: Add `testID` to `ScrollView`.
> - **Tests**:
>   - Update Predict positions and sell preview tests to use new testIDs (e.g., `predict-active-positions-list`, `predict-claimable-positions-list`, `predict-sell-preview-cash-out-button`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd7c1ce17f2664e58ad27aa4ab04b447597ae0b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->