### PR TITLE
fix: cp-7.58.0 close position disabled when receiveAmount <0

### DIFF
--- a/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
@@ -800,7 +800,6 @@ const PerpsClosePositionView: React.FC = () => {
               (orderType === 'limit' &&
                 (!limitPrice || parseFloat(limitPrice) <= 0)) ||
               (orderType === 'market' && closePercentage === 0) ||
-              receiveAmount <= 0 ||
               !validationResult.isValid
             }
             loading={isClosing}

--- a/app/components/UI/Perps/hooks/usePerpsClosePositionValidation.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsClosePositionValidation.test.ts
@@ -110,7 +110,7 @@ describe('usePerpsClosePositionValidation', () => {
     expect(result.current.errors).toHaveLength(0);
   });
 
-  it('should return error when user will receive negative amount', async () => {
+  it('returns warning (not error) when user will receive negative amount', async () => {
     mockValidateClosePosition.mockResolvedValue({ isValid: true });
 
     const params = {
@@ -126,9 +126,12 @@ describe('usePerpsClosePositionValidation', () => {
       expect(result.current.isValidating).toBe(false);
     });
 
-    expect(result.current.isValid).toBe(false);
-    expect(result.current.errors).toContain(
-      strings('perps.close_position.negative_receive_amount'),
+    expect(result.current.isValid).toBe(true);
+    expect(result.current.errors).toHaveLength(0);
+    expect(result.current.warnings).toContain(
+      strings('perps.close_position.negative_receive_warning', {
+        amount: '100.00',
+      }),
     );
   });
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1220,6 +1220,7 @@
       "minimum_remaining_error": "Cannot partial close: remaining position (${{remaining}}) would be below minimum order size (${{minimum}}). Please close 100% instead.",
       "must_close_full_below_minimum": "Position value is below $10. You must close 100% of the position.",
       "negative_receive_amount": "The fees exceed your position value",
+      "negative_receive_warning": "Closing this position will cost you ${{amount}} due to fees and losses.",
       "no_amount_selected": "Please select an amount to close",
       "order_type_reverted_to_market_order": "Changed to market order",
       "you_need_set_price_limit_order": "You need to set a price for a limit order."


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

### Problem

Users were blocked from closing positions when fees exceeded recoverable value (receiveAmount <= 0), creating a financial trap where they couldn't exit losing positions. This particularly affected accounts that lost all available margin in the position after price movement.

### Solution

Changed negative receive amount validation from a blocking error to a non-blocking warning, allowing users to always close positions while still informing them of the cost.

### Changes
usePerpsClosePositionValidation.ts: Moved receiveAmount < 0 check from errors to warnings array
PerpsClosePositionView.tsx: Removed receiveAmount <= 0 from button disable logic
en.json: Added negative_receive_warning locale string
usePerpsClosePositionValidation.test.ts: Updated test to expect warning instead of error

### Impact
✅ Users can now always exit positions (critical for risk management)
✅ Clear warning can be shown when closing will cost money (we are not currently showing warnings)

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1887
Fixes: https://github.com/MetaMask/metamask-mobile/issues/21624

## **Manual testing steps**

*** You may need to mock receiveAmount to simulate less than 0 on main and then compare with this branch

```gherkin
Feature: close position disabled when receiveAmount <0

  Scenario: user creates a btc position at the min amount
    Given user loses all of the margin in their position to the point of have nothing left to get back
    When user attempts to close their position at total loss <0 
    Then user should be able to close that position
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

[Message from Matthieu Saint Olive in #tmp-beta-bip44-mobile](https://consensys.slack.com/archives/C09H8PG9FBJ/p1760716074716439)

<!-- [screenshots/recordings] -->

### **After**

n/a position can close

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Negative receive amount is now a non-blocking warning (not an error); confirm button no longer disabled by receiveAmount <= 0; tests and locales updated.
> 
> - **Perps Close Position Validation**:
>   - Downgrades `receiveAmount < 0` from error to warning with formatted amount in `usePerpsClosePositionValidation`.
>   - Updates validation docs/comments and preserves other error/warning rules.
> - **UI**:
>   - Removes `receiveAmount <= 0` from confirm button `isDisabled` logic in `PerpsClosePositionView`.
> - **Tests**:
>   - Adjusts test to expect valid state with warning for negative receive amount.
> - **i18n**:
>   - Adds `perps.close_position.negative_receive_warning` string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a15b64f79ee94c94d32d8abf2b9e34d1e659488. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->