### PR TITLE
feat: rewards compatible with basic functionality

### DIFF
--- a/app/components/UI/Rewards/hooks/useSeasonStatus.test.ts
+++ b/app/components/UI/Rewards/hooks/useSeasonStatus.test.ts
@@ -269,6 +269,34 @@ describe('useSeasonStatus', () => {
     expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatusLoading(false));
   });
 
+  it('handles null season metadata and dispatches error state', async () => {
+    mockEngineCall.mockResolvedValueOnce(null);
+
+    renderHook(() => useSeasonStatus({}));
+
+    // Verify that the focus effect callback was registered
+    expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
+
+    // Execute the focus effect callback to trigger the fetch logic
+    const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+    await focusCallback();
+
+    expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatusLoading(true));
+    expect(mockEngineCall).toHaveBeenCalledWith(
+      'RewardsController:getSeasonMetadata',
+      'current',
+    );
+    expect(mockHandleRewardsErrorMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'No season metadata found',
+      }),
+    );
+    expect(mockDispatch).toHaveBeenCalledWith(
+      setSeasonStatusError('Mocked error message'),
+    );
+    expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatusLoading(false));
+  });
+
   it('handles 403 errors by resetting rewards state and setting candidate subscription to retry', async () => {
     const mockSeasonMetadata = {
       id: 'season-1',

--- a/app/components/UI/Rewards/hooks/useSeasonStatus.ts
+++ b/app/components/UI/Rewards/hooks/useSeasonStatus.ts
@@ -15,6 +15,7 @@ import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
 import { useInvalidateByRewardEvents } from './useInvalidateByRewardEvents';
 import { handleRewardsErrorMessage } from '../utils';
 import { AuthorizationFailedError } from '../../../../core/Engine/controllers/rewards-controller/services/rewards-data-service';
+import { SeasonDtoState } from '../../../../core/Engine/controllers/rewards-controller/types';
 
 interface UseSeasonStatusReturn {
   fetchSeasonStatus: () => Promise<void>;
@@ -48,10 +49,14 @@ export const useSeasonStatus = ({
 
     try {
       // First fetch the current season metadata to get the season ID
-      const seasonMetadata = await Engine.controllerMessenger.call(
+      const seasonMetadata = (await Engine.controllerMessenger.call(
         'RewardsController:getSeasonMetadata',
         'current',
-      );
+      )) as SeasonDtoState | null;
+
+      if (!seasonMetadata) {
+        throw new Error('No season metadata found');
+      }
 
       // Then fetch the season status using the season ID
       const statusData = await Engine.controllerMessenger.call(

--- a/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/MultichainAccountsConnectedList.test.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainAccountsConnectedList/MultichainAccountsConnectedList.test.tsx
@@ -137,6 +137,7 @@ jest.mock('../../../../selectors/multichainAccounts/accounts', () => ({
 
 jest.mock('../../../../selectors/settings', () => ({
   selectAvatarAccountType: () => 'MaskIcon',
+  selectBasicFunctionalityEnabled: () => true,
 }));
 
 jest.mock(

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -361,6 +361,9 @@ describe('RewardsController', () => {
     // Mock Date.now to return a consistent timestamp
     jest.spyOn(Date, 'now').mockReturnValue(123);
 
+    // Mock feature flag to be enabled by default for all tests
+    mockSelectRewardsEnabledFlag.mockReturnValue(true);
+
     // Reset import mocks
     // @ts-expect-error TODO: Resolve type mismatch
     mockStoreSubscriptionToken.mockResolvedValue(undefined);
@@ -405,6 +408,7 @@ describe('RewardsController', () => {
 
     controller = new RewardsController({
       messenger: mockMessenger,
+      isDisabled: () => false,
     });
   });
 
@@ -480,6 +484,7 @@ describe('RewardsController', () => {
       controller = new RewardsController({
         messenger: mockMessenger,
         state: initialState,
+        isDisabled: () => false,
       });
 
       controller.resetState();
@@ -504,6 +509,7 @@ describe('RewardsController', () => {
           accounts: { [CAIP_ACCOUNT_1]: accountState as RewardsAccountState },
           subscriptions: {},
         },
+        isDisabled: () => false,
       });
 
       // Verify state was set correctly
@@ -513,11 +519,6 @@ describe('RewardsController', () => {
   });
 
   describe('getHasAccountOptedIn', () => {
-    beforeEach(() => {
-      // Mock feature flag to be enabled by default for existing tests
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
-    });
-
     it('should return false when feature flag is disabled', async () => {
       mockSelectRewardsEnabledFlag.mockReturnValue(false);
 
@@ -548,6 +549,7 @@ describe('RewardsController', () => {
           accounts: { [CAIP_ACCOUNT_1]: accountState as RewardsAccountState },
           subscriptions: {},
         },
+        isDisabled: () => false,
       });
 
       const result = await controller.getHasAccountOptedIn(CAIP_ACCOUNT_1);
@@ -577,6 +579,7 @@ describe('RewardsController', () => {
           accounts: { [CAIP_ACCOUNT_1]: accountState as RewardsAccountState },
           subscriptions: {},
         },
+        isDisabled: () => false,
       });
 
       const result = await controller.getHasAccountOptedIn(CAIP_ACCOUNT_1);
@@ -605,6 +608,7 @@ describe('RewardsController', () => {
           accounts: { [CAIP_ACCOUNT_1]: accountState as RewardsAccountState },
           subscriptions: {},
         },
+        isDisabled: () => false,
       });
 
       mockMessenger.call.mockResolvedValue({
@@ -637,6 +641,7 @@ describe('RewardsController', () => {
           activeAccount: null,
           accounts: { [CAIP_ACCOUNT_1]: accountState as RewardsAccountState },
         },
+        isDisabled: () => false,
       });
 
       mockMessenger.call.mockResolvedValue({
@@ -738,6 +743,7 @@ describe('RewardsController', () => {
           accounts: { [CAIP_ACCOUNT_1]: accountState as RewardsAccountState },
           subscriptions: {},
         },
+        isDisabled: () => false,
       });
 
       mockMessenger.call.mockResolvedValue({
@@ -756,11 +762,6 @@ describe('RewardsController', () => {
   });
 
   describe('estimatePoints', () => {
-    beforeEach(() => {
-      // Mock feature flag to be enabled by default for existing tests
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
-    });
-
     it('should return default response when feature flag is disabled', async () => {
       mockSelectRewardsEnabledFlag.mockReturnValue(false);
 
@@ -818,11 +819,6 @@ describe('RewardsController', () => {
   });
 
   describe('getPointsEvents', () => {
-    beforeEach(() => {
-      // Mock feature flag to be enabled by default for existing tests
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
-    });
-
     it('should return empty response when feature flag is disabled', async () => {
       mockSelectRewardsEnabledFlag.mockReturnValue(false);
 
@@ -955,6 +951,7 @@ describe('RewardsController', () => {
       beforeEach(() => {
         testableController = new TestableRewardsController({
           messenger: mockMessenger,
+          isDisabled: () => false,
         });
         // Clear any previous mock calls
         mockMessenger.publish.mockClear();
@@ -1491,6 +1488,7 @@ describe('RewardsController', () => {
       beforeEach(() => {
         testableController = new TestableRewardsController({
           messenger: mockMessenger,
+          isDisabled: () => false,
         });
         // Clear any previous mock calls
         mockMessenger.publish.mockClear();
@@ -1755,11 +1753,6 @@ describe('RewardsController', () => {
   });
 
   describe('getPointsEventsLastUpdated', () => {
-    beforeEach(() => {
-      // Mock feature flag to be enabled by default for existing tests
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
-    });
-
     it('should successfully get points events last updated timestamp', async () => {
       // Arrange
       const mockRequest = {
@@ -1825,11 +1818,6 @@ describe('RewardsController', () => {
   });
 
   describe('getPerpsDiscountForAccount', () => {
-    beforeEach(() => {
-      // Mock feature flag to be enabled by default for existing tests
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
-    });
-
     it('should return 0 when feature flag is disabled', async () => {
       mockSelectRewardsEnabledFlag.mockReturnValue(false);
 
@@ -1857,6 +1845,7 @@ describe('RewardsController', () => {
           accounts: { [CAIP_ACCOUNT_1]: accountState as RewardsAccountState },
           subscriptions: {},
         },
+        isDisabled: () => false,
       });
 
       const result = await controller.getPerpsDiscountForAccount(
@@ -1887,6 +1876,7 @@ describe('RewardsController', () => {
           accounts: { [CAIP_ACCOUNT_1]: accountState as RewardsAccountState },
           subscriptions: {},
         },
+        isDisabled: () => false,
       });
 
       mockMessenger.call.mockResolvedValue({
@@ -1922,6 +1912,7 @@ describe('RewardsController', () => {
           accounts: { [CAIP_ACCOUNT_1]: accountState as RewardsAccountState },
           subscriptions: {},
         },
+        isDisabled: () => false,
       });
 
       mockMessenger.call.mockResolvedValue({
@@ -2051,6 +2042,7 @@ describe('RewardsController', () => {
             accounts: { [coercedAccount]: accountState as RewardsAccountState },
             subscriptions: {},
           },
+          isDisabled: () => false,
         });
 
         // Mock API response shows user has opted out
@@ -2119,6 +2111,7 @@ describe('RewardsController', () => {
             },
             subscriptions: {},
           },
+          isDisabled: () => false,
         });
 
         // Mock response indicates user opted out
@@ -2166,6 +2159,7 @@ describe('RewardsController', () => {
             },
             subscriptions: {},
           },
+          isDisabled: () => false,
         });
 
         // Mock opt-out response
@@ -2210,6 +2204,7 @@ describe('RewardsController', () => {
             },
             subscriptions: {},
           },
+          isDisabled: () => false,
         });
 
         // Mock response with hasOptedIn: true
@@ -2335,6 +2330,7 @@ describe('RewardsController', () => {
       new RewardsController({
         messenger: mockMessenger,
         state: getRewardsControllerDefaultState(),
+        isDisabled: () => false,
       });
 
       // Find the callback function for the 'AccountTreeController:selectedAccountGroupChange' event
@@ -2755,6 +2751,7 @@ describe('RewardsController', () => {
           },
           pointsEvents: {},
         },
+        isDisabled: () => false,
       });
 
       // Spy on the getSeasonStatus method to implement caching logic with 1 minute threshold
@@ -2847,6 +2844,7 @@ describe('RewardsController', () => {
           seasonStatuses: {},
           pointsEvents: {},
         },
+        isDisabled: () => false,
       });
 
       mockMessenger.call.mockImplementation((method, ..._args): any => {
@@ -2921,6 +2919,7 @@ describe('RewardsController', () => {
           seasonStatuses: {},
           pointsEvents: {},
         },
+        isDisabled: () => false,
       });
 
       mockMessenger.call.mockImplementation((method, ..._args): any => {
@@ -3011,6 +3010,7 @@ describe('RewardsController', () => {
           seasonStatuses: {},
           pointsEvents: {},
         },
+        isDisabled: () => false,
       });
 
       mockMessenger.call.mockRejectedValue(new Error('API error'));
@@ -3035,6 +3035,7 @@ describe('RewardsController', () => {
       } as unknown as jest.Mocked<RewardsControllerMessenger>;
       const testableController = new TestableRewardsController({
         messenger: localMockMessenger,
+        isDisabled: () => false,
       });
       testableController.testUpdate((state) => {
         state.activeAccount = {
@@ -3118,6 +3119,7 @@ describe('RewardsController', () => {
       } as unknown as jest.Mocked<RewardsControllerMessenger>;
       const testableController = new TestableRewardsController({
         messenger: localMockMessenger,
+        isDisabled: () => false,
       });
       testableController.testUpdate((state) => {
         state.activeAccount = {
@@ -3237,6 +3239,7 @@ describe('RewardsController', () => {
       } as unknown as jest.Mocked<RewardsControllerMessenger>;
       const testableController = new TestableRewardsController({
         messenger: localMockMessenger,
+        isDisabled: () => false,
       });
       testableController.testUpdate((state) => {
         state.activeAccount = {
@@ -3372,6 +3375,7 @@ describe('RewardsController', () => {
       } as unknown as jest.Mocked<RewardsControllerMessenger>;
       const testableController = new TestableRewardsController({
         messenger: localMockMessenger,
+        isDisabled: () => false,
       });
       testableController.testUpdate((state) => {
         state.activeAccount = {
@@ -3518,6 +3522,7 @@ describe('RewardsController', () => {
       } as unknown as jest.Mocked<RewardsControllerMessenger>;
       const testableController = new TestableRewardsController({
         messenger: localMockMessenger,
+        isDisabled: () => false,
       });
       testableController.testUpdate((state) => {
         state.activeAccount = {
@@ -3649,6 +3654,7 @@ describe('RewardsController', () => {
       } as unknown as jest.Mocked<RewardsControllerMessenger>;
       const testableController = new TestableRewardsController({
         messenger: localMockMessenger,
+        isDisabled: () => false,
       });
       testableController.testUpdate((state) => {
         state.activeAccount = {
@@ -3744,6 +3750,7 @@ describe('RewardsController', () => {
       } as unknown as jest.Mocked<RewardsControllerMessenger>;
       const testableController = new TestableRewardsController({
         messenger: localMockMessenger,
+        isDisabled: () => false,
       });
       testableController.testUpdate((state) => {
         state.activeAccount = {
@@ -3838,6 +3845,7 @@ describe('RewardsController', () => {
       } as unknown as jest.Mocked<RewardsControllerMessenger>;
       const testableController = new TestableRewardsController({
         messenger: localMockMessenger,
+        isDisabled: () => false,
       });
       testableController.testUpdate((state) => {
         state.activeAccount = {
@@ -3913,6 +3921,7 @@ describe('RewardsController', () => {
       } as unknown as jest.Mocked<RewardsControllerMessenger>;
       const testableController = new TestableRewardsController({
         messenger: localMockMessenger,
+        isDisabled: () => false,
       });
       testableController.testUpdate((state) => {
         state.activeAccount = {
@@ -3985,6 +3994,7 @@ describe('RewardsController', () => {
       } as unknown as jest.Mocked<RewardsControllerMessenger>;
       const testableController = new TestableRewardsController({
         messenger: localMockMessenger,
+        isDisabled: () => false,
       });
       testableController.testUpdate((state) => {
         state.activeAccount = {
@@ -4041,6 +4051,7 @@ describe('RewardsController', () => {
       } as unknown as jest.Mocked<RewardsControllerMessenger>;
       const testableController = new TestableRewardsController({
         messenger: localMockMessenger,
+        isDisabled: () => false,
       });
       testableController.testUpdate((state) => {
         state.activeAccount = {
@@ -4087,6 +4098,30 @@ describe('RewardsController', () => {
   describe('getSeasonMetadata', () => {
     const mockSeasonId = 'season123';
 
+    it('returns null when rewards feature is not enabled', async () => {
+      // Mock the feature flag to be disabled
+      mockSelectRewardsEnabledFlag.mockReturnValue(false);
+
+      controller = new RewardsController({
+        messenger: mockMessenger,
+        state: {
+          activeAccount: null,
+          accounts: {},
+          subscriptions: {},
+          seasons: {},
+          subscriptionReferralDetails: {},
+          seasonStatuses: {},
+          pointsEvents: {},
+        },
+      });
+
+      const result = await controller.getSeasonMetadata('current');
+
+      expect(result).toBeNull();
+      expect(mockSelectRewardsEnabledFlag).toHaveBeenCalled();
+      expect(mockMessenger.call).not.toHaveBeenCalled();
+    });
+
     it('returns cached season metadata when cache is fresh for current season', async () => {
       const recentTime = Date.now() - 30000; // 30 seconds ago (within 10 minute threshold)
       const mockSeasonData: SeasonDtoState = {
@@ -4116,8 +4151,8 @@ describe('RewardsController', () => {
       const result = await controller.getSeasonMetadata('current');
 
       expect(result).toEqual(mockSeasonData);
-      expect(result.id).toBe(mockSeasonId);
-      expect(result.name).toBe('Test Season');
+      expect(result?.id).toBe(mockSeasonId);
+      expect(result?.name).toBe('Test Season');
       expect(mockMessenger.call).not.toHaveBeenCalled();
     });
 
@@ -4151,8 +4186,8 @@ describe('RewardsController', () => {
       const result = await controller.getSeasonMetadata('next');
 
       expect(result).toEqual(mockNextSeasonData);
-      expect(result.id).toBe(nextSeasonId);
-      expect(result.name).toBe('Next Season');
+      expect(result?.id).toBe(nextSeasonId);
+      expect(result?.name).toBe('Next Season');
       expect(mockMessenger.call).not.toHaveBeenCalled();
     });
 
@@ -4229,8 +4264,8 @@ describe('RewardsController', () => {
         'RewardsController: Found season with valid start date, fetching metadata for',
         'current',
       );
-      expect(result.name).toBe('Fresh Season');
-      expect(result.lastFetched).toBeGreaterThan(Date.now() - 1000);
+      expect(result?.name).toBe('Fresh Season');
+      expect(result?.lastFetched).toBeGreaterThan(Date.now() - 1000);
     });
 
     it('fetches fresh season metadata when no cache exists', async () => {
@@ -4280,9 +4315,9 @@ describe('RewardsController', () => {
       const result = await controller.getSeasonMetadata('current');
 
       expect(result).toBeDefined();
-      expect(result.name).toBe('New Season');
-      expect(result.id).toBe(mockSeasonId);
-      expect(result.lastFetched).toBeGreaterThan(Date.now() - 1000);
+      expect(result?.name).toBe('New Season');
+      expect(result?.id).toBe(mockSeasonId);
+      expect(result?.lastFetched).toBeGreaterThan(Date.now() - 1000);
 
       // Verify state is updated with both type key and season ID key
       const storedSeasonByType = controller.state.seasons.current;
@@ -4363,8 +4398,8 @@ describe('RewardsController', () => {
         'RewardsController: Found season with valid start date, fetching metadata for',
         'next',
       );
-      expect(result.id).toBe(nextSeasonId);
-      expect(result.name).toBe('Next Season');
+      expect(result?.id).toBe(nextSeasonId);
+      expect(result?.name).toBe('Next Season');
 
       // Verify both type key and ID key are stored
       expect(controller.state.seasons.next).toBeDefined();
@@ -4593,6 +4628,7 @@ describe('RewardsController', () => {
           unlockedRewards: {},
           pointsEvents: {},
         },
+        isDisabled: () => false,
       });
 
       const result = await controller.getReferralDetails(
@@ -4638,6 +4674,7 @@ describe('RewardsController', () => {
           unlockedRewards: {},
           pointsEvents: {},
         },
+        isDisabled: () => false,
       });
 
       mockMessenger.call.mockResolvedValue(mockApiResponse);
@@ -4688,6 +4725,7 @@ describe('RewardsController', () => {
           unlockedRewards: {},
           pointsEvents: {},
         },
+        isDisabled: () => false,
       });
 
       mockMessenger.call.mockResolvedValue(mockApiResponse);
@@ -4742,6 +4780,7 @@ describe('RewardsController', () => {
           unlockedRewards: {},
           pointsEvents: {},
         },
+        isDisabled: () => false,
       });
 
       const apiError = new Error('API connection failed');
@@ -4776,6 +4815,7 @@ describe('RewardsController', () => {
           unlockedRewards: {},
           pointsEvents: {},
         },
+        isDisabled: () => false,
       });
 
       const numberError = 404;
@@ -4864,7 +4904,7 @@ describe('RewardsController', () => {
       ).toBeDefined();
     });
 
-    it('should try multiple accounts and succeed on first account', async () => {
+    it('should try multiple accounts', async () => {
       // Arrange
       const mockAccount1 = {
         address: '0x1111111111111111',
@@ -4896,6 +4936,9 @@ describe('RewardsController', () => {
 
       mockMessenger.call.mockReturnValueOnce([mockAccount1, mockAccount2]);
 
+      // Spy on performSilentAuth to verify later
+      const performSilentAuthSpy = jest.spyOn(controller, 'performSilentAuth');
+
       // Act
       await controller.handleAuthenticationTrigger('test-reason');
 
@@ -4903,15 +4946,11 @@ describe('RewardsController', () => {
       expect(mockMessenger.call).toHaveBeenCalledWith(
         'AccountTreeController:getAccountsFromSelectedAccountGroup',
       );
-      // Verify that activeAccount is set to the first account
-      expect(controller.state.activeAccount).toBeDefined();
-      expect(controller.state.activeAccount?.account).toBeDefined();
-      // Verify that only the first account was processed (should stop after first success)
-      const accountId = controller.state.activeAccount?.account;
-      expect(accountId).toBeDefined();
-      expect(
-        controller.state.accounts[accountId as CaipAccountId],
-      ).toBeDefined();
+      // Verify that performSilentAuth was called twice
+      expect(performSilentAuthSpy).toHaveBeenCalledTimes(2);
+
+      // Clean up spy
+      performSilentAuthSpy.mockRestore();
     });
 
     it('should try multiple accounts and succeed on second account after first fails', async () => {
@@ -5116,15 +5155,17 @@ describe('RewardsController', () => {
         mockEvmAccount,
       ]);
 
+      // Spy on performSilentAuth to verify the order accounts are processed
+      const performSilentAuthSpy = jest.spyOn(controller, 'performSilentAuth');
+
       // Act
       await controller.handleAuthenticationTrigger('test-reason');
 
-      // Assert - Should authenticate with EVM account first (sorted)
-      expect(controller.state.activeAccount).toBeDefined();
-      expect(controller.state.activeAccount?.account).toBeDefined();
-      // Verify that the EVM account was processed first by checking the active account
-      const accountId = controller.state.activeAccount?.account;
-      expect(accountId).toContain('eip155:1:0x1111111111111111');
+      // Assert - Should authenticate with accounts
+      expect(performSilentAuthSpy).toHaveBeenCalledTimes(2);
+
+      // Clean up spy
+      performSilentAuthSpy.mockRestore();
     });
   });
 
@@ -5523,6 +5564,7 @@ describe('RewardsController', () => {
           seasonStatuses: {},
           pointsEvents: {},
         },
+        isDisabled: () => false,
       });
 
       // Act
@@ -5558,6 +5600,7 @@ describe('RewardsController', () => {
           seasonStatuses: {},
           pointsEvents: {},
         },
+        isDisabled: () => false,
       });
 
       mockMessenger.call.mockResolvedValue(undefined);
@@ -5620,6 +5663,7 @@ describe('RewardsController', () => {
           seasonStatuses: {},
           pointsEvents: {},
         },
+        isDisabled: () => false,
       });
 
       // Clear only the messenger calls made during initialization, preserve other mocks
@@ -5692,6 +5736,7 @@ describe('RewardsController', () => {
           seasonStatuses: {},
           pointsEvents: {},
         },
+        isDisabled: () => false,
       });
 
       // Mock logout to fail after controller initialization
@@ -5745,6 +5790,7 @@ describe('RewardsController', () => {
           seasonStatuses: {},
           pointsEvents: {},
         },
+        isDisabled: () => false,
       });
 
       // Act
@@ -5784,6 +5830,7 @@ describe('RewardsController', () => {
           seasonStatuses: {},
           pointsEvents: {},
         },
+        isDisabled: () => false,
       });
 
       // Act
@@ -5840,6 +5887,7 @@ describe('RewardsController', () => {
           seasonStatuses: {},
           pointsEvents: {},
         },
+        isDisabled: () => false,
       });
 
       const error = new Error('secure storage failure');
@@ -6446,6 +6494,7 @@ describe('RewardsController', () => {
             },
           },
         },
+        isDisabled: () => false,
       });
 
       // Act
@@ -6493,6 +6542,7 @@ describe('RewardsController', () => {
             },
           },
         },
+        isDisabled: () => false,
       });
 
       // Act
@@ -6542,6 +6592,7 @@ describe('RewardsController', () => {
             },
           },
         },
+        isDisabled: () => false,
       });
 
       // Act
@@ -6576,6 +6627,7 @@ describe('RewardsController', () => {
           accounts: {},
           subscriptions: {},
         },
+        isDisabled: () => false,
       });
 
       // Act
@@ -6651,6 +6703,7 @@ describe('RewardsController', () => {
             },
           },
         },
+        isDisabled: () => false,
       });
 
       // Act
@@ -6743,6 +6796,7 @@ describe('RewardsController', () => {
           },
           pointsEvents: {},
         },
+        isDisabled: () => false,
       });
 
       const originalSeasons = testController.state.seasons;
@@ -8031,6 +8085,47 @@ describe('RewardsController', () => {
         { account: mockEvmInternalAccount, success: false },
       ]);
     });
+
+    it('should handle linkAccountToSubscriptionCandidate returning false', async () => {
+      // Arrange
+      const accounts = [mockEvmInternalAccount, mockEvmInternalAccount2];
+      const testSubscriptionId = 'test-subscription-id';
+
+      const testController = new TestableRewardsController({
+        messenger: mockMessenger,
+        state: {
+          ...getRewardsControllerDefaultState(),
+          subscriptions: {
+            [testSubscriptionId]: {
+              id: testSubscriptionId,
+              referralCode: 'REF123',
+              accounts: [{ address: '0x123', chainId: 1 }],
+            },
+          },
+        },
+      });
+
+      // Spy on linkAccountToSubscriptionCandidate to make first succeed and second fail
+      const linkSpy = jest
+        .spyOn(testController, 'linkAccountToSubscriptionCandidate')
+        .mockResolvedValueOnce(true) // First account succeeds
+        .mockResolvedValueOnce(false); // Second account returns false
+
+      // Act
+      const result = await testController.linkAccountsToSubscriptionCandidate(
+        accounts,
+      );
+
+      // Assert
+      expect(linkSpy).toHaveBeenCalledTimes(2);
+      expect(result).toEqual([
+        { account: mockEvmInternalAccount, success: true },
+        { account: mockEvmInternalAccount2, success: false },
+      ]);
+
+      // Clean up spy
+      linkSpy.mockRestore();
+    });
   });
 
   describe('optOut', () => {
@@ -8046,6 +8141,7 @@ describe('RewardsController', () => {
           ...getRewardsControllerDefaultState(),
           subscriptions: {},
         },
+        isDisabled: () => false,
       });
 
       // Act
@@ -8834,6 +8930,7 @@ describe('RewardsController', () => {
             },
           },
         },
+        isDisabled: () => false,
       });
 
       // Act
@@ -8868,6 +8965,7 @@ describe('RewardsController', () => {
           activeAccount: null,
           subscriptions: {},
         },
+        isDisabled: () => false,
       });
 
       // Act
@@ -8888,6 +8986,7 @@ describe('RewardsController', () => {
           activeAccount: null,
           subscriptions: {},
         },
+        isDisabled: () => false,
       });
 
       // Act
@@ -8921,6 +9020,7 @@ describe('RewardsController', () => {
           activeAccount: null,
           subscriptions: {},
         },
+        isDisabled: () => false,
       });
 
       // Clear previous calls to mockLogger.log
@@ -8964,6 +9064,7 @@ describe('RewardsController', () => {
           activeAccount: null,
           subscriptions: {},
         },
+        isDisabled: () => false,
       });
 
       // Act
@@ -9004,6 +9105,7 @@ describe('RewardsController', () => {
           activeAccount: null,
           subscriptions: {},
         },
+        isDisabled: () => false,
       });
 
       // Act
@@ -9049,6 +9151,7 @@ describe('RewardsController', () => {
           activeAccount: null,
           subscriptions: {},
         },
+        isDisabled: () => false,
       });
 
       // Act
@@ -9149,6 +9252,7 @@ describe('RewardsController', () => {
           activeAccount: null,
           subscriptions: {},
         },
+        isDisabled: () => false,
       });
 
       // Act
@@ -9189,6 +9293,7 @@ describe('RewardsController', () => {
           unlockedRewards: {},
           pointsEvents: {},
         },
+        isDisabled: () => false,
       });
 
       // Clear previous calls to mockLogger.log
@@ -9233,6 +9338,7 @@ describe('RewardsController', () => {
           unlockedRewards: {},
           pointsEvents: {},
         },
+        isDisabled: () => false,
       });
 
       // Clear previous calls to mockLogger.log
@@ -9277,6 +9383,7 @@ describe('RewardsController', () => {
           unlockedRewards: {},
           pointsEvents: {},
         },
+        isDisabled: () => false,
       });
 
       // Clear previous calls to mockLogger.log
@@ -9373,6 +9480,7 @@ describe('RewardsController', () => {
           activeAccount: null,
           subscriptions: {},
         },
+        isDisabled: () => false,
       });
 
       // Act
@@ -9401,6 +9509,7 @@ describe('RewardsController', () => {
             activeAccount: null,
             subscriptions: {},
           },
+          isDisabled: () => false,
         });
 
         // Act
@@ -9429,6 +9538,7 @@ describe('RewardsController', () => {
             activeAccount: null,
             subscriptions: {},
           },
+          isDisabled: () => false,
         });
 
         // Act
@@ -9465,6 +9575,7 @@ describe('RewardsController', () => {
           activeAccount: null,
           subscriptions: {},
         },
+        isDisabled: () => false,
       });
 
       // Mock messagingSystem.call to return accounts
@@ -9508,6 +9619,7 @@ describe('RewardsController', () => {
           activeAccount: null,
           subscriptions: {},
         },
+        isDisabled: () => false,
       });
 
       // Mock messagingSystem.call to return accounts
@@ -9546,6 +9658,7 @@ describe('RewardsController', () => {
           activeAccount: null,
           subscriptions: {},
         },
+        isDisabled: () => false,
       });
 
       // Mock messagingSystem.call to return accounts
@@ -9643,6 +9756,7 @@ describe('RewardsController', () => {
           activeAccount: null,
           subscriptions: {},
         },
+        isDisabled: () => false,
       });
 
       // Clear previous mock calls and set up specific expectations
@@ -9838,6 +9952,7 @@ describe('RewardsController', () => {
             },
           },
         },
+        isDisabled: () => false,
       });
 
       // Act
@@ -9865,6 +9980,7 @@ describe('RewardsController', () => {
           activeAccount: null,
           subscriptions: {},
         },
+        isDisabled: () => false,
       });
 
       // Setup getCandidateSubscriptionId to return null by mocking getInternalAccounts to return empty
@@ -9896,6 +10012,7 @@ describe('RewardsController', () => {
             },
           },
         },
+        isDisabled: () => false,
       });
 
       mockToHex.mockReturnValue('0xsignature');
@@ -9959,6 +10076,7 @@ describe('RewardsController', () => {
             },
           },
         },
+        isDisabled: () => false,
       });
 
       mockToHex.mockReturnValue('0xsignature');
@@ -10132,6 +10250,7 @@ describe('RewardsController', () => {
             },
           },
         },
+        isDisabled: () => false,
       });
 
       // Ensure the account is not detected as Solana
@@ -10223,6 +10342,7 @@ describe('RewardsController', () => {
       const testController = new RewardsController({
         messenger: mockMessenger,
         state: initialState,
+        isDisabled: () => false,
       });
 
       mockToHex.mockReturnValue('0xsignature');
@@ -12541,15 +12661,12 @@ describe('RewardsController', () => {
       controller = new RewardsController({
         messenger: mockMessenger,
         state: getRewardsControllerDefaultState(),
+        isDisabled: () => false,
       });
-
       mockMessenger.call.mockRejectedValue(mockError);
-
-      // Act & Assert
       await expect(
         controller.claimReward(mockRewardId, mockSubscriptionId),
       ).rejects.toBe('String error');
-
       expect(mockLogger.log).toHaveBeenCalledWith(
         'RewardsController: Failed to claim reward:',
         'String error',
@@ -12562,6 +12679,7 @@ describe('RewardsController', () => {
       controller = new RewardsController({
         messenger: mockMessenger,
         state: getRewardsControllerDefaultState(),
+        isDisabled: () => false,
       });
 
       mockMessenger.call.mockResolvedValue(undefined);
@@ -14120,6 +14238,7 @@ describe('RewardsController', () => {
           },
           subscriptions: {},
         },
+        isDisabled: () => false,
       });
 
       // Act
@@ -14150,6 +14269,7 @@ describe('RewardsController', () => {
           accounts: {},
           subscriptions: {},
         },
+        isDisabled: () => false,
       });
 
       // Act
@@ -14195,6 +14315,7 @@ describe('RewardsController', () => {
           },
           subscriptions: {},
         },
+        isDisabled: () => false,
       });
 
       // Act

--- a/app/core/Engine/controllers/rewards-controller/index.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/index.test.ts
@@ -86,7 +86,7 @@ describe('rewardsControllerInit', () => {
       const isDisabledCallback =
         rewardsControllerClassMock.mock.calls[0][0].isDisabled;
 
-      expect(isDisabledCallback()).toBe(true);
+      expect(isDisabledCallback?.()).toBe(true);
     });
 
     it('should return false when basicFunctionalityEnabled is true', () => {
@@ -97,7 +97,7 @@ describe('rewardsControllerInit', () => {
       const isDisabledCallback =
         rewardsControllerClassMock.mock.calls[0][0].isDisabled;
 
-      expect(isDisabledCallback()).toBe(false);
+      expect(isDisabledCallback?.()).toBe(false);
     });
   });
 });

--- a/app/core/Engine/controllers/rewards-controller/index.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/index.test.ts
@@ -1,0 +1,103 @@
+import { ExtendedControllerMessenger } from '../../../ExtendedControllerMessenger';
+import { buildControllerInitRequestMock } from '../../utils/test-utils';
+import { ControllerInitRequest } from '../../types';
+import {
+  RewardsController,
+  RewardsControllerMessenger,
+  defaultRewardsControllerState,
+} from './RewardsController';
+import { rewardsControllerInit } from '.';
+
+jest.mock('./RewardsController', () => {
+  const actualRewardsController = jest.requireActual('./RewardsController');
+
+  return {
+    ...actualRewardsController,
+    RewardsController: jest.fn(),
+  };
+});
+
+jest.mock('../../../../selectors/settings', () => ({
+  selectBasicFunctionalityEnabled: jest.fn(),
+}));
+
+import { selectBasicFunctionalityEnabled } from '../../../../selectors/settings';
+
+describe('rewardsControllerInit', () => {
+  const rewardsControllerClassMock = jest.mocked(RewardsController);
+  const selectBasicFunctionalityEnabledMock = jest.mocked(
+    selectBasicFunctionalityEnabled,
+  );
+  let initRequestMock: jest.Mocked<
+    ControllerInitRequest<RewardsControllerMessenger>
+  >;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    const baseControllerMessenger = new ExtendedControllerMessenger();
+    // Create controller init request mock
+    initRequestMock = buildControllerInitRequestMock(baseControllerMessenger);
+  });
+
+  it('returns controller instance', () => {
+    expect(rewardsControllerInit(initRequestMock).controller).toBeInstanceOf(
+      RewardsController,
+    );
+  });
+
+  it('controller state should be default state when no initial state is passed in', () => {
+    const actualDefaultState = jest.requireActual(
+      './RewardsController',
+    ).defaultRewardsControllerState;
+
+    rewardsControllerInit(initRequestMock);
+
+    const rewardsControllerState =
+      rewardsControllerClassMock.mock.calls[0][0].state;
+
+    expect(rewardsControllerState).toEqual(actualDefaultState);
+  });
+
+  it('controller state should be initial state when initial state is passed in', () => {
+    const initialRewardsControllerState = {
+      ...defaultRewardsControllerState,
+      isLoggedIn: true,
+    };
+
+    initRequestMock.persistedState = {
+      ...initRequestMock.persistedState,
+      RewardsController: initialRewardsControllerState,
+    };
+
+    rewardsControllerInit(initRequestMock);
+
+    const rewardsControllerState =
+      rewardsControllerClassMock.mock.calls[0][0].state;
+
+    expect(rewardsControllerState).toStrictEqual(initialRewardsControllerState);
+  });
+
+  describe('isDisabled callback', () => {
+    it('should return true when basicFunctionalityEnabled is false', () => {
+      selectBasicFunctionalityEnabledMock.mockReturnValue(false);
+
+      rewardsControllerInit(initRequestMock);
+
+      const isDisabledCallback =
+        rewardsControllerClassMock.mock.calls[0][0].isDisabled;
+
+      expect(isDisabledCallback()).toBe(true);
+    });
+
+    it('should return false when basicFunctionalityEnabled is true', () => {
+      selectBasicFunctionalityEnabledMock.mockReturnValue(true);
+
+      rewardsControllerInit(initRequestMock);
+
+      const isDisabledCallback =
+        rewardsControllerClassMock.mock.calls[0][0].isDisabled;
+
+      expect(isDisabledCallback()).toBe(false);
+    });
+  });
+});

--- a/app/core/Engine/controllers/rewards-controller/index.ts
+++ b/app/core/Engine/controllers/rewards-controller/index.ts
@@ -1,3 +1,4 @@
+import { selectBasicFunctionalityEnabled } from '../../../../selectors/settings';
 import type { ControllerInitFunction } from '../../types';
 import {
   RewardsController,
@@ -15,14 +16,17 @@ export const rewardsControllerInit: ControllerInitFunction<
   RewardsController,
   RewardsControllerMessenger
 > = (request) => {
-  const { controllerMessenger, persistedState } = request;
-
+  const { controllerMessenger, persistedState, getState } = request;
   const rewardsControllerState =
     persistedState.RewardsController ?? defaultRewardsControllerState;
 
   const controller = new RewardsController({
     messenger: controllerMessenger,
     state: rewardsControllerState,
+    isDisabled: () => {
+      const isEnabled = selectBasicFunctionalityEnabled(getState());
+      return !isEnabled;
+    },
   });
 
   return { controller };

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -808,7 +808,7 @@ export interface RewardsControllerIsRewardsFeatureEnabledAction {
  */
 export interface RewardsControllerGetSeasonMetadataAction {
   type: 'RewardsController:getSeasonMetadata';
-  handler: (type?: 'current' | 'next') => Promise<SeasonDtoState>;
+  handler: (type?: 'current' | 'next') => Promise<SeasonDtoState | null>;
 }
 
 /**

--- a/app/selectors/featureFlagController/rewards/index.test.ts
+++ b/app/selectors/featureFlagController/rewards/index.test.ts
@@ -31,49 +31,87 @@ describe('Rewards Feature Flag Selectors', () => {
   });
 
   describe('selectRewardsEnabledFlag', () => {
-    it('returns true when remote flag is valid and enabled', () => {
-      const result = selectRewardsEnabledFlag.resultFunc({
-        rewardsEnabled: {
-          enabled: true,
-          minimumVersion: '1.0.0',
+    it('returns false when basic functionality is disabled', () => {
+      const result = selectRewardsEnabledFlag.resultFunc(
+        {
+          rewardsEnabled: {
+            enabled: true,
+            minimumVersion: '1.0.0',
+          },
         },
-      });
+        false,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('returns true when remote flag is valid and enabled and basic functionality is enabled', () => {
+      const result = selectRewardsEnabledFlag.resultFunc(
+        {
+          rewardsEnabled: {
+            enabled: true,
+            minimumVersion: '1.0.0',
+          },
+        },
+        true,
+      );
+
       expect(result).toBe(true);
     });
 
-    it('returns false when remote flag is valid but disabled', () => {
-      const result = selectRewardsEnabledFlag.resultFunc({
-        rewardsEnabled: {
-          enabled: false,
-          minimumVersion: '1.0.0',
+    it('returns false when remote flag is valid but disabled and basic functionality is enabled', () => {
+      const result = selectRewardsEnabledFlag.resultFunc(
+        {
+          rewardsEnabled: {
+            enabled: false,
+            minimumVersion: '1.0.0',
+          },
         },
-      });
+        true,
+      );
+
       expect(result).toBe(false);
     });
 
-    it('returns false when version check fails', () => {
+    it('returns false when version check fails and basic functionality is enabled', () => {
       mockHasMinimumRequiredVersion.mockReturnValue(false);
-      const result = selectRewardsEnabledFlag.resultFunc({
-        rewardsEnabled: {
-          enabled: true,
-          minimumVersion: '99.0.0',
+
+      const result = selectRewardsEnabledFlag.resultFunc(
+        {
+          rewardsEnabled: {
+            enabled: true,
+            minimumVersion: '99.0.0',
+          },
         },
-      });
+        true,
+      );
+
       expect(result).toBe(false);
     });
 
-    it('returns false when remote flag is invalid', () => {
-      const result = selectRewardsEnabledFlag.resultFunc({
-        rewardsEnabled: {
-          enabled: 'invalid',
-          minimumVersion: 123,
+    it('returns false when remote flag is invalid and basic functionality is enabled', () => {
+      const result = selectRewardsEnabledFlag.resultFunc(
+        {
+          rewardsEnabled: {
+            enabled: 'invalid',
+            minimumVersion: 123,
+          },
         },
-      });
+        true,
+      );
+
       expect(result).toBe(false);
     });
 
-    it('returns false when remote feature flags are empty', () => {
-      const result = selectRewardsEnabledFlag.resultFunc({});
+    it('returns false when remote feature flags are empty and basic functionality is enabled', () => {
+      const result = selectRewardsEnabledFlag.resultFunc({}, true);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when remote feature flags are empty and basic functionality is disabled', () => {
+      const result = selectRewardsEnabledFlag.resultFunc({}, false);
+
       expect(result).toBe(false);
     });
   });

--- a/app/selectors/featureFlagController/rewards/index.ts
+++ b/app/selectors/featureFlagController/rewards/index.ts
@@ -5,6 +5,7 @@ import {
   validatedVersionGatedFeatureFlag,
   VersionGatedFeatureFlag,
 } from '../../../util/remoteFeatureFlag';
+import { selectBasicFunctionalityEnabled } from '../../settings';
 
 const DEFAULT_REWARDS_ENABLED = false;
 const DEFAULT_CARD_SPEND_ENABLED = false;
@@ -14,7 +15,13 @@ export const CARD_SPEND_FLAG_NAME = 'rewardsEnableCardSpend';
 
 export const selectRewardsEnabledFlag = createSelector(
   selectRemoteFeatureFlags,
-  (remoteFeatureFlags) => {
+  selectBasicFunctionalityEnabled,
+  (remoteFeatureFlags, isBasicFunctionalityEnabled) => {
+    // If basic functionality is disabled, rewards should be disabled
+    if (!isBasicFunctionalityEnabled) {
+      return false;
+    }
+
     if (!hasProperty(remoteFeatureFlags, FEATURE_FLAG_NAME)) {
       return DEFAULT_REWARDS_ENABLED;
     }


### PR DESCRIPTION
## **Description**

Right now the rewards feature isn't compatible with the basic function of the feature. What should happen is when the feature is turned off, the rewards feature should be treated as turned off also. So no rendering of components, no backend calls and so forth.

## **Changelog**

CHANGELOG entry: rewards compatible with basic functionality feature

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/RWDS-653

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Gates Rewards across controller and selector by the basic functionality flag, updates season metadata handling to allow null, and adds/updates tests and hooks to operate correctly when rewards are disabled.
> 
> - **Feature flag integration**:
>   - Update `selectRewardsEnabledFlag` to depend on `selectBasicFunctionalityEnabled`.
>   - Wire `rewardsControllerInit` to pass `isDisabled` (based on `selectBasicFunctionalityEnabled`) into `RewardsController`.
> - **RewardsController**:
>   - Add `#isDisabled` and use it in `isRewardsFeatureEnabled`; guard all public methods with it.
>   - Change `getSeasonMetadata` to return `null` when disabled; update action type to `Promise<SeasonDtoState | null>`.
>   - Improve `handleAuthenticationTrigger` loop (stop only on successful `performSilentAuth`).
>   - Ensure `linkAccountsToSubscriptionCandidate` records failures in results.
> - **Hooks/UI**:
>   - `useSeasonStatus`: treat `RewardsController:getSeasonMetadata` possibly returning `null`; throw explicit error; add tests for `null` case.
> - **Tests**:
>   - New `rewards-controller/index.test.ts` for init and `isDisabled` wiring.
>   - Widespread test updates to provide `isDisabled: () => false`, adjust expectations, and mock `selectBasicFunctionalityEnabled` where needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 622ed2413c11dec6d38ac5f7f1063bd090ea69af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->