### PR TITLE
fix: incorrect network when adding token

### DIFF
--- a/app/components/hooks/useNetworkSelection/useNetworkSelection.test.ts
+++ b/app/components/hooks/useNetworkSelection/useNetworkSelection.test.ts
@@ -670,13 +670,13 @@ describe('useNetworkSelection', () => {
         .mockReturnValueOnce([]); // selectInternalAccounts
 
       // Mock setActiveNetwork to throw an error
-      const mockSetActiveNetwork = jest
+      const mockSetActiveNetworkWithError = jest
         .fn()
         .mockRejectedValue(new Error('Network error'));
       jest.doMock('../../../core/Engine', () => ({
         context: {
           MultichainNetworkController: {
-            setActiveNetwork: mockSetActiveNetwork,
+            setActiveNetwork: mockSetActiveNetworkWithError,
           },
           NetworkController: {
             findNetworkClientIdByChainId: jest.fn(),
@@ -909,6 +909,9 @@ describe('useNetworkSelection', () => {
       await result.current.selectAllPopularNetworks(mockCallback);
 
       expect(mockEnableAllPopularNetworks).toHaveBeenCalled();
+      expect(
+        Engine.context.MultichainNetworkController.setActiveNetwork,
+      ).toHaveBeenCalledWith('mainnet-client-id');
       expect(mockCallback).toHaveBeenCalled();
     });
 
@@ -922,6 +925,21 @@ describe('useNetworkSelection', () => {
       ).resolves.toBeUndefined();
 
       expect(mockEnableAllPopularNetworks).toHaveBeenCalled();
+      expect(
+        Engine.context.MultichainNetworkController.setActiveNetwork,
+      ).toHaveBeenCalledWith('mainnet-client-id');
+    });
+
+    it('switches active network to ethereum mainnet', async () => {
+      const { result } = renderHook(() =>
+        useNetworkSelection({ networks: mockNetworks }),
+      );
+
+      await result.current.selectAllPopularNetworks();
+
+      expect(
+        Engine.context.MultichainNetworkController.setActiveNetwork,
+      ).toHaveBeenCalledWith('mainnet-client-id');
     });
   });
 

--- a/app/components/hooks/useNetworkSelection/useNetworkSelection.test.ts
+++ b/app/components/hooks/useNetworkSelection/useNetworkSelection.test.ts
@@ -13,7 +13,10 @@ import { useNetworkEnablement } from '../useNetworkEnablement/useNetworkEnableme
 import { ProcessedNetwork } from '../useNetworksByNamespace/useNetworksByNamespace';
 import { useNetworkSelection } from './useNetworkSelection';
 import { selectMultichainAccountsState2Enabled } from '../../../selectors/featureFlagController/multichainAccounts/enabledMultichainAccounts';
-import { selectPopularNetworkConfigurationsByCaipChainId } from '../../../selectors/networkController';
+import {
+  selectPopularNetworkConfigurationsByCaipChainId,
+  selectNetworkConfigurationsByCaipChainId,
+} from '../../../selectors/networkController';
 import { selectInternalAccounts } from '../../../selectors/accountsController';
 import Engine from '../../../core/Engine';
 import NavigationService from '../../../core/NavigationService';
@@ -101,6 +104,9 @@ jest.mock('../../../core/Engine', () => ({
     NetworkController: {
       findNetworkClientIdByChainId: jest.fn(),
     },
+    PreferencesController: {
+      setTokenNetworkFilter: jest.fn(),
+    },
   },
   setSelectedAddress: jest.fn(), // Add this line
 }));
@@ -154,6 +160,7 @@ jest.mock('../../../selectors/accountsController', () => ({
 jest.mock('../../../selectors/networkController', () => ({
   selectEvmChainId: jest.fn(),
   selectPopularNetworkConfigurationsByCaipChainId: jest.fn(),
+  selectNetworkConfigurationsByCaipChainId: jest.fn(),
 }));
 
 jest.mock('../../../core/NavigationService', () => {
@@ -237,6 +244,48 @@ describe('useNetworkSelection', () => {
     },
   ];
 
+  const mockNetworkConfigurations = {
+    'eip155:1': {
+      caipChainId: 'eip155:1' as CaipChainId,
+      chainId: '0x1' as Hex,
+      name: 'Ethereum Mainnet',
+      rpcEndpoints: [
+        {
+          networkClientId: 'mainnet-client-id',
+          url: 'https://mainnet.infura.io',
+          type: 'infura',
+        },
+      ],
+      defaultRpcEndpointIndex: 0,
+    },
+    'eip155:137': {
+      caipChainId: 'eip155:137' as CaipChainId,
+      chainId: '0x89' as Hex,
+      name: 'Polygon',
+      rpcEndpoints: [
+        {
+          networkClientId: 'polygon-client-id',
+          url: 'https://polygon-rpc.com',
+          type: 'custom',
+        },
+      ],
+      defaultRpcEndpointIndex: 0,
+    },
+    'eip155:13881': {
+      caipChainId: 'eip155:13881' as CaipChainId,
+      chainId: '0x13881' as Hex,
+      name: 'Mumbai Testnet',
+      rpcEndpoints: [
+        {
+          networkClientId: 'mumbai-client-id',
+          url: 'https://mumbai.polygonscan.com',
+          type: 'custom',
+        },
+      ],
+      defaultRpcEndpointIndex: 0,
+    },
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockEnableNetwork.mockReset();
@@ -248,6 +297,9 @@ describe('useNetworkSelection', () => {
     mockUseSelector.mockImplementation((selector) => {
       if (selector === selectPopularNetworkConfigurationsByCaipChainId) {
         return mockPopularNetworkConfigurations;
+      }
+      if (selector === selectNetworkConfigurationsByCaipChainId) {
+        return mockNetworkConfigurations;
       }
       if (selector === selectMultichainAccountsState2Enabled) {
         return false;
@@ -1116,6 +1168,9 @@ describe('useNetworkSelection', () => {
             },
           ];
         }
+        if (selector === selectNetworkConfigurationsByCaipChainId) {
+          return mockNetworkConfigurations;
+        }
         if (selector === selectMultichainAccountsState2Enabled) {
           return false;
         }
@@ -1147,6 +1202,9 @@ describe('useNetworkSelection', () => {
               name: 'Bitcoin Mainnet',
             },
           ];
+        }
+        if (selector === selectNetworkConfigurationsByCaipChainId) {
+          return mockNetworkConfigurations;
         }
         if (selector === selectMultichainAccountsState2Enabled) {
           return false;

--- a/app/components/hooks/useNetworkSelection/useNetworkSelection.ts
+++ b/app/components/hooks/useNetworkSelection/useNetworkSelection.ts
@@ -183,9 +183,13 @@ export const useNetworkSelection = ({
   const selectAllPopularNetworks = useCallback(
     async (onComplete?: () => void) => {
       await enableAllPopularNetworks();
+
+      // Switch the active network in MultichainNetworkController to ethereum mainnet
+      await switchActiveNetwork('eip155:1');
+
       onComplete?.();
     },
-    [enableAllPopularNetworks],
+    [enableAllPopularNetworks, switchActiveNetwork],
   );
 
   /** Toggles a popular network and resets all custom networks */


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Switching networks does not affect the selected network on the "Import Tokens" screen, the selected network should be the chosen network by default.

After investigation I found out that if prior to opening the "Import tokens" screen, we opened the "Swap" screen, the issue was fixed. After further digging it turns out we are not updating the network on the MultichainNetworkController when switching networks and Swaps had a fallback for this.

**Furthermore, the looks of this screen should be improved in a separate PR to improve user experience on adding tokens**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: when adding a token the network selected is wrong

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/20927 & https://consensyssoftware.atlassian.net/browse/ASSETS-1390

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/aec5cef7-d5e1-4d6b-860d-042733c2cc8a

### **After**

https://github.com/user-attachments/assets/14152b4e-bf09-470d-8e2d-353eaca0cb26

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure MultichainNetworkController switches to the correct active network when enabling/selecting networks, defaulting to Ethereum after enabling all popular networks, with tests updated accordingly.
> 
> - **Hooks (`useNetworkSelection`)**:
>   - Add `selectNetworkConfigurationsByCaipChainId` selector to access full network configs.
>   - Implement `switchActiveNetwork(caipChainId)` to set `MultichainNetworkController` active network via `networkClientId` from config `rpcEndpoints`.
>   - Invoke `switchActiveNetwork` after `enableNetwork` in `selectCustomNetwork` and `selectPopularNetwork`.
>   - After `enableAllPopularNetworks`, switch active network to `eip155:1` (Ethereum Mainnet).
> - **Tests**:
>   - Mock `selectNetworkConfigurationsByCaipChainId` and provide configs with `networkClientId`s.
>   - Assert `MultichainNetworkController.setActiveNetwork` is called (e.g., with `mainnet-client-id`) after selection and after enabling all popular networks.
>   - Minor test adjustments, including error-path coverage for `setActiveNetwork`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 636ad9572653c38faed50f179a0f8cdec300cb1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->