### PR TITLE
fix: Use account group address in `SnapUIAvatar` when applicable

### DIFF
--- a/app/components/Snaps/SnapUIAddressInput/SnapUIAddressInput.test.tsx
+++ b/app/components/Snaps/SnapUIAddressInput/SnapUIAddressInput.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react-native';
+import { fireEvent } from '@testing-library/react-native';
 import { SnapUIAddressInput } from './SnapUIAddressInput';
 import { useSnapInterfaceContext } from '../SnapInterfaceContext';
 import { useDisplayName } from '../SnapUIAddress/useDisplayName';
@@ -8,6 +8,28 @@ import { AvatarAccountType } from '../../../component-library/components/Avatars
 import { SNAP_UI_AVATAR_TEST_ID } from '../SnapUIAvatar/SnapUIAvatar';
 
 const mockInitialState = {
+  engine: {
+    backgroundState: {
+      KeyringController: {
+        keyrings: [],
+      },
+      RemoteFeatureFlagController: {
+        remoteFeatureFlags: {},
+      },
+      AccountsController: {
+        internalAccounts: {
+          accounts: {
+            foo: {
+              address: '0xab16a96D359eC26a11e2C2b3d8f8B8942d5Bfcdb',
+              metadata: {
+                name: 'My Account',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
   settings: {
     avatarAccountType: AvatarAccountType.Maskicon,
   },
@@ -39,8 +61,9 @@ describe('SnapUIAddressInput', () => {
   });
 
   it('will render', () => {
-    const { getByTestId } = render(
+    const { getByTestId } = renderWithProvider(
       <SnapUIAddressInput name="testAddress" chainId={testChainId} />,
+      { state: mockInitialState },
     );
 
     expect(getByTestId('testAddress-snap-address-input')).toBeTruthy();
@@ -169,6 +192,7 @@ describe('SnapUIAddressInput', () => {
         chainId="eip155:0"
         displayAvatar={false}
       />,
+      { state: mockInitialState },
     );
 
     expect(toJSON()).toMatchSnapshot();
@@ -220,6 +244,7 @@ describe('SnapUIAddressInput', () => {
 
     const { getByTestId, toJSON } = renderWithProvider(
       <SnapUIAddressInput name="testAddress" chainId={testChainId} disabled />,
+      { state: mockInitialState },
     );
 
     const input = getByTestId('testAddress-snap-address-input');

--- a/app/components/Snaps/SnapUIAvatar/SnapUIAvatar.tsx
+++ b/app/components/Snaps/SnapUIAvatar/SnapUIAvatar.tsx
@@ -1,9 +1,13 @@
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { CaipAccountId, parseCaipAccountId } from '@metamask/utils';
+import { isEvmAccountType } from '@metamask/keyring-api';
 import { selectAvatarAccountType } from '../../../selectors/settings';
 import AvatarAccount from '../../../component-library/components/Avatars/Avatar/variants/AvatarAccount';
 import { AvatarSize } from '../../../component-library/components/Avatars/Avatar';
+import { selectMultichainAccountsState2Enabled } from '../../../selectors/featureFlagController/multichainAccounts';
+import { selectAccountGroupsByAddress } from '../../../selectors/multichainAccounts/accounts';
+import { RootState } from '../../../reducers';
 
 export const DIAMETERS: Record<string, number> = {
   xs: 16,
@@ -21,19 +25,33 @@ export interface SnapUIAvatarProps {
 }
 
 export const SnapUIAvatar: React.FunctionComponent<SnapUIAvatarProps> = ({
-  address,
+  address: caipAddress,
   size = AvatarSize.Md,
 }) => {
-  const parsed = useMemo(
-    () => parseCaipAccountId(address as CaipAccountId),
-    [address],
+  const { address } = useMemo(
+    () => parseCaipAccountId(caipAddress as CaipAccountId),
+    [caipAddress],
   );
   const avatarAccountType = useSelector(selectAvatarAccountType);
+
+  const useAccountGroups = useSelector(selectMultichainAccountsState2Enabled);
+
+  const accountGroups = useSelector((state: RootState) =>
+    selectAccountGroupsByAddress(state, [address]),
+  );
+
+  const accountGroupAddress = accountGroups[0]?.accounts.find((account) =>
+    isEvmAccountType(account.type),
+  )?.address;
+
+  // Display the account group address if it exists as the default.
+  const displayAddress =
+    useAccountGroups && accountGroupAddress ? accountGroupAddress : caipAddress;
 
   return (
     <AvatarAccount
       type={avatarAccountType}
-      accountAddress={parsed.address}
+      accountAddress={displayAddress}
       size={size}
       testID={SNAP_UI_AVATAR_TEST_ID}
     />

--- a/app/components/Snaps/SnapUIAvatar/SnapUIAvatar.tsx
+++ b/app/components/Snaps/SnapUIAvatar/SnapUIAvatar.tsx
@@ -46,7 +46,7 @@ export const SnapUIAvatar: React.FunctionComponent<SnapUIAvatarProps> = ({
 
   // Display the account group address if it exists as the default.
   const displayAddress =
-    useAccountGroups && accountGroupAddress ? accountGroupAddress : caipAddress;
+    useAccountGroups && accountGroupAddress ? accountGroupAddress : address;
 
   return (
     <AvatarAccount


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adjusts `SnapUIAvatar` to use the account group address when it is available and the feature flag is enabled. If no address is found it falls back to the default behavior.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an issue where some avatars would be out of sync

## **Manual testing steps**

1. Initiate a Solana send
2. Notice that the account avatar on the confirmation matches the account list

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Uses account group address for `SnapUIAvatar` when the multichain accounts flag is enabled; updates address input tests to render with provider state.
> 
> - **Avatar rendering**
>   - `app/components/Snaps/SnapUIAvatar/SnapUIAvatar.tsx`
>     - Parse CAIP-10 `address` as `caipAddress` and derive `address` via `parseCaipAccountId`.
>     - Gate behavior behind `selectMultichainAccountsState2Enabled`.
>     - Lookup account group via `selectAccountGroupsByAddress`; pick first EVM account (`isEvmAccountType`).
>     - Use group `address` as `displayAddress` when available; fallback to parsed address.
>     - Pass `displayAddress` to `AvatarAccount`.
> - **Tests**
>   - `app/components/Snaps/SnapUIAddressInput/SnapUIAddressInput.test.tsx`
>     - Switch initial render to `renderWithProvider` and supply `mockInitialState` (including `engine.backgroundState` and accounts).
>     - Add state to several tests and minor adjustments to expectations/snapshots.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 143337da7f2ebea14c3adb3c56700062854cc2da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->