### PR TITLE
chore: Configure NPM age gate

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -14,3 +14,13 @@ npmAuditIgnoreAdvisories:
   - 1104663
 
 yarnPath: .yarn/releases/yarn-4.10.3.cjs
+
+# Configure the NPM minimal age gate to 3 days, meaning packages must be at
+# least 3 days old to be installed.
+npmMinimalAgeGate: 4320 # 3 days (in minutes)
+
+# Override the minimal age gate, allowing certain packages to be installed
+# regardless of their publish age.
+npmPreapprovedPackages:
+  - "@metamask/*"
+  - "@lavamoat/*"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Yarn 4.10.3 includes support for setting an age gate for NPM packages. I've set it to 3 days following the security recommendations, meaning that packages must be at least 3 days old to be installed.

From the [Yarn docs](https://yarnpkg.com/configuration/yarnrc):

> Minimum age of a package version according to the publish date on the npm registry in minutes to be considered for installation.
> 
> If a package version is newer than the minimal age gate, it will not be considered for installation. This can be used to reduce the likelihood of installing compromised packages.

See https://github.com/MetaMask/metamask-module-template/pull/270 for reference.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets a 3-day npm age gate in `.yarnrc.yml` and preapproves `@metamask/*` and `@lavamoat/*` packages.
> 
> - **Config (`.yarnrc.yml`)**:
>   - Set `npmMinimalAgeGate: 4320` (3 days) to restrict installation of very new packages.
>   - Add `npmPreapprovedPackages` allowing `@metamask/*` and `@lavamoat/*` to bypass the age gate.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00535c23ce99e86fb37493f212aa0bf2b243cfc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->