### PR TITLE
fix: invalid balance passed to parseUnits

### DIFF
--- a/app/components/UI/Bridge/hooks/useLatestBalance/index.ts
+++ b/app/components/UI/Bridge/hooks/useLatestBalance/index.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useMemo } from 'react';
 import { type Hex, type CaipChainId, isCaipChainId } from '@metamask/utils';
 import { abiERC20 } from '@metamask/metamask-eth-abis';
 import { Web3Provider } from '@ethersproject/providers';
@@ -163,16 +163,24 @@ export const useLatestBalance = (token: {
     }
   }, [handleFetchEvmAtomicBalance, handleNonEvmAtomicBalance, chainId]);
 
+  const cachedBalance = useMemo(() => {
+    const displayBalance = token.balance;
+
+    let atomicBalance: BigNumber | undefined;
+    if (token.balance) {
+      try {
+        atomicBalance = parseUnits(token.balance, token.decimals);
+      } catch {
+        atomicBalance = undefined;
+      }
+    }
+
+    return { displayBalance, atomicBalance };
+  }, [token.balance, token.decimals]);
+
   if (!token.address || !token.decimals) {
     return undefined;
   }
-
-  const cachedBalance = {
-    displayBalance: token.balance,
-    atomicBalance: token.balance
-      ? parseUnits(token.balance, token.decimals)
-      : undefined,
-  };
 
   // If the token has changed, return cached balance of new token, so we have time to fetch the new balance
   if (previousToken?.address !== token.address) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
After investigating this issue, we concluded that the root cause was been an invalid balance value saved in BridgeState sourceToken slice. useLatestBalance accepts an optional balance parameter and pass it to parseUnits function. However if the value is malformed parseUnits throws an exception. 

Checking the calls to useLatestBalance I found that there is no instance where the balance parameter is provided at the moment. If balance is not provided, parseUnits , is not called thus cannot fail. This error was likely triggered by consuming a wrong value from the Redux slice, probably by users who held a very old version of MM app. 

To mitigate future instances of similar errors from being triggered, we wrapped the logic for calculating the cacheBalance into a useMemo with the appropriate try/catch block. Another potential solution could be remove the balance parameter from the function, but this would require refactoring existing logic and no on guarantees that we won’t need this functionality again in the future.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Scenario: user swaps token with formatted balance from cached state
    Given user has previously opened swap with a token
    And that token's balance was cached with display formatting (e.g., "1,234.56" or "< 0.00001")
    And app state has been persisted to storage

    When user reopens the app
    And navigates to swap/bridge screen
    Then app does not crash with parseUnits error
    And token selector displays without errors
    And real balance is fetched from blockchain

  Scenario: user changes source token to one with malformed cached balance
    Given user is on the swap/bridge screen
    And user has selected ETH as source token
    And there is a token in state with malformed balance string

    When user taps source token selector
    And scrolls through token list
    Then token list displays without crashing
    And tokens with malformed balances show correctly
    And user can select any token from the list
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Memoizes cached balance with parse safety and falls back to fetching real balance; adds comprehensive tests for malformed/edge-case balances.
> 
> - **Bridge Hook (`useLatestBalance`)**:
>   - Memoizes `cachedBalance` with `useMemo`, safely parsing `token.balance` via `parseUnits` with try/catch; returns `undefined` `atomicBalance` on parse failure.
>   - Keeps existing EVM/non-EVM fetch paths; returns cached balance for new tokens until fetch completes.
> - **Tests (`useLatestBalance.test.tsx`)**:
>   - Add cases for malformed balances (e.g., "< 0.00001", "1,234.56", invalid strings, empty/undefined) ensuring parse failures don’t crash and real balance is fetched.
>   - Verify cached parsing for valid strings and behavior across chain/account scenarios (EVM, Solana, Bitcoin), including race/selection edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20cc17c4f9382ecc68119870611adcc43b80ce1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->