### PR TITLE
fix: Add shouldEnableAndroidPressIn prop to TempTouchableOpacity in Perps domain cp-7.57.1

### DIFF
--- a/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
@@ -119,6 +119,7 @@ const PerpsTabView: React.FC<PerpsTabViewProps> = () => {
       style={styles.startTradeCTA}
       onPress={memoizedPressHandler}
       testID={PerpsTabViewSelectorsIDs.START_NEW_TRADE_CTA}
+      shouldEnableAndroidPressIn
     >
       <View style={styles.startTradeContent}>
         <View style={styles.startTradeIconContainer}>

--- a/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
+++ b/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
@@ -110,6 +110,7 @@ const PerpsCard: React.FC<PerpsCardProps> = ({
       activeOpacity={0.7}
       onPress={memoizedPressHandler}
       testID={testID}
+      shouldEnableAndroidPressIn
     >
       <View style={styles.cardContent}>
         {/* Left side: Icon and info */}

--- a/app/components/UI/Perps/components/PerpsTutorialCard/PerpsTutorialCard.tsx
+++ b/app/components/UI/Perps/components/PerpsTutorialCard/PerpsTutorialCard.tsx
@@ -29,6 +29,7 @@ const PerpsTutorialCard = () => {
       style={styles.container}
       onPress={handlePress}
       testID={PerpsTutorialSelectorsIDs.TUTORIAL_CARD}
+      shouldEnableAndroidPressIn
     >
       <Text variant={TextVariant.BodyMd}>
         {strings('perps.tutorial.card.title')}


### PR DESCRIPTION
## **Description**

Fixes issue where position list items were not pressable in the Perps tab. This was a regression from the TempTouchableOpacity work being done.

This is intended to be a surgical fix, which adds back in a memoized coordinated press handler to fix the issue only for the PerpsPositionCard component, which renders in the PerpsTab.



## **Changelog**

CHANGELOG entry: Adds shouldEnableAndroidPressIn prop to TempTouchableOpacity in perps domain

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user want to view their position details
    Given the user has multiple positions open

    When user presses a position
    Then they are navigated to the proper position
```

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/0e625b4d-3279-49ef-a983-de89911a4dc2

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable Android press-in for Perps touchables by adding `shouldEnableAndroidPressIn` to key `TempTouchableOpacity` instances.
> 
> - **Perps**:
>   - Enable Android press-in on interactive elements by adding `shouldEnableAndroidPressIn` to `TempTouchableOpacity` in:
>     - `app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx` (`renderStartTradeCTA`)
>     - `app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx` (card root touchable)
>     - `app/components/UI/Perps/components/PerpsTutorialCard/PerpsTutorialCard.tsx` (tutorial card touchable)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a733598e310836db53570f4558f26b2f5b1ed76a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->