### PR TITLE
chore: update to 2 buttons when max leverage is 3

### DIFF
--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.test.tsx
@@ -650,6 +650,22 @@ describe('PerpsLeverageBottomSheet', () => {
       expect(screen.queryByText('20x')).toBeNull(); // Should not show 20x in quick select
       expect(screen.queryByText('40x')).toBeNull(); // Should not show 40x
     });
+
+    it('shows both 2x and 3x buttons when maxLeverage is 3', () => {
+      // Arrange - maxLeverage: 3, should show [2, 3] to give users more choice
+      const props = { ...defaultProps, maxLeverage: 3, leverage: 2 };
+
+      // Act
+      render(<PerpsLeverageBottomSheet {...props} />);
+
+      // Assert - Both buttons should be present (text appears in slider labels too)
+      const twoXElements = screen.getAllByText('2x');
+      const threeXElements = screen.getAllByText('3x');
+      expect(twoXElements.length).toBeGreaterThan(0);
+      expect(threeXElements.length).toBeGreaterThan(0);
+      // 5x should not appear in slider labels or buttons (initial leverage is now 2x)
+      expect(screen.queryByText('5x')).toBeNull();
+    });
   });
 
   describe('Leverage Risk Styling', () => {
@@ -841,24 +857,6 @@ describe('PerpsLeverageBottomSheet', () => {
       expect(() =>
         render(<PerpsLeverageBottomSheet {...singleLeverageProps} />),
       ).not.toThrow();
-    });
-
-    it('logs leverage options generation', () => {
-      // Arrange
-      const { DevLogger } = jest.requireMock(
-        '../../../../../core/SDKConnect/utils/DevLogger',
-      );
-
-      // Act
-      render(<PerpsLeverageBottomSheet {...defaultProps} />);
-
-      // Assert
-      expect(DevLogger.log).toHaveBeenCalledWith(
-        'Generating leverage options for maxLeverage: 20',
-      );
-      expect(DevLogger.log).toHaveBeenCalledWith(
-        'Available leverage options: 2, 5, 10, 20',
-      );
     });
   });
 

--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.tsx
@@ -471,8 +471,12 @@ const PerpsLeverageBottomSheet: React.FC<PerpsLeverageBottomSheetProps> = ({
     );
     const baseOptions = [2, 5, 10, 20, 40];
     const filtered = baseOptions.filter((option) => option <= maxLeverage);
-    DevLogger.log(`Available leverage options: ${filtered.join(', ')}`);
-    return filtered;
+
+    // Special case: when maxLeverage is 3, show both 2x and 3x buttons
+    const options = maxLeverage === 3 ? [2, 3] : filtered;
+
+    DevLogger.log(`Available leverage options: ${options.join(', ')}`);
+    return options;
   }, [maxLeverage]);
 
   /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

### Problem
When leverage range was 1x-3x, only the 2x button appeared, creating confusing UX where users saw "2x" displayed three times (top display, slider label, and single button).
### Solution
Added special case handling in quickSelectValues to display [2x, 3x] buttons when maxLeverage === 3.
### Result
maxLeverage = 3: Shows [2x, 3x] buttons ✅
Other maxLeverage values: Unchanged behavior
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Adds a button for max leverage when the max leverage is 3 such that there are 2 buttons to choose from

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1607

## **Manual testing steps**

```gherkin
Feature: Leverage Selection for 1x-3x Range

  Scenario: user selects leverage when maximum is 3x
    Given user is on the perps order screen
    And the selected asset has a maximum leverage of 3x
    
    When user taps the leverage selector
    Then the leverage modal displays
    And the quick select buttons show "2x" and "3x" options
    And the quick select buttons do not show "5x" or higher options
    
  Scenario: user switches between 2x and 3x leverage
    Given user has opened the leverage modal
    And the maximum leverage is 3x
    And both "2x" and "3x" buttons are visible
    
    When user taps the "3x" button
    Then the leverage display shows "3x"
    And the "3x" button is highlighted as active
    
    When user taps "Set 3x" button
    Then the modal closes
    And the order screen displays "3x" as the selected leverage
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
https://github.com/user-attachments/assets/23bed63c-e061-4aa1-a0ec-c85d71fa7a78

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Special-cases leverage quick select to display [2x, 3x] when `maxLeverage` is 3, updating logs and tests accordingly.
> 
> - **Perps Leverage Bottom Sheet**
>   - Adjust `quickSelectValues` in `PerpsLeverageBottomSheet.tsx` to return `[2, 3]` when `maxLeverage === 3`; otherwise filter base options by `maxLeverage`.
>   - Update `DevLogger.log` to reflect the new options list.
> - **Tests**
>   - Add test ensuring both `2x` and `3x` appear when `maxLeverage` is `3` and `5x` does not.
>   - Remove redundant logging assertion test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aaadf1fe5e5c942c2630800ce0f22d4aa0ed9891. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->