### PR TITLE
feat(ramps): remove unnecessary fiatCurrencies fetch

### DIFF
--- a/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx
@@ -140,8 +140,6 @@ const BuildQuote = () => {
     selectedPaymentMethodId,
     selectedRegion,
     selectedAsset,
-    selectedFiatCurrencyId,
-    setSelectedFiatCurrencyId,
     selectedAddress,
     selectedNetworkName,
     sdkError,
@@ -185,7 +183,6 @@ const BuildQuote = () => {
   }, [paymentMethods, themeAppearance]);
 
   const {
-    defaultFiatCurrency,
     queryDefaultFiatCurrency,
     fiatCurrencies,
     queryGetFiatCurrencies,
@@ -241,32 +238,6 @@ const BuildQuote = () => {
       }
     }, [shouldShowUnsupportedModal, navigation, regions, selectedRegion]),
   );
-
-  useEffect(() => {
-    const handleRegionChange = async () => {
-      if (
-        selectedRegion &&
-        selectedFiatCurrencyId === defaultFiatCurrency?.id
-      ) {
-        const newRegionCurrency = await queryDefaultFiatCurrency(
-          selectedRegion.id,
-          selectedPaymentMethodId ? [selectedPaymentMethodId] : null,
-        );
-        if (newRegionCurrency?.id) {
-          setSelectedFiatCurrencyId(newRegionCurrency.id);
-        }
-      }
-    };
-
-    handleRegionChange();
-  }, [
-    selectedRegion,
-    selectedFiatCurrencyId,
-    defaultFiatCurrency?.id,
-    queryDefaultFiatCurrency,
-    selectedPaymentMethodId,
-    setSelectedFiatCurrencyId,
-  ]);
 
   const gasLimitEstimation = useERC20GasLimitEstimation({
     tokenAddress: selectedAsset?.address,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
We were manually performing a refresh for the fiatCurrency when the region changed. That was unnecessary because the useFiatCurrencies hook already handles that refresh.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-2746?atlOrigin=eyJpIjoiMTA2MDg2ZjNjYmJiNGQxNzk0MzA2ZGVmNjE1ZjU1YzEiLCJwIjoiaiJ9

## **Manual testing steps**

```gherkin
Feature: Remove unnecessary fiat currency API calls on region change

  Scenario: user opens buy crypto screen without redundant API calls
    Given user is on the wallet home screen

    When user opens the buy crypto screen
    Then the app should make exactly 5 SDK API requests
    And the app should not make duplicate fiat currency queries
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
6 requests were made to ramps API.
<img width="1480" height="240" alt="image" src="https://github.com/user-attachments/assets/d8521383-eb07-4645-86a9-73066374edcc" />

### **After**

<!-- [screenshots/recordings] -->
only 5 requests
<img width="1846" height="360" alt="image" src="https://github.com/user-attachments/assets/a663d4cf-319e-436d-9ee4-ba42840a8078" />


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes manual fiat currency refresh in BuildQuote and unused variables, relying on useFiatCurrencies to update on region changes.
> 
> - **BuildQuote (`app/components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx`)**:
>   - Remove region-change `useEffect` that queried `queryDefaultFiatCurrency` and updated `selectedFiatCurrencyId`.
>   - Drop unused fields from hooks: `selectedFiatCurrencyId`, `setSelectedFiatCurrencyId` from `useRampSDK` and `defaultFiatCurrency` from `useFiatCurrencies`.
>   - Rely on `useFiatCurrencies` to manage fiat currency updates on region change, reducing redundant API calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 947c42efe3e38542748e81a74242ab08d1057968. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->