### PR TITLE
fix: show edit account bottomsheet on android when its behind the keyboard cp-7.57.1

### DIFF
--- a/app/components/Views/MultichainAccounts/sheets/EditMultichainAccountName/EditMultichainAccountName.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/EditMultichainAccountName/EditMultichainAccountName.tsx
@@ -27,11 +27,12 @@ import { ButtonProps } from '../../../../../component-library/components/Buttons
 import styleSheet from './EditMultichainAccountName.styles';
 import { useStyles } from '../../../../hooks/useStyles';
 import { useTheme } from '../../../../../util/theme';
-import { TextInput } from 'react-native';
+import { Platform, TextInput } from 'react-native';
 import { EditAccountNameIds } from '../../../../../../e2e/selectors/MultichainAccounts/EditAccountName.selectors';
 import { AccountGroupObject } from '@metamask/account-tree-controller';
 import { RootState } from '../../../../../reducers';
 import { selectAccountGroupById } from '../../../../../selectors/multichainAccounts/accountTreeController';
+import { useKeyboardHeight } from '../../../../hooks/useKeyboardHeight';
 
 interface RootNavigationParamList extends ParamListBase {
   EditMultichainAccountName: {
@@ -64,6 +65,8 @@ export const EditMultichainAccountName = () => {
 
   const [accountName, setAccountName] = useState(initialName);
   const [error, setError] = useState<string | null>(null);
+
+  const keyboardHeight = useKeyboardHeight();
 
   const handleAccountNameChange = useCallback(() => {
     // Validate that account name is not empty
@@ -144,7 +147,10 @@ export const EditMultichainAccountName = () => {
         {error && <Text color={TextColor.Error}>{error}</Text>}
       </Box>
       <BottomSheetFooter
-        style={styles.footer}
+        style={
+          styles.footer &&
+          Platform.OS === 'android' && { marginBottom: keyboardHeight }
+        }
         buttonsAlignment={ButtonsAlignment.Horizontal}
         buttonPropsArray={[saveButtonProps]}
       />

--- a/app/components/Views/MultichainAccounts/sheets/EditMultichainAccountName/EditMultichainAccountName.tsx
+++ b/app/components/Views/MultichainAccounts/sheets/EditMultichainAccountName/EditMultichainAccountName.tsx
@@ -147,10 +147,10 @@ export const EditMultichainAccountName = () => {
         {error && <Text color={TextColor.Error}>{error}</Text>}
       </Box>
       <BottomSheetFooter
-        style={
-          styles.footer &&
-          Platform.OS === 'android' && { marginBottom: keyboardHeight }
-        }
+        style={{
+          ...styles.footer,
+          ...(Platform.OS === 'android' && { marginBottom: keyboardHeight }),
+        }}
         buttonsAlignment={ButtonsAlignment.Horizontal}
         buttonPropsArray={[saveButtonProps]}
       />

--- a/app/components/hooks/useKeyboardHeight/index.ts
+++ b/app/components/hooks/useKeyboardHeight/index.ts
@@ -1,0 +1,1 @@
+export { useKeyboardHeight } from './useKeyboardHeight';

--- a/app/components/hooks/useKeyboardHeight/useKeyboardHeight.test.ts
+++ b/app/components/hooks/useKeyboardHeight/useKeyboardHeight.test.ts
@@ -1,0 +1,72 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { Keyboard } from 'react-native';
+import { useKeyboardHeight } from './useKeyboardHeight';
+
+describe('useKeyboardHeight', () => {
+  let mockSubscription: { remove: jest.Mock };
+  let showListener: (e: { endCoordinates: { height: number } }) => void;
+  let hideListener: () => void;
+
+  beforeEach(() => {
+    mockSubscription = { remove: jest.fn() };
+    jest
+      .spyOn(Keyboard, 'addListener')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockReturnValue(mockSubscription as any);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const getListeners = () => {
+    const calls = (Keyboard.addListener as jest.Mock).mock.calls;
+    showListener = calls.find((call) => call[0] === 'keyboardDidShow')?.[1];
+    hideListener = calls.find((call) => call[0] === 'keyboardDidHide')?.[1];
+  };
+
+  it('should initialize with height of 0', () => {
+    const { result } = renderHook(() => useKeyboardHeight());
+    expect(result.current).toBe(0);
+  });
+
+  it('should register keyboard listeners', () => {
+    renderHook(() => useKeyboardHeight());
+    expect(Keyboard.addListener).toHaveBeenCalledWith(
+      'keyboardDidShow',
+      expect.any(Function),
+    );
+    expect(Keyboard.addListener).toHaveBeenCalledWith(
+      'keyboardDidHide',
+      expect.any(Function),
+    );
+  });
+
+  it('should update height on show and reset on hide', () => {
+    const { result } = renderHook(() => useKeyboardHeight());
+    getListeners();
+
+    act(() => showListener({ endCoordinates: { height: 300 } }));
+    expect(result.current).toBe(300);
+
+    act(() => hideListener());
+    expect(result.current).toBe(0);
+  });
+
+  it('should handle multiple height changes', () => {
+    const { result } = renderHook(() => useKeyboardHeight());
+    getListeners();
+
+    act(() => showListener({ endCoordinates: { height: 250 } }));
+    expect(result.current).toBe(250);
+
+    act(() => showListener({ endCoordinates: { height: 400 } }));
+    expect(result.current).toBe(400);
+  });
+
+  it('should remove listeners on unmount', () => {
+    const { unmount } = renderHook(() => useKeyboardHeight());
+    unmount();
+    expect(mockSubscription.remove).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/components/hooks/useKeyboardHeight/useKeyboardHeight.ts
+++ b/app/components/hooks/useKeyboardHeight/useKeyboardHeight.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState, useCallback } from 'react';
+import { Keyboard, KeyboardEvent } from 'react-native';
+
+export const useKeyboardHeight = (): number => {
+  const [keyboardHeight, setKeyboardHeight] = useState<number>(0);
+
+  const handleKeyboardDidShow = useCallback((event: KeyboardEvent) => {
+    setKeyboardHeight(event.endCoordinates.height);
+  }, []);
+
+  const handleKeyboardDidHide = useCallback(() => {
+    setKeyboardHeight(0);
+  }, []);
+
+  useEffect(() => {
+    const keyboardDidShowListener = Keyboard.addListener(
+      'keyboardDidShow',
+      handleKeyboardDidShow,
+    );
+    const keyboardDidHideListener = Keyboard.addListener(
+      'keyboardDidHide',
+      handleKeyboardDidHide,
+    );
+
+    return () => {
+      keyboardDidShowListener.remove();
+      keyboardDidHideListener.remove();
+    };
+  }, [handleKeyboardDidShow, handleKeyboardDidHide]);
+
+  return keyboardHeight;
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug where users could not edit their account names on Android due to the input being hidden by the keyboard.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/21459

## **Manual testing steps**

```gherkin
Feature: Account renaming

  Scenario: user opens accounts list
    Given Account 1 is present in the list

    When user taps to rename the account
    Then the keyboard doesn't hide the input
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="843" height="917" alt="image" src="https://github.com/user-attachments/assets/dbb33751-4493-4cb0-ac06-e27b6dbb66dc" />


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure the edit account name bottom sheet footer stays visible on Android by offsetting it with a new `useKeyboardHeight` hook (with tests).
> 
> - **Android UI**:
>   - Update `app/components/Views/MultichainAccounts/sheets/EditMultichainAccountName/EditMultichainAccountName.tsx` to offset `BottomSheetFooter` by the keyboard height on Android (`Platform.OS === 'android'`) so the save button remains visible.
>   - Import and use new `useKeyboardHeight` hook; add `Platform` import.
> - **Hooks**:
>   - Add `useKeyboardHeight` (`app/components/hooks/useKeyboardHeight/useKeyboardHeight.ts`) that listens to `keyboardDidShow/Hide` and returns current keyboard height.
>   - Export via `app/components/hooks/useKeyboardHeight/index.ts`.
>   - Add unit tests `useKeyboardHeight.test.ts` covering initialization, show/hide updates, multiple changes, and listener cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ba72306b13ba7810ee983bba820c39097b78d74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->