### PR TITLE
test: Improve `Engine` unit test isolation

### DIFF
--- a/app/core/Engine/Engine.test.ts
+++ b/app/core/Engine/Engine.test.ts
@@ -102,6 +102,7 @@ describe('Engine', () => {
     jest.restoreAllMocks();
     (backupVault as jest.Mock).mockReset();
     await Engine.destroyEngine();
+    await EngineClass.instance?.destroyEngineInstance();
   });
 
   it('should expose an API', () => {


### PR DESCRIPTION
## **Description**

The `Engine` unit tests were not effectively destroying the `Engine` instance in between tests, resulting in sporadic failures due to race conditions. In a separate PR where I was making further changes to this class, this lack of test isolation was causing tests to consistently fail.

The reason was that there are two `Engine` singleton instances - the `instance` module-scoped variable, and the `Engine.instance` static class property. When you call `Engine.destroyEngine`, it only destroys `instance`, not `Engine.instance`. And `Engine.instance` is what gets used by `Engine.init`, so failure to destory it means `init` isn't running as it should.

The `afterEach` hook for these tests has been updated to ensure both instances get destroyed in between each test. Ideally we would eliminate one of these instances instead, but this at least fixes the tests without risking some unexpected impact from consolidating these two instances.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A
## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update `Engine.test.ts` afterEach to also destroy `EngineClass.instance`, ensuring the singleton is fully reset between tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff5be606ae1b2785e971916a6b8cd4c7fe03de98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->