### PR TITLE
feat(predict): sticky tabs in predict feed

### DIFF
--- a/app/components/UI/Predict/components/MarketListContent/MarketListContent.tsx
+++ b/app/components/UI/Predict/components/MarketListContent/MarketListContent.tsx
@@ -190,7 +190,7 @@ const MarketListContent: React.FC<MarketListContentProps> = ({
         refreshControl={
           <RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} />
         }
-        contentContainerStyle={tw.style('pb-5')}
+        contentContainerStyle={tw.style('pt-4 pb-5')}
         showsVerticalScrollIndicator={false}
         removeClippedSubviews
         getItemType={() => 'market'}
@@ -210,7 +210,7 @@ const MarketListContent: React.FC<MarketListContentProps> = ({
       refreshControl={
         <RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} />
       }
-      contentContainerStyle={tw.style('pb-5')}
+      contentContainerStyle={tw.style('pt-4 pb-5')}
       showsVerticalScrollIndicator={false}
       removeClippedSubviews
       getItemType={() => 'market'}

--- a/app/components/UI/Predict/components/MarketListContent/MarketListContent.tsx
+++ b/app/components/UI/Predict/components/MarketListContent/MarketListContent.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useRef, useState } from 'react';
 import { RefreshControl } from 'react-native';
+import Animated from 'react-native-reanimated';
 import { useStyles } from '../../../../../component-library/hooks';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { Box } from '@metamask/design-system-react-native';
@@ -19,17 +20,20 @@ import { PredictEntryPoint } from '../../types/navigation';
 import { PredictEventValues } from '../../constants/eventNames';
 import PredictMarket from '../PredictMarket';
 import { getPredictMarketListSelector } from '../../../../../../e2e/selectors/Predict/Predict.selectors';
+import { ScrollCoordinator } from '../../types/scrollCoordinator';
 
 interface MarketListContentProps {
   q?: string;
   category: PredictCategory;
   entryPoint?: PredictEntryPoint;
+  scrollCoordinator?: ScrollCoordinator;
 }
 
 const MarketListContent: React.FC<MarketListContentProps> = ({
   category,
   q,
   entryPoint = PredictEventValues.ENTRY_POINT.PREDICT_FEED,
+  scrollCoordinator,
 }) => {
   const { styles } = useStyles(styleSheet, {});
   const tw = useTailwind();
@@ -45,6 +49,8 @@ const MarketListContent: React.FC<MarketListContentProps> = ({
 
   const listRef = useRef<FlashListRef<PredictMarketType>>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const scrollHandler = scrollCoordinator?.getScrollHandler(category);
 
   const renderItem = useCallback(
     ({ item, index }: { item: PredictMarketType; index: number }) => (
@@ -162,6 +168,33 @@ const MarketListContent: React.FC<MarketListContentProps> = ({
           No {category} markets available
         </Text>
       </Box>
+    );
+  }
+
+  if (scrollCoordinator && scrollHandler) {
+    const AnimatedFlashList = Animated.createAnimatedComponent(
+      FlashList<PredictMarketType>,
+    );
+
+    return (
+      <AnimatedFlashList
+        ref={listRef}
+        data={marketData}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        onEndReached={handleEndReached}
+        onEndReachedThreshold={0.7}
+        ListFooterComponent={renderFooter}
+        onScroll={scrollHandler as never}
+        scrollEventThrottle={16}
+        refreshControl={
+          <RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} />
+        }
+        contentContainerStyle={tw.style('pb-5')}
+        showsVerticalScrollIndicator={false}
+        removeClippedSubviews
+        getItemType={() => 'market'}
+      />
     );
   }
 

--- a/app/components/UI/Predict/components/PredictBalance/PredictBalance.tsx
+++ b/app/components/UI/Predict/components/PredictBalance/PredictBalance.tsx
@@ -34,7 +34,11 @@ import { PredictDepositStatus } from '../../types';
 import { formatPrice } from '../../utils/format';
 
 // This is a temporary component that will be removed when the deposit flow is fully implemented
-const PredictBalance: React.FC = () => {
+interface PredictBalanceProps {
+  onLayout?: (height: number) => void;
+}
+
+const PredictBalance: React.FC<PredictBalanceProps> = ({ onLayout }) => {
   const tw = useTailwind();
 
   const { balance, isLoading, loadBalance } = usePredictBalance({
@@ -109,6 +113,10 @@ const PredictBalance: React.FC = () => {
           isAddingFunds ? 'rounded-t-none' : 'rounded-t-xl',
         )}
         testID="predict-balance-card"
+        onLayout={(event) => {
+          const { height } = event.nativeEvent.layout;
+          onLayout?.(height);
+        }}
       >
         <Box
           flexDirection={BoxFlexDirection.Row}

--- a/app/components/UI/Predict/components/PredictFeedHeader/PredictFeedHeader.tsx
+++ b/app/components/UI/Predict/components/PredictFeedHeader/PredictFeedHeader.tsx
@@ -55,6 +55,7 @@ const PredictFeedHeader: React.FC<PredictFeedHeaderProps> = ({
           alignItems={BoxAlignItems.Center}
           justifyContent={BoxJustifyContent.Between}
           twClassName="w-full py-2"
+          style={{ backgroundColor: colors.background.default }}
         >
           <Box
             flexDirection={BoxFlexDirection.Row}

--- a/app/components/UI/Predict/components/PredictMarketList/PredictMarketList.tsx
+++ b/app/components/UI/Predict/components/PredictMarketList/PredictMarketList.tsx
@@ -1,24 +1,47 @@
 import { Box } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import ScrollableTabView from '@tommasini/react-native-scrollable-tab-view';
-import React from 'react';
+import React, { useCallback } from 'react';
 import { View } from 'react-native';
 import { PredictMarketListSelectorsIDs } from '../../../../../../e2e/selectors/Predict/Predict.selectors';
 import { strings } from '../../../../../../locales/i18n';
 import TabBar from '../../../../Base/TabBar';
 import { PredictEventValues } from '../../constants/eventNames';
 import MarketListContent from '../MarketListContent';
+import { PredictCategory } from '../../types';
+import { ScrollCoordinator } from '../../types/scrollCoordinator';
 
 interface PredictMarketListProps {
   isSearchVisible: boolean;
   searchQuery: string;
+  scrollCoordinator?: ScrollCoordinator;
 }
 
 const PredictMarketList: React.FC<PredictMarketListProps> = ({
   isSearchVisible,
   searchQuery,
+  scrollCoordinator,
 }) => {
   const tw = useTailwind();
+
+  const handleTabChange = useCallback(
+    (changeInfo: { i: number; ref: unknown; from?: number }) => {
+      if (!scrollCoordinator) return;
+
+      const categories: PredictCategory[] = [
+        'trending',
+        'new',
+        'sports',
+        'crypto',
+        'politics',
+      ];
+      const category = categories[changeInfo.i];
+      if (category) {
+        scrollCoordinator.setCurrentCategory(category);
+      }
+    },
+    [scrollCoordinator],
+  );
 
   return (
     <>
@@ -46,6 +69,7 @@ const PredictMarketList: React.FC<PredictMarketListProps> = ({
             )}
             style={tw.style('flex-1 w-full')}
             initialPage={0}
+            onChangeTab={handleTabChange}
           >
             <View
               key="trending"
@@ -53,7 +77,10 @@ const PredictMarketList: React.FC<PredictMarketListProps> = ({
               style={tw.style('flex-1 pt-4 w-full')}
               testID={PredictMarketListSelectorsIDs.TRENDING_TAB}
             >
-              <MarketListContent category="trending" />
+              <MarketListContent
+                category="trending"
+                scrollCoordinator={scrollCoordinator}
+              />
             </View>
 
             <View
@@ -62,7 +89,10 @@ const PredictMarketList: React.FC<PredictMarketListProps> = ({
               style={tw.style('flex-1 pt-4 w-full')}
               testID={PredictMarketListSelectorsIDs.NEW_TAB}
             >
-              <MarketListContent category="new" />
+              <MarketListContent
+                category="new"
+                scrollCoordinator={scrollCoordinator}
+              />
             </View>
 
             <View
@@ -71,7 +101,10 @@ const PredictMarketList: React.FC<PredictMarketListProps> = ({
               style={tw.style('flex-1 pt-4 w-full')}
               testID={PredictMarketListSelectorsIDs.SPORTS_TAB}
             >
-              <MarketListContent category="sports" />
+              <MarketListContent
+                category="sports"
+                scrollCoordinator={scrollCoordinator}
+              />
             </View>
 
             <View
@@ -80,7 +113,10 @@ const PredictMarketList: React.FC<PredictMarketListProps> = ({
               style={tw.style('flex-1 pt-4 w-full')}
               testID={PredictMarketListSelectorsIDs.CRYPTO_TAB}
             >
-              <MarketListContent category="crypto" />
+              <MarketListContent
+                category="crypto"
+                scrollCoordinator={scrollCoordinator}
+              />
             </View>
 
             <View
@@ -89,7 +125,10 @@ const PredictMarketList: React.FC<PredictMarketListProps> = ({
               style={tw.style('flex-1 pt-4 w-full')}
               testID={PredictMarketListSelectorsIDs.POLITICS_TAB}
             >
-              <MarketListContent category="politics" />
+              <MarketListContent
+                category="politics"
+                scrollCoordinator={scrollCoordinator}
+              />
             </View>
           </ScrollableTabView>
         </Box>

--- a/app/components/UI/Predict/components/PredictMarketList/PredictMarketList.tsx
+++ b/app/components/UI/Predict/components/PredictMarketList/PredictMarketList.tsx
@@ -47,8 +47,10 @@ const PredictMarketList: React.FC<PredictMarketListProps> = ({
     if (!scrollCoordinator) {
       return {};
     }
+    const offset = scrollCoordinator.balanceCardOffset.value;
     return {
-      transform: [{ translateY: scrollCoordinator.balanceCardOffset.value }],
+      transform: [{ translateY: offset }],
+      marginBottom: offset,
     };
   }, [scrollCoordinator]);
 

--- a/app/components/UI/Predict/components/PredictMarketList/PredictMarketList.tsx
+++ b/app/components/UI/Predict/components/PredictMarketList/PredictMarketList.tsx
@@ -1,8 +1,8 @@
-import { Box } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import ScrollableTabView from '@tommasini/react-native-scrollable-tab-view';
 import React, { useCallback } from 'react';
 import { View } from 'react-native';
+import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 import { PredictMarketListSelectorsIDs } from '../../../../../../e2e/selectors/Predict/Predict.selectors';
 import { strings } from '../../../../../../locales/i18n';
 import TabBar from '../../../../Base/TabBar';
@@ -43,6 +43,15 @@ const PredictMarketList: React.FC<PredictMarketListProps> = ({
     [scrollCoordinator],
   );
 
+  const tabsAnimatedStyle = useAnimatedStyle(() => {
+    if (!scrollCoordinator) {
+      return {};
+    }
+    return {
+      transform: [{ translateY: scrollCoordinator.balanceCardOffset.value }],
+    };
+  }, [scrollCoordinator]);
+
   return (
     <>
       {isSearchVisible && searchQuery.length > 0 && (
@@ -62,7 +71,7 @@ const PredictMarketList: React.FC<PredictMarketListProps> = ({
       )}
 
       {!isSearchVisible && (
-        <Box style={tw.style('flex-1 w-full')}>
+        <Animated.View style={[tw.style('flex-1 w-full'), tabsAnimatedStyle]}>
           <ScrollableTabView
             renderTabBar={() => (
               <TabBar textStyle={tw.style('text-base font-bold')} />
@@ -131,7 +140,7 @@ const PredictMarketList: React.FC<PredictMarketListProps> = ({
               />
             </View>
           </ScrollableTabView>
-        </Box>
+        </Animated.View>
       )}
     </>
   );

--- a/app/components/UI/Predict/components/PredictMarketList/PredictMarketList.tsx
+++ b/app/components/UI/Predict/components/PredictMarketList/PredictMarketList.tsx
@@ -62,7 +62,7 @@ const PredictMarketList: React.FC<PredictMarketListProps> = ({
           style={tw.style('flex-1 w-full')}
           initialPage={0}
         >
-          <View key="search" style={tw.style('flex-1 pt-4 w-full')}>
+          <View key="search" style={tw.style('flex-1 w-full')}>
             <MarketListContent
               category="trending"
               q={searchQuery}
@@ -85,7 +85,7 @@ const PredictMarketList: React.FC<PredictMarketListProps> = ({
             <View
               key="trending"
               {...{ tabLabel: strings('predict.category.trending') }}
-              style={tw.style('flex-1 pt-4 w-full')}
+              style={tw.style('flex-1 w-full')}
               testID={PredictMarketListSelectorsIDs.TRENDING_TAB}
             >
               <MarketListContent
@@ -97,7 +97,7 @@ const PredictMarketList: React.FC<PredictMarketListProps> = ({
             <View
               key="new"
               {...{ tabLabel: strings('predict.category.new') }}
-              style={tw.style('flex-1 pt-4 w-full')}
+              style={tw.style('flex-1 w-full')}
               testID={PredictMarketListSelectorsIDs.NEW_TAB}
             >
               <MarketListContent
@@ -109,7 +109,7 @@ const PredictMarketList: React.FC<PredictMarketListProps> = ({
             <View
               key="sports"
               {...{ tabLabel: strings('predict.category.sports') }}
-              style={tw.style('flex-1 pt-4 w-full')}
+              style={tw.style('flex-1 w-full')}
               testID={PredictMarketListSelectorsIDs.SPORTS_TAB}
             >
               <MarketListContent
@@ -121,7 +121,7 @@ const PredictMarketList: React.FC<PredictMarketListProps> = ({
             <View
               key="crypto"
               {...{ tabLabel: strings('predict.category.crypto') }}
-              style={tw.style('flex-1 pt-4 w-full')}
+              style={tw.style('flex-1 w-full')}
               testID={PredictMarketListSelectorsIDs.CRYPTO_TAB}
             >
               <MarketListContent
@@ -133,7 +133,7 @@ const PredictMarketList: React.FC<PredictMarketListProps> = ({
             <View
               key="politics"
               {...{ tabLabel: strings('predict.category.politics') }}
-              style={tw.style('flex-1 pt-4 w-full')}
+              style={tw.style('flex-1 w-full')}
               testID={PredictMarketListSelectorsIDs.POLITICS_TAB}
             >
               <MarketListContent

--- a/app/components/UI/Predict/hooks/useSharedScrollCoordinator.test.ts
+++ b/app/components/UI/Predict/hooks/useSharedScrollCoordinator.test.ts
@@ -1,0 +1,250 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useSharedScrollCoordinator } from './useSharedScrollCoordinator';
+import type { PredictCategory } from '../types';
+
+jest.mock('react-native-reanimated', () => {
+  const actualReanimated = jest.requireActual('react-native-reanimated/mock');
+  return {
+    ...actualReanimated,
+    useSharedValue: jest.fn((initialValue) => ({ value: initialValue })),
+    useAnimatedScrollHandler: jest.fn((handlers) => handlers),
+    runOnJS: jest.fn((fn) => fn),
+  };
+});
+
+describe('useSharedScrollCoordinator', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('initialization', () => {
+    it('initializes with default values', () => {
+      const { result } = renderHook(() => useSharedScrollCoordinator());
+
+      expect(result.current.balanceCardOffset).toBeDefined();
+      expect(result.current.balanceCardHeight).toBeDefined();
+      expect(result.current.balanceCardOffset.value).toBe(0);
+      expect(result.current.balanceCardHeight.value).toBe(0);
+    });
+
+    it('provides all required methods', () => {
+      const { result } = renderHook(() => useSharedScrollCoordinator());
+
+      expect(typeof result.current.setBalanceCardHeight).toBe('function');
+      expect(typeof result.current.setCurrentCategory).toBe('function');
+      expect(typeof result.current.getTabScrollPosition).toBe('function');
+      expect(typeof result.current.setTabScrollPosition).toBe('function');
+      expect(typeof result.current.getScrollHandler).toBe('function');
+      expect(typeof result.current.isBalanceCardHidden).toBe('function');
+      expect(typeof result.current.updateBalanceCardHiddenState).toBe(
+        'function',
+      );
+    });
+  });
+
+  describe('setBalanceCardHeight', () => {
+    it('updates balance card height', () => {
+      const { result } = renderHook(() => useSharedScrollCoordinator());
+
+      act(() => {
+        result.current.setBalanceCardHeight(150);
+      });
+
+      expect(result.current.balanceCardHeight.value).toBe(150);
+    });
+
+    it('updates with different height values', () => {
+      const { result } = renderHook(() => useSharedScrollCoordinator());
+
+      act(() => {
+        result.current.setBalanceCardHeight(200);
+      });
+      expect(result.current.balanceCardHeight.value).toBe(200);
+
+      act(() => {
+        result.current.setBalanceCardHeight(100);
+      });
+      expect(result.current.balanceCardHeight.value).toBe(100);
+    });
+  });
+
+  describe('tab scroll position management', () => {
+    it('returns 0 for uninitialized tab position', () => {
+      const { result } = renderHook(() => useSharedScrollCoordinator());
+
+      const position = result.current.getTabScrollPosition('trending');
+
+      expect(position).toBe(0);
+    });
+
+    it('stores and retrieves tab scroll position', () => {
+      const { result } = renderHook(() => useSharedScrollCoordinator());
+
+      act(() => {
+        result.current.setTabScrollPosition('trending', 100);
+      });
+
+      const position = result.current.getTabScrollPosition('trending');
+      expect(position).toBe(100);
+    });
+
+    it('manages independent positions for different tabs', () => {
+      const { result } = renderHook(() => useSharedScrollCoordinator());
+
+      act(() => {
+        result.current.setTabScrollPosition('trending', 50);
+        result.current.setTabScrollPosition('new', 100);
+        result.current.setTabScrollPosition('sports', 150);
+      });
+
+      expect(result.current.getTabScrollPosition('trending')).toBe(50);
+      expect(result.current.getTabScrollPosition('new')).toBe(100);
+      expect(result.current.getTabScrollPosition('sports')).toBe(150);
+    });
+
+    it('updates existing tab position', () => {
+      const { result } = renderHook(() => useSharedScrollCoordinator());
+
+      act(() => {
+        result.current.setTabScrollPosition('crypto', 200);
+      });
+      expect(result.current.getTabScrollPosition('crypto')).toBe(200);
+
+      act(() => {
+        result.current.setTabScrollPosition('crypto', 300);
+      });
+      expect(result.current.getTabScrollPosition('crypto')).toBe(300);
+    });
+  });
+
+  describe('getScrollHandler', () => {
+    it('returns scroll handler for each category', () => {
+      const { result } = renderHook(() => useSharedScrollCoordinator());
+
+      const trendingHandler = result.current.getScrollHandler('trending');
+      const newHandler = result.current.getScrollHandler('new');
+      const sportsHandler = result.current.getScrollHandler('sports');
+      const cryptoHandler = result.current.getScrollHandler('crypto');
+      const politicsHandler = result.current.getScrollHandler('politics');
+
+      expect(trendingHandler).toBeDefined();
+      expect(newHandler).toBeDefined();
+      expect(sportsHandler).toBeDefined();
+      expect(cryptoHandler).toBeDefined();
+      expect(politicsHandler).toBeDefined();
+    });
+
+    it('returns trending handler for unknown category', () => {
+      const { result } = renderHook(() => useSharedScrollCoordinator());
+
+      const unknownHandler = result.current.getScrollHandler(
+        'unknown' as PredictCategory,
+      );
+      const trendingHandler = result.current.getScrollHandler('trending');
+
+      expect(unknownHandler).toBe(trendingHandler);
+    });
+
+    it('returns consistent handler for same category', () => {
+      const { result } = renderHook(() => useSharedScrollCoordinator());
+
+      const handler1 = result.current.getScrollHandler('new');
+      const handler2 = result.current.getScrollHandler('new');
+
+      expect(handler1).toBe(handler2);
+    });
+  });
+
+  describe('setCurrentCategory', () => {
+    it('does not throw error when called', () => {
+      const { result } = renderHook(() => useSharedScrollCoordinator());
+
+      expect(() => {
+        act(() => {
+          result.current.setCurrentCategory('trending');
+        });
+      }).not.toThrow();
+    });
+
+    it('handles all valid categories', () => {
+      const { result } = renderHook(() => useSharedScrollCoordinator());
+      const categories = [
+        'trending',
+        'new',
+        'sports',
+        'crypto',
+        'politics',
+      ] as const;
+
+      categories.forEach((category) => {
+        expect(() => {
+          act(() => {
+            result.current.setCurrentCategory(category);
+          });
+        }).not.toThrow();
+      });
+    });
+  });
+
+  describe('isBalanceCardHidden', () => {
+    it('returns false initially', () => {
+      const { result } = renderHook(() => useSharedScrollCoordinator());
+
+      expect(result.current.isBalanceCardHidden()).toBe(false);
+    });
+
+    it('returns boolean value', () => {
+      const { result } = renderHook(() => useSharedScrollCoordinator());
+
+      const hidden = result.current.isBalanceCardHidden();
+
+      expect(typeof hidden).toBe('boolean');
+    });
+  });
+
+  describe('updateBalanceCardHiddenState', () => {
+    it('does not throw error when called', () => {
+      const { result } = renderHook(() => useSharedScrollCoordinator());
+
+      expect(() => {
+        act(() => {
+          result.current.updateBalanceCardHiddenState(true);
+        });
+      }).not.toThrow();
+
+      expect(() => {
+        act(() => {
+          result.current.updateBalanceCardHiddenState(false);
+        });
+      }).not.toThrow();
+    });
+  });
+
+  describe('hook stability', () => {
+    it('maintains function references across renders', () => {
+      const { result, rerender } = renderHook(() =>
+        useSharedScrollCoordinator(),
+      );
+
+      const initialGetPosition = result.current.getTabScrollPosition;
+      const initialSetPosition = result.current.setTabScrollPosition;
+      const initialGetHandler = result.current.getScrollHandler;
+
+      rerender();
+
+      expect(result.current.getTabScrollPosition).toBe(initialGetPosition);
+      expect(result.current.setTabScrollPosition).toBe(initialSetPosition);
+      expect(result.current.getScrollHandler).toBe(initialGetHandler);
+    });
+
+    it('provides consistent API across multiple renders', () => {
+      const { result, rerender } = renderHook(() =>
+        useSharedScrollCoordinator(),
+      );
+
+      expect(typeof result.current.setBalanceCardHeight).toBe('function');
+      rerender();
+      expect(typeof result.current.setBalanceCardHeight).toBe('function');
+    });
+  });
+});

--- a/app/components/UI/Predict/hooks/useSharedScrollCoordinator.ts
+++ b/app/components/UI/Predict/hooks/useSharedScrollCoordinator.ts
@@ -1,0 +1,145 @@
+import { useRef, useCallback } from 'react';
+import {
+  useSharedValue,
+  runOnJS,
+  useAnimatedScrollHandler,
+} from 'react-native-reanimated';
+import { PredictCategory } from '../types';
+
+export const useSharedScrollCoordinator = () => {
+  const balanceCardOffset = useSharedValue(0);
+  const balanceCardHeightRef = useRef(0);
+  const tabScrollPositionsRef = useRef<Map<PredictCategory, number>>(new Map());
+
+  const setBalanceCardHeight = useCallback((height: number) => {
+    balanceCardHeightRef.current = height;
+  }, []);
+
+  const setCurrentCategory = useCallback((_category: PredictCategory) => {
+    // No-op for now, can be used for future enhancements
+  }, []);
+
+  const getTabScrollPosition = useCallback(
+    (category: PredictCategory): number =>
+      tabScrollPositionsRef.current.get(category) || 0,
+    [],
+  );
+
+  const setTabScrollPosition = useCallback(
+    (category: PredictCategory, position: number) => {
+      tabScrollPositionsRef.current.set(category, position);
+    },
+    [],
+  );
+
+  const updateBalanceCardVisibility = useCallback((_hidden: boolean) => {
+    // No-op for now, can be used for future enhancements
+  }, []);
+
+  const trendingScrollHandler = useAnimatedScrollHandler({
+    onScroll: (event) => {
+      const scrollY = event.contentOffset.y;
+      const balanceCardHeight = balanceCardHeightRef.current;
+
+      if (balanceCardHeight > 0) {
+        const newOffset = Math.max(-balanceCardHeight, Math.min(0, -scrollY));
+        balanceCardOffset.value = newOffset;
+      }
+
+      runOnJS(setTabScrollPosition)('trending', Math.max(0, scrollY));
+    },
+  });
+
+  const newScrollHandler = useAnimatedScrollHandler({
+    onScroll: (event) => {
+      const scrollY = event.contentOffset.y;
+      const balanceCardHeight = balanceCardHeightRef.current;
+
+      if (balanceCardHeight > 0) {
+        const newOffset = Math.max(-balanceCardHeight, Math.min(0, -scrollY));
+        balanceCardOffset.value = newOffset;
+      }
+
+      runOnJS(setTabScrollPosition)('new', Math.max(0, scrollY));
+    },
+  });
+
+  const sportsScrollHandler = useAnimatedScrollHandler({
+    onScroll: (event) => {
+      const scrollY = event.contentOffset.y;
+      const balanceCardHeight = balanceCardHeightRef.current;
+
+      if (balanceCardHeight > 0) {
+        const newOffset = Math.max(-balanceCardHeight, Math.min(0, -scrollY));
+        balanceCardOffset.value = newOffset;
+      }
+
+      runOnJS(setTabScrollPosition)('sports', Math.max(0, scrollY));
+    },
+  });
+
+  const cryptoScrollHandler = useAnimatedScrollHandler({
+    onScroll: (event) => {
+      const scrollY = event.contentOffset.y;
+      const balanceCardHeight = balanceCardHeightRef.current;
+
+      if (balanceCardHeight > 0) {
+        const newOffset = Math.max(-balanceCardHeight, Math.min(0, -scrollY));
+        balanceCardOffset.value = newOffset;
+      }
+
+      runOnJS(setTabScrollPosition)('crypto', Math.max(0, scrollY));
+    },
+  });
+
+  const politicsScrollHandler = useAnimatedScrollHandler({
+    onScroll: (event) => {
+      const scrollY = event.contentOffset.y;
+      const balanceCardHeight = balanceCardHeightRef.current;
+
+      if (balanceCardHeight > 0) {
+        const newOffset = Math.max(-balanceCardHeight, Math.min(0, -scrollY));
+        balanceCardOffset.value = newOffset;
+      }
+
+      runOnJS(setTabScrollPosition)('politics', Math.max(0, scrollY));
+    },
+  });
+
+  const getScrollHandler = useCallback(
+    (category: PredictCategory) => {
+      switch (category) {
+        case 'trending':
+          return trendingScrollHandler;
+        case 'new':
+          return newScrollHandler;
+        case 'sports':
+          return sportsScrollHandler;
+        case 'crypto':
+          return cryptoScrollHandler;
+        case 'politics':
+          return politicsScrollHandler;
+        default:
+          return trendingScrollHandler;
+      }
+    },
+    [
+      trendingScrollHandler,
+      newScrollHandler,
+      sportsScrollHandler,
+      cryptoScrollHandler,
+      politicsScrollHandler,
+    ],
+  );
+
+  return {
+    balanceCardOffset,
+    setBalanceCardHeight,
+    setCurrentCategory,
+    getTabScrollPosition,
+    setTabScrollPosition,
+    getScrollHandler,
+    isBalanceCardHidden: () => false,
+    updateBalanceCardHiddenState: updateBalanceCardVisibility,
+  };
+};

--- a/app/components/UI/Predict/hooks/useSharedScrollCoordinator.ts
+++ b/app/components/UI/Predict/hooks/useSharedScrollCoordinator.ts
@@ -8,12 +8,17 @@ import { PredictCategory } from '../types';
 
 export const useSharedScrollCoordinator = () => {
   const balanceCardOffset = useSharedValue(0);
+  const balanceCardHeight = useSharedValue(0);
   const balanceCardHeightRef = useRef(0);
   const tabScrollPositionsRef = useRef<Map<PredictCategory, number>>(new Map());
 
-  const setBalanceCardHeight = useCallback((height: number) => {
-    balanceCardHeightRef.current = height;
-  }, []);
+  const setBalanceCardHeight = useCallback(
+    (height: number) => {
+      balanceCardHeightRef.current = height;
+      balanceCardHeight.value = height;
+    },
+    [balanceCardHeight],
+  );
 
   const setCurrentCategory = useCallback((_category: PredictCategory) => {
     // No-op for now, can be used for future enhancements
@@ -39,10 +44,10 @@ export const useSharedScrollCoordinator = () => {
   const trendingScrollHandler = useAnimatedScrollHandler({
     onScroll: (event) => {
       const scrollY = event.contentOffset.y;
-      const balanceCardHeight = balanceCardHeightRef.current;
+      const cardHeight = balanceCardHeightRef.current;
 
-      if (balanceCardHeight > 0) {
-        const newOffset = Math.max(-balanceCardHeight, Math.min(0, -scrollY));
+      if (cardHeight > 0) {
+        const newOffset = Math.max(-cardHeight, Math.min(0, -scrollY));
         balanceCardOffset.value = newOffset;
       }
 
@@ -53,10 +58,10 @@ export const useSharedScrollCoordinator = () => {
   const newScrollHandler = useAnimatedScrollHandler({
     onScroll: (event) => {
       const scrollY = event.contentOffset.y;
-      const balanceCardHeight = balanceCardHeightRef.current;
+      const cardHeight = balanceCardHeightRef.current;
 
-      if (balanceCardHeight > 0) {
-        const newOffset = Math.max(-balanceCardHeight, Math.min(0, -scrollY));
+      if (cardHeight > 0) {
+        const newOffset = Math.max(-cardHeight, Math.min(0, -scrollY));
         balanceCardOffset.value = newOffset;
       }
 
@@ -67,10 +72,10 @@ export const useSharedScrollCoordinator = () => {
   const sportsScrollHandler = useAnimatedScrollHandler({
     onScroll: (event) => {
       const scrollY = event.contentOffset.y;
-      const balanceCardHeight = balanceCardHeightRef.current;
+      const cardHeight = balanceCardHeightRef.current;
 
-      if (balanceCardHeight > 0) {
-        const newOffset = Math.max(-balanceCardHeight, Math.min(0, -scrollY));
+      if (cardHeight > 0) {
+        const newOffset = Math.max(-cardHeight, Math.min(0, -scrollY));
         balanceCardOffset.value = newOffset;
       }
 
@@ -81,10 +86,10 @@ export const useSharedScrollCoordinator = () => {
   const cryptoScrollHandler = useAnimatedScrollHandler({
     onScroll: (event) => {
       const scrollY = event.contentOffset.y;
-      const balanceCardHeight = balanceCardHeightRef.current;
+      const cardHeight = balanceCardHeightRef.current;
 
-      if (balanceCardHeight > 0) {
-        const newOffset = Math.max(-balanceCardHeight, Math.min(0, -scrollY));
+      if (cardHeight > 0) {
+        const newOffset = Math.max(-cardHeight, Math.min(0, -scrollY));
         balanceCardOffset.value = newOffset;
       }
 
@@ -95,10 +100,10 @@ export const useSharedScrollCoordinator = () => {
   const politicsScrollHandler = useAnimatedScrollHandler({
     onScroll: (event) => {
       const scrollY = event.contentOffset.y;
-      const balanceCardHeight = balanceCardHeightRef.current;
+      const cardHeight = balanceCardHeightRef.current;
 
-      if (balanceCardHeight > 0) {
-        const newOffset = Math.max(-balanceCardHeight, Math.min(0, -scrollY));
+      if (cardHeight > 0) {
+        const newOffset = Math.max(-cardHeight, Math.min(0, -scrollY));
         balanceCardOffset.value = newOffset;
       }
 
@@ -134,6 +139,7 @@ export const useSharedScrollCoordinator = () => {
 
   return {
     balanceCardOffset,
+    balanceCardHeight,
     setBalanceCardHeight,
     setCurrentCategory,
     getTabScrollPosition,

--- a/app/components/UI/Predict/types/scrollCoordinator.ts
+++ b/app/components/UI/Predict/types/scrollCoordinator.ts
@@ -3,6 +3,7 @@ import { PredictCategory } from './index';
 
 export interface ScrollCoordinator {
   balanceCardOffset: SharedValue<number>;
+  balanceCardHeight: SharedValue<number>;
   setBalanceCardHeight: (height: number) => void;
   setCurrentCategory: (category: PredictCategory) => void;
   getTabScrollPosition: (category: PredictCategory) => number;

--- a/app/components/UI/Predict/types/scrollCoordinator.ts
+++ b/app/components/UI/Predict/types/scrollCoordinator.ts
@@ -1,0 +1,13 @@
+import { SharedValue } from 'react-native-reanimated';
+import { PredictCategory } from './index';
+
+export interface ScrollCoordinator {
+  balanceCardOffset: SharedValue<number>;
+  setBalanceCardHeight: (height: number) => void;
+  setCurrentCategory: (category: PredictCategory) => void;
+  getTabScrollPosition: (category: PredictCategory) => number;
+  setTabScrollPosition: (category: PredictCategory, position: number) => void;
+  getScrollHandler: (category: PredictCategory) => unknown;
+  isBalanceCardHidden: () => boolean;
+  updateBalanceCardHiddenState: (hidden: boolean) => void;
+}

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.test.tsx
@@ -27,8 +27,8 @@ jest.mock('../../components/PredictFeedHeader', () => {
 jest.mock('../../components/PredictBalance', () => {
   const { View, Text } = jest.requireActual('react-native');
   return {
-    PredictBalance: jest.fn(() => (
-      <View testID="predict-balance-mock">
+    PredictBalance: jest.fn(({ onLayout }) => (
+      <View testID="predict-balance-mock" onLayout={() => onLayout?.(100)}>
         <Text>Balance Component</Text>
       </View>
     )),
@@ -66,6 +66,36 @@ jest.mock('../../../../../util/theme', () => ({
       },
     },
   }),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: jest.requireActual('react-native').View,
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('react-native-reanimated', () => {
+  const View = jest.requireActual('react-native').View;
+  return {
+    default: {
+      View,
+    },
+    useAnimatedStyle: jest.fn(() => ({})),
+    useSharedValue: jest.fn((val) => ({ value: val })),
+  };
+});
+
+jest.mock('../../hooks/useSharedScrollCoordinator', () => ({
+  useSharedScrollCoordinator: jest.fn(() => ({
+    balanceCardOffset: { value: 0 },
+    balanceCardHeight: { value: 0 },
+    setBalanceCardHeight: jest.fn(),
+    setCurrentCategory: jest.fn(),
+    getTabScrollPosition: jest.fn(() => 0),
+    setTabScrollPosition: jest.fn(),
+    getScrollHandler: jest.fn(),
+    isBalanceCardHidden: jest.fn(() => false),
+    updateBalanceCardHiddenState: jest.fn(),
+  })),
 }));
 
 describe('PredictFeed', () => {

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
@@ -1,6 +1,10 @@
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React, { useState } from 'react';
-import { SafeAreaView, View } from 'react-native';
+import { View } from 'react-native';
+import {
+  SafeAreaView,
+  useSafeAreaInsets,
+} from 'react-native-safe-area-context';
 import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 import { PredictMarketListSelectorsIDs } from '../../../../../../e2e/selectors/Predict/Predict.selectors';
 import { useTheme } from '../../../../../util/theme';
@@ -12,6 +16,7 @@ import { useSharedScrollCoordinator } from '../../hooks/useSharedScrollCoordinat
 const PredictFeed = () => {
   const tw = useTailwind();
   const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
   const [isSearchVisible, setIsSearchVisible] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
 
@@ -41,17 +46,26 @@ const PredictFeed = () => {
   return (
     <SafeAreaView
       testID={PredictMarketListSelectorsIDs.CONTAINER}
-      style={tw.style('flex-1', {
-        backgroundColor: colors.background.default,
-      })}
+      style={tw.style('flex-1', { backgroundColor: colors.background.default })}
+      edges={['left', 'right', 'bottom']}
     >
-      <View style={tw.style('flex-1 pt-2 px-6')}>
-        <PredictFeedHeader
-          isSearchVisible={isSearchVisible}
-          onSearchToggle={handleSearchToggle}
-          onSearchCancel={handleSearchCancel}
-          onSearch={handleSearch}
-        />
+      <View style={tw.style('flex-1 px-6')}>
+        <View
+          style={[
+            tw.style('z-10'),
+            {
+              backgroundColor: colors.background.default,
+              paddingTop: insets.top + 8,
+            },
+          ]}
+        >
+          <PredictFeedHeader
+            isSearchVisible={isSearchVisible}
+            onSearchToggle={handleSearchToggle}
+            onSearchCancel={handleSearchCancel}
+            onSearch={handleSearch}
+          />
+        </View>
         {!isSearchVisible && (
           <Animated.View style={balanceCardAnimatedStyle}>
             <PredictBalance onLayout={handleBalanceCardLayout} />

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
@@ -47,7 +47,7 @@ const PredictFeed = () => {
     <SafeAreaView
       testID={PredictMarketListSelectorsIDs.CONTAINER}
       style={tw.style('flex-1', { backgroundColor: colors.background.default })}
-      edges={['left', 'right', 'bottom']}
+      edges={['left', 'right']}
     >
       <View style={tw.style('flex-1 px-6')}>
         <View

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
@@ -1,17 +1,29 @@
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React, { useState } from 'react';
 import { SafeAreaView, View } from 'react-native';
+import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 import { PredictMarketListSelectorsIDs } from '../../../../../../e2e/selectors/Predict/Predict.selectors';
 import { useTheme } from '../../../../../util/theme';
 import { PredictBalance } from '../../components/PredictBalance';
 import PredictFeedHeader from '../../components/PredictFeedHeader';
 import PredictMarketList from '../../components/PredictMarketList';
+import { useSharedScrollCoordinator } from '../../hooks/useSharedScrollCoordinator';
 
 const PredictFeed = () => {
   const tw = useTailwind();
   const { colors } = useTheme();
   const [isSearchVisible, setIsSearchVisible] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
+
+  const scrollCoordinator = useSharedScrollCoordinator();
+
+  const handleBalanceCardLayout = (height: number) => {
+    scrollCoordinator.setBalanceCardHeight(height);
+  };
+
+  const balanceCardAnimatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: scrollCoordinator.balanceCardOffset.value }],
+  }));
 
   const handleSearchToggle = () => {
     setIsSearchVisible(true);
@@ -40,10 +52,15 @@ const PredictFeed = () => {
           onSearchCancel={handleSearchCancel}
           onSearch={handleSearch}
         />
-        {!isSearchVisible && <PredictBalance />}
+        {!isSearchVisible && (
+          <Animated.View style={balanceCardAnimatedStyle}>
+            <PredictBalance onLayout={handleBalanceCardLayout} />
+          </Animated.View>
+        )}
         <PredictMarketList
           isSearchVisible={isSearchVisible}
           searchQuery={searchQuery}
+          scrollCoordinator={scrollCoordinator}
         />
       </View>
     </SafeAreaView>

--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.tsx
@@ -26,9 +26,16 @@ const PredictFeed = () => {
     scrollCoordinator.setBalanceCardHeight(height);
   };
 
-  const balanceCardAnimatedStyle = useAnimatedStyle(() => ({
-    transform: [{ translateY: scrollCoordinator.balanceCardOffset.value }],
-  }));
+  const balanceCardAnimatedStyle = useAnimatedStyle(() => {
+    const offset = scrollCoordinator.balanceCardOffset.value;
+    const height = scrollCoordinator.balanceCardHeight.value;
+    const opacity = height > 0 ? Math.max(0, 1 + offset / height) : 1;
+
+    return {
+      transform: [{ translateY: offset }],
+      opacity,
+    };
+  });
 
   const handleSearchToggle = () => {
     setIsSearchVisible(true);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Update scroll behavior in Predict feed, so the tabs stick to the top as we scroll down, as the balance card fades away.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/dd454cf9-7c67-47ec-a358-f9cc479bcf8a



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements a shared scroll coordinator to translate tabs and fade/slide the balance card on scroll, integrating animated handlers across feed, lists, and adding tests.
> 
> - **Predict Feed/UI**:
>   - Introduces `useSharedScrollCoordinator` to manage shared scroll state (`balanceCardOffset/Height`, per-tab positions) and expose scroll handlers.
>   - Animates balance card (translateY + opacity) and applies safe area padded header; passes coordinator to `PredictMarketList`.
> - **Market Lists**:
>   - `PredictMarketList`: Wraps tabs in `Animated.View` to follow `balanceCardOffset`; updates current category on tab change; passes `scrollCoordinator` to each `MarketListContent`.
>   - `MarketListContent`: Supports optional `scrollCoordinator`; uses `Animated` `FlashList` with `onScroll` handler when provided; adds top padding.
> - **Balance Card**:
>   - `PredictBalance`: Adds `onLayout` prop to report height to the coordinator.
> - **Types & Tests**:
>   - Adds `types/scrollCoordinator.ts` and `hooks/useSharedScrollCoordinator.ts` with unit tests.
>   - Updates `PredictFeed` tests/mocks for Reanimated and Safe Area.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f93568685ed3c254271315edab78cf3b098afcc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->