### PR TITLE
feat(predict): Updates market details view to use sticky tabs

### DIFF
--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -584,8 +584,12 @@ describe('PredictMarketDetails', () => {
     it('renders tab bar with correct tabs', () => {
       setupPredictMarketDetailsTest();
 
-      expect(screen.getByTestId('tab-bar')).toBeOnTheScreen();
-      expect(screen.getByTestId('scrollable-tab-view')).toBeOnTheScreen();
+      expect(
+        screen.getByTestId('predict-market-details-tab-bar'),
+      ).toBeOnTheScreen();
+      expect(
+        screen.getByTestId('predict-market-details-scrollable-tab-view'),
+      ).toBeOnTheScreen();
     });
 
     it('displays About tab content', () => {
@@ -604,6 +608,12 @@ describe('PredictMarketDetails', () => {
 
     it('displays Positions tab content', () => {
       setupPredictMarketDetailsTest();
+
+      // Switch to Positions tab
+      const positionsTab = screen.getByTestId(
+        'predict-market-details-tab-bar-tab-1',
+      );
+      fireEvent.press(positionsTab);
 
       expect(
         screen.getByText('predict.market_details.no_positions_found'),
@@ -799,6 +809,12 @@ describe('PredictMarketDetails', () => {
         { positions: { positions: [mockPosition] } },
       );
 
+      // Switch to Positions tab to see the cash out button
+      const positionsTab = screen.getByTestId(
+        'predict-market-details-tab-bar-tab-1',
+      );
+      fireEvent.press(positionsTab);
+
       const cashOutButton = screen.getByText('Cash out');
       fireEvent.press(cashOutButton);
 
@@ -897,6 +913,12 @@ describe('PredictMarketDetails', () => {
         { positions: { positions: [mockPosition] } },
       );
 
+      // Switch to Positions tab to see the positions content
+      const positionsTab = screen.getByTestId(
+        'predict-market-details-tab-bar-tab-1',
+      );
+      fireEvent.press(positionsTab);
+
       expect(screen.getByText('Cash out')).toBeOnTheScreen();
       expect(
         screen.getByText(/\$65\.00\s+predict\.market_details\.on\s+Yes/),
@@ -922,6 +944,12 @@ describe('PredictMarketDetails', () => {
         {},
         { positions: { positions: [mockPosition] } },
       );
+
+      // Switch to Positions tab to see the positions content
+      const positionsTab = screen.getByTestId(
+        'predict-market-details-tab-bar-tab-1',
+      );
+      fireEvent.press(positionsTab);
 
       expect(screen.getByText('-7.7%')).toBeOnTheScreen();
     });
@@ -951,6 +979,12 @@ describe('PredictMarketDetails', () => {
       });
 
       setupPredictMarketDetailsTest(multiOutcomeMarket);
+
+      // Switch to Outcomes tab to see the outcomes content
+      const outcomesTab = screen.getByTestId(
+        'predict-market-details-tab-bar-tab-2',
+      );
+      fireEvent.press(outcomesTab);
 
       // Should render outcomes for multi-outcome markets
       expect(screen.getAllByTestId('predict-market-outcome')).toHaveLength(3);
@@ -1048,6 +1082,12 @@ describe('PredictMarketDetails', () => {
         { positions: { positions: [mockPosition] } },
       );
 
+      // Switch to Positions tab to see the positions content
+      const positionsTab = screen.getByTestId(
+        'predict-market-details-tab-bar-tab-1',
+      );
+      fireEvent.press(positionsTab);
+
       expect(
         screen.getByText(/\$65\.00\s+predict\.market_details\.on\s+Yes Option/),
       ).toBeOnTheScreen();
@@ -1071,6 +1111,12 @@ describe('PredictMarketDetails', () => {
         { positions: { positions: [mockPosition] } },
       );
 
+      // Switch to Positions tab to see the positions content
+      const positionsTab = screen.getByTestId(
+        'predict-market-details-tab-bar-tab-1',
+      );
+      fireEvent.press(positionsTab);
+
       expect(
         screen.getByText(/\$65\.00\s+predict\.market_details\.on\s+Yes/),
       ).toBeOnTheScreen();
@@ -1093,6 +1139,12 @@ describe('PredictMarketDetails', () => {
         {},
         { positions: { positions: [mockPosition] } },
       );
+
+      // Switch to Positions tab to see the positions content
+      const positionsTab = screen.getByTestId(
+        'predict-market-details-tab-bar-tab-1',
+      );
+      fireEvent.press(positionsTab);
 
       expect(screen.getByText('+0.0%')).toBeOnTheScreen();
     });
@@ -1256,6 +1308,12 @@ describe('PredictMarketDetails', () => {
       });
 
       setupPredictMarketDetailsTest(closedMarket);
+
+      // Switch to Outcomes tab to see the outcomes content
+      const outcomesTab = screen.getByTestId(
+        'predict-market-details-tab-bar-tab-2',
+      );
+      fireEvent.press(outcomesTab);
 
       // Should render outcomes tab for closed markets
       expect(
@@ -1486,6 +1544,12 @@ describe('PredictMarketDetails', () => {
 
       setupPredictMarketDetailsTest(closedMarket);
 
+      // Switch to Outcomes tab to see the outcomes content
+      const outcomesTab = screen.getByTestId(
+        'predict-market-details-tab-bar-tab-2',
+      );
+      fireEvent.press(outcomesTab);
+
       // Should render outcomes tab for closed markets
       expect(screen.getByTestId('predict-market-outcome')).toBeOnTheScreen();
     });
@@ -1631,6 +1695,12 @@ describe('PredictMarketDetails', () => {
         {},
         { positions: { positions: [mockPosition] } },
       );
+
+      // Switch to Positions tab to see the positions content
+      const positionsTab = screen.getByTestId(
+        'predict-market-details-tab-bar-tab-1',
+      );
+      fireEvent.press(positionsTab);
 
       // Verify the position section renders with icon
       expect(screen.getByText('Cash out')).toBeOnTheScreen();

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -6,7 +6,6 @@ import {
 } from '@react-navigation/native';
 import React, { useMemo, useState, useEffect } from 'react';
 import { Image, Pressable, ScrollView } from 'react-native';
-import ScrollableTabView from '@tommasini/react-native-scrollable-tab-view';
 import {
   SafeAreaView,
   useSafeAreaInsets,
@@ -51,7 +50,6 @@ import {
   PredictOutcomeToken,
 } from '../../types';
 import PredictMarketOutcome from '../../components/PredictMarketOutcome';
-import TabBar from '../../../../Base/TabBar';
 import { usePredictPositions } from '../../hooks/usePredictPositions';
 import { usePredictBalance } from '../../hooks/usePredictBalance';
 import { usePredictClaim } from '../../hooks/usePredictClaim';
@@ -91,6 +89,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
   const tw = useTailwind();
   const [selectedTimeframe, setSelectedTimeframe] =
     useState<PredictPriceHistoryInterval>(PredictPriceHistoryInterval.ONE_DAY);
+  const [activeTab, setActiveTab] = useState(0);
   const insets = useSafeAreaInsets();
   const { hasNoBalance } = usePredictBalance();
 
@@ -322,8 +321,66 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
     await claim();
   };
 
+  const handleTabPress = (tabIndex: number) => {
+    setActiveTab(tabIndex);
+  };
+
+  const renderCustomTabBar = () => {
+    const tabs = [
+      { label: strings('predict.tabs.about'), index: 0 },
+      { label: strings('predict.tabs.positions'), index: 1 },
+    ];
+
+    // Add Outcomes tab if market has multiple outcomes or is closed
+    if (multipleOutcomes || market?.status === PredictMarketStatus.CLOSED) {
+      tabs.push({ label: strings('predict.tabs.outcomes'), index: 2 });
+    }
+
+    return (
+      <Box
+        twClassName="bg-default border-b border-muted"
+        testID={PredictMarketDetailsSelectorsIDs.TAB_BAR}
+      >
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          twClassName="px-3"
+        >
+          {tabs.map((tab) => (
+            <Pressable
+              key={tab.index}
+              onPress={() => handleTabPress(tab.index)}
+              style={tw.style(
+                'flex-1 py-3',
+                activeTab === tab.index
+                  ? 'border-b-2 border-primary-default'
+                  : '',
+              )}
+              testID={`${PredictMarketDetailsSelectorsIDs.TAB_BAR}-tab-${tab.index}`}
+            >
+              <Text
+                variant={TextVariant.BodyMDMedium}
+                color={
+                  activeTab === tab.index
+                    ? TextColor.Primary
+                    : TextColor.Alternative
+                }
+                style={tw.style('text-center font-bold')}
+              >
+                {tab.label}
+              </Text>
+            </Pressable>
+          ))}
+        </Box>
+      </Box>
+    );
+  };
+
   const renderHeader = () => (
-    <Box twClassName="flex-row items-center gap-3">
+    <Box
+      twClassName="flex-row items-center gap-3"
+      style={{ paddingTop: insets.top + 12 }}
+    >
       <Pressable
         onPress={handleBackPress}
         hitSlop={12}
@@ -737,15 +794,89 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
     </>
   );
 
+  const renderTabContent = () => {
+    switch (activeTab) {
+      case 0:
+        return (
+          <Box
+            twClassName="px-3 pt-4 pb-8"
+            testID={PredictMarketDetailsSelectorsIDs.ABOUT_TAB}
+          >
+            {renderAboutSection()}
+          </Box>
+        );
+      case 1:
+        return (
+          <Box
+            twClassName="px-3 pt-4 pb-8"
+            testID={PredictMarketDetailsSelectorsIDs.POSITIONS_TAB}
+          >
+            {renderPositionsSection()}
+          </Box>
+        );
+      case 2:
+        return (
+          <Box
+            twClassName="px-3 pt-4 pb-8"
+            testID={PredictMarketDetailsSelectorsIDs.OUTCOMES_TAB}
+          >
+            {market?.status === PredictMarketStatus.CLOSED ? (
+              <Box>
+                {winningOutcome && (
+                  <PredictMarketOutcome
+                    market={market}
+                    outcome={winningOutcome}
+                    outcomeToken={winningOutcomeToken}
+                    isClosed
+                  />
+                )}
+                {losingOutcome && (
+                  <PredictMarketOutcome
+                    market={market}
+                    outcome={losingOutcome}
+                    outcomeToken={losingOutcomeToken}
+                    isClosed
+                  />
+                )}
+              </Box>
+            ) : (
+              <Box>
+                {market?.outcomes?.map((outcome, index) => (
+                  <PredictMarketOutcome
+                    key={
+                      outcome?.id ??
+                      outcome?.tokens?.[0]?.id ??
+                      outcome?.title ??
+                      `outcome-${index}`
+                    }
+                    market={market}
+                    outcome={outcome}
+                  />
+                ))}
+              </Box>
+            )}
+          </Box>
+        );
+      default:
+        return null;
+    }
+  };
+
   return (
     <SafeAreaView
       style={tw.style('flex-1 bg-default')}
       edges={['left', 'right', 'bottom']}
       testID={PredictMarketDetailsSelectorsIDs.SCREEN}
     >
-      <Box twClassName="flex-1">
-        <Box twClassName="px-3 gap-4" style={{ paddingTop: insets.top + 12 }}>
-          {renderHeader()}
+      <Box twClassName="px-3 gap-4">{renderHeader()}</Box>
+      <ScrollView
+        testID={PredictMarketDetailsSelectorsIDs.SCROLLABLE_TAB_VIEW}
+        stickyHeaderIndices={[1]}
+        showsVerticalScrollIndicator={false}
+        style={tw.style('flex-1')}
+      >
+        {/* Header content - scrollable */}
+        <Box twClassName="px-3 gap-4">
           {renderMarketStatus()}
           <PredictDetailsChart
             data={chartData}
@@ -756,87 +887,14 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
             emptyLabel={chartEmptyLabel}
           />
         </Box>
-        <ScrollableTabView
-          testID={PredictMarketDetailsSelectorsIDs.SCROLLABLE_TAB_VIEW}
-          renderTabBar={() => (
-            <TabBar
-              textStyle={tw.style('text-base font-bold text-center')}
-              testID={PredictMarketDetailsSelectorsIDs.TAB_BAR}
-            />
-          )}
-          style={tw.style('flex-1 mt-2')}
-          initialPage={0}
-        >
-          <ScrollView
-            key="about"
-            {...{ tabLabel: 'About' }}
-            style={tw.style('flex-1')}
-            contentContainerStyle={tw.style('px-3 pt-4 pb-8')}
-            showsVerticalScrollIndicator={false}
-            testID={PredictMarketDetailsSelectorsIDs.ABOUT_TAB}
-          >
-            {renderAboutSection()}
-          </ScrollView>
-          <ScrollView
-            key="positions"
-            {...{ tabLabel: 'Positions' }}
-            style={tw.style('flex-1')}
-            contentContainerStyle={tw.style('px-3 pt-4 pb-8')}
-            showsVerticalScrollIndicator={false}
-            testID={PredictMarketDetailsSelectorsIDs.POSITIONS_TAB}
-          >
-            {renderPositionsSection()}
-          </ScrollView>
-          {/* only render outcomes tab if the market has multiple outcomes or is closed */}
-          {(multipleOutcomes ||
-            market?.status === PredictMarketStatus.CLOSED) && (
-            <ScrollView
-              key="outcomes"
-              {...{ tabLabel: 'Outcomes' }}
-              style={tw.style('flex-1')}
-              contentContainerStyle={tw.style('px-3 pt-4 pb-8')}
-              showsVerticalScrollIndicator={false}
-              testID={PredictMarketDetailsSelectorsIDs.OUTCOMES_TAB}
-            >
-              {market?.status === PredictMarketStatus.CLOSED ? (
-                <Box>
-                  {winningOutcome && (
-                    <PredictMarketOutcome
-                      market={market}
-                      outcome={winningOutcome}
-                      outcomeToken={winningOutcomeToken}
-                      isClosed
-                    />
-                  )}
-                  {losingOutcome && (
-                    <PredictMarketOutcome
-                      market={market}
-                      outcome={losingOutcome}
-                      outcomeToken={losingOutcomeToken}
-                      isClosed
-                    />
-                  )}
-                </Box>
-              ) : (
-                <Box>
-                  {market?.outcomes?.map((outcome, index) => (
-                    <PredictMarketOutcome
-                      key={
-                        outcome?.id ??
-                        outcome?.tokens?.[0]?.id ??
-                        outcome?.title ??
-                        `outcome-${index}`
-                      }
-                      market={market}
-                      outcome={outcome}
-                    />
-                  ))}
-                </Box>
-              )}
-            </ScrollView>
-          )}
-        </ScrollableTabView>
-      </Box>
+
+        {/* Sticky tab bar */}
+        {renderCustomTabBar()}
+
+        {/* Tab content */}
+        {renderTabContent()}
+      </ScrollView>
+
       <Box twClassName="px-3 bg-default border-t border-muted">
         {/* only render action buttons if the market has a single outcome */}
         {/* otherwise, it's handled via the buttons within tabs */}

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1627,6 +1627,11 @@
       "new_prediction": "New prediction",
       "resolved_markets": "Resolved markets"
     },
+    "tabs": {
+      "about": "About",
+      "positions": "Positions",
+      "outcomes": "Outcomes"
+    },
     "sell_position": "Sell Position",
     "cash_out": "Cash Out",
     "buy_yes": "Yes",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Updates market details to make the whole view scrollable and stick the tabs (About, Positions, Outcomes) below the header

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: [PRED-188](https://consensyssoftware.atlassian.net/browse/PRED-188)

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="420" alt="image" src="https://github.com/user-attachments/assets/c28138f5-a5c6-429a-adbf-54592edc241d" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[PRED-188]: https://consensyssoftware.atlassian.net/browse/PRED-188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces the third‑party tab view with a custom sticky tab bar in `PredictMarketDetails`, updates tests to new tab behaviors/testIDs, and adds i18n strings for tab labels.
> 
> - **PredictMarketDetails UI**:
>   - Replace `ScrollableTabView`/`TabBar` with custom sticky tab bar inside a `ScrollView` (`stickyHeaderIndices`), controlled via new `activeTab` state and `handleTabPress`.
>   - Add `renderCustomTabBar` and `renderTabContent`; keep conditional rendering of `Outcomes` (multi-outcome or closed markets).
>   - Adjust header padding and restructure layout; update testIDs to `predict-market-details-*`.
> - **Tests** (`app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx`):
>   - Update selectors to new testIDs and simulate tab presses before asserting `Positions`/`Outcomes` content.
> - **Localization** (`locales/languages/en.json`):
>   - Add `predict.tabs.{about,positions,outcomes}` strings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1640ba369f3eefa19c1d0e2c08a6b2ec0a7c0dc4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->