### PR TITLE
fix: redirect to blockexplorer from tx details

### DIFF
--- a/app/components/UI/MultichainTransactionDetailsModal/MultichainTransactionDetailsModal.test.tsx
+++ b/app/components/UI/MultichainTransactionDetailsModal/MultichainTransactionDetailsModal.test.tsx
@@ -1,9 +1,27 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { render, fireEvent, act } from '@testing-library/react-native';
 import { ParamListBase, NavigationProp } from '@react-navigation/native';
 import { Transaction, TransactionType } from '@metamask/keyring-api';
 import MultichainTransactionDetailsModal from './MultichainTransactionDetailsModal';
 import { MultichainTransactionDisplayData } from '../../hooks/useMultichainTransactionDisplay';
+
+// Mock react-native-modal to capture onModalHide callback
+let mockOnModalHide: (() => void) | undefined;
+jest.mock('react-native-modal', () => {
+  const MockModal = ({
+    children,
+    onModalHide,
+    ...props
+  }: {
+    children: React.ReactNode;
+    onModalHide?: () => void;
+    isVisible: boolean;
+  }) => {
+    mockOnModalHide = onModalHide;
+    return props.isVisible ? children : null;
+  };
+  return MockModal;
+});
 
 const mockUseTheme = jest.fn();
 jest.mock('../../../util/theme', () => ({
@@ -70,6 +88,7 @@ describe('MultichainTransactionDetailsModal', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockOnModalHide = undefined;
   });
 
   it('renders correctly a transaction', () => {
@@ -125,7 +144,7 @@ describe('MultichainTransactionDetailsModal', () => {
     expect(getByText('0.000001 SOL')).toBeTruthy();
   });
 
-  it('navigates to block explorer when view details is pressed', () => {
+  it('navigates to block explorer when view details is pressed', async () => {
     const { getByText } = render(
       <MultichainTransactionDetailsModal
         isVisible
@@ -137,16 +156,28 @@ describe('MultichainTransactionDetailsModal', () => {
     );
 
     const viewDetailsButton = getByText('networks.view_details');
-    fireEvent.press(viewDetailsButton);
+
+    await act(async () => {
+      fireEvent.press(viewDetailsButton);
+    });
 
     expect(mockOnClose).toHaveBeenCalledTimes(1);
+
+    // Navigation should not happen immediately
+    expect(mockNavigation.navigate).not.toHaveBeenCalled();
+
+    // Simulate modal hide event
+    await act(async () => {
+      mockOnModalHide?.();
+    });
+
     expect(mockNavigation.navigate).toHaveBeenCalledWith('Webview', {
       screen: 'SimpleWebview',
       params: { url: 'https://solscan.io/tx/123' },
     });
   });
 
-  it('navigates to address explorer when address link is pressed', () => {
+  it('navigates to address explorer when address link is pressed', async () => {
     const { getAllByText } = render(
       <MultichainTransactionDetailsModal
         isVisible
@@ -158,12 +189,43 @@ describe('MultichainTransactionDetailsModal', () => {
     );
 
     const fromAddressLinks = getAllByText('7RoSF9...zZNV');
-    fireEvent.press(fromAddressLinks[0]);
+
+    await act(async () => {
+      fireEvent.press(fromAddressLinks[0]);
+    });
 
     expect(mockOnClose).toHaveBeenCalledTimes(1);
+
+    // Navigation should not happen immediately
+    expect(mockNavigation.navigate).not.toHaveBeenCalled();
+
+    // Simulate modal hide event
+    await act(async () => {
+      mockOnModalHide?.();
+    });
+
     expect(mockNavigation.navigate).toHaveBeenCalledWith('Webview', {
       screen: 'SimpleWebview',
       params: { url: 'https://solscan.io/account/123' },
     });
+  });
+
+  it('does not navigate when modal closes without pressing any link', async () => {
+    render(
+      <MultichainTransactionDetailsModal
+        isVisible
+        onClose={mockOnClose}
+        transaction={mockTransaction}
+        displayData={mockDisplayData}
+        navigation={mockNavigation as unknown as NavigationProp<ParamListBase>}
+      />,
+    );
+
+    // Simulate modal hide event without pressing any buttons
+    await act(async () => {
+      mockOnModalHide?.();
+    });
+
+    expect(mockNavigation.navigate).not.toHaveBeenCalled();
   });
 });

--- a/app/components/UI/MultichainTransactionDetailsModal/MultichainTransactionDetailsModal.tsx
+++ b/app/components/UI/MultichainTransactionDetailsModal/MultichainTransactionDetailsModal.tsx
@@ -45,9 +45,22 @@ const MultichainTransactionDetailsModal: React.FC<TransactionDetailsProps> = ({
 }) => {
   const { colors, typography } = useTheme();
   const style = styles(colors, typography);
+  const [pendingNavigation, setPendingNavigation] = React.useState<
+    string | null
+  >(null);
 
   const { title, from, to, baseFee, priorityFee } = displayData;
   const { id, timestamp, chain, status } = transaction;
+
+  const handleModalHide = () => {
+    if (pendingNavigation) {
+      navigation.navigate('Webview', {
+        screen: 'SimpleWebview',
+        params: { url: pendingNavigation },
+      });
+      setPendingNavigation(null);
+    }
+  };
 
   const viewOnBlockExplorer = (label: string) => {
     let url = '';
@@ -66,11 +79,8 @@ const MultichainTransactionDetailsModal: React.FC<TransactionDetailsProps> = ({
     }
 
     try {
+      setPendingNavigation(url);
       onClose();
-      navigation.navigate('Webview', {
-        screen: 'SimpleWebview',
-        params: { url },
-      });
     } catch (e) {
       console.error(e, {
         message: `failed to open block explorer for ${chain}`,
@@ -117,6 +127,7 @@ const MultichainTransactionDetailsModal: React.FC<TransactionDetailsProps> = ({
     <Modal
       isVisible={isVisible}
       onBackdropPress={onClose}
+      onModalHide={handleModalHide}
       backdropOpacity={0.7}
       animationIn="slideInUp"
       animationOut="slideOutDown"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
There is an issue when trying to open transaction details on blockexplorers. Sometimes the whole app freezes.
This PR fixes the issue by making sure there is no race condtition. First the bottom sheet is closed and then the new window with blockexplorer is opened.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug that was causing app freeze on opening blockexplorer transaction details

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Show transaction details on blockexplorer

  Scenario: user checks SolScan transaction details
    Given user transacted on solana in the past

    When user opens Activity tab
    Then opens solana transaction details
    Then clicks "View details"
    Then bottom sheet is closed and blockexplorer opened correctly
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/c51eada8-d470-4547-8b79-24340e2b018e


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/a49bee14-303f-4cef-8b32-2a73a3d962f8


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Defers navigation to the block explorer until after the modal closes, and updates tests to validate deferred navigation behavior.
> 
> - **UI/Behavior**:
>   - Defer navigation by storing `pendingNavigation` and triggering `navigation.navigate` on `onModalHide` in `app/components/UI/MultichainTransactionDetailsModal/MultichainTransactionDetailsModal.tsx`.
>   - Move immediate navigation from `viewOnBlockExplorer` to modal hide flow; call `onClose()` first.
>   - Pass `onModalHide={handleModalHide}` to `react-native-modal`.
> - **Tests**:
>   - Mock `react-native-modal` to capture `onModalHide`; use `act` to simulate hide events.
>   - Update assertions to ensure navigation happens only after modal hide for both "view details" and address link.
>   - Add test ensuring no navigation occurs when the modal hides without any link pressed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4a55cff098bae71e5f545193603fa3528fdda14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->