### PR TITLE
feat: Add comprehensive Sentry error logging to PredictController and Polymarket Provider

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -158,12 +158,10 @@ export class PolymarketProvider implements PredictProvider {
         context: 'PolymarketProvider.getMarkets',
         feature: 'Predict',
         provider: POLYMARKET_PROVIDER_ID,
-        params: {
-          category: params?.category,
-          status: params?.status,
-          sortBy: params?.sortBy,
-          hasSearchQuery: !!params?.q,
-        },
+        category: params?.category,
+        status: params?.status,
+        sortBy: params?.sortBy,
+        hasSearchQuery: !!params?.q,
       });
 
       return [];
@@ -227,11 +225,9 @@ export class PolymarketProvider implements PredictProvider {
         context: 'PolymarketProvider.getPriceHistory',
         feature: 'Predict',
         provider: POLYMARKET_PROVIDER_ID,
-        params: {
-          marketId,
-          fidelity,
-          interval,
-        },
+        marketId,
+        fidelity,
+        interval,
       });
 
       return [];


### PR DESCRIPTION
## **Description**

This PR adds comprehensive Sentry error logging to the Predict feature's controller and provider layers, following the established patterns used in the Perps feature. This ensures all errors are properly captured and reported to Sentry with appropriate non-sensitive context.

## **Changelog**

CHANGELOG entry: null

### **Key Changes**

#### **PredictController Error Logging (13 methods)**

Added `Logger.error()` to all controller methods that can fail:

1. **Provider Management**
   - `initializeProviders`: Logs provider initialization failures

2. **Eligibility & Geo-Restrictions**
   - `refreshEligibility`: Logs geoblock check failures (outer loop and per-provider loop)

3. **Market Data**
   - `getMarkets`: Logs market list fetch failures
   - `getMarket`: Logs single market fetch failures
   - `getPriceHistory`: Logs price data fetch failures

4. **User Positions & Activity**
   - `getPositions`: Logs position fetch failures with filter context (claimable, marketId)
   - `getActivity`: Logs activity fetch failures
   - `getUnrealizedPnL`: Logs P&L calculation failures

5. **Order Management**
   - `previewOrder`: Logs order preview calculation failures
   - `placeOrder`: Enhanced existing error logging with additional context

6. **Financial Operations**
   - `claimWithConfirmation`: Logs claim transaction failures
   - `depositWithConfirmation`: Logs deposit transaction failures

7. **Account State**
   - `getAccountState`: Logs account state fetch failures
   - `getBalance`: Logs balance fetch failures

**Pattern Used:**
```typescript
Logger.error(
  ensureError(error),
  this.getErrorContext('methodName', {
    providerId,
    marketId,
    category,
    // ... other non-sensitive context
  }),
);
```

#### **PolymarketProvider Error Logging (4 methods)**

Added error logging to methods that swallow errors and return fallback values:

1. **`getMarkets`**: Returns `[]` on error, now logs with category, status, sortBy, and search query context
2. **`getPriceHistory`**: Returns `[]` on error, now logs with marketId, fidelity, and interval context
3. **`fetchActivity`**: Returns `[]` on error, now logs with context
4. **`isEligible`**: Returns `false` on error, now logs with geoblock check context

**Pattern Used:**
```typescript
Logger.error(error as Error, {
  message: 'Predict: Descriptive error message',
  context: 'ClassName.methodName',
  param1,
  param2,
  // ... flat params at top level
});
```

#### **Supporting Infrastructure**

- **`getErrorContext` Helper**: Added private method in `PredictController` to generate standardized error context with feature name and method context
- **Flat Parameter Structure**: Refactored all error logging to use flat params at the top level (not nested), matching the Perps controller pattern

### **Data Protection**

All error logs exclude sensitive user data:
- ❌ **NO** user addresses, amounts, balances, order IDs
- ✅ **YES** provider IDs, market IDs, categories, operations, intervals, filter flags

## **Changelog**

**CHANGELOG entry:** Added comprehensive Sentry error logging to PredictController and PolymarketProvider methods.

## **Related issues**

Fixes: 

## **Manual testing steps**

```gherkin
Feature: Predict Controller Error Logging

  Scenario: Verify error logging in PredictController.getMarkets
    Given a scenario where the market fetch fails (e.g., network error)
    When markets are fetched via PredictController
    Then a Sentry error should be captured via Logger.error()
    And the error context should include providerId and category
    And no sensitive data should be included

  Scenario: Verify error logging in PredictController.placeOrder
    Given a scenario where order placement fails
    When an order is placed via PredictController
    Then a Sentry error should be captured via Logger.error()
    And the error context should include providerId, marketId, and transactionType
    And no amounts or user addresses should be included

  Scenario: Verify error logging in PolymarketProvider.getMarkets
    Given a scenario where the Polymarket API fails
    When markets are fetched via PolymarketProvider
    Then a Sentry error should be captured via Logger.error()
    And an empty array should be returned
    And the error context should include category and status

  Scenario: Verify error logging in PolymarketProvider.isEligible
    Given a scenario where the geoblock check fails
    When eligibility is checked via PolymarketProvider
    Then a Sentry error should be captured via Logger.error()
    And false should be returned
    And the error context should include geoblock check operation
```

## **Architecture Overview**

### **Error Logging Hierarchy**

```
┌─────────────────────────────────────────────────────┐
│   PredictController (13 methods)                    │
│   ├── Provider Management (1 method)                │
│   ├── Eligibility (1 method with 2 catch blocks)    │
│   ├── Market Data (3 methods)                       │
│   ├── User Data (3 methods)                         │
│   ├── Order Management (2 methods)                  │
│   ├── Financial Operations (2 methods)              │
│   └── Account State (2 methods)                     │
│                                                      │
│   Pattern: Logger.error() with flat params          │
│   Structure: this.getErrorContext(method, params)   │
│   Context: providerId, marketId, category, etc.     │
└─────────────────────────────────────────────────────┘

┌─────────────────────────────────────────────────────┐
│   PolymarketProvider (4 methods)                    │
│   ├── getMarkets → returns [] on error              │
│   ├── getPriceHistory → returns [] on error         │
│   ├── fetchActivity → returns [] on error           │
│   └── isEligible → returns false on error           │
│                                                      │
│   Pattern: Logger.error() with flat params          │
│   Structure: { message, context, ...params }        │
│   Context: category, status, marketId, etc.         │
└─────────────────────────────────────────────────────┘
```

### **Error Context Structure**

**Controller Pattern (Nested via Helper):**
```typescript
{
  feature: 'Predict',
  context: 'PredictController.methodName',
  providerId: 'polymarket',
  marketId: 'm123',
  category: 'crypto',
  // ... other params spread at top level
}
```

**Provider Pattern (Flat at Top Level):**
```typescript
{
  message: 'Predict: Failed to fetch markets',
  context: 'PolymarketProvider.getMarkets',
  category: 'crypto',
  status: 'open',
  sortBy: 'liquidity',
  hasSearchQuery: false,
}
```

## **Code Examples**

### **Controller Error Logging with Helper**

```typescript
// Helper method
private getErrorContext(
  method: string,
  extra?: Record<string, unknown>,
): Record<string, unknown> {
  return {
    feature: 'Predict',
    context: `PredictController.${method}`,
    ...extra,
  };
}

// Usage
} catch (error) {
  Logger.error(
    ensureError(error),
    this.getErrorContext('getMarkets', {
      providerId,
      category,
      status,
      sortBy,
    }),
  );
  return [];
}
```

### **Provider Error Logging**

```typescript
} catch (error) {
  Logger.error(error as Error, {
    message: 'Predict: Failed to fetch markets from PolymarketProvider',
    context: 'PolymarketProvider.getMarkets',
    category,
    status,
    sortBy,
    hasSearchQuery: !!search,
  });
  return [];
}
```

## **Files Changed**

```
 app/components/UI/Predict/controllers/PredictController.ts           | +217 -75
 app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts | +41
 2 files changed, 258 insertions(+), 75 deletions(-)
```

## **Commits**

1. `393f69d0f9` - feat: Add comprehensive Sentry error logging to PredictController
2. `3fc7fd33ba` - feat: Add Sentry error logging to PolymarketProvider for swallowed errors
3. `c570952183` - refactor: Flatten error logging params to match Perps pattern

## **Testing Evidence**

**Before:**
- No error logging in controller or provider methods
- Errors silently fail or only log to console
- No visibility into production failures

**After:**
- All 13 controller methods log errors to Sentry
- All 4 provider methods that swallow errors now log
- Consistent error context across all methods
- Non-sensitive data only

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Logger.error with standardized, non-sensitive context across PredictController and PolymarketProvider, wrapping error paths in try/catch and rethrowing where appropriate.
> 
> - **PredictController**
>   - Add `Logger.error(ensureError(...), getErrorContext(...))` across error paths: initialization, `refreshEligibility`, `getMarkets`, `getMarket`, `getPriceHistory`, `getPositions`, `getActivity`, `getUnrealizedPnL`, `previewOrder`, `placeOrder`, `claimWithConfirmation`, `depositWithConfirmation`, `getAccountState`, `getBalance`.
>   - Introduce try/catch around several methods (`previewOrder`, `claimWithConfirmation`, `depositWithConfirmation`, `getAccountState`, `getBalance`) to log and rethrow while maintaining existing state updates.
>   - Standardize error context via private `getErrorContext(method, extra)`.
> - **PolymarketProvider**
>   - Import `Logger` and log swallowed errors with flat context in: `getMarkets` (returns `[]`), `getPriceHistory` (returns `[]`), `fetchActivity` (returns `[]`), `isEligible` (returns `false`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a699615288ce6a48e73e559c9eafd70b2bef0835. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->