### PR TITLE
fix: Decrease threshold before RPC failover is activated

### DIFF
--- a/app/core/Engine/controllers/network-controller-init.ts
+++ b/app/core/Engine/controllers/network-controller-init.ts
@@ -6,7 +6,7 @@ import {
   type NetworkControllerMessenger,
 } from '@metamask/network-controller';
 import { NetworkControllerInitMessenger } from '../messengers/network-controller-messenger';
-import { ChainId } from '@metamask/controller-utils';
+import { ChainId, DEFAULT_MAX_RETRIES } from '@metamask/controller-utils';
 import { getFailoverUrlsForInfuraNetwork } from '../../../util/networks/customNetworks';
 import { INFURA_PROJECT_ID } from '../../../constants/network';
 import { SECOND } from '../../../constants/time';
@@ -95,25 +95,32 @@ export const networkControllerInit: ControllerInitFunction<
             // failures quickly.
             retryTimeout: 20 * SECOND,
           },
-
     getRpcServiceOptions: (rpcEndpointUrl: string) => {
-      const maxRetries = 4;
+      // Note that the total number of attempts is 1 more than this
+      // (which is why we add 1 below).
+      const maxRetries = DEFAULT_MAX_RETRIES;
       const commonOptions = {
         fetch: globalThis.fetch.bind(globalThis),
         btoa: globalThis.btoa.bind(globalThis),
+      };
+      const commonPolicyOptions = {
+        // Ensure that the "cooldown" period after breaking the circuit is short.
+        circuitBreakDuration: 30 * SECOND,
+        maxRetries,
       };
 
       if (getIsQuicknodeEndpointUrl(rpcEndpointUrl)) {
         return {
           ...commonOptions,
           policyOptions: {
-            maxRetries,
-            // When we fail over to Quicknode, we expect it to be down at
-            // first while it is being automatically activated. If an endpoint
-            // is down, the failover logic enters a "cooldown period" of 30
-            // minutes. We'd really rather not enter that for Quicknode, so
-            // keep retrying longer.
-            maxConsecutiveFailures: (maxRetries + 1) * 14,
+            ...commonPolicyOptions,
+            // The number of rounds of retries that will break the circuit,
+            // triggering a "cooldown".
+            //
+            // When we fail over to QuickNode, we expect it to be down at first
+            // while it is being automatically activated, and we don't want to
+            // activate the "cooldown" accidentally.
+            maxConsecutiveFailures: (maxRetries + 1) * 10,
           },
         };
       }
@@ -121,9 +128,14 @@ export const networkControllerInit: ControllerInitFunction<
       return {
         ...commonOptions,
         policyOptions: {
-          maxRetries,
-          // Ensure that the circuit does not break too quickly.
-          maxConsecutiveFailures: (maxRetries + 1) * 7,
+          ...commonPolicyOptions,
+          // Ensure that if the endpoint continually responds with errors, we
+          // break the circuit relatively fast (but not prematurely).
+          //
+          // Note that the circuit will break much faster if the errors are
+          // retriable (e.g. 503) than if not (e.g. 500), so we attempt to strike
+          // a balance here.
+          maxConsecutiveFailures: (maxRetries + 1) * 3,
         },
       };
     },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The network request code within the client makes use of the circuit breaker pattern. Currently, there must be 28 consecutive failed attempts to hit an RPC endpoint before the circuit breaks and it is perceived to be unavailable. At this point, if the endpoint is configured with a failover, the failover will be activated and all requests will be automatically diverted to it; otherwise requests are paused for 30 minutes.

There are two problems we are seeing now:

- If Infura is degraded enough to where failing over to QuickNode is warranted, the failover may be activated too late.
- If the user is attempting to access a custom network and they are experiencing issues (either due to a local connection issue or an issue with the endpoint itself), they will be prevented from using that network for 30 minutes. This is way too long.

To fix these problems, this commit:

- Lowers the "max consecutive failures" (the number of successive attempts to obtain a successful response from an endpoint before requests are paused or the failover is triggered) from 28 to 8.
- Lowers the "circuit break duration" (the period during which requests to an unavailable endpoint will be paused) from 30 minutes to 30 *seconds*.

In summary, if a network starts to become degraded or the user is experiencing connection issues, the network is more likely to be flagged as unavailable, but if the situation improves the user may be able to use the network more quickly.

How quickly does the circuit break now? It depends on whether the errors encountered are retriable or non-retriable:

- Retriable errors (e.g. connection errors, 502/503/504, etc.) will, as the name implies, be automatically retried. If these errors are continually produced, the circuit will break very quickly (if the extension is restarted, then it will break immediately).
- Non-retriable errors (e.g. 4xx errors) do not get automatically retried, so it takes longer for the circuit to break.

**One final note is that on Mobile, requests do not take place as frequently as on Extension, because the mechanism and cadence used to poll for tokens and balances is a bit different. Therefore we may need to use different values here than on Extension.**

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Decrease time before activating QuickNode when Infura is degraded or unavailable; decrease time before allowing users to interact with a custom network following connection issues

## **Related issues**

- https://consensyssoftware.atlassian.net/browse/WPC-103

## **Manual testing steps**

(NOTE: These steps will only work on iOS, as the Simulator uses the system network settings, so we can set a proxy that way. You can probably set a proxy on the Android emulator via Android Studio, but I've never gotten it to work. If you can, great!)

### Prerequisites

1. Check out this branch. Run `yarn setup:expo`, then `yarn watch:clean`.
2. Ensure that you have a development build on your emulator/device.
3. Open MetaMask on your emulator/device, and go through onboarding.
4. Open DevTools by pressing `j`.
5. Install [`mitmproxy`](https://docs.mitmproxy.org/stable/overview/installation/). Make sure you [install the certificate on the Simulator](https://docs.mitmproxy.org/stable/concepts/certificates/).
6. Create a Python script somewhere on your computer with the following contents: https://gist.github.com/mcmire/1d43ce690d3a974217126cd584f79b7d. This script will cause all requests to Infura RPC endpoints to respond with 500, simulating an outage.
7. Run `mitmproxy -s <path to your script>` in an open terminal session. This will run the proxy server.
8. Go to the network settings on your computer. Add both an HTTP and HTTP proxy that points to `http://localhost:8080`. On macOS:
    1. Click on the Network icon in the menu bar.
    2. Go to Wifi Settings.
    3. Click on Details next to your active network
    4. Click on Proxies in the sidebar.
    5. Enable "Web proxy (HTTP)"
    6. Enter 127.0.0.1 for "Server" and 8080 for "Port".
    7. Do the same thing for "Secure web proxy (HTTPS)".

### Testing non-retriable errors

1. Ensure that in the `mitmproxy` script, all Infura endpoints return 500.
2. Restart the app.
3. Switch to DevTools. You should see an entry in the Console view like `RPC endpoint not found or unavailable`.
4. On the home screen, pull down on the tokens list several times. Eventually, you wil see a message `Creating Segment event "RPC Service Unavailable"`. This indicates that the circuit broke.
5. If you pull down on the tokens list a few times in quick succession, you will not see `Creating Segment event "RPC Service Unavailable"`. But, if you wait 30 seconds and pull down again, then you will see it.

### Testing retriable errors

1. Stop `mitmproxy`. Modify the script so that all Infura endpoints return 503 instead of 500. Restart it.
2. Restart the app.
3. Switch to DevTools. You should see already see an entry in the Console view like `Creating Segment event "RPC Service Unavailable"`.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

In this video, the endpoint continually responds with 500 (a non-retriable error):

https://github.com/user-attachments/assets/ec89d2e0-585a-4d0c-98ec-242b154e8cee

In this video, the endpoint continually responds with 503 (a retriable error):

https://github.com/user-attachments/assets/b6e5f237-07ef-45ba-959b-9e92258f1145

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Lowers RPC circuit-break thresholds and cooldown, uses shared DEFAULT_MAX_RETRIES, and adjusts QuickNode/general failure limits for faster failover and recovery.
> 
> - **Engine/Network**:
>   - **RPC policy tuning in `app/core/Engine/controllers/network-controller-init.ts`**:
>     - Use `DEFAULT_MAX_RETRIES` for `maxRetries`.
>     - Introduce shared `policyOptions` with `circuitBreakDuration: 30 * SECOND`.
>     - Adjust `maxConsecutiveFailures`:
>       - QuickNode: `(maxRetries + 1) * 10`.
>       - Other endpoints: `(maxRetries + 1) * 3`.
>     - Keep common transport options (`fetch`, `btoa`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f34d509096658092d81ff35d7af29dcc63d56530. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->