### PR TITLE
chore(predict): rate limit buy orders

### DIFF
--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -2082,6 +2082,11 @@ describe('PredictController', () => {
           outcomeTokenId: 'token-1',
           side: Side.BUY,
           size: 100,
+          signer: expect.objectContaining({
+            address: '0x1234567890123456789012345678901234567890',
+            signTypedMessage: expect.any(Function),
+            signPersonalMessage: expect.any(Function),
+          }),
         });
       });
     });

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -717,7 +717,19 @@ export class PredictController extends BaseController<
       throw new Error(PREDICT_ERROR_CODES.PROVIDER_NOT_AVAILABLE);
     }
 
-    return provider.previewOrder(params);
+    const { AccountsController, KeyringController } = Engine.context;
+    const selectedAddress = AccountsController.getSelectedAccount().address;
+    const signer = {
+      address: selectedAddress,
+      signTypedMessage: (
+        _params: TypedMessageParams,
+        _version: SignTypedDataVersion,
+      ) => KeyringController.signTypedMessage(_params, _version),
+      signPersonalMessage: (_params: PersonalMessageParams) =>
+        KeyringController.signPersonalMessage(_params),
+    };
+
+    return provider.previewOrder({ ...params, signer });
   }
 
   async placeOrder(params: PlaceOrderParams): Promise<Result> {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -2047,7 +2047,6 @@ describe('PolymarketProvider', () => {
         await provider.placeOrder({
           signer: mockSigner,
           preview,
-          providerId: 'polymarket',
         });
 
         // Now try to preview a SELL order - should NOT be rate limited
@@ -2103,7 +2102,6 @@ describe('PolymarketProvider', () => {
         const result = await provider.placeOrder({
           signer: mockSigner,
           preview,
-          providerId: 'polymarket',
         });
 
         expect(result.success).toBe(true);
@@ -2116,7 +2114,6 @@ describe('PolymarketProvider', () => {
         const result = await provider.placeOrder({
           signer: mockSigner,
           preview,
-          providerId: 'polymarket',
         });
 
         expect(result.success).toBe(true);
@@ -2134,7 +2131,6 @@ describe('PolymarketProvider', () => {
         const result = await provider.placeOrder({
           signer: mockSigner,
           preview,
-          providerId: 'polymarket',
         });
 
         expect(result.success).toBe(false);
@@ -2157,13 +2153,11 @@ describe('PolymarketProvider', () => {
         const result1 = await provider.placeOrder({
           signer: mockSigner1,
           preview,
-          providerId: 'polymarket',
         });
 
         const result2 = await provider.placeOrder({
           signer: mockSigner2,
           preview,
-          providerId: 'polymarket',
         });
 
         expect(result1.success).toBe(true);

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -5,7 +5,6 @@ import {
 import { CHAIN_IDS, TransactionType } from '@metamask/transaction-controller';
 import { Hex, numberToHex } from '@metamask/utils';
 import { parseUnits } from 'ethers/lib/utils';
-import Engine from '../../../../../core/Engine';
 import { DevLogger } from '../../../../../core/SDKConnect/utils/DevLogger';
 import {
   generateTransferData,
@@ -92,6 +91,7 @@ export class PolymarketProvider implements PredictProvider {
   #apiKeysByAddress: Map<string, ApiKeyCreds> = new Map();
   #accountStateByAddress: Map<string, AccountState> = new Map();
   #lastBuyOrderTimestampByAddress: Map<string, number> = new Map();
+  #buyOrderInProgressByAddress: Map<string, boolean> = new Map();
 
   private static readonly FALLBACK_CATEGORY: PredictCategory = 'trending';
 
@@ -149,6 +149,10 @@ export class PolymarketProvider implements PredictProvider {
   }
 
   private isRateLimited(address: string): boolean {
+    if (this.#buyOrderInProgressByAddress.get(address)) {
+      return true;
+    }
+
     const lastTimestamp = this.#lastBuyOrderTimestampByAddress.get(address);
     if (!lastTimestamp) {
       return false;
@@ -354,15 +358,12 @@ export class PolymarketProvider implements PredictProvider {
   }
 
   public async previewOrder(
-    params: Omit<PreviewOrderParams, 'providerId'>,
+    params: Omit<PreviewOrderParams, 'providerId'> & { signer?: Signer },
   ): Promise<OrderPreview> {
     const basePreview = await previewOrder(params);
 
-    if (params.side === Side.BUY) {
-      const { AccountsController } = Engine.context;
-      const address = AccountsController.getSelectedAccount().address;
-
-      if (this.isRateLimited(address)) {
+    if (params.side === Side.BUY && params.signer) {
+      if (this.isRateLimited(params.signer.address)) {
         return {
           ...basePreview,
           rateLimited: true,
@@ -388,134 +389,144 @@ export class PolymarketProvider implements PredictProvider {
       tickSize,
     } = preview;
 
-    const chainId = POLYGON_MAINNET_CHAIN_ID;
-
-    const makerAddress =
-      this.#accountStateByAddress.get(signer.address)?.address ??
-      (await this.getAccountState({ ownerAddress: signer.address })).address;
-
-    if (!makerAddress) {
-      throw new Error('Maker address not found');
+    if (side === Side.BUY) {
+      this.#buyOrderInProgressByAddress.set(signer.address, true);
     }
 
-    // Introduce slippage into minAmountReceived to reduce failure rate
-    const roundConfig = ROUNDING_CONFIG[tickSize.toString() as TickSize];
-    const decimals = roundConfig.amount ?? 4;
-    const minAmountWithSlippage = roundOrderAmount({
-      amount: minAmountReceived * (1 - slippage),
-      decimals,
-    });
+    try {
+      const chainId = POLYGON_MAINNET_CHAIN_ID;
 
-    const makerAmount = parseUnits(maxAmountSpent.toString(), 6).toString();
-    const takerAmount = parseUnits(
-      minAmountWithSlippage.toString(),
-      6,
-    ).toString();
+      const makerAddress =
+        this.#accountStateByAddress.get(signer.address)?.address ??
+        (await this.getAccountState({ ownerAddress: signer.address })).address;
 
-    /**
-     * Do NOT change the order below.
-     * This order needs to match the order on the relayer.
-     */
-    const order: OrderData & { salt: string } = {
-      salt: generateSalt(),
-      maker: makerAddress,
-      signer: signer.address,
-      taker: '0x0000000000000000000000000000000000000000',
-      tokenId: outcomeTokenId,
-      makerAmount,
-      takerAmount,
-      expiration: '0',
-      nonce: '0',
-      feeRateBps: '0',
-      side: side === Side.BUY ? UtilsSide.BUY : UtilsSide.SELL,
-      signatureType: SignatureType.POLY_GNOSIS_SAFE,
-    };
+      if (!makerAddress) {
+        throw new Error('Maker address not found');
+      }
 
-    const contractConfig = getContractConfig(chainId);
-
-    const exchangeContract = negRisk
-      ? contractConfig.negRiskExchange
-      : contractConfig.exchange;
-
-    const verifyingContract = exchangeContract;
-
-    const typedData = getOrderTypedData({
-      order,
-      chainId,
-      verifyingContract,
-    });
-
-    const signature = await signer.signTypedMessage(
-      { data: typedData, from: signer.address },
-      SignTypedDataVersion.V4,
-    );
-
-    const signedOrder = {
-      ...order,
-      signature,
-    };
-
-    const signerApiKey = await this.getApiKey({ address: signer.address });
-
-    const clobOrder = {
-      order: { ...signedOrder, side, salt: parseInt(signedOrder.salt) },
-      owner: signerApiKey.apiKey,
-      orderType: OrderType.FOK,
-    };
-
-    const body = JSON.stringify(clobOrder);
-
-    const headers = await getL2Headers({
-      l2HeaderArgs: {
-        method: 'POST',
-        requestPath: `/order`,
-        body,
-      },
-      address: clobOrder.order.signer ?? '',
-      apiKey: signerApiKey,
-    });
-
-    let feeAuthorization;
-    if (fees !== undefined && fees.totalFee > 0) {
-      const safeAddress = await computeSafeAddress(signer.address);
-      const feeAmountInUsdc = BigInt(
-        parseUnits(fees.totalFee.toString(), 6).toString(),
-      );
-      feeAuthorization = await createSafeFeeAuthorization({
-        safeAddress,
-        signer,
-        amount: feeAmountInUsdc,
-        to: FEE_COLLECTOR_ADDRESS,
+      // Introduce slippage into minAmountReceived to reduce failure rate
+      const roundConfig = ROUNDING_CONFIG[tickSize.toString() as TickSize];
+      const decimals = roundConfig.amount ?? 4;
+      const minAmountWithSlippage = roundOrderAmount({
+        amount: minAmountReceived * (1 - slippage),
+        decimals,
       });
-    }
 
-    const { success, response, error } = await submitClobOrder({
-      headers,
-      clobOrder,
-      feeAuthorization,
-    });
+      const makerAmount = parseUnits(maxAmountSpent.toString(), 6).toString();
+      const takerAmount = parseUnits(
+        minAmountWithSlippage.toString(),
+        6,
+      ).toString();
 
-    if (!response) {
+      /**
+       * Do NOT change the order below.
+       * This order needs to match the order on the relayer.
+       */
+      const order: OrderData & { salt: string } = {
+        salt: generateSalt(),
+        maker: makerAddress,
+        signer: signer.address,
+        taker: '0x0000000000000000000000000000000000000000',
+        tokenId: outcomeTokenId,
+        makerAmount,
+        takerAmount,
+        expiration: '0',
+        nonce: '0',
+        feeRateBps: '0',
+        side: side === Side.BUY ? UtilsSide.BUY : UtilsSide.SELL,
+        signatureType: SignatureType.POLY_GNOSIS_SAFE,
+      };
+
+      const contractConfig = getContractConfig(chainId);
+
+      const exchangeContract = negRisk
+        ? contractConfig.negRiskExchange
+        : contractConfig.exchange;
+
+      const verifyingContract = exchangeContract;
+
+      const typedData = getOrderTypedData({
+        order,
+        chainId,
+        verifyingContract,
+      });
+
+      const signature = await signer.signTypedMessage(
+        { data: typedData, from: signer.address },
+        SignTypedDataVersion.V4,
+      );
+
+      const signedOrder = {
+        ...order,
+        signature,
+      };
+
+      const signerApiKey = await this.getApiKey({ address: signer.address });
+
+      const clobOrder = {
+        order: { ...signedOrder, side, salt: parseInt(signedOrder.salt) },
+        owner: signerApiKey.apiKey,
+        orderType: OrderType.FOK,
+      };
+
+      const body = JSON.stringify(clobOrder);
+
+      const headers = await getL2Headers({
+        l2HeaderArgs: {
+          method: 'POST',
+          requestPath: `/order`,
+          body,
+        },
+        address: clobOrder.order.signer ?? '',
+        apiKey: signerApiKey,
+      });
+
+      let feeAuthorization;
+      if (fees !== undefined && fees.totalFee > 0) {
+        const safeAddress = await computeSafeAddress(signer.address);
+        const feeAmountInUsdc = BigInt(
+          parseUnits(fees.totalFee.toString(), 6).toString(),
+        );
+        feeAuthorization = await createSafeFeeAuthorization({
+          safeAddress,
+          signer,
+          amount: feeAmountInUsdc,
+          to: FEE_COLLECTOR_ADDRESS,
+        });
+      }
+
+      const { success, response, error } = await submitClobOrder({
+        headers,
+        clobOrder,
+        feeAuthorization,
+      });
+
+      if (!response) {
+        return {
+          success,
+          error,
+        } as OrderResult;
+      }
+
+      if (side === Side.BUY) {
+        this.#lastBuyOrderTimestampByAddress.set(signer.address, Date.now());
+      }
+
       return {
         success,
+        response: {
+          id: response.orderID,
+          spentAmount: response.makingAmount,
+          receivedAmount: response.takingAmount,
+          txHashes: response.transactionsHashes,
+        },
         error,
       } as OrderResult;
+    } finally {
+      if (side === Side.BUY) {
+        this.#buyOrderInProgressByAddress.set(signer.address, false);
+      }
     }
-
-    if (side === Side.BUY) {
-      this.#lastBuyOrderTimestampByAddress.set(signer.address, Date.now());
-    }
-
-    return {
-      success,
-      response: {
-        id: response.orderID,
-        spentAmount: response.makingAmount,
-        receivedAmount: response.takingAmount,
-        txHashes: response.transactionsHashes,
-      },
-      error,
-    } as OrderResult;
   }
 
   public async prepareClaim(

--- a/app/components/UI/Predict/providers/polymarket/constants.ts
+++ b/app/components/UI/Predict/providers/polymarket/constants.ts
@@ -13,6 +13,8 @@ export const FEE_COLLECTOR_ADDRESS =
  */
 export const SLIPPAGE = 0.005; // 0.5%
 
+export const BUY_ORDER_RATE_LIMIT_MS = 5000;
+
 export const POLYGON_MAINNET_CHAIN_ID = 137;
 
 export const COLLATERAL_TOKEN_DECIMALS = 6;

--- a/app/components/UI/Predict/providers/types.ts
+++ b/app/components/UI/Predict/providers/types.ts
@@ -57,6 +57,7 @@ export interface PreviewOrderParams {
   outcomeTokenId: string;
   side: Side;
   size: number;
+  signer?: Signer;
 }
 
 // Fees in US dollars

--- a/app/components/UI/Predict/providers/types.ts
+++ b/app/components/UI/Predict/providers/types.ts
@@ -94,6 +94,7 @@ export interface OrderPreview {
   minOrderSize: number;
   negRisk: boolean;
   fees?: PredictFees;
+  rateLimited?: boolean;
 }
 
 export type OrderResult = Result<{

--- a/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.test.tsx
@@ -1566,6 +1566,61 @@ describe('PredictBuyPreview', () => {
     });
   });
 
+  describe('rate limiting', () => {
+    it('button is enabled when rateLimited is undefined (backward compatibility)', () => {
+      mockExpectedAmount = 120;
+      mockBalance = 1000;
+      mockBalanceLoading = false;
+
+      const { getByText } = renderWithProvider(<PredictBuyPreview />, {
+        state: initialState,
+      });
+
+      // Enter valid amount
+      act(() => {
+        capturedOnChange?.({
+          value: '50',
+          valueAsNumber: 50,
+        });
+      });
+
+      const doneButton = getByText('Done');
+      fireEvent.press(doneButton);
+
+      const placeBetButton = getByText('Yes • 50¢');
+      fireEvent.press(placeBetButton);
+
+      // Button should work (backward compatibility)
+      expect(mockPlaceOrder).toHaveBeenCalled();
+    });
+
+    it('place bet button works with sufficient funds when not rate limited', () => {
+      mockBalance = 1000;
+      mockBalanceLoading = false;
+      mockExpectedAmount = 120;
+
+      const { getByText } = renderWithProvider(<PredictBuyPreview />, {
+        state: initialState,
+      });
+
+      // Enter valid amount
+      act(() => {
+        capturedOnChange?.({
+          value: '50',
+          valueAsNumber: 50,
+        });
+      });
+
+      const doneButton = getByText('Done');
+      fireEvent.press(doneButton);
+
+      // With default mocks (no rateLimited), button should work
+      const placeBetButton = getByText('Yes • 50¢');
+      fireEvent.press(placeBetButton);
+      expect(mockPlaceOrder).toHaveBeenCalled();
+    });
+  });
+
   describe('error message rendering', () => {
     it('renders insufficient funds error with correct text', () => {
       mockBalance = 50;

--- a/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
+++ b/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
@@ -133,6 +133,7 @@ const PredictBuyPreview = () => {
   }, []);
 
   const toWin = preview?.minAmountReceived ?? 0;
+  const isRateLimited = preview?.rateLimited ?? false;
 
   const metamaskFee = preview?.fees?.metamaskFee ?? 0;
   const providerFee = preview?.fees?.providerFee ?? 0;
@@ -148,7 +149,8 @@ const PredictBuyPreview = () => {
     preview &&
     !isCalculating &&
     !isLoading &&
-    !isBalanceLoading;
+    !isBalanceLoading &&
+    !isRateLimited;
 
   const title = market.title;
   const outcomeGroupTitle = outcome.groupItemTitle

--- a/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
+++ b/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
@@ -348,6 +348,7 @@ const PredictBuyPreview = () => {
                   outcomeToken?.title === 'Yes'
                     ? 'text-success-default'
                     : 'text-error-default',
+                  !canPlaceBet && 'opacity-40',
                 )}
                 disabled={!canPlaceBet}
                 loading={isLoading}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
In order to maximizing our chances of collecting the fees for every order, and due to the fact that every fee authorization requires the previous order's fee collection to be settled on chain, this PR introduces a rate limit for buy orders.
Right now it is configured for 5s, meaning users shouldn't be able to submit a buy order if the previous one was placed successfully less than 5s ago (or if a previous order is in progress).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/285ea08d-a8e1-45ec-a6cd-ff5370d7c01a


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements signer-aware buy-order rate limiting (5s) in Polymarket provider, passes signer through preview flow, surfaces `rateLimited` to UI, and disables the buy button when limited, with comprehensive tests.
> 
> - **Predict Provider (Polymarket)**:
>   - Add 5s buy-order rate limiting via `BUY_ORDER_RATE_LIMIT_MS`; track per-address last buy and in-progress state.
>   - `previewOrder` now accepts optional `signer` and returns `rateLimited` when applicable.
>   - `placeOrder` sets/clears in-progress flags and stamps last successful BUY timestamp.
> - **Controller**:
>   - `PredictController.previewOrder` injects selected-account `signer` and forwards to provider.
> - **Types**:
>   - Extend `PreviewOrderParams` with optional `signer` and `OrderPreview` with optional `rateLimited`.
> - **UI (PredictBuyPreview)**:
>   - Read `preview.rateLimited`; disable and dim Place Bet button when rate-limited; preserve backward compatibility when undefined.
> - **Tests**:
>   - Add rate limiting tests for provider and UI; update controller/provider tests to expect `signer` on preview; minor test refactors (fetch mocks, activity suite rename).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d54dd9c42835566392178678325da8aa998ed97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->