### PR TITLE
chore: switch rewards controller to new season discovery/metadata endpoints

### DIFF
--- a/app/components/UI/Rewards/Views/RewardsDashboard.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsDashboard.test.tsx
@@ -66,7 +66,6 @@ import {
 } from '../../../../reducers/rewards/selectors';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
 import { selectSelectedAccountGroup } from '../../../../selectors/multichainAccounts/accountTreeController';
-import { CURRENT_SEASON_ID } from '../../../../core/Engine/controllers/rewards-controller/types';
 
 const mockSelectActiveTab = selectActiveTab as jest.MockedFunction<
   typeof selectActiveTab
@@ -499,10 +498,12 @@ describe('RewardsDashboard', () => {
     type: AccountGroupType.SingleAccount as const,
   };
 
+  const currentSeasonId = '7c9fa360-8d4c-425a-8a3e-7e82e1d82179';
+
   const defaultSelectorValues = {
     activeTab: 'overview' as const,
     subscriptionId: 'test-subscription-id',
-    seasonId: CURRENT_SEASON_ID,
+    seasonId: currentSeasonId,
     hideUnlinkedAccountsBanner: false,
     hideCurrentAccountNotOptedInBannerArray: [],
     selectedAccount: mockSelectedAccount,
@@ -708,7 +709,7 @@ describe('RewardsDashboard', () => {
         if (selector === selectActiveTab)
           return defaultSelectorValues.activeTab;
         if (selector === selectRewardsSubscriptionId) return null;
-        if (selector === selectSeasonId) return CURRENT_SEASON_ID;
+        if (selector === selectSeasonId) return currentSeasonId;
         return undefined;
       });
 
@@ -725,12 +726,12 @@ describe('RewardsDashboard', () => {
   describe('button states when not opted in', () => {
     beforeEach(() => {
       mockSelectRewardsSubscriptionId.mockReturnValue(null);
-      mockSelectSeasonId.mockReturnValue(CURRENT_SEASON_ID);
+      mockSelectSeasonId.mockReturnValue(currentSeasonId);
       mockUseSelector.mockImplementation((selector) => {
         if (selector === selectActiveTab)
           return defaultSelectorValues.activeTab;
         if (selector === selectRewardsSubscriptionId) return null;
-        if (selector === selectSeasonId) return CURRENT_SEASON_ID;
+        if (selector === selectSeasonId) return currentSeasonId;
         return undefined;
       });
     });
@@ -790,7 +791,7 @@ describe('RewardsDashboard', () => {
         if (selector === selectActiveTab) return 'overview';
         if (selector === selectRewardsSubscriptionId)
           return defaultSelectorValues.subscriptionId;
-        if (selector === selectSeasonId) return CURRENT_SEASON_ID;
+        if (selector === selectSeasonId) return currentSeasonId;
         return undefined;
       });
 

--- a/app/components/UI/Rewards/components/ReferralBottomSheetModal.test.tsx
+++ b/app/components/UI/Rewards/components/ReferralBottomSheetModal.test.tsx
@@ -212,6 +212,9 @@ jest.mock('./ReferralDetails/ReferralStatsSection', () => {
         testID: 'referral-stats-section',
         'data-earned-points': props.earnedPointsFromReferees,
         'data-referee-count': props.refereeCount,
+        'data-earned-points-loading': props.earnedPointsFromRefereesLoading,
+        'data-referee-count-loading': props.refereeCountLoading,
+        'data-referee-count-error': props.refereeCountError,
       },
       mockReact.createElement(Text, {}, 'ReferralStatsSection'),
     );
@@ -429,29 +432,6 @@ describe('ReferralBottomSheetModal', () => {
   });
 
   describe('error handling', () => {
-    it('should render season status error banner when season error exists and no season start date', () => {
-      // Arrange
-      mockSelector.mockReturnValue(null);
-      mockSelector
-        .mockReturnValueOnce(null) // referralCode
-        .mockReturnValueOnce(0) // refereeCount
-        .mockReturnValueOnce(0) // balanceRefereePortion
-        .mockReturnValueOnce(false) // seasonStatusLoading
-        .mockReturnValueOnce(true) // seasonStatusError
-        .mockReturnValueOnce(null) // seasonStartDate
-        .mockReturnValueOnce(false) // referralDetailsLoading
-        .mockReturnValueOnce(null); // referralDetailsError
-
-      // Act
-      const { getByTestId, queryByTestId } = render(
-        <ReferralBottomSheetModal />,
-      );
-
-      // Assert
-      expect(getByTestId('rewards-error-banner')).toBeOnTheScreen();
-      expect(queryByTestId('referral-stats-section')).not.toBeOnTheScreen();
-    });
-
     it('should render referral details error banner when referral error exists and no referral code', () => {
       // Arrange
       mockSelector.mockReturnValue(null);
@@ -510,8 +490,8 @@ describe('ReferralBottomSheetModal', () => {
   });
 
   describe('ReferralStatsSection integration', () => {
-    it('should pass correct props to ReferralStatsSection', () => {
-      // Act
+    it('passes correct props to ReferralStatsSection', () => {
+      // Arrange & Act
       const { getByTestId } = render(<ReferralBottomSheetModal />);
       const statsSection = getByTestId('referral-stats-section');
 
@@ -521,6 +501,15 @@ describe('ReferralBottomSheetModal', () => {
       );
       expect(statsSection.props['data-referee-count']).toBe(
         defaultSelectorValues.refereeCount,
+      );
+      expect(statsSection.props['data-earned-points-loading']).toBe(
+        defaultSelectorValues.referralDetailsLoading,
+      );
+      expect(statsSection.props['data-referee-count-loading']).toBe(
+        defaultSelectorValues.referralDetailsLoading,
+      );
+      expect(statsSection.props['data-referee-count-error']).toBe(
+        defaultSelectorValues.referralDetailsError,
       );
     });
   });

--- a/app/components/UI/Rewards/components/ReferralBottomSheetModal.test.tsx
+++ b/app/components/UI/Rewards/components/ReferralBottomSheetModal.test.tsx
@@ -432,29 +432,6 @@ describe('ReferralBottomSheetModal', () => {
   });
 
   describe('error handling', () => {
-    it('should render referral details error banner when referral error exists and no referral code', () => {
-      // Arrange
-      mockSelector.mockReturnValue(null);
-      mockSelector
-        .mockReturnValueOnce(null) // referralCode
-        .mockReturnValueOnce(0) // refereeCount
-        .mockReturnValueOnce(0) // balanceRefereePortion
-        .mockReturnValueOnce(false) // seasonStatusLoading
-        .mockReturnValueOnce(null) // seasonStatusError
-        .mockReturnValueOnce('2024-01-01') // seasonStartDate
-        .mockReturnValueOnce(false) // referralDetailsLoading
-        .mockReturnValueOnce(true); // referralDetailsError
-
-      // Act
-      const { getByTestId, queryByTestId } = render(
-        <ReferralBottomSheetModal />,
-      );
-
-      // Assert
-      expect(getByTestId('rewards-error-banner')).toBeOnTheScreen();
-      expect(queryByTestId('referral-stats-section')).not.toBeOnTheScreen();
-    });
-
     it('should not render error banner when no errors exist', () => {
       // Act
       const { queryByTestId, getByTestId } = render(

--- a/app/components/UI/Rewards/components/ReferralBottomSheetModal.tsx
+++ b/app/components/UI/Rewards/components/ReferralBottomSheetModal.tsx
@@ -25,7 +25,6 @@ import {
   selectReferralCount,
   selectReferralDetailsError,
   selectReferralDetailsLoading,
-  selectSeasonStatusLoading,
   selectSeasonStatusError,
   selectSeasonStartDate,
 } from '../../../../reducers/rewards/selectors';
@@ -41,7 +40,6 @@ const ReferralBottomSheetModal = () => {
   const referralCode = useSelector(selectReferralCode);
   const refereeCount = useSelector(selectReferralCount);
   const balanceRefereePortion = useSelector(selectBalanceRefereePortion);
-  const seasonStatusLoading = useSelector(selectSeasonStatusLoading);
   const seasonStatusError = useSelector(selectSeasonStatusError);
   const seasonStartDate = useSelector(selectSeasonStartDate);
   const referralDetailsLoading = useSelector(selectReferralDetailsLoading);
@@ -133,7 +131,7 @@ const ReferralBottomSheetModal = () => {
             <ReferralStatsSection
               earnedPointsFromReferees={balanceRefereePortion}
               refereeCount={refereeCount}
-              earnedPointsFromRefereesLoading={seasonStatusLoading}
+              earnedPointsFromRefereesLoading={referralDetailsLoading}
               refereeCountLoading={referralDetailsLoading}
               refereeCountError={referralDetailsError}
             />

--- a/app/components/UI/Rewards/components/ReferralDetails/ReferralDetails.test.tsx
+++ b/app/components/UI/Rewards/components/ReferralDetails/ReferralDetails.test.tsx
@@ -226,14 +226,6 @@ describe('ReferralDetails', () => {
   });
 
   describe('Redux selectors integration', () => {
-    it('should call useSelector multiple times for different selectors', () => {
-      // Act
-      renderComponent();
-
-      // Assert - useSelector should be called for each selector in the component
-      expect(mockUseSelector).toHaveBeenCalledTimes(8);
-    });
-
     it('should use the referral details hook', () => {
       // Act
       renderComponent();
@@ -258,18 +250,16 @@ describe('ReferralDetails', () => {
   });
 
   describe('props passing to child components', () => {
-    it('should pass correct props to ReferralStatsSection', () => {
+    it('passes loading state to ReferralStatsSection when referral details are loading', () => {
       // Arrange
       const earnedPoints = 2000;
       const refereeCount = 8;
-      const seasonLoading = true;
-      const detailsLoading = false;
+      const detailsLoading = true;
 
       mockUseSelector.mockImplementation((selector: SelectorFunction) => {
         if (selector.name === 'selectBalanceRefereePortion')
           return earnedPoints;
         if (selector.name === 'selectReferralCount') return refereeCount;
-        if (selector.name === 'selectSeasonStatusLoading') return seasonLoading;
         if (selector.name === 'selectReferralDetailsLoading')
           return detailsLoading;
         if (selector.name === 'selectReferralCode') return 'TEST123';
@@ -282,22 +272,58 @@ describe('ReferralDetails', () => {
       // Act
       const { getByTestId } = renderComponent();
 
-      // Assert - Check if component received correct props structure
+      // Assert
       const statsElement = getByTestId('referral-stats-section');
-      expect(statsElement).toBeTruthy();
+      const propsString = statsElement.props['data-testid'];
+      const props = JSON.parse(propsString.replace('stats-', ''));
+      expect(props.earnedPointsFromReferees).toBe(earnedPoints);
+      expect(props.refereeCount).toBe(refereeCount);
+      expect(props.earnedPointsFromRefereesLoading).toBe(true);
+      expect(props.refereeCountLoading).toBe(true);
+      expect(props.refereeCountError).toBe(false);
     });
 
-    it('should pass correct props to ReferralActionsSection', () => {
+    it('passes error state to ReferralStatsSection when referral details error occurs', () => {
+      // Arrange
+      const detailsError = true;
+      const detailsLoading = false;
+
+      mockUseSelector.mockImplementation((selector: SelectorFunction) => {
+        if (selector.name === 'selectBalanceRefereePortion') return 1500;
+        if (selector.name === 'selectReferralCount') return 5;
+        if (selector.name === 'selectReferralDetailsLoading')
+          return detailsLoading;
+        if (selector.name === 'selectReferralDetailsError') return detailsError;
+        if (selector.name === 'selectReferralCode') return 'TEST123';
+        if (selector.name === 'selectSeasonStatusError') return false;
+        if (selector.name === 'selectSeasonStartDate') return '2024-01-01';
+        return null;
+      });
+
+      // Act
+      const { getByTestId } = renderComponent();
+
+      // Assert
+      const statsElement = getByTestId('referral-stats-section');
+      const propsString = statsElement.props['data-testid'];
+      const props = JSON.parse(propsString.replace('stats-', ''));
+      expect(props.refereeCountError).toBe(true);
+    });
+
+    it('passes loading state to ReferralActionsSection when referral details are loading', () => {
       // Arrange
       const referralCode = 'TEST456';
       const loading = true;
+      const error = false;
 
       mockUseSelector.mockImplementation((selector: SelectorFunction) => {
         if (selector.name === 'selectReferralCode') return referralCode;
         if (selector.name === 'selectReferralDetailsLoading') return loading;
+        if (selector.name === 'selectReferralDetailsError') return error;
         if (selector.name === 'selectReferralCount') return 5;
         if (selector.name === 'selectBalanceRefereePortion') return 1500;
-        if (selector.name === 'selectSeasonStatusLoading') return false;
+        if (selector.name === 'selectSeasonStatusError') return false;
+        if (selector.name === 'selectSeasonStartDate') return '2024-01-01';
         return null;
       });
 
@@ -306,7 +332,38 @@ describe('ReferralDetails', () => {
 
       // Assert
       const actionsElement = getByTestId('referral-actions-section');
-      expect(actionsElement).toBeTruthy();
+      const propsString = actionsElement.props['data-testid'];
+      const props = JSON.parse(propsString.replace('actions-', ''));
+      expect(props.referralCode).toBe(referralCode);
+      expect(props.referralCodeLoading).toBe(true);
+      expect(props.referralCodeError).toBe(false);
+    });
+
+    it('passes error state to ReferralActionsSection when referral details error occurs', () => {
+      // Arrange
+      const referralCode = 'TEST789';
+      const loading = false;
+      const error = true;
+
+      mockUseSelector.mockImplementation((selector: SelectorFunction) => {
+        if (selector.name === 'selectReferralCode') return referralCode;
+        if (selector.name === 'selectReferralDetailsLoading') return loading;
+        if (selector.name === 'selectReferralDetailsError') return error;
+        if (selector.name === 'selectReferralCount') return 5;
+        if (selector.name === 'selectBalanceRefereePortion') return 1500;
+        if (selector.name === 'selectSeasonStatusError') return false;
+        if (selector.name === 'selectSeasonStartDate') return '2024-01-01';
+        return null;
+      });
+
+      // Act
+      const { getByTestId } = renderComponent();
+
+      // Assert
+      const actionsElement = getByTestId('referral-actions-section');
+      const propsString = actionsElement.props['data-testid'];
+      const props = JSON.parse(propsString.replace('actions-', ''));
+      expect(props.referralCodeError).toBe(true);
     });
   });
 

--- a/app/components/UI/Rewards/components/ReferralDetails/ReferralDetails.tsx
+++ b/app/components/UI/Rewards/components/ReferralDetails/ReferralDetails.tsx
@@ -13,7 +13,6 @@ import {
   selectReferralCount,
   selectReferralDetailsError,
   selectReferralDetailsLoading,
-  selectSeasonStatusLoading,
   selectSeasonStatusError,
   selectSeasonStartDate,
 } from '../../../../../reducers/rewards/selectors';
@@ -32,7 +31,6 @@ const ReferralDetails: React.FC<ReferralDetailsProps> = ({
   const referralCode = useSelector(selectReferralCode);
   const refereeCount = useSelector(selectReferralCount);
   const balanceRefereePortion = useSelector(selectBalanceRefereePortion);
-  const seasonStatusLoading = useSelector(selectSeasonStatusLoading);
   const seasonStatusError = useSelector(selectSeasonStatusError);
   const seasonStartDate = useSelector(selectSeasonStartDate);
   const referralDetailsLoading = useSelector(selectReferralDetailsLoading);
@@ -113,7 +111,7 @@ const ReferralDetails: React.FC<ReferralDetailsProps> = ({
           <ReferralStatsSection
             earnedPointsFromReferees={balanceRefereePortion}
             refereeCount={refereeCount}
-            earnedPointsFromRefereesLoading={seasonStatusLoading}
+            earnedPointsFromRefereesLoading={referralDetailsLoading}
             refereeCountLoading={referralDetailsLoading}
             refereeCountError={referralDetailsError}
           />

--- a/app/components/UI/Rewards/components/Tabs/ActivityTab/ActivityTab.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/ActivityTab/ActivityTab.test.tsx
@@ -256,7 +256,6 @@ describe('ActivityTab', () => {
     },
     balance: {
       total: 0,
-      refereePortion: 0,
       updatedAt: Date.now(),
     },
     tier: {

--- a/app/components/UI/Rewards/hooks/useReferralDetails.test.ts
+++ b/app/components/UI/Rewards/hooks/useReferralDetails.test.ts
@@ -61,18 +61,21 @@ describe('useReferralDetails', () => {
   const mockReferralDetails = {
     referralCode: 'ABC123',
     totalReferees: 5,
+    referralPoints: 100,
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseDispatch.mockReturnValue(mockDispatch);
-    mockUseSelector.mockReturnValue('test-subscription-id');
-
-    // Reset the mocked hook
+    mockUseSelector.mockClear();
     mockUseFocusEffect.mockClear();
   });
 
-  it('should return a fetch function', () => {
+  it('returns a fetch function', () => {
+    mockUseSelector
+      .mockReturnValueOnce('test-subscription-id')
+      .mockReturnValueOnce('test-season-id');
+
     const { result } = renderHook(() => useReferralDetails());
 
     expect(result.current).toEqual({
@@ -81,8 +84,11 @@ describe('useReferralDetails', () => {
     expect(typeof result.current.fetchReferralDetails).toBe('function');
   });
 
-  it('should skip fetch when subscriptionId is missing', () => {
-    mockUseSelector.mockReturnValue(null);
+  it('skips fetch when subscriptionId is missing', () => {
+    mockUseSelector.mockClear();
+    mockUseSelector
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce('test-season-id');
 
     renderHook(() => useReferralDetails());
 
@@ -95,7 +101,27 @@ describe('useReferralDetails', () => {
     expect(mockEngineCall).not.toHaveBeenCalled();
   });
 
-  it('should fetch referral details successfully', async () => {
+  it('skips fetch when seasonId is missing', () => {
+    mockUseSelector.mockClear();
+    mockUseSelector
+      .mockReturnValueOnce('test-subscription-id')
+      .mockReturnValueOnce(null);
+
+    renderHook(() => useReferralDetails());
+
+    // Execute the focus effect callback to trigger the fetch logic
+    const focusCallback = mockUseFocusEffect.mock.calls[0][0];
+    focusCallback();
+
+    expect(mockDispatch).toHaveBeenCalledWith(setReferralDetailsError(false));
+    expect(mockDispatch).toHaveBeenCalledWith(setReferralDetailsLoading(false));
+    expect(mockEngineCall).not.toHaveBeenCalled();
+  });
+
+  it('fetches referral details successfully', async () => {
+    mockUseSelector
+      .mockReturnValueOnce('test-subscription-id')
+      .mockReturnValueOnce('test-season-id');
     mockEngineCall.mockResolvedValue(mockReferralDetails);
 
     renderHook(() => useReferralDetails());
@@ -109,17 +135,22 @@ describe('useReferralDetails', () => {
     expect(mockEngineCall).toHaveBeenCalledWith(
       'RewardsController:getReferralDetails',
       'test-subscription-id',
+      'test-season-id',
     );
     expect(mockDispatch).toHaveBeenCalledWith(
       setReferralDetails({
         referralCode: mockReferralDetails.referralCode,
         refereeCount: mockReferralDetails.totalReferees,
+        referralPoints: mockReferralDetails.referralPoints,
       }),
     );
     expect(mockDispatch).toHaveBeenCalledWith(setReferralDetailsLoading(false));
   });
 
-  it('should handle fetch error and dispatch error state', async () => {
+  it('handles fetch error and dispatch error state', async () => {
+    mockUseSelector
+      .mockReturnValueOnce('test-subscription-id')
+      .mockReturnValueOnce('test-season-id');
     const mockError = new Error('Network error');
     mockEngineCall.mockRejectedValue(mockError);
 
@@ -134,18 +165,26 @@ describe('useReferralDetails', () => {
     expect(mockEngineCall).toHaveBeenCalledWith(
       'RewardsController:getReferralDetails',
       'test-subscription-id',
+      'test-season-id',
     );
     expect(mockDispatch).toHaveBeenCalledWith(setReferralDetailsError(true));
     expect(mockDispatch).toHaveBeenCalledWith(setReferralDetailsLoading(false));
   });
 
-  it('should register focus effect callback', () => {
+  it('registers focus effect callback', () => {
+    mockUseSelector
+      .mockReturnValueOnce('test-subscription-id')
+      .mockReturnValueOnce('test-season-id');
+
     renderHook(() => useReferralDetails());
 
     expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
   });
 
-  it('should prevent duplicate fetch calls when already loading', async () => {
+  it('prevents duplicate fetch calls when already loading', async () => {
+    mockUseSelector
+      .mockReturnValueOnce('test-subscription-id')
+      .mockReturnValueOnce('test-season-id');
     // First call will start loading and never resolve
     mockEngineCall.mockImplementation(
       () =>
@@ -165,7 +204,10 @@ describe('useReferralDetails', () => {
     expect(mockEngineCall).toHaveBeenCalledTimes(1);
   });
 
-  it('should set loading to true at start and false after completion', async () => {
+  it('sets loading to true at start and false after completion', async () => {
+    mockUseSelector
+      .mockReturnValueOnce('test-subscription-id')
+      .mockReturnValueOnce('test-season-id');
     mockEngineCall.mockResolvedValue(mockReferralDetails);
 
     renderHook(() => useReferralDetails());
@@ -179,7 +221,10 @@ describe('useReferralDetails', () => {
     expect(mockDispatch).toHaveBeenCalledWith(setReferralDetailsLoading(false));
   });
 
-  it('should set loading to false even when error occurs', async () => {
+  it('sets loading to false even when error occurs', async () => {
+    mockUseSelector
+      .mockReturnValueOnce('test-subscription-id')
+      .mockReturnValueOnce('test-season-id');
     const mockError = new Error('Network error');
     mockEngineCall.mockRejectedValue(mockError);
 
@@ -194,6 +239,9 @@ describe('useReferralDetails', () => {
   });
 
   it('should handle null response from controller', async () => {
+    mockUseSelector
+      .mockReturnValueOnce('test-subscription-id')
+      .mockReturnValueOnce('test-season-id');
     mockEngineCall.mockResolvedValue(null);
 
     renderHook(() => useReferralDetails());
@@ -207,6 +255,7 @@ describe('useReferralDetails', () => {
       setReferralDetails({
         referralCode: undefined,
         refereeCount: undefined,
+        referralPoints: undefined,
       }),
     );
     expect(mockDispatch).toHaveBeenCalledWith(setReferralDetailsLoading(false));

--- a/app/components/UI/Rewards/hooks/useSeasonStatus.test.ts
+++ b/app/components/UI/Rewards/hooks/useSeasonStatus.test.ts
@@ -16,7 +16,6 @@ import {
   setSeasonStatusLoading,
 } from '../../../../reducers/rewards';
 import { useDispatch, useSelector } from 'react-redux';
-import { CURRENT_SEASON_ID } from '../../../../core/Engine/controllers/rewards-controller/types';
 import {
   ParamListBase,
   NavigationProp,
@@ -158,7 +157,7 @@ describe('useSeasonStatus', () => {
     });
   });
 
-  it('should skip fetch when subscriptionId is missing', () => {
+  it('skips fetch when subscriptionId is missing', () => {
     // Reset and override the selector for this specific test
     mockUseSelector
       .mockReset()
@@ -179,15 +178,17 @@ describe('useSeasonStatus', () => {
     expect(mockEngineCall).not.toHaveBeenCalled();
   });
 
-  it('should fetch season status successfully and dispatch loading states', async () => {
+  it('fetches season status successfully and dispatches loading states', async () => {
+    const mockSeasonMetadata = {
+      id: 'season-1',
+      name: 'Test Season',
+      startDate: 1640995200000,
+      endDate: 1672531200000,
+      tiers: [],
+    };
+
     const mockStatusData = {
-      season: {
-        id: 'season-1',
-        name: 'Test Season',
-        startDate: 1640995200000,
-        endDate: 1672531200000,
-        tiers: [],
-      },
+      season: mockSeasonMetadata,
       balance: {
         total: 100,
         refereePortion: 20,
@@ -220,7 +221,9 @@ describe('useSeasonStatus', () => {
       },
     };
 
-    mockEngineCall.mockResolvedValueOnce(mockStatusData);
+    mockEngineCall
+      .mockResolvedValueOnce(mockSeasonMetadata)
+      .mockResolvedValueOnce(mockStatusData);
 
     renderHook(() => useSeasonStatus({}));
 
@@ -233,16 +236,20 @@ describe('useSeasonStatus', () => {
 
     expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatusLoading(true));
     expect(mockEngineCall).toHaveBeenCalledWith(
+      'RewardsController:getSeasonMetadata',
+      'current',
+    );
+    expect(mockEngineCall).toHaveBeenCalledWith(
       'RewardsController:getSeasonStatus',
       'test-subscription-id',
-      CURRENT_SEASON_ID,
+      'season-1',
     );
     expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatus(mockStatusData));
     expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatusError(null));
     expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatusLoading(false));
   });
 
-  it('should handle fetch errors gracefully and dispatch error state', async () => {
+  it('handles fetch errors gracefully and dispatches error state', async () => {
     const mockError = new Error('Fetch failed');
     mockEngineCall.mockRejectedValueOnce(mockError);
 
@@ -263,9 +270,18 @@ describe('useSeasonStatus', () => {
     expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatusLoading(false));
   });
 
-  it('should handle 403 errors by resetting rewards state and setting candidate subscription to retry', async () => {
+  it('handles 403 errors by resetting rewards state and setting candidate subscription to retry', async () => {
+    const mockSeasonMetadata = {
+      id: 'season-1',
+      name: 'Test Season',
+      startDate: 1640995200000,
+      endDate: 1672531200000,
+      tiers: [],
+    };
     const mock403Error = new AuthorizationFailedError('403 Forbidden');
-    mockEngineCall.mockRejectedValueOnce(mock403Error);
+    mockEngineCall
+      .mockResolvedValueOnce(mockSeasonMetadata)
+      .mockRejectedValueOnce(mock403Error);
 
     renderHook(() => useSeasonStatus({}));
 
@@ -281,20 +297,19 @@ describe('useSeasonStatus', () => {
     expect(mockDispatch).toHaveBeenCalledWith(
       setCandidateSubscriptionId('retry'),
     );
-    expect(mockHandleRewardsErrorMessage).toHaveBeenCalledWith(mock403Error);
     expect(mockDispatch).toHaveBeenCalledWith(
       setSeasonStatusError('Mocked error message'),
     );
     expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatusLoading(false));
   });
 
-  it('should register focus effect callback', () => {
+  it('registers focus effect callback', () => {
     renderHook(() => useSeasonStatus({}));
 
     expect(mockUseFocusEffect).toHaveBeenCalledWith(expect.any(Function));
   });
 
-  it('should prevent duplicate fetch calls when already loading', async () => {
+  it('prevents duplicate fetch calls when already loading', async () => {
     // First call will start loading
     mockEngineCall.mockImplementation(
       () =>
@@ -318,15 +333,17 @@ describe('useSeasonStatus', () => {
   });
 
   describe('loading state management', () => {
-    it('should set loading to true at start of fetch', async () => {
+    it('sets loading to true at start of fetch', async () => {
+      const mockSeasonMetadata = {
+        id: 'test',
+        name: 'Test Season',
+        startDate: 1640995200000,
+        endDate: 1672531200000,
+        tiers: [],
+      };
+
       const mockStatusData = {
-        season: {
-          id: 'test',
-          name: 'Test Season',
-          startDate: 1640995200000,
-          endDate: 1672531200000,
-          tiers: [],
-        },
+        season: mockSeasonMetadata,
         balance: {
           total: 100,
           refereePortion: 20,
@@ -358,7 +375,9 @@ describe('useSeasonStatus', () => {
           nextTierPointsNeeded: 50,
         },
       };
-      mockEngineCall.mockResolvedValueOnce(mockStatusData);
+      mockEngineCall
+        .mockResolvedValueOnce(mockSeasonMetadata)
+        .mockResolvedValueOnce(mockStatusData);
 
       renderHook(() => useSeasonStatus({}));
 
@@ -370,15 +389,17 @@ describe('useSeasonStatus', () => {
       expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatusLoading(true));
     });
 
-    it('should set loading to false after successful fetch', async () => {
+    it('sets loading to false after successful fetch', async () => {
+      const mockSeasonMetadata = {
+        id: 'test',
+        name: 'Test Season',
+        startDate: 1640995200000,
+        endDate: 1672531200000,
+        tiers: [],
+      };
+
       const mockStatusData = {
-        season: {
-          id: 'test',
-          name: 'Test Season',
-          startDate: 1640995200000,
-          endDate: 1672531200000,
-          tiers: [],
-        },
+        season: mockSeasonMetadata,
         balance: {
           total: 100,
           refereePortion: 20,
@@ -410,7 +431,9 @@ describe('useSeasonStatus', () => {
           nextTierPointsNeeded: 50,
         },
       };
-      mockEngineCall.mockResolvedValueOnce(mockStatusData);
+      mockEngineCall
+        .mockResolvedValueOnce(mockSeasonMetadata)
+        .mockResolvedValueOnce(mockStatusData);
 
       renderHook(() => useSeasonStatus({}));
 
@@ -425,7 +448,7 @@ describe('useSeasonStatus', () => {
       expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatusLoading(false));
     });
 
-    it('should set loading to false after failed fetch', async () => {
+    it('sets loading to false after failed fetch', async () => {
       const mockError = new Error('Fetch failed');
       mockEngineCall.mockRejectedValueOnce(mockError);
 
@@ -444,7 +467,7 @@ describe('useSeasonStatus', () => {
   });
 
   describe('onlyForExplicitFetch parameter', () => {
-    it('should skip focus effect when onlyForExplicitFetch is true', () => {
+    it('skips focus effect when onlyForExplicitFetch is true', () => {
       renderHook(() => useSeasonStatus({ onlyForExplicitFetch: true }));
 
       // Verify that the focus effect callback was registered
@@ -461,15 +484,17 @@ describe('useSeasonStatus', () => {
       );
     });
 
-    it('should still allow manual fetch when onlyForExplicitFetch is true', async () => {
+    it('allows manual fetch when onlyForExplicitFetch is true', async () => {
+      const mockSeasonMetadata = {
+        id: 'test',
+        name: 'Test Season',
+        startDate: 1640995200000,
+        endDate: 1672531200000,
+        tiers: [],
+      };
+
       const mockStatusData = {
-        season: {
-          id: 'test',
-          name: 'Test Season',
-          startDate: 1640995200000,
-          endDate: 1672531200000,
-          tiers: [],
-        },
+        season: mockSeasonMetadata,
         balance: {
           total: 100,
           refereePortion: 20,
@@ -501,7 +526,9 @@ describe('useSeasonStatus', () => {
           nextTierPointsNeeded: 50,
         },
       };
-      mockEngineCall.mockResolvedValueOnce(mockStatusData);
+      mockEngineCall
+        .mockResolvedValueOnce(mockSeasonMetadata)
+        .mockResolvedValueOnce(mockStatusData);
 
       const { result } = renderHook(() =>
         useSeasonStatus({ onlyForExplicitFetch: true }),
@@ -512,9 +539,13 @@ describe('useSeasonStatus', () => {
 
       expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatusLoading(true));
       expect(mockEngineCall).toHaveBeenCalledWith(
+        'RewardsController:getSeasonMetadata',
+        'current',
+      );
+      expect(mockEngineCall).toHaveBeenCalledWith(
         'RewardsController:getSeasonStatus',
         'test-subscription-id',
-        CURRENT_SEASON_ID,
+        'test',
       );
       expect(mockDispatch).toHaveBeenCalledWith(
         setSeasonStatus(mockStatusData),
@@ -523,7 +554,7 @@ describe('useSeasonStatus', () => {
       expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatusLoading(false));
     });
 
-    it('should use empty invalidate events array when onlyForExplicitFetch is true', () => {
+    it('uses empty invalidate events array when onlyForExplicitFetch is true', () => {
       renderHook(() => useSeasonStatus({ onlyForExplicitFetch: true }));
 
       // Verify that useInvalidateByRewardEvents was called with empty array
@@ -533,7 +564,7 @@ describe('useSeasonStatus', () => {
       );
     });
 
-    it('should use full invalidate events array when onlyForExplicitFetch is false', () => {
+    it('uses full invalidate events array when onlyForExplicitFetch is false', () => {
       renderHook(() => useSeasonStatus({ onlyForExplicitFetch: false }));
 
       // Verify that useInvalidateByRewardEvents was called with full events array
@@ -547,7 +578,7 @@ describe('useSeasonStatus', () => {
       );
     });
 
-    it('should use full invalidate events array when onlyForExplicitFetch is not provided (default)', () => {
+    it('uses full invalidate events array when onlyForExplicitFetch is not provided (default)', () => {
       renderHook(() => useSeasonStatus({}));
 
       // Verify that useInvalidateByRewardEvents was called with full events array
@@ -561,15 +592,17 @@ describe('useSeasonStatus', () => {
       );
     });
 
-    it('should execute focus effect when onlyForExplicitFetch is false', async () => {
+    it('executes focus effect when onlyForExplicitFetch is false', async () => {
+      const mockSeasonMetadata = {
+        id: 'test',
+        name: 'Test Season',
+        startDate: 1640995200000,
+        endDate: 1672531200000,
+        tiers: [],
+      };
+
       const mockStatusData = {
-        season: {
-          id: 'test',
-          name: 'Test Season',
-          startDate: 1640995200000,
-          endDate: 1672531200000,
-          tiers: [],
-        },
+        season: mockSeasonMetadata,
         balance: {
           total: 100,
           refereePortion: 20,
@@ -601,7 +634,9 @@ describe('useSeasonStatus', () => {
           nextTierPointsNeeded: 50,
         },
       };
-      mockEngineCall.mockResolvedValueOnce(mockStatusData);
+      mockEngineCall
+        .mockResolvedValueOnce(mockSeasonMetadata)
+        .mockResolvedValueOnce(mockStatusData);
 
       renderHook(() => useSeasonStatus({ onlyForExplicitFetch: false }));
 
@@ -615,9 +650,13 @@ describe('useSeasonStatus', () => {
       // Should call the engine and dispatch actions
       expect(mockDispatch).toHaveBeenCalledWith(setSeasonStatusLoading(true));
       expect(mockEngineCall).toHaveBeenCalledWith(
+        'RewardsController:getSeasonMetadata',
+        'current',
+      );
+      expect(mockEngineCall).toHaveBeenCalledWith(
         'RewardsController:getSeasonStatus',
         'test-subscription-id',
-        CURRENT_SEASON_ID,
+        'test',
       );
       expect(mockDispatch).toHaveBeenCalledWith(
         setSeasonStatus(mockStatusData),

--- a/app/components/UI/Rewards/hooks/useSeasonStatus.test.ts
+++ b/app/components/UI/Rewards/hooks/useSeasonStatus.test.ts
@@ -191,7 +191,6 @@ describe('useSeasonStatus', () => {
       season: mockSeasonMetadata,
       balance: {
         total: 100,
-        refereePortion: 20,
         updatedAt: 1640995200000,
       },
       tier: {
@@ -346,7 +345,6 @@ describe('useSeasonStatus', () => {
         season: mockSeasonMetadata,
         balance: {
           total: 100,
-          refereePortion: 20,
           updatedAt: 1640995200000,
         },
         tier: {
@@ -402,7 +400,6 @@ describe('useSeasonStatus', () => {
         season: mockSeasonMetadata,
         balance: {
           total: 100,
-          refereePortion: 20,
           updatedAt: 1640995200000,
         },
         tier: {
@@ -497,7 +494,6 @@ describe('useSeasonStatus', () => {
         season: mockSeasonMetadata,
         balance: {
           total: 100,
-          refereePortion: 20,
           updatedAt: 1640995200000,
         },
         tier: {
@@ -605,7 +601,6 @@ describe('useSeasonStatus', () => {
         season: mockSeasonMetadata,
         balance: {
           total: 100,
-          refereePortion: 20,
           updatedAt: 1640995200000,
         },
         tier: {

--- a/app/components/UI/Rewards/hooks/useSeasonStatus.ts
+++ b/app/components/UI/Rewards/hooks/useSeasonStatus.ts
@@ -11,7 +11,6 @@ import {
   setCandidateSubscriptionId,
   setSeasonStatusLoading,
 } from '../../../../reducers/rewards';
-import { CURRENT_SEASON_ID } from '../../../../core/Engine/controllers/rewards-controller/types';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
 import { useInvalidateByRewardEvents } from './useInvalidateByRewardEvents';
 import { handleRewardsErrorMessage } from '../utils';
@@ -48,10 +47,17 @@ export const useSeasonStatus = ({
     dispatch(setSeasonStatusLoading(true));
 
     try {
+      // First fetch the current season metadata to get the season ID
+      const seasonMetadata = await Engine.controllerMessenger.call(
+        'RewardsController:getSeasonMetadata',
+        'current',
+      );
+
+      // Then fetch the season status using the season ID
       const statusData = await Engine.controllerMessenger.call(
         'RewardsController:getSeasonStatus',
         subscriptionId,
-        CURRENT_SEASON_ID,
+        seasonMetadata.id,
       );
 
       dispatch(setSeasonStatus(statusData));

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -11,9 +11,8 @@ import {
   type SeasonStatusState,
   type SeasonTierState,
   type SeasonTierDto,
-  type SubscriptionReferralDetailsState,
+  type SubscriptionSeasonReferralDetailState,
   type GeoRewardsMetadata,
-  type SeasonStatusDto,
   type SubscriptionDto,
   type PaginatedPointsEventsDto,
   type GetPointsEventsDto,
@@ -22,10 +21,13 @@ import {
   type PointsBoostDto,
   type PointsEventDto,
   type RewardDto,
-  CURRENT_SEASON_ID,
   ClaimRewardDto,
   PointsEventsDtoState,
   GetPointsEventsLastUpdatedDto,
+  SeasonStatusDto,
+  type DiscoverSeasonsDto,
+  type SeasonMetadataDto,
+  type SeasonStateDto,
 } from './types';
 import type { RewardsControllerMessenger } from '../../messengers/rewards-controller-messenger';
 import {
@@ -68,8 +70,11 @@ const PERPS_DISCOUNT_CACHE_THRESHOLD_MS = 1000 * 60 * 5; // 5 minutes
 // Season status cache threshold
 const SEASON_STATUS_CACHE_THRESHOLD_MS = 1000 * 60 * 1; // 1 minute
 
+// Season metadata cache threshold
+const SEASON_METADATA_CACHE_THRESHOLD_MS = 1000 * 60 * 10; // 10 minutes
+
 // Referral details cache threshold
-const REFERRAL_DETAILS_CACHE_THRESHOLD_MS = 1000 * 60 * 10; // 10 minutes
+const REFERRAL_DETAILS_CACHE_THRESHOLD_MS = 1000 * 60 * 1; // 1 minutes
 
 // Active boosts cache threshold
 const ACTIVE_BOOSTS_CACHE_THRESHOLD_MS = 1000 * 60 * 1; // 1 minute
@@ -247,7 +252,6 @@ export class RewardsController extends BaseController<
   RewardsControllerMessenger
 > {
   #geoLocation: GeoRewardsMetadata | null = null;
-  #currentSeasonIdMap: Record<string, string> = {};
 
   /**
    * Calculate tier status and next tier information
@@ -305,6 +309,29 @@ export class RewardsController extends BaseController<
   }
 
   /**
+   * Combine season metadata and season state into a SeasonStatusDto
+   */
+  convertToSeasonStatusDto(
+    seasonMetadata: SeasonDtoState,
+    seasonState: SeasonStateDto,
+  ): SeasonStatusDto {
+    return {
+      season: {
+        id: seasonMetadata.id,
+        name: seasonMetadata.name,
+        startDate: new Date(seasonMetadata.startDate),
+        endDate: new Date(seasonMetadata.endDate),
+        tiers: seasonMetadata.tiers,
+      },
+      balance: {
+        total: seasonState.balance,
+        updatedAt: seasonState.updatedAt,
+      },
+      currentTierId: seasonState.currentTierId,
+    };
+  }
+
+  /**
    * Convert SeasonStatusDto to SeasonStatusState and update seasons map
    */
   #convertSeasonStatusToSubscriptionState(
@@ -320,7 +347,6 @@ export class RewardsController extends BaseController<
       season: this.#convertSeasonToState(seasonStatus.season),
       balance: {
         total: seasonStatus.balance.total,
-        refereePortion: seasonStatus.balance.refereePortion,
         updatedAt: seasonStatus.balance.updatedAt?.getTime(),
       },
       tier: tierState,
@@ -404,6 +430,10 @@ export class RewardsController extends BaseController<
     this.messagingSystem.registerActionHandler(
       'RewardsController:isRewardsFeatureEnabled',
       this.isRewardsFeatureEnabled.bind(this),
+    );
+    this.messagingSystem.registerActionHandler(
+      'RewardsController:getSeasonMetadata',
+      this.getSeasonMetadata.bind(this),
     );
     this.messagingSystem.registerActionHandler(
       'RewardsController:getSeasonStatus',
@@ -546,12 +576,6 @@ export class RewardsController extends BaseController<
     seasonId: string,
     subscriptionId: string,
   ): string {
-    if (
-      seasonId === CURRENT_SEASON_ID &&
-      this.#currentSeasonIdMap[CURRENT_SEASON_ID]
-    ) {
-      seasonId = this.#currentSeasonIdMap[CURRENT_SEASON_ID];
-    }
     return `${seasonId}:${subscriptionId}`;
   }
 
@@ -560,7 +584,7 @@ export class RewardsController extends BaseController<
    */
   #getSeasonStatus(
     subscriptionId: string,
-    seasonId: string = CURRENT_SEASON_ID,
+    seasonId: string,
   ): SeasonStatusState | null {
     const compositeKey = this.#createSeasonSubscriptionCompositeKey(
       seasonId,
@@ -981,11 +1005,6 @@ export class RewardsController extends BaseController<
       Date.now() - accountState.lastPerpsDiscountRateFetched <
         PERPS_DISCOUNT_CACHE_THRESHOLD_MS
     ) {
-      Logger.log(
-        'RewardsController: Using cached perps discount data for',
-        account,
-        accountState.perpsFeeDiscount,
-      );
       return {
         hasOptedIn: !!accountState.hasOptedIn,
         discountBips: accountState.perpsFeeDiscount,
@@ -1546,6 +1565,88 @@ export class RewardsController extends BaseController<
   }
 
   /**
+   * Get season metadata with caching. This fetches and caches the season metadata
+   * including id, name, dates, and tiers.
+   * @param type - The type of season to get
+   * @returns Promise<SeasonDtoState> - The season metadata
+   */
+  async getSeasonMetadata(
+    type: 'current' | 'next' = 'current',
+  ): Promise<SeasonDtoState> {
+    const result = await wrapWithCache<SeasonDtoState>({
+      key: type,
+      ttl: SEASON_METADATA_CACHE_THRESHOLD_MS,
+      readCache: (key) => {
+        const cached = this.state.seasons[key] || undefined;
+        if (!cached) return;
+        return { payload: cached, lastFetched: cached.lastFetched };
+      },
+      fetchFresh: async () => {
+        Logger.log(
+          'RewardsController: Fetching fresh season metadata via API call for type',
+          type,
+        );
+
+        // Get discover seasons to find if this season has a valid start date
+        const discoverSeasons = (await this.messagingSystem.call(
+          'RewardsDataService:getDiscoverSeasons',
+        )) as DiscoverSeasonsDto;
+
+        // Check if the requested season is either current or next
+        const seasonInfo =
+          type === 'current'
+            ? discoverSeasons.current
+            : type === 'next'
+            ? discoverSeasons.next
+            : null;
+
+        // If found with valid start date, fetch metadata and populate cache
+        if (seasonInfo?.startDate) {
+          Logger.log(
+            'RewardsController: Found season with valid start date, fetching metadata for',
+            type,
+          );
+
+          // Fetch season metadata
+          const seasonMetadata = (await this.messagingSystem.call(
+            'RewardsDataService:getSeasonMetadata',
+            seasonInfo.id,
+          )) as SeasonMetadataDto;
+
+          // Convert to state format
+          const seasonStateFromMetadata = this.#convertSeasonToState({
+            id: seasonMetadata.id,
+            name: seasonMetadata.name,
+            startDate: seasonMetadata.startDate,
+            endDate: seasonMetadata.endDate,
+            tiers: seasonMetadata.tiers,
+          });
+
+          // Add lastFetched timestamp
+          const seasonStateWithTimestamp = {
+            ...seasonStateFromMetadata,
+            lastFetched: Date.now(),
+          };
+
+          return seasonStateWithTimestamp;
+        }
+
+        throw new Error(
+          `No valid season metadata could be found for type: ${type}`,
+        );
+      },
+      writeCache: (key, value) => {
+        this.update((state: RewardsControllerState) => {
+          state.seasons[key] = value;
+          state.seasons[value.id] = value;
+        });
+      },
+    });
+
+    return result;
+  }
+
+  /**
    * Get season status with caching
    * @param seasonId - The ID of the season to get status for
    * @param subscriptionId - The subscription ID for authentication
@@ -1553,23 +1654,26 @@ export class RewardsController extends BaseController<
    */
   async getSeasonStatus(
     subscriptionId: string,
-    seasonId: string = CURRENT_SEASON_ID,
+    seasonId: string,
   ): Promise<SeasonStatusState | null> {
     const rewardsEnabled = selectRewardsEnabledFlag(store.getState());
     if (!rewardsEnabled) {
       return null;
     }
+
+    const season = this.state.seasons[seasonId];
+    if (!season) {
+      throw new Error(
+        `Failed to get season status: season not found for seasonId: ${seasonId}`,
+      );
+    }
+
     const result = await wrapWithCache<SeasonStatusState>({
       key: this.#createSeasonSubscriptionCompositeKey(seasonId, subscriptionId),
       ttl: SEASON_STATUS_CACHE_THRESHOLD_MS,
       readCache: (key) => {
         const cached = this.state.seasonStatuses[key] || undefined;
         if (!cached) return;
-        Logger.log(
-          'RewardsController: Using cached season status data for',
-          subscriptionId,
-          seasonId,
-        );
         return { payload: cached, lastFetched: cached.lastFetched };
       },
       fetchFresh: async () => {
@@ -1579,11 +1683,20 @@ export class RewardsController extends BaseController<
             subscriptionId,
             seasonId,
           );
-          const seasonStatus = await this.messagingSystem.call(
+
+          // Now fetch season status (balance, currentTierId, etc.)
+          const seasonState = await this.messagingSystem.call(
             'RewardsDataService:getSeasonStatus',
             seasonId,
             subscriptionId,
           );
+
+          // Combine all data into SeasonStatusDto
+          const seasonStatus = this.convertToSeasonStatusDto(
+            season,
+            seasonState,
+          );
+
           return this.#convertSeasonStatusToSubscriptionState(seasonStatus);
         } catch (error) {
           if (error instanceof AuthorizationFailedError) {
@@ -1610,11 +1723,13 @@ export class RewardsController extends BaseController<
                   );
                   const convertInternalAccountToCaipAccountId =
                     this.convertInternalAccountToCaipAccountId;
-                  const intAccountForSub = accounts.find((acc) => {
-                    const accCaipId =
-                      convertInternalAccountToCaipAccountId(acc);
-                    return accCaipId === accountForSub.account;
-                  });
+                  const intAccountForSub = accounts.find(
+                    (acc: InternalAccount) => {
+                      const accCaipId =
+                        convertInternalAccountToCaipAccountId(acc);
+                      return accCaipId === accountForSub.account;
+                    },
+                  );
                   if (intAccountForSub) {
                     Logger.log(
                       'RewardsController: Attempting to reauth with any valid account after 403 error',
@@ -1627,15 +1742,21 @@ export class RewardsController extends BaseController<
                   }
                 }
               }
-              // Fetch season status again
-              const seasonStatus = await this.messagingSystem.call(
+              // Now fetch season status (balance, currentTierId, etc.)
+              const seasonState = await this.messagingSystem.call(
                 'RewardsDataService:getSeasonStatus',
-                seasonId,
+                season.id,
                 subscriptionId,
               );
+
+              // Combine all data into SeasonStatusDto
+              const seasonStatus = this.convertToSeasonStatusDto(
+                season,
+                seasonState,
+              );
+
               Logger.log(
                 'RewardsController: Successfully fetched season status after reauth',
-                seasonStatus,
               );
               return this.#convertSeasonStatusToSubscriptionState(seasonStatus);
             } catch {
@@ -1656,28 +1777,9 @@ export class RewardsController extends BaseController<
         }
       },
       writeCache: (key, subscriptionSeasonStatus) => {
-        const { season: seasonState } = subscriptionSeasonStatus;
         this.update((state: RewardsControllerState) => {
-          // Update seasons map with season data
-          state.seasons[seasonId] = seasonState;
-
           // Update season status with composite key
           state.seasonStatuses[key] = subscriptionSeasonStatus;
-
-          if (
-            seasonId === CURRENT_SEASON_ID &&
-            seasonState.id !== CURRENT_SEASON_ID &&
-            seasonState.id
-          ) {
-            this.#currentSeasonIdMap[CURRENT_SEASON_ID] = seasonState.id;
-            state.seasons[seasonState.id] = seasonState;
-            state.seasonStatuses[
-              this.#createSeasonSubscriptionCompositeKey(
-                seasonState.id,
-                subscriptionId,
-              )
-            ] = subscriptionSeasonStatus;
-          }
         });
       },
     });
@@ -1707,40 +1809,44 @@ export class RewardsController extends BaseController<
   /**
    * Get referral details with caching
    * @param subscriptionId - The subscription ID for authentication
-   * @returns Promise<SubscriptionReferralDetailsDto> - The referral details data
+   * @param seasonId - The season ID to get referral details for
+   * @returns Promise<SubscriptionSeasonReferralDetailsDto> - The referral details data
    */
   async getReferralDetails(
     subscriptionId: string,
-  ): Promise<SubscriptionReferralDetailsState | null> {
+    seasonId: string,
+  ): Promise<SubscriptionSeasonReferralDetailState | null> {
     const rewardsEnabled = selectRewardsEnabledFlag(store.getState());
     if (!rewardsEnabled) {
       return null;
     }
-    const result = await wrapWithCache<SubscriptionReferralDetailsState>({
-      key: subscriptionId,
+    const compositeKey = this.#createSeasonSubscriptionCompositeKey(
+      seasonId,
+      subscriptionId,
+    );
+    const result = await wrapWithCache<SubscriptionSeasonReferralDetailState>({
+      key: compositeKey,
       ttl: REFERRAL_DETAILS_CACHE_THRESHOLD_MS,
       readCache: (key) => {
         const cached = this.state.subscriptionReferralDetails[key] || undefined;
         if (!cached) return;
-        Logger.log(
-          'RewardsController: Using cached referral details data for',
-          subscriptionId,
-        );
         return { payload: cached, lastFetched: cached.lastFetched };
       },
       fetchFresh: async () => {
         try {
           Logger.log(
             'RewardsController: Fetching fresh referral details data via API call for',
-            subscriptionId,
+            { subscriptionId, seasonId },
           );
           const referralDetails = await this.messagingSystem.call(
             'RewardsDataService:getReferralDetails',
+            seasonId,
             subscriptionId,
           );
           return {
             referralCode: referralDetails.referralCode,
             totalReferees: referralDetails.totalReferees,
+            referralPoints: referralDetails.referralPoints,
             lastFetched: Date.now(),
           };
         } catch (error) {
@@ -2094,9 +2200,6 @@ export class RewardsController extends BaseController<
     }
 
     if (this.#geoLocation) {
-      Logger.log('RewardsController: Using cached geo location', {
-        location: this.#geoLocation,
-      });
       return this.#geoLocation;
     }
 
@@ -2596,18 +2699,6 @@ export class RewardsController extends BaseController<
       readCache: (key) => {
         const cachedActiveBoosts = this.state.activeBoosts[key] || undefined;
         if (!cachedActiveBoosts) return;
-        Logger.log(
-          'RewardsController: Using cached active boosts data for',
-          subscriptionId,
-          seasonId,
-          {
-            boostCount: cachedActiveBoosts.boosts.length,
-            cacheAge: Math.round(
-              (Date.now() - cachedActiveBoosts.lastFetched) / 1000,
-            ),
-            maxAge: Math.round(ACTIVE_BOOSTS_CACHE_THRESHOLD_MS / 1000),
-          },
-        );
         return {
           payload: cachedActiveBoosts.boosts,
           lastFetched: cachedActiveBoosts.lastFetched,
@@ -2668,18 +2759,6 @@ export class RewardsController extends BaseController<
         const cachedUnlockedRewards =
           this.state.unlockedRewards[key] || undefined;
         if (!cachedUnlockedRewards) return;
-        Logger.log(
-          'RewardsController: Using cached unlocked rewards data for',
-          subscriptionId,
-          seasonId,
-          {
-            rewardCount: cachedUnlockedRewards.rewards.length,
-            cacheAge: Math.round(
-              (Date.now() - cachedUnlockedRewards.lastFetched) / 1000,
-            ),
-            maxAge: Math.round(UNLOCKED_REWARDS_CACHE_THRESHOLD_MS / 1000),
-          },
-        );
         return {
           payload: cachedUnlockedRewards.rewards,
           lastFetched: cachedUnlockedRewards.lastFetched,

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
@@ -9,13 +9,15 @@ import type {
   LoginResponseDto,
   EstimatePointsDto,
   EstimatedPointsDto,
-  SeasonStatusDto,
-  SubscriptionReferralDetailsDto,
+  SeasonStateDto,
+  SubscriptionSeasonReferralDetailsDto,
   PointsBoostEnvelopeDto,
   ClaimRewardDto,
   GetPointsEventsLastUpdatedDto,
   MobileLoginDto,
   MobileOptinDto,
+  DiscoverSeasonsDto,
+  SeasonMetadataDto,
 } from '../types';
 import { getSubscriptionToken } from '../utils/multi-subscription-token-vault';
 import type { CaipAccountId } from '@metamask/utils';
@@ -137,6 +139,14 @@ describe('RewardsDataService', () => {
       );
       expect(mockMessenger.registerActionHandler).toHaveBeenCalledWith(
         'RewardsDataService:claimReward',
+        expect.any(Function),
+      );
+      expect(mockMessenger.registerActionHandler).toHaveBeenCalledWith(
+        'RewardsDataService:getDiscoverSeasons',
+        expect.any(Function),
+      );
+      expect(mockMessenger.registerActionHandler).toHaveBeenCalledWith(
+        'RewardsDataService:getSeasonMetadata',
         expect.any(Function),
       );
     });
@@ -934,43 +944,10 @@ describe('RewardsDataService', () => {
     });
   });
 
-  const mockSeasonStatusResponse: SeasonStatusDto = {
-    season: {
-      id: 'season-123',
-      name: 'Test Season',
-      startDate: new Date('2023-06-01T00:00:00Z'),
-      endDate: new Date('2023-08-31T23:59:59Z'),
-      tiers: [
-        {
-          id: 'tier-gold',
-          name: 'Gold Tier',
-          pointsNeeded: 1000,
-          image: {
-            lightModeUrl: 'https://example.com/gold-light.png',
-            darkModeUrl: 'https://example.com/gold-dark.png',
-          },
-          levelNumber: '3',
-          rewards: [],
-        },
-        {
-          id: 'tier-silver',
-          name: 'Silver Tier',
-          pointsNeeded: 500,
-          image: {
-            lightModeUrl: 'https://example.com/silver-light.png',
-            darkModeUrl: 'https://example.com/silver-dark.png',
-          },
-          levelNumber: '2',
-          rewards: [],
-        },
-      ],
-    },
-    balance: {
-      total: 1000,
-      refereePortion: 500,
-      updatedAt: new Date('2023-12-01T10:00:00Z'),
-    },
+  const mockSeasonStateResponse: SeasonStateDto = {
+    balance: 1000,
     currentTierId: 'tier-gold',
+    updatedAt: new Date('2023-12-01T10:00:00Z'),
   };
 
   describe('getSeasonStatus', () => {
@@ -978,34 +955,27 @@ describe('RewardsDataService', () => {
     const mockSubscriptionId = 'subscription-456';
 
     beforeEach(() => {
-      // Mock successful fetch response for season status
+      // Mock successful fetch response for season state
       const mockResponse = {
         ok: true,
         json: jest.fn().mockResolvedValue({
-          season: {
-            ...mockSeasonStatusResponse.season,
-            startDate: '2023-06-01T00:00:00Z', // API returns strings, not Date objects
-            endDate: '2023-08-31T23:59:59Z',
-          },
-          balance: {
-            ...mockSeasonStatusResponse.balance,
-            updatedAt: '2023-12-01T10:00:00Z', // API returns string, not Date
-          },
-          currentTierId: mockSeasonStatusResponse.currentTierId,
+          balance: mockSeasonStateResponse.balance,
+          currentTierId: mockSeasonStateResponse.currentTierId,
+          updatedAt: '2023-12-01T10:00:00Z', // API returns string, not Date
         }),
       } as unknown as Response;
       mockFetch.mockResolvedValue(mockResponse);
     });
 
-    it('should successfully get season status', async () => {
+    it('fetches season state from the correct endpoint', async () => {
       const result = await service.getSeasonStatus(
         mockSeasonId,
         mockSubscriptionId,
       );
 
-      expect(result).toEqual(mockSeasonStatusResponse);
+      expect(result).toEqual(mockSeasonStateResponse);
       expect(mockFetch).toHaveBeenCalledWith(
-        `${AppConstants.REWARDS_API_URL.DEV}/seasons/${mockSeasonId}/status`,
+        `${AppConstants.REWARDS_API_URL.DEV}/seasons/${mockSeasonId}/state`,
         {
           credentials: 'omit',
           method: 'GET',
@@ -1020,30 +990,19 @@ describe('RewardsDataService', () => {
       );
     });
 
-    it('should convert date strings to Date objects', async () => {
+    it('converts updatedAt string to Date object', async () => {
       const result = await service.getSeasonStatus(
         mockSeasonId,
         mockSubscriptionId,
       );
 
-      // Check balance updatedAt
-      expect(result.balance.updatedAt).toBeInstanceOf(Date);
-      expect(result.balance.updatedAt?.getTime()).toBe(
+      expect(result.updatedAt).toBeInstanceOf(Date);
+      expect(result.updatedAt.getTime()).toBe(
         new Date('2023-12-01T10:00:00Z').getTime(),
-      );
-
-      // Check season dates
-      expect(result.season.startDate).toBeInstanceOf(Date);
-      expect(result.season.startDate?.getTime()).toBe(
-        new Date('2023-06-01T00:00:00Z').getTime(),
-      );
-      expect(result.season.endDate).toBeInstanceOf(Date);
-      expect(result.season.endDate.getTime()).toBe(
-        new Date('2023-08-31T23:59:59Z').getTime(),
       );
     });
 
-    it('should include authentication headers with subscription token', async () => {
+    it('includes authentication headers with subscription token', async () => {
       await service.getSeasonStatus(mockSeasonId, mockSubscriptionId);
 
       expect(mockGetSubscriptionToken).toHaveBeenCalledWith(mockSubscriptionId);
@@ -1058,7 +1017,7 @@ describe('RewardsDataService', () => {
       );
     });
 
-    it('should throw error when response is not ok', async () => {
+    it('throws error when response is not ok', async () => {
       const mockResponse = {
         ok: false,
         status: 404,
@@ -1068,10 +1027,10 @@ describe('RewardsDataService', () => {
 
       await expect(
         service.getSeasonStatus(mockSeasonId, mockSubscriptionId),
-      ).rejects.toThrow('Get season status failed: 404');
+      ).rejects.toThrow('Get season state failed: 404');
     });
 
-    it('should throw AuthorizationFailedError when rewards authorization fails', async () => {
+    it('throws AuthorizationFailedError when rewards authorization fails', async () => {
       const mockResponse = {
         ok: false,
         status: 401,
@@ -1096,7 +1055,7 @@ describe('RewardsDataService', () => {
       );
     });
 
-    it('should detect authorization failure when message contains the phrase', async () => {
+    it('detects authorization failure when message contains the phrase', async () => {
       const mockResponse = {
         ok: false,
         status: 403,
@@ -1112,7 +1071,7 @@ describe('RewardsDataService', () => {
       ).rejects.toBeInstanceOf(AuthorizationFailedError);
     });
 
-    it('should throw error when fetch fails', async () => {
+    it('throws error when fetch fails', async () => {
       const fetchError = new Error('Network error');
       mockFetch.mockRejectedValue(fetchError);
 
@@ -1121,8 +1080,7 @@ describe('RewardsDataService', () => {
       ).rejects.toThrow('Network error');
     });
 
-    it('should handle missing subscription token gracefully', async () => {
-      // Mock token retrieval failure
+    it('handles missing subscription token gracefully', async () => {
       mockGetSubscriptionToken.mockResolvedValue({
         success: false,
         token: undefined,
@@ -1133,7 +1091,7 @@ describe('RewardsDataService', () => {
         mockSubscriptionId,
       );
 
-      expect(result).toEqual(mockSeasonStatusResponse);
+      expect(result).toEqual(mockSeasonStateResponse);
       expect(mockFetch).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({
@@ -1145,12 +1103,249 @@ describe('RewardsDataService', () => {
     });
   });
 
+  describe('getDiscoverSeasons', () => {
+    const mockDiscoverSeasonsResponse: DiscoverSeasonsDto = {
+      current: {
+        id: '7444682d-9050-43b8-9038-28a6a62d6264',
+        startDate: new Date('2025-09-01T04:00:00.000Z'),
+        endDate: new Date('2025-11-30T04:00:00.000Z'),
+      },
+      next: null,
+    };
+
+    beforeEach(() => {
+      const mockResponse = {
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          current: {
+            id: mockDiscoverSeasonsResponse.current?.id,
+            startDate: '2025-09-01T04:00:00.000Z',
+            endDate: '2025-11-30T04:00:00.000Z',
+          },
+          next: null,
+        }),
+      } as unknown as Response;
+      mockFetch.mockResolvedValue(mockResponse);
+    });
+
+    it('fetches discover seasons from the correct public endpoint', async () => {
+      const result = await service.getDiscoverSeasons();
+
+      expect(result).toEqual(mockDiscoverSeasonsResponse);
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${AppConstants.REWARDS_API_URL.DEV}/public/seasons/status`,
+        {
+          credentials: 'omit',
+          method: 'GET',
+          headers: {
+            'Accept-Language': 'en-US',
+            'Content-Type': 'application/json',
+            'rewards-client-id': 'mobile-7.50.1',
+          },
+          signal: expect.any(AbortSignal),
+        },
+      );
+    });
+
+    it('converts date strings to Date objects for current season', async () => {
+      const result = await service.getDiscoverSeasons();
+
+      expect(result.current?.startDate).toBeInstanceOf(Date);
+      expect(result.current?.startDate.getTime()).toBe(
+        new Date('2025-09-01T04:00:00.000Z').getTime(),
+      );
+      expect(result.current?.endDate).toBeInstanceOf(Date);
+      expect(result.current?.endDate.getTime()).toBe(
+        new Date('2025-11-30T04:00:00.000Z').getTime(),
+      );
+    });
+
+    it('handles response with both current and next seasons', async () => {
+      const mockResponse = {
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          current: {
+            id: '7444682d-9050-43b8-9038-28a6a62d6264',
+            startDate: '2025-09-01T04:00:00.000Z',
+            endDate: '2025-11-30T04:00:00.000Z',
+          },
+          next: {
+            id: '8555793e-0161-54c9-0149-39b7b73e7375',
+            startDate: '2025-12-01T04:00:00.000Z',
+            endDate: '2026-02-28T04:00:00.000Z',
+          },
+        }),
+      } as unknown as Response;
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const result = await service.getDiscoverSeasons();
+
+      expect(result.current).not.toBeNull();
+      expect(result.next).not.toBeNull();
+      expect(result.next?.id).toBe('8555793e-0161-54c9-0149-39b7b73e7375');
+      expect(result.next?.startDate).toBeInstanceOf(Date);
+      expect(result.next?.endDate).toBeInstanceOf(Date);
+    });
+
+    it('handles response with null current and next seasons', async () => {
+      const mockResponse = {
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          current: null,
+          next: null,
+        }),
+      } as unknown as Response;
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const result = await service.getDiscoverSeasons();
+
+      expect(result.current).toBeNull();
+      expect(result.next).toBeNull();
+    });
+
+    it('throws error when response is not ok', async () => {
+      const mockResponse = {
+        ok: false,
+        status: 500,
+        json: jest.fn().mockResolvedValue({ message: 'Server error' }),
+      } as unknown as Response;
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await expect(service.getDiscoverSeasons()).rejects.toThrow(
+        'Get discover seasons failed: 500',
+      );
+    });
+
+    it('throws error when fetch fails', async () => {
+      const fetchError = new Error('Network error');
+      mockFetch.mockRejectedValue(fetchError);
+
+      await expect(service.getDiscoverSeasons()).rejects.toThrow(
+        'Network error',
+      );
+    });
+  });
+
+  describe('getSeasonMetadata', () => {
+    const mockSeasonId = '7444682d-9050-43b8-9038-28a6a62d6264';
+    const mockSeasonMetadataResponse: SeasonMetadataDto = {
+      id: mockSeasonId,
+      name: 'Season 1',
+      startDate: new Date('2025-09-01T04:00:00.000Z'),
+      endDate: new Date('2025-11-30T04:00:00.000Z'),
+      tiers: [
+        {
+          id: 'tier-bronze',
+          name: 'Bronze Tier',
+          pointsNeeded: 0,
+          image: {
+            lightModeUrl: 'https://example.com/bronze-light.png',
+            darkModeUrl: 'https://example.com/bronze-dark.png',
+          },
+          levelNumber: '1',
+          rewards: [],
+        },
+        {
+          id: 'tier-silver',
+          name: 'Silver Tier',
+          pointsNeeded: 500,
+          image: {
+            lightModeUrl: 'https://example.com/silver-light.png',
+            darkModeUrl: 'https://example.com/silver-dark.png',
+          },
+          levelNumber: '2',
+          rewards: [],
+        },
+      ],
+    };
+
+    beforeEach(() => {
+      const mockResponse = {
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          id: mockSeasonMetadataResponse.id,
+          name: mockSeasonMetadataResponse.name,
+          startDate: '2025-09-01T04:00:00.000Z',
+          endDate: '2025-11-30T04:00:00.000Z',
+          tiers: mockSeasonMetadataResponse.tiers,
+        }),
+      } as unknown as Response;
+      mockFetch.mockResolvedValue(mockResponse);
+    });
+
+    it('fetches season metadata from the correct public endpoint', async () => {
+      const result = await service.getSeasonMetadata(mockSeasonId);
+
+      expect(result).toEqual(mockSeasonMetadataResponse);
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${AppConstants.REWARDS_API_URL.DEV}/public/seasons/${mockSeasonId}/meta`,
+        {
+          credentials: 'omit',
+          method: 'GET',
+          headers: {
+            'Accept-Language': 'en-US',
+            'Content-Type': 'application/json',
+            'rewards-client-id': 'mobile-7.50.1',
+          },
+          signal: expect.any(AbortSignal),
+        },
+      );
+    });
+
+    it('converts date strings to Date objects', async () => {
+      const result = await service.getSeasonMetadata(mockSeasonId);
+
+      expect(result.startDate).toBeInstanceOf(Date);
+      expect(result.startDate.getTime()).toBe(
+        new Date('2025-09-01T04:00:00.000Z').getTime(),
+      );
+      expect(result.endDate).toBeInstanceOf(Date);
+      expect(result.endDate.getTime()).toBe(
+        new Date('2025-11-30T04:00:00.000Z').getTime(),
+      );
+    });
+
+    it('includes tiers in the response', async () => {
+      const result = await service.getSeasonMetadata(mockSeasonId);
+
+      expect(result.tiers).toHaveLength(2);
+      expect(result.tiers[0].id).toBe('tier-bronze');
+      expect(result.tiers[0].name).toBe('Bronze Tier');
+      expect(result.tiers[1].id).toBe('tier-silver');
+      expect(result.tiers[1].name).toBe('Silver Tier');
+    });
+
+    it('throws error when response is not ok', async () => {
+      const mockResponse = {
+        ok: false,
+        status: 404,
+        json: jest.fn().mockResolvedValue({ message: 'Season not found' }),
+      } as unknown as Response;
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await expect(service.getSeasonMetadata(mockSeasonId)).rejects.toThrow(
+        'Get season metadata failed: 404',
+      );
+    });
+
+    it('throws error when fetch fails', async () => {
+      const fetchError = new Error('Network error');
+      mockFetch.mockRejectedValue(fetchError);
+
+      await expect(service.getSeasonMetadata(mockSeasonId)).rejects.toThrow(
+        'Network error',
+      );
+    });
+  });
+
   describe('getReferralDetails', () => {
     const mockSubscriptionId = 'test-subscription-123';
+    const mockSeasonId = 'test-season-456';
 
-    const mockReferralDetailsResponse: SubscriptionReferralDetailsDto = {
+    const mockReferralDetailsResponse: SubscriptionSeasonReferralDetailsDto = {
       referralCode: 'TEST123',
       totalReferees: 5,
+      referralPoints: 100,
     };
 
     beforeEach(() => {
@@ -1162,12 +1357,15 @@ describe('RewardsDataService', () => {
       mockFetch.mockResolvedValue(mockResponse);
     });
 
-    it('should successfully get referral details', async () => {
-      const result = await service.getReferralDetails(mockSubscriptionId);
+    it('gets referral details for a season', async () => {
+      const result = await service.getReferralDetails(
+        mockSeasonId,
+        mockSubscriptionId,
+      );
 
       expect(result).toEqual(mockReferralDetailsResponse);
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://api.rewards.test/subscriptions/referral-details',
+        `https://api.rewards.test/seasons/${mockSeasonId}/referral-details`,
         expect.objectContaining({
           method: 'GET',
           credentials: 'omit',
@@ -1180,8 +1378,8 @@ describe('RewardsDataService', () => {
       );
     });
 
-    it('should include subscription ID in token retrieval', async () => {
-      await service.getReferralDetails(mockSubscriptionId);
+    it('includes subscription ID in token retrieval', async () => {
+      await service.getReferralDetails(mockSeasonId, mockSubscriptionId);
 
       expect(mockGetSubscriptionToken).toHaveBeenCalledWith(mockSubscriptionId);
       expect(mockFetch).toHaveBeenCalledWith(
@@ -1195,7 +1393,7 @@ describe('RewardsDataService', () => {
       );
     });
 
-    it('should throw error when response is not ok', async () => {
+    it('throws error when response is not ok', async () => {
       const mockResponse = {
         ok: false,
         status: 404,
@@ -1203,27 +1401,30 @@ describe('RewardsDataService', () => {
       mockFetch.mockResolvedValue(mockResponse);
 
       await expect(
-        service.getReferralDetails(mockSubscriptionId),
+        service.getReferralDetails(mockSeasonId, mockSubscriptionId),
       ).rejects.toThrow('Get referral details failed: 404');
     });
 
-    it('should throw error when fetch fails', async () => {
+    it('throws error when fetch fails', async () => {
       const fetchError = new Error('Network error');
       mockFetch.mockRejectedValue(fetchError);
 
       await expect(
-        service.getReferralDetails(mockSubscriptionId),
+        service.getReferralDetails(mockSeasonId, mockSubscriptionId),
       ).rejects.toThrow('Network error');
     });
 
-    it('should handle missing subscription token gracefully', async () => {
+    it('handles missing subscription token gracefully', async () => {
       // Mock token retrieval failure
       mockGetSubscriptionToken.mockResolvedValue({
         success: false,
         token: undefined,
       });
 
-      const result = await service.getReferralDetails(mockSubscriptionId);
+      const result = await service.getReferralDetails(
+        mockSeasonId,
+        mockSubscriptionId,
+      );
 
       expect(result).toEqual(mockReferralDetailsResponse);
       expect(mockFetch).toHaveBeenCalledWith(
@@ -1236,11 +1437,14 @@ describe('RewardsDataService', () => {
       );
     });
 
-    it('should handle subscription token retrieval error', async () => {
+    it('handles subscription token retrieval error', async () => {
       // Mock token retrieval throwing an error
       mockGetSubscriptionToken.mockRejectedValue(new Error('Token error'));
 
-      const result = await service.getReferralDetails(mockSubscriptionId);
+      const result = await service.getReferralDetails(
+        mockSeasonId,
+        mockSubscriptionId,
+      );
 
       expect(result).toEqual(mockReferralDetailsResponse);
       expect(mockFetch).toHaveBeenCalledWith(
@@ -1253,7 +1457,7 @@ describe('RewardsDataService', () => {
       );
     });
 
-    it('should handle timeout correctly', async () => {
+    it('handles timeout correctly', async () => {
       // Mock fetch that never resolves (simulate timeout)
       mockFetch.mockImplementation(
         () =>
@@ -1263,7 +1467,7 @@ describe('RewardsDataService', () => {
       );
 
       await expect(
-        service.getReferralDetails(mockSubscriptionId),
+        service.getReferralDetails(mockSeasonId, mockSubscriptionId),
       ).rejects.toThrow('AbortError');
     });
   });

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.ts
@@ -6,8 +6,7 @@ import type {
   EstimatedPointsDto,
   GetPerpsDiscountDto,
   PerpsDiscountData,
-  SeasonStatusDto,
-  SubscriptionReferralDetailsDto,
+  SubscriptionSeasonReferralDetailsDto,
   PaginatedPointsEventsDto,
   GetPointsEventsDto,
   MobileLoginDto,
@@ -20,6 +19,9 @@ import type {
   ClaimRewardDto,
   GetPointsEventsLastUpdatedDto,
   MobileOptinDto,
+  DiscoverSeasonsDto,
+  SeasonMetadataDto,
+  SeasonStateDto,
 } from '../types';
 import { getSubscriptionToken } from '../utils/multi-subscription-token-vault';
 import Logger from '../../../../../util/Logger';
@@ -156,6 +158,16 @@ export interface RewardsDataServiceClaimRewardAction {
   handler: RewardsDataService['claimReward'];
 }
 
+export interface RewardsDataServiceGetDiscoverSeasonsAction {
+  type: `${typeof SERVICE_NAME}:getDiscoverSeasons`;
+  handler: RewardsDataService['getDiscoverSeasons'];
+}
+
+export interface RewardsDataServiceGetSeasonMetadataAction {
+  type: `${typeof SERVICE_NAME}:getSeasonMetadata`;
+  handler: RewardsDataService['getSeasonMetadata'];
+}
+
 export type RewardsDataServiceActions =
   | RewardsDataServiceLoginAction
   | RewardsDataServiceGetPointsEventsAction
@@ -173,7 +185,9 @@ export type RewardsDataServiceActions =
   | RewardsDataServiceOptOutAction
   | RewardsDataServiceGetActivePointsBoostsAction
   | RewardsDataServiceGetUnlockedRewardsAction
-  | RewardsDataServiceClaimRewardAction;
+  | RewardsDataServiceClaimRewardAction
+  | RewardsDataServiceGetDiscoverSeasonsAction
+  | RewardsDataServiceGetSeasonMetadataAction;
 
 export type RewardsDataServiceMessenger = RestrictedMessenger<
   typeof SERVICE_NAME,
@@ -285,6 +299,14 @@ export class RewardsDataService {
     this.#messenger.registerActionHandler(
       `${SERVICE_NAME}:claimReward`,
       this.claimReward.bind(this),
+    );
+    this.#messenger.registerActionHandler(
+      `${SERVICE_NAME}:getDiscoverSeasons`,
+      this.getDiscoverSeasons.bind(this),
+    );
+    this.#messenger.registerActionHandler(
+      `${SERVICE_NAME}:getSeasonMetadata`,
+      this.getSeasonMetadata.bind(this),
     );
   }
 
@@ -600,17 +622,17 @@ export class RewardsDataService {
   }
 
   /**
-   * Get season status for a specific season.
-   * @param seasonId - The ID of the season to get status for.
+   * Get season state for a specific season.
+   * @param seasonId - The ID of the season to get state for.
    * @param subscriptionId - The subscription ID for authentication.
-   * @returns The season status DTO.
+   * @returns The season state DTO.
    */
   async getSeasonStatus(
     seasonId: string,
     subscriptionId: string,
-  ): Promise<SeasonStatusDto> {
+  ): Promise<SeasonStateDto> {
     const response = await this.makeRequest(
-      `/seasons/${seasonId}/status`,
+      `/seasons/${seasonId}/state`,
       {
         method: 'GET',
       },
@@ -625,37 +647,31 @@ export class RewardsDataService {
         );
       }
 
-      throw new Error(`Get season status failed: ${response.status}`);
+      throw new Error(`Get season state failed: ${response.status}`);
     }
 
     const data = await response.json();
 
     // Convert date strings to Date objects
-    if (data.balance?.updatedAt) {
-      data.balance.updatedAt = new Date(data.balance.updatedAt);
-    }
-    if (data.season) {
-      if (data.season.startDate) {
-        data.season.startDate = new Date(data.season.startDate);
-      }
-      if (data.season.endDate) {
-        data.season.endDate = new Date(data.season.endDate);
-      }
+    if (data.updatedAt) {
+      data.updatedAt = new Date(data.updatedAt);
     }
 
-    return data as SeasonStatusDto;
+    return data as SeasonStateDto;
   }
 
   /**
-   * Get referral details for a specific subscription.
+   * Get referral details for a specific subscription and season.
+   * @param seasonId - The season ID to get referral details for.
    * @param subscriptionId - The subscription ID for authentication.
    * @returns The referral details DTO.
    */
   async getReferralDetails(
+    seasonId: string,
     subscriptionId: string,
-  ): Promise<SubscriptionReferralDetailsDto> {
+  ): Promise<SubscriptionSeasonReferralDetailsDto> {
     const response = await this.makeRequest(
-      '/subscriptions/referral-details',
+      `/seasons/${seasonId}/referral-details`,
       {
         method: 'GET',
       },
@@ -666,7 +682,7 @@ export class RewardsDataService {
       throw new Error(`Get referral details failed: ${response.status}`);
     }
 
-    return (await response.json()) as SubscriptionReferralDetailsDto;
+    return (await response.json()) as SubscriptionSeasonReferralDetailsDto;
   }
 
   /**
@@ -875,5 +891,73 @@ export class RewardsDataService {
     if (!response.ok) {
       throw new Error(`Failed to claim reward: ${response.status}`);
     }
+  }
+
+  /**
+   * Get discover seasons information (current and next season).
+   * @returns The discover seasons DTO with current and next season information.
+   */
+  async getDiscoverSeasons(): Promise<DiscoverSeasonsDto> {
+    const response = await this.makeRequest('/public/seasons/status', {
+      method: 'GET',
+    });
+
+    if (!response.ok) {
+      throw new Error(`Get discover seasons failed: ${response.status}`);
+    }
+
+    const data = await response.json();
+
+    // Convert date strings to Date objects for current season
+    if (data.current) {
+      if (data.current.startDate) {
+        data.current.startDate = new Date(data.current.startDate);
+      }
+      if (data.current.endDate) {
+        data.current.endDate = new Date(data.current.endDate);
+      }
+    }
+
+    // Convert date strings to Date objects for next season
+    if (data.next) {
+      if (data.next.startDate) {
+        data.next.startDate = new Date(data.next.startDate);
+      }
+      if (data.next.endDate) {
+        data.next.endDate = new Date(data.next.endDate);
+      }
+    }
+
+    return data as DiscoverSeasonsDto;
+  }
+
+  /**
+   * Get season metadata for a specific season.
+   * @param seasonId - The ID of the season to get metadata for.
+   * @returns The season metadata DTO.
+   */
+  async getSeasonMetadata(seasonId: string): Promise<SeasonMetadataDto> {
+    const response = await this.makeRequest(
+      `/public/seasons/${seasonId}/meta`,
+      {
+        method: 'GET',
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`Get season metadata failed: ${response.status}`);
+    }
+
+    const data = await response.json();
+
+    // Convert date strings to Date objects
+    if (data.startDate) {
+      data.startDate = new Date(data.startDate);
+    }
+    if (data.endDate) {
+      data.endDate = new Date(data.endDate);
+    }
+
+    return data as SeasonMetadataDto;
   }
 }

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -415,7 +415,6 @@ export interface SeasonDto {
 
 export interface SeasonStatusBalanceDto {
   total: number;
-  refereePortion: number;
   updatedAt?: Date;
 }
 
@@ -425,9 +424,10 @@ export interface SeasonStatusDto {
   currentTierId: string;
 }
 
-export interface SubscriptionReferralDetailsDto {
+export interface SubscriptionSeasonReferralDetailsDto {
   referralCode: string;
   totalReferees: number;
+  referralPoints: number;
 }
 
 export interface PointsBoostEnvelopeDto {
@@ -491,9 +491,10 @@ export interface ClaimRewardDto {
 }
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export type SubscriptionReferralDetailsState = {
+export type SubscriptionSeasonReferralDetailState = {
   referralCode: string;
   totalReferees: number;
+  referralPoints: number;
   lastFetched?: number;
 };
 
@@ -531,12 +532,12 @@ export type SeasonDtoState = {
   startDate: number; // timestamp
   endDate: number; // timestamp
   tiers: SeasonTierDtoState[];
+  lastFetched?: number;
 };
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type SeasonStatusBalanceDtoState = {
   total: number;
-  refereePortion: number;
   updatedAt?: number; // timestamp
 };
 
@@ -624,7 +625,7 @@ export type RewardsControllerState = {
   subscriptions: { [subscriptionId: string]: SubscriptionDto };
   seasons: { [seasonId: string]: SeasonDtoState };
   subscriptionReferralDetails: {
-    [subscriptionId: string]: SubscriptionReferralDetailsState;
+    [compositeId: string]: SubscriptionSeasonReferralDetailState;
   };
   seasonStatuses: { [compositeId: string]: SeasonStatusState };
   activeBoosts: { [compositeId: string]: ActiveBoostsState };
@@ -803,13 +804,21 @@ export interface RewardsControllerIsRewardsFeatureEnabledAction {
 }
 
 /**
+ * Action for getting season metadata with caching
+ */
+export interface RewardsControllerGetSeasonMetadataAction {
+  type: 'RewardsController:getSeasonMetadata';
+  handler: (type?: 'current' | 'next') => Promise<SeasonDtoState>;
+}
+
+/**
  * Action for getting season status with caching
  */
 export interface RewardsControllerGetSeasonStatusAction {
   type: 'RewardsController:getSeasonStatus';
   handler: (
-    seasonId: string,
     subscriptionId: string,
+    seasonId: string,
   ) => Promise<SeasonStatusState | null>;
 }
 
@@ -820,7 +829,8 @@ export interface RewardsControllerGetReferralDetailsAction {
   type: 'RewardsController:getReferralDetails';
   handler: (
     subscriptionId: string,
-  ) => Promise<SubscriptionReferralDetailsState | null>;
+    seasonId: string,
+  ) => Promise<SubscriptionSeasonReferralDetailState | null>;
 }
 
 /**
@@ -955,6 +965,7 @@ export type RewardsControllerActions =
   | RewardsControllerEstimatePointsAction
   | RewardsControllerGetPerpsDiscountAction
   | RewardsControllerIsRewardsFeatureEnabledAction
+  | RewardsControllerGetSeasonMetadataAction
   | RewardsControllerGetSeasonStatusAction
   | RewardsControllerGetReferralDetailsAction
   | RewardsControllerOptInAction
@@ -972,8 +983,6 @@ export type RewardsControllerActions =
   | RewardsControllerGetUnlockedRewardsAction
   | RewardsControllerClaimRewardAction
   | RewardsControllerResetAllAction;
-
-export const CURRENT_SEASON_ID = 'current';
 
 /**
  * Input DTO for getting opt-in status of multiple addresses
@@ -1016,4 +1025,99 @@ export interface OptOutDto {
    * @example true
    */
   success: boolean;
+}
+
+/**
+ * Season info for discover seasons endpoint
+ */
+export interface SeasonInfoDto {
+  /**
+   * The ID of the season
+   * @example '7444682d-9050-43b8-9038-28a6a62d6264'
+   */
+  id: string;
+
+  /**
+   * The start date of the season
+   * @example '2025-09-01T04:00:00.000Z'
+   */
+  startDate: Date;
+
+  /**
+   * The end date of the season
+   * @example '2025-11-30T04:00:00.000Z'
+   */
+  endDate: Date;
+}
+
+/**
+ * Response DTO for discover seasons endpoint
+ */
+export interface DiscoverSeasonsDto {
+  /**
+   * Current season information
+   */
+  current: SeasonInfoDto | null;
+
+  /**
+   * Next season information
+   */
+  next: SeasonInfoDto | null;
+}
+
+/**
+ * Response DTO for season metadata endpoint
+ */
+export interface SeasonMetadataDto {
+  /**
+   * The ID of the season
+   * @example '7444682d-9050-43b8-9038-28a6a62d6264'
+   */
+  id: string;
+
+  /**
+   * The name of the season
+   * @example 'Season 1'
+   */
+  name: string;
+
+  /**
+   * The start date of the season
+   * @example '2025-09-01T04:00:00.000Z'
+   */
+  startDate: Date;
+
+  /**
+   * The end date of the season
+   * @example '2025-11-30T04:00:00.000Z'
+   */
+  endDate: Date;
+
+  /**
+   * The tiers for the season
+   */
+  tiers: SeasonTierDto[];
+}
+
+/**
+ * Response DTO for season state endpoint (new getSeasonStatus)
+ */
+export interface SeasonStateDto {
+  /**
+   * The balance for the season
+   * @example 0
+   */
+  balance: number;
+
+  /**
+   * The current tier ID
+   * @example '555260e8-d88b-4196-adb1-0844807bddc3'
+   */
+  currentTierId: string;
+
+  /**
+   * When the season state was last updated
+   * @example '2025-10-21T16:45:50.732Z'
+   */
+  updatedAt: Date;
 }

--- a/app/core/Engine/messengers/rewards-controller-messenger/index.ts
+++ b/app/core/Engine/messengers/rewards-controller-messenger/index.ts
@@ -37,6 +37,8 @@ import {
   RewardsDataServiceGetUnlockedRewardsAction,
   RewardsDataServiceClaimRewardAction,
   RewardsDataServiceGetPointsEventsLastUpdatedAction,
+  RewardsDataServiceGetDiscoverSeasonsAction,
+  RewardsDataServiceGetSeasonMetadataAction,
 } from '../../controllers/rewards-controller/services/rewards-data-service';
 
 const name = 'RewardsController';
@@ -63,7 +65,9 @@ type AllowedActions =
   | RewardsDataServiceOptOutAction
   | RewardsDataServiceGetActivePointsBoostsAction
   | RewardsDataServiceGetUnlockedRewardsAction
-  | RewardsDataServiceClaimRewardAction;
+  | RewardsDataServiceClaimRewardAction
+  | RewardsDataServiceGetDiscoverSeasonsAction
+  | RewardsDataServiceGetSeasonMetadataAction;
 
 // Don't reexport as per guidelines
 type AllowedEvents =
@@ -108,6 +112,8 @@ export function getRewardsControllerMessenger(
       'RewardsDataService:getActivePointsBoosts',
       'RewardsDataService:getUnlockedRewards',
       'RewardsDataService:claimReward',
+      'RewardsDataService:getDiscoverSeasons',
+      'RewardsDataService:getSeasonMetadata',
     ],
     allowedEvents: [
       'AccountTreeController:selectedAccountGroupChange',

--- a/app/reducers/rewards/index.test.ts
+++ b/app/reducers/rewards/index.test.ts
@@ -204,7 +204,6 @@ describe('rewardsReducer', () => {
       expect(state.seasonTiers).toHaveLength(1);
       expect(state.seasonTiers[0].id).toBe('tier-bronze');
       expect(state.balanceTotal).toBe(1500);
-      expect(state.balanceRefereePortion).toBe(300);
       expect(state.balanceUpdatedAt).toEqual(new Date(1714857600000));
       expect(state.currentTier?.id).toBe('tier-bronze');
       expect(state.nextTier?.id).toBe('tier-silver');
@@ -258,7 +257,6 @@ describe('rewardsReducer', () => {
       expect(state.seasonEndDate).toBe(null);
       expect(state.seasonTiers).toEqual([]);
       expect(state.balanceTotal).toBe(null);
-      expect(state.balanceRefereePortion).toBe(null);
       expect(state.balanceUpdatedAt).toBe(null);
       expect(state.currentTier).toBe(null);
       expect(state.nextTier).toBe(null);
@@ -289,7 +287,6 @@ describe('rewardsReducer', () => {
       // Assert
       expect(state.seasonName).toBe('Season 4');
       expect(state.balanceTotal).toBe(null); // Should be null due to invalid type
-      expect(state.balanceRefereePortion).toBe(null); // Should be null due to invalid type
       expect(state.balanceUpdatedAt).toEqual(new Date(1714857600000));
     });
 
@@ -375,7 +372,6 @@ describe('rewardsReducer', () => {
 
       // Assert
       expect(state.balanceTotal).toBe(100);
-      expect(state.balanceRefereePortion).toBe(50);
       expect(state.balanceUpdatedAt).toBe(null);
     });
 
@@ -506,6 +502,100 @@ describe('rewardsReducer', () => {
         // Assert
         expect(state.refereeCount).toBe(-1); // Should accept negative values
         expect(state.referralDetailsLoading).toBe(false);
+      });
+
+      it('updates balanceRefereePortion when referralPoints is provided', () => {
+        // Arrange
+        const action = setReferralDetails({ referralPoints: 500 });
+
+        // Act
+        const state = rewardsReducer(initialState, action);
+
+        // Assert
+        expect(state.balanceRefereePortion).toBe(500);
+        expect(state.referralDetailsLoading).toBe(false);
+      });
+
+      it('updates balanceRefereePortion with zero value', () => {
+        // Arrange
+        const stateWithPoints = {
+          ...initialState,
+          balanceRefereePortion: 300,
+        };
+        const action = setReferralDetails({ referralPoints: 0 });
+
+        // Act
+        const state = rewardsReducer(stateWithPoints, action);
+
+        // Assert
+        expect(state.balanceRefereePortion).toBe(0);
+      });
+
+      it('updates all fields including referralPoints when provided together', () => {
+        // Arrange
+        const action = setReferralDetails({
+          referralCode: 'COMBO123',
+          refereeCount: 15,
+          referralPoints: 750,
+        });
+
+        // Act
+        const state = rewardsReducer(initialState, action);
+
+        // Assert
+        expect(state.referralCode).toBe('COMBO123');
+        expect(state.refereeCount).toBe(15);
+        expect(state.balanceRefereePortion).toBe(750);
+        expect(state.referralDetailsLoading).toBe(false);
+      });
+
+      it('preserves balanceRefereePortion when referralPoints is not provided', () => {
+        // Arrange
+        const stateWithPoints = {
+          ...initialState,
+          balanceRefereePortion: 200,
+        };
+        const action = setReferralDetails({ referralCode: 'TEST456' });
+
+        // Act
+        const state = rewardsReducer(stateWithPoints, action);
+
+        // Assert
+        expect(state.balanceRefereePortion).toBe(200);
+        expect(state.referralCode).toBe('TEST456');
+      });
+
+      it('handles negative referralPoints value', () => {
+        // Arrange
+        const action = setReferralDetails({ referralPoints: -50 });
+
+        // Act
+        const state = rewardsReducer(initialState, action);
+
+        // Assert
+        expect(state.balanceRefereePortion).toBe(-50);
+      });
+
+      it('handles large referralPoints value', () => {
+        // Arrange
+        const action = setReferralDetails({ referralPoints: 999999 });
+
+        // Act
+        const state = rewardsReducer(initialState, action);
+
+        // Assert
+        expect(state.balanceRefereePortion).toBe(999999);
+      });
+
+      it('handles decimal referralPoints value', () => {
+        // Arrange
+        const action = setReferralDetails({ referralPoints: 125.75 });
+
+        // Act
+        const state = rewardsReducer(initialState, action);
+
+        // Assert
+        expect(state.balanceRefereePortion).toBe(125.75);
       });
     });
 

--- a/app/reducers/rewards/index.test.ts
+++ b/app/reducers/rewards/index.test.ts
@@ -163,7 +163,6 @@ describe('rewardsReducer', () => {
         },
         balance: {
           total: 1500,
-          refereePortion: 300,
           updatedAt: 1714857600000,
         },
         tier: {
@@ -275,7 +274,6 @@ describe('rewardsReducer', () => {
         },
         balance: {
           total: 'invalid' as unknown as number, // Invalid type
-          refereePortion: null as unknown as number, // Invalid type
           updatedAt: 1714857600000,
         },
       } as unknown as SeasonStatusState;
@@ -314,7 +312,6 @@ describe('rewardsReducer', () => {
         },
         balance: {
           total: 500,
-          refereePortion: 100,
           updatedAt: 1714857600000,
         },
         tier: {
@@ -356,8 +353,6 @@ describe('rewardsReducer', () => {
         },
         balance: {
           total: 100,
-          refereePortion: 50,
-          // No updatedAt property
         },
         tier: {
           currentTier: null,

--- a/app/reducers/rewards/index.ts
+++ b/app/reducers/rewards/index.ts
@@ -160,11 +160,6 @@ const rewardsSlice = createSlice({
         typeof action.payload.balance.total === 'number'
           ? action.payload.balance.total
           : null;
-      state.balanceRefereePortion =
-        action.payload?.balance &&
-        typeof action.payload.balance.refereePortion === 'number'
-          ? action.payload.balance.refereePortion
-          : null;
       state.balanceUpdatedAt = action.payload?.balance?.updatedAt
         ? new Date(action.payload.balance.updatedAt)
         : null;
@@ -181,6 +176,7 @@ const rewardsSlice = createSlice({
       action: PayloadAction<{
         referralCode?: string;
         refereeCount?: number;
+        referralPoints?: number;
       }>,
     ) => {
       if (action.payload.referralCode !== undefined) {
@@ -188,6 +184,9 @@ const rewardsSlice = createSlice({
       }
       if (action.payload.refereeCount !== undefined) {
         state.refereeCount = action.payload.refereeCount;
+      }
+      if (action.payload.referralPoints !== undefined) {
+        state.balanceRefereePortion = action.payload.referralPoints;
       }
       state.referralDetailsLoading = false;
     },


### PR DESCRIPTION
## **Description**

1. Instead of doing 1 season status API call which has all the state (season static, season specific subscription state) we now split both into separate actions. The useSeasonStatus hook is responsible for getting the current season through controller functions for season discovery & getting specific season details. Once it has those, it can call the season status controller function with the appropriate season ID. 
2. The balance referee portion is now retrieved through season referral details, which is a new endpoint as well.
3. This PR also removes some tech debt to no longer use CURRENT_SEASON_ID in certain places in the controller.

## **Changelog**

CHANGELOG entry: null

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches rewards flow to new season discovery/metadata and season-scoped endpoints, updating controller, data service, hooks, reducer, and tests.
> 
> - **Backend (Engine/Controller/Data Service)**:
>   - Add `getSeasonMetadata` (controller) and data-service endpoints: `GET /public/seasons/status`, `GET /public/seasons/:id/meta`, `GET /seasons/:id/state`, `GET /seasons/:id/referral-details`.
>   - Refactor `getSeasonStatus` to consume season metadata + new season state; require explicit `seasonId`; remove reliance on `CURRENT_SEASON_ID` and balance `refereePortion`.
>   - Introduce season-scoped referral details with `referralPoints`; cache keys updated to `seasonId:subscriptionId`; adjust cache TTLs.
>   - Update messenger to expose new data-service actions.
>   - Add `convertToSeasonStatusDto`; update state shapes and types accordingly.
> - **Hooks**:
>   - `useSeasonStatus`: fetch current season metadata then season status by `seasonId`; update error/reauth flows.
>   - `useReferralDetails`: include `seasonId`, fetch season-scoped details, and store `referralPoints`.
> - **Reducer**:
>   - `setSeasonStatus`: drop `balance.refereePortion` handling.
>   - `setReferralDetails`: accept `referralPoints` and map to `balanceRefereePortion`.
> - **UI**:
>   - Referral components/tests now use `referralDetailsLoading` for points loading; pass new stats props; remove season-error banner cases tied to old flow.
>   - RewardsDashboard tests stop importing `CURRENT_SEASON_ID` and use explicit `seasonId`.
> - **Tests**:
>   - Broad updates to reflect new endpoints, types, cache keys, and flows (season metadata/state split, season-scoped referral details).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb45a27029041a8112fe688c63121eedc5176026. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->