### PR TITLE
INFRA-3073:Add semver pre-release identifier to builds

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -353,7 +353,9 @@ prebuild_ios(){
 	CURRENT_SEMVER=$(jq -r '.version' $PACKAGE_JSON_FILE)
 	# Strip any existing pre-release suffix (e.g., 7.59.0-dev -> 7.59.0)
 	BASE_VERSION=$(echo "$CURRENT_SEMVER" | sed 's/-.*$//')
-	# For production builds, use base version without suffix; otherwise append environment
+	# For production, use base version without suffix
+	# For all other environments, append environment suffix to CFBundleVersion for identification
+	# Note: CFBundleShortVersionString always uses base version (Apple requirement)
 	if [ "$METAMASK_ENVIRONMENT" == "production" ]; then
 		./scripts/set-semvar-version.sh $BASE_VERSION
 	else
@@ -400,7 +402,8 @@ prebuild_android(){
 	CURRENT_SEMVER=$(jq -r '.version' $PACKAGE_JSON_FILE)
 	# Strip any existing pre-release suffix (e.g., 7.59.0-dev -> 7.59.0)
 	BASE_VERSION=$(echo "$CURRENT_SEMVER" | sed 's/-.*$//')
-	# For production builds, use base version without suffix; otherwise append environment
+	# Android is more flexible than iOS and can handle version suffixes
+	# Use clean version for production, add suffix for other environments
 	if [ "$METAMASK_ENVIRONMENT" == "production" ]; then
 		./scripts/set-semvar-version.sh $BASE_VERSION
 	else

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -347,6 +347,18 @@ remapMainExperimentalEnvVariables() {
 }
 
 prebuild_ios(){
+	# Update current SEMVER with environment variable
+	# Read current version from package.json and strip any existing suffix
+	PACKAGE_JSON_FILE=package.json
+	CURRENT_SEMVER=$(jq -r '.version' $PACKAGE_JSON_FILE)
+	# Strip any existing pre-release suffix (e.g., 7.59.0-dev -> 7.59.0)
+	BASE_VERSION=$(echo "$CURRENT_SEMVER" | sed 's/-.*$//')
+	# For production builds, use base version without suffix; otherwise append environment
+	if [ "$METAMASK_ENVIRONMENT" == "production" ]; then
+		./scripts/set-semvar-version.sh $BASE_VERSION
+	else
+		./scripts/set-semvar-version.sh $BASE_VERSION-$METAMASK_ENVIRONMENT
+	fi
 	# Generate xcconfig files for CircleCI
 	if [ "$PRE_RELEASE" = true ] ; then
 		echo "" > ios/debug.xcconfig
@@ -382,6 +394,18 @@ installICULibraries(){
 }
 
 prebuild_android(){
+	# Update current SEMVER with environment variable
+	# Read current version from package.json and strip any existing suffix
+	PACKAGE_JSON_FILE=package.json
+	CURRENT_SEMVER=$(jq -r '.version' $PACKAGE_JSON_FILE)
+	# Strip any existing pre-release suffix (e.g., 7.59.0-dev -> 7.59.0)
+	BASE_VERSION=$(echo "$CURRENT_SEMVER" | sed 's/-.*$//')
+	# For production builds, use base version without suffix; otherwise append environment
+	if [ "$METAMASK_ENVIRONMENT" == "production" ]; then
+		./scripts/set-semvar-version.sh $BASE_VERSION
+	else
+		./scripts/set-semvar-version.sh $BASE_VERSION-$METAMASK_ENVIRONMENT
+	fi
 	# Install ICU libraries if on Linux
 	installICULibraries
 	

--- a/scripts/set-semvar-version.sh
+++ b/scripts/set-semvar-version.sh
@@ -12,6 +12,9 @@ fi
 
 SEMVER_VERSION=$1
 
+# Extract base version (strip any suffix like -beta, -dev, etc.)
+BASE_VERSION=$(echo "$SEMVER_VERSION" | sed 's/-.*$//')
+
 NAT='0|[1-9][0-9]*'
 ALPHANUM='[0-9]*[A-Za-z-][0-9A-Za-z-]*'
 IDENT="$NAT|$ALPHANUM"
@@ -59,7 +62,10 @@ perform_updates () {
     echo "- $BITRISE_YML_FILE successfully updated"
 
     echo "Updating iOS project settings..."
-    sed -i '' 's/\(\s*MARKETING_VERSION = \).*/\1'"$SEMVER_VERSION;"'/' "$IOS_PROJECT_FILE"
+    # Set MARKETING_VERSION (CFBundleShortVersionString) to base version (Apple requirement)
+    sed -i '' 's/\(\s*MARKETING_VERSION = \).*/\1'"$BASE_VERSION;"'/' "$IOS_PROJECT_FILE"
+    # Set CURRENT_PROJECT_VERSION (CFBundleVersion) to full version (can include suffix)
+    sed -i '' 's/\(\s*CURRENT_PROJECT_VERSION = \).*/\1'"$SEMVER_VERSION;"'/' "$IOS_PROJECT_FILE"
     echo "- $IOS_PROJECT_FILE successfully updated"
 
   else
@@ -77,7 +83,10 @@ perform_updates () {
 
     # update ios/MetaMask.xcodeproj/project.pbxproj
     echo "Updating iOS project settings..."
-    sed -i 's/\(\s*MARKETING_VERSION = \).*/\1'"$SEMVER_VERSION;"'/' "$IOS_PROJECT_FILE"
+    # Set MARKETING_VERSION (CFBundleShortVersionString) to base version (Apple requirement)
+    sed -i 's/\(\s*MARKETING_VERSION = \).*/\1'"$BASE_VERSION;"'/' "$IOS_PROJECT_FILE"
+    # Set CURRENT_PROJECT_VERSION (CFBundleVersion) to full version (can include suffix)
+    sed -i 's/\(\s*CURRENT_PROJECT_VERSION = \).*/\1'"$SEMVER_VERSION;"'/' "$IOS_PROJECT_FILE"
     echo "- $IOS_PROJECT_FILE updated"
 
   fi


### PR DESCRIPTION
Testing examples:
IOS Dev: https://app.bitrise.io/build/44273036-d3e2-4b85-a132-c671030ff7ad?tab=artifacts
Android Dev:  https://app.bitrise.io/build/74e16bdb-4894-4506-b8d4-4cf27a1ea182
IOS Prod: https://app.bitrise.io/build/a42361ad-471b-4f7c-9812-8d8d6484e057
Android Prod: https://app.bitrise.io/build/df7ad45b-e9c3-45d9-a138-73c09cf5f9b7?tab=artifacts

Testing shop pipeline: https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/38311728-ef76-4b60-a021-0f86a5a9e111

## **Description**

Add environment to end of build name
https://consensyssoftware.atlassian.net/browse/INFRA-3073

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add environment-specific semver suffixing during prebuild and update iOS/Android/Bitrise version fields accordingly.
> 
> - **Build/versioning**:
>   - `scripts/build.sh` now derives `BASE_VERSION` from `package.json` and sets the app version per environment:
>     - Production uses `BASE_VERSION`.
>     - Non-production appends `-$METAMASK_ENVIRONMENT` when invoking `scripts/set-semvar-version.sh` for both iOS and Android.
>   - iOS prebuild notes: keep CFBundleShortVersionString as base; use suffixed version only for build identification.
>   - Android prebuild keeps production clean; uses suffixed version for other envs.
> - **Versioning script** (`scripts/set-semvar-version.sh`):
>   - Parses `BASE_VERSION` and updates:
>     - `package.json` `version` to full semver (possibly suffixed).
>     - Android `versionName` and `bitrise.yml` `VERSION_NAME` to full semver.
>     - iOS `MARKETING_VERSION` to base version and `CURRENT_PROJECT_VERSION` to full semver (macOS/Linux sed variants).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0c497f75a70d0850c5db83f182fc00c5ca31c65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->