### PR TITLE
chore: Update `sample-controllers` from v0.1.0 to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -274,7 +274,7 @@
     "@metamask/react-native-webview": "^14.5.0",
     "@metamask/remote-feature-flag-controller": "^1.9.0",
     "@metamask/rpc-errors": "^7.0.2",
-    "@metamask/sample-controllers": "^0.1.0",
+    "@metamask/sample-controllers": "^2.0.1",
     "@metamask/scure-bip39": "^2.1.0",
     "@metamask/sdk-analytics": "0.0.5",
     "@metamask/sdk-communication-layer": "0.33.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8410,15 +8410,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/sample-controllers@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "@metamask/sample-controllers@npm:0.1.0"
+"@metamask/sample-controllers@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@metamask/sample-controllers@npm:2.0.1"
   dependencies:
-    "@metamask/base-controller": "npm:^8.0.0"
-    "@metamask/utils": "npm:^11.2.0"
+    "@metamask/base-controller": "npm:^8.4.1"
+    "@metamask/utils": "npm:^11.8.1"
   peerDependencies:
-    "@metamask/network-controller": ^23.0.0
-  checksum: 10/016bf9f68117e2cd25b69d11a341a57c5783bdbb4de4e311e9b04d2db2ff8d078efffa4a7b3d206d8b4fffe96af914a9457b10d7eb3db3a8873fee94f031701c
+    "@metamask/network-controller": ^24.0.0
+  checksum: 10/3a76e79560caaeba03f0def0039c1016d33c60f998267d7783539f1a7bc7c4f16c8422c6a3e24ecf31bd15bf93c52737b584694692070d9051b3080daa98ee45
   languageName: node
   linkType: hard
 
@@ -34167,7 +34167,7 @@ __metadata:
     "@metamask/react-native-webview": "npm:^14.5.0"
     "@metamask/remote-feature-flag-controller": "npm:^1.9.0"
     "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/sample-controllers": "npm:^0.1.0"
+    "@metamask/sample-controllers": "npm:^2.0.1"
     "@metamask/scure-bip39": "npm:^2.1.0"
     "@metamask/sdk-analytics": "npm:0.0.5"
     "@metamask/sdk-communication-layer": "npm:0.33.1"


### PR DESCRIPTION
## **Description**

Update `@metamask/sample-controllers` from v0.1 to v2. The breaking changes did not impact the `SamplePetnamesController`, which is the only part used by mobile.

Changelog: https://github.com/MetaMask/core/blob/main/packages/sample-controllers/CHANGELOG.md#200

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update @metamask/sample-controllers from ^0.1.0 to ^2.0.1 and refresh yarn.lock to reflect new transitive requirements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec7d0213fb4e1bf845607a004098c372895e408e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->