### PR TITLE
feat: update recipients UI on swaps cp-7.58.0

### DIFF
--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.test.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.test.tsx
@@ -126,6 +126,8 @@ jest.mock(
   '../../../../../selectors/multichainAccounts/accountTreeController',
   () => ({
     selectAccountToGroupMap: () => ({}),
+    selectAccountToWalletMap: () => ({}),
+    selectWalletsMap: () => ({}),
     selectSelectedAccountGroupWithInternalAccountsAddresses: () => [],
     selectAccountTreeControllerState: () => ({}),
     selectAccountGroupWithInternalAccounts: () => [],

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { TouchableOpacity, Platform, UIManager } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import I18n, { strings } from '../../../../../../locales/i18n';
@@ -28,19 +28,14 @@ import {
   selectSourceAmount,
   selectDestToken,
   selectSourceToken,
-  selectDestAddress,
-  selectIsSwap,
 } from '../../../../../core/redux/slices/bridge';
-import { selectAccountToGroupMap } from '../../../../../selectors/multichainAccounts/accountTreeController';
-import { selectMultichainAccountsState2Enabled } from '../../../../../selectors/featureFlagController/multichainAccounts';
-import { selectInternalAccounts } from '../../../../../selectors/accountsController';
 import { getIntlNumberFormatter } from '../../../../../util/intl';
 import { useRewards } from '../../hooks/useRewards';
-import { areAddressesEqual } from '../../../../../util/address';
 import RewardsAnimations, {
   RewardAnimationState,
 } from '../../../Rewards/components/RewardPointsAnimation';
 import QuoteCountdownTimer from '../QuoteCountdownTimer';
+import QuoteDetailsRecipientKeyValueRow from '../QuoteDetailsRecipientKeyValueRow/QuoteDetailsRecipientKeyValueRow';
 
 if (
   Platform.OS === 'android' &&
@@ -68,13 +63,6 @@ const QuoteDetailsCard: React.FC = () => {
   const sourceToken = useSelector(selectSourceToken);
   const destToken = useSelector(selectDestToken);
   const sourceAmount = useSelector(selectSourceAmount);
-  const destAddress = useSelector(selectDestAddress);
-  const isSwap = useSelector(selectIsSwap);
-  const internalAccounts = useSelector(selectInternalAccounts);
-  const accountToGroupMap = useSelector(selectAccountToGroupMap);
-  const isMultichainAccountsState2Enabled = useSelector(
-    selectMultichainAccountsState2Enabled,
-  );
   const {
     estimatedPoints,
     isLoading: isRewardsLoading,
@@ -85,39 +73,9 @@ const QuoteDetailsCard: React.FC = () => {
     isQuoteLoading,
   });
 
-  // Get the display name for the destination account
-  const destinationDisplayName = useMemo(() => {
-    if (!destAddress) return undefined;
-
-    const internalAccount = internalAccounts.find((account) =>
-      areAddressesEqual(account.address, destAddress),
-    );
-
-    if (!internalAccount) return undefined;
-
-    // Use account group name if available, otherwise use account name
-    if (isMultichainAccountsState2Enabled) {
-      const accountGroup = accountToGroupMap[internalAccount.id];
-      return accountGroup?.metadata.name || internalAccount.metadata.name;
-    }
-
-    return internalAccount.metadata.name;
-  }, [
-    destAddress,
-    internalAccounts,
-    accountToGroupMap,
-    isMultichainAccountsState2Enabled,
-  ]);
-
   const handleSlippagePress = () => {
     navigation.navigate(Routes.BRIDGE.MODALS.ROOT, {
       screen: Routes.BRIDGE.MODALS.SLIPPAGE_MODAL,
-    });
-  };
-
-  const handleRecipientPress = () => {
-    navigation.navigate(Routes.BRIDGE.MODALS.ROOT, {
-      screen: Routes.BRIDGE.MODALS.RECIPIENT_SELECTOR_MODAL,
     });
   };
 
@@ -307,43 +265,7 @@ const QuoteDetailsCard: React.FC = () => {
           />
         )}
 
-        {!isSwap && (
-          <KeyValueRow
-            field={{
-              label: {
-                text: strings('bridge.recipient'),
-                variant: TextVariant.BodyMDMedium,
-              },
-            }}
-            value={{
-              label: (
-                <TouchableOpacity
-                  onPress={handleRecipientPress}
-                  activeOpacity={0.6}
-                  testID="recipient-selector-button"
-                  style={styles.slippageButton}
-                >
-                  <Text
-                    variant={TextVariant.BodyMD}
-                    numberOfLines={1}
-                    ellipsizeMode="tail"
-                    style={styles.recipientText}
-                  >
-                    {destAddress
-                      ? destinationDisplayName ||
-                        strings('bridge.external_account')
-                      : strings('bridge.select_recipient')}
-                  </Text>
-                  <Icon
-                    name={IconName.Edit}
-                    size={IconSize.Sm}
-                    color={IconColor.Muted}
-                  />
-                </TouchableOpacity>
-              ),
-            }}
-          />
-        )}
+        <QuoteDetailsRecipientKeyValueRow />
 
         {/* Estimated Points */}
         {shouldShowRewardsRow && (

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/__snapshots__/QuoteDetailsCard.test.tsx.snap
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/__snapshots__/QuoteDetailsCard.test.tsx.snap
@@ -962,125 +962,97 @@ exports[`QuoteDetailsCard renders initial state 1`] = `
                                 "justifyContent": "space-between",
                                 "overflow": "hidden",
                               },
-                              [
-                                undefined,
-                              ],
+                              undefined,
                             ]
                           }
                         >
                           <View
                             style={
-                              {
-                                "alignItems": "flex-start",
-                                "flex": 1,
-                              }
+                              [
+                                {
+                                  "display": "flex",
+                                },
+                                {
+                                  "flex": 1,
+                                  "minWidth": "auto",
+                                  "width": "auto",
+                                },
+                              ]
                             }
                           >
-                            <View
+                            <Text
+                              accessibilityRole="text"
                               style={
                                 {
-                                  "alignItems": "center",
-                                  "flexDirection": "row",
-                                  "gap": 8,
+                                  "color": "#121314",
+                                  "fontFamily": "Geist Medium",
+                                  "fontSize": 16,
+                                  "letterSpacing": 0,
+                                  "lineHeight": 24,
                                 }
                               }
                             >
-                              <View
-                                style={
-                                  {
-                                    "alignItems": "center",
-                                    "flexDirection": "row",
-                                  }
-                                }
-                              >
-                                <Text
-                                  accessibilityRole="text"
-                                  style={
-                                    {
-                                      "color": "#121314",
-                                      "fontFamily": "Geist Medium",
-                                      "fontSize": 16,
-                                      "letterSpacing": 0,
-                                      "lineHeight": 24,
-                                    }
-                                  }
-                                  testID="label"
-                                >
-                                  Recipient
-                                </Text>
-                              </View>
-                            </View>
+                              Recipient
+                            </Text>
                           </View>
                           <View
                             style={
-                              {
-                                "alignItems": "flex-end",
-                                "flex": 1,
-                              }
+                              [
+                                {
+                                  "alignItems": "flex-end",
+                                  "display": "flex",
+                                  "justifyContent": "flex-end",
+                                },
+                                {
+                                  "flex": 1,
+                                },
+                              ]
                             }
                           >
-                            <View
+                            <TouchableOpacity
+                              activeOpacity={0.6}
+                              onPress={[Function]}
                               style={
                                 {
                                   "alignItems": "center",
+                                  "flex": 1,
                                   "flexDirection": "row",
-                                  "gap": 8,
+                                  "gap": 4,
                                 }
                               }
+                              testID="recipient-selector-button"
                             >
-                              <View
+                              <Text
+                                accessibilityRole="text"
+                                ellipsizeMode="tail"
+                                numberOfLines={1}
                                 style={
                                   {
-                                    "alignItems": "center",
-                                    "flexDirection": "row",
+                                    "color": "#121314",
+                                    "flexShrink": 1,
+                                    "fontFamily": "Geist Regular",
+                                    "fontSize": 16,
+                                    "letterSpacing": 0,
+                                    "lineHeight": 24,
                                   }
                                 }
                               >
-                                <TouchableOpacity
-                                  activeOpacity={0.6}
-                                  onPress={[Function]}
-                                  style={
-                                    {
-                                      "alignItems": "center",
-                                      "flexDirection": "row",
-                                      "gap": 4,
-                                    }
+                                Select recipient
+                              </Text>
+                              <SvgMock
+                                color="#b7bbc8"
+                                fill="currentColor"
+                                height={16}
+                                name="Edit"
+                                style={
+                                  {
+                                    "height": 16,
+                                    "width": 16,
                                   }
-                                  testID="recipient-selector-button"
-                                >
-                                  <Text
-                                    accessibilityRole="text"
-                                    ellipsizeMode="tail"
-                                    numberOfLines={1}
-                                    style={
-                                      {
-                                        "color": "#121314",
-                                        "flexShrink": 1,
-                                        "fontFamily": "Geist Regular",
-                                        "fontSize": 16,
-                                        "letterSpacing": 0,
-                                        "lineHeight": 24,
-                                      }
-                                    }
-                                  >
-                                    Select recipient
-                                  </Text>
-                                  <SvgMock
-                                    color="#b7bbc8"
-                                    fill="currentColor"
-                                    height={16}
-                                    name="Edit"
-                                    style={
-                                      {
-                                        "height": 16,
-                                        "width": 16,
-                                      }
-                                    }
-                                    width={16}
-                                  />
-                                </TouchableOpacity>
-                              </View>
-                            </View>
+                                }
+                                width={16}
+                              />
+                            </TouchableOpacity>
                           </View>
                         </View>
                       </View>

--- a/app/components/UI/Bridge/components/QuoteDetailsRecipientKeyValueRow/QuoteDetailsRecipientKeyValueRow.styles.ts
+++ b/app/components/UI/Bridge/components/QuoteDetailsRecipientKeyValueRow/QuoteDetailsRecipientKeyValueRow.styles.ts
@@ -20,6 +20,9 @@ const createStyles = () =>
       flexShrink: 0,
       minWidth: 0,
     },
+    recipientText: {
+      flexShrink: 1,
+    },
   });
 
 export default createStyles;

--- a/app/components/UI/Bridge/components/QuoteDetailsRecipientKeyValueRow/QuoteDetailsRecipientKeyValueRow.styles.ts
+++ b/app/components/UI/Bridge/components/QuoteDetailsRecipientKeyValueRow/QuoteDetailsRecipientKeyValueRow.styles.ts
@@ -1,0 +1,25 @@
+import { StyleSheet } from 'react-native';
+
+const createStyles = () =>
+  StyleSheet.create({
+    recipientFieldSection: {
+      flex: 1,
+      minWidth: 'auto',
+      width: 'auto',
+    },
+    recipientValueSection: {
+      flex: 1,
+    },
+    recipientButton: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      flex: 1,
+      gap: 4,
+    },
+    accountNameText: {
+      flexShrink: 0,
+      minWidth: 0,
+    },
+  });
+
+export default createStyles;

--- a/app/components/UI/Bridge/components/QuoteDetailsRecipientKeyValueRow/QuoteDetailsRecipientKeyValueRow.test.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsRecipientKeyValueRow/QuoteDetailsRecipientKeyValueRow.test.tsx
@@ -87,17 +87,18 @@ describe('QuoteDetailsRecipientKeyValueRow', () => {
     expect(toJSON()).toBeNull();
   });
 
-  it('returns null when destAddress is undefined', () => {
+  it('renders select recipient text when destAddress is undefined', () => {
     const state = createMockState({
       bridge: { destAddress: undefined },
     });
 
-    const { toJSON } = renderWithProvider(
+    const { getByText } = renderWithProvider(
       <QuoteDetailsRecipientKeyValueRow />,
       { state },
     );
 
-    expect(toJSON()).toBeNull();
+    expect(getByText('Recipient')).toBeTruthy();
+    expect(getByText('Select recipient')).toBeTruthy();
   });
 
   it('renders recipient row with internal account display name', () => {
@@ -175,7 +176,7 @@ describe('QuoteDetailsRecipientKeyValueRow', () => {
     });
   });
 
-  it('renders empty string when destinationAccountAddress is undefined', () => {
+  it('renders select recipient text when destinationAccountAddress is undefined', () => {
     mockUseRecipientDisplayData.mockReturnValue({
       destinationDisplayName: undefined,
       destinationWalletName: undefined,
@@ -184,12 +185,13 @@ describe('QuoteDetailsRecipientKeyValueRow', () => {
 
     const state = createMockState();
 
-    const { getByTestId, queryByText } = renderWithProvider(
+    const { getByTestId, getByText, queryByText } = renderWithProvider(
       <QuoteDetailsRecipientKeyValueRow />,
       { state },
     );
 
     expect(getByTestId('recipient-selector-button')).toBeTruthy();
+    expect(getByText('Select recipient')).toBeTruthy();
     expect(queryByText('0x12345...67890')).toBeNull();
   });
 });

--- a/app/components/UI/Bridge/components/QuoteDetailsRecipientKeyValueRow/QuoteDetailsRecipientKeyValueRow.test.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsRecipientKeyValueRow/QuoteDetailsRecipientKeyValueRow.test.tsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import QuoteDetailsRecipientKeyValueRow from './QuoteDetailsRecipientKeyValueRow';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import { Hex } from '@metamask/utils';
+import { AvatarAccountType } from '../../../../../component-library/components/Avatars/Avatar/variants/AvatarAccount/AvatarAccount.types';
+import Routes from '../../../../../constants/navigation/Routes';
+
+const mockNavigate = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({
+    navigate: mockNavigate,
+  }),
+}));
+
+jest.mock('../../hooks/useRecipientDisplayData', () => ({
+  useRecipientDisplayData: jest.fn(),
+}));
+
+jest.mock('../../../../../util/notifications', () => ({
+  ...jest.requireActual('../../../../../util/notifications'),
+  shortenString: jest.fn((address, options) => {
+    if (!address) return '';
+    const start = address.slice(0, options.truncatedStartChars);
+    const end = address.slice(-options.truncatedEndChars);
+    return `${start}...${end}`;
+  }),
+}));
+
+import { useRecipientDisplayData } from '../../hooks/useRecipientDisplayData';
+
+const mockUseRecipientDisplayData =
+  useRecipientDisplayData as jest.MockedFunction<
+    typeof useRecipientDisplayData
+  >;
+
+describe('QuoteDetailsRecipientKeyValueRow', () => {
+  const mockDestAddress = '0x1234567890123456789012345678901234567890' as Hex;
+
+  // Simplify typing for tests
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const createMockState = (overrides: any = {}): any => ({
+    engine: {
+      backgroundState: {
+        BridgeController: {
+          destAddress: mockDestAddress,
+        },
+        KeyringController: {
+          keyrings: [],
+        },
+      },
+    },
+    bridge: {
+      isSwap: false,
+      destAddress: mockDestAddress,
+      ...overrides.bridge,
+    },
+    settings: {
+      avatarAccountType: AvatarAccountType.Maskicon,
+    },
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseRecipientDisplayData.mockReturnValue({
+      destinationDisplayName: undefined,
+      destinationWalletName: undefined,
+      destinationAccountAddress: undefined,
+    });
+  });
+
+  it('returns null when isSwap is true', () => {
+    const state = createMockState({
+      bridge: {
+        sourceToken: { chainId: 1, symbol: 'ETH' },
+        destToken: { chainId: 1, symbol: 'USDC' },
+      },
+    });
+
+    const { toJSON } = renderWithProvider(
+      <QuoteDetailsRecipientKeyValueRow />,
+      { state },
+    );
+
+    expect(toJSON()).toBeNull();
+  });
+
+  it('returns null when destAddress is undefined', () => {
+    const state = createMockState({
+      bridge: { destAddress: undefined },
+    });
+
+    const { toJSON } = renderWithProvider(
+      <QuoteDetailsRecipientKeyValueRow />,
+      { state },
+    );
+
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders recipient row with internal account display name', () => {
+    mockUseRecipientDisplayData.mockReturnValue({
+      destinationDisplayName: 'Account 1',
+      destinationWalletName: undefined,
+      destinationAccountAddress: mockDestAddress,
+    });
+
+    const state = createMockState();
+
+    const { getByText, getByTestId } = renderWithProvider(
+      <QuoteDetailsRecipientKeyValueRow />,
+      { state },
+    );
+
+    expect(getByText('Recipient')).toBeTruthy();
+    expect(getByText('Account 1')).toBeTruthy();
+    expect(getByTestId('recipient-selector-button')).toBeTruthy();
+  });
+
+  it('renders recipient row with account display name and wallet name', () => {
+    mockUseRecipientDisplayData.mockReturnValue({
+      destinationDisplayName: 'Account 1',
+      destinationWalletName: 'Wallet 1',
+      destinationAccountAddress: mockDestAddress,
+    });
+
+    const state = createMockState();
+
+    const { getByText } = renderWithProvider(
+      <QuoteDetailsRecipientKeyValueRow />,
+      { state },
+    );
+
+    expect(getByText(/Wallet 1.*Account 1/)).toBeTruthy();
+  });
+
+  it('renders recipient row with shortened external address when no display name', () => {
+    mockUseRecipientDisplayData.mockReturnValue({
+      destinationDisplayName: undefined,
+      destinationWalletName: undefined,
+      destinationAccountAddress: mockDestAddress,
+    });
+
+    const state = createMockState();
+
+    const { getByText } = renderWithProvider(
+      <QuoteDetailsRecipientKeyValueRow />,
+      { state },
+    );
+
+    expect(getByText('0x12345...67890')).toBeTruthy();
+  });
+
+  it('navigates to recipient selector modal when button is pressed', () => {
+    mockUseRecipientDisplayData.mockReturnValue({
+      destinationDisplayName: 'Account 1',
+      destinationWalletName: undefined,
+      destinationAccountAddress: mockDestAddress,
+    });
+
+    const state = createMockState();
+
+    const { getByTestId } = renderWithProvider(
+      <QuoteDetailsRecipientKeyValueRow />,
+      { state },
+    );
+
+    const button = getByTestId('recipient-selector-button');
+    fireEvent.press(button);
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.MODALS.ROOT, {
+      screen: Routes.BRIDGE.MODALS.RECIPIENT_SELECTOR_MODAL,
+    });
+  });
+
+  it('renders empty string when destinationAccountAddress is undefined', () => {
+    mockUseRecipientDisplayData.mockReturnValue({
+      destinationDisplayName: undefined,
+      destinationWalletName: undefined,
+      destinationAccountAddress: undefined,
+    });
+
+    const state = createMockState();
+
+    const { getByTestId, queryByText } = renderWithProvider(
+      <QuoteDetailsRecipientKeyValueRow />,
+      { state },
+    );
+
+    expect(getByTestId('recipient-selector-button')).toBeTruthy();
+    expect(queryByText('0x12345...67890')).toBeNull();
+  });
+});

--- a/app/components/UI/Bridge/components/QuoteDetailsRecipientKeyValueRow/QuoteDetailsRecipientKeyValueRow.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsRecipientKeyValueRow/QuoteDetailsRecipientKeyValueRow.tsx
@@ -11,10 +11,7 @@ import {
   BoxJustifyContent,
 } from '@metamask/design-system-react-native';
 import { useSelector } from 'react-redux';
-import {
-  selectDestAddress,
-  selectIsSwap,
-} from '../../../../../core/redux/slices/bridge';
+import { selectIsSwap } from '../../../../../core/redux/slices/bridge';
 import createStyles from './QuoteDetailsRecipientKeyValueRow.styles';
 import Routes from '../../../../../constants/navigation/Routes';
 import { useNavigation } from '@react-navigation/native';
@@ -30,7 +27,6 @@ const QuoteDetailsRecipientKeyValueRow = () => {
   const styles = createStyles();
   const navigation = useNavigation();
   const isSwap = useSelector(selectIsSwap);
-  const destAddress = useSelector(selectDestAddress);
 
   // Get the display name and wallet name for the destination account
   const {
@@ -45,7 +41,7 @@ const QuoteDetailsRecipientKeyValueRow = () => {
     });
   };
 
-  if (isSwap || !destAddress) {
+  if (isSwap) {
     return null;
   }
 
@@ -73,10 +69,10 @@ const QuoteDetailsRecipientKeyValueRow = () => {
               numberOfLines={1}
               style={styles.accountNameText}
             >
-              {destinationWalletName ? `${destinationWalletName} / ` : ''}{' '}
+              {destinationWalletName ? `${destinationWalletName} / ` : ''}
               {destinationDisplayName}
             </Text>
-          ) : (
+          ) : destinationAccountAddress ? (
             <Text variant={TextVariant.BodyMD}>
               {shortenString(destinationAccountAddress, {
                 truncatedCharLimit: 15,
@@ -84,6 +80,15 @@ const QuoteDetailsRecipientKeyValueRow = () => {
                 truncatedEndChars: 5,
                 skipCharacterInEnd: false,
               })}
+            </Text>
+          ) : (
+            <Text
+              variant={TextVariant.BodyMD}
+              numberOfLines={1}
+              ellipsizeMode="tail"
+              style={styles.recipientText}
+            >
+              {strings('bridge.select_recipient')}
             </Text>
           )}
           <Icon

--- a/app/components/UI/Bridge/components/QuoteDetailsRecipientKeyValueRow/QuoteDetailsRecipientKeyValueRow.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsRecipientKeyValueRow/QuoteDetailsRecipientKeyValueRow.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { TouchableOpacity } from 'react-native';
+import { strings } from '../../../../../../locales/i18n';
+import Text, {
+  TextVariant,
+} from '../../../../../component-library/components/Texts/Text';
+import { KeyValueRowStubs } from '../../../../../component-library/components-temp/KeyValueRow';
+import {
+  Box,
+  BoxAlignItems,
+  BoxJustifyContent,
+} from '@metamask/design-system-react-native';
+import { useSelector } from 'react-redux';
+import {
+  selectDestAddress,
+  selectIsSwap,
+} from '../../../../../core/redux/slices/bridge';
+import createStyles from './QuoteDetailsRecipientKeyValueRow.styles';
+import Routes from '../../../../../constants/navigation/Routes';
+import { useNavigation } from '@react-navigation/native';
+import { useRecipientDisplayData } from '../../hooks/useRecipientDisplayData';
+import { shortenString } from '../../../../../util/notifications';
+import Icon, {
+  IconColor,
+  IconName,
+  IconSize,
+} from '../../../../../component-library/components/Icons/Icon';
+
+const QuoteDetailsRecipientKeyValueRow = () => {
+  const styles = createStyles();
+  const navigation = useNavigation();
+  const isSwap = useSelector(selectIsSwap);
+  const destAddress = useSelector(selectDestAddress);
+
+  // Get the display name and wallet name for the destination account
+  const {
+    destinationDisplayName,
+    destinationWalletName,
+    destinationAccountAddress,
+  } = useRecipientDisplayData();
+
+  const handleRecipientPress = () => {
+    navigation.navigate(Routes.BRIDGE.MODALS.ROOT, {
+      screen: Routes.BRIDGE.MODALS.RECIPIENT_SELECTOR_MODAL,
+    });
+  };
+
+  if (isSwap || !destAddress) {
+    return null;
+  }
+
+  return (
+    <KeyValueRowStubs.Root>
+      <Box style={styles.recipientFieldSection}>
+        <Text variant={TextVariant.BodyMDMedium}>
+          {strings('bridge.recipient')}
+        </Text>
+      </Box>
+      <Box
+        style={styles.recipientValueSection}
+        alignItems={BoxAlignItems.End}
+        justifyContent={BoxJustifyContent.End}
+      >
+        <TouchableOpacity
+          onPress={handleRecipientPress}
+          activeOpacity={0.6}
+          testID="recipient-selector-button"
+          style={styles.recipientButton}
+        >
+          {destinationDisplayName ? (
+            <Text
+              variant={TextVariant.BodyMD}
+              numberOfLines={1}
+              style={styles.accountNameText}
+            >
+              {destinationWalletName ? `${destinationWalletName} / ` : ''}{' '}
+              {destinationDisplayName}
+            </Text>
+          ) : (
+            <Text variant={TextVariant.BodyMD}>
+              {shortenString(destinationAccountAddress, {
+                truncatedCharLimit: 15,
+                truncatedStartChars: 7,
+                truncatedEndChars: 5,
+                skipCharacterInEnd: false,
+              })}
+            </Text>
+          )}
+          <Icon
+            name={IconName.Edit}
+            size={IconSize.Sm}
+            color={IconColor.Muted}
+          />
+        </TouchableOpacity>
+      </Box>
+    </KeyValueRowStubs.Root>
+  );
+};
+
+export default QuoteDetailsRecipientKeyValueRow;

--- a/app/components/UI/Bridge/hooks/useRecipientDisplayData/index.ts
+++ b/app/components/UI/Bridge/hooks/useRecipientDisplayData/index.ts
@@ -1,0 +1,1 @@
+export { useRecipientDisplayData } from './useRecipientDisplayData';

--- a/app/components/UI/Bridge/hooks/useRecipientDisplayData/useRecipientDisplayData.test.ts
+++ b/app/components/UI/Bridge/hooks/useRecipientDisplayData/useRecipientDisplayData.test.ts
@@ -6,823 +6,266 @@ import { Hex } from '@metamask/utils';
 import { EthAccountType, EthScope } from '@metamask/keyring-api';
 import { AccountWalletType, AccountGroupType } from '@metamask/account-api';
 
+const ADDR = '0xabcdef1234567890abcdef1234567890abcdef12' as Hex;
+const ADDR_UPPER = '0xABCDEF1234567890ABCDEF1234567890ABCDEF12' as Hex;
+const EXTERNAL_ADDR = '0x1111111111111111111111111111111111111111' as Hex;
+
+const createAccount = (id: string, address: Hex, name: string) => ({
+  [id]: {
+    id,
+    address,
+    metadata: { name, lastSelected: 0 },
+    type: EthAccountType.Eoa,
+    scopes: [EthScope.Eoa],
+  },
+});
+
+const createWallet = (
+  walletId: string,
+  walletName: string,
+  groupId: string,
+  groupName: string,
+  accountIds: string[],
+) => ({
+  [`${AccountWalletType.Entropy}:${walletId}`]: {
+    id: `${AccountWalletType.Entropy}:${walletId}`,
+    type: AccountWalletType.Entropy,
+    metadata: { name: walletName, entropy: { id: walletId } },
+    groups: {
+      [`${AccountWalletType.Entropy}:${walletId}/${groupId}`]: {
+        id: `${AccountWalletType.Entropy}:${walletId}/${groupId}`,
+        type: AccountGroupType.MultichainAccount,
+        metadata: {
+          name: groupName,
+          pinned: false,
+          hidden: false,
+          entropy: { groupIndex: Number(groupId) },
+        },
+        accounts: accountIds,
+      },
+    },
+  },
+});
+
+const setupMultichainState = (
+  accountId: string,
+  address: Hex,
+  accountName: string,
+  options: {
+    multichainEnabled?: boolean;
+    groupName?: string;
+    walletName?: string;
+    walletsMap?: object;
+    emptyWalletsMap?: boolean;
+  } = {},
+) => {
+  const state = createBridgeTestState({
+    bridgeReducerOverrides: { destAddress: address },
+  });
+  const multichainEnabled = options.multichainEnabled ?? true;
+
+  state.engine = {
+    ...state.engine,
+    backgroundState: {
+      ...state.engine?.backgroundState,
+      RemoteFeatureFlagController: {
+        ...state.engine?.backgroundState?.RemoteFeatureFlagController,
+        remoteFeatureFlags: {
+          ...state.engine?.backgroundState?.RemoteFeatureFlagController
+            ?.remoteFeatureFlags,
+          multichainAccountsState2: multichainEnabled,
+        },
+      },
+      AccountsController: {
+        internalAccounts: {
+          selectedAccount: accountId,
+          accounts: createAccount(accountId, address, accountName),
+        },
+      },
+      ...(multichainEnabled && {
+        AccountTreeController: {
+          accountTree: {
+            selectedAccountGroup: `${AccountWalletType.Entropy}:wallet1/0`,
+            wallets: options.emptyWalletsMap
+              ? {}
+              : options.walletsMap ??
+                createWallet(
+                  'wallet1',
+                  options.walletName ?? 'Wallet 1',
+                  '0',
+                  options.groupName ?? accountName,
+                  [accountId],
+                ),
+          },
+        },
+      }),
+    },
+  };
+
+  return state;
+};
+
 describe('useRecipientDisplayData', () => {
-  const testAccountId = 'testAccountId';
-  const testAccountAddress =
-    '0xabcdef1234567890abcdef1234567890abcdef12' as Hex;
-  const testAccountId2 = 'testAccountId2';
+  const accountId = 'testAccountId';
 
-  beforeEach(() => {
-    jest.clearAllMocks();
+  beforeEach(() => jest.clearAllMocks());
+
+  // Keep any typing for tests
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const renderHook = (state: any) =>
+    renderHookWithProvider(() => useRecipientDisplayData(), { state }).result
+      .current;
+
+  it('returns undefined for all fields when destAddress is not set', () => {
+    const state = createBridgeTestState({
+      bridgeReducerOverrides: { destAddress: undefined },
+    });
+
+    expect(renderHook(state)).toEqual({
+      destinationDisplayName: undefined,
+      destinationWalletName: undefined,
+      destinationAccountAddress: undefined,
+    });
   });
 
-  describe('when destAddress is not set', () => {
-    it('returns undefined for all fields', () => {
-      const testState = createBridgeTestState({
-        bridgeReducerOverrides: {
-          destAddress: undefined,
-        },
+  it('returns external address without display name or wallet name', () => {
+    const state = createBridgeTestState({
+      bridgeReducerOverrides: { destAddress: EXTERNAL_ADDR },
+    });
+
+    expect(renderHook(state)).toEqual({
+      destinationDisplayName: undefined,
+      destinationWalletName: undefined,
+      destinationAccountAddress: EXTERNAL_ADDR,
+    });
+  });
+
+  describe('with multichain disabled', () => {
+    it('returns account metadata name without wallet name', () => {
+      const state = setupMultichainState(accountId, ADDR, 'My Account', {
+        multichainEnabled: false,
       });
 
-      const { result } = renderHookWithProvider(
-        () => useRecipientDisplayData(),
-        {
-          state: testState,
-        },
-      );
-
-      expect(result.current).toEqual({
-        destinationDisplayName: undefined,
+      expect(renderHook(state)).toEqual({
+        destinationDisplayName: 'My Account',
         destinationWalletName: undefined,
-        destinationAccountAddress: undefined,
+        destinationAccountAddress: ADDR,
       });
+    });
+
+    it('matches addresses case-insensitively', () => {
+      const state = setupMultichainState(accountId, ADDR, 'Case Test', {
+        multichainEnabled: false,
+      });
+      state.bridge.destAddress = ADDR_UPPER;
+
+      const result = renderHook(state);
+      expect(result.destinationDisplayName).toBe('Case Test');
+      expect(result.destinationAccountAddress).toBe(ADDR);
     });
   });
 
-  describe('when destAddress is set but not an internal account', () => {
-    it('returns external address without display name or wallet name', () => {
-      const externalAddress =
-        '0x1111111111111111111111111111111111111111' as Hex;
-
-      const testState = createBridgeTestState({
-        bridgeReducerOverrides: {
-          destAddress: externalAddress,
-        },
+  describe('with multichain enabled', () => {
+    it('returns account group name and wallet name when available', () => {
+      const state = setupMultichainState(accountId, ADDR, 'Account', {
+        groupName: 'Group Name',
+        walletName: 'My Wallet',
       });
 
-      const { result } = renderHookWithProvider(
-        () => useRecipientDisplayData(),
-        {
-          state: testState,
-        },
-      );
+      expect(renderHook(state)).toEqual({
+        destinationDisplayName: 'Group Name',
+        destinationWalletName: 'My Wallet',
+        destinationAccountAddress: ADDR,
+      });
+    });
 
-      expect(result.current).toEqual({
-        destinationDisplayName: undefined,
+    it('falls back to account name when account group not found', () => {
+      const state = setupMultichainState(accountId, ADDR, 'Fallback Account', {
+        emptyWalletsMap: true,
+      });
+
+      expect(renderHook(state)).toEqual({
+        destinationDisplayName: 'Fallback Account',
         destinationWalletName: undefined,
-        destinationAccountAddress: externalAddress,
-      });
-    });
-  });
-
-  describe('when destAddress matches an internal account', () => {
-    describe('with multichain accounts state 2 disabled', () => {
-      it('returns account metadata name without wallet name', () => {
-        const testState = createBridgeTestState();
-
-        testState.engine = {
-          ...testState.engine,
-          backgroundState: {
-            ...testState.engine?.backgroundState,
-            RemoteFeatureFlagController: {
-              ...testState.engine?.backgroundState?.RemoteFeatureFlagController,
-              remoteFeatureFlags: {
-                ...testState.engine?.backgroundState
-                  ?.RemoteFeatureFlagController?.remoteFeatureFlags,
-                multichainAccountsState2: false,
-              },
-            },
-            AccountsController: {
-              internalAccounts: {
-                selectedAccount: testAccountId,
-                accounts: {
-                  [testAccountId]: {
-                    id: testAccountId,
-                    address: testAccountAddress,
-                    metadata: {
-                      name: 'My Test Account',
-                      lastSelected: 0,
-                    },
-                    type: EthAccountType.Eoa,
-                    scopes: [EthScope.Eoa],
-                  },
-                },
-              },
-            },
-          },
-        };
-
-        testState.bridge = {
-          ...testState.bridge,
-          destAddress: testAccountAddress,
-        };
-
-        const { result } = renderHookWithProvider(
-          () => useRecipientDisplayData(),
-          {
-            state: testState,
-          },
-        );
-
-        expect(result.current).toEqual({
-          destinationDisplayName: 'My Test Account',
-          destinationWalletName: undefined,
-          destinationAccountAddress: testAccountAddress,
-        });
+        destinationAccountAddress: ADDR,
       });
     });
 
-    describe('with multichain accounts state 2 enabled', () => {
-      it('returns account group name when available', () => {
-        const testState = createBridgeTestState();
-
-        testState.engine = {
-          ...testState.engine,
-          backgroundState: {
-            ...testState.engine?.backgroundState,
-            RemoteFeatureFlagController: {
-              ...testState.engine?.backgroundState?.RemoteFeatureFlagController,
-              remoteFeatureFlags: {
-                ...testState.engine?.backgroundState
-                  ?.RemoteFeatureFlagController?.remoteFeatureFlags,
-                multichainAccountsState2: true,
-              },
-            },
-            AccountsController: {
-              internalAccounts: {
-                selectedAccount: testAccountId,
-                accounts: {
-                  [testAccountId]: {
-                    id: testAccountId,
-                    address: testAccountAddress,
-                    metadata: {
-                      name: 'Account Name',
-                      lastSelected: 0,
-                    },
-                    type: EthAccountType.Eoa,
-                    scopes: [EthScope.Eoa],
-                  },
-                },
-              },
-            },
-            AccountTreeController: {
-              accountTree: {
-                selectedAccountGroup: `${AccountWalletType.Entropy}:wallet1/0`,
-                wallets: {
-                  [`${AccountWalletType.Entropy}:wallet1`]: {
-                    id: `${AccountWalletType.Entropy}:wallet1`,
-                    type: AccountWalletType.Entropy,
-                    metadata: {
-                      name: 'Wallet 1',
-                      entropy: {
-                        id: 'wallet1',
-                      },
-                    },
-                    groups: {
-                      [`${AccountWalletType.Entropy}:wallet1/0`]: {
-                        id: `${AccountWalletType.Entropy}:wallet1/0`,
-                        type: AccountGroupType.MultichainAccount,
-                        metadata: {
-                          name: 'Group Display Name',
-                          pinned: false,
-                          hidden: false,
-                          entropy: {
-                            groupIndex: 0,
-                          },
-                        },
-                        accounts: [testAccountId],
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        };
-
-        testState.bridge = {
-          ...testState.bridge,
-          destAddress: testAccountAddress,
-        };
-
-        const { result } = renderHookWithProvider(
-          () => useRecipientDisplayData(),
-          {
-            state: testState,
-          },
-        );
-
-        expect(result.current).toEqual({
-          destinationDisplayName: 'Group Display Name',
-          destinationWalletName: 'Wallet 1',
-          destinationAccountAddress: testAccountAddress,
-        });
+    it('includes wallet name with multiple wallets', () => {
+      const wallets = {
+        ...createWallet('wallet1', 'First Wallet', '0', 'Group 1', [accountId]),
+        ...createWallet('wallet2', 'Second Wallet', '0', 'Group 2', [
+          'otherAccount',
+        ]),
+      };
+      const state = setupMultichainState(accountId, ADDR, 'Account', {
+        walletsMap: wallets,
+        groupName: 'Group 1',
       });
 
-      it('falls back to account metadata name when account group is not found', () => {
-        const testState = createBridgeTestState();
-
-        testState.engine = {
-          ...testState.engine,
-          backgroundState: {
-            ...testState.engine?.backgroundState,
-            RemoteFeatureFlagController: {
-              ...testState.engine?.backgroundState?.RemoteFeatureFlagController,
-              remoteFeatureFlags: {
-                ...testState.engine?.backgroundState
-                  ?.RemoteFeatureFlagController?.remoteFeatureFlags,
-                multichainAccountsState2: true,
-              },
-            },
-            AccountsController: {
-              internalAccounts: {
-                selectedAccount: testAccountId,
-                accounts: {
-                  [testAccountId]: {
-                    id: testAccountId,
-                    address: testAccountAddress,
-                    metadata: {
-                      name: 'Fallback Account Name',
-                      lastSelected: 0,
-                    },
-                    type: EthAccountType.Eoa,
-                    scopes: [EthScope.Eoa],
-                  },
-                },
-              },
-            },
-            AccountTreeController: {
-              accountTree: {
-                selectedAccountGroup: `${AccountWalletType.Entropy}:wallet1/0`,
-                wallets: {},
-              },
-            },
-          },
-        };
-
-        testState.bridge = {
-          ...testState.bridge,
-          destAddress: testAccountAddress,
-        };
-
-        const { result } = renderHookWithProvider(
-          () => useRecipientDisplayData(),
-          {
-            state: testState,
-          },
-        );
-
-        expect(result.current).toEqual({
-          destinationDisplayName: 'Fallback Account Name',
-          destinationWalletName: undefined,
-          destinationAccountAddress: testAccountAddress,
-        });
-      });
-
-      it('includes wallet name when multiple wallets exist', () => {
-        const testState = createBridgeTestState();
-
-        testState.engine = {
-          ...testState.engine,
-          backgroundState: {
-            ...testState.engine?.backgroundState,
-            RemoteFeatureFlagController: {
-              ...testState.engine?.backgroundState?.RemoteFeatureFlagController,
-              remoteFeatureFlags: {
-                ...testState.engine?.backgroundState
-                  ?.RemoteFeatureFlagController?.remoteFeatureFlags,
-                multichainAccountsState2: true,
-              },
-            },
-            AccountsController: {
-              internalAccounts: {
-                selectedAccount: testAccountId,
-                accounts: {
-                  [testAccountId]: {
-                    id: testAccountId,
-                    address: testAccountAddress,
-                    metadata: {
-                      name: 'Account 1',
-                      lastSelected: 0,
-                    },
-                    type: EthAccountType.Eoa,
-                    scopes: [EthScope.Eoa],
-                  },
-                },
-              },
-            },
-            AccountTreeController: {
-              accountTree: {
-                selectedAccountGroup: `${AccountWalletType.Entropy}:wallet1/0`,
-                wallets: {
-                  [`${AccountWalletType.Entropy}:wallet1`]: {
-                    id: `${AccountWalletType.Entropy}:wallet1`,
-                    type: AccountWalletType.Entropy,
-                    metadata: {
-                      name: 'First Wallet',
-                      entropy: {
-                        id: 'wallet1',
-                      },
-                    },
-                    groups: {
-                      [`${AccountWalletType.Entropy}:wallet1/0`]: {
-                        id: `${AccountWalletType.Entropy}:wallet1/0`,
-                        type: AccountGroupType.MultichainAccount,
-                        metadata: {
-                          name: 'Group 1',
-                          pinned: false,
-                          hidden: false,
-                          entropy: {
-                            groupIndex: 0,
-                          },
-                        },
-                        accounts: [testAccountId],
-                      },
-                    },
-                  },
-                  [`${AccountWalletType.Entropy}:wallet2`]: {
-                    id: `${AccountWalletType.Entropy}:wallet2`,
-                    type: AccountWalletType.Entropy,
-                    metadata: {
-                      name: 'Second Wallet',
-                      entropy: {
-                        id: 'wallet2',
-                      },
-                    },
-                    groups: {
-                      [`${AccountWalletType.Entropy}:wallet2/0`]: {
-                        id: `${AccountWalletType.Entropy}:wallet2/0`,
-                        type: AccountGroupType.MultichainAccount,
-                        metadata: {
-                          name: 'Group 2',
-                          pinned: false,
-                          hidden: false,
-                          entropy: {
-                            groupIndex: 0,
-                          },
-                        },
-                        accounts: [testAccountId2],
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        };
-
-        testState.bridge = {
-          ...testState.bridge,
-          destAddress: testAccountAddress,
-        };
-
-        const { result } = renderHookWithProvider(
-          () => useRecipientDisplayData(),
-          {
-            state: testState,
-          },
-        );
-
-        expect(result.current).toEqual({
-          destinationDisplayName: 'Group 1',
-          destinationWalletName: 'First Wallet',
-          destinationAccountAddress: testAccountAddress,
-        });
-      });
-
-      it('includes wallet name even when only one wallet exists', () => {
-        const testState = createBridgeTestState();
-
-        testState.engine = {
-          ...testState.engine,
-          backgroundState: {
-            ...testState.engine?.backgroundState,
-            RemoteFeatureFlagController: {
-              ...testState.engine?.backgroundState?.RemoteFeatureFlagController,
-              remoteFeatureFlags: {
-                ...testState.engine?.backgroundState
-                  ?.RemoteFeatureFlagController?.remoteFeatureFlags,
-                multichainAccountsState2: true,
-              },
-            },
-            AccountsController: {
-              internalAccounts: {
-                selectedAccount: testAccountId,
-                accounts: {
-                  [testAccountId]: {
-                    id: testAccountId,
-                    address: testAccountAddress,
-                    metadata: {
-                      name: 'Account 1',
-                      lastSelected: 0,
-                    },
-                    type: EthAccountType.Eoa,
-                    scopes: [EthScope.Eoa],
-                  },
-                },
-              },
-            },
-            AccountTreeController: {
-              accountTree: {
-                selectedAccountGroup: `${AccountWalletType.Entropy}:wallet1/0`,
-                wallets: {
-                  [`${AccountWalletType.Entropy}:wallet1`]: {
-                    id: `${AccountWalletType.Entropy}:wallet1`,
-                    type: AccountWalletType.Entropy,
-                    metadata: {
-                      name: 'Only Wallet',
-                      entropy: {
-                        id: 'wallet1',
-                      },
-                    },
-                    groups: {
-                      [`${AccountWalletType.Entropy}:wallet1/0`]: {
-                        id: `${AccountWalletType.Entropy}:wallet1/0`,
-                        type: AccountGroupType.MultichainAccount,
-                        metadata: {
-                          name: 'Group 1',
-                          pinned: false,
-                          hidden: false,
-                          entropy: {
-                            groupIndex: 0,
-                          },
-                        },
-                        accounts: [testAccountId],
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        };
-
-        testState.bridge = {
-          ...testState.bridge,
-          destAddress: testAccountAddress,
-        };
-
-        const { result } = renderHookWithProvider(
-          () => useRecipientDisplayData(),
-          {
-            state: testState,
-          },
-        );
-
-        expect(result.current).toEqual({
-          destinationDisplayName: 'Group 1',
-          destinationWalletName: 'Only Wallet',
-          destinationAccountAddress: testAccountAddress,
-        });
-      });
-
-      it('returns undefined wallet name when walletId exists in map but wallet does not exist in walletsMap', () => {
-        const testState = createBridgeTestState();
-
-        testState.engine = {
-          ...testState.engine,
-          backgroundState: {
-            ...testState.engine?.backgroundState,
-            RemoteFeatureFlagController: {
-              ...testState.engine?.backgroundState?.RemoteFeatureFlagController,
-              remoteFeatureFlags: {
-                ...testState.engine?.backgroundState
-                  ?.RemoteFeatureFlagController?.remoteFeatureFlags,
-                multichainAccountsState2: true,
-              },
-            },
-            AccountsController: {
-              internalAccounts: {
-                selectedAccount: testAccountId,
-                accounts: {
-                  [testAccountId]: {
-                    id: testAccountId,
-                    address: testAccountAddress,
-                    metadata: {
-                      name: 'Account 1',
-                      lastSelected: 0,
-                    },
-                    type: EthAccountType.Eoa,
-                    scopes: [EthScope.Eoa],
-                  },
-                },
-              },
-            },
-            AccountTreeController: {
-              accountTree: {
-                selectedAccountGroup: `${AccountWalletType.Entropy}:wallet1/0`,
-                wallets: {
-                  [`${AccountWalletType.Entropy}:wallet1`]: {
-                    id: `${AccountWalletType.Entropy}:wallet1`,
-                    type: AccountWalletType.Entropy,
-                    metadata: {
-                      name: 'Wallet 1',
-                      entropy: {
-                        id: 'wallet1',
-                      },
-                    },
-                    groups: {
-                      [`${AccountWalletType.Entropy}:wallet1/0`]: {
-                        id: `${AccountWalletType.Entropy}:wallet1/0`,
-                        type: AccountGroupType.MultichainAccount,
-                        metadata: {
-                          name: 'Group 1',
-                          pinned: false,
-                          hidden: false,
-                          entropy: {
-                            groupIndex: 0,
-                          },
-                        },
-                        accounts: [testAccountId],
-                      },
-                    },
-                  },
-                  [`${AccountWalletType.Entropy}:wallet2`]: {
-                    id: `${AccountWalletType.Entropy}:wallet2`,
-                    type: AccountWalletType.Entropy,
-                    metadata: {
-                      name: 'Wallet 2',
-                      entropy: {
-                        id: 'wallet2',
-                      },
-                    },
-                    groups: {},
-                  },
-                },
-              },
-            },
-          },
-        };
-
-        testState.bridge = {
-          ...testState.bridge,
-          destAddress: testAccountAddress,
-        };
-
-        const { result } = renderHookWithProvider(
-          () => useRecipientDisplayData(),
-          {
-            state: testState,
-          },
-        );
-
-        expect(result.current).toEqual({
-          destinationDisplayName: 'Group 1',
-          destinationWalletName: 'Wallet 1',
-          destinationAccountAddress: testAccountAddress,
-        });
-      });
-
-      it('returns undefined wallet name when walletId is not in accountToWalletMap', () => {
-        const testState = createBridgeTestState();
-
-        testState.engine = {
-          ...testState.engine,
-          backgroundState: {
-            ...testState.engine?.backgroundState,
-            RemoteFeatureFlagController: {
-              ...testState.engine?.backgroundState?.RemoteFeatureFlagController,
-              remoteFeatureFlags: {
-                ...testState.engine?.backgroundState
-                  ?.RemoteFeatureFlagController?.remoteFeatureFlags,
-                multichainAccountsState2: true,
-              },
-            },
-            AccountsController: {
-              internalAccounts: {
-                selectedAccount: testAccountId,
-                accounts: {
-                  [testAccountId]: {
-                    id: testAccountId,
-                    address: testAccountAddress,
-                    metadata: {
-                      name: 'Account 1',
-                      lastSelected: 0,
-                    },
-                    type: EthAccountType.Eoa,
-                    scopes: [EthScope.Eoa],
-                  },
-                },
-              },
-            },
-            AccountTreeController: {
-              accountTree: {
-                selectedAccountGroup: `${AccountWalletType.Entropy}:wallet1/0`,
-                wallets: {
-                  [`${AccountWalletType.Entropy}:wallet1`]: {
-                    id: `${AccountWalletType.Entropy}:wallet1`,
-                    type: AccountWalletType.Entropy,
-                    metadata: {
-                      name: 'Wallet 1',
-                      entropy: {
-                        id: 'wallet1',
-                      },
-                    },
-                    groups: {
-                      [`${AccountWalletType.Entropy}:wallet1/0`]: {
-                        id: `${AccountWalletType.Entropy}:wallet1/0`,
-                        type: AccountGroupType.MultichainAccount,
-                        metadata: {
-                          name: 'Group 1',
-                          pinned: false,
-                          hidden: false,
-                          entropy: {
-                            groupIndex: 0,
-                          },
-                        },
-                        accounts: [], // Account not in this group
-                      },
-                    },
-                  },
-                  [`${AccountWalletType.Entropy}:wallet2`]: {
-                    id: `${AccountWalletType.Entropy}:wallet2`,
-                    type: AccountWalletType.Entropy,
-                    metadata: {
-                      name: 'Wallet 2',
-                      entropy: {
-                        id: 'wallet2',
-                      },
-                    },
-                    groups: {},
-                  },
-                },
-              },
-            },
-          },
-        };
-
-        testState.bridge = {
-          ...testState.bridge,
-          destAddress: testAccountAddress,
-        };
-
-        const { result } = renderHookWithProvider(
-          () => useRecipientDisplayData(),
-          {
-            state: testState,
-          },
-        );
-
-        expect(result.current).toEqual({
-          destinationDisplayName: 'Account 1',
-          destinationWalletName: undefined,
-          destinationAccountAddress: testAccountAddress,
-        });
-      });
-
-      it('handles case where walletsMap is empty but multichain is enabled', () => {
-        const testState = createBridgeTestState();
-
-        testState.engine = {
-          ...testState.engine,
-          backgroundState: {
-            ...testState.engine?.backgroundState,
-            RemoteFeatureFlagController: {
-              ...testState.engine?.backgroundState?.RemoteFeatureFlagController,
-              remoteFeatureFlags: {
-                ...testState.engine?.backgroundState
-                  ?.RemoteFeatureFlagController?.remoteFeatureFlags,
-                multichainAccountsState2: true,
-              },
-            },
-            AccountsController: {
-              internalAccounts: {
-                selectedAccount: testAccountId,
-                accounts: {
-                  [testAccountId]: {
-                    id: testAccountId,
-                    address: testAccountAddress,
-                    metadata: {
-                      name: 'Account Name',
-                      lastSelected: 0,
-                    },
-                    type: EthAccountType.Eoa,
-                    scopes: [EthScope.Eoa],
-                  },
-                },
-              },
-            },
-            AccountTreeController: {
-              accountTree: {
-                selectedAccountGroup: `${AccountWalletType.Entropy}:wallet1/0`,
-                wallets: {},
-              },
-            },
-          },
-        };
-
-        testState.bridge = {
-          ...testState.bridge,
-          destAddress: testAccountAddress,
-        };
-
-        const { result } = renderHookWithProvider(
-          () => useRecipientDisplayData(),
-          {
-            state: testState,
-          },
-        );
-
-        expect(result.current).toEqual({
-          destinationDisplayName: 'Account Name',
-          destinationWalletName: undefined,
-          destinationAccountAddress: testAccountAddress,
-        });
+      expect(renderHook(state)).toEqual({
+        destinationDisplayName: 'Group 1',
+        destinationWalletName: 'First Wallet',
+        destinationAccountAddress: ADDR,
       });
     });
 
-    describe('address matching', () => {
-      it('matches addresses case-insensitively', () => {
-        const lowerCaseAddress =
-          '0xabcdef1234567890abcdef1234567890abcdef12' as Hex;
-        const upperCaseAddress =
-          '0xABCDEF1234567890ABCDEF1234567890ABCDEF12' as Hex;
+    it('includes wallet name with single wallet', () => {
+      const state = setupMultichainState(accountId, ADDR, 'Account', {
+        groupName: 'Group 1',
+        walletName: 'Only Wallet',
+      });
 
-        const testState = createBridgeTestState({
-          bridgeReducerOverrides: {
-            destAddress: upperCaseAddress,
-          },
-        });
+      expect(renderHook(state)).toEqual({
+        destinationDisplayName: 'Group 1',
+        destinationWalletName: 'Only Wallet',
+        destinationAccountAddress: ADDR,
+      });
+    });
 
-        testState.engine = {
-          ...testState.engine,
-          backgroundState: {
-            ...testState.engine?.backgroundState,
-            RemoteFeatureFlagController: {
-              ...testState.engine?.backgroundState?.RemoteFeatureFlagController,
-              remoteFeatureFlags: {
-                ...testState.engine?.backgroundState
-                  ?.RemoteFeatureFlagController?.remoteFeatureFlags,
-                multichainAccountsState2: false,
-              },
-            },
-            AccountsController: {
-              internalAccounts: {
-                selectedAccount: testAccountId,
-                accounts: {
-                  [testAccountId]: {
-                    id: testAccountId,
-                    address: lowerCaseAddress,
-                    metadata: {
-                      name: 'Case Test Account',
-                      lastSelected: 0,
-                    },
-                    type: EthAccountType.Eoa,
-                    scopes: [EthScope.Eoa],
-                  },
-                },
-              },
-            },
-          },
-        };
+    it('returns undefined wallet name when walletId not in accountToWalletMap', () => {
+      const wallets = {
+        ...createWallet('wallet1', 'Wallet 1', '0', 'Group 1', []),
+        ...createWallet('wallet2', 'Wallet 2', '0', 'Group 2', []),
+      };
+      const state = setupMultichainState(accountId, ADDR, 'Account 1', {
+        walletsMap: wallets,
+      });
 
-        const { result } = renderHookWithProvider(
-          () => useRecipientDisplayData(),
-          {
-            state: testState,
-          },
-        );
+      expect(renderHook(state)).toEqual({
+        destinationDisplayName: 'Account 1',
+        destinationWalletName: undefined,
+        destinationAccountAddress: ADDR,
+      });
+    });
 
-        expect(result.current.destinationDisplayName).toBe('Case Test Account');
-        expect(result.current.destinationAccountAddress).toBe(lowerCaseAddress);
+    it('handles empty walletsMap', () => {
+      const state = setupMultichainState(accountId, ADDR, 'Account', {
+        emptyWalletsMap: true,
+      });
+
+      expect(renderHook(state)).toEqual({
+        destinationDisplayName: 'Account',
+        destinationWalletName: undefined,
+        destinationAccountAddress: ADDR,
       });
     });
   });
 
   describe('memoization', () => {
-    it('returns the same object reference when dependencies do not change', () => {
-      const testState = createBridgeTestState({
-        bridgeReducerOverrides: {
-          destAddress: testAccountAddress,
-        },
+    it('returns same object reference when dependencies unchanged', () => {
+      const state = setupMultichainState(accountId, ADDR, 'Memo Test', {
+        multichainEnabled: false,
       });
-
-      testState.engine = {
-        ...testState.engine,
-        backgroundState: {
-          ...testState.engine?.backgroundState,
-          AccountsController: {
-            internalAccounts: {
-              selectedAccount: testAccountId,
-              accounts: {
-                [testAccountId]: {
-                  id: testAccountId,
-                  address: testAccountAddress,
-                  metadata: {
-                    name: 'Memo Test Account',
-                    lastSelected: 0,
-                  },
-                  type: EthAccountType.Eoa,
-                  scopes: [EthScope.Eoa],
-                },
-              },
-            },
-          },
-        },
-      };
 
       const { result, rerender } = renderHookWithProvider(
         () => useRecipientDisplayData(),
-        {
-          state: testState,
-        },
+        { state },
       );
-
       const firstResult = result.current;
-      rerender({ state: testState });
-      const secondResult = result.current;
+      rerender({ state });
 
-      expect(firstResult).toBe(secondResult);
+      expect(result.current).toBe(firstResult);
     });
   });
 });

--- a/app/components/UI/Bridge/hooks/useRecipientDisplayData/useRecipientDisplayData.test.ts
+++ b/app/components/UI/Bridge/hooks/useRecipientDisplayData/useRecipientDisplayData.test.ts
@@ -1,0 +1,828 @@
+import '../../_mocks_/initialState';
+import { createBridgeTestState } from '../../testUtils';
+import { useRecipientDisplayData } from './useRecipientDisplayData';
+import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
+import { Hex } from '@metamask/utils';
+import { EthAccountType, EthScope } from '@metamask/keyring-api';
+import { AccountWalletType, AccountGroupType } from '@metamask/account-api';
+
+describe('useRecipientDisplayData', () => {
+  const testAccountId = 'testAccountId';
+  const testAccountAddress =
+    '0xabcdef1234567890abcdef1234567890abcdef12' as Hex;
+  const testAccountId2 = 'testAccountId2';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when destAddress is not set', () => {
+    it('returns undefined for all fields', () => {
+      const testState = createBridgeTestState({
+        bridgeReducerOverrides: {
+          destAddress: undefined,
+        },
+      });
+
+      const { result } = renderHookWithProvider(
+        () => useRecipientDisplayData(),
+        {
+          state: testState,
+        },
+      );
+
+      expect(result.current).toEqual({
+        destinationDisplayName: undefined,
+        destinationWalletName: undefined,
+        destinationAccountAddress: undefined,
+      });
+    });
+  });
+
+  describe('when destAddress is set but not an internal account', () => {
+    it('returns external address without display name or wallet name', () => {
+      const externalAddress =
+        '0x1111111111111111111111111111111111111111' as Hex;
+
+      const testState = createBridgeTestState({
+        bridgeReducerOverrides: {
+          destAddress: externalAddress,
+        },
+      });
+
+      const { result } = renderHookWithProvider(
+        () => useRecipientDisplayData(),
+        {
+          state: testState,
+        },
+      );
+
+      expect(result.current).toEqual({
+        destinationDisplayName: undefined,
+        destinationWalletName: undefined,
+        destinationAccountAddress: externalAddress,
+      });
+    });
+  });
+
+  describe('when destAddress matches an internal account', () => {
+    describe('with multichain accounts state 2 disabled', () => {
+      it('returns account metadata name without wallet name', () => {
+        const testState = createBridgeTestState();
+
+        testState.engine = {
+          ...testState.engine,
+          backgroundState: {
+            ...testState.engine?.backgroundState,
+            RemoteFeatureFlagController: {
+              ...testState.engine?.backgroundState?.RemoteFeatureFlagController,
+              remoteFeatureFlags: {
+                ...testState.engine?.backgroundState
+                  ?.RemoteFeatureFlagController?.remoteFeatureFlags,
+                multichainAccountsState2: false,
+              },
+            },
+            AccountsController: {
+              internalAccounts: {
+                selectedAccount: testAccountId,
+                accounts: {
+                  [testAccountId]: {
+                    id: testAccountId,
+                    address: testAccountAddress,
+                    metadata: {
+                      name: 'My Test Account',
+                      lastSelected: 0,
+                    },
+                    type: EthAccountType.Eoa,
+                    scopes: [EthScope.Eoa],
+                  },
+                },
+              },
+            },
+          },
+        };
+
+        testState.bridge = {
+          ...testState.bridge,
+          destAddress: testAccountAddress,
+        };
+
+        const { result } = renderHookWithProvider(
+          () => useRecipientDisplayData(),
+          {
+            state: testState,
+          },
+        );
+
+        expect(result.current).toEqual({
+          destinationDisplayName: 'My Test Account',
+          destinationWalletName: undefined,
+          destinationAccountAddress: testAccountAddress,
+        });
+      });
+    });
+
+    describe('with multichain accounts state 2 enabled', () => {
+      it('returns account group name when available', () => {
+        const testState = createBridgeTestState();
+
+        testState.engine = {
+          ...testState.engine,
+          backgroundState: {
+            ...testState.engine?.backgroundState,
+            RemoteFeatureFlagController: {
+              ...testState.engine?.backgroundState?.RemoteFeatureFlagController,
+              remoteFeatureFlags: {
+                ...testState.engine?.backgroundState
+                  ?.RemoteFeatureFlagController?.remoteFeatureFlags,
+                multichainAccountsState2: true,
+              },
+            },
+            AccountsController: {
+              internalAccounts: {
+                selectedAccount: testAccountId,
+                accounts: {
+                  [testAccountId]: {
+                    id: testAccountId,
+                    address: testAccountAddress,
+                    metadata: {
+                      name: 'Account Name',
+                      lastSelected: 0,
+                    },
+                    type: EthAccountType.Eoa,
+                    scopes: [EthScope.Eoa],
+                  },
+                },
+              },
+            },
+            AccountTreeController: {
+              accountTree: {
+                selectedAccountGroup: `${AccountWalletType.Entropy}:wallet1/0`,
+                wallets: {
+                  [`${AccountWalletType.Entropy}:wallet1`]: {
+                    id: `${AccountWalletType.Entropy}:wallet1`,
+                    type: AccountWalletType.Entropy,
+                    metadata: {
+                      name: 'Wallet 1',
+                      entropy: {
+                        id: 'wallet1',
+                      },
+                    },
+                    groups: {
+                      [`${AccountWalletType.Entropy}:wallet1/0`]: {
+                        id: `${AccountWalletType.Entropy}:wallet1/0`,
+                        type: AccountGroupType.MultichainAccount,
+                        metadata: {
+                          name: 'Group Display Name',
+                          pinned: false,
+                          hidden: false,
+                          entropy: {
+                            groupIndex: 0,
+                          },
+                        },
+                        accounts: [testAccountId],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+
+        testState.bridge = {
+          ...testState.bridge,
+          destAddress: testAccountAddress,
+        };
+
+        const { result } = renderHookWithProvider(
+          () => useRecipientDisplayData(),
+          {
+            state: testState,
+          },
+        );
+
+        expect(result.current).toEqual({
+          destinationDisplayName: 'Group Display Name',
+          destinationWalletName: 'Wallet 1',
+          destinationAccountAddress: testAccountAddress,
+        });
+      });
+
+      it('falls back to account metadata name when account group is not found', () => {
+        const testState = createBridgeTestState();
+
+        testState.engine = {
+          ...testState.engine,
+          backgroundState: {
+            ...testState.engine?.backgroundState,
+            RemoteFeatureFlagController: {
+              ...testState.engine?.backgroundState?.RemoteFeatureFlagController,
+              remoteFeatureFlags: {
+                ...testState.engine?.backgroundState
+                  ?.RemoteFeatureFlagController?.remoteFeatureFlags,
+                multichainAccountsState2: true,
+              },
+            },
+            AccountsController: {
+              internalAccounts: {
+                selectedAccount: testAccountId,
+                accounts: {
+                  [testAccountId]: {
+                    id: testAccountId,
+                    address: testAccountAddress,
+                    metadata: {
+                      name: 'Fallback Account Name',
+                      lastSelected: 0,
+                    },
+                    type: EthAccountType.Eoa,
+                    scopes: [EthScope.Eoa],
+                  },
+                },
+              },
+            },
+            AccountTreeController: {
+              accountTree: {
+                selectedAccountGroup: `${AccountWalletType.Entropy}:wallet1/0`,
+                wallets: {},
+              },
+            },
+          },
+        };
+
+        testState.bridge = {
+          ...testState.bridge,
+          destAddress: testAccountAddress,
+        };
+
+        const { result } = renderHookWithProvider(
+          () => useRecipientDisplayData(),
+          {
+            state: testState,
+          },
+        );
+
+        expect(result.current).toEqual({
+          destinationDisplayName: 'Fallback Account Name',
+          destinationWalletName: undefined,
+          destinationAccountAddress: testAccountAddress,
+        });
+      });
+
+      it('includes wallet name when multiple wallets exist', () => {
+        const testState = createBridgeTestState();
+
+        testState.engine = {
+          ...testState.engine,
+          backgroundState: {
+            ...testState.engine?.backgroundState,
+            RemoteFeatureFlagController: {
+              ...testState.engine?.backgroundState?.RemoteFeatureFlagController,
+              remoteFeatureFlags: {
+                ...testState.engine?.backgroundState
+                  ?.RemoteFeatureFlagController?.remoteFeatureFlags,
+                multichainAccountsState2: true,
+              },
+            },
+            AccountsController: {
+              internalAccounts: {
+                selectedAccount: testAccountId,
+                accounts: {
+                  [testAccountId]: {
+                    id: testAccountId,
+                    address: testAccountAddress,
+                    metadata: {
+                      name: 'Account 1',
+                      lastSelected: 0,
+                    },
+                    type: EthAccountType.Eoa,
+                    scopes: [EthScope.Eoa],
+                  },
+                },
+              },
+            },
+            AccountTreeController: {
+              accountTree: {
+                selectedAccountGroup: `${AccountWalletType.Entropy}:wallet1/0`,
+                wallets: {
+                  [`${AccountWalletType.Entropy}:wallet1`]: {
+                    id: `${AccountWalletType.Entropy}:wallet1`,
+                    type: AccountWalletType.Entropy,
+                    metadata: {
+                      name: 'First Wallet',
+                      entropy: {
+                        id: 'wallet1',
+                      },
+                    },
+                    groups: {
+                      [`${AccountWalletType.Entropy}:wallet1/0`]: {
+                        id: `${AccountWalletType.Entropy}:wallet1/0`,
+                        type: AccountGroupType.MultichainAccount,
+                        metadata: {
+                          name: 'Group 1',
+                          pinned: false,
+                          hidden: false,
+                          entropy: {
+                            groupIndex: 0,
+                          },
+                        },
+                        accounts: [testAccountId],
+                      },
+                    },
+                  },
+                  [`${AccountWalletType.Entropy}:wallet2`]: {
+                    id: `${AccountWalletType.Entropy}:wallet2`,
+                    type: AccountWalletType.Entropy,
+                    metadata: {
+                      name: 'Second Wallet',
+                      entropy: {
+                        id: 'wallet2',
+                      },
+                    },
+                    groups: {
+                      [`${AccountWalletType.Entropy}:wallet2/0`]: {
+                        id: `${AccountWalletType.Entropy}:wallet2/0`,
+                        type: AccountGroupType.MultichainAccount,
+                        metadata: {
+                          name: 'Group 2',
+                          pinned: false,
+                          hidden: false,
+                          entropy: {
+                            groupIndex: 0,
+                          },
+                        },
+                        accounts: [testAccountId2],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+
+        testState.bridge = {
+          ...testState.bridge,
+          destAddress: testAccountAddress,
+        };
+
+        const { result } = renderHookWithProvider(
+          () => useRecipientDisplayData(),
+          {
+            state: testState,
+          },
+        );
+
+        expect(result.current).toEqual({
+          destinationDisplayName: 'Group 1',
+          destinationWalletName: 'First Wallet',
+          destinationAccountAddress: testAccountAddress,
+        });
+      });
+
+      it('includes wallet name even when only one wallet exists', () => {
+        const testState = createBridgeTestState();
+
+        testState.engine = {
+          ...testState.engine,
+          backgroundState: {
+            ...testState.engine?.backgroundState,
+            RemoteFeatureFlagController: {
+              ...testState.engine?.backgroundState?.RemoteFeatureFlagController,
+              remoteFeatureFlags: {
+                ...testState.engine?.backgroundState
+                  ?.RemoteFeatureFlagController?.remoteFeatureFlags,
+                multichainAccountsState2: true,
+              },
+            },
+            AccountsController: {
+              internalAccounts: {
+                selectedAccount: testAccountId,
+                accounts: {
+                  [testAccountId]: {
+                    id: testAccountId,
+                    address: testAccountAddress,
+                    metadata: {
+                      name: 'Account 1',
+                      lastSelected: 0,
+                    },
+                    type: EthAccountType.Eoa,
+                    scopes: [EthScope.Eoa],
+                  },
+                },
+              },
+            },
+            AccountTreeController: {
+              accountTree: {
+                selectedAccountGroup: `${AccountWalletType.Entropy}:wallet1/0`,
+                wallets: {
+                  [`${AccountWalletType.Entropy}:wallet1`]: {
+                    id: `${AccountWalletType.Entropy}:wallet1`,
+                    type: AccountWalletType.Entropy,
+                    metadata: {
+                      name: 'Only Wallet',
+                      entropy: {
+                        id: 'wallet1',
+                      },
+                    },
+                    groups: {
+                      [`${AccountWalletType.Entropy}:wallet1/0`]: {
+                        id: `${AccountWalletType.Entropy}:wallet1/0`,
+                        type: AccountGroupType.MultichainAccount,
+                        metadata: {
+                          name: 'Group 1',
+                          pinned: false,
+                          hidden: false,
+                          entropy: {
+                            groupIndex: 0,
+                          },
+                        },
+                        accounts: [testAccountId],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+
+        testState.bridge = {
+          ...testState.bridge,
+          destAddress: testAccountAddress,
+        };
+
+        const { result } = renderHookWithProvider(
+          () => useRecipientDisplayData(),
+          {
+            state: testState,
+          },
+        );
+
+        expect(result.current).toEqual({
+          destinationDisplayName: 'Group 1',
+          destinationWalletName: 'Only Wallet',
+          destinationAccountAddress: testAccountAddress,
+        });
+      });
+
+      it('returns undefined wallet name when walletId exists in map but wallet does not exist in walletsMap', () => {
+        const testState = createBridgeTestState();
+
+        testState.engine = {
+          ...testState.engine,
+          backgroundState: {
+            ...testState.engine?.backgroundState,
+            RemoteFeatureFlagController: {
+              ...testState.engine?.backgroundState?.RemoteFeatureFlagController,
+              remoteFeatureFlags: {
+                ...testState.engine?.backgroundState
+                  ?.RemoteFeatureFlagController?.remoteFeatureFlags,
+                multichainAccountsState2: true,
+              },
+            },
+            AccountsController: {
+              internalAccounts: {
+                selectedAccount: testAccountId,
+                accounts: {
+                  [testAccountId]: {
+                    id: testAccountId,
+                    address: testAccountAddress,
+                    metadata: {
+                      name: 'Account 1',
+                      lastSelected: 0,
+                    },
+                    type: EthAccountType.Eoa,
+                    scopes: [EthScope.Eoa],
+                  },
+                },
+              },
+            },
+            AccountTreeController: {
+              accountTree: {
+                selectedAccountGroup: `${AccountWalletType.Entropy}:wallet1/0`,
+                wallets: {
+                  [`${AccountWalletType.Entropy}:wallet1`]: {
+                    id: `${AccountWalletType.Entropy}:wallet1`,
+                    type: AccountWalletType.Entropy,
+                    metadata: {
+                      name: 'Wallet 1',
+                      entropy: {
+                        id: 'wallet1',
+                      },
+                    },
+                    groups: {
+                      [`${AccountWalletType.Entropy}:wallet1/0`]: {
+                        id: `${AccountWalletType.Entropy}:wallet1/0`,
+                        type: AccountGroupType.MultichainAccount,
+                        metadata: {
+                          name: 'Group 1',
+                          pinned: false,
+                          hidden: false,
+                          entropy: {
+                            groupIndex: 0,
+                          },
+                        },
+                        accounts: [testAccountId],
+                      },
+                    },
+                  },
+                  [`${AccountWalletType.Entropy}:wallet2`]: {
+                    id: `${AccountWalletType.Entropy}:wallet2`,
+                    type: AccountWalletType.Entropy,
+                    metadata: {
+                      name: 'Wallet 2',
+                      entropy: {
+                        id: 'wallet2',
+                      },
+                    },
+                    groups: {},
+                  },
+                },
+              },
+            },
+          },
+        };
+
+        testState.bridge = {
+          ...testState.bridge,
+          destAddress: testAccountAddress,
+        };
+
+        const { result } = renderHookWithProvider(
+          () => useRecipientDisplayData(),
+          {
+            state: testState,
+          },
+        );
+
+        expect(result.current).toEqual({
+          destinationDisplayName: 'Group 1',
+          destinationWalletName: 'Wallet 1',
+          destinationAccountAddress: testAccountAddress,
+        });
+      });
+
+      it('returns undefined wallet name when walletId is not in accountToWalletMap', () => {
+        const testState = createBridgeTestState();
+
+        testState.engine = {
+          ...testState.engine,
+          backgroundState: {
+            ...testState.engine?.backgroundState,
+            RemoteFeatureFlagController: {
+              ...testState.engine?.backgroundState?.RemoteFeatureFlagController,
+              remoteFeatureFlags: {
+                ...testState.engine?.backgroundState
+                  ?.RemoteFeatureFlagController?.remoteFeatureFlags,
+                multichainAccountsState2: true,
+              },
+            },
+            AccountsController: {
+              internalAccounts: {
+                selectedAccount: testAccountId,
+                accounts: {
+                  [testAccountId]: {
+                    id: testAccountId,
+                    address: testAccountAddress,
+                    metadata: {
+                      name: 'Account 1',
+                      lastSelected: 0,
+                    },
+                    type: EthAccountType.Eoa,
+                    scopes: [EthScope.Eoa],
+                  },
+                },
+              },
+            },
+            AccountTreeController: {
+              accountTree: {
+                selectedAccountGroup: `${AccountWalletType.Entropy}:wallet1/0`,
+                wallets: {
+                  [`${AccountWalletType.Entropy}:wallet1`]: {
+                    id: `${AccountWalletType.Entropy}:wallet1`,
+                    type: AccountWalletType.Entropy,
+                    metadata: {
+                      name: 'Wallet 1',
+                      entropy: {
+                        id: 'wallet1',
+                      },
+                    },
+                    groups: {
+                      [`${AccountWalletType.Entropy}:wallet1/0`]: {
+                        id: `${AccountWalletType.Entropy}:wallet1/0`,
+                        type: AccountGroupType.MultichainAccount,
+                        metadata: {
+                          name: 'Group 1',
+                          pinned: false,
+                          hidden: false,
+                          entropy: {
+                            groupIndex: 0,
+                          },
+                        },
+                        accounts: [], // Account not in this group
+                      },
+                    },
+                  },
+                  [`${AccountWalletType.Entropy}:wallet2`]: {
+                    id: `${AccountWalletType.Entropy}:wallet2`,
+                    type: AccountWalletType.Entropy,
+                    metadata: {
+                      name: 'Wallet 2',
+                      entropy: {
+                        id: 'wallet2',
+                      },
+                    },
+                    groups: {},
+                  },
+                },
+              },
+            },
+          },
+        };
+
+        testState.bridge = {
+          ...testState.bridge,
+          destAddress: testAccountAddress,
+        };
+
+        const { result } = renderHookWithProvider(
+          () => useRecipientDisplayData(),
+          {
+            state: testState,
+          },
+        );
+
+        expect(result.current).toEqual({
+          destinationDisplayName: 'Account 1',
+          destinationWalletName: undefined,
+          destinationAccountAddress: testAccountAddress,
+        });
+      });
+
+      it('handles case where walletsMap is empty but multichain is enabled', () => {
+        const testState = createBridgeTestState();
+
+        testState.engine = {
+          ...testState.engine,
+          backgroundState: {
+            ...testState.engine?.backgroundState,
+            RemoteFeatureFlagController: {
+              ...testState.engine?.backgroundState?.RemoteFeatureFlagController,
+              remoteFeatureFlags: {
+                ...testState.engine?.backgroundState
+                  ?.RemoteFeatureFlagController?.remoteFeatureFlags,
+                multichainAccountsState2: true,
+              },
+            },
+            AccountsController: {
+              internalAccounts: {
+                selectedAccount: testAccountId,
+                accounts: {
+                  [testAccountId]: {
+                    id: testAccountId,
+                    address: testAccountAddress,
+                    metadata: {
+                      name: 'Account Name',
+                      lastSelected: 0,
+                    },
+                    type: EthAccountType.Eoa,
+                    scopes: [EthScope.Eoa],
+                  },
+                },
+              },
+            },
+            AccountTreeController: {
+              accountTree: {
+                selectedAccountGroup: `${AccountWalletType.Entropy}:wallet1/0`,
+                wallets: {},
+              },
+            },
+          },
+        };
+
+        testState.bridge = {
+          ...testState.bridge,
+          destAddress: testAccountAddress,
+        };
+
+        const { result } = renderHookWithProvider(
+          () => useRecipientDisplayData(),
+          {
+            state: testState,
+          },
+        );
+
+        expect(result.current).toEqual({
+          destinationDisplayName: 'Account Name',
+          destinationWalletName: undefined,
+          destinationAccountAddress: testAccountAddress,
+        });
+      });
+    });
+
+    describe('address matching', () => {
+      it('matches addresses case-insensitively', () => {
+        const lowerCaseAddress =
+          '0xabcdef1234567890abcdef1234567890abcdef12' as Hex;
+        const upperCaseAddress =
+          '0xABCDEF1234567890ABCDEF1234567890ABCDEF12' as Hex;
+
+        const testState = createBridgeTestState({
+          bridgeReducerOverrides: {
+            destAddress: upperCaseAddress,
+          },
+        });
+
+        testState.engine = {
+          ...testState.engine,
+          backgroundState: {
+            ...testState.engine?.backgroundState,
+            RemoteFeatureFlagController: {
+              ...testState.engine?.backgroundState?.RemoteFeatureFlagController,
+              remoteFeatureFlags: {
+                ...testState.engine?.backgroundState
+                  ?.RemoteFeatureFlagController?.remoteFeatureFlags,
+                multichainAccountsState2: false,
+              },
+            },
+            AccountsController: {
+              internalAccounts: {
+                selectedAccount: testAccountId,
+                accounts: {
+                  [testAccountId]: {
+                    id: testAccountId,
+                    address: lowerCaseAddress,
+                    metadata: {
+                      name: 'Case Test Account',
+                      lastSelected: 0,
+                    },
+                    type: EthAccountType.Eoa,
+                    scopes: [EthScope.Eoa],
+                  },
+                },
+              },
+            },
+          },
+        };
+
+        const { result } = renderHookWithProvider(
+          () => useRecipientDisplayData(),
+          {
+            state: testState,
+          },
+        );
+
+        expect(result.current.destinationDisplayName).toBe('Case Test Account');
+        expect(result.current.destinationAccountAddress).toBe(lowerCaseAddress);
+      });
+    });
+  });
+
+  describe('memoization', () => {
+    it('returns the same object reference when dependencies do not change', () => {
+      const testState = createBridgeTestState({
+        bridgeReducerOverrides: {
+          destAddress: testAccountAddress,
+        },
+      });
+
+      testState.engine = {
+        ...testState.engine,
+        backgroundState: {
+          ...testState.engine?.backgroundState,
+          AccountsController: {
+            internalAccounts: {
+              selectedAccount: testAccountId,
+              accounts: {
+                [testAccountId]: {
+                  id: testAccountId,
+                  address: testAccountAddress,
+                  metadata: {
+                    name: 'Memo Test Account',
+                    lastSelected: 0,
+                  },
+                  type: EthAccountType.Eoa,
+                  scopes: [EthScope.Eoa],
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const { result, rerender } = renderHookWithProvider(
+        () => useRecipientDisplayData(),
+        {
+          state: testState,
+        },
+      );
+
+      const firstResult = result.current;
+      rerender({ state: testState });
+      const secondResult = result.current;
+
+      expect(firstResult).toBe(secondResult);
+    });
+  });
+});

--- a/app/components/UI/Bridge/hooks/useRecipientDisplayData/useRecipientDisplayData.ts
+++ b/app/components/UI/Bridge/hooks/useRecipientDisplayData/useRecipientDisplayData.ts
@@ -1,0 +1,84 @@
+import { useSelector } from 'react-redux';
+import { selectDestAddress } from '../../../../../core/redux/slices/bridge';
+import { selectInternalAccounts } from '../../../../../selectors/accountsController';
+import {
+  selectAccountToGroupMap,
+  selectAccountToWalletMap,
+  selectWalletsMap,
+} from '../../../../../selectors/multichainAccounts/accountTreeController';
+import { selectMultichainAccountsState2Enabled } from '../../../../../selectors/featureFlagController/multichainAccounts';
+import { useMemo } from 'react';
+import { areAddressesEqual } from '../../../../../util/address';
+
+/**
+ * Custom hook to retrieve display information for the bridge recipient account.
+ *
+ * This hook determines the appropriate display name, wallet name, and address for the
+ * destination/recipient account in a bridge transaction. It handles both internal accounts
+ * (accounts within the wallet) and external accounts (addresses not in the wallet).
+ *
+ * When multichain accounts state 2 is enabled, it uses account group names and wallet names
+ * for better organization.
+ */
+export const useRecipientDisplayData = () => {
+  const destAddress = useSelector(selectDestAddress);
+  const internalAccounts = useSelector(selectInternalAccounts);
+  const accountToGroupMap = useSelector(selectAccountToGroupMap);
+  const accountToWalletMap = useSelector(selectAccountToWalletMap);
+  const isMultichainAccountsState2Enabled = useSelector(
+    selectMultichainAccountsState2Enabled,
+  );
+  const walletsMap = useSelector(selectWalletsMap);
+
+  return useMemo(() => {
+    if (!destAddress) {
+      return {
+        destinationDisplayName: undefined,
+        destinationWalletName: undefined,
+        destinationAccountAddress: undefined,
+      };
+    }
+
+    const internalAccount = internalAccounts.find((account) =>
+      areAddressesEqual(account.address, destAddress),
+    );
+
+    if (!internalAccount) {
+      return {
+        destinationDisplayName: undefined,
+        destinationWalletName: undefined,
+        destinationAccountAddress: destAddress,
+      };
+    }
+
+    let displayName = internalAccount.metadata.name;
+    let walletName: string | undefined;
+
+    // Use account group name if available, otherwise use account name
+    if (isMultichainAccountsState2Enabled) {
+      const accountGroup = accountToGroupMap[internalAccount.id];
+      displayName =
+        accountGroup?.metadata.name || internalAccount.metadata.name;
+
+      if (walletsMap) {
+        const walletId = accountToWalletMap[internalAccount.id];
+        if (walletId && walletsMap[walletId]) {
+          walletName = walletsMap[walletId].metadata.name;
+        }
+      }
+    }
+
+    return {
+      destinationDisplayName: displayName,
+      destinationWalletName: walletName,
+      destinationAccountAddress: internalAccount.address,
+    };
+  }, [
+    destAddress,
+    internalAccounts,
+    accountToGroupMap,
+    isMultichainAccountsState2Enabled,
+    accountToWalletMap,
+    walletsMap,
+  ]);
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Render wallet and account name if the recipient is an imported account, else render the truncated wallet address if the recipient is an external account. We also introduced some refactoring to make us scale the `QuestDetailsCard` by extracting UI and business logic to separate components. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Render wallet and account name if the recipient is an imported account, else render the truncated wallet address if the recipient is an external account.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3311

## **Manual testing steps**

```gherkin
  Scenario: user views bridge quote with wallet and account name
    Given user is on bridge quote details screen
    And recipient is set to "Account 1" in "Wallet 1"

    When bridge quote details are displayed
    Then recipient row shows "Wallet 1 / Account 1"


  Scenario: user views bridge quote with external address as recipient
    Given user is on bridge quote details screen
    And recipient is set to external address "0x1234567890123456789012345678901234567890"

    When bridge quote details are displayed
    Then recipient row shows shortened address "0x12345...67890"

  Scenario: user opens recipient selector
    Given user is on bridge quote details screen
    And recipient is set to "Account 1"

    When user taps recipient selector button
    Then recipient selector modal opens

  Scenario: user views swap quote details
    Given user is performing a swap (not a bridge)
    And swap quote details are displayed

    When bridge recipient row renders
    Then recipient row is not displayed


  Scenario: user views bridge quote with no recipient address
    Given user is on bridge quote details screen
    And no recipient address is available

    When bridge quote details are displayed
    Then recipient row shows "Select recipient" placeholder
    And no shortened address is displayed
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="786" height="293" alt="image" src="https://github.com/user-attachments/assets/179c99cb-1f5a-4451-9929-6519e9a60d31" />

<img width="786" height="293" alt="image" src="https://github.com/user-attachments/assets/20409fb5-ca18-40e6-ac0b-92bf9ac02750" />

<img width="786" height="293" alt="image" src="https://github.com/user-attachments/assets/3ac89b42-a9c9-454e-9a60-e89018319fb2" />


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extracts the recipient row from QuoteDetailsCard into a dedicated component powered by a new hook to display wallet/account names or a shortened external address, and updates tests/snapshots.
> 
> - **Bridge UI**:
>   - **Recipient Row**: Replaces inline recipient logic in `QuoteDetailsCard` with `QuoteDetailsRecipientKeyValueRow`, which navigates to the recipient selector and hides on swaps.
>   - Displays `walletName / accountName` for internal accounts or a shortened address for external recipients.
> - **Hooks**:
>   - Adds `useRecipientDisplayData` (`hooks/useRecipientDisplayData`) to derive `destinationDisplayName`, `destinationWalletName`, and `destinationAccountAddress` using multichain selectors and feature flag.
> - **Styles**:
>   - Adds `QuoteDetailsRecipientKeyValueRow.styles.ts` for layout and text truncation.
> - **Tests**:
>   - Adds unit tests for `QuoteDetailsRecipientKeyValueRow` and `useRecipientDisplayData`.
>   - Updates `QuoteDetailsCard.test.tsx` mocks (multichain selectors) and snapshots to reflect new recipient row structure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7db00356f27637c2d3896ce2be392c4304f2fa6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->