### PR TITLE
chore: Remove `RewardsController` constructor side-effects

### DIFF
--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -363,7 +363,9 @@ const createTestSeasonStatusState = (
 describe('RewardsController', () => {
   let mockMessenger: jest.Mocked<RewardsControllerMessenger>;
   let controller: RewardsController;
-  let mockRewardsDataService: InstanceType<typeof RewardsDataService>;
+  let mockRewardsDataService: jest.Mocked<
+    InstanceType<typeof RewardsDataService>
+  >;
 
   beforeEach(() => {
     // Mock Date.now to return a consistent timestamp
@@ -382,6 +384,7 @@ describe('RewardsController', () => {
     });
     // @ts-expect-error TODO: Resolve type mismatch
     MockRewardsDataServiceClass.mockImplementation(() => ({
+      // TODO: Remove this mock, there is no `getJwt` method
       getJwt: jest.fn(),
       linkAccount: jest.fn(),
       getReferralCode: jest.fn(),
@@ -2092,12 +2095,16 @@ describe('RewardsController', () => {
           // Mimic the controller calling into data service; delegate to getJwt
           const { timestamp, signature } = payload || {};
           // Make sure to pass the account address correctly
-          return mockRewardsDataService
-            .getJwt(signature, timestamp, mockInternalAccount.address)
-            .then((jwt: string) => ({
-              subscription: { id: 'sub-123' },
-              sessionId: jwt,
-            }));
+          return (
+            mockRewardsDataService
+              // @ts-expect-error TODO: There is no `getJwt` method. We should remove it from the
+              // RewardsDataService mock, and fix this mock
+              .getJwt(signature, timestamp, mockInternalAccount.address)
+              .then((jwt: string) => ({
+                subscription: { id: 'sub-123' },
+                sessionId: jwt,
+              }))
+          );
         }
         return Promise.resolve(undefined);
       }) as any);
@@ -4213,6 +4220,7 @@ describe('RewardsController', () => {
       mockRewardsDataService.login
         .mockRejectedValueOnce(new Error('First account auth failed'))
         .mockResolvedValueOnce({
+          // @ts-expect-error TODO: Fix type mismatch
           subscription: { id: 'subscription-id-123' },
           jwt: 'mock-jwt-token',
         });

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -11286,6 +11286,13 @@ describe('RewardsController', () => {
       (global as any).Logger = mockLogger;
     });
 
+    afterEach(() => {
+      delete (global as any).isSolanaAddress;
+      delete (global as any).isNonEvmAddress;
+      delete (global as any).signSolanaRewardsMessage;
+      delete (global as any).Logger;
+    });
+
     it('should sign EVM message correctly', async () => {
       // Arrange
       const mockInternalAccount = {

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -366,9 +366,6 @@ describe('RewardsController', () => {
   let mockRewardsDataService: InstanceType<typeof RewardsDataService>;
 
   beforeEach(() => {
-    jest.resetAllMocks();
-    jest.restoreAllMocks();
-
     // Mock Date.now to return a consistent timestamp
     jest.spyOn(Date, 'now').mockReturnValue(123);
 
@@ -416,6 +413,11 @@ describe('RewardsController', () => {
     controller = new RewardsController({
       messenger: mockMessenger,
     });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
   });
 
   describe('initialization', () => {

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -369,6 +369,9 @@ describe('RewardsController', () => {
     jest.resetAllMocks();
     jest.restoreAllMocks();
 
+    // Mock Date.now to return a consistent timestamp
+    jest.spyOn(Date, 'now').mockReturnValue(123);
+
     // Reset import mocks
     // @ts-expect-error TODO: Resolve type mismatch
     mockStoreSubscriptionToken.mockResolvedValue(undefined);

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -2007,11 +2007,6 @@ describe('RewardsController', () => {
   });
 
   describe('isRewardsFeatureEnabled', () => {
-    beforeEach(() => {
-      // Reset all mocks for this test suite
-      jest.clearAllMocks();
-    });
-
     it('should return true when feature flag is enabled', () => {
       // Mock the feature flag selector to return true
       mockSelectRewardsEnabledFlag.mockReturnValue(true);
@@ -2344,9 +2339,6 @@ describe('RewardsController', () => {
         signedMessage: 'signedMessage123',
         signatureType: 'ed25519',
       });
-
-      // Restore Date.now
-      jest.restoreAllMocks();
     });
 
     it('should throw error when session token storage fails', async () => {
@@ -3998,7 +3990,6 @@ describe('RewardsController', () => {
     });
 
     it('should log and rethrow Error objects when API call fails', async () => {
-      jest.clearAllMocks();
       controller = new RewardsController({
         messenger: mockMessenger,
         state: {
@@ -4031,7 +4022,6 @@ describe('RewardsController', () => {
     });
 
     it('should log and rethrow non-Error objects when API call fails', async () => {
-      jest.clearAllMocks();
       controller = new RewardsController({
         messenger: mockMessenger,
         state: {
@@ -4646,7 +4636,6 @@ describe('RewardsController', () => {
   describe('resetAll', () => {
     beforeEach(() => {
       mockSelectRewardsEnabledFlag.mockReturnValue(true);
-      jest.clearAllMocks();
     });
 
     it('should skip reset when feature flag is disabled', async () => {
@@ -4826,7 +4815,6 @@ describe('RewardsController', () => {
 
     it('should return true for valid referral codes from service', async () => {
       // Arrange
-      jest.clearAllMocks();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       mockMessenger.call.mockImplementation((action, ..._args): any => {
         if (action === 'RewardsDataService:validateReferralCode') {
@@ -4848,7 +4836,6 @@ describe('RewardsController', () => {
 
     it('should return false for invalid referral codes from service', async () => {
       // Arrange
-      jest.clearAllMocks();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       mockMessenger.call.mockImplementation((action, ..._args): any => {
         if (action === 'RewardsDataService:validateReferralCode') {
@@ -4873,7 +4860,6 @@ describe('RewardsController', () => {
       const validCodes = ['ABCDEF', 'ABC234', 'XYZ567', 'DEF237'];
 
       for (const code of validCodes) {
-        jest.clearAllMocks();
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         mockMessenger.call.mockImplementation((action, ..._args): any => {
           if (action === 'RewardsDataService:validateReferralCode') {
@@ -4893,7 +4879,6 @@ describe('RewardsController', () => {
 
     it('should handle service errors and throw error', async () => {
       // Arrange
-      jest.clearAllMocks();
       mockMessenger.call.mockRejectedValue(new Error('Service error'));
 
       // Act & Assert
@@ -5053,7 +5038,6 @@ describe('RewardsController', () => {
   describe('convertInternalAccountToCaipAccountId', () => {
     beforeEach(() => {
       mockSelectRewardsEnabledFlag.mockReturnValue(true);
-      jest.clearAllMocks();
     });
 
     it('should log error when conversion fails due to invalid internal account', () => {
@@ -5143,10 +5127,6 @@ describe('RewardsController', () => {
   });
 
   describe('invalidateAccountsAndSubscriptions', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-    });
-
     it('should correctly invalidate accounts and subscriptions', async () => {
       // Arrange
       const testController = new TestableRewardsController({
@@ -5672,6 +5652,7 @@ describe('RewardsController', () => {
 
     beforeEach(() => {
       mockSelectRewardsEnabledFlag.mockReturnValue(true);
+      // Clear calls resulting from top-level `beforeEach`
       jest.clearAllMocks();
     });
 
@@ -6407,9 +6388,6 @@ describe('RewardsController', () => {
 
     beforeEach(() => {
       mockSelectRewardsEnabledFlag.mockReturnValue(true);
-      jest.clearAllMocks();
-      // Restore any spies that might be left over from previous tests
-      jest.restoreAllMocks();
     });
 
     it('should return empty array when accounts array is empty', async () => {
@@ -6625,12 +6603,10 @@ describe('RewardsController', () => {
   describe('optOut', () => {
     beforeEach(() => {
       mockSelectRewardsEnabledFlag.mockReturnValue(true);
-      jest.clearAllMocks();
     });
 
     it('should return false when subscription ID is not found', async () => {
       // Arrange
-      jest.clearAllMocks(); // Clear mocks to ensure clean test
       const testController = new TestableRewardsController({
         messenger: mockMessenger,
         state: {
@@ -6838,7 +6814,6 @@ describe('RewardsController', () => {
   describe('optIn and optOut edge cases', () => {
     beforeEach(() => {
       mockSelectRewardsEnabledFlag.mockReturnValue(true);
-      jest.clearAllMocks();
     });
 
     describe('optIn edge cases', () => {
@@ -8246,7 +8221,6 @@ describe('RewardsController', () => {
     } as InternalAccount;
 
     beforeEach(() => {
-      jest.clearAllMocks();
       mockSelectRewardsEnabledFlag.mockReturnValue(true);
       mockIsSolanaAddress.mockReturnValue(false); // Default to non-Solana
     });
@@ -9125,7 +9099,6 @@ describe('RewardsController', () => {
     } as InternalAccount;
 
     beforeEach(() => {
-      jest.clearAllMocks();
       mockSelectRewardsEnabledFlag.mockReturnValue(true);
       mockIsSolanaAddress.mockReturnValue(false);
     });
@@ -9219,7 +9192,6 @@ describe('RewardsController', () => {
 
     it('should return false array when feature flag is disabled', async () => {
       // Arrange
-      jest.clearAllMocks(); // Clear any calls from initialization
       mockSelectRewardsEnabledFlag.mockReturnValue(false);
 
       // Act
@@ -12181,8 +12153,6 @@ describe('RewardsController', () => {
       mockWriteCache = jest.fn();
       mockFetchFresh = jest.fn();
       mockSwrCallback = jest.fn();
-      jest.clearAllMocks();
-      mockLogger.log.mockClear();
       const mockTimestamp = 1234567890;
       jest.spyOn(Date, 'now').mockReturnValue(mockTimestamp);
     });

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -489,9 +489,6 @@ export class RewardsController extends BaseController<
     this.messagingSystem.subscribe('KeyringController:unlock', () =>
       this.handleAuthenticationTrigger('KeyringController unlocked'),
     );
-
-    // Initialize silent authentication on startup
-    this.handleAuthenticationTrigger('Controller initialized');
   }
 
   /**

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -1604,6 +1604,8 @@ export class RewardsController extends BaseController<
       if (state.activeAccount) {
         state.activeAccount = {
           ...state.activeAccount,
+          lastPerpsDiscountRateFetched: null,
+          perpsFeeDiscount: null,
           hasOptedIn: false,
           subscriptionId: null,
           account: state.activeAccount.account, // Ensure account is always present (never undefined)


### PR DESCRIPTION
## **Description**

The `RewardsController` would attempt to authenticate upon startup. This was responsible for some difficult-to-prevent unit test failures in test modules that indirectly used the `RewardsController`, and is generally against our guidelines (side-effects make initialization more difficult to control, and make unit testing unnecessarily difficult).

This authentication trigger has been removed. The remaining authentication triggers should suffice to ensure the user is authenticated (especially the `unlock` trigger, which should happen every session).

## **Changelog**

CHANGELOG entry: Delay Rewards authentication until after unlock

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stops automatic silent auth on controller init; resets activeAccount by preserving account while clearing auth/discount fields; extensive test/mocking refactors and stability fixes.
> 
> - **Engine/RewardsController**:
>   - **Init behavior**: Remove constructor side-effect that triggered silent auth on startup (now only on account-group change and unlock).
>   - **State invalidation**: `invalidateAccountsAndSubscriptions` now preserves `activeAccount.account` and clears `hasOptedIn`, `subscriptionId`, `perpsFeeDiscount`, `lastPerpsDiscountRateFetched` instead of nulling the whole object.
> - **Tests**:
>   - **Mocks/Determinism**: Rework Jest mocks (e.g., `RewardsDataService` as class, token vault methods, Solana signing), add `Date.now` spies for stable timestamps, and adjust messenger call flows.
>   - **Coverage/Behavior**: Update/expand scenarios for season status (including default `CURRENT_SEASON_ID` and 403 reauth), Solana/EVM signing, logout/reset, opt-in/out, linking, cache invalidation, and points events/boosts/unlocked rewards.
>   - **Cleanup**: Add consistent `afterEach` resets and targeted mock resets to reduce flakiness.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb291647bf47240437960a6d500ee3b110326d06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->