### PR TITLE
chore: Update initial background state fixture

### DIFF
--- a/app/core/Engine/Engine.test.ts
+++ b/app/core/Engine/Engine.test.ts
@@ -2,7 +2,6 @@ import { MarketDataDetails } from '@metamask/assets-controllers';
 import Engine, { Engine as EngineClass } from './Engine';
 import { EngineState } from './types';
 import { backgroundState } from '../../util/test/initial-root-state';
-import { InitializationState } from '../../components/UI/Perps/controllers';
 import { zeroAddress } from 'ethereumjs-util';
 import {
   createMockAccountsControllerState,
@@ -221,76 +220,18 @@ describe('Engine', () => {
     const currentAppVersion = getVersion();
     const currentMigrationVersion = migrationVersion;
 
-    // Create expected state by merging the static fixture with current AppMetadataController state
     const expectedState = {
       ...backgroundState,
-      AccountTrackerController: {
-        ...backgroundState.AccountTrackerController,
-        // This is just hotfix, because it should not be empty but it reflects current state of Engine code
-        // More info: https://github.com/MetaMask/metamask-mobile/pull/18949
-        accountsByChainId: {},
-      },
-      AnalyticsController: {
-        analyticsId: TEST_ANALYTICS_ID,
-        optedIn: false,
-      },
+      // Update application version here, so that we don't have to update
+      // `initial-background-state.json` every release
       AppMetadataController: {
         currentAppVersion,
-        previousAppVersion: '', // This will be managed by the controller
-        previousMigrationVersion: 0, // This will be managed by the controller
+        previousAppVersion: '',
+        previousMigrationVersion: 0,
         currentMigrationVersion,
       },
-      PredictController: {
-        eligibility: {},
-        lastError: null,
-        lastUpdateTimestamp: 0,
-        balances: {},
-        claimablePositions: {},
-        pendingDeposits: {},
-        withdrawTransaction: null,
-        accountMeta: {},
-      },
-      GatorPermissionsController: {
-        gatorPermissionsMapSerialized: JSON.stringify({
-          'native-token-stream': {},
-          'native-token-periodic': {},
-          'erc20-token-stream': {},
-          'erc20-token-periodic': {},
-          other: {},
-        }),
-        gatorPermissionsProviderSnapId: 'npm:@metamask/gator-permissions-snap',
-        isFetchingGatorPermissions: false,
-        isGatorPermissionsEnabled: false,
-      },
-      PerpsController: {
-        ...backgroundState.PerpsController,
-        depositRequests: [],
-        withdrawalRequests: [],
-        withdrawalProgress: {
-          progress: 0,
-          lastUpdated: 0,
-          activeWithdrawalId: null,
-        },
-        marketFilterPreferences: 'volume',
-        tradeConfigurations: {
-          mainnet: {},
-          testnet: {},
-        },
-        watchlistMarkets: {
-          mainnet: [],
-          testnet: [],
-        },
-        hip3ConfigVersion: 0,
-        initializationState: InitializationState.UNINITIALIZED,
-        initializationError: null,
-        initializationAttempts: 0,
-      },
-      RampsController: {
-        ...backgroundState.RampsController,
-        preferredProvider: null,
-        providers: [],
-        tokens: null,
-      },
+      // WARNING: Do not make further changes to expected state here.
+      // Update `initial-background-state.json` instead.
     };
 
     expect(initialBackgroundState).toStrictEqual(expectedState);

--- a/app/util/logs/__snapshots__/index.test.ts.snap
+++ b/app/util/logs/__snapshots__/index.test.ts.snap
@@ -7,9 +7,7 @@ exports[`logs :: generateStateLogs Sanitized SeedlessOnboardingController State 
   "engine": {
     "backgroundState": {
       "AccountTrackerController": {
-        "accountsByChainId": {
-          "0x1": {},
-        },
+        "accountsByChainId": {},
       },
       "AccountTreeController": {
         "accountGroupsMetadata": {},
@@ -127,6 +125,12 @@ exports[`logs :: generateStateLogs Sanitized SeedlessOnboardingController State 
         "gasFeeEstimates": {},
         "gasFeeEstimatesByChainId": {},
         "nonRPCGasFeeApisDisabled": false,
+      },
+      "GatorPermissionsController": {
+        "gatorPermissionsMapSerialized": "{"native-token-stream":{},"native-token-periodic":{},"erc20-token-stream":{},"erc20-token-periodic":{},"other":{}}",
+        "gatorPermissionsProviderSnapId": "npm:@metamask/gator-permissions-snap",
+        "isFetchingGatorPermissions": false,
+        "isGatorPermissionsEnabled": false,
       },
       "KeyringController": {
         "isUnlocked": true,
@@ -790,9 +794,7 @@ exports[`logs :: generateStateLogs generates a valid json export 1`] = `
   "engine": {
     "backgroundState": {
       "AccountTrackerController": {
-        "accountsByChainId": {
-          "0x1": {},
-        },
+        "accountsByChainId": {},
       },
       "AccountTreeController": {
         "accountGroupsMetadata": {},
@@ -910,6 +912,12 @@ exports[`logs :: generateStateLogs generates a valid json export 1`] = `
         "gasFeeEstimates": {},
         "gasFeeEstimatesByChainId": {},
         "nonRPCGasFeeApisDisabled": false,
+      },
+      "GatorPermissionsController": {
+        "gatorPermissionsMapSerialized": "{"native-token-stream":{},"native-token-periodic":{},"erc20-token-stream":{},"erc20-token-periodic":{},"other":{}}",
+        "gatorPermissionsProviderSnapId": "npm:@metamask/gator-permissions-snap",
+        "isFetchingGatorPermissions": false,
+        "isGatorPermissionsEnabled": false,
       },
       "KeyringController": {
         "isUnlocked": true,

--- a/app/util/logs/__snapshots__/index.test.ts.snap
+++ b/app/util/logs/__snapshots__/index.test.ts.snap
@@ -28,6 +28,10 @@ exports[`logs :: generateStateLogs Sanitized SeedlessOnboardingController State 
       "AddressBookController": {
         "addressBook": {},
       },
+      "AnalyticsController": {
+        "analyticsId": "59710bcf-06cc-4247-9386-12425e7fc905",
+        "optedIn": false,
+      },
       "ApprovalController": {
         "approvalFlows": [],
         "pendingApprovalCount": 0,
@@ -510,10 +514,16 @@ exports[`logs :: generateStateLogs Sanitized SeedlessOnboardingController State 
         "lastError": null,
         "lastUpdateTimestamp": 0,
         "lastWithdrawResult": null,
-        "marketFilterPreferences": {},
+        "marketFilterPreferences": "volume",
         "perpsBalances": {},
-        "tradeConfigurations": {},
-        "watchlistMarkets": [],
+        "tradeConfigurations": {
+          "mainnet": {},
+          "testnet": {},
+        },
+        "watchlistMarkets": {
+          "mainnet": [],
+          "testnet": [],
+        },
         "withdrawInProgress": false,
         "withdrawalProgress": {
           "activeWithdrawalId": null,
@@ -815,6 +825,10 @@ exports[`logs :: generateStateLogs generates a valid json export 1`] = `
       "AddressBookController": {
         "addressBook": {},
       },
+      "AnalyticsController": {
+        "analyticsId": "59710bcf-06cc-4247-9386-12425e7fc905",
+        "optedIn": false,
+      },
       "ApprovalController": {
         "approvalFlows": [],
         "pendingApprovalCount": 0,
@@ -1297,10 +1311,16 @@ exports[`logs :: generateStateLogs generates a valid json export 1`] = `
         "lastError": null,
         "lastUpdateTimestamp": 0,
         "lastWithdrawResult": null,
-        "marketFilterPreferences": {},
+        "marketFilterPreferences": "volume",
         "perpsBalances": {},
-        "tradeConfigurations": {},
-        "watchlistMarkets": [],
+        "tradeConfigurations": {
+          "mainnet": {},
+          "testnet": {},
+        },
+        "watchlistMarkets": {
+          "mainnet": [],
+          "testnet": [],
+        },
         "withdrawInProgress": false,
         "withdrawalProgress": {
           "activeWithdrawalId": null,

--- a/app/util/test/initial-background-state.json
+++ b/app/util/test/initial-background-state.json
@@ -7,9 +7,7 @@
     "logs": {}
   },
   "AccountTrackerController": {
-    "accountsByChainId": {
-      "0x1": {}
-    }
+    "accountsByChainId": {}
   },
   "AccountsController": {
     "internalAccounts": {
@@ -29,6 +27,16 @@
   },
   "AddressBookController": {
     "addressBook": {}
+  },
+  "AnalyticsController": {
+    "analyticsId": "59710bcf-06cc-4247-9386-12425e7fc905",
+    "optedIn": false
+  },
+  "GatorPermissionsController": {
+    "gatorPermissionsMapSerialized": "{\"native-token-stream\":{},\"native-token-periodic\":{},\"erc20-token-stream\":{},\"erc20-token-periodic\":{},\"other\":{}}",
+    "gatorPermissionsProviderSnapId": "npm:@metamask/gator-permissions-snap",
+    "isFetchingGatorPermissions": false,
+    "isGatorPermissionsEnabled": false
   },
   "NftController": {
     "allNftContracts": {},
@@ -497,9 +505,15 @@
       "testnet": false,
       "mainnet": false
     },
-    "watchlistMarkets": [],
-    "tradeConfigurations": {},
-    "marketFilterPreferences": {},
+    "watchlistMarkets": {
+      "mainnet": [],
+      "testnet": []
+    },
+    "tradeConfigurations": {
+      "mainnet": {},
+      "testnet": {}
+    },
+    "marketFilterPreferences": "volume",
     "hip3ConfigVersion": 0,
     "perpsBalances": {}
   },


### PR DESCRIPTION
## **Description**

The file `app/util/test/initial-background-state.json` is intended to represent the initial background state. The unit test we used to ensure this stays up-to- date was apparently misunderstood, and state changes have been made directly in the test.

These changes have been undone and applied to the state fixture instead, as was intended. The inline comments in the test have been updated to make this more clear as well.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns tests with the single source of truth for initial background state and updates dependent snapshots.
> 
> - Refactors `Engine.test.ts` to build expected state from `initial-background-state.json` (only injecting app/migration versions) and adds clarifying comments; removes inline state overrides
> - Updates `initial-background-state.json`: adds `AnalyticsController` and `GatorPermissionsController`, sets `AccountTrackerController.accountsByChainId` to `{}`, and adjusts `PerpsController` defaults (`marketFilterPreferences: "volume"`, structured `watchlistMarkets` and `tradeConfigurations`)
> - Refreshes logs snapshots to reflect the new fixture state
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ba3c7cbc28646999669c217847c34e57924981d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->