### PR TITLE
fix(predict): missing geoblock in certain actions

### DIFF
--- a/app/components/UI/Predict/components/PredictAddFundsSheet/PredictAddFundsSheet.tsx
+++ b/app/components/UI/Predict/components/PredictAddFundsSheet/PredictAddFundsSheet.tsx
@@ -23,6 +23,10 @@ import BottomSheetFooter from '../../../../../component-library/components/Botto
 import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader/BottomSheetHeader';
 import { ButtonVariants } from '../../../../../component-library/components/Buttons/Button/Button.types';
 import { usePredictDeposit } from '../../hooks/usePredictDeposit';
+import { usePredictActionGuard } from '../../hooks/usePredictActionGuard';
+import { POLYMARKET_PROVIDER_ID } from '../../providers/polymarket/constants';
+import { NavigationProp, useNavigation } from '@react-navigation/native';
+import { PredictNavigationParamList } from '../../types/navigation';
 
 interface PredictAddFundsSheetProps {
   onDismiss?: () => void;
@@ -40,7 +44,13 @@ const PredictAddFundsSheet = forwardRef<
   const sheetRef = useRef<BottomSheetRef>(null);
   const [isVisible, setIsVisible] = useState(false);
   const tw = useTailwind();
+  const navigation =
+    useNavigation<NavigationProp<PredictNavigationParamList>>();
   const { deposit } = usePredictDeposit();
+  const { executeGuardedAction } = usePredictActionGuard({
+    providerId: POLYMARKET_PROVIDER_ID,
+    navigation,
+  });
 
   const handleSheetClosed = useCallback(() => {
     setIsVisible(false);
@@ -65,7 +75,9 @@ const PredictAddFundsSheet = forwardRef<
 
   const handleAddFunds = () => {
     handleClose();
-    deposit();
+    executeGuardedAction(() => {
+      deposit();
+    });
   };
 
   useImperativeHandle(

--- a/app/components/UI/Predict/components/PredictBalance/PredictBalance.test.tsx
+++ b/app/components/UI/Predict/components/PredictBalance/PredictBalance.test.tsx
@@ -33,6 +33,16 @@ jest.mock('../../hooks/usePredictDeposit', () => ({
   },
 }));
 
+// Mock usePredictActionGuard hook
+const mockExecuteGuardedAction = jest.fn((action) => action());
+jest.mock('../../hooks/usePredictActionGuard', () => ({
+  usePredictActionGuard: () => ({
+    executeGuardedAction: mockExecuteGuardedAction,
+    isEligible: true,
+    hasNoBalance: false,
+  }),
+}));
+
 // Mock Clipboard
 jest.mock('@react-native-clipboard/clipboard', () => ({
   setString: jest.fn(),
@@ -62,6 +72,9 @@ describe('PredictBalance', () => {
       deposit: jest.fn(),
       status: 'IDLE',
     });
+
+    // Reset executeGuardedAction mock to default behavior
+    mockExecuteGuardedAction.mockImplementation((action) => action());
   });
 
   afterEach(() => {

--- a/app/components/UI/Predict/components/PredictMarketMultiple/PredictMarketMultiple.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarketMultiple/PredictMarketMultiple.test.tsx
@@ -295,6 +295,60 @@ describe('PredictMarketMultiple', () => {
     });
   });
 
+  it('checks eligibility before balance for Yes button', () => {
+    // Mock user is not eligible AND has no balance
+    mockUsePredictEligibility.mockReturnValue({
+      isEligible: false,
+      refreshEligibility: jest.fn(),
+    });
+    mockUsePredictBalance.mockReturnValue({
+      hasNoBalance: true,
+    });
+
+    const { getAllByText } = renderWithProvider(
+      <PredictMarketMultiple market={mockMarket} />,
+      { state: initialState },
+    );
+
+    const yesButtons = getAllByText('Yes');
+    fireEvent.press(yesButtons[0]);
+
+    // Should navigate to unavailable (not add funds sheet)
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
+      screen: Routes.PREDICT.MODALS.UNAVAILABLE,
+    });
+    expect(mockNavigate).not.toHaveBeenCalledWith('PredictModals', {
+      screen: 'PredictAddFundsSheet',
+    });
+  });
+
+  it('checks eligibility before balance for No button', () => {
+    // Mock user is not eligible AND has no balance
+    mockUsePredictEligibility.mockReturnValue({
+      isEligible: false,
+      refreshEligibility: jest.fn(),
+    });
+    mockUsePredictBalance.mockReturnValue({
+      hasNoBalance: true,
+    });
+
+    const { getAllByText } = renderWithProvider(
+      <PredictMarketMultiple market={mockMarket} />,
+      { state: initialState },
+    );
+
+    const noButtons = getAllByText('No');
+    fireEvent.press(noButtons[0]);
+
+    // Should navigate to unavailable (not add funds sheet)
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
+      screen: Routes.PREDICT.MODALS.UNAVAILABLE,
+    });
+    expect(mockNavigate).not.toHaveBeenCalledWith('PredictModals', {
+      screen: 'PredictAddFundsSheet',
+    });
+  });
+
   it('handle market with exactly 3 outcomes showing no additional text', () => {
     const marketWithThreeOutcomes: PredictMarket = {
       ...mockMarket,

--- a/app/components/UI/Predict/components/PredictMarketMultiple/PredictMarketMultiple.tsx
+++ b/app/components/UI/Predict/components/PredictMarketMultiple/PredictMarketMultiple.tsx
@@ -105,7 +105,10 @@ const PredictMarketMultiple: React.FC<PredictMarketMultipleProps> = ({
     return sum + volume;
   }, 0);
 
-  const handleYes = (outcome: PredictOutcome) => {
+  const handleBuy = (
+    outcome: PredictOutcome,
+    outcomeToken: PredictOutcomeToken,
+  ) => {
     executeGuardedAction(
       () => {
         navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
@@ -113,24 +116,7 @@ const PredictMarketMultiple: React.FC<PredictMarketMultipleProps> = ({
           params: {
             market,
             outcome,
-            outcomeToken: outcome.tokens[0],
-            entryPoint,
-          },
-        });
-      },
-      { checkBalance: true },
-    );
-  };
-
-  const handleNo = (outcome: PredictOutcome) => {
-    executeGuardedAction(
-      () => {
-        navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-          screen: Routes.PREDICT.MODALS.BUY_PREVIEW,
-          params: {
-            market,
-            outcome,
-            outcomeToken: outcome.tokens[1],
+            outcomeToken,
             entryPoint,
           },
         });
@@ -225,7 +211,7 @@ const PredictMarketMultiple: React.FC<PredictMarketMultipleProps> = ({
                         {truncateLabel(outcomeLabels[0])}
                       </Text>
                     }
-                    onPress={() => handleYes(outcome)}
+                    onPress={() => handleBuy(outcome, outcome.tokens[0])}
                     style={styles.buttonYes}
                   />
                   <Button
@@ -240,7 +226,7 @@ const PredictMarketMultiple: React.FC<PredictMarketMultipleProps> = ({
                         {truncateLabel(outcomeLabels[1])}
                       </Text>
                     }
-                    onPress={() => handleNo(outcome)}
+                    onPress={() => handleBuy(outcome, outcome.tokens[1])}
                     style={styles.buttonNo}
                   />
                 </Box>

--- a/app/components/UI/Predict/components/PredictMarketMultiple/PredictMarketMultiple.tsx
+++ b/app/components/UI/Predict/components/PredictMarketMultiple/PredictMarketMultiple.tsx
@@ -84,16 +84,16 @@ const PredictMarketMultiple: React.FC<PredictMarketMultipleProps> = ({
   }, 0);
 
   const handleYes = (outcome: PredictOutcome) => {
-    if (hasNoBalance) {
+    if (!isEligible) {
       navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-        screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,
+        screen: Routes.PREDICT.MODALS.UNAVAILABLE,
       });
       return;
     }
 
-    if (!isEligible) {
+    if (hasNoBalance) {
       navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-        screen: Routes.PREDICT.MODALS.UNAVAILABLE,
+        screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,
       });
       return;
     }
@@ -110,16 +110,16 @@ const PredictMarketMultiple: React.FC<PredictMarketMultipleProps> = ({
   };
 
   const handleNo = (outcome: PredictOutcome) => {
-    if (hasNoBalance) {
+    if (!isEligible) {
       navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-        screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,
+        screen: Routes.PREDICT.MODALS.UNAVAILABLE,
       });
       return;
     }
 
-    if (!isEligible) {
+    if (hasNoBalance) {
       navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-        screen: Routes.PREDICT.MODALS.UNAVAILABLE,
+        screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,
       });
       return;
     }

--- a/app/components/UI/Predict/components/PredictMarketMultiple/PredictMarketMultiple.tsx
+++ b/app/components/UI/Predict/components/PredictMarketMultiple/PredictMarketMultiple.tsx
@@ -23,7 +23,7 @@ import Text, {
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../../component-library/hooks';
-import { usePredictEligibility } from '../../hooks/usePredictEligibility';
+import { usePredictActionGuard } from '../../hooks/usePredictActionGuard';
 import Routes from '../../../../../constants/navigation/Routes';
 import { PredictMarket, PredictOutcome } from '../../types';
 import {
@@ -33,7 +33,6 @@ import {
 import { PredictEventValues } from '../../constants/eventNames';
 import { formatVolume } from '../../utils/format';
 import styleSheet from './PredictMarketMultiple.styles';
-import { usePredictBalance } from '../../hooks/usePredictBalance';
 interface PredictMarketMultipleProps {
   market: PredictMarket;
   testID?: string;
@@ -50,10 +49,10 @@ const PredictMarketMultiple: React.FC<PredictMarketMultipleProps> = ({
   const { styles } = useStyles(styleSheet, {});
   const tw = useTailwind();
 
-  const { isEligible } = usePredictEligibility({
+  const { executeGuardedAction } = usePredictActionGuard({
     providerId: market.providerId,
+    navigation,
   });
-  const { hasNoBalance } = usePredictBalance();
 
   const getFirstOutcomePrice = (
     outcomePrices?: number[],
@@ -84,55 +83,37 @@ const PredictMarketMultiple: React.FC<PredictMarketMultipleProps> = ({
   }, 0);
 
   const handleYes = (outcome: PredictOutcome) => {
-    if (!isEligible) {
-      navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-        screen: Routes.PREDICT.MODALS.UNAVAILABLE,
-      });
-      return;
-    }
-
-    if (hasNoBalance) {
-      navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-        screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,
-      });
-      return;
-    }
-
-    navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-      screen: Routes.PREDICT.MODALS.BUY_PREVIEW,
-      params: {
-        market,
-        outcome,
-        outcomeToken: outcome.tokens[0],
-        entryPoint,
+    executeGuardedAction(
+      () => {
+        navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
+          screen: Routes.PREDICT.MODALS.BUY_PREVIEW,
+          params: {
+            market,
+            outcome,
+            outcomeToken: outcome.tokens[0],
+            entryPoint,
+          },
+        });
       },
-    });
+      { checkBalance: true },
+    );
   };
 
   const handleNo = (outcome: PredictOutcome) => {
-    if (!isEligible) {
-      navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-        screen: Routes.PREDICT.MODALS.UNAVAILABLE,
-      });
-      return;
-    }
-
-    if (hasNoBalance) {
-      navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-        screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,
-      });
-      return;
-    }
-
-    navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-      screen: Routes.PREDICT.MODALS.BUY_PREVIEW,
-      params: {
-        market,
-        outcome,
-        outcomeToken: outcome.tokens[1],
-        entryPoint,
+    executeGuardedAction(
+      () => {
+        navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
+          screen: Routes.PREDICT.MODALS.BUY_PREVIEW,
+          params: {
+            market,
+            outcome,
+            outcomeToken: outcome.tokens[1],
+            entryPoint,
+          },
+        });
       },
-    });
+      { checkBalance: true },
+    );
   };
 
   const totalVolumeDisplay = formatVolume(totalVolume);

--- a/app/components/UI/Predict/components/PredictMarketMultiple/PredictMarketMultiple.tsx
+++ b/app/components/UI/Predict/components/PredictMarketMultiple/PredictMarketMultiple.tsx
@@ -27,7 +27,11 @@ import Text, {
 import { useStyles } from '../../../../../component-library/hooks';
 import { usePredictActionGuard } from '../../hooks/usePredictActionGuard';
 import Routes from '../../../../../constants/navigation/Routes';
-import { PredictMarket, PredictOutcome } from '../../types';
+import {
+  PredictMarket,
+  PredictOutcome,
+  PredictOutcomeToken,
+} from '../../types';
 import {
   PredictNavigationParamList,
   PredictEntryPoint,

--- a/app/components/UI/Predict/components/PredictMarketOutcome/PredictMarketOutcome.tsx
+++ b/app/components/UI/Predict/components/PredictMarketOutcome/PredictMarketOutcome.tsx
@@ -36,6 +36,7 @@ import { PredictEventValues } from '../../constants/eventNames';
 import { formatPercentage, formatVolume } from '../../utils/format';
 import styleSheet from './PredictMarketOutcome.styles';
 import { usePredictBalance } from '../../hooks/usePredictBalance';
+import { usePredictEligibility } from '../../hooks/usePredictEligibility';
 interface PredictMarketOutcomeProps {
   market: PredictMarket;
   outcome: PredictOutcomeType;
@@ -56,6 +57,9 @@ const PredictMarketOutcome: React.FC<PredictMarketOutcomeProps> = ({
   const navigation =
     useNavigation<NavigationProp<PredictNavigationParamList>>();
 
+  const { isEligible } = usePredictEligibility({
+    providerId: market.providerId,
+  });
   const { hasNoBalance } = usePredictBalance();
 
   const getOutcomePrices = (): number[] =>
@@ -81,6 +85,13 @@ const PredictMarketOutcome: React.FC<PredictMarketOutcomeProps> = ({
   const getVolumeDisplay = (): string => formatVolume(outcome.volume ?? 0);
 
   const handleYes = () => {
+    if (!isEligible) {
+      navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
+        screen: Routes.PREDICT.MODALS.UNAVAILABLE,
+      });
+      return;
+    }
+
     if (hasNoBalance) {
       navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
         screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,
@@ -100,6 +111,13 @@ const PredictMarketOutcome: React.FC<PredictMarketOutcomeProps> = ({
   };
 
   const handleNo = () => {
+    if (!isEligible) {
+      navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
+        screen: Routes.PREDICT.MODALS.UNAVAILABLE,
+      });
+      return;
+    }
+
     if (hasNoBalance) {
       navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
         screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,

--- a/app/components/UI/Predict/components/PredictMarketOutcome/PredictMarketOutcome.tsx
+++ b/app/components/UI/Predict/components/PredictMarketOutcome/PredictMarketOutcome.tsx
@@ -35,8 +35,7 @@ import {
 import { PredictEventValues } from '../../constants/eventNames';
 import { formatPercentage, formatVolume } from '../../utils/format';
 import styleSheet from './PredictMarketOutcome.styles';
-import { usePredictBalance } from '../../hooks/usePredictBalance';
-import { usePredictEligibility } from '../../hooks/usePredictEligibility';
+import { usePredictActionGuard } from '../../hooks/usePredictActionGuard';
 interface PredictMarketOutcomeProps {
   market: PredictMarket;
   outcome: PredictOutcomeType;
@@ -57,10 +56,10 @@ const PredictMarketOutcome: React.FC<PredictMarketOutcomeProps> = ({
   const navigation =
     useNavigation<NavigationProp<PredictNavigationParamList>>();
 
-  const { isEligible } = usePredictEligibility({
+  const { executeGuardedAction } = usePredictActionGuard({
     providerId: market.providerId,
+    navigation,
   });
-  const { hasNoBalance } = usePredictBalance();
 
   const getOutcomePrices = (): number[] =>
     outcome.tokens.map((token) => token.price);
@@ -85,55 +84,37 @@ const PredictMarketOutcome: React.FC<PredictMarketOutcomeProps> = ({
   const getVolumeDisplay = (): string => formatVolume(outcome.volume ?? 0);
 
   const handleYes = () => {
-    if (!isEligible) {
-      navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-        screen: Routes.PREDICT.MODALS.UNAVAILABLE,
-      });
-      return;
-    }
-
-    if (hasNoBalance) {
-      navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-        screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,
-      });
-      return;
-    }
-
-    navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-      screen: Routes.PREDICT.MODALS.BUY_PREVIEW,
-      params: {
-        market,
-        outcome,
-        outcomeToken: outcome.tokens[0],
-        entryPoint,
+    executeGuardedAction(
+      () => {
+        navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
+          screen: Routes.PREDICT.MODALS.BUY_PREVIEW,
+          params: {
+            market,
+            outcome,
+            outcomeToken: outcome.tokens[0],
+            entryPoint,
+          },
+        });
       },
-    });
+      { checkBalance: true },
+    );
   };
 
   const handleNo = () => {
-    if (!isEligible) {
-      navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-        screen: Routes.PREDICT.MODALS.UNAVAILABLE,
-      });
-      return;
-    }
-
-    if (hasNoBalance) {
-      navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-        screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,
-      });
-      return;
-    }
-
-    navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-      screen: Routes.PREDICT.MODALS.BUY_PREVIEW,
-      params: {
-        market,
-        outcome,
-        outcomeToken: outcome.tokens[1],
-        entryPoint,
+    executeGuardedAction(
+      () => {
+        navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
+          screen: Routes.PREDICT.MODALS.BUY_PREVIEW,
+          params: {
+            market,
+            outcome,
+            outcomeToken: outcome.tokens[1],
+            entryPoint,
+          },
+        });
       },
-    });
+      { checkBalance: true },
+    );
   };
 
   return (

--- a/app/components/UI/Predict/components/PredictMarketOutcome/PredictMarketOutcome.tsx
+++ b/app/components/UI/Predict/components/PredictMarketOutcome/PredictMarketOutcome.tsx
@@ -83,7 +83,7 @@ const PredictMarketOutcome: React.FC<PredictMarketOutcomeProps> = ({
 
   const getVolumeDisplay = (): string => formatVolume(outcome.volume ?? 0);
 
-  const handleYes = () => {
+  const handleBuy = (token: PredictOutcomeToken) => {
     executeGuardedAction(
       () => {
         navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
@@ -91,24 +91,7 @@ const PredictMarketOutcome: React.FC<PredictMarketOutcomeProps> = ({
           params: {
             market,
             outcome,
-            outcomeToken: outcome.tokens[0],
-            entryPoint,
-          },
-        });
-      },
-      { checkBalance: true },
-    );
-  };
-
-  const handleNo = () => {
-    executeGuardedAction(
-      () => {
-        navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-          screen: Routes.PREDICT.MODALS.BUY_PREVIEW,
-          params: {
-            market,
-            outcome,
-            outcomeToken: outcome.tokens[1],
+            outcomeToken: token,
             entryPoint,
           },
         });
@@ -194,7 +177,7 @@ const PredictMarketOutcome: React.FC<PredictMarketOutcomeProps> = ({
                 {(outcome.tokens[0].price * 100).toFixed(2)}¢
               </Text>
             }
-            onPress={handleYes}
+            onPress={() => handleBuy(outcome.tokens[0])}
             style={styles.buttonYes}
           />
           <Button
@@ -207,7 +190,7 @@ const PredictMarketOutcome: React.FC<PredictMarketOutcomeProps> = ({
                 {(outcome.tokens[1].price * 100).toFixed(2)}¢
               </Text>
             }
-            onPress={handleNo}
+            onPress={() => handleBuy(outcome.tokens[1])}
             style={styles.buttonNo}
           />
         </View>

--- a/app/components/UI/Predict/components/PredictMarketSingle/PredictMarketSingle.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSingle/PredictMarketSingle.test.tsx
@@ -341,6 +341,60 @@ describe('PredictMarketSingle', () => {
     });
   });
 
+  it('checks eligibility before balance for Yes button', () => {
+    // Mock user is not eligible AND has no balance
+    mockUsePredictEligibility.mockReturnValue({
+      isEligible: false,
+      refreshEligibility: jest.fn(),
+    });
+    mockUsePredictBalance.mockReturnValue({
+      hasNoBalance: true,
+    });
+
+    const { getByText } = renderWithProvider(
+      <PredictMarketSingle market={mockMarket} />,
+      { state: initialState },
+    );
+
+    const yesButton = getByText('Yes');
+    fireEvent.press(yesButton);
+
+    // Should navigate to unavailable (not add funds sheet)
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
+      screen: Routes.PREDICT.MODALS.UNAVAILABLE,
+    });
+    expect(mockNavigate).not.toHaveBeenCalledWith('PredictModals', {
+      screen: 'PredictAddFundsSheet',
+    });
+  });
+
+  it('checks eligibility before balance for No button', () => {
+    // Mock user is not eligible AND has no balance
+    mockUsePredictEligibility.mockReturnValue({
+      isEligible: false,
+      refreshEligibility: jest.fn(),
+    });
+    mockUsePredictBalance.mockReturnValue({
+      hasNoBalance: true,
+    });
+
+    const { getByText } = renderWithProvider(
+      <PredictMarketSingle market={mockMarket} />,
+      { state: initialState },
+    );
+
+    const noButton = getByText('No');
+    fireEvent.press(noButton);
+
+    // Should navigate to unavailable (not add funds sheet)
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
+      screen: Routes.PREDICT.MODALS.UNAVAILABLE,
+    });
+    expect(mockNavigate).not.toHaveBeenCalledWith('PredictModals', {
+      screen: 'PredictAddFundsSheet',
+    });
+  });
+
   it('displays 0% when tokens have price 0', () => {
     const marketWithZeroPriceTokens: PredictMarketType = {
       ...mockMarket,

--- a/app/components/UI/Predict/components/PredictMarketSingle/PredictMarketSingle.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSingle/PredictMarketSingle.tsx
@@ -21,7 +21,10 @@ import Text, {
 import { useStyles } from '../../../../../component-library/hooks';
 import { usePredictActionGuard } from '../../hooks/usePredictActionGuard';
 import Routes from '../../../../../constants/navigation/Routes';
-import { PredictMarket as PredictMarketType } from '../../types';
+import {
+  PredictMarket as PredictMarketType,
+  PredictOutcomeToken,
+} from '../../types';
 import {
   PredictNavigationParamList,
   PredictEntryPoint,
@@ -70,7 +73,7 @@ const PredictMarketSingle: React.FC<PredictMarketSingleProps> = ({
 
   const yesPercentage = getYesPercentage();
 
-  const handleYes = () => {
+  const handleBuy = (token: PredictOutcomeToken) => {
     executeGuardedAction(
       () => {
         navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
@@ -78,24 +81,7 @@ const PredictMarketSingle: React.FC<PredictMarketSingleProps> = ({
           params: {
             market,
             outcome,
-            outcomeToken: outcome.tokens[0],
-            entryPoint,
-          },
-        });
-      },
-      { checkBalance: true },
-    );
-  };
-
-  const handleNo = () => {
-    executeGuardedAction(
-      () => {
-        navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-          screen: Routes.PREDICT.MODALS.BUY_PREVIEW,
-          params: {
-            market,
-            outcome,
-            outcomeToken: outcome.tokens[1],
+            outcomeToken: token,
             entryPoint,
           },
         });
@@ -244,7 +230,7 @@ const PredictMarketSingle: React.FC<PredictMarketSingleProps> = ({
                 {strings('predict.buy_yes')}
               </Text>
             }
-            onPress={handleYes}
+            onPress={() => handleBuy(outcome.tokens[0])}
             style={styles.buttonYes}
           />
           <Button
@@ -256,7 +242,7 @@ const PredictMarketSingle: React.FC<PredictMarketSingleProps> = ({
                 {strings('predict.buy_no')}
               </Text>
             }
-            onPress={handleNo}
+            onPress={() => handleBuy(outcome.tokens[1])}
             style={styles.buttonNo}
           />
         </View>

--- a/app/components/UI/Predict/components/PredictMarketSingle/PredictMarketSingle.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSingle/PredictMarketSingle.tsx
@@ -19,7 +19,7 @@ import Text, {
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../../component-library/hooks';
-import { usePredictEligibility } from '../../hooks/usePredictEligibility';
+import { usePredictActionGuard } from '../../hooks/usePredictActionGuard';
 import Routes from '../../../../../constants/navigation/Routes';
 import { PredictMarket as PredictMarketType } from '../../types';
 import {
@@ -29,7 +29,6 @@ import {
 import { PredictEventValues } from '../../constants/eventNames';
 import { formatVolume } from '../../utils/format';
 import styleSheet from './PredictMarketSingle.styles';
-import { usePredictBalance } from '../../hooks/usePredictBalance';
 interface PredictMarketSingleProps {
   market: PredictMarketType;
   testID?: string;
@@ -47,10 +46,10 @@ const PredictMarketSingle: React.FC<PredictMarketSingleProps> = ({
   const { styles } = useStyles(styleSheet, {});
   const tw = useTailwind();
 
-  const { isEligible } = usePredictEligibility({
+  const { executeGuardedAction } = usePredictActionGuard({
     providerId: market.providerId,
+    navigation,
   });
-  const { hasNoBalance } = usePredictBalance();
 
   const getOutcomePrices = (): number[] =>
     outcome.tokens.map((token) => token.price);
@@ -72,55 +71,37 @@ const PredictMarketSingle: React.FC<PredictMarketSingleProps> = ({
   const yesPercentage = getYesPercentage();
 
   const handleYes = () => {
-    if (!isEligible) {
-      navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-        screen: Routes.PREDICT.MODALS.UNAVAILABLE,
-      });
-      return;
-    }
-
-    if (hasNoBalance) {
-      navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-        screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,
-      });
-      return;
-    }
-
-    navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-      screen: Routes.PREDICT.MODALS.BUY_PREVIEW,
-      params: {
-        market,
-        outcome,
-        outcomeToken: outcome.tokens[0],
-        entryPoint,
+    executeGuardedAction(
+      () => {
+        navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
+          screen: Routes.PREDICT.MODALS.BUY_PREVIEW,
+          params: {
+            market,
+            outcome,
+            outcomeToken: outcome.tokens[0],
+            entryPoint,
+          },
+        });
       },
-    });
+      { checkBalance: true },
+    );
   };
 
   const handleNo = () => {
-    if (!isEligible) {
-      navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-        screen: Routes.PREDICT.MODALS.UNAVAILABLE,
-      });
-      return;
-    }
-
-    if (hasNoBalance) {
-      navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-        screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,
-      });
-      return;
-    }
-
-    navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-      screen: Routes.PREDICT.MODALS.BUY_PREVIEW,
-      params: {
-        market,
-        outcome,
-        outcomeToken: outcome.tokens[1],
-        entryPoint,
+    executeGuardedAction(
+      () => {
+        navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
+          screen: Routes.PREDICT.MODALS.BUY_PREVIEW,
+          params: {
+            market,
+            outcome,
+            outcomeToken: outcome.tokens[1],
+            entryPoint,
+          },
+        });
       },
-    });
+      { checkBalance: true },
+    );
   };
 
   interface SemiCircleYesPercentageProps {

--- a/app/components/UI/Predict/components/PredictMarketSingle/PredictMarketSingle.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSingle/PredictMarketSingle.tsx
@@ -72,16 +72,16 @@ const PredictMarketSingle: React.FC<PredictMarketSingleProps> = ({
   const yesPercentage = getYesPercentage();
 
   const handleYes = () => {
-    if (hasNoBalance) {
+    if (!isEligible) {
       navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-        screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,
+        screen: Routes.PREDICT.MODALS.UNAVAILABLE,
       });
       return;
     }
 
-    if (!isEligible) {
+    if (hasNoBalance) {
       navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-        screen: Routes.PREDICT.MODALS.UNAVAILABLE,
+        screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,
       });
       return;
     }
@@ -98,16 +98,16 @@ const PredictMarketSingle: React.FC<PredictMarketSingleProps> = ({
   };
 
   const handleNo = () => {
-    if (hasNoBalance) {
+    if (!isEligible) {
       navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-        screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,
+        screen: Routes.PREDICT.MODALS.UNAVAILABLE,
       });
       return;
     }
 
-    if (!isEligible) {
+    if (hasNoBalance) {
       navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-        screen: Routes.PREDICT.MODALS.UNAVAILABLE,
+        screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,
       });
       return;
     }

--- a/app/components/UI/Predict/components/PredictPositionDetail/PredictPositionDetail.test.tsx
+++ b/app/components/UI/Predict/components/PredictPositionDetail/PredictPositionDetail.test.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react-native';
+import { screen, fireEvent } from '@testing-library/react-native';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import { backgroundState } from '../../../../../util/test/initial-root-state';
 import PredictPositionDetail from './PredictPositionDetail';
 import {
   type PredictPosition as PredictPositionType,
@@ -34,10 +36,12 @@ jest.mock('../../../../../../locales/i18n', () => ({
 }));
 
 jest.mock('@react-navigation/native', () => {
+  const actualNav = jest.requireActual('@react-navigation/native');
   const mockNavigate = jest.fn() as jest.Mock;
   // expose for tests without out-of-scope reference
   global.__mockNavigate = mockNavigate;
   return {
+    ...actualNav,
     useNavigation: () => ({ navigate: mockNavigate }),
   };
 });
@@ -65,6 +69,15 @@ jest.mock('@metamask/design-system-twrnc-preset', () => {
     useTailwind: () => mockTw,
   };
 });
+
+const mockExecuteGuardedAction = jest.fn((action) => action());
+jest.mock('../../hooks/usePredictActionGuard', () => ({
+  usePredictActionGuard: () => ({
+    executeGuardedAction: mockExecuteGuardedAction,
+    isEligible: true,
+    hasNoBalance: false,
+  }),
+}));
 
 const basePosition: PredictPositionType = {
   id: 'pos-1',
@@ -130,6 +143,12 @@ const baseMarket: PredictMarket = {
   volume: 200000,
 };
 
+const initialState = {
+  engine: {
+    backgroundState,
+  },
+};
+
 const renderComponent = (
   overrides?: Partial<PredictPositionType>,
   marketOverrides?: Partial<PredictMarket>,
@@ -143,18 +162,21 @@ const renderComponent = (
     ...baseMarket,
     ...marketOverrides,
   } as PredictMarket;
-  return render(
+  return renderWithProvider(
     <PredictPositionDetail
       position={position}
       market={market}
       marketStatus={marketStatus}
     />,
+    { state: initialState },
   );
 };
 
 describe('PredictPositionDetail', () => {
   beforeEach(() => {
     global.__mockNavigate.mockClear();
+    mockExecuteGuardedAction.mockClear();
+    mockExecuteGuardedAction.mockImplementation((action) => action());
   });
 
   it('renders open position with current value, percent change and cash out', () => {

--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.test.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.test.tsx
@@ -193,6 +193,16 @@ jest.mock('../../hooks/usePredictBalance', () => ({
   usePredictBalance: () => mockBalanceResult,
 }));
 
+// Mock usePredictActionGuard hook
+const mockExecuteGuardedAction = jest.fn((action) => action());
+jest.mock('../../hooks/usePredictActionGuard', () => ({
+  usePredictActionGuard: () => ({
+    executeGuardedAction: mockExecuteGuardedAction,
+    isEligible: true,
+    hasNoBalance: false,
+  }),
+}));
+
 // Mock usePredictClaimablePositions hook
 const mockLoadClaimablePositions = jest.fn();
 const mockClaimablePositionsResult: {

--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
@@ -30,6 +30,7 @@ import { usePredictBalance } from '../../hooks/usePredictBalance';
 import { usePredictClaim } from '../../hooks/usePredictClaim';
 import { usePredictDeposit } from '../../hooks/usePredictDeposit';
 import { useUnrealizedPnL } from '../../hooks/useUnrealizedPnL';
+import { usePredictActionGuard } from '../../hooks/usePredictActionGuard';
 import { POLYMARKET_PROVIDER_ID } from '../../providers/polymarket/constants';
 import { selectPredictClaimablePositions } from '../../selectors/predictController';
 import {
@@ -53,6 +54,10 @@ const PredictPositionsHeader = forwardRef<PredictPositionsHeaderHandle>(
     const navigation =
       useNavigation<NavigationProp<PredictNavigationParamList>>();
     const tw = useTailwind();
+    const { executeGuardedAction } = usePredictActionGuard({
+      providerId: POLYMARKET_PROVIDER_ID,
+      navigation,
+    });
     const {
       balance,
       loadBalance,
@@ -131,7 +136,9 @@ const PredictPositionsHeader = forwardRef<PredictPositionsHeaderHandle>(
     const shouldShowMainCard = hasAvailableBalance || hasUnrealizedPnL;
 
     const handleClaim = async () => {
-      await claim();
+      executeGuardedAction(async () => {
+        await claim();
+      });
     };
 
     if (isBalanceLoading || isUnrealizedPnLLoading) {

--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
@@ -136,7 +136,7 @@ const PredictPositionsHeader = forwardRef<PredictPositionsHeaderHandle>(
     const shouldShowMainCard = hasAvailableBalance || hasUnrealizedPnL;
 
     const handleClaim = async () => {
-      executeGuardedAction(async () => {
+      await executeGuardedAction(async () => {
         await claim();
       });
     };

--- a/app/components/UI/Predict/hooks/usePredictActionGuard.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictActionGuard.test.ts
@@ -1,0 +1,242 @@
+import { renderHook } from '@testing-library/react-hooks';
+import Routes from '../../../../constants/navigation/Routes';
+import { usePredictActionGuard } from './usePredictActionGuard';
+
+const mockNavigate = jest.fn();
+const mockNavigation = {
+  navigate: mockNavigate,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as any;
+
+const mockUsePredictEligibility = jest.fn();
+jest.mock('./usePredictEligibility', () => ({
+  usePredictEligibility: () => mockUsePredictEligibility(),
+}));
+
+const mockUsePredictBalance = jest.fn();
+jest.mock('./usePredictBalance', () => ({
+  usePredictBalance: () => mockUsePredictBalance(),
+}));
+
+describe('usePredictActionGuard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePredictEligibility.mockReturnValue({
+      isEligible: true,
+      refreshEligibility: jest.fn(),
+    });
+    mockUsePredictBalance.mockReturnValue({
+      hasNoBalance: false,
+    });
+  });
+
+  describe('when user is eligible and has balance', () => {
+    it('executes action without navigation when checkBalance is false', () => {
+      const { result } = renderHook(() =>
+        usePredictActionGuard({
+          providerId: 'polymarket',
+          navigation: mockNavigation,
+        }),
+      );
+
+      const mockAction = jest.fn();
+      result.current.executeGuardedAction(mockAction);
+
+      expect(mockAction).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('executes action without navigation when checkBalance is true', () => {
+      const { result } = renderHook(() =>
+        usePredictActionGuard({
+          providerId: 'polymarket',
+          navigation: mockNavigation,
+        }),
+      );
+
+      const mockAction = jest.fn();
+      result.current.executeGuardedAction(mockAction, { checkBalance: true });
+
+      expect(mockAction).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('returns correct eligibility and balance state', () => {
+      const { result } = renderHook(() =>
+        usePredictActionGuard({
+          providerId: 'polymarket',
+          navigation: mockNavigation,
+        }),
+      );
+
+      expect(result.current.isEligible).toBe(true);
+      expect(result.current.hasNoBalance).toBe(false);
+    });
+  });
+
+  describe('when user is not eligible', () => {
+    beforeEach(() => {
+      mockUsePredictEligibility.mockReturnValue({
+        isEligible: false,
+        refreshEligibility: jest.fn(),
+      });
+    });
+
+    it('navigates to unavailable modal and does not execute action', () => {
+      const { result } = renderHook(() =>
+        usePredictActionGuard({
+          providerId: 'polymarket',
+          navigation: mockNavigation,
+        }),
+      );
+
+      const mockAction = jest.fn();
+      result.current.executeGuardedAction(mockAction);
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
+        screen: Routes.PREDICT.MODALS.UNAVAILABLE,
+      });
+      expect(mockAction).not.toHaveBeenCalled();
+    });
+
+    it('navigates to unavailable modal even with checkBalance option', () => {
+      const { result } = renderHook(() =>
+        usePredictActionGuard({
+          providerId: 'polymarket',
+          navigation: mockNavigation,
+        }),
+      );
+
+      const mockAction = jest.fn();
+      result.current.executeGuardedAction(mockAction, { checkBalance: true });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
+        screen: Routes.PREDICT.MODALS.UNAVAILABLE,
+      });
+      expect(mockAction).not.toHaveBeenCalled();
+    });
+
+    it('returns correct eligibility state', () => {
+      const { result } = renderHook(() =>
+        usePredictActionGuard({
+          providerId: 'polymarket',
+          navigation: mockNavigation,
+        }),
+      );
+
+      expect(result.current.isEligible).toBe(false);
+    });
+  });
+
+  describe('when user is eligible but has no balance', () => {
+    beforeEach(() => {
+      mockUsePredictBalance.mockReturnValue({
+        hasNoBalance: true,
+      });
+    });
+
+    it('executes action when checkBalance is false (default)', () => {
+      const { result } = renderHook(() =>
+        usePredictActionGuard({
+          providerId: 'polymarket',
+          navigation: mockNavigation,
+        }),
+      );
+
+      const mockAction = jest.fn();
+      result.current.executeGuardedAction(mockAction);
+
+      expect(mockAction).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('navigates to add funds sheet when checkBalance is true', () => {
+      const { result } = renderHook(() =>
+        usePredictActionGuard({
+          providerId: 'polymarket',
+          navigation: mockNavigation,
+        }),
+      );
+
+      const mockAction = jest.fn();
+      result.current.executeGuardedAction(mockAction, { checkBalance: true });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
+        screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,
+      });
+      expect(mockAction).not.toHaveBeenCalled();
+    });
+
+    it('returns correct balance state', () => {
+      const { result } = renderHook(() =>
+        usePredictActionGuard({
+          providerId: 'polymarket',
+          navigation: mockNavigation,
+        }),
+      );
+
+      expect(result.current.hasNoBalance).toBe(true);
+    });
+  });
+
+  describe('when user is not eligible and has no balance', () => {
+    beforeEach(() => {
+      mockUsePredictEligibility.mockReturnValue({
+        isEligible: false,
+        refreshEligibility: jest.fn(),
+      });
+      mockUsePredictBalance.mockReturnValue({
+        hasNoBalance: true,
+      });
+    });
+
+    it('checks eligibility before balance (navigates to unavailable, not add funds)', () => {
+      const { result } = renderHook(() =>
+        usePredictActionGuard({
+          providerId: 'polymarket',
+          navigation: mockNavigation,
+        }),
+      );
+
+      const mockAction = jest.fn();
+      result.current.executeGuardedAction(mockAction, { checkBalance: true });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
+        screen: Routes.PREDICT.MODALS.UNAVAILABLE,
+      });
+      expect(mockNavigate).not.toHaveBeenCalledWith(
+        Routes.PREDICT.MODALS.ROOT,
+        {
+          screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,
+        },
+      );
+      expect(mockAction).not.toHaveBeenCalled();
+    });
+
+    it('returns correct eligibility and balance state', () => {
+      const { result } = renderHook(() =>
+        usePredictActionGuard({
+          providerId: 'polymarket',
+          navigation: mockNavigation,
+        }),
+      );
+
+      expect(result.current.isEligible).toBe(false);
+      expect(result.current.hasNoBalance).toBe(true);
+    });
+  });
+
+  describe('providerId usage', () => {
+    it('works with different provider IDs', () => {
+      const { result } = renderHook(() =>
+        usePredictActionGuard({
+          providerId: 'custom-provider',
+          navigation: mockNavigation,
+        }),
+      );
+
+      expect(result.current.executeGuardedAction).toBeDefined();
+      expect(typeof result.current.executeGuardedAction).toBe('function');
+    });
+  });
+});

--- a/app/components/UI/Predict/hooks/usePredictActionGuard.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictActionGuard.test.ts
@@ -72,6 +72,23 @@ describe('usePredictActionGuard', () => {
       expect(result.current.isEligible).toBe(true);
       expect(result.current.hasNoBalance).toBe(false);
     });
+
+    it('executes async action and returns promise', async () => {
+      const { result } = renderHook(() =>
+        usePredictActionGuard({
+          providerId: 'polymarket',
+          navigation: mockNavigation,
+        }),
+      );
+
+      const mockAsyncAction = jest.fn().mockResolvedValue('success');
+      const promise = result.current.executeGuardedAction(mockAsyncAction);
+
+      expect(promise).toBeInstanceOf(Promise);
+      await promise;
+      expect(mockAsyncAction).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
   });
 
   describe('when user is not eligible', () => {

--- a/app/components/UI/Predict/hooks/usePredictActionGuard.ts
+++ b/app/components/UI/Predict/hooks/usePredictActionGuard.ts
@@ -1,0 +1,61 @@
+import { useCallback } from 'react';
+import { NavigationProp } from '@react-navigation/native';
+import Routes from '../../../../constants/navigation/Routes';
+import { PredictNavigationParamList } from '../types/navigation';
+import { usePredictEligibility } from './usePredictEligibility';
+import { usePredictBalance } from './usePredictBalance';
+
+interface UsePredictActionGuardOptions {
+  providerId: string;
+  navigation: NavigationProp<PredictNavigationParamList>;
+}
+
+interface ExecuteGuardedActionOptions {
+  checkBalance?: boolean;
+}
+
+interface UsePredictActionGuardResult {
+  executeGuardedAction: (
+    action: () => void,
+    options?: ExecuteGuardedActionOptions,
+  ) => void;
+  isEligible: boolean;
+  hasNoBalance: boolean;
+}
+
+export const usePredictActionGuard = ({
+  providerId,
+  navigation,
+}: UsePredictActionGuardOptions): UsePredictActionGuardResult => {
+  const { isEligible } = usePredictEligibility({ providerId });
+  const { hasNoBalance } = usePredictBalance();
+
+  const executeGuardedAction = useCallback(
+    (action: () => void, options: ExecuteGuardedActionOptions = {}) => {
+      const { checkBalance = false } = options;
+
+      if (!isEligible) {
+        navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
+          screen: Routes.PREDICT.MODALS.UNAVAILABLE,
+        });
+        return;
+      }
+
+      if (checkBalance && hasNoBalance) {
+        navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
+          screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,
+        });
+        return;
+      }
+
+      action();
+    },
+    [isEligible, hasNoBalance, navigation],
+  );
+
+  return {
+    executeGuardedAction,
+    isEligible,
+    hasNoBalance,
+  };
+};

--- a/app/components/UI/Predict/hooks/usePredictActionGuard.ts
+++ b/app/components/UI/Predict/hooks/usePredictActionGuard.ts
@@ -28,7 +28,9 @@ export const usePredictActionGuard = ({
   navigation,
 }: UsePredictActionGuardOptions): UsePredictActionGuardResult => {
   const { isEligible } = usePredictEligibility({ providerId });
-  const { hasNoBalance } = usePredictBalance();
+  const { hasNoBalance } = usePredictBalance({
+    loadOnMount: true,
+  });
 
   const executeGuardedAction = useCallback(
     (

--- a/app/components/UI/Predict/hooks/usePredictActionGuard.ts
+++ b/app/components/UI/Predict/hooks/usePredictActionGuard.ts
@@ -16,9 +16,9 @@ interface ExecuteGuardedActionOptions {
 
 interface UsePredictActionGuardResult {
   executeGuardedAction: (
-    action: () => void,
+    action: () => void | Promise<void>,
     options?: ExecuteGuardedActionOptions,
-  ) => void;
+  ) => void | Promise<void>;
   isEligible: boolean;
   hasNoBalance: boolean;
 }
@@ -31,7 +31,10 @@ export const usePredictActionGuard = ({
   const { hasNoBalance } = usePredictBalance();
 
   const executeGuardedAction = useCallback(
-    (action: () => void, options: ExecuteGuardedActionOptions = {}) => {
+    (
+      action: () => void | Promise<void>,
+      options: ExecuteGuardedActionOptions = {},
+    ) => {
       const { checkBalance = false } = options;
 
       if (!isEligible) {
@@ -48,7 +51,7 @@ export const usePredictActionGuard = ({
         return;
       }
 
-      action();
+      return action();
     },
     [isEligible, hasNoBalance, navigation],
   );

--- a/app/components/UI/Predict/hooks/usePredictClaim.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictClaim.test.ts
@@ -6,7 +6,6 @@ import { ToastContext } from '../../../../component-library/components/Toast/Toa
 import Routes from '../../../../constants/navigation/Routes';
 import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
 import { usePredictClaim } from './usePredictClaim';
-import { usePredictEligibility } from './usePredictEligibility';
 import { usePredictTrading } from './usePredictTrading';
 import { useConfirmNavigation } from '../../../Views/confirmations/hooks/useConfirmNavigation';
 import { strings } from '../../../../../locales/i18n';
@@ -52,9 +51,6 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
-const mockUsePredictEligibility = usePredictEligibility as jest.MockedFunction<
-  typeof usePredictEligibility
->;
 const mockUsePredictTrading = usePredictTrading as jest.MockedFunction<
   typeof usePredictTrading
 >;
@@ -81,11 +77,6 @@ describe('usePredictClaim', () => {
     jest.requireMock('@react-navigation/native').useNavigation = jest
       .fn()
       .mockReturnValue(mockNavigation);
-
-    mockUsePredictEligibility.mockReturnValue({
-      isEligible: true,
-      refreshEligibility: jest.fn(),
-    });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mockUsePredictTrading.mockReturnValue({
@@ -123,60 +114,11 @@ describe('usePredictClaim', () => {
       expect(result.current.claim).toBeInstanceOf(Function);
       expect(result.current.status).toBe('pending');
     });
-
-    it('uses default providerId when not specified', () => {
-      // Arrange & Act
-      renderHook(() => usePredictClaim(), { wrapper });
-
-      // Assert
-      expect(mockUsePredictEligibility).toHaveBeenCalledWith({
-        providerId: POLYMARKET_PROVIDER_ID,
-      });
-    });
-
-    it('uses custom providerId when specified', () => {
-      // Arrange
-      const customProviderId = 'custom-provider';
-
-      // Act
-      renderHook(() => usePredictClaim({ providerId: customProviderId }), {
-        wrapper,
-      });
-
-      // Assert
-      expect(mockUsePredictEligibility).toHaveBeenCalledWith({
-        providerId: customProviderId,
-      });
-    });
   });
 
   describe('claim function', () => {
-    it('navigates to unavailable modal when user is not eligible', async () => {
+    it('navigates to confirmation and claims winnings', async () => {
       // Arrange
-      mockUsePredictEligibility.mockReturnValue({
-        isEligible: false,
-        refreshEligibility: jest.fn(),
-      });
-
-      const { result } = renderHook(() => usePredictClaim(), { wrapper });
-
-      // Act
-      await result.current.claim();
-
-      // Assert
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
-        screen: Routes.PREDICT.MODALS.UNAVAILABLE,
-      });
-      expect(mockNavigateToConfirmation).not.toHaveBeenCalled();
-      expect(mockClaimWinnings).not.toHaveBeenCalled();
-    });
-
-    it('navigates to confirmation and claims winnings when user is eligible', async () => {
-      // Arrange
-      mockUsePredictEligibility.mockReturnValue({
-        isEligible: true,
-        refreshEligibility: jest.fn(),
-      });
       mockClaimWinnings.mockResolvedValue(undefined);
 
       const { result } = renderHook(() => usePredictClaim(), { wrapper });
@@ -198,10 +140,6 @@ describe('usePredictClaim', () => {
     it('uses custom providerId when claiming', async () => {
       // Arrange
       const customProviderId = 'custom-provider';
-      mockUsePredictEligibility.mockReturnValue({
-        isEligible: true,
-        refreshEligibility: jest.fn(),
-      });
       mockClaimWinnings.mockResolvedValue(undefined);
 
       const { result } = renderHook(
@@ -223,10 +161,6 @@ describe('usePredictClaim', () => {
     it('displays error toast when claim fails', async () => {
       // Arrange
       const mockError = new Error('Claim failed');
-      mockUsePredictEligibility.mockReturnValue({
-        isEligible: true,
-        refreshEligibility: jest.fn(),
-      });
       mockClaimWinnings.mockRejectedValue(mockError);
       const consoleErrorSpy = jest
         .spyOn(console, 'error')
@@ -268,10 +202,6 @@ describe('usePredictClaim', () => {
     it('retries claim when try again button is pressed on error toast', async () => {
       // Arrange
       const mockError = new Error('Claim failed');
-      mockUsePredictEligibility.mockReturnValue({
-        isEligible: true,
-        refreshEligibility: jest.fn(),
-      });
       mockClaimWinnings
         .mockRejectedValueOnce(mockError)
         .mockResolvedValueOnce(undefined);
@@ -312,10 +242,6 @@ describe('usePredictClaim', () => {
     it('logs error to console when claim fails', async () => {
       // Arrange
       const mockError = new Error('Network error');
-      mockUsePredictEligibility.mockReturnValue({
-        isEligible: true,
-        refreshEligibility: jest.fn(),
-      });
       mockClaimWinnings.mockRejectedValue(mockError);
       const consoleErrorSpy = jest
         .spyOn(console, 'error')
@@ -366,10 +292,6 @@ describe('usePredictClaim', () => {
     it('handles missing toastRef gracefully on error', async () => {
       // Arrange
       const mockError = new Error('Claim failed');
-      mockUsePredictEligibility.mockReturnValue({
-        isEligible: true,
-        refreshEligibility: jest.fn(),
-      });
       mockClaimWinnings.mockRejectedValue(mockError);
       const consoleErrorSpy = jest
         .spyOn(console, 'error')

--- a/app/components/UI/Predict/hooks/usePredictClaim.ts
+++ b/app/components/UI/Predict/hooks/usePredictClaim.ts
@@ -1,4 +1,3 @@
-import { NavigationProp, useNavigation } from '@react-navigation/native';
 import { useCallback, useContext } from 'react';
 import { useSelector } from 'react-redux';
 import { createSelector } from 'reselect';
@@ -8,8 +7,6 @@ import { ToastContext } from '../../../../component-library/components/Toast/Toa
 import Routes from '../../../../constants/navigation/Routes';
 import { RootState } from '../../../../reducers';
 import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
-import { PredictNavigationParamList } from '../types/navigation';
-import { usePredictEligibility } from './usePredictEligibility';
 import { usePredictTrading } from './usePredictTrading';
 import { useAppThemeFromContext } from '../../../../util/theme';
 import { strings } from '../../../../../locales/i18n';
@@ -22,13 +19,8 @@ interface UsePredictClaimParams {
 export const usePredictClaim = ({
   providerId = POLYMARKET_PROVIDER_ID,
 }: UsePredictClaimParams = {}) => {
-  const navigation =
-    useNavigation<NavigationProp<PredictNavigationParamList>>();
   const { navigateToConfirmation } = useConfirmNavigation();
   const { claim: claimWinnings } = usePredictTrading();
-  const { isEligible } = usePredictEligibility({
-    providerId,
-  });
   const theme = useAppThemeFromContext();
   const { toastRef } = useContext(ToastContext);
 
@@ -39,12 +31,6 @@ export const usePredictClaim = ({
   const claimTransaction = useSelector(selectClaimTransaction);
 
   const claim = useCallback(async () => {
-    if (!isEligible) {
-      navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-        screen: Routes.PREDICT.MODALS.UNAVAILABLE,
-      });
-      return;
-    }
     try {
       navigateToConfirmation({
         headerShown: false,
@@ -77,9 +63,7 @@ export const usePredictClaim = ({
     }
   }, [
     claimWinnings,
-    isEligible,
     navigateToConfirmation,
-    navigation,
     providerId,
     theme.colors.accent04.normal,
     theme.colors.error.default,

--- a/app/components/UI/Predict/hooks/usePredictDeposit.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictDeposit.test.ts
@@ -166,23 +166,7 @@ describe('usePredictDeposit', () => {
   });
 
   describe('deposit function', () => {
-    it('navigates to unavailable modal when user is not eligible', async () => {
-      mockEligibilityResult.isEligible = false;
-
-      const { result } = setupUsePredictDepositTest();
-
-      await result.current.deposit();
-
-      expect(mockNavigate).toHaveBeenCalledWith('PredictModals', {
-        screen: 'PredictUnavailable',
-      });
-      expect(mockNavigateToConfirmation).not.toHaveBeenCalled();
-      expect(
-        Engine.context.PredictController.depositWithConfirmation,
-      ).not.toHaveBeenCalled();
-    });
-
-    it('calls navigateToConfirmation with correct params when eligible', async () => {
+    it('calls navigateToConfirmation with correct params', async () => {
       (
         Engine.context.PredictController.depositWithConfirmation as jest.Mock
       ).mockResolvedValue({

--- a/app/components/UI/Predict/hooks/usePredictDeposit.ts
+++ b/app/components/UI/Predict/hooks/usePredictDeposit.ts
@@ -5,9 +5,6 @@ import Routes from '../../../../constants/navigation/Routes';
 import { createSelector } from 'reselect';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../../../reducers';
-import { usePredictEligibility } from './usePredictEligibility';
-import { NavigationProp, useNavigation } from '@react-navigation/native';
-import { PredictNavigationParamList } from '../types/navigation';
 import { ConfirmationLoader } from '../../../Views/confirmations/components/confirm/confirm-component';
 
 interface UsePredictDepositParams {
@@ -18,11 +15,6 @@ export const usePredictDeposit = ({
   providerId = 'polymarket',
 }: UsePredictDepositParams = {}) => {
   const { navigateToConfirmation } = useConfirmNavigation();
-  const navigation =
-    useNavigation<NavigationProp<PredictNavigationParamList>>();
-  const { isEligible } = usePredictEligibility({
-    providerId,
-  });
 
   const selectDepositTransaction = createSelector(
     (state: RootState) => state.engine.backgroundState.PredictController,
@@ -32,13 +24,6 @@ export const usePredictDeposit = ({
   const depositTransaction = useSelector(selectDepositTransaction);
 
   const deposit = useCallback(async () => {
-    if (!isEligible) {
-      navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-        screen: Routes.PREDICT.MODALS.UNAVAILABLE,
-      });
-      return;
-    }
-
     try {
       navigateToConfirmation({
         loader: ConfirmationLoader.CustomAmount,
@@ -53,7 +38,7 @@ export const usePredictDeposit = ({
     } catch (err) {
       console.error('Failed to proceed with deposit:', err);
     }
-  }, [isEligible, navigateToConfirmation, navigation, providerId]);
+  }, [navigateToConfirmation, providerId]);
 
   return {
     deposit,

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -1983,6 +1983,7 @@ describe('PredictMarketDetails', () => {
 
     it('navigates to unavailable modal when user is not eligible - Yes button', () => {
       const singleOutcomeMarket = createMockMarket({
+        status: 'open',
         outcomes: [
           {
             id: 'outcome-1',
@@ -2011,6 +2012,7 @@ describe('PredictMarketDetails', () => {
 
     it('navigates to unavailable modal when user is not eligible - No button', () => {
       const singleOutcomeMarket = createMockMarket({
+        status: 'open',
         outcomes: [
           {
             id: 'outcome-1',
@@ -2049,6 +2051,7 @@ describe('PredictMarketDetails', () => {
       });
 
       const singleOutcomeMarket = createMockMarket({
+        status: 'open',
         outcomes: [
           {
             id: 'outcome-1',
@@ -2090,6 +2093,7 @@ describe('PredictMarketDetails', () => {
       });
 
       const singleOutcomeMarket = createMockMarket({
+        status: 'open',
         outcomes: [
           {
             id: 'outcome-1',

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -53,6 +53,7 @@ import PredictMarketOutcome from '../../components/PredictMarketOutcome';
 import { usePredictPositions } from '../../hooks/usePredictPositions';
 import { usePredictBalance } from '../../hooks/usePredictBalance';
 import { usePredictClaim } from '../../hooks/usePredictClaim';
+import { usePredictEligibility } from '../../hooks/usePredictEligibility';
 
 const PRICE_HISTORY_TIMEFRAMES: PredictPriceHistoryInterval[] = [
   PredictPriceHistoryInterval.ONE_HOUR,
@@ -96,6 +97,10 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
   const { marketId } = route.params || {};
   const resolvedMarketId = marketId;
   const providerId = 'polymarket';
+
+  const { isEligible } = usePredictEligibility({
+    providerId,
+  });
 
   const { market, isFetching: isMarketFetching } = usePredictMarket({
     id: resolvedMarketId,
@@ -255,6 +260,12 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
   };
 
   const onCashOut = () => {
+    if (!isEligible) {
+      navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
+        screen: Routes.PREDICT.MODALS.UNAVAILABLE,
+      });
+      return;
+    }
     const outcome = market?.outcomes.find(
       (o) => o.id === currentPosition?.outcomeId,
     );
@@ -282,6 +293,13 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
   };
 
   const handleYesPress = () => {
+    if (!isEligible) {
+      navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
+        screen: Routes.PREDICT.MODALS.UNAVAILABLE,
+      });
+      return;
+    }
+
     if (hasNoBalance) {
       navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
         screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,
@@ -300,6 +318,13 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
   };
 
   const handleNoPress = () => {
+    if (!isEligible) {
+      navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
+        screen: Routes.PREDICT.MODALS.UNAVAILABLE,
+      });
+      return;
+    }
+
     if (hasNoBalance) {
       navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
         screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,
@@ -318,6 +343,12 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
   };
 
   const handleClaimPress = async () => {
+    if (!isEligible) {
+      navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
+        screen: Routes.PREDICT.MODALS.UNAVAILABLE,
+      });
+      return;
+    }
     await claim();
   };
 

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -271,7 +271,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
     return 0;
   };
 
-  const handleYesPress = () => {
+  const handleBuyPress = (token: PredictOutcomeToken) => {
     executeGuardedAction(
       () => {
         navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
@@ -279,24 +279,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
           params: {
             market,
             outcome: market?.outcomes?.[0],
-            outcomeToken: market?.outcomes?.[0]?.tokens?.[0],
-            entryPoint: PredictEventValues.ENTRY_POINT.PREDICT_MARKET_DETAILS,
-          },
-        });
-      },
-      { checkBalance: true },
-    );
-  };
-
-  const handleNoPress = () => {
-    executeGuardedAction(
-      () => {
-        navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-          screen: Routes.PREDICT.MODALS.BUY_PREVIEW,
-          params: {
-            market,
-            outcome: market?.outcomes?.[0],
-            outcomeToken: market?.outcomes?.[0]?.tokens?.[1],
+            outcomeToken: token,
             entryPoint: PredictEventValues.ENTRY_POINT.PREDICT_MARKET_DETAILS,
           },
         });
@@ -690,7 +673,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
                     {getYesPercentage()}¢
                   </Text>
                 }
-                onPress={handleYesPress}
+                onPress={() => handleBuyPress(market?.outcomes[0].tokens[0])}
               />
               <Button
                 variant={ButtonVariants.Secondary}
@@ -703,7 +686,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
                     {100 - getYesPercentage()}¢
                   </Text>
                 }
-                onPress={handleNoPress}
+                onPress={() => handleBuyPress(market?.outcomes[0].tokens[1])}
               />
             </Box>
           );

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -322,7 +322,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
   };
 
   const handleClaimPress = async () => {
-    executeGuardedAction(async () => {
+    await executeGuardedAction(async () => {
       await claim();
     });
   };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
This PR fixes the missing geoblock drawer showing for certain actions across the app.
A new `usePredictActionGuard()` hook was created so we can easily wrap protected actions that require eligibility and balance checks.
I also refactored some duplicate code in a few places, to minimize code duplication.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces usePredictActionGuard to gate predict actions (buy, deposit, claim, cash out) by eligibility/balance, refactors components to use it, and updates tests accordingly.
> 
> - **Core**:
>   - Add `usePredictActionGuard` hook to run guarded actions with eligibility and optional balance checks, navigating to `PREDICT_MODALS.UNAVAILABLE` or `ADD_FUNDS_SHEET` as needed.
> - **Refactors (use guard + navigation)**:
>   - `components/PredictMarketMultiple.tsx`, `PredictMarketSingle.tsx`, `PredictMarketOutcome.tsx`, `views/PredictMarketDetails.tsx`: Replace inline eligibility/balance logic with `executeGuardedAction` for buy flows; pass `navigation` and use `checkBalance: true`.
>   - `components/PredictPositionsHeader.tsx`: Wrap `claim` with `executeGuardedAction`.
>   - `components/PredictPositionDetail.tsx`: Wrap cash-out navigation with `executeGuardedAction`.
>   - `components/PredictAddFundsSheet.tsx`, `components/PredictBalance.tsx`: Guard `deposit` via `executeGuardedAction` (use `POLYMARKET_PROVIDER_ID` where applicable).
>   - `hooks/usePredictDeposit.ts`, `hooks/usePredictClaim.ts`: Remove inline eligibility gating; rely on callers/guard; keep confirmation flows.
> - **Tests**:
>   - Add `hooks/usePredictActionGuard.test.ts`.
>   - Update component and view tests to mock guard and assert eligibility-before-balance behavior and new navigation targets.
>   - Adjust existing deposit/claim tests to reflect removed internal eligibility checks and new guarded usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20705fe8c3cb1203ae8d73ffa5bca41b6c2bbebd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->