### PR TITLE
fix: Check case sensitive `Content-Length` header

### DIFF
--- a/app/core/Snaps/location/npm.ts
+++ b/app/core/Snaps/location/npm.ts
@@ -65,7 +65,9 @@ export class NpmLocation extends BaseNpmLocation {
       );
 
       // We assume that NPM is a good actor and provides us with a valid `content-length` header.
-      const tarballSizeString = responseInfo.headers['content-length'];
+      const tarballSizeString =
+        responseInfo.headers['content-length'] ??
+        responseInfo.headers['Content-Length'];
       assert(tarballSizeString, 'Snap tarball has invalid content-length');
       const tarballSize = parseInt(tarballSizeString, 10);
       assert(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

iOS may use a case sensitive header for `Content-Length`, which would fail the assertion below it. This PR checks both lowercase and PascalCase.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Checks both `content-length` and `Content-Length` headers to validate NPM tarball size.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba165071b0f501682a355ad4792f3de662ab6c23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->