### PR TITLE
INFRA-3073:Add semver pre-release identifier to builds

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -347,6 +347,19 @@ remapMainExperimentalEnvVariables() {
 }
 
 prebuild_ios(){
+	#Update current SEMVER with environment variable
+	# Read current version from package.json and strip any existing suffix
+	PACKAGE_JSON_FILE=package.json
+	CURRENT_SEMVER=$(jq -r '.version' $PACKAGE_JSON_FILE)
+	# Strip any existing pre-release suffix (e.g., 7.59.0-dev -> 7.59.0)
+	BASE_VERSION=$(echo "$CURRENT_SEMVER" | sed 's/-.*$//')
+	# For production builds, use base version without suffix; otherwise append environment
+	if [ "$METAMASK_ENVIRONMENT" == "production" ]; then
+		./scripts/set-semvar-version.sh $BASE_VERSION
+	else
+		./scripts/set-semvar-version.sh $BASE_VERSION-$METAMASK_ENVIRONMENT
+	fi
+
 	# Generate xcconfig files for CircleCI
 	if [ "$PRE_RELEASE" = true ] ; then
 		echo "" > ios/debug.xcconfig
@@ -369,6 +382,19 @@ prebuild_ios(){
 }
 
 prebuild_android(){
+
+	#Update current BUILD VERSION with environment variable	#Update current SEMVER with environment variable
+	# Read current version from package.json and strip any existing suffix
+	PACKAGE_JSON_FILE=package.json
+	CURRENT_SEMVER=$(jq -r '.version' $PACKAGE_JSON_FILE)
+	# Strip any existing pre-release suffix (e.g., 7.59.0-dev -> 7.59.0)
+	BASE_VERSION=$(echo "$CURRENT_SEMVER" | sed 's/-.*$//')
+	# For production builds, use base version without suffix; otherwise append environment
+	if [ "$METAMASK_ENVIRONMENT" == "production" ]; then
+		./scripts/set-semvar-version.sh $BASE_VERSION
+	else
+		./scripts/set-semvar-version.sh $BASE_VERSION-$METAMASK_ENVIRONMENT
+	fi
 	# Copy JS files for injection
 	yes | cp -rf app/core/InpageBridgeWeb3.js android/app/src/main/assets/.
 	# Copy fonts with iconset


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Ticket: https://consensyssoftware.atlassian.net/browse/INFRA-3073
All builds that are not prod should have a pre-release identifier to easily identify test/internal builds and production.
This requires appending the environment and build number to the semver during the build process.
For both android and IOS

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Apply environment-based semver pre-release identifiers during iOS/Android prebuilds, keeping production builds on the base version.
> 
> - **Build scripts**:
>   - **Versioning**: Update `prebuild_ios` and `prebuild_android` in `scripts/build.sh` to set app semver from `package.json` by stripping any existing suffix and applying a pre-release identifier based on `METAMASK_ENVIRONMENT` (production uses base version; others use `BASE-ENV`).
>   - Uses `./scripts/set-semvar-version.sh` to write the computed version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae46a24586d143e8160330b9f5dca9d3756ba44d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->