### PR TITLE
fix: predict deposit token amount

### DIFF
--- a/app/components/Views/confirmations/components/pay-token-amount/pay-token-amount.tsx
+++ b/app/components/Views/confirmations/components/pay-token-amount/pay-token-amount.tsx
@@ -11,6 +11,7 @@ import { useTokenFiatRates } from '../../hooks/tokens/useTokenFiatRates';
 import { Hex } from 'viem';
 import { useTransactionMetadataRequest } from '../../hooks/transactions/useTransactionMetadataRequest';
 import { Skeleton } from '../../../../../component-library/components/Skeleton';
+import { getTokenAddress } from '../../utils/transaction-pay';
 
 export interface PayTokenAmountProps {
   amountHuman: string;
@@ -18,13 +19,14 @@ export interface PayTokenAmountProps {
 
 export function PayTokenAmount({ amountHuman }: PayTokenAmountProps) {
   const { styles } = useStyles(styleSheet, {});
-  const { chainId, txParams } = useTransactionMetadataRequest() ?? {};
+  const transaction = useTransactionMetadataRequest();
+  const { chainId } = transaction ?? { chainId: '0x0' };
   const { payToken } = useTransactionPayToken();
-  const { to } = txParams ?? {};
+  const targetTokenAddress = getTokenAddress(transaction);
 
   const fiatRequests = useMemo(
     () =>
-      payToken && to
+      payToken && targetTokenAddress
         ? [
             {
               chainId: payToken.chainId,
@@ -32,11 +34,11 @@ export function PayTokenAmount({ amountHuman }: PayTokenAmountProps) {
             },
             {
               chainId: chainId as Hex,
-              address: to as Hex,
+              address: targetTokenAddress,
             },
           ]
         : [],
-    [chainId, payToken, to],
+    [chainId, payToken, targetTokenAddress],
   );
 
   const fiatRates = useTokenFiatRates(fiatRequests);

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -9,7 +9,7 @@ import {
 } from '@metamask/transaction-controller';
 import { useTransactionPayToken } from '../pay/useTransactionPayToken';
 import { useUpdateTokenAmount } from './useUpdateTokenAmount';
-import { getTokenTransferData } from '../../utils/transaction-pay';
+import { getTokenAddress } from '../../utils/transaction-pay';
 import { useParams } from '../../../../../util/navigation/navUtils';
 import { debounce } from 'lodash';
 import { useSelector } from 'react-redux';
@@ -162,16 +162,6 @@ function useMaxPercentage() {
 
     return 100 - bufferPercentage * 100;
   }, [chainId, featureFlags, payToken, requiredTokens]);
-}
-
-function getTokenAddress(transactionMeta: TransactionMeta | undefined): Hex {
-  const nestedCall = transactionMeta && getTokenTransferData(transactionMeta);
-
-  if (nestedCall) {
-    return nestedCall.to;
-  }
-
-  return transactionMeta?.txParams?.to as Hex;
 }
 
 function useTokenBalance() {

--- a/app/components/Views/confirmations/hooks/ui/useNavbar.ts
+++ b/app/components/Views/confirmations/hooks/ui/useNavbar.ts
@@ -47,7 +47,7 @@ export function useModalNavbar() {
   useEffect(() => {
     navigation.setOptions(
       getModalNavigationOptions({
-        onBack: onReject,
+        onBack: () => onReject(),
       }),
     );
   }, [navigation, onReject]);

--- a/app/components/Views/confirmations/utils/transaction-pay.test.ts
+++ b/app/components/Views/confirmations/utils/transaction-pay.test.ts
@@ -2,7 +2,11 @@ import {
   TransactionMeta,
   TransactionType,
 } from '@metamask/transaction-controller';
-import { getRequiredBalance, getTokenTransferData } from './transaction-pay';
+import {
+  getRequiredBalance,
+  getTokenAddress,
+  getTokenTransferData,
+} from './transaction-pay';
 import { PERPS_MINIMUM_DEPOSIT } from '../constants/perps';
 import { PREDICT_MINIMUM_DEPOSIT } from '../constants/predict';
 
@@ -87,6 +91,40 @@ describe('Transaction Pay Utils', () => {
         to: TO_MOCK,
         index: 1,
       });
+    });
+  });
+
+  describe('getTokenAddress', () => {
+    it('returns token address from nested token transfer', () => {
+      const transactionMeta = {
+        txParams: {
+          data: '0x1234',
+          to: '0x5678',
+        },
+        nestedTransactions: [
+          {
+            data: '0x123456',
+            to: '0x567890',
+          },
+          {
+            data: TOKEN_TRANSFER_DATA_MOCK,
+            to: TO_MOCK,
+          },
+        ],
+      } as unknown as TransactionMeta;
+
+      expect(getTokenAddress(transactionMeta)).toBe(TO_MOCK);
+    });
+
+    it('returns to param if no nested transfer', () => {
+      const transactionMeta = {
+        txParams: {
+          data: TOKEN_TRANSFER_DATA_MOCK,
+          to: TO_MOCK,
+        },
+      } as TransactionMeta;
+
+      expect(getTokenAddress(transactionMeta)).toBe(TO_MOCK);
     });
   });
 });

--- a/app/components/Views/confirmations/utils/transaction-pay.ts
+++ b/app/components/Views/confirmations/utils/transaction-pay.ts
@@ -59,3 +59,15 @@ export function getTokenTransferData(
 
   return undefined;
 }
+
+export function getTokenAddress(
+  transactionMeta: TransactionMeta | undefined,
+): Hex {
+  const nestedCall = transactionMeta && getTokenTransferData(transactionMeta);
+
+  if (nestedCall) {
+    return nestedCall.to;
+  }
+
+  return transactionMeta?.txParams?.to as Hex;
+}


### PR DESCRIPTION
## **Description**

Fix the token amount displayed in the Predict deposit confirmation.

Also prevent transaction failure when rejecting Predict claim transactions.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes token address resolution via getTokenAddress and updates amount/rate calculations to use it; adds tests and wraps modal navbar onBack.
> 
> - **Utils**
>   - Add `getTokenAddress` to `utils/transaction-pay.ts` to derive the target token from nested token transfers or `txParams.to`.
> - **Confirmations**
>   - `components/pay-token-amount/pay-token-amount.tsx`: Use `getTokenAddress(transaction)` and updated `fiatRequests` dependencies to fetch correct fiat rates.
>   - `hooks/transactions/useTransactionCustomAmount.ts`: Use shared `getTokenAddress` instead of local helper; remove duplicate logic.
> - **Tests**
>   - Extend `utils/transaction-pay.test.ts` to cover `getTokenAddress` and update imports.
> - **UI**
>   - `hooks/ui/useNavbar.ts`: Wrap `onReject` in `onBack` callback.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a93c9bc024ce40c3bda5f47450c0c6df53e116d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->