### PR TITLE
fix: add small margin bottom to TabBar

### DIFF
--- a/app/component-library/components/Navigation/TabBar/TabBar.tsx
+++ b/app/component-library/components/Navigation/TabBar/TabBar.tsx
@@ -131,7 +131,7 @@ const TabBar = ({ state, descriptors, navigation }: TabBarProps) => {
       <Box
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.End}
-        twClassName="w-full pt-3 px-2 bg-default border-t border-muted"
+        twClassName="w-full pt-3 mb-1 px-2 bg-default border-t border-muted"
         style={[tw.style(`pb-[${bottomInset}px]`)]}
       >
         {renderTabBarItems()}

--- a/app/component-library/components/Navigation/TabBar/__snapshots__/TabBar.test.tsx.snap
+++ b/app/component-library/components/Navigation/TabBar/__snapshots__/TabBar.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`TabBar renders correctly 1`] = `
           "borderTopWidth": 1,
           "display": "flex",
           "flexDirection": "row",
+          "marginBottom": 4,
           "paddingLeft": 8,
           "paddingRight": 8,
           "paddingTop": 12,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR elevates a footer tap bar a little bit (4px).
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Elevates a footer tap bar a little bit

## **Related issues**

Fixes:
Jira ticket: https://consensyssoftware.atlassian.net/browse/TMCU-34
## **Manual testing steps**

```gherkin
Feature: Unlock extension

  Scenario: user unlocks extension
    Given user finished onboarding

    When user unlocks extension
    Then footer tap bar should be a little higher
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="410" height="120" alt="Screenshot 2025-10-23 at 14 32 51" src="https://github.com/user-attachments/assets/67e0a056-0769-4f31-afe6-52e61fd915be" />

<!-- [screenshots/recordings] -->

### **After**
<img width="411" height="118" alt="Screenshot 2025-10-23 at 14 33 03" src="https://github.com/user-attachments/assets/9c63e63b-b37e-41b5-a61a-109f4bbb9962" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a 4px bottom margin to the TabBar container and updates the snapshot accordingly.
> 
> - **UI**:
>   - Add `mb-1` (4px) bottom margin to `TabBar` container in `app/component-library/components/Navigation/TabBar/TabBar.tsx`.
> - **Tests**:
>   - Update snapshot `TabBar.test.tsx.snap` to reflect `marginBottom: 4`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 978e351679f0de0c510f55f372d5340e987aa7b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->