### PR TITLE
feat(component-library): add customizable styling props to TabsBar and Tab

### DIFF
--- a/app/component-library/components-temp/Tabs/Tab/Tab.tsx
+++ b/app/component-library/components-temp/Tabs/Tab/Tab.tsx
@@ -20,6 +20,7 @@ const Tab: React.FC<TabProps> = ({
   onPress,
   testID,
   onLayout,
+  twClassName,
   ...pressableProps
 }) => {
   const tw = useTailwind();
@@ -38,7 +39,7 @@ const Tab: React.FC<TabProps> = ({
     <View
       ref={viewRef}
       onLayout={handleOnLayout}
-      style={tw.style('flex-shrink-0')}
+      style={tw.style(twClassName || 'flex-shrink-0')}
     >
       <Pressable
         style={tw.style(

--- a/app/component-library/components-temp/Tabs/Tab/Tab.types.ts
+++ b/app/component-library/components-temp/Tabs/Tab/Tab.types.ts
@@ -25,4 +25,8 @@ export interface TabProps extends PressableProps {
    * Callback when tab layout changes
    */
   onLayout?: (event: LayoutChangeEvent) => void;
+  /**
+   * Tailwind CSS classes to apply to the tab
+   */
+  twClassName?: string;
 }

--- a/app/component-library/components-temp/Tabs/TabsBar/TabsBar.tsx
+++ b/app/component-library/components-temp/Tabs/TabsBar/TabsBar.tsx
@@ -26,6 +26,8 @@ const TabsBar: React.FC<TabsBarProps> = ({
   onTabPress,
   testID,
   twClassName,
+  tabsContainerClassName = 'gap-6',
+  tabClassName,
   ...boxProps
 }) => {
   const tw = useTailwind();
@@ -260,7 +262,7 @@ const TabsBar: React.FC<TabsBarProps> = ({
           <Box
             flexDirection={BoxFlexDirection.Row}
             alignItems={BoxAlignItems.Center}
-            twClassName="relative gap-6"
+            twClassName={`relative ${tabsContainerClassName}`}
           >
             {tabs.map((tab, index) => (
               <Tab
@@ -271,6 +273,7 @@ const TabsBar: React.FC<TabsBarProps> = ({
                 onPress={() => handleTabPress(index)}
                 onLayout={(layoutEvent) => handleTabLayout(index, layoutEvent)}
                 testID={`${testID}-tab-${index}`}
+                twClassName={tabClassName}
               />
             ))}
 
@@ -289,7 +292,7 @@ const TabsBar: React.FC<TabsBarProps> = ({
         <Box
           flexDirection={BoxFlexDirection.Row}
           alignItems={BoxAlignItems.Center}
-          twClassName="relative gap-6"
+          twClassName={`relative ${tabsContainerClassName}`}
         >
           {tabs.map((tab, index) => (
             <Tab
@@ -300,6 +303,7 @@ const TabsBar: React.FC<TabsBarProps> = ({
               onPress={() => handleTabPress(index)}
               onLayout={(layoutEvent) => handleTabLayout(index, layoutEvent)}
               testID={`${testID}-tab-${index}`}
+              twClassName={tabClassName}
             />
           ))}
 

--- a/app/component-library/components-temp/Tabs/TabsBar/TabsBar.types.ts
+++ b/app/component-library/components-temp/Tabs/TabsBar/TabsBar.types.ts
@@ -38,4 +38,12 @@ export interface TabsBarProps extends BoxProps {
    * Tailwind CSS classes to apply to the main container
    */
   twClassName?: string;
+  /**
+   * Tailwind CSS classes to apply to the tabs container (controls gap, width, etc)
+   */
+  tabsContainerClassName?: string;
+  /**
+   * Tailwind CSS classes to apply to each individual tab
+   */
+  tabClassName?: string;
 }


### PR DESCRIPTION
## **Description**

**⚠️ 100% BACKWARD COMPATIBLE - No breaking changes, all modifications are additive only**

This PR enhances the TabsBar and Tab components with customizable styling options. All new props are optional with sensible defaults that maintain exact existing behavior.

**What is the reason for the change?**
The current TabsBar implementation has hardcoded styling (e.g., `gap-6` spacing, `flex-shrink-0` on tabs) that cannot be customized without modifying the component-library code. This limits flexibility for use cases that require different layouts, such as full-width tabs with equal distribution.

**What is the improvement/solution?**
Added three **optional** Tailwind className props:
- `tabsContainerClassName` - Controls tabs container styling (gap, width, etc.), **defaults to `gap-6`** (existing behavior)
- `tabClassName` - Controls individual tab wrapper styling, **defaults to `flex-shrink-0`** (existing behavior)
- `twClassName` on Tab component - Allows per-tab customization, **defaults to `flex-shrink-0`** (existing behavior)

**Backward Compatibility Guarantee:**
- ✅ All new props are optional
- ✅ Default values match current hardcoded behavior exactly
- ✅ All existing TabsBar/Tab usages work unchanged without any modifications
- ✅ No TypeScript breaking changes - all new props are optional
- ✅ No visual changes unless new props are explicitly provided

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A (Internal improvement for component-library flexibility)

## **Manual testing steps**

```gherkin
Feature: TabsBar custom styling support

  Scenario: user views tabs with default styling
    Given a TabsBar without custom className props
    When the component renders
    Then tabs display with gap-6 spacing and flex-shrink-0 behavior (existing behavior)

  Scenario: user views tabs with custom full-width styling
    Given a TabsBar with tabsContainerClassName='w-full' and tabClassName='flex-1'
    When the component renders
    Then tabs expand equally to fill container width

  Scenario: user views tabs with custom gap spacing
    Given a TabsBar with tabsContainerClassName='gap-2'
    When the component renders
    Then tabs display with reduced spacing between them
```

## **Screenshots/Recordings**

### **Before**
No change to existing behavior - tabs render with default gap-6 spacing.

### **After**
Same default behavior maintained. New props enable custom layouts when explicitly provided:
- `tabsContainerClassName='w-full'` - Full width container
- `tabClassName='flex-1 items-center'` - Equal width tabs with centered content
- `tabsContainerClassName='gap-2'` - Custom spacing

https://github.com/user-attachments/assets/fd6d9eeb-c0d7-4ca0-b2dc-d5c071e6a3cd


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable (No new tests needed - additive change with defaults)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional Tailwind class props to customize TabsBar container and individual Tab styling, defaulting to previous spacing/shrink behavior.
> 
> - **Component Library — Tabs**
>   - **`TabsBar`** (`TabsBar.tsx`, `TabsBar.types.ts`):
>     - Add `tabsContainerClassName` (default `gap-6`) to control tabs container layout.
>     - Add `tabClassName` and forward to each `Tab`.
>     - Replace hardcoded container classes with `tabsContainerClassName` in both scrollable and non-scrollable layouts.
>   - **`Tab`** (`Tab.tsx`, `Tab.types.ts`):
>     - Add `twClassName` prop; apply to root `View` style with fallback to `flex-shrink-0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6fa3296cdbd2688a2bf271da4eeff5196697ba80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->