### PR TITLE
fix: unresponsive perps card

### DIFF
--- a/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
@@ -21,7 +21,6 @@ import { MetaMetricsEvents } from '../../../../hooks/useMetrics';
 import PerpsBottomSheetTooltip from '../../components/PerpsBottomSheetTooltip';
 import PerpsCard from '../../components/PerpsCard';
 import { PerpsTabControlBar } from '../../components/PerpsTabControlBar';
-import TempTouchableOpacity from '../../../../../component-library/components-temp/TempTouchableOpacity';
 import {
   PerpsEventProperties,
   PerpsEventValues,
@@ -40,6 +39,10 @@ import styleSheet from './PerpsTabView.styles';
 
 import Skeleton from '../../../../../component-library/components/Skeleton/Skeleton';
 import { PerpsEmptyState } from '../PerpsEmptyState';
+import {
+  TouchablePerpsComponent,
+  useCoordinatedPress,
+} from '../../components/PressablePerpsComponent/PressablePerpsComponent';
 
 interface PerpsTabViewProps {}
 
@@ -50,6 +53,8 @@ const PerpsTabView: React.FC<PerpsTabViewProps> = () => {
 
   const navigation = useNavigation<NavigationProp<PerpsNavigationParamList>>();
   const { account } = usePerpsLiveAccount();
+
+  const coordinatedPress = useCoordinatedPress();
 
   const { positions, isInitialLoading } = usePerpsLivePositions({
     throttleMs: 1000, // Update positions every second
@@ -111,12 +116,15 @@ const PerpsTabView: React.FC<PerpsTabViewProps> = () => {
     }
   }, [navigation, isFirstTimeUser]);
 
+  // const memoizedPressHandler = useCallback(() => {
+  //   handleNewTrade();
+  // }, [handleNewTrade]);
   const memoizedPressHandler = useCallback(() => {
-    handleNewTrade();
-  }, [handleNewTrade]);
+    coordinatedPress(handleNewTrade);
+  }, [coordinatedPress, handleNewTrade]);
 
   const renderStartTradeCTA = () => (
-    <TempTouchableOpacity
+    <TouchablePerpsComponent
       style={styles.startTradeCTA}
       onPress={memoizedPressHandler}
       testID={PerpsTabViewSelectorsIDs.START_NEW_TRADE_CTA}
@@ -133,7 +141,7 @@ const PerpsTabView: React.FC<PerpsTabViewProps> = () => {
           {strings('perps.position.list.start_new_trade')}
         </Text>
       </View>
-    </TempTouchableOpacity>
+    </TouchablePerpsComponent>
   );
 
   const renderOrdersSection = () => {

--- a/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
+++ b/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
@@ -18,7 +18,10 @@ import { usePerpsMarkets } from '../../hooks/usePerpsMarkets';
 import PerpsTokenLogo from '../PerpsTokenLogo';
 import styleSheet from './PerpsCard.styles';
 import type { PerpsCardProps } from './PerpsCard.types';
-import TempTouchableOpacity from '../../../../../component-library/components-temp/TempTouchableOpacity';
+import {
+  useCoordinatedPress,
+  TouchablePerpsComponent,
+} from '../PressablePerpsComponent/PressablePerpsComponent';
 
 /**
  * PerpsCard Component
@@ -35,6 +38,8 @@ const PerpsCard: React.FC<PerpsCardProps> = ({
 }) => {
   const { styles } = useStyles(styleSheet, {});
   const navigation = useNavigation<NavigationProp<PerpsNavigationParamList>>();
+
+  const coordinatedPress = useCoordinatedPress();
 
   // Determine which type of data we have
   const symbol = position?.coin || order?.symbol || '';
@@ -95,15 +100,15 @@ const PerpsCard: React.FC<PerpsCardProps> = ({
   }, [onPress, markets, symbol, navigation, order, position, source]);
 
   const memoizedPressHandler = useCallback(() => {
-    handlePress();
-  }, [handlePress]);
+    coordinatedPress(handlePress);
+  }, [coordinatedPress, handlePress]);
 
   if (!position && !order) {
     return null;
   }
 
   return (
-    <TempTouchableOpacity
+    <TouchablePerpsComponent
       style={styles.card}
       activeOpacity={0.7}
       onPress={memoizedPressHandler}
@@ -139,7 +144,7 @@ const PerpsCard: React.FC<PerpsCardProps> = ({
           </Text>
         </View>
       </View>
-    </TempTouchableOpacity>
+    </TouchablePerpsComponent>
   );
 };
 

--- a/app/components/UI/Perps/components/PressablePerpsComponent/PressablePerpsComponent.tsx
+++ b/app/components/UI/Perps/components/PressablePerpsComponent/PressablePerpsComponent.tsx
@@ -1,7 +1,10 @@
-import { Platform, TouchableOpacity as RNTouchableOpacity } from 'react-native';
-
-import { useCallback, useRef } from 'react';
-import TempTouchableOpacity from '../../../../../component-library/components-temp/TempTouchableOpacity';
+import React, { useCallback, useRef, useState, useEffect } from 'react';
+import {
+  Platform,
+  TouchableOpacity as RNTouchableOpacity,
+  GestureResponderEvent,
+  AccessibilityInfo,
+} from 'react-native';
 
 /**
  * TouchablePerpsComponent - Platform-specific TouchableOpacity for Perps components
@@ -9,20 +12,23 @@ import TempTouchableOpacity from '../../../../../component-library/components-te
  * WHY THIS IS NECESSARY:
  *
  * This addresses a known React Native bug where TouchableOpacity components inside ScrollViews
- * on Android often fail to respond to touch events. This is a common issue with React Native's
- * new architecture update that affects scrollable views on Android.
+ * on Android often fail to respond to touch events after scrolling. Cards work on load but
+ * become unresponsive after scroll gestures.
  *
  * The issue is documented in this outstanding Facebook PR:
  * https://github.com/facebook/react-native/pull/51835
  *
  * SOLUTION APPROACH:
  *
- * 1. Use Android-specific TouchableOpacity (from ButtonBase) in production Android environments
- * - This TouchableOpacity has built-in press coordination logic
- * 2. Use standard TouchableOpacity in test environments to prevent E2E test failures
- * 3. Replicate ButtonBase's conditional press logic for consistent behavior
+ * 1. Custom AndroidTouchableOpacity with optimized thresholds on Android
+ * - MAX_DURATION: 500ms (vs 150ms default) - allows longer touches
+ * - MAX_MOVEMENT: 25px (vs 5px default) - allows more finger movement
+ * - MAX_VELOCITY: 0.3 px/ms (vs 0.2 default) - more restrictive for scroll detection
+ * - These thresholds prevent accidental taps while scrolling
+ * 2. Use standard TouchableOpacity on iOS and in test environments
+ * 3. Maintains accessibility support and TalkBack compatibility
  *
- * This is a temporary workaround until React Native fixes the underlying issue on their side.
+ * This is a temporary workaround until React Native fixes the underlying issue.
  *
  * REFERENCE:
  * - React Native Issue: https://github.com/facebook/react-native/pull/51835
@@ -32,11 +38,148 @@ import TempTouchableOpacity from '../../../../../component-library/components-te
 const isE2ETest =
   process.env.IS_TEST === 'true' || process.env.METAMASK_ENVIRONMENT === 'e2e';
 const isUnitTest = process.env.NODE_ENV === 'test';
+const isTestEnvironment = isE2ETest || isUnitTest;
 
-export const TouchablePerpsComponent =
-  Platform.OS === 'android' && !isE2ETest && !isUnitTest
-    ? TempTouchableOpacity
-    : RNTouchableOpacity;
+// Custom Android TouchableOpacity with less sensitive thresholds
+const AndroidTouchableOpacity = ({
+  onPress,
+  onPressIn,
+  onPressOut,
+  children,
+  ...props
+}: React.ComponentProps<typeof RNTouchableOpacity>) => {
+  const [isAccessibilityEnabled, setIsAccessibilityEnabled] = useState(false);
+  const touchStartRef = useRef<{ time: number; x: number; y: number } | null>(
+    null,
+  );
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    if (isTestEnvironment) {
+      setIsAccessibilityEnabled(false);
+      return;
+    }
+
+    if (!AccessibilityInfo?.isScreenReaderEnabled) {
+      setIsAccessibilityEnabled(false);
+      return;
+    }
+
+    AccessibilityInfo.isScreenReaderEnabled()
+      .then(setIsAccessibilityEnabled)
+      .catch(() => setIsAccessibilityEnabled(false));
+
+    if (AccessibilityInfo.addEventListener) {
+      const subscription = AccessibilityInfo.addEventListener(
+        'screenReaderChanged',
+        setIsAccessibilityEnabled,
+      );
+      return () => subscription?.remove();
+    }
+  }, []);
+
+  const handlePressIn = (pressEvent: GestureResponderEvent) => {
+    if (onPressIn) {
+      onPressIn(pressEvent);
+    }
+
+    if (!isAccessibilityEnabled && onPress) {
+      touchStartRef.current = {
+        time: Date.now(),
+        x: pressEvent.nativeEvent.locationX,
+        y: pressEvent.nativeEvent.locationY,
+      };
+
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+
+      timeoutRef.current = setTimeout(() => {
+        // This will be cancelled by onPressOut if it's a real tap
+      }, 50);
+    }
+  };
+
+  const handlePressOut = (pressEvent: GestureResponderEvent) => {
+    if (!isAccessibilityEnabled && onPress && touchStartRef.current) {
+      const now = Date.now();
+      const duration = now - touchStartRef.current.time;
+      const deltaX = Math.abs(
+        pressEvent.nativeEvent.locationX - touchStartRef.current.x,
+      );
+      const deltaY = Math.abs(
+        pressEvent.nativeEvent.locationY - touchStartRef.current.y,
+      );
+
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+
+      // Less sensitive thresholds for better scroll experience
+      const MAX_DURATION = 900; // Increased from 300ms to 900ms
+      const MAX_MOVEMENT = 50; // Increased from 15px to 25px
+      const velocity = Math.sqrt(deltaX * deltaX + deltaY * deltaY) / duration;
+      const MAX_VELOCITY = 0.3; // Decreased from 0.5 to 0.3 px/ms (more restrictive)
+
+      if (
+        duration < MAX_DURATION &&
+        deltaX < MAX_MOVEMENT &&
+        deltaY < MAX_MOVEMENT &&
+        velocity < MAX_VELOCITY
+      ) {
+        onPress(pressEvent);
+      }
+
+      touchStartRef.current = null;
+    }
+  };
+
+  useEffect(
+    () => () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    },
+    [],
+  );
+
+  let finalOnPress = onPress;
+  let finalOnPressIn = onPressIn;
+  let finalOnPressOut = onPressOut;
+
+  if (!isAccessibilityEnabled) {
+    finalOnPress = undefined;
+    finalOnPressIn = handlePressIn;
+    finalOnPressOut = handlePressOut;
+  }
+
+  return (
+    <RNTouchableOpacity
+      onPress={finalOnPress}
+      onPressIn={finalOnPressIn}
+      onPressOut={finalOnPressOut}
+      {...props}
+    >
+      {children}
+    </RNTouchableOpacity>
+  );
+};
+
+export const TouchablePerpsComponent = ({
+  children,
+  ...props
+}: React.ComponentProps<typeof RNTouchableOpacity>) => {
+  // Use custom Android TouchableOpacity with less sensitive thresholds
+  if (Platform.OS === 'android' && !isE2ETest && !isUnitTest) {
+    return (
+      <AndroidTouchableOpacity {...props}>{children}</AndroidTouchableOpacity>
+    );
+  }
+
+  // Use standard TouchableOpacity on iOS and in test environments
+  return <RNTouchableOpacity {...props}>{children}</RNTouchableOpacity>;
+};
 /**
  * useCoordinatedPress - Hook that replicates ButtonBase's press coordination logic
  *

--- a/app/components/UI/Perps/components/PressablePerpsComponent/PressablePerpsComponent.tsx
+++ b/app/components/UI/Perps/components/PressablePerpsComponent/PressablePerpsComponent.tsx
@@ -1,0 +1,67 @@
+import { Platform, TouchableOpacity as RNTouchableOpacity } from 'react-native';
+
+import { useCallback, useRef } from 'react';
+import TempTouchableOpacity from '../../../../../component-library/components-temp/TempTouchableOpacity';
+
+/**
+ * TouchablePerpsComponent - Platform-specific TouchableOpacity for Perps components
+ *
+ * WHY THIS IS NECESSARY:
+ *
+ * This addresses a known React Native bug where TouchableOpacity components inside ScrollViews
+ * on Android often fail to respond to touch events. This is a common issue with React Native's
+ * new architecture update that affects scrollable views on Android.
+ *
+ * The issue is documented in this outstanding Facebook PR:
+ * https://github.com/facebook/react-native/pull/51835
+ *
+ * SOLUTION APPROACH:
+ *
+ * 1. Use Android-specific TouchableOpacity (from ButtonBase) in production Android environments
+ * - This TouchableOpacity has built-in press coordination logic
+ * 2. Use standard TouchableOpacity in test environments to prevent E2E test failures
+ * 3. Replicate ButtonBase's conditional press logic for consistent behavior
+ *
+ * This is a temporary workaround until React Native fixes the underlying issue on their side.
+ *
+ * REFERENCE:
+ * - React Native Issue: https://github.com/facebook/react-native/pull/51835
+ */
+
+// Disable gesture wrapper in test environments to prevent test interference
+const isE2ETest =
+  process.env.IS_TEST === 'true' || process.env.METAMASK_ENVIRONMENT === 'e2e';
+const isUnitTest = process.env.NODE_ENV === 'test';
+
+export const TouchablePerpsComponent =
+  Platform.OS === 'android' && !isE2ETest && !isUnitTest
+    ? TempTouchableOpacity
+    : RNTouchableOpacity;
+/**
+ * useCoordinatedPress - Hook that replicates ButtonBase's press coordination logic
+ *
+ * This hook provides the exact same press coordination behavior as ButtonBase,
+ * including test environment handling and TalkBack compatibility.
+ */
+export const useCoordinatedPress = () => {
+  // Shared coordination system for maximum reliability
+  // Both custom TouchableOpacity and main component use the same timestamp reference
+  const lastPressTime = useRef(0);
+  const COORDINATION_WINDOW = 100; // 100ms window for TalkBack compatibility
+
+  return useCallback((onPress?: () => void) => {
+    // Skip coordination logic in test environments
+    if (process.env.NODE_ENV === 'test') {
+      onPress?.();
+      return;
+    }
+
+    const now = Date.now();
+    const timeSinceLastPress = now - lastPressTime.current;
+
+    if (onPress && timeSinceLastPress > COORDINATION_WINDOW) {
+      lastPressTime.current = now;
+      onPress();
+    }
+  }, []); // Empty dependency array - function never changes
+};

--- a/app/components/UI/Perps/components/PressablePerpsComponent/PressablePerpsComponent.tsx
+++ b/app/components/UI/Perps/components/PressablePerpsComponent/PressablePerpsComponent.tsx
@@ -21,9 +21,9 @@ import {
  * SOLUTION APPROACH:
  *
  * 1. Custom AndroidTouchableOpacity with optimized thresholds on Android
- * - MAX_DURATION: 500ms (vs 150ms default) - allows longer touches
- * - MAX_MOVEMENT: 25px (vs 5px default) - allows more finger movement
- * - MAX_VELOCITY: 0.3 px/ms (vs 0.2 default) - more restrictive for scroll detection
+ * - MAX_DURATION: 900ms (vs 150ms default) - allows much longer touches
+ * - MAX_MOVEMENT: 50px (vs 5px default) - allows significant finger movement
+ * - MAX_VELOCITY: 0.15 px/ms (vs 0.2 default) - very restrictive for scroll detection
  * - These thresholds prevent accidental taps while scrolling
  * 2. Use standard TouchableOpacity on iOS and in test environments
  * 3. Maintains accessibility support and TalkBack compatibility
@@ -116,11 +116,11 @@ const AndroidTouchableOpacity = ({
         timeoutRef.current = null;
       }
 
-      // Less sensitive thresholds for better scroll experience
-      const MAX_DURATION = 900; // Increased from 300ms to 900ms
-      const MAX_MOVEMENT = 50; // Increased from 15px to 25px
+      // Very conservative thresholds to prevent accidental taps while scrolling
+      const MAX_DURATION = 900; // Very long duration - only deliberate taps
+      const MAX_MOVEMENT = 50; // Large movement allowance - natural finger positioning
       const velocity = Math.sqrt(deltaX * deltaX + deltaY * deltaY) / duration;
-      const MAX_VELOCITY = 0.3; // Decreased from 0.5 to 0.3 px/ms (more restrictive)
+      const MAX_VELOCITY = 0.15; // Very restrictive velocity - distinguishes scrolls from taps
 
       if (
         duration < MAX_DURATION &&


### PR DESCRIPTION
## **Description**

Fixes issue where position list items were not pressable in the Perps tab. This was a regression from the TempTouchableOpacity work being done.

This is intended to be a surgical fix, which adds back in a memoized coordinated press handler to fix the issue only for the PerpsPositionCard component, which renders in the PerpsTab.

## **Changelog**

CHANGELOG entry: fix to coordinated press handler on PerpsPositionCard

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user want to view their position details
    Given the user has multiple positions open

    When user presses a position
    Then they are navigated to the proper position
```

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/4537402b-0d18-4fa4-b4fb-79505d900807

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces TempTouchableOpacity with a platform-aware TouchablePerpsComponent and coordinated press hook to fix unresponsive taps on Perps cards and CTA.
> 
> - **Perps UI**:
>   - **New pressable utilities** (`components/PressablePerpsComponent/PressablePerpsComponent.tsx`):
>     - Adds `TouchablePerpsComponent` with Android-specific touch thresholds and accessibility/test handling.
>     - Adds `useCoordinatedPress` to debounce/coordinate presses.
>   - **PerpsCard** (`components/PerpsCard/PerpsCard.tsx`):
>     - Replaces `TempTouchableOpacity` with `TouchablePerpsComponent`.
>     - Wraps `handlePress` with `useCoordinatedPress`.
>   - **PerpsTabView** (`Views/PerpsTabView/PerpsTabView.tsx`):
>     - Replaces CTA `TempTouchableOpacity` with `TouchablePerpsComponent`.
>     - Wraps new trade handler with `useCoordinatedPress`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1e4bf6f71535aa0ed322ddf9d386f106621660f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->