### PR TITLE
chore: move user from redux store to card sdk context

### DIFF
--- a/app/components/UI/Card/components/Onboarding/ConfirmPhoneNumber.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/ConfirmPhoneNumber.test.tsx
@@ -273,6 +273,7 @@ jest.mock('../../../../../../locales/i18n', () => ({
 // Mock hooks
 const mockUsePhoneVerificationVerify = jest.fn();
 const mockUsePhoneVerificationSend = jest.fn();
+const mockSetUser = jest.fn();
 
 jest.mock('../../hooks/usePhoneVerificationVerify', () => ({
   __esModule: true,
@@ -282,6 +283,17 @@ jest.mock('../../hooks/usePhoneVerificationVerify', () => ({
 jest.mock('../../hooks/usePhoneVerificationSend', () => ({
   __esModule: true,
   default: () => mockUsePhoneVerificationSend(),
+}));
+
+// Mock SDK
+jest.mock('../../sdk', () => ({
+  useCardSDK: jest.fn(() => ({
+    sdk: {},
+    isLoading: false,
+    user: { id: 'user-123', email: 'test@example.com' },
+    setUser: mockSetUser,
+    logoutFromProvider: jest.fn(),
+  })),
 }));
 
 // Create test store

--- a/app/components/UI/Card/components/Onboarding/ConfirmPhoneNumber.tsx
+++ b/app/components/UI/Card/components/Onboarding/ConfirmPhoneNumber.tsx
@@ -23,11 +23,11 @@ import usePhoneVerificationVerify from '../../hooks/usePhoneVerificationVerify';
 import {
   selectContactVerificationId,
   selectOnboardingId,
-  setUser,
 } from '../../../../../core/redux/slices/card';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { CardError } from '../../types';
 import usePhoneVerificationSend from '../../hooks/usePhoneVerificationSend';
+import { useCardSDK } from '../../sdk';
 
 const CELL_COUNT = 6;
 
@@ -61,7 +61,7 @@ const createStyles = (params: { theme: Theme }) => {
 
 const ConfirmPhoneNumber = () => {
   const navigation = useNavigation();
-  const dispatch = useDispatch();
+  const { setUser } = useCardSDK();
   const { styles } = useStyles(createStyles, {});
   const inputRef = useRef<TextInput>(null);
   const [resendCooldown, setResendCooldown] = useState(0);
@@ -113,7 +113,7 @@ const ConfirmPhoneNumber = () => {
         contactVerificationId,
       });
       if (user) {
-        dispatch(setUser(user));
+        setUser(user);
         navigation.navigate(Routes.CARD.ONBOARDING.VERIFY_IDENTITY);
       }
     } catch (error) {
@@ -139,7 +139,7 @@ const ConfirmPhoneNumber = () => {
     phoneCountryCode,
     contactVerificationId,
     verifyPhoneVerification,
-    dispatch,
+    setUser,
     navigation,
   ]);
 

--- a/app/components/UI/Card/components/Onboarding/MailingAddress.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/MailingAddress.test.tsx
@@ -7,6 +7,7 @@ import { configureStore } from '@reduxjs/toolkit';
 import MailingAddress from './MailingAddress';
 import useRegisterMailingAddress from '../../hooks/useRegisterMailingAddress';
 import useRegistrationSettings from '../../hooks/useRegistrationSettings';
+import { useCardSDK } from '../../sdk';
 
 // Mock navigation
 jest.mock('@react-navigation/native', () => ({
@@ -17,6 +18,7 @@ jest.mock('@react-navigation/native', () => ({
 jest.mock('../../hooks/useRegisterMailingAddress');
 jest.mock('../../hooks/useRegisterUserConsent');
 jest.mock('../../hooks/useRegistrationSettings');
+jest.mock('../../sdk');
 
 // Mock OnboardingStep component
 jest.mock('./OnboardingStep', () => {
@@ -358,6 +360,8 @@ const mockUseRegistrationSettings =
   useRegistrationSettings as jest.MockedFunction<
     typeof useRegistrationSettings
   >;
+const mockSetUser = jest.fn();
+const mockUseCardSDK = useCardSDK as jest.MockedFunction<typeof useCardSDK>;
 
 describe('MailingAddress Component', () => {
   let store: ReturnType<typeof createTestStore>;
@@ -439,6 +443,18 @@ describe('MailingAddress Component', () => {
       isLoading: false,
       error: false,
       fetchData: jest.fn(),
+    });
+
+    // Mock useCardSDK
+    mockUseCardSDK.mockReturnValue({
+      sdk: null,
+      isLoading: false,
+      user: {
+        id: 'user-id',
+        email: 'test@example.com',
+      },
+      setUser: mockSetUser,
+      logoutFromProvider: jest.fn(),
     });
 
     // Mock useSelector

--- a/app/components/UI/Card/components/Onboarding/MailingAddress.tsx
+++ b/app/components/UI/Card/components/Onboarding/MailingAddress.tsx
@@ -12,16 +12,16 @@ import { AddressFields } from './PhysicalAddress';
 import {
   selectOnboardingId,
   selectSelectedCountry,
-  setUser,
 } from '../../../../../core/redux/slices/card';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import useRegisterMailingAddress from '../../hooks/useRegisterMailingAddress';
 import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
 import { CardError } from '../../types';
+import { useCardSDK } from '../../sdk';
 
 const MailingAddress = () => {
   const navigation = useNavigation();
-  const dispatch = useDispatch();
+  const { setUser } = useCardSDK();
   const onboardingId = useSelector(selectOnboardingId);
   const selectedCountry = useSelector(selectSelectedCountry);
 
@@ -122,7 +122,7 @@ const MailingAddress = () => {
       });
 
       if (updatedUser) {
-        dispatch(setUser(updatedUser));
+        setUser(updatedUser);
       }
 
       if (accessToken) {

--- a/app/components/UI/Card/components/Onboarding/PersonalDetails.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/PersonalDetails.test.tsx
@@ -241,6 +241,10 @@ jest.mock('../../hooks/useRegistrationSettings', () => ({
   default: jest.fn(),
 }));
 
+jest.mock('../../sdk', () => ({
+  useCardSDK: jest.fn(),
+}));
+
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string) => {
     const mockStrings: Record<string, string> = {
@@ -272,11 +276,13 @@ import { useDispatch, useSelector } from 'react-redux';
 import PersonalDetails from './PersonalDetails';
 import useRegisterPersonalDetails from '../../hooks/useRegisterPersonalDetails';
 import useRegistrationSettings from '../../hooks/useRegistrationSettings';
+import { useCardSDK } from '../../sdk';
 
 // Mock implementations
 const mockNavigate = jest.fn();
 const mockDispatch = jest.fn();
 const mockRegisterPersonalDetails = jest.fn();
+const mockSetUser = jest.fn();
 
 // Mock hooks
 (useNavigation as jest.Mock).mockReturnValue({
@@ -312,6 +318,14 @@ const mockRegisterPersonalDetails = jest.fn();
       { code: 'CA', name: 'Canada' },
     ],
   },
+});
+
+(useCardSDK as jest.Mock).mockReturnValue({
+  sdk: null,
+  isLoading: false,
+  user: null,
+  setUser: mockSetUser,
+  logoutFromProvider: jest.fn(),
 });
 
 describe('PersonalDetails Component', () => {

--- a/app/components/UI/Card/components/Onboarding/PersonalDetails.tsx
+++ b/app/components/UI/Card/components/Onboarding/PersonalDetails.tsx
@@ -18,9 +18,8 @@ import { useDebouncedValue } from '../../../../hooks/useDebouncedValue';
 import {
   selectOnboardingId,
   selectSelectedCountry,
-  setUser,
 } from '../../../../../core/redux/slices/card';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import SelectComponent from '../../../SelectComponent';
 import useRegisterPersonalDetails from '../../hooks/useRegisterPersonalDetails';
 import useRegistrationSettings from '../../hooks/useRegistrationSettings';
@@ -29,10 +28,11 @@ import {
   validateDateOfBirth,
 } from '../../util/validateDateOfBirth';
 import { CardError } from '../../types';
+import { useCardSDK } from '../../sdk';
 
 const PersonalDetails = () => {
   const navigation = useNavigation();
-  const dispatch = useDispatch();
+  const { setUser } = useCardSDK();
   const onboardingId = useSelector(selectOnboardingId);
   const selectedCountry = useSelector(selectSelectedCountry);
 
@@ -152,7 +152,7 @@ const PersonalDetails = () => {
       });
 
       if (user) {
-        dispatch(setUser(user));
+        setUser(user);
         navigation.navigate(Routes.CARD.ONBOARDING.PHYSICAL_ADDRESS);
       }
     } catch (error) {

--- a/app/components/UI/Card/components/Onboarding/PhysicalAddress.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/PhysicalAddress.test.tsx
@@ -9,6 +9,7 @@ import Routes from '../../../../../constants/navigation/Routes';
 import useRegisterPhysicalAddress from '../../hooks/useRegisterPhysicalAddress';
 import useRegisterUserConsent from '../../hooks/useRegisterUserConsent';
 import useRegistrationSettings from '../../hooks/useRegistrationSettings';
+import { useCardSDK } from '../../sdk';
 
 // Mock navigation
 jest.mock('@react-navigation/native', () => ({
@@ -19,6 +20,11 @@ jest.mock('@react-navigation/native', () => ({
 jest.mock('../../hooks/useRegisterPhysicalAddress');
 jest.mock('../../hooks/useRegisterUserConsent');
 jest.mock('../../hooks/useRegistrationSettings');
+
+// Mock SDK
+jest.mock('../../sdk', () => ({
+  useCardSDK: jest.fn(),
+}));
 
 // Mock OnboardingStep component
 jest.mock('./OnboardingStep', () => {
@@ -362,6 +368,7 @@ const mockUseRegistrationSettings =
   useRegistrationSettings as jest.MockedFunction<
     typeof useRegistrationSettings
   >;
+const mockUseCardSDK = useCardSDK as jest.MockedFunction<typeof useCardSDK>;
 
 describe('PhysicalAddress Component', () => {
   let store: ReturnType<typeof createTestStore>;
@@ -455,6 +462,18 @@ describe('PhysicalAddress Component', () => {
       isLoading: false,
       error: false,
       fetchData: jest.fn(),
+    });
+
+    // Mock useCardSDK
+    mockUseCardSDK.mockReturnValue({
+      sdk: null,
+      isLoading: false,
+      user: {
+        id: 'user-id',
+        email: 'test@example.com',
+      },
+      setUser: jest.fn(),
+      logoutFromProvider: jest.fn(),
     });
 
     // Mock useSelector

--- a/app/components/UI/Card/components/Onboarding/PhysicalAddress.tsx
+++ b/app/components/UI/Card/components/Onboarding/PhysicalAddress.tsx
@@ -16,17 +16,16 @@ import OnboardingStep from './OnboardingStep';
 import Checkbox from '../../../../../component-library/components/Checkbox';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import useRegisterPhysicalAddress from '../../hooks/useRegisterPhysicalAddress';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import {
   selectOnboardingId,
   selectSelectedCountry,
-  selectUser,
-  setUser,
 } from '../../../../../core/redux/slices/card';
 import useRegisterUserConsent from '../../hooks/useRegisterUserConsent';
 import { CardError } from '../../types';
 import useRegistrationSettings from '../../hooks/useRegistrationSettings';
 import SelectComponent from '../../../SelectComponent';
+import { useCardSDK } from '../../sdk';
 
 export const AddressFields = ({
   addressLine1,
@@ -182,11 +181,10 @@ export const AddressFields = ({
 
 const PhysicalAddress = () => {
   const navigation = useNavigation();
-  const dispatch = useDispatch();
   const tw = useTailwind();
+  const { user, setUser } = useCardSDK();
   const onboardingId = useSelector(selectOnboardingId);
   const selectedCountry = useSelector(selectSelectedCountry);
-  const user = useSelector(selectUser);
 
   const [addressLine1, setAddressLine1] = useState('');
   const [addressLine2, setAddressLine2] = useState('');
@@ -318,7 +316,7 @@ const PhysicalAddress = () => {
       });
 
       if (updatedUser) {
-        dispatch(setUser(updatedUser));
+        setUser(updatedUser);
       }
 
       if (accessToken) {

--- a/app/components/UI/Card/components/Onboarding/VerifyIdentity.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/VerifyIdentity.test.tsx
@@ -6,6 +6,7 @@ import { useNavigation } from '@react-navigation/native';
 import VerifyIdentity from './VerifyIdentity';
 import Routes from '../../../../../constants/navigation/Routes';
 import useStartVerification from '../../hooks/useStartVerification';
+import { useCardSDK } from '../../sdk';
 
 // Mock dependencies
 jest.mock('@react-navigation/native', () => ({
@@ -14,6 +15,11 @@ jest.mock('@react-navigation/native', () => ({
 
 // Mock useStartVerification hook
 jest.mock('../../hooks/useStartVerification');
+
+// Mock useCardSDK hook
+jest.mock('../../sdk', () => ({
+  useCardSDK: jest.fn(),
+}));
 
 // Mock OnboardingStep component
 jest.mock('./OnboardingStep', () => {
@@ -191,6 +197,14 @@ describe('VerifyIdentity Component', () => {
       error: null,
     });
 
+    (useCardSDK as jest.Mock).mockReturnValue({
+      sdk: null,
+      isLoading: false,
+      user: null,
+      setUser: jest.fn(),
+      logoutFromProvider: jest.fn(),
+    });
+
     store = createTestStore();
   });
 
@@ -351,12 +365,16 @@ describe('VerifyIdentity Component', () => {
 
   describe('User State Testing', () => {
     it('navigates to validating KYC when user verification state is PENDING', async () => {
-      const storeWithPendingUser = createTestStore({
+      (useCardSDK as jest.Mock).mockReturnValue({
+        sdk: null,
+        isLoading: false,
         user: { verificationState: 'PENDING' },
+        setUser: jest.fn(),
+        logoutFromProvider: jest.fn(),
       });
 
       render(
-        <Provider store={storeWithPendingUser}>
+        <Provider store={store}>
           <VerifyIdentity />
         </Provider>,
       );
@@ -369,12 +387,16 @@ describe('VerifyIdentity Component', () => {
     });
 
     it('does not auto-navigate when user verification state is not PENDING', () => {
-      const storeWithNonPendingUser = createTestStore({
+      (useCardSDK as jest.Mock).mockReturnValue({
+        sdk: null,
+        isLoading: false,
         user: { verificationState: 'VERIFIED' },
+        setUser: jest.fn(),
+        logoutFromProvider: jest.fn(),
       });
 
       render(
-        <Provider store={storeWithNonPendingUser}>
+        <Provider store={store}>
           <VerifyIdentity />
         </Provider>,
       );
@@ -383,12 +405,16 @@ describe('VerifyIdentity Component', () => {
     });
 
     it('does not auto-navigate when user is null', () => {
-      const storeWithNullUser = createTestStore({
+      (useCardSDK as jest.Mock).mockReturnValue({
+        sdk: null,
+        isLoading: false,
         user: null,
+        setUser: jest.fn(),
+        logoutFromProvider: jest.fn(),
       });
 
       render(
-        <Provider store={storeWithNullUser}>
+        <Provider store={store}>
           <VerifyIdentity />
         </Provider>,
       );

--- a/app/components/UI/Card/components/Onboarding/VerifyIdentity.tsx
+++ b/app/components/UI/Card/components/Onboarding/VerifyIdentity.tsx
@@ -10,12 +10,11 @@ import Button, {
 } from '../../../../../component-library/components/Buttons/Button';
 import Routes from '../../../../../constants/navigation/Routes';
 import useStartVerification from '../../hooks/useStartVerification';
-import { useSelector } from 'react-redux';
-import { selectUser } from '../../../../../core/redux/slices/card';
+import { useCardSDK } from '../../sdk';
 
 const VerifyIdentity = () => {
   const navigation = useNavigation();
-  const user = useSelector(selectUser);
+  const { user } = useCardSDK();
 
   const {
     data: verificationResponse,

--- a/app/components/UI/Card/hooks/isBaanxLoginEnabled.test.ts
+++ b/app/components/UI/Card/hooks/isBaanxLoginEnabled.test.ts
@@ -26,6 +26,8 @@ const mockCardSDKResponse = (sdk: Partial<CardSDK> | null) => {
   mockUseCardSDK.mockReturnValue({
     sdk: sdk as CardSDK | null,
     isLoading: false,
+    user: null,
+    setUser: jest.fn(),
     logoutFromProvider: jest.fn(),
   });
 };

--- a/app/components/UI/Card/hooks/useCardDetails.test.ts
+++ b/app/components/UI/Card/hooks/useCardDetails.test.ts
@@ -49,6 +49,8 @@ describe('useCardDetails', () => {
     mockUseCardSDK.mockReturnValue({
       sdk: mockSDK,
       isLoading: false,
+      user: null,
+      setUser: jest.fn(),
       logoutFromProvider: mockLogoutFromProvider,
     });
   });
@@ -238,6 +240,8 @@ describe('useCardDetails', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: true,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: mockLogoutFromProvider,
       });
       mockGetCardDetails.mockResolvedValue(mockCardDetailsResponse);
@@ -254,6 +258,8 @@ describe('useCardDetails', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: mockLogoutFromProvider,
       });
       mockGetCardDetails.mockResolvedValue(mockCardDetailsResponse);
@@ -291,6 +297,8 @@ describe('useCardDetails', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: true,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: mockLogoutFromProvider,
       });
       mockGetCardDetails.mockResolvedValue(mockCardDetailsResponse);
@@ -305,6 +313,8 @@ describe('useCardDetails', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: mockSDK,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: mockLogoutFromProvider,
       });
       rerender();
@@ -322,6 +332,8 @@ describe('useCardDetails', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: mockLogoutFromProvider,
       });
 
@@ -660,6 +672,8 @@ describe('useCardDetails', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: mockLogoutFromProvider,
       });
 

--- a/app/components/UI/Card/hooks/useCardProviderAuthentication.test.ts
+++ b/app/components/UI/Card/hooks/useCardProviderAuthentication.test.ts
@@ -88,6 +88,8 @@ describe('useCardProviderAuthentication', () => {
     mockUseCardSDK.mockReturnValue({
       sdk: mockSdk as unknown as CardSDK,
       isLoading: false,
+      user: null,
+      setUser: jest.fn(),
       logoutFromProvider: jest.fn(),
     });
     mockStrings.mockImplementation((key: string) => `mocked_${key}`);
@@ -395,6 +397,8 @@ describe('useCardProviderAuthentication', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: jest.fn(),
       });
 
@@ -703,6 +707,8 @@ describe('useCardProviderAuthentication', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: jest.fn(),
       });
 

--- a/app/components/UI/Card/hooks/useCardProvision.test.ts
+++ b/app/components/UI/Card/hooks/useCardProvision.test.ts
@@ -36,6 +36,8 @@ describe('useCardProvision', () => {
     mockUseCardSDK.mockReturnValue({
       sdk: mockSDK,
       isLoading: false,
+      user: null,
+      setUser: jest.fn(),
       logoutFromProvider: mockLogoutFromProvider,
     });
   });
@@ -194,6 +196,8 @@ describe('useCardProvision', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: mockLogoutFromProvider,
       });
 
@@ -214,6 +218,8 @@ describe('useCardProvision', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: mockLogoutFromProvider,
       });
 
@@ -272,6 +278,8 @@ describe('useCardProvision', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: newMockSDK,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: mockLogoutFromProvider,
       });
 

--- a/app/components/UI/Card/hooks/useEmailVerificationSend.test.ts
+++ b/app/components/UI/Card/hooks/useEmailVerificationSend.test.ts
@@ -49,6 +49,8 @@ describe('useEmailVerificationSend', () => {
     mockUseCardSDK.mockReturnValue({
       sdk: mockSDK,
       isLoading: false,
+      user: null,
+      setUser: jest.fn(),
       logoutFromProvider: mockLogoutFromProvider,
     });
     mockGetErrorMessage.mockReturnValue('Mocked error message');
@@ -190,6 +192,8 @@ describe('useEmailVerificationSend', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: mockLogoutFromProvider,
       });
 
@@ -388,6 +392,8 @@ describe('useEmailVerificationSend', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: mockLogoutFromProvider,
       });
 

--- a/app/components/UI/Card/hooks/useEmailVerificationVerify.test.ts
+++ b/app/components/UI/Card/hooks/useEmailVerificationVerify.test.ts
@@ -69,6 +69,8 @@ describe('useEmailVerificationVerify', () => {
     mockUseCardSDK.mockReturnValue({
       sdk: mockSDK,
       isLoading: false,
+      user: null,
+      setUser: jest.fn(),
       logoutFromProvider: mockLogoutFromProvider,
     });
     mockGetErrorMessage.mockReturnValue('Mocked error message');
@@ -204,6 +206,8 @@ describe('useEmailVerificationVerify', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: mockLogoutFromProvider,
       });
 
@@ -421,6 +425,8 @@ describe('useEmailVerificationVerify', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: mockLogoutFromProvider,
       });
 

--- a/app/components/UI/Card/hooks/usePhoneVerificationSend.test.ts
+++ b/app/components/UI/Card/hooks/usePhoneVerificationSend.test.ts
@@ -55,6 +55,8 @@ describe('usePhoneVerificationSend', () => {
   const mockCardSDKReturn = {
     sdk: mockSDK,
     isLoading: false,
+    user: null,
+    setUser: jest.fn(),
     logoutFromProvider: mockLogoutFromProvider,
     userCardLocation: 'us' as CardLocation,
   };
@@ -130,6 +132,8 @@ describe('usePhoneVerificationSend', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: mockLogoutFromProvider,
       });
 
@@ -150,6 +154,8 @@ describe('usePhoneVerificationSend', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: mockLogoutFromProvider,
       });
 
@@ -333,6 +339,8 @@ describe('usePhoneVerificationSend', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: sdkWithoutMethod,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: mockLogoutFromProvider,
       });
 

--- a/app/components/UI/Card/hooks/usePhoneVerificationVerify.test.ts
+++ b/app/components/UI/Card/hooks/usePhoneVerificationVerify.test.ts
@@ -66,6 +66,8 @@ describe('usePhoneVerificationVerify', () => {
     mockUseCardSDK.mockReturnValue({
       sdk: mockSDK,
       isLoading: false,
+      user: null,
+      setUser: jest.fn(),
       logoutFromProvider: mockLogoutFromProvider,
     });
     mockGetErrorMessage.mockReturnValue('Mocked error message');
@@ -141,6 +143,8 @@ describe('usePhoneVerificationVerify', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: mockLogoutFromProvider,
       });
 
@@ -369,6 +373,8 @@ describe('usePhoneVerificationVerify', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: mockLogoutFromProvider,
       });
 

--- a/app/components/UI/Card/hooks/useRegisterMailingAddress.test.ts
+++ b/app/components/UI/Card/hooks/useRegisterMailingAddress.test.ts
@@ -65,6 +65,8 @@ describe('useRegisterMailingAddress', () => {
   const mockCardSDK: ICardSDK = {
     sdk: mockSDK,
     isLoading: false,
+    user: null,
+    setUser: jest.fn(),
     logoutFromProvider: mockLogoutFromProvider,
   };
 
@@ -143,6 +145,8 @@ describe('useRegisterMailingAddress', () => {
       const mockCardSDKUndefined: ICardSDK = {
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: mockLogoutFromProvider,
       };
       mockUseCardSDK.mockReturnValue(mockCardSDKUndefined);
@@ -437,6 +441,8 @@ describe('useRegisterMailingAddress', () => {
       const mockCardSDKUndefined: ICardSDK = {
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: mockLogoutFromProvider,
       };
       mockUseCardSDK.mockReturnValue(mockCardSDKUndefined);

--- a/app/components/UI/Card/hooks/useRegisterPersonalDetails.test.ts
+++ b/app/components/UI/Card/hooks/useRegisterPersonalDetails.test.ts
@@ -67,6 +67,8 @@ describe('useRegisterPersonalDetails', () => {
     mockUseCardSDK.mockReturnValue({
       sdk: mockSDK,
       isLoading: false,
+      user: null,
+      setUser: jest.fn(),
       logoutFromProvider: mockLogoutFromProvider,
       userCardLocation: 'us',
     } as ICardSDK);
@@ -146,6 +148,8 @@ describe('useRegisterPersonalDetails', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: mockLogoutFromProvider,
         userCardLocation: 'us',
       } as ICardSDK);
@@ -461,6 +465,8 @@ describe('useRegisterPersonalDetails', () => {
       const mockCardSDKUndefined: ICardSDK = {
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: mockLogoutFromProvider,
       };
 

--- a/app/components/UI/Card/hooks/useRegisterPhysicalAddress.test.ts
+++ b/app/components/UI/Card/hooks/useRegisterPhysicalAddress.test.ts
@@ -68,6 +68,8 @@ describe('useRegisterPhysicalAddress', () => {
     const mockCardSDK: ICardSDK = {
       sdk: mockSDK,
       isLoading: false,
+      user: null,
+      setUser: jest.fn(),
       logoutFromProvider: mockLogoutFromProvider,
     };
     mockUseCardSDK.mockReturnValue(mockCardSDK);
@@ -148,6 +150,8 @@ describe('useRegisterPhysicalAddress', () => {
       const mockCardSDKNull: ICardSDK = {
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: mockLogoutFromProvider,
       };
       mockUseCardSDK.mockReturnValue(mockCardSDKNull);
@@ -456,6 +460,8 @@ describe('useRegisterPhysicalAddress', () => {
       const mockCardSDKUndefined: ICardSDK = {
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: mockLogoutFromProvider,
       };
       mockUseCardSDK.mockReturnValue(mockCardSDKUndefined);

--- a/app/components/UI/Card/hooks/useRegisterUserConsent.test.ts
+++ b/app/components/UI/Card/hooks/useRegisterUserConsent.test.ts
@@ -58,6 +58,8 @@ describe('useRegisterUserConsent', () => {
     mockUseCardSDK.mockReturnValue({
       sdk: mockSDK,
       isLoading: false,
+      user: null,
+      setUser: jest.fn(),
       logoutFromProvider: jest.fn(),
     });
 
@@ -223,6 +225,8 @@ describe('useRegisterUserConsent', () => {
         mockUseCardSDK.mockReturnValue({
           sdk: null,
           isLoading: false,
+          user: null,
+          setUser: jest.fn(),
           logoutFromProvider: jest.fn(),
         });
 
@@ -572,6 +576,8 @@ describe('useRegisterUserConsent', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: customSDK,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: jest.fn(),
       });
 
@@ -589,6 +595,8 @@ describe('useRegisterUserConsent', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: mockSDK,
         isLoading: true,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: jest.fn(),
       });
 
@@ -605,6 +613,8 @@ describe('useRegisterUserConsent', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: jest.fn(),
       });
 
@@ -682,6 +692,8 @@ describe('useRegisterUserConsent', () => {
           linkUserToConsent: jest.fn(),
         } as unknown as CardSDK,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: jest.fn(),
       });
 

--- a/app/components/UI/Card/hooks/useRegistrationSettings.test.ts
+++ b/app/components/UI/Card/hooks/useRegistrationSettings.test.ts
@@ -46,6 +46,8 @@ describe('useRegistrationSettings', () => {
     mockUseCardSDK.mockReturnValue({
       sdk: mockSDK,
       isLoading: false,
+      user: null,
+      setUser: jest.fn(),
       logoutFromProvider: jest.fn(),
     });
 
@@ -93,6 +95,8 @@ describe('useRegistrationSettings', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: jest.fn(),
       });
 
@@ -184,6 +188,8 @@ describe('useRegistrationSettings', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: jest.fn(),
       });
 

--- a/app/components/UI/Card/hooks/useStartVerification.test.ts
+++ b/app/components/UI/Card/hooks/useStartVerification.test.ts
@@ -48,6 +48,8 @@ describe('useStartVerification', () => {
     mockUseCardSDK.mockReturnValue({
       sdk: mockSDK,
       isLoading: false,
+      user: null,
+      setUser: jest.fn(),
       logoutFromProvider: jest.fn(),
     });
     mockUseSelector.mockReturnValue('US'); // selectedCountry
@@ -60,6 +62,8 @@ describe('useStartVerification', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: jest.fn(),
       });
 
@@ -80,6 +84,8 @@ describe('useStartVerification', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: jest.fn(),
       });
 
@@ -184,6 +190,8 @@ describe('useStartVerification', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: jest.fn(),
       });
       const { result, rerender } = renderHook(() => useStartVerification());
@@ -199,6 +207,8 @@ describe('useStartVerification', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: mockSDK,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: jest.fn(),
       });
       mockStartUserVerification.mockResolvedValue(
@@ -223,6 +233,8 @@ describe('useStartVerification', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: jest.fn(),
       });
 
@@ -277,6 +289,8 @@ describe('useStartVerification', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: jest.fn(),
       });
       mockUseSelector.mockReturnValue('US');
@@ -403,6 +417,8 @@ describe('useStartVerification', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: jest.fn(),
       });
       mockUseSelector.mockReturnValue(null);
@@ -418,6 +434,8 @@ describe('useStartVerification', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: mockSDK,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: jest.fn(),
       });
       mockStartUserVerification.mockResolvedValue(

--- a/app/components/UI/Card/hooks/useUserRegistrationStatus.test.ts
+++ b/app/components/UI/Card/hooks/useUserRegistrationStatus.test.ts
@@ -54,9 +54,6 @@ describe('useUserRegistrationStatus', () => {
 
     // Default mocks - handle multiple useSelector calls
     mockUseSelector.mockImplementation((selector) => {
-      if (selector.toString().includes('selectUser')) {
-        return null; // No user by default
-      }
       if (selector.toString().includes('selectOnboardingId')) {
         return 'onboarding-123';
       }
@@ -76,6 +73,8 @@ describe('useUserRegistrationStatus', () => {
     mockUseCardSDK.mockReturnValue({
       sdk: mockSDK,
       isLoading: false,
+      user: null,
+      setUser: jest.fn(),
       logoutFromProvider: jest.fn(),
     });
     mockGetErrorMessage.mockReturnValue('Mocked error message');
@@ -104,7 +103,6 @@ describe('useUserRegistrationStatus', () => {
 
       // Then: Initial state should have PENDING verification state and not be loading after initial fetch
       expect(result.current.verificationState).toBe('PENDING');
-      expect(result.current.userResponse).toEqual(pendingUserResponse);
       expect(result.current.isLoading).toBe(false);
       expect(result.current.isError).toBe(false);
       expect(result.current.error).toBeNull();
@@ -127,7 +125,7 @@ describe('useUserRegistrationStatus', () => {
       });
 
       // Then: Should have completed the fetch
-      expect(result.current.userResponse).toEqual(mockUserResponse);
+      expect(result.current.verificationState).toBe('VERIFIED');
       expect(result.current.isLoading).toBe(false);
     });
 
@@ -136,6 +134,8 @@ describe('useUserRegistrationStatus', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: jest.fn(),
       });
 
@@ -183,6 +183,8 @@ describe('useUserRegistrationStatus', () => {
       mockUseCardSDK.mockReturnValue({
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: jest.fn(),
       });
 
@@ -223,7 +225,7 @@ describe('useUserRegistrationStatus', () => {
 
       // Then: Should fetch immediately
       expect(mockGetRegistrationStatus).toHaveBeenCalledTimes(1);
-      expect(result.current.userResponse).toEqual(mockUserResponse);
+      expect(result.current.verificationState).toBe('VERIFIED');
     });
 
     it('sets up polling interval after initial fetch', async () => {
@@ -499,11 +501,8 @@ describe('useUserRegistrationStatus', () => {
         result.current.startPolling();
       });
 
-      // Then: Should handle gracefully - verificationState should be 'PENDING' after fetch
+      // Then: Should handle gracefully - verificationState should be 'PENDING' (default fallback)
       expect(result.current.verificationState).toBe('PENDING');
-      expect(result.current.userResponse).toEqual(
-        responseWithoutVerificationState,
-      );
       expect(result.current.isError).toBe(false);
     });
 

--- a/app/components/UI/Card/hooks/useUserRegistrationStatus.ts
+++ b/app/components/UI/Card/hooks/useUserRegistrationStatus.ts
@@ -1,17 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useCardSDK } from '../sdk';
-import { UserResponse, CardVerificationState } from '../types';
+import { CardVerificationState } from '../types';
 import { getErrorMessage } from '../util/getErrorMessage';
-import {
-  selectOnboardingId,
-  selectUser,
-  setUser,
-} from '../../../../core/redux/slices/card';
-import { useDispatch, useSelector } from 'react-redux';
+import { selectOnboardingId } from '../../../../core/redux/slices/card';
+import { useSelector } from 'react-redux';
 
 interface UseUserRegistrationStatusReturn {
   verificationState: CardVerificationState | null;
-  userResponse: UserResponse | null;
   isLoading: boolean;
   isError: boolean;
   error: string | null;
@@ -27,12 +22,9 @@ interface UseUserRegistrationStatusReturn {
  */
 export const useUserRegistrationStatus =
   (): UseUserRegistrationStatusReturn => {
-    const { sdk } = useCardSDK();
-    const user = useSelector(selectUser);
-    const dispatch = useDispatch();
+    const { sdk, user, setUser } = useCardSDK();
     const [verificationState, setVerificationState] =
       useState<CardVerificationState>(user?.verificationState || 'PENDING');
-    const [userResponse, setUserResponse] = useState<UserResponse | null>(null);
     const [isLoading, setIsLoading] = useState(false);
     const [isError, setIsError] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -68,8 +60,7 @@ export const useUserRegistrationStatus =
         setError(null);
 
         const response = await sdk.getRegistrationStatus(onboardingId);
-        dispatch(setUser(response));
-        setUserResponse(response);
+        setUser(response);
         setVerificationState(response.verificationState || 'PENDING');
         setIsLoading(false);
       } catch (err) {
@@ -78,7 +69,7 @@ export const useUserRegistrationStatus =
         setIsError(true);
         setIsLoading(false);
       }
-    }, [dispatch, onboardingId, sdk]);
+    }, [setUser, onboardingId, sdk]);
 
     const startPolling = useCallback(() => {
       // Clear any existing interval
@@ -118,7 +109,6 @@ export const useUserRegistrationStatus =
 
     return {
       verificationState,
-      userResponse,
       isLoading,
       isError,
       error,

--- a/app/components/UI/Card/routes/OnboardingNavigator.tsx
+++ b/app/components/UI/Card/routes/OnboardingNavigator.tsx
@@ -13,17 +13,15 @@ import PhysicalAddress from '../components/Onboarding/PhysicalAddress';
 import MailingAddress from '../components/Onboarding/MailingAddress';
 import Complete from '../components/Onboarding/Complete';
 import { cardAuthenticationNavigationOptions } from '.';
-import {
-  selectOnboardingId,
-  selectUser,
-} from '../../../../core/redux/slices/card';
+import { selectOnboardingId } from '../../../../core/redux/slices/card';
 import { useSelector } from 'react-redux';
+import { useCardSDK } from '../sdk';
 
 const Stack = createStackNavigator();
 
 const OnboardingNavigator: React.FC = () => {
   const onboardingId = useSelector(selectOnboardingId);
-  const user = useSelector(selectUser);
+  const { user } = useCardSDK();
 
   const getInitialRouteName = () => {
     if (!onboardingId || !user?.id) {

--- a/app/components/UI/Card/sdk/index.test.tsx
+++ b/app/components/UI/Card/sdk/index.test.tsx
@@ -18,7 +18,10 @@ import {
   SupportedToken,
   selectCardFeatureFlag,
 } from '../../../../selectors/featureFlagController/card';
-import { selectUserCardLocation } from '../../../../core/redux/slices/card';
+import {
+  selectUserCardLocation,
+  selectOnboardingId,
+} from '../../../../core/redux/slices/card';
 import { useCardholderCheck } from '../hooks/useCardholderCheck';
 import { useCardAuthenticationVerification } from '../hooks/useCardAuthenticationVerification';
 import {
@@ -28,6 +31,7 @@ import {
 } from '../util/cardTokenVault';
 import Logger from '../../../../util/Logger';
 import { View } from 'react-native';
+import { UserResponse } from '../types';
 
 jest.mock('./CardSDK', () => ({
   CardSDK: jest.fn().mockImplementation(() => ({
@@ -39,6 +43,7 @@ jest.mock('./CardSDK', () => ({
     getSupportedTokensAllowances: jest.fn(),
     getPriorityToken: jest.fn(),
     refreshLocalToken: jest.fn(),
+    getRegistrationStatus: jest.fn(),
   })),
 }));
 
@@ -55,6 +60,7 @@ jest.mock('../../../../core/redux/slices/card', () => ({
   setIsAuthenticatedCard: jest.fn(),
   selectUserCardLocation: jest.fn(),
   setUserCardLocation: jest.fn(),
+  selectOnboardingId: jest.fn(),
 }));
 
 jest.mock('../../../../selectors/multichainAccounts/accounts', () => ({
@@ -124,10 +130,13 @@ describe('CardSDK Context', () => {
     },
   };
 
+  const mockSelectOnboardingId = jest.mocked(selectOnboardingId);
+
   // Helper: Setup feature flag selector
   const setupMockUseSelector = (
     featureFlag: CardFeatureFlag | null | undefined | Record<string, never>,
     userCardLocation: 'us' | 'international' | null = null,
+    onboardingId: string | null = null,
   ) => {
     mockUseSelector.mockImplementation((selector) => {
       if (selector === mockSelectCardFeatureFlag) {
@@ -135,6 +144,9 @@ describe('CardSDK Context', () => {
       }
       if (selector === mockSelectUserCardLocation) {
         return userCardLocation;
+      }
+      if (selector === mockSelectOnboardingId) {
+        return onboardingId;
       }
       return null;
     });
@@ -151,6 +163,7 @@ describe('CardSDK Context', () => {
     getGeoLocation: jest.fn(),
     getSupportedTokensAllowances: jest.fn(),
     getPriorityToken: jest.fn(),
+    getRegistrationStatus: jest.fn(),
     ...overrides,
   });
 
@@ -229,6 +242,8 @@ describe('CardSDK Context', () => {
       const providedValue: ICardSDK = {
         sdk: null,
         isLoading: false,
+        user: null,
+        setUser: jest.fn(),
         logoutFromProvider: jest.fn(),
       };
 
@@ -268,6 +283,8 @@ describe('CardSDK Context', () => {
         sdk: expect.any(Object),
         isLoading: expect.any(Boolean),
         logoutFromProvider: expect.any(Function),
+        user: null,
+        setUser: expect.any(Function),
       });
     });
 
@@ -434,6 +451,261 @@ describe('CardSDK Context', () => {
 
       // Then: should return null
       expect(toJSON()).toBeNull();
+    });
+  });
+
+  describe('User State Management', () => {
+    it('initializes with null user state', () => {
+      // Given: CardSDK provider is rendered
+      setupMockUseSelector(mockCardFeatureFlag);
+      setupMockSDK();
+
+      // When: hook is rendered
+      const { result } = renderHook(() => useCardSDK(), {
+        wrapper: createWrapper,
+      });
+
+      // Then: user should be null initially
+      expect(result.current.user).toBe(null);
+    });
+
+    it('provides setUser function', () => {
+      // Given: CardSDK provider is rendered
+      setupMockUseSelector(mockCardFeatureFlag);
+      setupMockSDK();
+
+      // When: hook is rendered
+      const { result } = renderHook(() => useCardSDK(), {
+        wrapper: createWrapper,
+      });
+
+      // Then: setUser function should be available
+      expect(result.current.setUser).toBeDefined();
+      expect(typeof result.current.setUser).toBe('function');
+    });
+
+    it('updates user state when setUser is called', () => {
+      // Given: CardSDK provider is rendered
+      setupMockUseSelector(mockCardFeatureFlag);
+      setupMockSDK();
+
+      const mockUser: UserResponse = {
+        id: 'test-user-id',
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'john.doe@example.com',
+        phoneNumber: '+1234567890',
+        phoneCountryCode: '+1',
+        verificationState: 'VERIFIED',
+        dateOfBirth: '1990-01-01',
+        addressLine1: '123 Main St',
+        city: 'Anytown',
+        usState: 'CA',
+        zip: '12345',
+        countryOfResidence: 'US',
+      };
+
+      // When: hook is rendered and setUser is called
+      const { result } = renderHook(() => useCardSDK(), {
+        wrapper: createWrapper,
+      });
+
+      act(() => {
+        result.current.setUser(mockUser);
+      });
+
+      // Then: user state should be updated
+      expect(result.current.user).toEqual(mockUser);
+    });
+
+    it('clears user data when logoutFromProvider is called', async () => {
+      // Given: CardSDK provider is rendered with user data
+      setupMockUseSelector(mockCardFeatureFlag);
+      setupMockSDK();
+
+      const mockUser: UserResponse = {
+        id: 'test-user-id',
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'john.doe@example.com',
+        phoneNumber: '+1234567890',
+        phoneCountryCode: '+1',
+        verificationState: 'VERIFIED',
+        dateOfBirth: '1990-01-01',
+        addressLine1: '123 Main St',
+        city: 'Anytown',
+        usState: 'CA',
+        zip: '12345',
+        countryOfResidence: 'US',
+      };
+
+      const { result } = renderHook(() => useCardSDK(), {
+        wrapper: createWrapper,
+      });
+
+      // Set user first
+      act(() => {
+        result.current.setUser(mockUser);
+      });
+
+      expect(result.current.user).toEqual(mockUser);
+
+      // When: logoutFromProvider is called
+      await act(async () => {
+        await result.current.logoutFromProvider();
+      });
+
+      // Then: user should be cleared
+      expect(result.current.user).toBe(null);
+    });
+
+    it('can set user to null explicitly', () => {
+      // Given: CardSDK provider is rendered with user data
+      setupMockUseSelector(mockCardFeatureFlag);
+      setupMockSDK();
+
+      const mockUser: UserResponse = {
+        id: 'test-user-id',
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'john.doe@example.com',
+        phoneNumber: '+1234567890',
+        phoneCountryCode: '+1',
+        verificationState: 'VERIFIED',
+        dateOfBirth: '1990-01-01',
+        addressLine1: '123 Main St',
+        city: 'Anytown',
+        usState: 'CA',
+        zip: '12345',
+        countryOfResidence: 'US',
+      };
+
+      const { result } = renderHook(() => useCardSDK(), {
+        wrapper: createWrapper,
+      });
+
+      // Set user first
+      act(() => {
+        result.current.setUser(mockUser);
+      });
+
+      expect(result.current.user).toEqual(mockUser);
+
+      // When: setUser is called with null
+      act(() => {
+        result.current.setUser(null);
+      });
+
+      // Then: user should be null
+      expect(result.current.user).toBe(null);
+    });
+  });
+
+  describe('Fetch User on Mount', () => {
+    const mockUserResponse: UserResponse = {
+      id: 'test-user-id',
+      firstName: 'John',
+      lastName: 'Doe',
+      email: 'john.doe@example.com',
+      phoneNumber: '+1234567890',
+      phoneCountryCode: '+1',
+      verificationState: 'VERIFIED',
+      dateOfBirth: '1990-01-01',
+      addressLine1: '123 Main St',
+      city: 'Anytown',
+      usState: 'CA',
+      zip: '12345',
+      countryOfResidence: 'US',
+    };
+
+    it('fetches user data when SDK and onboardingId are available', async () => {
+      // Given: SDK with getRegistrationStatus and onboardingId available
+      const mockGetRegistrationStatus = jest
+        .fn()
+        .mockResolvedValue(mockUserResponse);
+      setupMockSDK({ getRegistrationStatus: mockGetRegistrationStatus });
+      setupMockUseSelector(mockCardFeatureFlag, null, 'test-onboarding-id');
+
+      // When: provider initializes
+      const { result } = renderHook(() => useCardSDK(), {
+        wrapper: createWrapper,
+      });
+
+      // Then: user data should be fetched and set
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(mockGetRegistrationStatus).toHaveBeenCalledWith(
+        'test-onboarding-id',
+      );
+      expect(result.current.user).toEqual(mockUserResponse);
+    });
+
+    it('does not fetch user data when SDK is not available', async () => {
+      // Given: no SDK available but onboardingId exists
+      setupMockUseSelector(
+        null, // Pass null to indicate no card feature flag
+        null,
+        'test-onboarding-id',
+      );
+
+      // When: provider initializes
+      const { result } = renderHook(() => useCardSDK(), {
+        wrapper: createWrapper,
+      });
+
+      // Then: no user data should be fetched
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.sdk).toBe(null);
+      expect(result.current.user).toBe(null);
+    });
+
+    it('does not fetch user data when onboardingId is not available', async () => {
+      // Given: SDK available but no onboardingId
+      const mockGetRegistrationStatus = jest.fn();
+      setupMockSDK({ getRegistrationStatus: mockGetRegistrationStatus });
+      setupMockUseSelector(mockCardFeatureFlag, null, null);
+
+      // When: provider initializes
+      const { result } = renderHook(() => useCardSDK(), {
+        wrapper: createWrapper,
+      });
+
+      // Then: no user data should be fetched
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(mockGetRegistrationStatus).not.toHaveBeenCalled();
+      expect(result.current.user).toBe(null);
+    });
+
+    it('handles errors during user data fetch', async () => {
+      // Given: SDK that throws error on getRegistrationStatus
+      const mockGetRegistrationStatus = jest
+        .fn()
+        .mockRejectedValue(new Error('API Error'));
+      setupMockSDK({ getRegistrationStatus: mockGetRegistrationStatus });
+      setupMockUseSelector(mockCardFeatureFlag, null, 'test-onboarding-id');
+
+      // When: provider initializes
+      const { result } = renderHook(() => useCardSDK(), {
+        wrapper: createWrapper,
+      });
+
+      // Then: error should be handled gracefully
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(mockGetRegistrationStatus).toHaveBeenCalledWith(
+        'test-onboarding-id',
+      );
+      expect(result.current.user).toBe(null);
     });
   });
 });

--- a/app/core/redux/slices/card/index.test.ts
+++ b/app/core/redux/slices/card/index.test.ts
@@ -27,7 +27,6 @@ import cardReducer, {
   setOnboardingId,
   setSelectedCountry,
   setContactVerificationId,
-  setUser,
   resetOnboardingState,
   setCacheData,
   clearCacheData,
@@ -35,12 +34,10 @@ import cardReducer, {
   selectOnboardingId,
   selectSelectedCountry,
   selectContactVerificationId,
-  selectUser,
 } from '.';
 import {
   CardTokenAllowance,
   AllowanceState,
-  UserResponse,
 } from '../../../../components/UI/Card/types';
 
 // Mock the multichain selectors
@@ -138,7 +135,6 @@ const CARD_STATE_MOCK: CardSliceState = {
     onboardingId: null,
     selectedCountry: null,
     contactVerificationId: null,
-    user: null,
   },
   cache: {
     data: {},
@@ -162,7 +158,6 @@ const EMPTY_CARD_STATE_MOCK: CardSliceState = {
     onboardingId: null,
     selectedCountry: null,
     contactVerificationId: null,
-    user: null,
   },
   cache: {
     data: {},
@@ -421,67 +416,6 @@ describe('Card Selectors', () => {
         );
       });
     });
-
-    describe('selectUser', () => {
-      const mockUser: UserResponse = {
-        id: 'user-789',
-        firstName: 'Jane',
-        lastName: 'Smith',
-        email: 'jane.smith@example.com',
-        verificationState: 'VERIFIED',
-        addressLine1: '456 Oak Ave',
-        city: 'Los Angeles',
-        usState: 'CA',
-        zip: '90210',
-        countryOfResidence: 'US',
-      };
-
-      it('should return null by default from initial state', () => {
-        const mockRootState = { card: initialState } as unknown as RootState;
-        expect(selectUser(mockRootState)).toBe(null);
-      });
-
-      it('should return the user when set', () => {
-        const stateWithUser: CardSliceState = {
-          ...initialState,
-          onboarding: {
-            ...initialState.onboarding,
-            user: mockUser,
-          },
-        };
-        const mockRootState = { card: stateWithUser } as unknown as RootState;
-        expect(selectUser(mockRootState)).toEqual(mockUser);
-      });
-
-      it('should return the complete user object with all properties', () => {
-        const stateWithUser: CardSliceState = {
-          ...initialState,
-          onboarding: {
-            ...initialState.onboarding,
-            user: mockUser,
-          },
-        };
-        const mockRootState = { card: stateWithUser } as unknown as RootState;
-        const result = selectUser(mockRootState);
-
-        expect(result).toHaveProperty('id', mockUser.id);
-        expect(result).toHaveProperty('firstName', mockUser.firstName);
-        expect(result).toHaveProperty('lastName', mockUser.lastName);
-        expect(result).toHaveProperty('email', mockUser.email);
-        expect(result).toHaveProperty(
-          'verificationState',
-          mockUser.verificationState,
-        );
-        expect(result).toHaveProperty('addressLine1', mockUser.addressLine1);
-        expect(result).toHaveProperty('city', mockUser.city);
-        expect(result).toHaveProperty('usState', mockUser.usState);
-        expect(result).toHaveProperty('zip', mockUser.zip);
-        expect(result).toHaveProperty(
-          'countryOfResidence',
-          mockUser.countryOfResidence,
-        );
-      });
-    });
   });
 });
 
@@ -593,7 +527,6 @@ describe('Card Reducer', () => {
           onboardingId: null,
           selectedCountry: null,
           contactVerificationId: null,
-          user: null,
         },
         cache: {
           data: {},
@@ -640,7 +573,6 @@ describe('Card Reducer', () => {
           // ensure other parts of state untouched
           expect(state.onboarding.selectedCountry).toBe(null);
           expect(state.onboarding.contactVerificationId).toBe(null);
-          expect(state.onboarding.user).toBe(null);
         });
 
         it('should update onboardingId when previously set', () => {
@@ -677,7 +609,6 @@ describe('Card Reducer', () => {
           // ensure other parts of state untouched
           expect(state.onboarding.onboardingId).toBe(null);
           expect(state.onboarding.contactVerificationId).toBe(null);
-          expect(state.onboarding.user).toBe(null);
         });
 
         it('should update selectedCountry when previously set', () => {
@@ -717,7 +648,6 @@ describe('Card Reducer', () => {
           // ensure other parts of state untouched
           expect(state.onboarding.onboardingId).toBe(null);
           expect(state.onboarding.selectedCountry).toBe(null);
-          expect(state.onboarding.user).toBe(null);
         });
 
         it('should update contactVerificationId when previously set', () => {
@@ -751,87 +681,14 @@ describe('Card Reducer', () => {
         });
       });
 
-      describe('setUser', () => {
-        const mockUser: UserResponse = {
-          id: 'user-123',
-          firstName: 'John',
-          lastName: 'Doe',
-          email: 'john.doe@example.com',
-          verificationState: 'VERIFIED',
-          addressLine1: '123 Main St',
-          city: 'New York',
-          usState: 'NY',
-          zip: '10001',
-          countryOfResidence: 'US',
-        };
-
-        it('should set user', () => {
-          const state = cardReducer(initialState, setUser(mockUser));
-          expect(state.onboarding.user).toEqual(mockUser);
-          // ensure other parts of state untouched
-          expect(state.onboarding.onboardingId).toBe(null);
-          expect(state.onboarding.selectedCountry).toBe(null);
-          expect(state.onboarding.contactVerificationId).toBe(null);
-        });
-
-        it('should update user when previously set', () => {
-          const oldUser: UserResponse = {
-            id: 'old-user',
-            firstName: 'Jane',
-            lastName: 'Smith',
-            email: 'jane.smith@example.com',
-            verificationState: 'PENDING',
-            addressLine1: '456 Oak Ave',
-            city: 'Los Angeles',
-            usState: 'CA',
-            zip: '90210',
-            countryOfResidence: 'US',
-          };
-          const current: CardSliceState = {
-            ...initialState,
-            onboarding: {
-              ...initialState.onboarding,
-              user: oldUser,
-            },
-          };
-          const state = cardReducer(current, setUser(mockUser));
-          expect(state.onboarding.user).toEqual(mockUser);
-        });
-
-        it('should set user to null', () => {
-          const current: CardSliceState = {
-            ...initialState,
-            onboarding: {
-              ...initialState.onboarding,
-              user: mockUser,
-            },
-          };
-          const state = cardReducer(current, setUser(null));
-          expect(state.onboarding.user).toBe(null);
-        });
-      });
-
       describe('resetOnboardingState', () => {
         it('should reset all onboarding state to initial values', () => {
-          const mockUser: UserResponse = {
-            id: 'user-123',
-            firstName: 'John',
-            lastName: 'Doe',
-            email: 'john.doe@example.com',
-            verificationState: 'VERIFIED',
-            addressLine1: '123 Main St',
-            city: 'New York',
-            usState: 'NY',
-            zip: '10001',
-            countryOfResidence: 'US',
-          };
           const current: CardSliceState = {
             ...initialState,
             onboarding: {
               onboardingId: 'test-id',
               selectedCountry: 'US',
               contactVerificationId: 'verification-123',
-              user: mockUser,
             },
           };
           const state = cardReducer(current, resetOnboardingState());
@@ -839,7 +696,6 @@ describe('Card Reducer', () => {
             onboardingId: null,
             selectedCountry: null,
             contactVerificationId: null,
-            user: null,
           });
           // ensure other parts of state untouched
           expect(state.cardholderAccounts).toEqual(current.cardholderAccounts);
@@ -852,7 +708,6 @@ describe('Card Reducer', () => {
             onboardingId: null,
             selectedCountry: null,
             contactVerificationId: null,
-            user: null,
           });
         });
       });

--- a/app/core/redux/slices/card/index.ts
+++ b/app/core/redux/slices/card/index.ts
@@ -8,7 +8,6 @@ import { isEthAccount } from '../../../Multichain/utils';
 import {
   CardLocation,
   CardTokenAllowance,
-  UserResponse,
 } from '../../../../components/UI/Card/types';
 import {
   selectCardExperimentalSwitch,
@@ -21,7 +20,6 @@ export interface OnboardingState {
   onboardingId: string | null;
   selectedCountry: string | null; // ISO 3166 alpha-2 country code, e.g. 'US'
   contactVerificationId: string | null;
-  user: UserResponse | null;
 }
 
 export interface CacheState {
@@ -61,7 +59,6 @@ export const initialState: CardSliceState = {
     onboardingId: null,
     selectedCountry: null,
     contactVerificationId: null,
-    user: null,
   },
   cache: {
     data: {},
@@ -144,15 +141,11 @@ const slice = createSlice({
     setContactVerificationId: (state, action: PayloadAction<string | null>) => {
       state.onboarding.contactVerificationId = action.payload;
     },
-    setUser: (state, action: PayloadAction<UserResponse | null>) => {
-      state.onboarding.user = action.payload;
-    },
     resetOnboardingState: (state) => {
       state.onboarding = {
         onboardingId: null,
         selectedCountry: null,
         contactVerificationId: null,
-        user: null,
       };
     },
     setCacheData: (
@@ -361,11 +354,6 @@ export const selectContactVerificationId = createSelector(
   (card) => card.onboarding.contactVerificationId,
 );
 
-export const selectUser = createSelector(
-  selectCardState,
-  (card) => card.onboarding.user,
-);
-
 // Actions
 export const {
   resetCardState,
@@ -380,7 +368,6 @@ export const {
   setOnboardingId,
   setSelectedCountry,
   setContactVerificationId,
-  setUser,
   resetOnboardingState,
   setCacheData,
   clearCacheData,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves user state management from Redux to Card SDK context and updates components/hooks, SDK, navigator, and tests accordingly.
> 
> - **SDK Context (`components/UI/Card/sdk`)**:
>   - Add `user` and `setUser` to `useCardSDK` context and clear on logout.
>   - Fetch user on mount via `sdk.getRegistrationStatus(onboardingId)`.
> - **Onboarding Components**:
>   - `ConfirmPhoneNumber`, `PersonalDetails`, `PhysicalAddress`: replace Redux `dispatch(setUser)` with `useCardSDK().setUser`; remove `useDispatch` usage.
>   - `VerifyIdentity`: read `user` from `useCardSDK` instead of Redux.
>   - `OnboardingNavigator`: use `useCardSDK().user` for initial route logic.
> - **Hooks**:
>   - `useUserRegistrationStatus`: switch to `useCardSDK` for `user`/`setUser`; remove `userResponse` from return; update polling to set user via SDK.
> - **Redux (`core/redux/slices/card`)**:
>   - Remove onboarding `user` selector and related tests where applicable; trim reducer/tests accordingly.
> - **Tests**:
>   - Update extensive tests to mock `useCardSDK` with `user` and `setUser`; adjust expectations across onboarding screens and hooks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea216d7fc4d4f1f78e21c6e9157ae904d3d1987e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->