### PR TITLE
feat(predict): add slippage to orders to improve failure rate

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -374,9 +374,10 @@ export class PolymarketProvider implements PredictProvider {
 
     // Introduce slippage into minAmountReceived to reduce failure rate
     const roundConfig = ROUNDING_CONFIG[tickSize.toString() as TickSize];
+    const decimals = roundConfig.amount ?? 4;
     const minAmountWithSlippage = roundOrderAmount({
       amount: minAmountReceived * (1 - slippage),
-      decimals: roundConfig.amount,
+      decimals,
     });
 
     const makerAmount = parseUnits(maxAmountSpent.toString(), 6).toString();

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -41,6 +41,7 @@ import {
   MATIC_CONTRACTS,
   POLYGON_MAINNET_CHAIN_ID,
   POLYMARKET_PROVIDER_ID,
+  ROUNDING_CONFIG,
 } from './constants';
 import {
   computeSafeAddress,
@@ -58,6 +59,7 @@ import {
   PolymarketApiActivity,
   SignatureType,
   UtilsSide,
+  TickSize,
 } from './types';
 import {
   createApiKey,
@@ -74,6 +76,7 @@ import {
   submitClobOrder,
   previewOrder,
   generateSalt,
+  roundOrderAmount,
 } from './utils';
 
 export type SignTypedMessageFn = (
@@ -355,6 +358,8 @@ export class PolymarketProvider implements PredictProvider {
       minAmountReceived,
       negRisk,
       fees,
+      slippage,
+      tickSize,
     } = preview;
 
     const chainId = POLYGON_MAINNET_CHAIN_ID;
@@ -367,8 +372,18 @@ export class PolymarketProvider implements PredictProvider {
       throw new Error('Maker address not found');
     }
 
+    // Introduce slippage into minAmountReceived to reduce failure rate
+    const roundConfig = ROUNDING_CONFIG[tickSize.toString() as TickSize];
+    const minAmountWithSlippage = roundOrderAmount({
+      amount: minAmountReceived * (1 - slippage),
+      decimals: roundConfig.amount,
+    });
+
     const makerAmount = parseUnits(maxAmountSpent.toString(), 6).toString();
-    const takerAmount = parseUnits(minAmountReceived.toString(), 6).toString();
+    const takerAmount = parseUnits(
+      minAmountWithSlippage.toString(),
+      6,
+    ).toString();
 
     /**
      * Do NOT change the order below.

--- a/app/components/UI/Predict/providers/polymarket/constants.ts
+++ b/app/components/UI/Predict/providers/polymarket/constants.ts
@@ -8,10 +8,8 @@ export const FEE_COLLECTOR_ADDRESS =
 
 /**
  * Default slippage for market orders.
- * TODO: This is not currently being used, so we can test
- * how often orders fail before we need to apply slippage.
  */
-export const DEFAULT_SLIPPAGE = 0.005; // 0.5%
+export const SLIPPAGE = 0.005; // 0.5%
 
 export const POLYGON_MAINNET_CHAIN_ID = 137;
 

--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -62,6 +62,7 @@ import {
   roundNormal,
   roundDown,
   roundUp,
+  roundOrderAmount,
   roundOrderAmounts,
   previewOrder,
   getAllowanceCalls,
@@ -2085,6 +2086,80 @@ describe('polymarket utils', () => {
     it('should handle edge cases', () => {
       expect(roundUp(0.001, 2)).toBe(0.01);
       expect(roundUp(100.123456, 3)).toBe(100.124);
+    });
+  });
+
+  describe('roundOrderAmount', () => {
+    it('should return same amount if decimal places are within limit', () => {
+      expect(roundOrderAmount({ amount: 1.5, decimals: 2 })).toBe(1.5);
+      expect(roundOrderAmount({ amount: 10.25, decimals: 2 })).toBe(10.25);
+      expect(roundOrderAmount({ amount: 5, decimals: 2 })).toBe(5);
+    });
+
+    it('should round down amount if it exceeds decimals after rounding up', () => {
+      expect(roundOrderAmount({ amount: 1.235, decimals: 2 })).toBe(1.23);
+      expect(roundOrderAmount({ amount: 10.999, decimals: 2 })).toBe(10.99);
+    });
+
+    it('should round down when amount has more decimals than target', () => {
+      expect(roundOrderAmount({ amount: 1.001, decimals: 2 })).toBe(1);
+      expect(roundOrderAmount({ amount: 0.0001, decimals: 2 })).toBe(0);
+      expect(roundOrderAmount({ amount: 1.0001, decimals: 2 })).toBe(1);
+    });
+
+    it('should handle zero decimals', () => {
+      expect(roundOrderAmount({ amount: 1.5, decimals: 0 })).toBe(1);
+      expect(roundOrderAmount({ amount: 1.999, decimals: 0 })).toBe(1);
+      expect(roundOrderAmount({ amount: 5, decimals: 0 })).toBe(5);
+    });
+
+    it('should handle large decimal precision', () => {
+      expect(roundOrderAmount({ amount: 1.123456789, decimals: 6 })).toBe(
+        1.123456,
+      );
+      expect(roundOrderAmount({ amount: 0.123456789, decimals: 5 })).toBe(
+        0.12345,
+      );
+    });
+
+    it('should handle edge case with very small amounts', () => {
+      expect(roundOrderAmount({ amount: 0.00001, decimals: 2 })).toBe(0);
+      expect(roundOrderAmount({ amount: 0.000001, decimals: 4 })).toBe(0);
+      expect(roundOrderAmount({ amount: 0.123456, decimals: 4 })).toBe(0.1234);
+    });
+
+    it('should handle edge case with large amounts', () => {
+      expect(roundOrderAmount({ amount: 1000.123456, decimals: 2 })).toBe(
+        1000.12,
+      );
+      expect(roundOrderAmount({ amount: 99999.999999, decimals: 3 })).toBe(
+        99999.999,
+      );
+    });
+
+    it('should apply roundUp with extra decimals then roundDown if needed', () => {
+      const amount = 1.12345678;
+      const decimals = 2;
+      const result = roundOrderAmount({ amount, decimals });
+      expect(result).toBe(1.12);
+      expect(decimalPlaces(result)).toBeLessThanOrEqual(decimals);
+    });
+
+    it('should round up when amount can fit exactly into target decimals', () => {
+      expect(roundOrderAmount({ amount: 1.2345, decimals: 2 })).toBe(1.23);
+      expect(roundOrderAmount({ amount: 10.1234567, decimals: 4 })).toBe(
+        10.1234,
+      );
+    });
+
+    it('should handle negative amounts', () => {
+      expect(roundOrderAmount({ amount: -1.235, decimals: 2 })).toBe(-1.24);
+      expect(roundOrderAmount({ amount: -10.999, decimals: 2 })).toBe(-11);
+    });
+
+    it('should handle amounts that round up to exceed decimals', () => {
+      expect(roundOrderAmount({ amount: 1.996, decimals: 2 })).toBe(1.99);
+      expect(roundOrderAmount({ amount: 0.999999, decimals: 2 })).toBe(0.99);
     });
   });
 

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -25,7 +25,7 @@ import type {
 } from '../types';
 import {
   ClobAuthDomain,
-  DEFAULT_SLIPPAGE,
+  SLIPPAGE,
   EIP712Domain,
   FEE_PERCENTAGE,
   HASH_ZERO_BYTES32,
@@ -1064,6 +1064,22 @@ export const roundUp = (num: number, decimals: number): number => {
   return Math.ceil(num * 10 ** decimals) / 10 ** decimals;
 };
 
+export const roundOrderAmount = ({
+  amount,
+  decimals,
+}: {
+  amount: number;
+  decimals: number;
+}): number => {
+  if (decimalPlaces(amount) > decimals) {
+    amount = roundUp(amount, decimals + 4);
+    if (decimalPlaces(amount) > decimals) {
+      amount = roundDown(amount, decimals);
+    }
+  }
+  return amount;
+};
+
 export const roundOrderAmounts = ({
   roundConfig,
   side,
@@ -1076,30 +1092,17 @@ export const roundOrderAmounts = ({
   price: number;
 }): { makerAmount: number; takerAmount: number } => {
   const rawPrice = roundDown(price, roundConfig.price);
-
-  if (side === Side.BUY) {
-    const rawMakerAmt = roundDown(size, roundConfig.size);
-    let rawTakerAmt = rawMakerAmt / rawPrice;
-    if (decimalPlaces(rawTakerAmt) > roundConfig.amount) {
-      rawTakerAmt = roundUp(rawTakerAmt, roundConfig.amount + 4);
-      if (decimalPlaces(rawTakerAmt) > roundConfig.amount) {
-        rawTakerAmt = roundDown(rawTakerAmt, roundConfig.amount);
-      }
-    }
-    return {
-      makerAmount: rawMakerAmt,
-      takerAmount: rawTakerAmt,
-    };
-  }
   const rawMakerAmt = roundDown(size, roundConfig.size);
-  let rawTakerAmt = rawMakerAmt * rawPrice;
-  if (decimalPlaces(rawTakerAmt) > roundConfig.amount) {
-    rawTakerAmt = roundUp(rawTakerAmt, roundConfig.amount + 4);
-    if (decimalPlaces(rawTakerAmt) > roundConfig.amount) {
-      rawTakerAmt = roundDown(rawTakerAmt, roundConfig.amount);
-    }
+  let rawTakerAmt;
+  if (side === Side.BUY) {
+    rawTakerAmt = rawMakerAmt / rawPrice;
+  } else {
+    rawTakerAmt = rawMakerAmt * rawPrice;
   }
-
+  rawTakerAmt = roundOrderAmount({
+    amount: rawTakerAmt,
+    decimals: roundConfig.amount,
+  });
   return {
     makerAmount: rawMakerAmt,
     takerAmount: rawTakerAmt,
@@ -1141,7 +1144,7 @@ export const previewOrder = async (
       sharePrice: bestPrice,
       maxAmountSpent: makerAmount,
       minAmountReceived: takerAmount,
-      slippage: DEFAULT_SLIPPAGE,
+      slippage: SLIPPAGE,
       tickSize: parseFloat(book.tick_size),
       minOrderSize: parseFloat(book.min_order_size),
       negRisk: book.neg_risk,
@@ -1175,7 +1178,7 @@ export const previewOrder = async (
     sharePrice: bestPrice,
     maxAmountSpent: makerAmount,
     minAmountReceived: takerAmount,
-    slippage: DEFAULT_SLIPPAGE,
+    slippage: SLIPPAGE,
     tickSize: parseFloat(book.tick_size),
     minOrderSize: parseFloat(book.min_order_size),
     negRisk: book.neg_risk,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Add 0.5% slippage when placing buy/sell orders, in order to reduce failure rate due to FOK behavior.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Applies 0.5% slippage and tick-size-based rounding to order amounts, updates preview/placement logic, and adds rounding tests.
> 
> - **Order placement (`PolymarketProvider.ts`)**:
>   - Apply `slippage` from preview to compute `minAmountWithSlippage`; round via `ROUNDING_CONFIG[tickSize]` and `roundOrderAmount`; use for `takerAmount`.
> - **Utils (`utils.ts`)**:
>   - Add `roundOrderAmount` helper and refactor `roundOrderAmounts` to use it for BUY/SELL flows.
>   - Replace `DEFAULT_SLIPPAGE` with `SLIPPAGE` in `previewOrder` responses.
> - **Constants (`constants.ts`)**:
>   - Rename `DEFAULT_SLIPPAGE` -> `SLIPPAGE` (0.5%).
> - **Tests (`utils.test.ts`)**:
>   - Add comprehensive tests for `roundOrderAmount` and adjust expectations/imports for refactored rounding and `SLIPPAGE`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 690db5862e786498f2ac3b6379903b0090f45c27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->