### PR TITLE
fix: Fix flakey async unit tests in Perps domain

### DIFF
--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
@@ -830,7 +830,9 @@ describe('PerpsOrderView', () => {
     render(<PerpsOrderView />, { wrapper: TestWrapper });
 
     const leverageText = await screen.findByText('Leverage');
-    fireEvent.press(leverageText);
+    await act(async () => {
+      fireEvent.press(leverageText);
+    });
 
     // The bottom sheet should become visible
     await waitFor(() => {
@@ -1150,7 +1152,9 @@ describe('PerpsOrderView', () => {
     const placeOrderButton = await screen.findByTestId(
       PerpsOrderViewSelectorsIDs.PLACE_ORDER_BUTTON,
     );
-    fireEvent.press(placeOrderButton);
+    await act(async () => {
+      fireEvent.press(placeOrderButton);
+    });
 
     // Should not call placeOrder due to validation failure
     await waitFor(() => {
@@ -1753,11 +1757,8 @@ describe('PerpsOrderView', () => {
       );
 
       // Press the TP/SL button
-      fireEvent.press(tpSlButton);
-
-      // Give the event handler time to execute
       await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 100));
+        fireEvent.press(tpSlButton);
       });
 
       // Verify that showToast was called with the correct argument
@@ -1855,7 +1856,9 @@ describe('PerpsOrderView', () => {
       const tpSlButton = screen.getByTestId(
         PerpsOrderViewSelectorsIDs.STOP_LOSS_BUTTON,
       );
-      fireEvent.press(tpSlButton);
+      await act(async () => {
+        fireEvent.press(tpSlButton);
+      });
 
       // Verify that navigation to TP/SL screen was triggered
       await waitFor(() => {

--- a/app/components/UI/Perps/hooks/usePerpsFunding.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsFunding.test.ts
@@ -383,7 +383,7 @@ describe('usePerpsFunding', () => {
       jest.clearAllMocks();
 
       // Act - advance time
-      act(() => {
+      await act(async () => {
         jest.advanceTimersByTime(120000); // 2 minutes
       });
 
@@ -406,7 +406,7 @@ describe('usePerpsFunding', () => {
       jest.clearAllMocks();
 
       // Act - advance time by polling interval
-      act(() => {
+      await act(async () => {
         jest.advanceTimersByTime(pollingInterval);
       });
 
@@ -416,7 +416,7 @@ describe('usePerpsFunding', () => {
       });
 
       // Act - advance time again
-      act(() => {
+      await act(async () => {
         jest.advanceTimersByTime(pollingInterval);
       });
 
@@ -442,7 +442,7 @@ describe('usePerpsFunding', () => {
       jest.clearAllMocks();
 
       // Act - advance time less than interval
-      act(() => {
+      await act(async () => {
         jest.advanceTimersByTime(customInterval - 1000);
       });
 
@@ -450,7 +450,7 @@ describe('usePerpsFunding', () => {
       expect(mockPerpsController.getFunding).not.toHaveBeenCalled();
 
       // Act - advance time to complete interval
-      act(() => {
+      await act(async () => {
         jest.advanceTimersByTime(1000);
       });
 
@@ -476,7 +476,7 @@ describe('usePerpsFunding', () => {
       unmount();
 
       // Advance time
-      act(() => {
+      await act(async () => {
         jest.advanceTimersByTime(pollingInterval * 3);
       });
 

--- a/app/components/UI/Perps/hooks/usePerpsPositions.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsPositions.test.ts
@@ -390,7 +390,7 @@ describe('usePerpsPositions', () => {
       expect(result.current.isRefreshing).toBe(true);
       expect(result.current.isLoading).toBe(false);
 
-      act(() => {
+      await act(async () => {
         resolvePromise(mockPositions);
       });
 
@@ -549,7 +549,7 @@ describe('usePerpsPositions', () => {
       expect(result.current.isRefreshing).toBe(true);
       expect(result.current.isLoading).toBe(false);
 
-      act(() => {
+      await act(async () => {
         resolvePromise(mockPositions);
       });
 


### PR DESCRIPTION
## **Description**

Fixes async unit test interactions from flaking due to improper test setup.

## **Changelog**

CHANGELOG entry: Unit test async fix to Perps domain

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/21621

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wraps async presses and timer advances in await act(...) across Perps tests to prevent flakiness.
> 
> - **Tests (Perps)**
>   - `app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx`
>     - Wrap button presses (e.g., `Leverage`, `PLACE_ORDER_BUTTON`, `STOP_LOSS_BUTTON`) in `await act(async () => fireEvent.press(...))`.
>     - Remove ad-hoc delays; rely on `act` to flush effects before assertions/navigation checks.
>   - `app/components/UI/Perps/hooks/usePerpsFunding.test.ts`
>     - Wrap `jest.advanceTimersByTime(...)` calls in `await act(async () => ...)` during polling and timer-driven flows.
>   - `app/components/UI/Perps/hooks/usePerpsPositions.test.ts`
>     - Wrap async resolution of pending promises and refresh flows in `await act(async () => ...)` to ensure stable state updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8faf8ab25bdb7465e1e6d42ff0d9a1c580f3bec9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->