### PR TITLE
test: Remove `Date.now` mock

### DIFF
--- a/app/util/test/testSetup.js
+++ b/app/util/test/testSetup.js
@@ -197,8 +197,6 @@ jest.mock('react-native-blob-util', () => ({
   },
 }));
 
-Date.now = jest.fn(() => 123);
-
 jest.mock('../../core/NotificationManager', () => ({
   init: jest.fn(),
   watchSubmittedTransaction: jest.fn(),


### PR DESCRIPTION
## **Description**

This mock was getting reset when `jest.restoreAllMocks()` was called. Using `restoreAllMocks` in-between each test is recommended, so it didn't seem advisable to leave this mock in place when it would only last for 1 test per suite.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
