### PR TITLE
feat: add feature flag to blacklist custom networks (used to hide Monad before launch)

### DIFF
--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.test.tsx
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.test.tsx
@@ -4,8 +4,25 @@ import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import CustomNetwork from './CustomNetwork';
 import { CustomNetworkProps } from './CustomNetwork.types';
 import { PopularList } from '../../../../../../util/networks/customNetworks';
+import { selectAdditionalNetworksBlacklistFeatureFlag } from '../../../../../../selectors/featureFlagController/networkBlacklist';
+import { toHex } from '@metamask/controller-utils';
 
-const getMockState = () => ({ engine: { backgroundState } });
+// Mock the blacklist selector
+jest.mock(
+  '../../../../../../selectors/featureFlagController/networkBlacklist',
+  () => ({
+    selectAdditionalNetworksBlacklistFeatureFlag: jest.fn(),
+  }),
+);
+
+const getMockState = (blacklistedChainIds: string[] = []) => {
+  // Set up the mock selector to return the blacklist
+  (selectAdditionalNetworksBlacklistFeatureFlag as jest.Mock).mockReturnValue(
+    blacklistedChainIds,
+  );
+
+  return { engine: { backgroundState } };
+};
 
 jest.mock('@react-navigation/native', () => {
   const actualNav = jest.requireActual('@react-navigation/native');
@@ -66,5 +83,35 @@ describe('CustomNetwork component', () => {
     ).forEach((n) => {
       expect(queryByText(n.name)).not.toBeOnTheScreen();
     });
+  });
+
+  it('hides blacklisted networks from the list', () => {
+    const props = getMockCustomNetworkProps({ showAddedNetworks: true });
+    const blacklistedChainIds = [toHex('43114'), toHex('42161')]; // Avalanche and Arbitrum
+    const mockState = getMockState(blacklistedChainIds);
+    const { queryByText } = renderWithProvider(<CustomNetwork {...props} />, {
+      state: mockState,
+    });
+
+    // These networks should be hidden
+    expect(queryByText('Avalanche')).not.toBeOnTheScreen();
+    expect(queryByText('Arbitrum')).not.toBeOnTheScreen();
+
+    // Other networks should still be visible
+    expect(queryByText('Base')).toBeOnTheScreen();
+    expect(queryByText('Polygon')).toBeOnTheScreen();
+  });
+
+  it('shows all networks when blacklist is empty', () => {
+    const props = getMockCustomNetworkProps({ showAddedNetworks: true });
+    const mockState = getMockState([]);
+    const { queryByText } = renderWithProvider(<CustomNetwork {...props} />, {
+      state: mockState,
+    });
+
+    // All networks should be visible
+    expect(queryByText('Avalanche')).toBeOnTheScreen();
+    expect(queryByText('Arbitrum')).toBeOnTheScreen();
+    expect(queryByText('Base')).toBeOnTheScreen();
   });
 });

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.test.tsx
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.test.tsx
@@ -17,9 +17,9 @@ jest.mock(
 
 const getMockState = (blacklistedChainIds: string[] = []) => {
   // Set up the mock selector to return the blacklist
-  (selectAdditionalNetworksBlacklistFeatureFlag as jest.Mock).mockReturnValue(
-    blacklistedChainIds,
-  );
+  (
+    selectAdditionalNetworksBlacklistFeatureFlag as unknown as jest.Mock
+  ).mockReturnValue(blacklistedChainIds);
 
   return { engine: { backgroundState } };
 };

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.tsx
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.tsx
@@ -8,7 +8,10 @@ import CustomText from '../../../../../Base/Text';
 import EmptyPopularList from '../emptyList';
 import { strings } from '../../../../../../../locales/i18n';
 import { useTheme } from '../../../../../../util/theme';
-import { PopularList } from '../../../../../../util/networks/customNetworks';
+import {
+  getFilteredPopularNetworks,
+  PopularList,
+} from '../../../../../../util/networks/customNetworks';
 import createStyles, { createCustomNetworkStyles } from '../styles';
 import { CustomNetworkProps, Network } from './CustomNetwork.types';
 import {
@@ -29,6 +32,7 @@ import Icon, {
   IconSize,
   IconName,
 } from '../../../../../../component-library/components/Icons/Icon';
+import { selectAdditionalNetworksBlacklistFeatureFlag } from '../../../../../../selectors/featureFlagController/networkBlacklist';
 
 const CustomNetwork = ({
   showPopularNetworkModal,
@@ -50,7 +54,18 @@ const CustomNetwork = ({
   const networkConfigurations = useSelector(selectNetworkConfigurations);
   const selectedChainId = useSelector(selectChainId);
   const { safeChains } = useSafeChains();
-  const supportedNetworkList = (customNetworksList ?? PopularList).map(
+  const blacklistedChainIds = useSelector(
+    selectAdditionalNetworksBlacklistFeatureFlag,
+  );
+
+  // Apply blacklist filter to the network list
+  const baseNetworkList = customNetworksList ?? PopularList;
+  const filteredNetworkList = getFilteredPopularNetworks(
+    blacklistedChainIds,
+    baseNetworkList,
+  );
+
+  const supportedNetworkList = filteredNetworkList.map(
     (networkConfiguration: Network) => {
       const isAdded = Object.values(networkConfigurations).some(
         (

--- a/app/selectors/featureFlagController/networkBlacklist/index.test.ts
+++ b/app/selectors/featureFlagController/networkBlacklist/index.test.ts
@@ -1,0 +1,98 @@
+import { selectAdditionalNetworksBlacklistFeatureFlag } from './index';
+import { StateWithPartialEngine } from '../types';
+import { Json } from '@metamask/utils';
+
+describe('selectAdditionalNetworksBlacklistFeatureFlag', () => {
+  const originalEnv = process.env;
+
+  // Helper function to create test state with proper typing
+  const createTestState = (
+    remoteFeatureFlags: Record<string, Json> = {},
+  ): StateWithPartialEngine => ({
+    engine: {
+      backgroundState: {
+        RemoteFeatureFlagController: {
+          remoteFeatureFlags,
+          cacheTimestamp: 0,
+        },
+      },
+    },
+  });
+
+  beforeEach(() => {
+    // Reset environment variables
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    // Restore original environment
+    process.env = originalEnv;
+  });
+
+  it('returns empty array when feature flag is not set', () => {
+    const state = createTestState();
+
+    const result = selectAdditionalNetworksBlacklistFeatureFlag(state);
+    expect(result).toEqual([]);
+  });
+
+  it('returns chain IDs array from remote feature flag', () => {
+    const state = createTestState({
+      additionalNetworkBlacklist: ['0x8f', '0x531', '0x1329'],
+    });
+
+    const result = selectAdditionalNetworksBlacklistFeatureFlag(state);
+    expect(result).toEqual(['0x8f', '0x531', '0x1329']);
+  });
+
+  it('handles empty environment variable', () => {
+    const originalEnvValue = process.env.MM_ADDITIONAL_NETWORK_BLACKLIST;
+    process.env.MM_ADDITIONAL_NETWORK_BLACKLIST = '';
+
+    const state = createTestState({
+      additionalNetworkBlacklist: ['0x8f', '0x531'],
+    });
+
+    const result = selectAdditionalNetworksBlacklistFeatureFlag(state);
+    expect(result).toEqual(['0x8f', '0x531']);
+
+    // Clean up
+    process.env.MM_ADDITIONAL_NETWORK_BLACKLIST = originalEnvValue;
+  });
+
+  it('handles invalid remote value gracefully', () => {
+    const state = createTestState({
+      additionalNetworkBlacklist: 'not-an-array',
+    });
+
+    const result = selectAdditionalNetworksBlacklistFeatureFlag(state);
+    expect(result).toEqual([]);
+  });
+
+  it('handles null remote value', () => {
+    const state = createTestState({
+      additionalNetworkBlacklist: null,
+    });
+
+    const result = selectAdditionalNetworksBlacklistFeatureFlag(state);
+    expect(result).toEqual([]);
+  });
+
+  it('handles undefined remote value', () => {
+    const state = createTestState({
+      // networkBlacklist not present
+    });
+
+    const result = selectAdditionalNetworksBlacklistFeatureFlag(state);
+    expect(result).toEqual([]);
+  });
+
+  it('validates array structure', () => {
+    const state = createTestState({
+      additionalNetworkBlacklist: ['0x8f', 123, null, '0x531'],
+    });
+
+    const result = selectAdditionalNetworksBlacklistFeatureFlag(state);
+    expect(result).toEqual(['0x8f', 123, null, '0x531']);
+  });
+});

--- a/app/selectors/featureFlagController/networkBlacklist/index.test.ts
+++ b/app/selectors/featureFlagController/networkBlacklist/index.test.ts
@@ -38,7 +38,7 @@ describe('selectAdditionalNetworksBlacklistFeatureFlag', () => {
 
   it('returns chain IDs array from remote feature flag', () => {
     const state = createTestState({
-      additionalNetworkBlacklist: ['0x8f', '0x531', '0x1329'],
+      additionalNetworksBlacklist: ['0x8f', '0x531', '0x1329'],
     });
 
     const result = selectAdditionalNetworksBlacklistFeatureFlag(state);
@@ -50,7 +50,7 @@ describe('selectAdditionalNetworksBlacklistFeatureFlag', () => {
     process.env.MM_ADDITIONAL_NETWORK_BLACKLIST = '';
 
     const state = createTestState({
-      additionalNetworkBlacklist: ['0x8f', '0x531'],
+      additionalNetworksBlacklist: ['0x8f', '0x531'],
     });
 
     const result = selectAdditionalNetworksBlacklistFeatureFlag(state);
@@ -62,7 +62,7 @@ describe('selectAdditionalNetworksBlacklistFeatureFlag', () => {
 
   it('handles invalid remote value gracefully', () => {
     const state = createTestState({
-      additionalNetworkBlacklist: 'not-an-array',
+      additionalNetworksBlacklist: 'not-an-array',
     });
 
     const result = selectAdditionalNetworksBlacklistFeatureFlag(state);
@@ -71,7 +71,7 @@ describe('selectAdditionalNetworksBlacklistFeatureFlag', () => {
 
   it('handles null remote value', () => {
     const state = createTestState({
-      additionalNetworkBlacklist: null,
+      additionalNetworksBlacklist: null,
     });
 
     const result = selectAdditionalNetworksBlacklistFeatureFlag(state);
@@ -89,7 +89,7 @@ describe('selectAdditionalNetworksBlacklistFeatureFlag', () => {
 
   it('validates array structure', () => {
     const state = createTestState({
-      additionalNetworkBlacklist: ['0x8f', 123, null, '0x531'],
+      additionalNetworksBlacklist: ['0x8f', 123, null, '0x531'],
     });
 
     const result = selectAdditionalNetworksBlacklistFeatureFlag(state);

--- a/app/selectors/featureFlagController/networkBlacklist/index.ts
+++ b/app/selectors/featureFlagController/networkBlacklist/index.ts
@@ -2,7 +2,7 @@ import { createSelector } from 'reselect';
 import { selectRemoteFeatureFlags } from '../index';
 
 export interface AdditionalNetworksBlacklistFeatureFlag {
-  additionalNetworkBlacklist: string[];
+  additionalNetworksBlacklist: string[];
 }
 
 /**
@@ -19,7 +19,7 @@ export interface AdditionalNetworksBlacklistFeatureFlag {
 export const selectAdditionalNetworksBlacklistFeatureFlag = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags) => {
-    const remoteValue = remoteFeatureFlags.additionalNetworkBlacklist as
+    const remoteValue = remoteFeatureFlags.additionalNetworksBlacklist as
       | string[]
       | undefined;
 

--- a/app/selectors/featureFlagController/networkBlacklist/index.ts
+++ b/app/selectors/featureFlagController/networkBlacklist/index.ts
@@ -1,0 +1,43 @@
+import { createSelector } from 'reselect';
+import { selectRemoteFeatureFlags } from '../index';
+
+export interface AdditionalNetworksBlacklistFeatureFlag {
+  additionalNetworkBlacklist: string[];
+}
+
+/**
+ * Selector to get the additional networks blacklist feature flag from remote feature flags.
+ * Allows to remove a network from the additional network selection.
+ * Returns an array of chain IDs that should be hidden from the Additional Networks list.
+ *
+ * Supports local environment variable override via MM_ADDITIONAL_NETWORK_BLACKLIST
+ * (comma-separated chain IDs, e.g., "0x8f,0x531")
+ *
+ * @param state - The Redux state
+ * @returns Array of blacklisted chain IDs
+ */
+export const selectAdditionalNetworksBlacklistFeatureFlag = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) => {
+    const remoteValue = remoteFeatureFlags.additionalNetworkBlacklist as
+      | string[]
+      | undefined;
+
+    // Parse environment variable override
+    const envValue = process.env.MM_ADDITIONAL_NETWORK_BLACKLIST;
+    let envArray: string[] = [];
+
+    if (envValue && typeof envValue === 'string') {
+      envArray = envValue
+        .split(',')
+        .map((id) => id.trim())
+        .filter((id) => id.length > 0);
+    }
+
+    // Use environment variable if provided, otherwise use remote value, fallback to empty array
+    const finalValue = envArray.length > 0 ? envArray : remoteValue || [];
+
+    // Ensure we return an array of strings
+    return Array.isArray(finalValue) ? finalValue : [];
+  },
+);

--- a/app/util/networks/customNetworks.test.ts
+++ b/app/util/networks/customNetworks.test.ts
@@ -1,6 +1,7 @@
 import {
   PopularList,
   getNonEvmNetworkImageSourceByChainId,
+  getFilteredPopularNetworks,
 } from './customNetworks';
 import { toHex } from '@metamask/controller-utils';
 import { BtcScope, SolScope } from '@metamask/keyring-api';
@@ -81,5 +82,88 @@ describe('getNonEvmNetworkImageSourceByChainId', () => {
     const invalidChainId = 'invalid:chain:id' as CaipChainId;
     const imageSource = getNonEvmNetworkImageSourceByChainId(invalidChainId);
     expect(imageSource).toBeUndefined();
+  });
+});
+
+describe('getFilteredPopularNetworks', () => {
+  it('filters out blacklisted chain IDs from PopularList', () => {
+    const blacklistedChainIds = [toHex('43114'), toHex('42161')];
+
+    const result = getFilteredPopularNetworks(blacklistedChainIds);
+
+    expect(result).not.toContainEqual(
+      expect.objectContaining({ chainId: toHex('43114') }),
+    );
+    expect(result).not.toContainEqual(
+      expect.objectContaining({ chainId: toHex('42161') }),
+    );
+    expect(result.length).toBeLessThan(PopularList.length);
+  });
+
+  it('returns full list when blacklist is empty array', () => {
+    const blacklistedChainIds: string[] = [];
+
+    const result = getFilteredPopularNetworks(blacklistedChainIds);
+
+    expect(result).toEqual(PopularList);
+    expect(result.length).toBe(PopularList.length);
+  });
+
+  it('filters single network from custom list', () => {
+    const customList = [
+      {
+        chainId: toHex('43114'),
+        nickname: 'Avalanche',
+        rpcUrl: 'https://avalanche.infura.io/v3/test',
+        ticker: 'AVAX',
+        rpcPrefs: { blockExplorerUrl: 'https://snowtrace.io' },
+      },
+      {
+        chainId: toHex('42161'),
+        nickname: 'Arbitrum',
+        rpcUrl: 'https://arbitrum.infura.io/v3/test',
+        ticker: 'ETH',
+        rpcPrefs: { blockExplorerUrl: 'https://arbiscan.io' },
+      },
+      {
+        chainId: toHex('137'),
+        nickname: 'Polygon',
+        rpcUrl: 'https://polygon.infura.io/v3/test',
+        ticker: 'POL',
+        rpcPrefs: { blockExplorerUrl: 'https://polygonscan.com' },
+      },
+    ];
+    const blacklistedChainIds = [toHex('42161')];
+
+    const result = getFilteredPopularNetworks(blacklistedChainIds, customList);
+
+    expect(result.length).toBe(2);
+    expect(result).not.toContainEqual(
+      expect.objectContaining({ chainId: toHex('42161') }),
+    );
+    expect(result).toContainEqual(
+      expect.objectContaining({ chainId: toHex('43114') }),
+    );
+    expect(result).toContainEqual(
+      expect.objectContaining({ chainId: toHex('137') }),
+    );
+  });
+
+  it('returns empty array when all networks are blacklisted', () => {
+    const allChainIds = PopularList.map((network) => network.chainId);
+
+    const result = getFilteredPopularNetworks(allChainIds);
+
+    expect(result).toEqual([]);
+    expect(result.length).toBe(0);
+  });
+
+  it('returns empty array when blacklisted chain IDs do not match any network', () => {
+    const blacklistedChainIds = [toHex('999999'), toHex('888888')];
+
+    const result = getFilteredPopularNetworks(blacklistedChainIds);
+
+    expect(result).toEqual(PopularList);
+    expect(result.length).toBe(PopularList.length);
   });
 });

--- a/app/util/networks/customNetworks.tsx
+++ b/app/util/networks/customNetworks.tsx
@@ -1,6 +1,7 @@
 import { CaipChainId, Hex } from '@metamask/utils';
 import { toHex } from '@metamask/controller-utils';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
+import { Network } from '../../components/Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.types';
 import {
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   BtcScope,
@@ -161,6 +162,25 @@ export const PopularList = [
     },
   },
 ];
+
+/**
+ * Filters the PopularList to exclude networks with blacklisted chain IDs.
+ * Allows to remove a network from the additional network selection.
+ * @param blacklistedChainIds - Array of chain IDs to exclude from the list
+ * @returns Filtered array of network configurations
+ */
+export const getFilteredPopularNetworks = (
+  blacklistedChainIds: string[],
+  baseNetworkList: Network[] = PopularList,
+) => {
+  if (!Array.isArray(blacklistedChainIds) || blacklistedChainIds.length === 0) {
+    return baseNetworkList;
+  }
+
+  return baseNetworkList.filter(
+    (network) => !blacklistedChainIds.includes(network.chainId),
+  );
+};
 
 export const getNonEvmNetworkImageSourceByChainId = (chainId: CaipChainId) => {
   switch (chainId) {

--- a/e2e/api-mocking/helpers/remoteFeatureFlagsHelper.ts
+++ b/e2e/api-mocking/helpers/remoteFeatureFlagsHelper.ts
@@ -268,7 +268,7 @@ const DEFAULT_FEATURE_FLAGS_ARRAY: Record<string, unknown>[] = [
     predictEnabled: false,
   },
   {
-    additionalNetworkBlacklist: [], // Empty by default, can be overridden in tests
+    additionalNetworksBlacklist: [], // Empty by default, can be overridden in tests
   },
 ];
 

--- a/e2e/api-mocking/helpers/remoteFeatureFlagsHelper.ts
+++ b/e2e/api-mocking/helpers/remoteFeatureFlagsHelper.ts
@@ -267,6 +267,9 @@ const DEFAULT_FEATURE_FLAGS_ARRAY: Record<string, unknown>[] = [
   {
     predictEnabled: false,
   },
+  {
+    additionalNetworkBlacklist: [], // Empty by default, can be overridden in tests
+  },
 ];
 
 /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR introduces support for remotely blacklisting networks from the “Add Popular Network” list in the Custom Networks settings view.

The feature is being added specifically to temporarily hide Monad ahead of its November 19 launch, preventing users from adding or interacting with the network before it is officially live.

The new additionalNetworksBlacklist feature flag can be controlled remotely or via the MM_ADDITIONAL_NETWORK_BLACKLIST environment variable, enabling flexible rollout management for upcoming network launches.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: added feature flag support to temporarily hide Monad (and other networks) from the “Add Popular Network” list.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Hide blacklisted networks from Custom Networks list

  Scenario: user opens the Add Popular Network view when a network is blacklisted
    Given the app has a remote feature flag "additionalNetworksBlacklist" containing the Monad chain ID
      And the user opens the List of Network pop-up
    When the Custom Network list is displayed
    Then the blacklisted network "Monad" should not be visible in the list
      And other non-blacklisted networks (e.g., Base, Polygon) should still be visible

  Scenario: user opens the Add Popular Network view when no network is blacklisted
    Given the app has an empty "additionalNetworksBlacklist" feature flag
      And the user open the List of Network pop-up
    When the Custom Network list is displayed
    Then all popular networks including "Monad" should be visible
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a feature flag (and ENV override) to hide specified chain IDs from the “Add Popular Network” list, with filtering utility and tests.
> 
> - **Settings UI**:
>   - `CustomNetwork.tsx`: Filters `PopularList` via `getFilteredPopularNetworks` using `selectAdditionalNetworksBlacklistFeatureFlag` to hide blacklisted chain IDs.
> - **Selectors**:
>   - `selectors/featureFlagController/networkBlacklist`: New `selectAdditionalNetworksBlacklistFeatureFlag` with `MM_ADDITIONAL_NETWORK_BLACKLIST` ENV override parsing.
> - **Utils**:
>   - `util/networks/customNetworks.tsx`: Add `getFilteredPopularNetworks(blacklistedChainIds, baseNetworkList?)` to exclude blacklisted networks.
> - **Tests**:
>   - Component test updates to verify hidden/visible networks based on blacklist.
>   - Selector tests for remote flag and ENV parsing edge cases.
>   - Utils tests for filtering behavior.
> - **E2E Mocks**:
>   - `e2e/api-mocking/helpers/remoteFeatureFlagsHelper.ts`: Include `additionalNetworksBlacklist` default in mocked flags.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac0beef78d60426dafb626c0550d85611498163b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->