### PR TITLE
chore: Remove `ComposableController`

### DIFF
--- a/app/core/BackgroundBridge/BackgroundBridge.test.js
+++ b/app/core/BackgroundBridge/BackgroundBridge.test.js
@@ -43,17 +43,6 @@ jest.mock('../Engine', () => ({
     tryUnsubscribe: jest.fn(),
     unsubscribe: jest.fn(),
   },
-  datamodel: {
-    state: {
-      PreferencesController: {
-        selectedAddress: '0x742C3cF9Af45f91B109a81EfEaf11535ECDe9571',
-      },
-      AccountTreeController: {
-        selectedAccountGroup:
-          'eip155:1:0x742C3cF9Af45f91B109a81EfEaf11535ECDe9571',
-      },
-    },
-  },
   context: {
     AccountsController: {
       listAccounts: jest.fn(),

--- a/app/core/BackgroundBridge/WalletConnectPort.ts
+++ b/app/core/BackgroundBridge/WalletConnectPort.ts
@@ -21,11 +21,7 @@ class WalletConnectPort extends EventEmitter {
   postMessage = (msg: any) => {
     try {
       if (msg?.data?.method === NOTIFICATION_NAMES.chainChanged) {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        const {
-          PreferencesController: { selectedAddress },
-        } = Engine.datamodel.state;
+        const { selectedAddress } = Engine.context.PreferencesController.state;
         this._wcRequestActions?.updateSession?.({
           chainId: parseInt(msg.data.params.chainId, 16),
           accounts: [selectedAddress],

--- a/app/core/Engine/Engine.test.ts
+++ b/app/core/Engine/Engine.test.ts
@@ -213,8 +213,8 @@ describe('Engine', () => {
 
   // Use this to keep the unit test initial background state fixture up-to-date
   it('matches initial state fixture', () => {
-    const engine = Engine.init(TEST_ANALYTICS_ID, {});
-    const initialBackgroundState = engine.datamodel.state;
+    Engine.init(TEST_ANALYTICS_ID, {});
+    const initialBackgroundState = Engine.state;
 
     // Get the current app version and migration version
     const currentAppVersion = getVersion();
@@ -337,30 +337,6 @@ describe('Engine', () => {
     const result = await engine.getSnapKeyring();
     expect(getSnapKeyringSpy).toHaveBeenCalled();
     expect(result).toEqual(mockSnapKeyring);
-  });
-
-  it('normalizes CurrencyController state property conversionRate from null to 0', () => {
-    const ticker = 'ETH';
-    const state = {
-      CurrencyRateController: {
-        currentCurrency: 'usd' as const,
-        currencyRates: {
-          [ticker]: {
-            conversionRate: null,
-            conversionDate: 0,
-            usdConversionRate: null,
-          },
-        },
-      },
-    };
-    const engine = Engine.init(TEST_ANALYTICS_ID, state);
-    expect(
-      engine.datamodel.state.CurrencyRateController.currencyRates[ticker],
-    ).toStrictEqual({
-      conversionRate: 0,
-      conversionDate: 0,
-      usdConversionRate: null,
-    });
   });
 
   it('enables the RPC failover feature if the walletFrameworkRpcFailoverEnabled feature flag is already enabled', () => {

--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -1366,7 +1366,6 @@ export default {
       SelectedNetworkController: SelectedNetworkController.state,
       SignatureController: SignatureController.state,
       SmartTransactionsController: SmartTransactionsController.state,
-      SnapInterfaceController: SnapInterfaceController.state,
       SwapsController: SwapsController.state,
       TokenBalancesController: TokenBalancesController.state,
       TokenListController: TokenListController.state,
@@ -1385,6 +1384,7 @@ export default {
       NotificationServicesPushController:
         NotificationServicesPushController.state,
       SnapController: SnapController.state,
+      SnapInterfaceController: SnapInterfaceController.state,
       SnapsRegistry: SnapsRegistry.state,
       SubjectMetadataController: SubjectMetadataController.state,
       UserStorageController: UserStorageController.state,

--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -11,7 +11,6 @@ import {
 ///: END:ONLY_INCLUDE_IF
 import { CodefiTokenPricesServiceV2 } from '@metamask/assets-controllers';
 import { AccountsController } from '@metamask/accounts-controller';
-import { ComposableController } from '@metamask/composable-controller';
 import {
   KeyringController,
   KeyringControllerState,
@@ -105,14 +104,9 @@ import {
   RootExtendedMessenger,
   EngineState,
   EngineContext,
-  StatefulControllers,
   getRootExtendedMessenger,
-  RootMessenger,
 } from './types';
-import {
-  BACKGROUND_STATE_CHANGE_EVENT_NAMES,
-  STATELESS_NON_CONTROLLER_NAMES,
-} from './constants';
+import { STATELESS_NON_CONTROLLER_NAMES } from './constants';
 import { getGlobalChainId } from '../../util/networks/global-network';
 import { logEngineCreation } from './utils/logger';
 import { initModularizedControllers } from './utils';
@@ -180,7 +174,6 @@ import { profileMetricsControllerInit } from './controllers/profile-metrics-cont
 import { profileMetricsServiceInit } from './controllers/profile-metrics-service-init';
 import { rampsServiceInit } from './controllers/ramps-controller/ramps-service-init';
 import { rampsControllerInit } from './controllers/ramps-controller/ramps-controller-init';
-import { Messenger, MessengerEvents } from '@metamask/messenger';
 
 // TODO: Replace "any" with type
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -207,10 +200,6 @@ export class Engine {
    * The global controller messenger.
    */
   controllerMessenger: RootExtendedMessenger;
-  /**
-   * ComposableController reference containing all child controllers
-   */
-  datamodel: ComposableController<EngineState, StatefulControllers>;
 
   /**
    * Object containing the info for the latest incoming tx block
@@ -572,28 +561,6 @@ export class Engine {
         delete childControllers[name];
       }
     });
-    const composableControllerMessenger = new Messenger<
-      'ComposableController',
-      never,
-      MessengerEvents<RootMessenger>,
-      RootMessenger
-    >({
-      namespace: 'ComposableController',
-      parent: this.controllerMessenger,
-    });
-
-    this.controllerMessenger.delegate({
-      actions: [],
-      events: Array.from(BACKGROUND_STATE_CHANGE_EVENT_NAMES),
-      messenger: composableControllerMessenger,
-    });
-
-    this.datamodel = new ComposableController<EngineState, StatefulControllers>(
-      {
-        controllers: childControllers as StatefulControllers,
-        messenger: composableControllerMessenger,
-      },
-    );
 
     this.controllerMessenger.subscribe(
       'TransactionController:incomingTransactionsReceived',
@@ -1360,79 +1327,76 @@ export default {
       MultichainTransactionsController,
       ///: END:ONLY_INCLUDE_IF
       ProfileMetricsController,
-    } = instance.datamodel.state;
+    } = instance.context;
 
     return {
       ///: BEGIN:ONLY_INCLUDE_IF(sample-feature)
-      SamplePetnamesController,
+      SamplePetnamesController: SamplePetnamesController.state,
       ///: END:ONLY_INCLUDE_IF
-      AccountsController,
-      AccountTrackerController,
-      AccountTreeController,
-      AddressBookController,
-      AppMetadataController,
-      AnalyticsController,
-      ApprovalController,
-      BridgeController,
-      BridgeStatusController,
-      ConnectivityController,
-      CurrencyRateController,
-      DeFiPositionsController,
-      DelegationController,
-      EarnController,
-      GasFeeController,
-      GatorPermissionsController,
-      KeyringController,
-      LoggingController,
-      MultichainNetworkController,
-      NetworkController,
-      NetworkEnablementController,
-      NftController,
-      PermissionController,
-      PerpsController,
-      PhishingController,
-      PredictController,
-      PreferencesController,
-      RemoteFeatureFlagController,
-      RewardsController,
-      SeedlessOnboardingController,
-      SelectedNetworkController,
-      SignatureController,
-      SmartTransactionsController,
-      SwapsController,
-      TokenBalancesController,
-      TokenListController,
-      TokenRatesController,
-      TokensController,
-      TokenSearchDiscoveryController,
-      TokenSearchDiscoveryDataController,
-      TransactionController,
-      TransactionPayController,
-      RampsController,
+      AccountsController: AccountsController.state,
+      AccountTrackerController: AccountTrackerController.state,
+      AccountTreeController: AccountTreeController.state,
+      AddressBookController: AddressBookController.state,
+      AppMetadataController: AppMetadataController.state,
+      AnalyticsController: AnalyticsController.state,
+      ApprovalController: ApprovalController.state,
+      BridgeController: BridgeController.state,
+      BridgeStatusController: BridgeStatusController.state,
+      ConnectivityController: ConnectivityController.state,
+      CurrencyRateController: CurrencyRateController.state,
+      DeFiPositionsController: DeFiPositionsController.state,
+      DelegationController: DelegationController.state,
+      EarnController: EarnController.state,
+      GasFeeController: GasFeeController.state,
+      GatorPermissionsController: GatorPermissionsController.state,
+      KeyringController: KeyringController.state,
+      LoggingController: LoggingController.state,
+      MultichainNetworkController: MultichainNetworkController.state,
+      NetworkController: NetworkController.state,
+      NetworkEnablementController: NetworkEnablementController.state,
+      NftController: NftController.state,
+      PermissionController: PermissionController.state,
+      PerpsController: PerpsController.state,
+      PhishingController: PhishingController.state,
+      PredictController: PredictController.state,
+      PreferencesController: PreferencesController.state,
+      RemoteFeatureFlagController: RemoteFeatureFlagController.state,
+      RewardsController: RewardsController.state,
+      SeedlessOnboardingController: SeedlessOnboardingController.state,
+      SelectedNetworkController: SelectedNetworkController.state,
+      SignatureController: SignatureController.state,
+      SmartTransactionsController: SmartTransactionsController.state,
+      SnapInterfaceController: SnapInterfaceController.state,
+      SwapsController: SwapsController.state,
+      TokenBalancesController: TokenBalancesController.state,
+      TokenListController: TokenListController.state,
+      TokenRatesController: TokenRatesController.state,
+      TokensController: TokensController.state,
+      TokenSearchDiscoveryController: TokenSearchDiscoveryController.state,
+      TokenSearchDiscoveryDataController:
+        TokenSearchDiscoveryDataController.state,
+      TransactionController: TransactionController.state,
+      TransactionPayController: TransactionPayController.state,
+      RampsController: RampsController.state,
       ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
-      AuthenticationController,
-      CronjobController,
-      NotificationServicesController,
-      NotificationServicesPushController,
-      SnapController,
-      SnapInterfaceController,
-      SnapsRegistry,
-      SubjectMetadataController,
-      UserStorageController,
+      AuthenticationController: AuthenticationController.state,
+      CronjobController: CronjobController.state,
+      NotificationServicesController: NotificationServicesController.state,
+      NotificationServicesPushController:
+        NotificationServicesPushController.state,
+      SnapController: SnapController.state,
+      SnapsRegistry: SnapsRegistry.state,
+      SubjectMetadataController: SubjectMetadataController.state,
+      UserStorageController: UserStorageController.state,
       ///: END:ONLY_INCLUDE_IF
       ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-      MultichainAssetsController,
-      MultichainAssetsRatesController,
-      MultichainBalancesController,
-      MultichainTransactionsController,
+      MultichainAssetsController: MultichainAssetsController.state,
+      MultichainAssetsRatesController: MultichainAssetsRatesController.state,
+      MultichainBalancesController: MultichainBalancesController.state,
+      MultichainTransactionsController: MultichainTransactionsController.state,
       ///: END:ONLY_INCLUDE_IF
-      ProfileMetricsController,
+      ProfileMetricsController: ProfileMetricsController.state,
     };
-  },
-
-  get datamodel() {
-    assertEngineExists(instance);
-    return instance.datamodel;
   },
 
   getTotalEvmFiatAccountBalance(account?: InternalAccount) {

--- a/app/core/Engine/types.ts
+++ b/app/core/Engine/types.ts
@@ -255,7 +255,6 @@ import {
   AccountsControllerState,
 } from '@metamask/accounts-controller';
 import { getPermissionSpecifications } from '../Permissions/specifications.js';
-import { ComposableControllerEvents } from '@metamask/composable-controller';
 import { STATELESS_NON_CONTROLLER_NAMES } from './constants';
 import {
   RemoteFeatureFlagController,
@@ -430,14 +429,6 @@ type OptionalControllers = Pick<
   | 'StorageService'
 >;
 
-/**
- * Controllers that are defined with state.
- */
-export type StatefulControllers = Omit<
-  Controllers,
-  (typeof STATELESS_NON_CONTROLLER_NAMES)[number]
->;
-
 type PermissionsByRpcMethod = ReturnType<typeof getPermissionSpecifications>;
 type Permissions = PermissionsByRpcMethod[keyof PermissionsByRpcMethod];
 
@@ -536,7 +527,6 @@ type GlobalEvents =
   ///: BEGIN:ONLY_INCLUDE_IF(sample-feature)
   | SamplePetnamesControllerEvents
   ///: END:ONLY_INCLUDE_IF
-  | ComposableControllerEvents<EngineState>
   | AccountTrackerControllerEvents
   | NftControllerEvents
   | SwapsControllerEvents

--- a/app/core/EngineService/EngineService.test.ts
+++ b/app/core/EngineService/EngineService.test.ts
@@ -94,7 +94,6 @@ jest.unmock('../Engine');
 
 interface MockControllerMessenger {
   subscribe: jest.MockedFunction<(...args: unknown[]) => void>;
-  subscribeOnceIf: jest.MockedFunction<(...args: unknown[]) => void>;
 }
 
 interface MockController {
@@ -128,7 +127,6 @@ jest.mock('../Engine', () => {
       mockInstance = {
         controllerMessenger: {
           subscribe: jest.fn(),
-          subscribeOnceIf: jest.fn(),
         },
         context: {
           AddressBookController: { subscribe: jest.fn() },
@@ -461,21 +459,13 @@ describe('EngineService', () => {
   describe('initializeControllers edge cases', () => {
     // Type for accessing private methods
     interface EngineServiceWithInitializeControllers {
-      initializeControllers: (engine: {
-        context: null;
-        controllerMessenger: {
-          subscribeOnceIf: jest.MockedFunction<(...args: unknown[]) => void>;
-        };
-      }) => void;
+      initializeControllers: (engine: { context: null }) => void;
     }
 
     it('handles missing engine context without errors', () => {
       // Arrange
       const mockEngine = {
         context: null,
-        controllerMessenger: {
-          subscribeOnceIf: jest.fn(),
-        },
       };
 
       // Act & Assert - should not throw
@@ -491,12 +481,9 @@ describe('EngineService', () => {
       );
     });
 
-    it('handles missing vault metadata in subscribeOnceIf callback without errors', async () => {
+    it('handles missing vault metadata without errors', async () => {
       // Types for Engine mock
       interface MockEngineType {
-        controllerMessenger: {
-          subscribeOnceIf: jest.MockedFunction<(...args: unknown[]) => void>;
-        };
         context: {
           KeyringController: {
             metadata?: Record<string, unknown>;
@@ -505,11 +492,7 @@ describe('EngineService', () => {
       }
 
       // Arrange
-      await engineService.start();
-
       const mockEngine = Engine as unknown as MockEngineType;
-      const mockSubscribeOnceIf =
-        mockEngine.controllerMessenger.subscribeOnceIf;
 
       // Mock missing vault metadata
       const originalContext = mockEngine.context;
@@ -521,15 +504,8 @@ describe('EngineService', () => {
         },
       };
 
-      // Act - trigger the subscribeOnceIf callback
-      type SubscribeCall = [string, () => void, () => boolean];
-      const subscribeCall = mockSubscribeOnceIf.mock.calls.find(
-        (call: unknown[]) => call[0] === 'ComposableController:stateChange',
-      ) as SubscribeCall;
-      expect(subscribeCall).toBeDefined();
-
-      const callback = subscribeCall[1];
-      callback();
+      // Act
+      await engineService.start();
 
       // Assert
       expect(Logger.log).toHaveBeenCalledWith(

--- a/app/core/EngineService/EngineService.ts
+++ b/app/core/EngineService/EngineService.ts
@@ -71,20 +71,16 @@ export class EngineService {
       return;
     }
 
-    engine.controllerMessenger.subscribeOnceIf(
-      'ComposableController:stateChange',
-      () => {
-        if (!engine.context.KeyringController.metadata?.vault) {
-          Logger.log('keyringController vault missing for INIT_BG_STATE_KEY');
-        }
-        this.updateBatcher.add(INIT_BG_STATE_KEY);
-        // immediately flush the redux action
-        // so that the initial state is available to the redux store
-        this.updateBatcher.flush();
-        this.engineInitialized = true;
-      },
-      () => !this.engineInitialized,
-    );
+    if (!this.engineInitialized) {
+      if (!engine.context.KeyringController.metadata?.vault) {
+        Logger.log('keyringController vault missing for INIT_BG_STATE_KEY');
+      }
+      this.updateBatcher.add(INIT_BG_STATE_KEY);
+      // immediately flush the redux action
+      // so that the initial state is available to the redux store
+      this.updateBatcher.flush();
+      this.engineInitialized = true;
+    }
 
     // Set up immediate Redux updates for all controller state changes
     // This ensures Redux is updated right away when controllers change

--- a/app/core/__mocks__/MockedEngine.ts
+++ b/app/core/__mocks__/MockedEngine.ts
@@ -24,9 +24,6 @@ export const mockedEngine = {
       }
     }),
   },
-  datamodel: {
-    state: { PreferencesController: { selectedAddress: '' } },
-  },
   context: {
     AccountsController: {
       listAccounts: jest.fn(),

--- a/package.json
+++ b/package.json
@@ -207,7 +207,6 @@
     "@metamask/bridge-controller": "^64.7.0",
     "@metamask/bridge-status-controller": "^64.4.1",
     "@metamask/chain-agnostic-permission": "^1.3.0",
-    "@metamask/composable-controller": "^12.0.0",
     "@metamask/connectivity-controller": "^0.1.0",
     "@metamask/controller-utils": "^11.18.0",
     "@metamask/core-backend": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7349,16 +7349,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/composable-controller@npm:^12.0.0":
-  version: 12.0.0
-  resolution: "@metamask/composable-controller@npm:12.0.0"
-  dependencies:
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/messenger": "npm:^0.3.0"
-  checksum: 10/f79432fb6d209084f9db4905f7882c9caa543a2f38f6699c9a1ef304aad5e1b760bd380aa7e0298017e2d74c5a8a3d0eafe67f92c817fb8f45d6373c5b9d13b6
-  languageName: node
-  linkType: hard
-
 "@metamask/connectivity-controller@npm:^0.1.0":
   version: 0.1.0
   resolution: "@metamask/connectivity-controller@npm:0.1.0"
@@ -34049,7 +34039,6 @@ __metadata:
     "@metamask/browser-passworder": "npm:^5.0.0"
     "@metamask/build-utils": "npm:^3.0.0"
     "@metamask/chain-agnostic-permission": "npm:^1.3.0"
-    "@metamask/composable-controller": "npm:^12.0.0"
     "@metamask/connectivity-controller": "npm:^0.1.0"
     "@metamask/controller-utils": "npm:^11.18.0"
     "@metamask/core-backend": "npm:^5.0.0"


### PR DESCRIPTION
## **Description**

The `ComposableController` has been removed. It was only used as a way to trigger one step of initialization, and to indirectly access certain parts of the wallet state. In both cases, it was easily replaced.

This removal helps unblock the pending `base-controller` breaking changes (we are making `metadata` static, which is incompatible with `ComposableController`), and it might marginally improve performance.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Unblocks https://github.com/MetaMask/metamask-mobile/issues/14590

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Removes `ComposableController` and refactors Engine/state access**
> 
> - Replaces `engine.datamodel` usage with direct `Engine.context` and a new `Engine.state` that aggregates `controller.state` for all controllers
> - Simplifies Engine initialization by removing `ComposableController` messenger wiring and related events; updates `EngineService.initializeControllers` to perform immediate init (no `subscribeOnceIf`)
> - Updates tests and mocks to stop referencing `datamodel`; adjusts fixtures to use `Engine.state` and `Engine.context`
> - Updates `WalletConnectPort` to read `selectedAddress` from `Engine.context.PreferencesController.state`
> - Removes `@metamask/composable-controller` from dependencies and lockfile
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 348563a370b2fcff43d6b60199ecad11cfc7259a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->