### PR TITLE
fix(predict): navigation stack

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -197,11 +197,6 @@ const WalletTabStackFlow = () => (
       options={{ headerShown: false }}
     />
     <Stack.Screen
-      name={Routes.PREDICT.ROOT}
-      component={PredictScreenStack}
-      options={{ headerShown: false }}
-    />
-    <Stack.Screen
       name="AddAsset"
       component={AddAsset}
       options={AddAsset.navigationOptions}
@@ -1081,7 +1076,19 @@ const MainNavigator = () => {
             name={Routes.PREDICT.ROOT}
             component={PredictScreenStack}
             options={{
-              animationEnabled: false,
+              animationEnabled: true,
+              cardStyleInterpolator: ({ current, layouts }) => ({
+                cardStyle: {
+                  transform: [
+                    {
+                      translateX: current.progress.interpolate({
+                        inputRange: [0, 1],
+                        outputRange: [layouts.screen.width, 0],
+                      }),
+                    },
+                  ],
+                },
+              }),
             }}
           />
           <Stack.Screen

--- a/app/components/UI/Predict/components/PredictFeedHeader/PredictFeedHeader.test.tsx
+++ b/app/components/UI/Predict/components/PredictFeedHeader/PredictFeedHeader.test.tsx
@@ -4,6 +4,20 @@ import { backgroundState } from '../../../../../util/test/initial-root-state';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import PredictFeedHeader from './PredictFeedHeader';
 
+// Mock navigation
+const mockNavigate = jest.fn();
+const mockCanGoBack = jest.fn(() => true);
+const mockGoBack = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({
+    navigate: mockNavigate,
+    canGoBack: mockCanGoBack,
+    goBack: mockGoBack,
+  }),
+}));
+
 // Mock SearchBox component
 jest.mock('../SearchBox', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
@@ -43,6 +57,10 @@ describe('PredictFeedHeader', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockNavigate.mockClear();
+    mockCanGoBack.mockClear();
+    mockGoBack.mockClear();
+    mockCanGoBack.mockReturnValue(true);
   });
 
   describe('default view', () => {

--- a/app/components/UI/Predict/components/PredictFeedHeader/PredictFeedHeader.test.tsx
+++ b/app/components/UI/Predict/components/PredictFeedHeader/PredictFeedHeader.test.tsx
@@ -691,4 +691,132 @@ describe('PredictFeedHeader', () => {
       expect(mockOnSearchCancel).toHaveBeenCalledWith();
     });
   });
+
+  describe('back button', () => {
+    it('displays back button when search is not visible', () => {
+      // Arrange & Act
+      const { getByTestId } = renderWithProvider(
+        <PredictFeedHeader
+          isSearchVisible={false}
+          onSearchToggle={mockOnSearchToggle}
+          onSearchCancel={mockOnSearchCancel}
+          onSearch={mockOnSearch}
+        />,
+        { state: initialState },
+      );
+
+      // Assert
+      expect(getByTestId('back-button')).toBeOnTheScreen();
+    });
+
+    it('does not display back button when search is visible', () => {
+      // Arrange & Act
+      const { queryByTestId } = renderWithProvider(
+        <PredictFeedHeader
+          isSearchVisible
+          onSearchToggle={mockOnSearchToggle}
+          onSearchCancel={mockOnSearchCancel}
+          onSearch={mockOnSearch}
+        />,
+        { state: initialState },
+      );
+
+      // Assert
+      expect(queryByTestId('back-button')).toBeNull();
+    });
+
+    it('calls goBack when back button is pressed and navigation can go back', () => {
+      // Arrange
+      mockCanGoBack.mockReturnValue(true);
+      const { getByTestId } = renderWithProvider(
+        <PredictFeedHeader
+          isSearchVisible={false}
+          onSearchToggle={mockOnSearchToggle}
+          onSearchCancel={mockOnSearchCancel}
+          onSearch={mockOnSearch}
+        />,
+        { state: initialState },
+      );
+
+      // Act
+      const backButton = getByTestId('back-button');
+      fireEvent.press(backButton);
+
+      // Assert
+      expect(mockGoBack).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('navigates to Wallet when back button is pressed and navigation cannot go back', () => {
+      // Arrange
+      mockCanGoBack.mockReturnValue(false);
+      const { getByTestId } = renderWithProvider(
+        <PredictFeedHeader
+          isSearchVisible={false}
+          onSearchToggle={mockOnSearchToggle}
+          onSearchCancel={mockOnSearchCancel}
+          onSearch={mockOnSearch}
+        />,
+        { state: initialState },
+      );
+
+      // Act
+      const backButton = getByTestId('back-button');
+      fireEvent.press(backButton);
+
+      // Assert
+      expect(mockNavigate).toHaveBeenCalledWith('WalletTabHome', {
+        screen: 'WalletTabStackFlow',
+        params: {
+          screen: 'WalletView',
+        },
+      });
+      expect(mockGoBack).not.toHaveBeenCalled();
+    });
+
+    it('handles multiple back button presses', () => {
+      // Arrange
+      mockCanGoBack.mockReturnValue(true);
+      const { getByTestId } = renderWithProvider(
+        <PredictFeedHeader
+          isSearchVisible={false}
+          onSearchToggle={mockOnSearchToggle}
+          onSearchCancel={mockOnSearchCancel}
+          onSearch={mockOnSearch}
+        />,
+        { state: initialState },
+      );
+
+      // Act
+      const backButton = getByTestId('back-button');
+      fireEvent.press(backButton);
+      fireEvent.press(backButton);
+      fireEvent.press(backButton);
+
+      // Assert
+      expect(mockGoBack).toHaveBeenCalledTimes(3);
+    });
+
+    it('does not interfere with search toggle when back button is pressed', () => {
+      // Arrange
+      const { getByTestId } = renderWithProvider(
+        <PredictFeedHeader
+          isSearchVisible={false}
+          onSearchToggle={mockOnSearchToggle}
+          onSearchCancel={mockOnSearchCancel}
+          onSearch={mockOnSearch}
+        />,
+        { state: initialState },
+      );
+
+      // Act
+      const backButton = getByTestId('back-button');
+      fireEvent.press(backButton);
+
+      // Assert
+      expect(mockOnSearchToggle).not.toHaveBeenCalled();
+      expect(mockOnSearchCancel).not.toHaveBeenCalled();
+      expect(mockOnSearch).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/app/components/UI/Predict/components/PredictFeedHeader/PredictFeedHeader.tsx
+++ b/app/components/UI/Predict/components/PredictFeedHeader/PredictFeedHeader.tsx
@@ -6,6 +6,7 @@ import {
 } from '@metamask/design-system-react-native';
 import React from 'react';
 import { Pressable } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
 import Icon, {
   IconName,
   IconSize,
@@ -14,6 +15,7 @@ import Text, {
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
 import { useTheme } from '../../../../../util/theme';
+import Routes from '../../../../../constants/navigation/Routes';
 import SearchBox from '../SearchBox';
 
 interface PredictFeedHeaderProps {
@@ -30,6 +32,20 @@ const PredictFeedHeader: React.FC<PredictFeedHeaderProps> = ({
   onSearch,
 }) => {
   const { colors } = useTheme();
+  const navigation = useNavigation();
+
+  const handleBackPress = () => {
+    if (navigation.canGoBack()) {
+      navigation.goBack();
+    } else {
+      navigation.navigate(Routes.WALLET.HOME, {
+        screen: Routes.WALLET.TAB_STACK_FLOW,
+        params: {
+          screen: Routes.WALLET_VIEW,
+        },
+      });
+    }
+  };
 
   return (
     <>
@@ -40,7 +56,20 @@ const PredictFeedHeader: React.FC<PredictFeedHeaderProps> = ({
           justifyContent={BoxJustifyContent.Between}
           twClassName="w-full py-2"
         >
-          <Text variant={TextVariant.HeadingLG}>Predictions</Text>
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            twClassName="gap-3"
+          >
+            <Pressable testID="back-button" onPress={handleBackPress}>
+              <Icon
+                name={IconName.ArrowLeft}
+                size={IconSize.Lg}
+                color={colors.text.default}
+              />
+            </Pressable>
+            <Text variant={TextVariant.HeadingLG}>Predictions</Text>
+          </Box>
           <Pressable testID="search-toggle-button" onPress={onSearchToggle}>
             <Icon
               name={IconName.Search}

--- a/app/components/UI/Predict/components/PredictNewButton/PredictNewButton.test.tsx
+++ b/app/components/UI/Predict/components/PredictNewButton/PredictNewButton.test.tsx
@@ -159,15 +159,12 @@ describe('PredictNewButton', () => {
 
       fireEvent.press(button);
 
-      expect(mockNavigation.navigate).toHaveBeenCalledWith(Routes.WALLET.HOME, {
-        screen: Routes.WALLET.TAB_STACK_FLOW,
-        params: {
-          screen: Routes.PREDICT.ROOT,
-          params: {
-            screen: Routes.PREDICT.MARKET_LIST,
-          },
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
+        Routes.PREDICT.ROOT,
+        {
+          screen: Routes.PREDICT.MARKET_LIST,
         },
-      });
+      );
     });
 
     it('calls navigation only once per press', () => {
@@ -188,15 +185,12 @@ describe('PredictNewButton', () => {
       fireEvent.press(button);
 
       expect(mockNavigation.navigate).toHaveBeenCalledTimes(3);
-      expect(mockNavigation.navigate).toHaveBeenCalledWith(Routes.WALLET.HOME, {
-        screen: Routes.WALLET.TAB_STACK_FLOW,
-        params: {
-          screen: Routes.PREDICT.ROOT,
-          params: {
-            screen: Routes.PREDICT.MARKET_LIST,
-          },
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
+        Routes.PREDICT.ROOT,
+        {
+          screen: Routes.PREDICT.MARKET_LIST,
         },
-      });
+      );
     });
   });
 

--- a/app/components/UI/Predict/components/PredictNewButton/PredictNewButton.tsx
+++ b/app/components/UI/Predict/components/PredictNewButton/PredictNewButton.tsx
@@ -26,14 +26,8 @@ const PredictNewButton: React.FC<PredictNewButtonProps> = () => {
   const tw = useTailwind();
 
   const handlePress = () => {
-    navigation.navigate(Routes.WALLET.HOME, {
-      screen: Routes.WALLET.TAB_STACK_FLOW,
-      params: {
-        screen: Routes.PREDICT.ROOT,
-        params: {
-          screen: Routes.PREDICT.MARKET_LIST,
-        },
-      },
+    navigation.navigate(Routes.PREDICT.ROOT, {
+      screen: Routes.PREDICT.MARKET_LIST,
     });
   };
 

--- a/app/components/UI/Predict/components/PredictPositionEmpty/PredictPositionEmpty.test.tsx
+++ b/app/components/UI/Predict/components/PredictPositionEmpty/PredictPositionEmpty.test.tsx
@@ -176,15 +176,12 @@ describe('PredictPositionEmpty', () => {
       const browseButton = screen.getByText('Browse markets');
       fireEvent.press(browseButton);
 
-      expect(mockNavigation.navigate).toHaveBeenCalledWith(Routes.WALLET.HOME, {
-        screen: Routes.WALLET.TAB_STACK_FLOW,
-        params: {
-          screen: Routes.PREDICT.ROOT,
-          params: {
-            screen: Routes.PREDICT.MARKET_LIST,
-          },
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
+        Routes.PREDICT.ROOT,
+        {
+          screen: Routes.PREDICT.MARKET_LIST,
         },
-      });
+      );
     });
   });
 

--- a/app/components/UI/Predict/components/PredictPositionEmpty/PredictPositionEmpty.tsx
+++ b/app/components/UI/Predict/components/PredictPositionEmpty/PredictPositionEmpty.tsx
@@ -40,14 +40,8 @@ const PredictPositionEmpty: React.FC<PredictPositionEmptyProps> = () => {
         variant={ButtonVariants.Secondary}
         size={ButtonSize.Lg}
         onPress={() =>
-          navigation.navigate(Routes.WALLET.HOME, {
-            screen: Routes.WALLET.TAB_STACK_FLOW,
-            params: {
-              screen: Routes.PREDICT.ROOT,
-              params: {
-                screen: Routes.PREDICT.MARKET_LIST,
-              },
-            },
+          navigation.navigate(Routes.PREDICT.ROOT, {
+            screen: Routes.PREDICT.MARKET_LIST,
           })
         }
         label={strings('predict.tab.explore')}

--- a/app/components/UI/Predict/hooks/usePredictDeposit.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictDeposit.test.ts
@@ -196,6 +196,7 @@ describe('usePredictDeposit', () => {
 
       expect(mockNavigateToConfirmation).toHaveBeenCalledWith({
         loader: ConfirmationLoader.CustomAmount,
+        stack: 'Predict',
       });
     });
 

--- a/app/components/UI/Predict/hooks/usePredictDeposit.ts
+++ b/app/components/UI/Predict/hooks/usePredictDeposit.ts
@@ -42,6 +42,7 @@ export const usePredictDeposit = ({
     try {
       navigateToConfirmation({
         loader: ConfirmationLoader.CustomAmount,
+        stack: Routes.PREDICT.ROOT,
       });
 
       Engine.context.PredictController.depositWithConfirmation({

--- a/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
+++ b/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
@@ -144,14 +144,8 @@ function TradeWalletActions() {
 
   const onPredict = useCallback(() => {
     postCallback.current = () => {
-      navigate(Routes.WALLET.HOME, {
-        screen: Routes.WALLET.TAB_STACK_FLOW,
-        params: {
-          screen: Routes.PREDICT.ROOT,
-          params: {
-            screen: Routes.PREDICT.MARKET_LIST,
-          },
-        },
+      navigate(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_LIST,
       });
     };
     handleNavigateBack();

--- a/app/components/Views/WalletActions/WalletActions.test.tsx
+++ b/app/components/Views/WalletActions/WalletActions.test.tsx
@@ -495,7 +495,7 @@ describe('WalletActions', () => {
     ).toBeDefined();
   });
 
-  it('should call the onPredict function when the Predict button is pressed', () => {
+  it('should call the onPredict function when the Predict button is pressed', async () => {
     (
       selectPredictEnabledFlag as jest.MockedFunction<
         typeof selectPredictEnabledFlag
@@ -510,14 +510,12 @@ describe('WalletActions', () => {
       getByTestId(WalletActionsBottomSheetSelectorsIDs.PREDICT_BUTTON),
     );
 
-    expect(mockNavigate).toHaveBeenCalledWith('WalletTabHome', {
-      screen: 'WalletTabStackFlow',
-      params: {
-        screen: 'Predict',
-        params: {
-          screen: 'PredictMarketList',
-        },
-      },
+    // Wait for the bottom sheet close callback to execute
+    // closeBottomSheetAndNavigate wraps navigation in a callback
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockNavigate).toHaveBeenCalledWith('Predict', {
+      screen: 'PredictMarketList',
     });
   });
 

--- a/app/components/Views/WalletActions/WalletActions.tsx
+++ b/app/components/Views/WalletActions/WalletActions.tsx
@@ -145,14 +145,8 @@ const WalletActions = () => {
 
   const onPredict = useCallback(() => {
     closeBottomSheetAndNavigate(() => {
-      navigate(Routes.WALLET.HOME, {
-        screen: Routes.WALLET.TAB_STACK_FLOW,
-        params: {
-          screen: Routes.PREDICT.ROOT,
-          params: {
-            screen: Routes.PREDICT.MARKET_LIST,
-          },
-        },
+      navigate(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_LIST,
       });
     });
   }, [closeBottomSheetAndNavigate, navigate]);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
This PR fixes the navigation stack issues we're currently seeing in Predict:
- confirmations showing a bottom nav bar
- predict screens showing a bottom nav bar (doesn't match designs)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/eb7e3650-1385-4b5b-b885-997ea154cb1d


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Route Predict flows directly to `Routes.PREDICT.ROOT`, add a back button to the Predict feed header, and enable slide-in animation for Predict screens.
> 
> - **Navigation**:
>   - Route Predict actions directly to `Routes.PREDICT.ROOT` with `screen: Routes.PREDICT.MARKET_LIST` from `PredictNewButton`, `PredictPositionEmpty`, `WalletActions`, and `TradeWalletActions` (remove intermediate `Routes.WALLET.HOME`/`TAB_STACK_FLOW`).
>   - Enable slide-in transition for `Routes.PREDICT.ROOT` (`animationEnabled: true` with `cardStyleInterpolator`).
>   - Update deposit flow to pass `stack: Routes.PREDICT.ROOT` to `navigateToConfirmation`.
> - **UI**:
>   - Add header back button to `PredictFeedHeader`; if `canGoBack` then `goBack()`, else navigate to wallet home (`Routes.WALLET_VIEW`).
> - **Tests**:
>   - Update/expand tests for new navigation targets, async bottom sheet callback, and `PredictFeedHeader` back button behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb0808905265a5d30b5872fbd4804750a11c2543. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->