### PR TITLE
fix: ShareAddressQR displays correct address for non-EVM assets

### DIFF
--- a/app/components/UI/AssetOverview/AssetOverview.test.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.test.tsx
@@ -51,6 +51,11 @@ jest.mock(
   }),
 );
 
+jest.mock('../../../selectors/multichainAccounts/accounts', () => ({
+  ...jest.requireActual('../../../selectors/multichainAccounts/accounts'),
+  selectSelectedInternalAccountByScope: jest.fn(),
+}));
+
 const MOCK_CHAIN_ID = '0x1';
 
 const mockInitialState = {
@@ -266,6 +271,15 @@ describe('AssetOverview', () => {
       address: MOCK_ADDRESS_2,
       type: 'eip155:eoa',
     });
+
+    // Default mock for selectSelectedInternalAccountByScope
+    const { selectSelectedInternalAccountByScope } = jest.requireMock(
+      '../../../selectors/multichainAccounts/accounts',
+    );
+    const mockGetAccountByScope = jest.fn().mockReturnValue({
+      address: MOCK_ADDRESS_2,
+    });
+    selectSelectedInternalAccountByScope.mockReturnValue(mockGetAccountByScope);
   });
 
   afterEach(() => {
@@ -545,7 +559,7 @@ describe('AssetOverview', () => {
     });
   });
 
-  it('should handle receive button press', async () => {
+  it('should handle receive button press for EVM asset with EVM address', async () => {
     // Arrange - Mock the selectors directly to ensure conditions are met
     const { selectSelectedInternalAccount } = jest.requireMock(
       '../../../selectors/accountsController',
@@ -553,8 +567,20 @@ describe('AssetOverview', () => {
     const { selectSelectedAccountGroup } = jest.requireMock(
       '../../../selectors/multichainAccounts/accountTreeController',
     );
-    selectSelectedInternalAccount.mockReturnValue({ address: MOCK_ADDRESS_2 });
+    const { selectSelectedInternalAccountByScope } = jest.requireMock(
+      '../../../selectors/multichainAccounts/accounts',
+    );
+
+    selectSelectedInternalAccount.mockReturnValue({
+      address: MOCK_ADDRESS_2,
+      type: 'eip155:eoa',
+    });
     selectSelectedAccountGroup.mockReturnValue({ id: 'group-id-123' });
+
+    const mockGetAccountByScope = jest.fn().mockReturnValue({
+      address: MOCK_ADDRESS_2,
+    });
+    selectSelectedInternalAccountByScope.mockReturnValue(mockGetAccountByScope);
 
     const { getByTestId } = renderWithProvider(
       <AssetOverview
@@ -570,7 +596,7 @@ describe('AssetOverview', () => {
     const receiveButton = getByTestId('token-receive-button');
     fireEvent.press(receiveButton);
 
-    // Assert - Should navigate to ShareAddressQR
+    // Assert - Should navigate to ShareAddressQR with EVM address
     expect(navigate).toHaveBeenCalledTimes(1);
     expect(navigate).toHaveBeenNthCalledWith(
       1,
@@ -578,7 +604,7 @@ describe('AssetOverview', () => {
       {
         screen: Routes.SHEET.MULTICHAIN_ACCOUNT_DETAILS.SHARE_ADDRESS_QR,
         params: expect.objectContaining({
-          address: MOCK_ADDRESS_2,
+          address: MOCK_ADDRESS_2, // Should use EVM address for EVM assets
           networkName: 'Ethereum Mainnet',
           chainId: MOCK_CHAIN_ID,
           groupId: 'group-id-123',
@@ -589,6 +615,7 @@ describe('AssetOverview', () => {
     // Cleanup mocks for isolation
     selectSelectedInternalAccount.mockReset();
     selectSelectedAccountGroup.mockReset();
+    selectSelectedInternalAccountByScope.mockReset();
   });
 
   it('should track receive button click analytics with correct properties', async () => {
@@ -638,6 +665,75 @@ describe('AssetOverview', () => {
     // Cleanup mocks for isolation
     selectSelectedInternalAccount.mockReset();
     selectSelectedAccountGroup.mockReset();
+  });
+
+  it('should handle receive button press for Solana asset with Solana address', async () => {
+    const SOLANA_ADDRESS = 'HN7cABqLq46Es1jh92dQQisAq662SmxELLLsHHe4YWrH';
+    const SOLANA_CHAIN_ID = SolScope.Mainnet;
+
+    const { selectSelectedInternalAccount } = jest.requireMock(
+      '../../../selectors/accountsController',
+    );
+    const { selectSelectedAccountGroup } = jest.requireMock(
+      '../../../selectors/multichainAccounts/accountTreeController',
+    );
+    const { selectSelectedInternalAccountByScope } = jest.requireMock(
+      '../../../selectors/multichainAccounts/accounts',
+    );
+
+    selectSelectedInternalAccount.mockReturnValue({
+      address: MOCK_ADDRESS_2,
+      type: 'eip155:eoa',
+    });
+    selectSelectedAccountGroup.mockReturnValue({ id: 'group-id-123' });
+
+    const mockGetAccountByScope = jest.fn().mockReturnValue({
+      address: SOLANA_ADDRESS,
+      type: SolAccountType.DataAccount,
+    });
+    selectSelectedInternalAccountByScope.mockReturnValue(mockGetAccountByScope);
+
+    const solanaAsset = {
+      ...asset,
+      address: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+      chainId: SOLANA_CHAIN_ID,
+      isNative: true,
+      symbol: 'SOL',
+    };
+
+    const { getByTestId } = renderWithProvider(
+      <AssetOverview
+        asset={solanaAsset}
+        displayBuyButton
+        displaySwapsButton
+        networkName="Solana Mainnet"
+      />,
+      { state: mockInitialState },
+    );
+
+    const receiveButton = getByTestId('token-receive-button');
+    fireEvent.press(receiveButton);
+
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenNthCalledWith(
+      1,
+      Routes.MODAL.MULTICHAIN_ACCOUNT_DETAIL_ACTIONS,
+      {
+        screen: Routes.SHEET.MULTICHAIN_ACCOUNT_DETAILS.SHARE_ADDRESS_QR,
+        params: expect.objectContaining({
+          address: SOLANA_ADDRESS, // Should use Solana address, not EVM address
+          networkName: 'Solana Mainnet',
+          chainId: SOLANA_CHAIN_ID,
+          groupId: 'group-id-123',
+        }),
+      },
+    );
+
+    expect(mockGetAccountByScope).toHaveBeenCalledWith(SOLANA_CHAIN_ID);
+
+    selectSelectedInternalAccount.mockReset();
+    selectSelectedAccountGroup.mockReset();
+    selectSelectedInternalAccountByScope.mockReset();
   });
 
   it('should not render swap button if displaySwapsButton is false', async () => {


### PR DESCRIPTION
## **Description**

### Problem
When viewing a non-EVM asset (e.g., Solana) and clicking "Receive", the `ShareAddressQR` screen incorrectly displayed the user's EVM address instead of the chain-specific address (e.g., Solana address).

###   Root Cause

`AssetOverview.tsx:215` always passed `selectedInternalAccountAddress` (EVM address) to the `ShareAddressQR` screen, regardless of the asset's chain type.

###   Solution

- Use `selectSelectedInternalAccountByScope` selector to get chain-specific accounts
- For non-EVM assets: retrieve the account using `getAccountByScope(asset.chainId as CaipChainId)`
- For EVM assets: continue using `selectedInternalAccount`
- Enhanced error logging with `isNonEvmAsset` and `assetChainId` fields

  
## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed issue where QR code share screen shows the incorrect wallet address

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/21447

## **Manual testing steps**

```gherkin
  Feature: Receive QR Share Screen

    Background:
      Given the user has a wallet with both EVM and non-EVM accounts
      And the user is on the Asset Overview screen

    Scenario: User shares QR code for EVM asset
      Given the user is viewing an Ethereum (EVM) asset

      When the user taps the "Receive" button
      Then the Share Address QR screen is displayed
      And the QR code contains the user's EVM address

    Scenario: User shares QR code for Solana asset
      Given the user is viewing a Solana asset

      When the user taps the "Receive" button
      Then the Share Address QR screen is displayed
      And the QR code contains the user's Solana address
```

## **Screenshots/Recordings**

`~`

### **Before**

https://github.com/user-attachments/assets/58872d26-829e-4bd1-aef7-08aa8abf2ff5

### **After**

https://github.com/user-attachments/assets/82ea57f2-c50a-4f91-9484-233f8363299f

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> ShareAddressQR now shows the chain-specific address for non-EVM assets; adds selector usage, logging, and tests for EVM and Solana.
> 
> - **Asset Overview (Receive flow)**:
>   - Use `selectSelectedInternalAccountByScope` to fetch chain-scoped account for non-EVM assets (`CaipChainId`), falling back to `selectedInternalAccount` for EVM.
>   - Pass chain-appropriate `address` to `Routes.SHEET.MULTICHAIN_ACCOUNT_DETAILS.SHARE_ADDRESS_QR`.
>   - Improve error logging with `isNonEvmAsset` and `assetChainId` context.
> - **Tests**:
>   - Mock `selectSelectedInternalAccountByScope` and add cases for EVM asset (uses EVM address) and Solana asset (uses Solana address, asserts scope call).
>   - Adjust existing receive test setup and cleanup to incorporate new selector behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55c41ac0c7320aa7e2682ee82ddac2e9d07e6554. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->