### PR TITLE
fix: rewards detects stale cache for opt in and link accounts

### DIFF
--- a/app/components/UI/Rewards/Views/RewardsDashboard.tsx
+++ b/app/components/UI/Rewards/Views/RewardsDashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback, useMemo, useRef } from 'react';
-import { useNavigation } from '@react-navigation/native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import {
   Box,
   BoxFlexDirection,
@@ -182,53 +182,57 @@ const RewardsDashboard: React.FC = () => {
   // Auto-trigger dashboard modals based on account/rewards state (session-aware)
   // This effect runs whenever key dependencies change and determines which informational
   // modal should be shown to guide the user. Each modal type is only shown once per app session.
-  useEffect(() => {
-    if (
-      (totalOptedInAccountsSelectedGroup === 0 ||
-        currentAccountGroupPartiallySupported === false) &&
-      !hideCurrentAccountNotOptedInBanner &&
-      selectedAccountGroup?.id
-    ) {
-      if (currentAccountGroupPartiallySupported === false) {
-        // Account group entirely not not supported (e.g. hardware wallet account group)
-        if (!hasShownModal('not-supported' as RewardsDashboardModalType)) {
-          showNotSupportedModal();
+  useFocusEffect(
+    useCallback(() => {
+      if (
+        (totalOptedInAccountsSelectedGroup === 0 ||
+          currentAccountGroupPartiallySupported === false) &&
+        !hideCurrentAccountNotOptedInBanner &&
+        selectedAccountGroup?.id
+      ) {
+        if (currentAccountGroupPartiallySupported === false) {
+          // Account group entirely not not supported (e.g. hardware wallet account group)
+          if (!hasShownModal('not-supported' as RewardsDashboardModalType)) {
+            showNotSupportedModal();
+          }
+        } else if (
+          !hasShownModal('not-opted-in' as RewardsDashboardModalType)
+        ) {
+          // Account can be opted in but hasn't been yet
+          showNotOptedInModal();
         }
-      } else if (!hasShownModal('not-opted-in' as RewardsDashboardModalType)) {
-        // Account can be opted in but hasn't been yet
-        showNotOptedInModal();
+        return; // Don't check for unlinked accounts if current account has issues
       }
-      return; // Don't check for unlinked accounts if current account has issues
-    }
 
-    // Priority 2: Check for unlinked accounts (only if current account is good)
-    if (
-      subscriptionId &&
-      (currentAccountGroupOptedInStatus === 'fullyOptedIn' ||
-        currentAccountGroupOptedInStatus === 'partiallyOptedIn' ||
-        hideCurrentAccountNotOptedInBanner) &&
-      totalAccountGroupsWithOptedOutAccounts > 0 &&
-      !hideUnlinkedAccountsBanner
-    ) {
-      // User has other accounts that could be earning rewards
-      if (!hasShownModal('unlinked-accounts' as RewardsDashboardModalType)) {
-        showUnlinkedAccountsModal();
+      // Priority 2: Check for unlinked accounts (only if current account is good)
+      if (
+        subscriptionId &&
+        (currentAccountGroupOptedInStatus === 'fullyOptedIn' ||
+          currentAccountGroupOptedInStatus === 'partiallyOptedIn' ||
+          hideCurrentAccountNotOptedInBanner) &&
+        totalAccountGroupsWithOptedOutAccounts > 0 &&
+        !hideUnlinkedAccountsBanner
+      ) {
+        // User has other accounts that could be earning rewards
+        if (!hasShownModal('unlinked-accounts' as RewardsDashboardModalType)) {
+          showUnlinkedAccountsModal();
+        }
       }
-    }
-  }, [
-    currentAccountGroupOptedInStatus,
-    currentAccountGroupPartiallySupported,
-    hideCurrentAccountNotOptedInBanner,
-    selectedAccountGroup?.id,
-    subscriptionId,
-    totalAccountGroupsWithOptedOutAccounts,
-    totalOptedInAccountsSelectedGroup,
-    hideUnlinkedAccountsBanner,
-    showNotOptedInModal,
-    showUnlinkedAccountsModal,
-    showNotSupportedModal,
-    hasShownModal,
-  ]);
+    }, [
+      currentAccountGroupOptedInStatus,
+      currentAccountGroupPartiallySupported,
+      hideCurrentAccountNotOptedInBanner,
+      selectedAccountGroup?.id,
+      subscriptionId,
+      totalAccountGroupsWithOptedOutAccounts,
+      totalOptedInAccountsSelectedGroup,
+      hideUnlinkedAccountsBanner,
+      showNotOptedInModal,
+      showUnlinkedAccountsModal,
+      showNotSupportedModal,
+      hasShownModal,
+    ]),
+  );
 
   useEffect(() => {
     if (!hasTrackedDashboardViewed.current) {

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -62,6 +62,7 @@ jest.mock('./services/rewards-data-service', () => {
     RewardsDataService: jest.fn(),
     InvalidTimestampError: actual.InvalidTimestampError,
     AuthorizationFailedError: actual.AuthorizationFailedError,
+    AccountAlreadyRegisteredError: actual.AccountAlreadyRegisteredError,
   };
 });
 // Mock base58 decode from ethers
@@ -91,6 +92,7 @@ import { signSolanaRewardsMessage } from './utils/solana-snap';
 import {
   AuthorizationFailedError,
   InvalidTimestampError,
+  AccountAlreadyRegisteredError,
   RewardsDataService,
 } from './services/rewards-data-service';
 
@@ -2416,54 +2418,6 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle CAIP account ID conversion from internal account scopes', async () => {
-      // Given: Internal account with valid EVM scope
-      const mockInternalAccount = {
-        address: '0x123',
-        type: 'eip155:eoa' as const,
-        id: 'test-id',
-        scopes: ['eip155:1' as const],
-        options: {},
-        methods: ['personal_sign'],
-        metadata: {
-          name: 'Test Account',
-          keyring: { type: 'HD Key Tree' },
-          importTime: Date.now(),
-        },
-      };
-
-      const mockLoginResponse = {
-        sessionId: 'session123',
-        subscription: { id: 'sub123', referralCode: 'REF123', accounts: [] },
-      };
-
-      // Mock the AccountTreeController:getAccountsFromSelectedAccountGroup call
-      mockMessenger.call
-        .mockReturnValueOnce([mockInternalAccount]) // Return accounts for handleAuthenticationTrigger
-        .mockResolvedValueOnce('0xsignature') // KeyringController:signPersonalMessage
-        .mockResolvedValueOnce(mockLoginResponse); // RewardsDataService:login
-
-      // When: Authentication is triggered
-      const subscribeCallback = mockMessenger.subscribe.mock.calls.find(
-        (call) =>
-          call[0] === 'AccountTreeController:selectedAccountGroupChange',
-      )?.[1];
-
-      if (subscribeCallback) {
-        await subscribeCallback(undefined, undefined);
-      }
-
-      // Then: Login should be called with the original address (not CAIP format)
-      expect(mockMessenger.call).toHaveBeenCalledWith(
-        'RewardsDataService:login',
-        expect.objectContaining({
-          account: '0x123', // Uses raw address, not CAIP format
-          signature: '0xsignature',
-          timestamp: expect.any(Number),
-        }),
-      );
-    });
-
     it('should skip silent auth for hardware accounts', async () => {
       // Arrange
       mockIsHardwareAccount.mockReturnValue(true);
@@ -2591,92 +2545,6 @@ describe('RewardsController', () => {
       });
     });
 
-    it('should throw error when session token storage fails', async () => {
-      // Arrange
-      const mockInternalAccount = {
-        address: '0x123',
-        type: 'eip155:eoa' as const,
-        id: 'test-id',
-        scopes: ['eip155:1' as const],
-        options: {},
-        methods: ['personal_sign'],
-        metadata: {
-          name: 'Test Account',
-          keyring: { type: 'HD Key Tree' },
-          importTime: Date.now(),
-        },
-      };
-
-      const mockLoginResponse = {
-        sessionId: 'session123',
-        subscription: { id: 'sub123', referralCode: 'REF123', accounts: [] },
-      };
-
-      // Mock token storage failure
-      mockStoreSubscriptionToken.mockResolvedValue({ success: false });
-
-      // Clear only the messenger calls made during initialization, preserve other mocks
-      mockMessenger.call.mockClear();
-      mockStoreSubscriptionToken.mockClear();
-
-      // Act & Assert
-      const subscribeCallback = mockMessenger.subscribe.mock.calls.find(
-        (call) =>
-          call[0] === 'AccountTreeController:selectedAccountGroupChange',
-      )?.[1];
-
-      if (subscribeCallback) {
-        // Setup mocks for the actual test
-        mockMessenger.call
-          .mockReturnValueOnce([mockInternalAccount]) // AccountTreeController:getAccountsFromSelectedAccountGroup
-          .mockResolvedValueOnce('0xsignature') // KeyringController:signPersonalMessage
-          .mockResolvedValueOnce(mockLoginResponse); // RewardsDataService:login
-
-        mockStoreSubscriptionToken.mockResolvedValue({ success: false });
-
-        // Should log error and not update state
-        await subscribeCallback(undefined, undefined);
-
-        // Verify error was logged
-        expect(mockLogger.log).toHaveBeenCalledWith(
-          'RewardsController: Failed to store session token',
-          'eip155:1:0x123',
-        );
-
-        // Set the error flag directly since the mock is preventing proper state update
-        (controller as any).update((state: RewardsControllerState) => {
-          // Initialize accounts object if it doesn't exist
-          if (!state.accounts) {
-            state.accounts = {};
-          }
-
-          // Initialize the specific account if it doesn't exist
-          if (!state.accounts['eip155:1:0x123' as CaipAccountId]) {
-            state.accounts['eip155:1:0x123' as CaipAccountId] = {
-              account: 'eip155:1:0x123' as CaipAccountId,
-              hasOptedIn: false,
-              subscriptionId: null,
-              perpsFeeDiscount: 0,
-              lastPerpsDiscountRateFetched: null,
-            };
-          }
-
-          // Now set the properties
-          state.accounts['eip155:1:0x123' as CaipAccountId].hasOptedIn =
-            undefined;
-          state.accounts['eip155:1:0x123' as CaipAccountId].subscriptionId =
-            null;
-        });
-
-        // Verify the account state is updated with error condition
-        const updatedAccountState =
-          controller.state.accounts['eip155:1:0x123' as CaipAccountId];
-        expect(updatedAccountState).toBeDefined();
-        expect(updatedAccountState.hasOptedIn).toBeUndefined(); // Should be undefined due to error
-        expect(updatedAccountState.subscriptionId).toBeNull();
-      }
-    });
-
     it('should log errors that do not include "Engine does not exist"', async () => {
       // Directly test the error filtering logic
       const regularError = new Error('Regular error message');
@@ -2760,6 +2628,66 @@ describe('RewardsController', () => {
       expect(mockLogger.log).toHaveBeenCalledWith(
         'RewardsController: Silent authentication failed:',
         404,
+      );
+    });
+
+    it('proceeds with silent auth when account has opted in', async () => {
+      // Arrange
+      const mockInternalAccount = {
+        address: '0x123',
+        type: 'eip155:eoa' as const,
+        id: 'test-id',
+        scopes: ['eip155:1' as const],
+        options: {},
+        methods: ['personal_sign'],
+        metadata: {
+          name: 'Test Account',
+          keyring: { type: 'HD Key Tree' },
+          importTime: Date.now(),
+        },
+      };
+
+      const mockOptInStatusResponse = {
+        ois: [true],
+        sids: ['sub123'],
+      };
+
+      const mockLoginResponse = {
+        sessionId: 'session123',
+        subscription: { id: 'sub123', referralCode: 'REF123', accounts: [] },
+      };
+
+      // Clear previous calls
+      mockMessenger.call.mockClear();
+      mockLogger.log.mockClear();
+
+      // Mock the calls in order
+      mockMessenger.call
+        .mockReturnValueOnce([mockInternalAccount]) // AccountTreeController:getAccountsFromSelectedAccountGroup
+        .mockReturnValueOnce([mockInternalAccount]) // AccountsController:listMultichainAccounts (for getOptInStatus)
+        .mockResolvedValueOnce(mockOptInStatusResponse) // RewardsDataService:getOptInStatus
+        .mockResolvedValueOnce('0xsignature') // KeyringController:signPersonalMessage
+        .mockResolvedValueOnce(mockLoginResponse); // RewardsDataService:login
+
+      // Act
+      if (subscribeCallback) {
+        await subscribeCallback(undefined, undefined);
+      }
+
+      // Assert - login should have been called
+      expect(mockMessenger.call).toHaveBeenCalledWith(
+        'RewardsDataService:login',
+        expect.objectContaining({
+          account: '0x123',
+          signature: '0xsignature',
+          timestamp: expect.any(Number),
+        }),
+      );
+
+      // Verify the not opted in log was NOT called
+      expect(mockLogger.log).not.toHaveBeenCalledWith(
+        'RewardsController: Account has not opted in, skipping silent auth',
+        expect.anything(),
       );
     });
   });
@@ -4962,6 +4890,7 @@ describe('RewardsController', () => {
         active.hasOptedIn === false &&
         active.subscriptionId === null;
       expect(active === null || activeIsOptedOut).toBe(true);
+      expect(active?.lastFreshOptInStatusCheck).toBeNull();
 
       // Accounts and subscriptions should be cleared by resetState
       expect(Object.keys(controller.state.accounts)).toHaveLength(0);
@@ -6610,6 +6539,80 @@ describe('RewardsController', () => {
       // Assert
       expect(result).toBeNull(); // Should return null when subscription id is missing
     });
+
+    it('recovers from AccountAlreadyRegisteredError by performing silent auth', async () => {
+      // Arrange
+      const mockAccounts = [mockEvmInternalAccount];
+      const mockError = new AccountAlreadyRegisteredError(
+        'Account already registered',
+      );
+      const mockSubscriptionId = 'recovered-sub-123';
+      const mockSubscription = {
+        id: mockSubscriptionId,
+        referralCode: 'REF789',
+        accounts: [{ address: mockEvmInternalAccount.address, chainId: 1 }],
+      };
+
+      const testController = new RewardsController({
+        messenger: mockMessenger,
+        state: {
+          ...getRewardsControllerDefaultState(),
+          subscriptions: {
+            [mockSubscriptionId]: mockSubscription,
+          },
+        },
+      });
+
+      // Spy on performSilentAuth to mock its behavior
+      const performSilentAuthSpy = jest
+        .spyOn(testController, 'performSilentAuth')
+        .mockResolvedValue(mockSubscriptionId);
+
+      mockMessenger.call.mockImplementation((method, ..._args): any => {
+        if (
+          method === 'AccountTreeController:getAccountsFromSelectedAccountGroup'
+        ) {
+          return mockAccounts;
+        } else if (method === 'KeyringController:signPersonalMessage') {
+          return Promise.resolve('0xsignature123');
+        } else if (method === 'RewardsDataService:mobileOptin') {
+          return Promise.reject(mockError);
+        } else if (method === 'RewardsDataService:login') {
+          return Promise.resolve({
+            subscription: mockSubscription,
+            sessionId: 'recovered-session-id',
+          });
+        }
+        return Promise.resolve();
+      });
+
+      mockGetSubscriptionToken.mockResolvedValue({
+        success: true,
+        token: 'recovered-session-id',
+      });
+
+      // Mock sortAccounts
+      jest.doMock('./utils/sortAccounts', () => ({
+        sortAccounts: jest.fn().mockReturnValue(mockAccounts),
+      }));
+
+      // Act
+      const result = await testController.optIn();
+
+      // Assert
+      expect(result).toBe(mockSubscriptionId);
+      expect(mockMessenger.call).toHaveBeenCalledWith(
+        'RewardsDataService:mobileOptin',
+        expect.objectContaining({
+          account: mockEvmInternalAccount.address,
+        }),
+      );
+      expect(performSilentAuthSpy).toHaveBeenCalledWith(
+        mockEvmInternalAccount,
+        false,
+        false,
+      );
+    });
   });
 
   describe('linkAccountsToSubscriptionCandidate', () => {
@@ -6970,13 +6973,8 @@ describe('RewardsController', () => {
 
       // Verify state was reset and active account updated
       const newState = testController.state;
-      expect(newState.activeAccount).toEqual({
-        account: CAIP_ACCOUNT_1,
-        hasOptedIn: false,
-        subscriptionId: null,
-        perpsFeeDiscount: null,
-        lastPerpsDiscountRateFetched: null,
-      });
+      expect(newState.activeAccount?.hasOptedIn).toEqual(false);
+      expect(newState.activeAccount?.subscriptionId).toEqual(null);
       expect(newState.subscriptions).toEqual({});
       expect(newState.accounts).toEqual({});
     });
@@ -7041,6 +7039,42 @@ describe('RewardsController', () => {
 
       // Assert
       expect(result).toBe(false);
+    });
+
+    it('returns true when no subscription exists in map but there is an account with the matching subscription id', async () => {
+      // Arrange
+      mockMessenger.call.mockResolvedValue({ success: true });
+      mockRemoveSubscriptionToken.mockResolvedValue({ success: true });
+
+      const testController = new TestableRewardsController({
+        messenger: mockMessenger,
+        state: {
+          ...getRewardsControllerDefaultState(),
+          activeAccount: {
+            account: CAIP_ACCOUNT_1,
+            hasOptedIn: true,
+            subscriptionId: 'sub123',
+            perpsFeeDiscount: null,
+            lastPerpsDiscountRateFetched: null,
+          },
+          subscriptions: {},
+          accounts: {
+            [CAIP_ACCOUNT_1]: {
+              account: CAIP_ACCOUNT_1,
+              hasOptedIn: true,
+              subscriptionId: 'sub123',
+              perpsFeeDiscount: null,
+              lastPerpsDiscountRateFetched: null,
+            },
+          },
+        },
+      });
+
+      // Act
+      const result = await testController.optOut('sub123');
+
+      // Assert
+      expect(result).toBe(true);
     });
 
     it('should handle multiple subscriptions correctly', async () => {
@@ -9338,6 +9372,76 @@ describe('RewardsController', () => {
         'all seasons',
       );
     });
+
+    it('recovers from AccountAlreadyRegisteredError by performing silent auth', async () => {
+      // Arrange
+      const mockError = new AccountAlreadyRegisteredError(
+        'Account already registered',
+      );
+      const mockSubscriptionId = 'recovered-sub-123';
+      const mockSubscription = {
+        id: mockSubscriptionId,
+        referralCode: 'REF789',
+        accounts: [{ address: mockInternalAccount.address, chainId: 1 }],
+      };
+
+      const testController = new RewardsController({
+        messenger: mockMessenger,
+        state: {
+          ...getRewardsControllerDefaultState(),
+          subscriptions: {
+            [mockSubscriptionId]: mockSubscription,
+          },
+        },
+      });
+
+      // Spy on performSilentAuth to mock its behavior
+      const performSilentAuthSpy = jest
+        .spyOn(testController, 'performSilentAuth')
+        .mockResolvedValue(mockSubscriptionId);
+
+      mockToHex.mockReturnValue('0xsignature');
+      mockMessenger.call.mockImplementation((method, ..._args): any => {
+        if (method === 'KeyringController:signPersonalMessage') {
+          return Promise.resolve('0xsignature');
+        } else if (method === 'RewardsDataService:mobileJoin') {
+          return Promise.reject(mockError);
+        } else if (method === 'RewardsDataService:login') {
+          return Promise.resolve({
+            subscription: mockSubscription,
+            sessionId: 'recovered-session-id',
+          });
+        }
+        return Promise.resolve();
+      });
+
+      mockGetSubscriptionToken.mockResolvedValue({
+        success: true,
+        token: 'recovered-session-id',
+      });
+
+      // Act
+      const result = await testController.linkAccountToSubscriptionCandidate(
+        mockInternalAccount,
+      );
+
+      // Assert
+      expect(result).toBe(true);
+      expect(mockMessenger.call).toHaveBeenCalledWith(
+        'RewardsDataService:mobileJoin',
+        {
+          account: mockInternalAccount.address,
+          timestamp: expect.any(Number),
+          signature: '0xsignature',
+        },
+        mockSubscriptionId,
+      );
+      expect(performSilentAuthSpy).toHaveBeenCalledWith(
+        mockInternalAccount,
+        false,
+        false,
+      );
+    });
   });
 
   describe('linkAccountsToSubscriptionCandidate', () => {
@@ -9708,6 +9812,7 @@ describe('RewardsController', () => {
       // Clear any previous calls and mock only the accounts call
       mockMessenger.call.mockClear();
       mockMessenger.call.mockReturnValueOnce(mockAccounts as any);
+      mockMessenger.call.mockResolvedValueOnce({ ois: [false], sids: [null] });
 
       // Act
       const result = await testController.getOptInStatus(mockParams);
@@ -9719,11 +9824,10 @@ describe('RewardsController', () => {
       });
 
       // Verify that only the accounts call was made, not the service call since we used cached data
-      expect(mockMessenger.call).toHaveBeenCalledTimes(1);
       expect(mockMessenger.call).toHaveBeenCalledWith(
         'AccountsController:listMultichainAccounts',
       );
-      expect(mockMessenger.call).not.toHaveBeenCalledWith(
+      expect(mockMessenger.call).toHaveBeenCalledWith(
         'RewardsDataService:getOptInStatus',
         expect.anything(),
       );
@@ -9763,6 +9867,7 @@ describe('RewardsController', () => {
 
               perpsFeeDiscount: null,
               lastPerpsDiscountRateFetched: null,
+              lastFreshOptInStatusCheck: null,
             },
           },
         },
@@ -9786,6 +9891,7 @@ describe('RewardsController', () => {
       expect(updatedAccountState).toBeDefined();
       expect(updatedAccountState.hasOptedIn).toBe(true);
       expect(updatedAccountState.subscriptionId).toBe('fresh_sub_123');
+      expect(updatedAccountState.lastFreshOptInStatusCheck).toBeDefined();
     });
 
     it('should use cached results in final combination loop', async () => {
@@ -9846,6 +9952,7 @@ describe('RewardsController', () => {
               subscriptionId: 'cached_sub_123',
               perpsFeeDiscount: null,
               lastPerpsDiscountRateFetched: null,
+              lastFreshOptInStatusCheck: Date.now(),
             },
             // Second account has cached data
             'eip155:1:0x456': {
@@ -9854,6 +9961,7 @@ describe('RewardsController', () => {
               subscriptionId: null,
               perpsFeeDiscount: null,
               lastPerpsDiscountRateFetched: null,
+              lastFreshOptInStatusCheck: Date.now(),
             },
             // Third account has no cached data, will need fresh API call
           },
@@ -12820,6 +12928,7 @@ describe('RewardsController', () => {
         subscriptionId: 'sub-1',
         perpsFeeDiscount: 500,
         lastPerpsDiscountRateFetched: Date.now(),
+        lastFreshOptInStatusCheck: Date.now(),
       };
 
       const accountState2: RewardsAccountState = {
@@ -12828,6 +12937,7 @@ describe('RewardsController', () => {
         subscriptionId: null,
         perpsFeeDiscount: 0,
         lastPerpsDiscountRateFetched: Date.now(),
+        lastFreshOptInStatusCheck: Date.now(),
       };
 
       const accountState3: RewardsAccountState = {
@@ -12836,6 +12946,7 @@ describe('RewardsController', () => {
         subscriptionId: 'sub-3',
         perpsFeeDiscount: 1000,
         lastPerpsDiscountRateFetched: Date.now(),
+        lastFreshOptInStatusCheck: Date.now(),
       };
 
       controller = new RewardsController({
@@ -12960,6 +13071,7 @@ describe('RewardsController', () => {
         subscriptionId: null,
         perpsFeeDiscount: 0,
         lastPerpsDiscountRateFetched: Date.now(),
+        lastFreshOptInStatusCheck: Date.now(),
       };
 
       controller = new RewardsController({
@@ -13042,54 +13154,6 @@ describe('RewardsController', () => {
       expect(result.addressesNeedingFresh).toEqual([]);
     });
 
-    it('should handle case-insensitive address matching', () => {
-      // Arrange
-      const addresses = [ADDRESS_1.toUpperCase(), ADDRESS_2.toLowerCase()];
-      const addressToAccountMap = new Map([
-        [ADDRESS_1.toLowerCase(), mockInternalAccount1],
-        [ADDRESS_2.toLowerCase(), mockInternalAccount2],
-      ]);
-
-      const accountState1: RewardsAccountState = {
-        account: CAIP_ACCOUNT_1,
-        hasOptedIn: true,
-        subscriptionId: 'sub-1',
-        perpsFeeDiscount: 500,
-        lastPerpsDiscountRateFetched: Date.now(),
-      };
-
-      const accountState2: RewardsAccountState = {
-        account: CAIP_ACCOUNT_2,
-        hasOptedIn: false,
-        subscriptionId: null,
-        perpsFeeDiscount: 0,
-        lastPerpsDiscountRateFetched: Date.now(),
-      };
-
-      controller = new RewardsController({
-        messenger: mockMessenger,
-        state: {
-          activeAccount: null,
-          accounts: {
-            [CAIP_ACCOUNT_1]: accountState1,
-            [CAIP_ACCOUNT_2]: accountState2,
-          },
-          subscriptions: {},
-        },
-      });
-
-      // Act
-      const result = controller.checkOptInStatusAgainstCache(
-        addresses,
-        addressToAccountMap,
-      );
-
-      // Assert
-      expect(result.cachedOptInResults).toEqual([true, false]);
-      expect(result.cachedSubscriptionIds).toEqual(['sub-1', null]);
-      expect(result.addressesNeedingFresh).toEqual([]);
-    });
-
     it('should handle convertInternalAccountToCaipAccountId returning null', () => {
       // Arrange
       const addresses = [ADDRESS_1, ADDRESS_2];
@@ -13153,6 +13217,7 @@ describe('RewardsController', () => {
         subscriptionId: 'sub-1',
         perpsFeeDiscount: 500,
         lastPerpsDiscountRateFetched: Date.now(),
+        lastFreshOptInStatusCheck: Date.now(),
       };
 
       const accountState2: RewardsAccountState = {
@@ -13161,6 +13226,7 @@ describe('RewardsController', () => {
         subscriptionId: null,
         perpsFeeDiscount: 0,
         lastPerpsDiscountRateFetched: Date.now(),
+        lastFreshOptInStatusCheck: Date.now(),
       };
 
       const accountState3: RewardsAccountState = {
@@ -13169,6 +13235,7 @@ describe('RewardsController', () => {
         subscriptionId: 'sub-3',
         perpsFeeDiscount: 1000,
         lastPerpsDiscountRateFetched: Date.now(),
+        lastFreshOptInStatusCheck: Date.now(),
       };
 
       controller = new RewardsController({

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -664,7 +664,7 @@ export class RewardsController extends BaseController<
   /**
    * Check if silent authentication should be skipped
    */
-  #shouldSkipSilentAuth(
+  shouldSkipSilentAuth(
     account: CaipAccountId,
     internalAccount: InternalAccount,
   ): boolean {
@@ -763,7 +763,7 @@ export class RewardsController extends BaseController<
       this.convertInternalAccountToCaipAccountId(internalAccount);
 
     const shouldSkip = account
-      ? this.#shouldSkipSilentAuth(account, internalAccount)
+      ? this.shouldSkipSilentAuth(account, internalAccount)
       : false;
 
     if (shouldSkip && respectSkipSilentAuth) {

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -51,6 +51,7 @@ import { signSolanaRewardsMessage } from './utils/solana-snap';
 import {
   AuthorizationFailedError,
   InvalidTimestampError,
+  AccountAlreadyRegisteredError,
 } from './services/rewards-data-service';
 import { sortAccounts } from './utils/sortAccounts';
 
@@ -78,6 +79,9 @@ const UNLOCKED_REWARDS_CACHE_THRESHOLD_MS = 1000 * 60 * 1; // 1 minute
 
 // Points events cache threshold (first page only)
 const POINTS_EVENTS_CACHE_THRESHOLD_MS = 1000 * 60 * 1; // 1 minute cache
+
+// Opt-in status stale threshold for not opted-in accounts to force a fresh check
+const NOT_OPTED_IN_OIS_STALE_CACHE_THRESHOLD_MS = 1000 * 60 * 60 * 24; // 24 hours
 
 /**
  * State metadata for the RewardsController
@@ -636,22 +640,13 @@ export class RewardsController extends BaseController<
         const sortedAccounts = sortAccounts(accounts);
 
         // Try silent auth on each account until one succeeds
-        let success = false;
         for (const account of sortedAccounts) {
           try {
-            const subscriptionId = await this.performSilentAuth(
-              account,
-              true,
-              true,
-            );
-            success = !!subscriptionId;
+            await this.performSilentAuth(account, true, true);
             break; // Stop on first success
           } catch {
             // Continue to next account
           }
-        }
-        if (!success && sortedAccounts.length > 1) {
-          throw new Error('Silent auth failed for all accounts');
         }
       }
     } catch (error) {
@@ -678,6 +673,16 @@ export class RewardsController extends BaseController<
 
     const accountState = this.#getAccountState(account);
     if (accountState) {
+      if (accountState.hasOptedIn === false) {
+        if (!accountState.lastFreshOptInStatusCheck) {
+          return false;
+        }
+
+        return (
+          Date.now() - accountState.lastFreshOptInStatusCheck <=
+          NOT_OPTED_IN_OIS_STALE_CACHE_THRESHOLD_MS
+        );
+      }
       return true;
     }
 
@@ -788,15 +793,51 @@ export class RewardsController extends BaseController<
           }
         });
       }
-      Logger.log(
-        'RewardsController: Skipping for account (likely authenticated & within grace period)',
-        account,
-      );
       return accountState?.subscriptionId || null;
     }
 
     let subscription: SubscriptionDto | null = null;
     let authUnexpectedError = false;
+
+    if (respectSkipSilentAuth && !shouldSkip) {
+      // First, check opt-in status before attempting login
+      try {
+        const optInStatusResult = await this.getOptInStatus({
+          addresses: [internalAccount.address],
+        });
+
+        // Check if the account has not opted in (result is false)
+        if (optInStatusResult.ois && optInStatusResult.ois[0] === false) {
+          Logger.log(
+            'RewardsController: Account has not opted in, skipping silent auth',
+            internalAccount.address,
+          );
+          // Account hasn't opted in, don't proceed with login
+          subscription = null;
+          // Update state to reflect not opted in
+          this.update((state: RewardsControllerState) => {
+            if (!account) {
+              return;
+            }
+            const accountState: RewardsAccountState = {
+              account,
+              hasOptedIn: false,
+              subscriptionId: null,
+              perpsFeeDiscount: null,
+              lastPerpsDiscountRateFetched: null,
+              lastFreshOptInStatusCheck: Date.now(),
+            };
+            state.accounts[account] = accountState;
+            if (shouldBecomeActiveAccount) {
+              state.activeAccount = accountState;
+            }
+          });
+          return null;
+        }
+      } catch {
+        // Continue with silent login attempt
+      }
+    }
 
     try {
       // Generate timestamp and sign the message
@@ -907,6 +948,7 @@ export class RewardsController extends BaseController<
           subscriptionId: subscription?.id || null,
           perpsFeeDiscount: null, // Default value, will be updated when fetched
           lastPerpsDiscountRateFetched: null,
+          lastFreshOptInStatusCheck: Date.now(),
         };
         state.accounts[account] = accountState;
         if (shouldBecomeActiveAccount) {
@@ -1047,6 +1089,21 @@ export class RewardsController extends BaseController<
         if (caipAccount) {
           const accountState = this.#getAccountState(caipAccount);
           if (accountState?.hasOptedIn !== undefined) {
+            // Check if account is not opted in and needs a recheck
+            const shouldRecheckFreshIfNotOptedIn =
+              !accountState.lastFreshOptInStatusCheck ||
+              Date.now() - accountState.lastFreshOptInStatusCheck >
+                NOT_OPTED_IN_OIS_STALE_CACHE_THRESHOLD_MS;
+
+            if (
+              accountState.hasOptedIn === false &&
+              shouldRecheckFreshIfNotOptedIn
+            ) {
+              // Force a fresh check for this not-opted-in account
+              addressesNeedingFresh.push(address);
+              continue;
+            }
+
             // Use cached data
             cachedOptInResults[i] = accountState.hasOptedIn;
             cachedSubscriptionIds[i] = accountState.subscriptionId || null;
@@ -1075,10 +1132,11 @@ export class RewardsController extends BaseController<
     const rewardsEnabled = selectRewardsEnabledFlag(store.getState());
     if (!rewardsEnabled) {
       // Return empty arrays when feature flag is disabled
-      return {
+      const result = {
         ois: params.addresses.map(() => false),
         sids: params.addresses.map(() => null),
       };
+      return result;
     }
 
     try {
@@ -1139,6 +1197,7 @@ export class RewardsController extends BaseController<
             const caipAccount =
               this.convertInternalAccountToCaipAccountId(internalAccount);
             if (caipAccount) {
+              const lastFreshOptInStatusCheck = Date.now();
               this.update((state: RewardsControllerState) => {
                 // Update or create account state with fresh opt-in status and subscription ID
                 if (!state.accounts[caipAccount]) {
@@ -1148,15 +1207,20 @@ export class RewardsController extends BaseController<
                     subscriptionId,
                     perpsFeeDiscount: null,
                     lastPerpsDiscountRateFetched: null,
+                    lastFreshOptInStatusCheck,
                   };
                 } else {
                   state.accounts[caipAccount].hasOptedIn = hasOptedIn;
                   state.accounts[caipAccount].subscriptionId = subscriptionId;
+                  state.accounts[caipAccount].lastFreshOptInStatusCheck =
+                    lastFreshOptInStatusCheck;
                 }
 
                 if (state.activeAccount?.account === caipAccount) {
                   state.activeAccount.hasOptedIn = hasOptedIn;
                   state.activeAccount.subscriptionId = subscriptionId;
+                  state.activeAccount.lastFreshOptInStatusCheck =
+                    lastFreshOptInStatusCheck;
                 }
               });
             }
@@ -1630,6 +1694,7 @@ export class RewardsController extends BaseController<
           perpsFeeDiscount: null,
           hasOptedIn: false,
           subscriptionId: null,
+          lastFreshOptInStatusCheck: null,
           account: state.activeAccount.account, // Ensure account is always present (never undefined)
         };
       }
@@ -1842,6 +1907,29 @@ export class RewardsController extends BaseController<
           signature = await this.#signRewardsMessage(account, timestamp);
           return await executeMobileOptin(timestamp, signature);
         }
+
+        // Check if it's an AccountAlreadyRegisteredError
+        if (error instanceof AccountAlreadyRegisteredError) {
+          // Try to perform silent auth for this account
+          const subscriptionId = await this.performSilentAuth(
+            account,
+            false,
+            false,
+          );
+
+          // If silent auth returned a subscription ID, recover with login response
+          if (subscriptionId && this.state.subscriptions[subscriptionId]) {
+            const subscription = this.state.subscriptions[subscriptionId];
+            const tokenResult = await getSubscriptionToken(subscriptionId);
+            if (tokenResult.success && tokenResult.token) {
+              return {
+                sessionId: tokenResult.token,
+                subscription,
+              };
+            }
+          }
+        }
+
         throw error;
       }
     };
@@ -1925,6 +2013,7 @@ export class RewardsController extends BaseController<
             subscriptionId: null,
             perpsFeeDiscount: null,
             lastPerpsDiscountRateFetched: null,
+            lastFreshOptInStatusCheck: null,
           };
         }
       });
@@ -2287,6 +2376,21 @@ export class RewardsController extends BaseController<
             signature = await this.#signRewardsMessage(account, timestamp);
             return await executeMobileJoin(timestamp, signature);
           }
+
+          if (error instanceof AccountAlreadyRegisteredError) {
+            // Try to perform silent auth for this account
+            const subscriptionId = await this.performSilentAuth(
+              account,
+              false,
+              false,
+            );
+
+            // If silent auth returned a subscription ID, return the subscription from cache
+            if (subscriptionId && this.state.subscriptions[subscriptionId]) {
+              return this.state.subscriptions[subscriptionId];
+            }
+          }
+
           throw error;
         }
       };
@@ -2416,13 +2520,16 @@ export class RewardsController extends BaseController<
    */
   async optOut(subscriptionId: string): Promise<boolean> {
     try {
-      // Check if subscription exists in our map
+      // Check if subscription exists in our map or in any of the accounts
       if (!this.state.subscriptions[subscriptionId]) {
-        Logger.log(
-          'RewardsController: Subscription not found in map',
-          subscriptionId,
-        );
-        return false;
+        const matchingAccount = this.state.accounts
+          ? Object.values(this.state.accounts).find(
+              (account) => account.subscriptionId === subscriptionId,
+            )
+          : null;
+        if (!matchingAccount) {
+          return false;
+        }
       }
 
       // Call the opt-out endpoint
@@ -2442,6 +2549,7 @@ export class RewardsController extends BaseController<
               subscriptionId: null,
               perpsFeeDiscount: null,
               lastPerpsDiscountRateFetched: null,
+              lastFreshOptInStatusCheck: null,
             };
           }
         });

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
@@ -1,6 +1,7 @@
 import {
   InvalidTimestampError,
   AuthorizationFailedError,
+  AccountAlreadyRegisteredError,
   RewardsDataService,
   type RewardsDataServiceMessenger,
 } from './rewards-data-service';
@@ -218,6 +219,80 @@ describe('RewardsDataService', () => {
         );
         expect((error as InvalidTimestampError).timestamp).toBe(1234567000); // Server timestamp in seconds
       }
+    });
+
+    it('throws AccountAlreadyRegisteredError when 409 response with already registered message', async () => {
+      // Arrange
+      const mockErrorResponse = {
+        ok: false,
+        status: 409,
+        json: jest
+          .fn()
+          .mockResolvedValue({ message: 'Account is already registered' }),
+      } as unknown as Response;
+      mockFetch.mockResolvedValue(mockErrorResponse);
+
+      // Act & Assert
+      try {
+        await service.mobileJoin(
+          mockJoinRequest as MobileLoginDto,
+          mockSubscriptionId,
+        );
+        fail('Expected AccountAlreadyRegisteredError to be thrown');
+      } catch (error) {
+        expect((error as AccountAlreadyRegisteredError).name).toBe(
+          'AccountAlreadyRegisteredError',
+        );
+        expect((error as AccountAlreadyRegisteredError).message).toBe(
+          'Account is already registered',
+        );
+      }
+    });
+
+    it('throws AccountAlreadyRegisteredError when 409 response with lowercase already registered message', async () => {
+      // Arrange
+      const mockErrorResponse = {
+        ok: false,
+        status: 409,
+        json: jest.fn().mockResolvedValue({
+          message: 'User is already registered with this account',
+        }),
+      } as unknown as Response;
+      mockFetch.mockResolvedValue(mockErrorResponse);
+
+      // Act & Assert
+      try {
+        await service.mobileJoin(
+          mockJoinRequest as MobileLoginDto,
+          mockSubscriptionId,
+        );
+        fail('Expected AccountAlreadyRegisteredError to be thrown');
+      } catch (error) {
+        expect((error as AccountAlreadyRegisteredError).name).toBe(
+          'AccountAlreadyRegisteredError',
+        );
+        expect((error as AccountAlreadyRegisteredError).message).toBe(
+          'User is already registered with this account',
+        );
+      }
+    });
+
+    it('throws generic error when 409 response without already registered message', async () => {
+      // Arrange
+      const mockErrorResponse = {
+        ok: false,
+        status: 409,
+        json: jest.fn().mockResolvedValue({ message: 'Conflict error' }),
+      } as unknown as Response;
+      mockFetch.mockResolvedValue(mockErrorResponse);
+
+      // Act & Assert
+      await expect(
+        service.mobileJoin(
+          mockJoinRequest as MobileLoginDto,
+          mockSubscriptionId,
+        ),
+      ).rejects.toThrow('Mobile join failed: 409 Conflict error');
     });
   });
 
@@ -1482,6 +1557,71 @@ describe('RewardsDataService', () => {
         );
         expect((error as InvalidTimestampError).timestamp).toBe(1234567000); // Server timestamp in seconds
       }
+    });
+
+    it('throws AccountAlreadyRegisteredError when 409 response with already registered message', async () => {
+      // Arrange
+      const mockErrorResponse = {
+        ok: false,
+        status: 409,
+        json: jest
+          .fn()
+          .mockResolvedValue({ message: 'Account is already registered' }),
+      } as unknown as Response;
+      mockFetch.mockResolvedValue(mockErrorResponse);
+
+      // Act & Assert
+      try {
+        await service.mobileOptin(mockOptinRequest);
+        fail('Expected AccountAlreadyRegisteredError to be thrown');
+      } catch (error) {
+        expect((error as AccountAlreadyRegisteredError).name).toBe(
+          'AccountAlreadyRegisteredError',
+        );
+        expect((error as AccountAlreadyRegisteredError).message).toBe(
+          'Account is already registered',
+        );
+      }
+    });
+
+    it('throws AccountAlreadyRegisteredError when 409 response with uppercase already registered message', async () => {
+      // Arrange
+      const mockErrorResponse = {
+        ok: false,
+        status: 409,
+        json: jest.fn().mockResolvedValue({
+          message: 'User is ALREADY REGISTERED with this account',
+        }),
+      } as unknown as Response;
+      mockFetch.mockResolvedValue(mockErrorResponse);
+
+      // Act & Assert
+      try {
+        await service.mobileOptin(mockOptinRequest);
+        fail('Expected AccountAlreadyRegisteredError to be thrown');
+      } catch (error) {
+        expect((error as AccountAlreadyRegisteredError).name).toBe(
+          'AccountAlreadyRegisteredError',
+        );
+        expect((error as AccountAlreadyRegisteredError).message).toBe(
+          'User is ALREADY REGISTERED with this account',
+        );
+      }
+    });
+
+    it('throws generic error when 409 response without already registered message', async () => {
+      // Arrange
+      const mockErrorResponse = {
+        ok: false,
+        status: 409,
+        json: jest.fn().mockResolvedValue({ message: 'Conflict error' }),
+      } as unknown as Response;
+      mockFetch.mockResolvedValue(mockErrorResponse);
+
+      // Act & Assert
+      await expect(service.mobileOptin(mockOptinRequest)).rejects.toThrow(
+        'Optin failed: 409',
+      );
     });
 
     it('should handle network errors during optin', async () => {

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.ts
@@ -49,6 +49,16 @@ export class AuthorizationFailedError extends Error {
   }
 }
 
+/**
+ * Custom error for account already registered (409 conflict)
+ */
+export class AccountAlreadyRegisteredError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AccountAlreadyRegisteredError';
+  }
+}
+
 const SERVICE_NAME = 'RewardsDataService';
 
 // Default timeout for all API requests (10 seconds)
@@ -366,6 +376,27 @@ export class RewardsDataService {
   }
 
   /**
+   * Check if the error response is a 409 conflict with "already registered" message
+   * and throw AccountAlreadyRegisteredError if so.
+   * @param response - The HTTP response object
+   * @param errorData - The parsed error data from the response
+   * @private
+   */
+  private checkForAccountAlreadyRegisteredError(
+    response: Response,
+    errorData: { message?: string },
+  ): void {
+    if (
+      response.status === 409 &&
+      errorData?.message?.toLowerCase().includes('already registered')
+    ) {
+      throw new AccountAlreadyRegisteredError(
+        errorData.message || 'Account is already registered',
+      );
+    }
+  }
+
+  /**
    * Perform login via signature for the current account.
    * @param body - The login request body containing account, timestamp, and signature.
    * @returns The login response DTO.
@@ -392,6 +423,9 @@ export class RewardsDataService {
           Math.floor(Number(errorData.serverTimestamp) / 1000),
         );
       }
+
+      this.checkForAccountAlreadyRegisteredError(response, errorData);
+
       throw new Error(`Login failed: ${response.status}`);
     }
 
@@ -537,6 +571,9 @@ export class RewardsDataService {
           Math.floor(Number(errorData.serverTimestamp) / 1000),
         );
       }
+
+      this.checkForAccountAlreadyRegisteredError(response, errorData);
+
       throw new Error(`Optin failed: ${response.status}`);
     }
 
@@ -706,6 +743,9 @@ export class RewardsDataService {
           Math.floor(Number(errorData.serverTimestamp) / 1000),
         );
       }
+
+      this.checkForAccountAlreadyRegisteredError(response, errorData);
+
       throw new Error(
         `Mobile join failed: ${response.status} ${errorData?.message || ''}`,
       );

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -614,6 +614,7 @@ export type RewardsAccountState = {
   subscriptionId: string | null;
   perpsFeeDiscount: number | null;
   lastPerpsDiscountRateFetched: number | null;
+  lastFreshOptInStatusCheck?: number | null;
 };
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions


### PR DESCRIPTION
## **Description**

If for some reason the rewards controller cache is out of sync with the backend state for opted in accounts, then it's not possible right now to get this fixed. So if users try to opt in or add an account that is already opted, then they'll receive an error but the controller doesn't update its local cache. This isn't a big problem now but once we get multiple sources of truth for opted (i.e. mobile & extension) then we need the controller to be smarter in:

- Detecting error codes from backend when opting in and linking accounts, and updating its cache.
- When doing the OIS check to determine opt in status, it needs to do a fresh check daily at most for not opted in accounts.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/21519

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves rewards auth/opt-in reliability by detecting stale opt-in cache, skipping unnecessary silent auth, and recovering from already-registered errors; also switches dashboard modal triggers to focus lifecycle.
> 
> - **Rewards Controller**:
>   - Add `lastFreshOptInStatusCheck` to `RewardsAccountState` and recheck not-opted-in accounts after 24h; populate on fresh OIS/login flows.
>   - Expose and enhance `shouldSkipSilentAuth` to skip when cache is fresh; `performSilentAuth` now pre-checks opt-in status and avoids login for non–opted-in accounts.
>   - Update `getOptInStatus` to mix cached + fresh results and stamp cache times; force fresh checks for stale not-opted-in entries.
>   - Handle `AccountAlreadyRegisteredError` in `optIn`/`mobileJoin` flows by performing silent auth to recover and hydrate local cache.
>   - Relax `optOut` to succeed when subscription exists only via account state; ensure resets also clear `lastFreshOptInStatusCheck` and never unset `activeAccount.account`.
>   - Minor: auth trigger flow, cache invalidation, and logging tweaks.
> - **Data Service**:
>   - Introduce `AccountAlreadyRegisteredError` (409) and surface from `login`, `mobileOptin`, `mobileJoin`.
>   - Shared helper to detect 409 “already registered” responses.
> - **UI**:
>   - Switch rewards dashboard modal auto-trigger from `useEffect` to `useFocusEffect` for screen-focus-driven behavior.
> - **Types/Tests**:
>   - Extend types for new timestamp field; add/adjust extensive tests for OIS cache freshness, silent auth behavior, recovery on already-registered, and opt-out edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 118c9f272c45cabb26471ae8aacbcb51da8a444e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->