### PR TITLE
chore: remove token selector from deposit/earn view

### DIFF
--- a/app/components/UI/Earn/Views/EarnInputView/EarnInputView.test.tsx
+++ b/app/components/UI/Earn/Views/EarnInputView/EarnInputView.test.tsx
@@ -546,12 +546,8 @@ describe('EarnInputView', () => {
       // "0" in the input display and on the keypad
       expect(getAllByText('0').length).toBe(2);
       // "USDC" in the input display and in the token selector
-      expect(getAllByText('USDC').length).toBe(2);
+      expect(getAllByText('USDC').length).toBe(1);
       expect(getByText('$0')).toBeDefined();
-
-      // Token Selector should display USDC as selected token
-      expect(getByText('2.5% APR')).toBeDefined();
-      expect(getByText('100 USDC')).toBeDefined();
 
       await act(async () => {
         fireEvent.press(getByText('1'));

--- a/app/components/UI/Earn/Views/EarnInputView/EarnInputView.test.tsx
+++ b/app/components/UI/Earn/Views/EarnInputView/EarnInputView.test.tsx
@@ -546,8 +546,12 @@ describe('EarnInputView', () => {
       // "0" in the input display and on the keypad
       expect(getAllByText('0').length).toBe(2);
       // "USDC" in the input display and in the token selector
-      expect(getAllByText('USDC').length).toBe(1);
+      expect(getAllByText('USDC').length).toBe(2);
       expect(getByText('$0')).toBeDefined();
+
+      // Token Selector should display USDC as selected token
+      expect(getByText('2.5% APR')).toBeDefined();
+      expect(getByText('100 USDC')).toBeDefined();
 
       await act(async () => {
         fireEvent.press(getByText('1'));

--- a/app/components/UI/Earn/Views/EarnInputView/EarnInputView.tsx
+++ b/app/components/UI/Earn/Views/EarnInputView/EarnInputView.tsx
@@ -58,7 +58,10 @@ import {
   generateLendingDepositTransaction,
 } from '../../utils/tempLending';
 import styleSheet from './EarnInputView.styles';
-import { EarnInputViewProps } from './EarnInputView.types';
+import {
+  EARN_INPUT_VIEW_ACTIONS,
+  EarnInputViewProps,
+} from './EarnInputView.types';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { getIsRedesignedStablecoinLendingScreenEnabled } from './utils';
 import { useEarnAnalyticsEventLogging } from '../../hooks/useEarnEventAnalyticsLogging';
@@ -67,6 +70,8 @@ import { ScrollView } from 'react-native-gesture-handler';
 import { trace, TraceName } from '../../../../../util/trace';
 import { useEndTraceOnMount } from '../../../../hooks/useEndTraceOnMount';
 import { EVM_SCOPE } from '../../constants/networks';
+import { selectTrxStakingEnabled } from '../../../../../selectors/featureFlagController/trxStakingEnabled';
+import EarnTokenSelector from '../../components/EarnTokenSelector';
 
 const EarnInputView = () => {
   // navigation hooks
@@ -102,6 +107,8 @@ const EarnInputView = () => {
   const isStablecoinLendingEnabled = useSelector(
     selectStablecoinLendingEnabledFlag,
   );
+
+  const isTrxStakingEnabled = useSelector(selectTrxStakingEnabled);
 
   // if token is ETH, use 1 as the exchange rate
   // otherwise, use the contract exchange rate or 0 if undefined
@@ -809,7 +816,15 @@ const EarnInputView = () => {
           currencyToggleValue={currencyToggleValue}
         />
         <View style={styles.rewardsRateContainer}>
-          {!isStablecoinLendingEnabled && (
+          {isStablecoinLendingEnabled && !isTrxStakingEnabled ? (
+            <>
+              <View style={styles.spacer} />
+              <EarnTokenSelector
+                token={token}
+                action={EARN_INPUT_VIEW_ACTIONS.DEPOSIT}
+              />
+            </>
+          ) : (
             <EstimatedAnnualRewardsCard
               estimatedAnnualRewards={estimatedAnnualRewards}
               onIconPress={withMetaMetrics(navigateToLearnMoreModal, {

--- a/app/components/UI/Earn/Views/EarnInputView/EarnInputView.tsx
+++ b/app/components/UI/Earn/Views/EarnInputView/EarnInputView.tsx
@@ -809,19 +809,21 @@ const EarnInputView = () => {
           currencyToggleValue={currencyToggleValue}
         />
         <View style={styles.rewardsRateContainer}>
-          <EstimatedAnnualRewardsCard
-            estimatedAnnualRewards={estimatedAnnualRewards}
-            onIconPress={withMetaMetrics(navigateToLearnMoreModal, {
-              event: MetaMetricsEvents.TOOLTIP_OPENED,
-              properties: {
-                selected_provider: EVENT_PROVIDERS.CONSENSYS,
-                text: 'Tooltip Opened',
-                location: EVENT_LOCATIONS.EARN_INPUT_VIEW,
-                tooltip_name: 'MetaMask Pool Estimated Rewards',
-              },
-            })}
-            isLoading={isLoadingEarnMetadata}
-          />
+          {!isStablecoinLendingEnabled && (
+            <EstimatedAnnualRewardsCard
+              estimatedAnnualRewards={estimatedAnnualRewards}
+              onIconPress={withMetaMetrics(navigateToLearnMoreModal, {
+                event: MetaMetricsEvents.TOOLTIP_OPENED,
+                properties: {
+                  selected_provider: EVENT_PROVIDERS.CONSENSYS,
+                  text: 'Tooltip Opened',
+                  location: EVENT_LOCATIONS.EARN_INPUT_VIEW,
+                  tooltip_name: 'MetaMask Pool Estimated Rewards',
+                },
+              })}
+              isLoading={isLoadingEarnMetadata}
+            />
+          )}
         </View>
       </ScrollView>
       <QuickAmounts

--- a/app/components/UI/Earn/Views/EarnInputView/EarnInputView.tsx
+++ b/app/components/UI/Earn/Views/EarnInputView/EarnInputView.tsx
@@ -44,7 +44,6 @@ import { EVENT_PROVIDERS } from '../../../Stake/constants/events';
 import { EVENT_LOCATIONS } from '../../constants/events';
 import usePoolStakedDeposit from '../../../Stake/hooks/usePoolStakedDeposit';
 import { withMetaMetrics } from '../../../Stake/utils/metaMetrics/withMetaMetrics';
-import EarnTokenSelector from '../../components/EarnTokenSelector';
 import InputDisplay from '../../components/InputDisplay';
 import { EARN_EXPERIENCES } from '../../constants/experiences';
 import useEarnInputHandlers from '../../hooks/useEarnInput';
@@ -59,10 +58,7 @@ import {
   generateLendingDepositTransaction,
 } from '../../utils/tempLending';
 import styleSheet from './EarnInputView.styles';
-import {
-  EARN_INPUT_VIEW_ACTIONS,
-  EarnInputViewProps,
-} from './EarnInputView.types';
+import { EarnInputViewProps } from './EarnInputView.types';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { getIsRedesignedStablecoinLendingScreenEnabled } from './utils';
 import { useEarnAnalyticsEventLogging } from '../../hooks/useEarnEventAnalyticsLogging';
@@ -813,29 +809,19 @@ const EarnInputView = () => {
           currencyToggleValue={currencyToggleValue}
         />
         <View style={styles.rewardsRateContainer}>
-          {isStablecoinLendingEnabled ? (
-            <>
-              <View style={styles.spacer} />
-              <EarnTokenSelector
-                token={token}
-                action={EARN_INPUT_VIEW_ACTIONS.DEPOSIT}
-              />
-            </>
-          ) : (
-            <EstimatedAnnualRewardsCard
-              estimatedAnnualRewards={estimatedAnnualRewards}
-              onIconPress={withMetaMetrics(navigateToLearnMoreModal, {
-                event: MetaMetricsEvents.TOOLTIP_OPENED,
-                properties: {
-                  selected_provider: EVENT_PROVIDERS.CONSENSYS,
-                  text: 'Tooltip Opened',
-                  location: EVENT_LOCATIONS.EARN_INPUT_VIEW,
-                  tooltip_name: 'MetaMask Pool Estimated Rewards',
-                },
-              })}
-              isLoading={isLoadingEarnMetadata}
-            />
-          )}
+          <EstimatedAnnualRewardsCard
+            estimatedAnnualRewards={estimatedAnnualRewards}
+            onIconPress={withMetaMetrics(navigateToLearnMoreModal, {
+              event: MetaMetricsEvents.TOOLTIP_OPENED,
+              properties: {
+                selected_provider: EVENT_PROVIDERS.CONSENSYS,
+                text: 'Tooltip Opened',
+                location: EVENT_LOCATIONS.EARN_INPUT_VIEW,
+                tooltip_name: 'MetaMask Pool Estimated Rewards',
+              },
+            })}
+            isLoading={isLoadingEarnMetadata}
+          />
         </View>
       </ScrollView>
       <QuickAmounts

--- a/app/components/UI/Earn/Views/EarnInputView/EarnInputView.tsx
+++ b/app/components/UI/Earn/Views/EarnInputView/EarnInputView.tsx
@@ -44,6 +44,7 @@ import { EVENT_PROVIDERS } from '../../../Stake/constants/events';
 import { EVENT_LOCATIONS } from '../../constants/events';
 import usePoolStakedDeposit from '../../../Stake/hooks/usePoolStakedDeposit';
 import { withMetaMetrics } from '../../../Stake/utils/metaMetrics/withMetaMetrics';
+import EarnTokenSelector from '../../components/EarnTokenSelector';
 import InputDisplay from '../../components/InputDisplay';
 import { EARN_EXPERIENCES } from '../../constants/experiences';
 import useEarnInputHandlers from '../../hooks/useEarnInput';
@@ -71,7 +72,6 @@ import { trace, TraceName } from '../../../../../util/trace';
 import { useEndTraceOnMount } from '../../../../hooks/useEndTraceOnMount';
 import { EVM_SCOPE } from '../../constants/networks';
 import { selectTrxStakingEnabled } from '../../../../../selectors/featureFlagController/trxStakingEnabled';
-import EarnTokenSelector from '../../components/EarnTokenSelector';
 
 const EarnInputView = () => {
   // navigation hooks


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

We want to remove the token selector from the earn view, when the Tron Staking Feature Flag is enabled (flask-dev), going forward the goal is for this selector to be removed completely, but for now we will keep it under the Tron FF.

Before:

<img height="500" alt="Screenshot 2025-10-22 at 11 24 47" src="https://github.com/user-attachments/assets/a6a4ec9d-1565-44a8-8bf7-a7889ba6b547" />

After (with Tron stakign FF enabled):

<img height="500" alt="Screenshot 2025-10-22 at 11 24 24" src="https://github.com/user-attachments/assets/8885d82d-24e1-4c09-bb97-627979e971c5" />



## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Removes the earn token selector.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Earn token selector is now shown only when stablecoin lending is enabled and TRX staking is disabled.
> 
> - **UI (EarnInputView)**:
>   - Gate `EarnTokenSelector` rendering behind `isStablecoinLendingEnabled && !isTrxStakingEnabled`; otherwise show `EstimatedAnnualRewardsCard`.
>   - Import and use `selectTrxStakingEnabled` feature flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28c86a71048447efa9c9ba91a05f1951ff1eeffc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->