### PR TITLE
fix: cp-7.58.0 gasless transaction submission method selection logic

### DIFF
--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
@@ -25,6 +25,9 @@ import { otherControllersMock } from '../../__mocks__/controllers/other-controll
 import { useNetworkEnablement } from '../../../../hooks/useNetworkEnablement/useNetworkEnablement';
 import { flushPromises } from '../../../../../util/test/utils';
 import { useSelectedGasFeeToken } from '../gas/useGasFeeToken';
+import { isSendBundleSupported } from '../../../../../util/transactions/sentinel-api';
+import { useAsyncResult as useAsyncResultHook } from '../../../../hooks/useAsyncResult';
+import { act } from '@testing-library/react-hooks';
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
@@ -39,6 +42,10 @@ jest.mock('../../../../../actions/transaction');
 jest.mock('../../../../../util/networks');
 jest.mock('../../../../hooks/useNetworkEnablement/useNetworkEnablement');
 jest.mock('../gas/useGasFeeToken');
+jest.mock('../../../../hooks/useAsyncResult', () => ({
+  useAsyncResult: jest.fn(),
+}));
+jest.mock('../../../../../util/transactions/sentinel-api');
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -106,6 +113,8 @@ describe('useTransactionConfirm', () => {
   const resetTransactionMock = jest.mocked(resetTransaction);
   const useNetworkEnablementMock = jest.mocked(useNetworkEnablement);
   const useSelectedGasFeeTokenMock = jest.mocked(useSelectedGasFeeToken);
+  const isSendBundleSupportedMock = jest.mocked(isSendBundleSupported);
+  const useAsyncResultMock = jest.mocked(useAsyncResultHook);
 
   const isRemoveGlobalNetworkSelectorEnabledMock = jest.mocked(
     isRemoveGlobalNetworkSelectorEnabled,
@@ -121,6 +130,7 @@ describe('useTransactionConfirm', () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
+    useAsyncResultMock.mockReturnValue({ pending: false, value: false });
 
     useApprovalRequestMock.mockReturnValue({
       onConfirm: onApprovalConfirm,
@@ -172,10 +182,12 @@ describe('useTransactionConfirm', () => {
     expect(onApprovalConfirm).toHaveBeenCalled();
   });
 
-  it('waits for result by default', async () => {
+  it('sets waitForResult true when not smart tx, no quotes, no fee token', async () => {
     const { result } = renderHook();
 
-    await result.current.onConfirm();
+    await act(async () => {
+      await result.current.onConfirm();
+    });
 
     expect(onApprovalConfirm).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -190,7 +202,9 @@ describe('useTransactionConfirm', () => {
 
     const { result } = renderHook();
 
-    await result.current.onConfirm();
+    await act(async () => {
+      await result.current.onConfirm();
+    });
 
     expect(onApprovalConfirm).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -203,7 +217,9 @@ describe('useTransactionConfirm', () => {
   it('does not wait for result if quotes', async () => {
     const { result } = renderHook({ hasQuotes: true });
 
-    await result.current.onConfirm();
+    await act(async () => {
+      await result.current.onConfirm();
+    });
 
     expect(onApprovalConfirm).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -216,7 +232,9 @@ describe('useTransactionConfirm', () => {
   it('adds metamask pay properties to transaction metadata', async () => {
     const { result } = renderHook();
 
-    await result.current.onConfirm();
+    await act(async () => {
+      await result.current.onConfirm();
+    });
 
     expect(onApprovalConfirm).toHaveBeenCalledWith(expect.anything(), {
       txMeta: expect.objectContaining({
@@ -234,7 +252,9 @@ describe('useTransactionConfirm', () => {
   it('resets transaction state', async () => {
     const { result } = renderHook();
 
-    await result.current.onConfirm();
+    await act(async () => {
+      await result.current.onConfirm();
+    });
 
     expect(resetTransactionMock).toHaveBeenCalled();
   });
@@ -250,7 +270,9 @@ describe('useTransactionConfirm', () => {
 
     const { result } = renderHook();
 
-    await result.current.onConfirm();
+    await act(async () => {
+      await result.current.onConfirm();
+    });
     await flushPromises();
 
     expect(tryEnableEvmNetworkMock).not.toHaveBeenCalled();
@@ -267,7 +289,9 @@ describe('useTransactionConfirm', () => {
 
     const { result } = renderHook();
 
-    await result.current.onConfirm();
+    await act(async () => {
+      await result.current.onConfirm();
+    });
     await flushPromises();
 
     expect(tryEnableEvmNetworkMock).toHaveBeenCalledWith(CHAIN_ID_MOCK);
@@ -276,7 +300,9 @@ describe('useTransactionConfirm', () => {
   it('adds batch transactions if quotes on same chain', async () => {
     const { result } = renderHook({ hasQuotes: true });
 
-    await result.current.onConfirm();
+    await act(async () => {
+      await result.current.onConfirm();
+    });
 
     expect(onApprovalConfirm).toHaveBeenCalledWith(expect.anything(), {
       txMeta: expect.objectContaining({
@@ -303,14 +329,51 @@ describe('useTransactionConfirm', () => {
     });
   });
 
-  it('handles error during approval', async () => {
+  it('navigates to Transactions view after approval error', async () => {
     onApprovalConfirm.mockRejectedValueOnce(new Error('Test error'));
 
     const { result } = renderHook();
 
-    await result.current.onConfirm();
+    await act(async () => {
+      await result.current.onConfirm();
+    });
 
     expect(mockNavigate).toHaveBeenCalled();
+  });
+
+  it('does nothing when transactionMetadata is missing', async () => {
+    useTransactionMetadataRequestMock.mockReturnValue(undefined);
+
+    const { result } = renderHook();
+
+    await act(async () => {
+      await result.current.onConfirm();
+    });
+
+    expect(onApprovalConfirm).not.toHaveBeenCalled();
+  });
+
+  it('returns false for chainSupportsSendBundle when chainId is undefined', async () => {
+    useTransactionMetadataRequestMock.mockReturnValue({
+      id: transactionIdMock,
+      chainId: undefined,
+    } as unknown as TransactionMeta);
+
+    isSendBundleSupportedMock.mockResolvedValue(true);
+
+    useAsyncResultMock.mockImplementation((fn) => {
+      fn();
+      return { pending: false, value: false };
+    });
+
+    const { result } = renderHook();
+
+    await act(async () => {
+      await result.current.onConfirm();
+    });
+
+    expect(isSendBundleSupportedMock).not.toHaveBeenCalled();
+    expect(onApprovalConfirm).toHaveBeenCalled();
   });
 
   describe('navigates to', () => {
@@ -322,7 +385,9 @@ describe('useTransactionConfirm', () => {
 
       const { result } = renderHook();
 
-      await result.current.onConfirm();
+      await act(async () => {
+        await result.current.onConfirm();
+      });
 
       expect(mockNavigate).toHaveBeenCalledWith(Routes.PERPS.ROOT, {
         screen: Routes.PERPS.MARKETS,
@@ -332,7 +397,9 @@ describe('useTransactionConfirm', () => {
     it('transactions if full screen', async () => {
       const { result } = renderHook();
 
-      await result.current.onConfirm();
+      await act(async () => {
+        await result.current.onConfirm();
+      });
 
       expect(mockNavigate).toHaveBeenCalledWith(Routes.TRANSACTIONS_VIEW);
     });
@@ -344,7 +411,9 @@ describe('useTransactionConfirm', () => {
 
       const { result } = renderHook();
 
-      await result.current.onConfirm();
+      await act(async () => {
+        await result.current.onConfirm();
+      });
 
       expect(mockNavigate).not.toHaveBeenCalled();
       expect(mockGoBack).toHaveBeenCalled();
@@ -374,6 +443,8 @@ describe('useTransactionConfirm', () => {
   describe('handleSmartTransaction', () => {
     beforeEach(() => {
       selectShouldUseSmartTransactionMock.mockReturnValue(true);
+      useAsyncResultMock.mockReturnValue({ pending: false, value: true });
+      isSendBundleSupportedMock.mockReturnValue(Promise.resolve(true));
       useSelectedGasFeeTokenMock.mockReturnValue({
         transferTransaction: { data: '0xabc', to: '0xdef', value: '0x0' },
         gas: '0x5208',
@@ -384,7 +455,9 @@ describe('useTransactionConfirm', () => {
     it('adds batchTransactions and gas properties when smart transaction is enabled', async () => {
       const { result } = renderHook();
 
-      await result.current.onConfirm();
+      await act(async () => {
+        await result.current.onConfirm();
+      });
 
       expect(onApprovalConfirm).toHaveBeenCalledWith(expect.anything(), {
         txMeta: expect.objectContaining({
@@ -407,7 +480,9 @@ describe('useTransactionConfirm', () => {
 
       const { result } = renderHook();
 
-      await result.current.onConfirm();
+      await act(async () => {
+        await result.current.onConfirm();
+      });
 
       expect(onApprovalConfirm).toHaveBeenCalledWith(expect.anything(), {
         txMeta: expect.not.objectContaining({
@@ -420,6 +495,7 @@ describe('useTransactionConfirm', () => {
   describe('handleGasless7702', () => {
     it('sets isExternalSign when selectedGasFeeToken is present and not smart transaction', async () => {
       selectShouldUseSmartTransactionMock.mockReturnValue(false);
+      isSendBundleSupportedMock.mockReturnValue(Promise.resolve(false));
 
       useSelectedGasFeeTokenMock.mockReturnValue({
         transferTransaction: { data: '0xabc' },
@@ -427,7 +503,30 @@ describe('useTransactionConfirm', () => {
 
       const { result } = renderHook();
 
-      await result.current.onConfirm();
+      await act(async () => {
+        await result.current.onConfirm();
+      });
+
+      expect(onApprovalConfirm).toHaveBeenCalledWith(expect.anything(), {
+        txMeta: expect.objectContaining({
+          isExternalSign: true,
+        }),
+      });
+    });
+
+    it('sets isExternalSign when selectedGasFeeToken is present and smart transaction but the chain does not support send bundle', async () => {
+      selectShouldUseSmartTransactionMock.mockReturnValue(true);
+      isSendBundleSupportedMock.mockReturnValue(Promise.resolve(false));
+
+      useSelectedGasFeeTokenMock.mockReturnValue({
+        transferTransaction: { data: '0xabc' },
+      } as unknown as ReturnType<typeof useSelectedGasFeeToken>);
+
+      const { result } = renderHook();
+
+      await act(async () => {
+        await result.current.onConfirm();
+      });
 
       expect(onApprovalConfirm).toHaveBeenCalledWith(expect.anything(), {
         txMeta: expect.objectContaining({
@@ -444,7 +543,9 @@ describe('useTransactionConfirm', () => {
 
       const { result } = renderHook();
 
-      await result.current.onConfirm();
+      await act(async () => {
+        await result.current.onConfirm();
+      });
 
       expect(onApprovalConfirm).toHaveBeenCalledWith(expect.anything(), {
         txMeta: expect.not.objectContaining({ isExternalSign: true }),

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { useNavigation } from '@react-navigation/native';
 import { useDispatch, useSelector } from 'react-redux';
-
+import { isSendBundleSupported } from '../../../../../util/transactions/sentinel-api';
 import { selectShouldUseSmartTransaction } from '../../../../../selectors/smartTransactionsController';
 import Routes from '../../../../../constants/navigation/Routes';
 import { RootState } from '../../../../../reducers';
@@ -26,6 +26,7 @@ import { toHex } from '@metamask/controller-utils';
 import { useSelectedGasFeeToken } from '../gas/useGasFeeToken';
 import { type TxData } from '@metamask/bridge-controller';
 import { hasTransactionType } from '../../utils/transaction';
+import { useAsyncResult } from '../../../../hooks/useAsyncResult';
 
 const log = createProjectLogger('transaction-confirm');
 
@@ -91,6 +92,11 @@ export function useTransactionConfirm() {
     [selectedGasFeeToken],
   );
 
+  const { value: chainSupportsSendBundle } = useAsyncResult(
+    async () => (chainId ? isSendBundleSupported(chainId) : false),
+    [chainId],
+  );
+
   const handleGasless7702 = useCallback(
     (updatedMetadata: TransactionMeta) => {
       if (!selectedGasFeeToken) {
@@ -120,7 +126,7 @@ export function useTransactionConfirm() {
       updatedMetadata.batchTransactionsOptions = {};
     }
 
-    if (shouldUseSmartTransaction) {
+    if (shouldUseSmartTransaction && chainSupportsSendBundle) {
       handleSmartTransaction(updatedMetadata);
     } else if (selectedGasFeeToken) {
       handleGasless7702(updatedMetadata);
@@ -163,6 +169,7 @@ export function useTransactionConfirm() {
   }, [
     batchTransactions,
     bridgeFeeFiat,
+    chainSupportsSendBundle,
     chainId,
     dispatch,
     handleGasless7702,

--- a/app/util/transactions/sentinel-api.ts
+++ b/app/util/transactions/sentinel-api.ts
@@ -1,6 +1,7 @@
 import { convertHexToDecimal } from '@metamask/controller-utils';
 import { Hex } from '@metamask/utils';
 
+// TODO: Make it configurable via environment variable
 const BASE_URL = 'https://tx-sentinel-{0}.api.cx.metamask.io/';
 const ENDPOINT_NETWORKS = 'networks';
 


### PR DESCRIPTION
## **Description**

Fixes issue https://github.com/MetaMask/metamask-mobile/issues/21613

This PR is a follow-up fix on https://github.com/MetaMask/metamask-mobile/pull/21604.(https://github.com/MetaMask/metamask-mobile/issues/21613) 

```gherkin
Feature: gasless transaction
  Scenario: successful gasless transaction with 7702 on network without sendBundle support
    Given user with smart account for the network and smart transaction off
    When user submit a gasless transaction
    Then the transaction is sent via relay and is successful

  Scenario: cancelled gasless transaction on network without sendBundle support
    Given user with smart account for the network and smart transaction on
    When user submit a gasless transaction
    Then the transaction is sent via smartTransaction submission and is cancelled
```

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

null

Fixes:

## **Manual testing steps**

https://docs.google.com/spreadsheets/d/1m0xBMr48fXhfuOFnzgm9xw2QG5L4sUm6r4Hqaun29E4/edit?gid=0#gid=0

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Gate smart-transaction batching by Sentinel sendBundle support and fall back to external-sign gasless flow; add Sentinel API util and expand tests.
> 
> - **Confirmations Hook (`useTransactionConfirm`)**:
>   - Integrates `isSendBundleSupported` via `useAsyncResult` to determine chain capability.
>   - Applies smart-transaction handling only when `shouldUseSmartTransaction` and `chainSupportsSendBundle` are true; otherwise uses gasless 7702 path by setting `txMeta.isExternalSign` when a `selectedGasFeeToken` exists.
>   - Preserves batch transactions for bridge quotes; updates dependencies to include `chainSupportsSendBundle`.
> - **Utilities**:
>   - Adds `util/transactions/sentinel-api` with `getSentinelNetworkFlags`, `isSendBundleSupported`, `getSendBundleSupportedChains`, and `buildUrl` (fetches from `tx-sentinel` service).
> - **Tests**:
>   - Mocks `useAsyncResult` and Sentinel API; wraps confirmations in `act`.
>   - Adds/updates cases for wait-for-result logic, missing metadata, navigation paths, batch transactions, smart vs gasless behavior based on sendBundle support, and undefined `chainId` handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3206f7dd7d21a31e7601e5543d74906b73925d0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->