### PR TITLE
feat: align quote card design with Figma specifications

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.styles.ts
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.styles.ts
@@ -22,7 +22,6 @@ export const createStyles = (params: { theme: Theme }) => {
       alignItems: 'center',
       justifyContent: 'center',
       backgroundColor: theme.colors.background.default,
-      paddingTop: 12,
     },
     button: {
       width: '100%',
@@ -54,7 +53,8 @@ export const createStyles = (params: { theme: Theme }) => {
       paddingTop: 1,
     },
     quoteContainer: {
-      paddingHorizontal: 24,
+      flex: 1,
+      justifyContent: 'flex-end',
     },
     keypadContainer: {
       flex: 1,
@@ -69,7 +69,6 @@ export const createStyles = (params: { theme: Theme }) => {
     },
     dynamicContent: {
       flex: 1,
-      paddingBottom: 12,
       justifyContent: 'flex-start',
     },
     keypadContainerWithDestinationPicker: {

--- a/app/components/UI/Bridge/Views/BridgeView/__snapshots__/BridgeView.test.tsx.snap
+++ b/app/components/UI/Bridge/Views/BridgeView/__snapshots__/BridgeView.test.tsx.snap
@@ -899,7 +899,6 @@ exports[`BridgeView Bottom Content blurs input when opening QuoteExpiredModal 1`
                                       {
                                         "flex": 1,
                                         "justifyContent": "flex-start",
-                                        "paddingBottom": 12,
                                       },
                                     ]
                                   }
@@ -1624,7 +1623,6 @@ exports[`BridgeView Bottom Content blurs input when opening QuoteExpiredModal 1`
                                     "justifyContent": "center",
                                     "paddingBottom": 24,
                                     "paddingHorizontal": 16,
-                                    "paddingTop": 12,
                                     "width": "100%",
                                   },
                                 ]
@@ -2560,7 +2558,6 @@ exports[`BridgeView renders 1`] = `
                                       {
                                         "flex": 1,
                                         "justifyContent": "flex-start",
-                                        "paddingBottom": 12,
                                       },
                                     ]
                                   }
@@ -3285,7 +3282,6 @@ exports[`BridgeView renders 1`] = `
                                     "justifyContent": "center",
                                     "paddingBottom": 24,
                                     "paddingHorizontal": 16,
-                                    "paddingTop": 12,
                                     "width": "100%",
                                   },
                                 ]

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -430,6 +430,18 @@ const BridgeView = () => {
               description={blockaidError}
             />
           )}
+
+          {!shouldDisplayKeypad && (
+            <Button
+              variant={ButtonVariants.Primary}
+              size={ButtonSize.Lg}
+              label={getButtonLabel()}
+              onPress={handleContinue}
+              style={styles.button}
+              testID="bridge-confirm-button"
+              isDisabled={submitDisabled}
+            />
+          )}
           <Box flexDirection={FlexDirection.Row} alignItems={AlignItems.center}>
             <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
               {hasFee
@@ -452,17 +464,6 @@ const BridgeView = () => {
               />
             )}
           </Box>
-          {!shouldDisplayKeypad && (
-            <Button
-              variant={ButtonVariants.Primary}
-              size={ButtonSize.Lg}
-              label={getButtonLabel()}
-              onPress={handleContinue}
-              style={styles.button}
-              testID="bridge-confirm-button"
-              isDisabled={submitDisabled}
-            />
-          )}
         </Box>
       )
     );

--- a/app/components/UI/Bridge/components/QuoteCountdownTimer/QuoteCountdownTimer.tsx
+++ b/app/components/UI/Bridge/components/QuoteCountdownTimer/QuoteCountdownTimer.tsx
@@ -64,12 +64,12 @@ const QuoteCountdownTimer: React.FC = () => {
   // Use fixed-width formatting to prevent UI jumping
   // Pad single digits with a space to maintain consistent width
   const formattedSeconds =
-    secondsRemaining < 10 ? ` ${secondsRemaining}` : `${secondsRemaining}`;
+    secondsRemaining < 10 ? `0${secondsRemaining}` : `${secondsRemaining}`;
 
   return (
     <Box style={styles.container}>
       <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
-        {`(${formattedSeconds}s)`}
+        {`0:${formattedSeconds}`}
       </Text>
     </Box>
   );

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.styles.ts
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.styles.ts
@@ -5,14 +5,11 @@ const createStyles = ({ colors }: Theme) =>
   StyleSheet.create({
     container: {
       backgroundColor: colors.background.default,
-      borderWidth: 1,
-      borderRadius: 8,
-      borderColor: colors.border.muted,
       overflow: 'hidden',
-      paddingVertical: 12,
+      paddingTop: 12,
+      paddingBottom: 16,
       paddingHorizontal: 16,
       gap: 12,
-      marginBottom: 12,
     },
     gradientContainer: {
       position: 'absolute',

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
@@ -108,7 +108,7 @@ const QuoteDetailsCard: React.FC = () => {
                 alignItems={BoxAlignItems.Center}
                 gap={1}
               >
-                <Text variant={TextVariant.BodyMDMedium}>
+                <Text variant={TextVariant.BodyMD}>
                   {strings('bridge.rate')}
                 </Text>
                 <QuoteCountdownTimer />
@@ -140,7 +140,7 @@ const QuoteDetailsCard: React.FC = () => {
             alignItems={BoxAlignItems.Center}
             justifyContent={BoxJustifyContent.Between}
           >
-            <Text variant={TextVariant.BodyMDMedium}>
+            <Text variant={TextVariant.BodyMD}>
               {strings('bridge.network_fee')}
             </Text>
             <Box
@@ -164,7 +164,7 @@ const QuoteDetailsCard: React.FC = () => {
             field={{
               label: {
                 text: strings('bridge.network_fee'),
-                variant: TextVariant.BodyMDMedium,
+                variant: TextVariant.BodyMD,
               },
               tooltip: {
                 title: strings('bridge.network_fee_info_title'),
@@ -186,7 +186,7 @@ const QuoteDetailsCard: React.FC = () => {
           field={{
             label: {
               text: strings('bridge.slippage'),
-              variant: TextVariant.BodyMDMedium,
+              variant: TextVariant.BodyMD,
             },
             tooltip: {
               title: strings('bridge.slippage_info_title'),
@@ -219,7 +219,7 @@ const QuoteDetailsCard: React.FC = () => {
             field={{
               label: {
                 text: strings('bridge.minimum_received'),
-                variant: TextVariant.BodyMDMedium,
+                variant: TextVariant.BodyMD,
               },
               tooltip: {
                 title: strings('bridge.minimum_received_tooltip_title'),
@@ -242,7 +242,7 @@ const QuoteDetailsCard: React.FC = () => {
             field={{
               label: {
                 text: strings('bridge.price_impact'),
-                variant: TextVariant.BodyMDMedium,
+                variant: TextVariant.BodyMD,
               },
               tooltip: {
                 title: strings('bridge.price_impact_info_title'),
@@ -273,7 +273,7 @@ const QuoteDetailsCard: React.FC = () => {
             field={{
               label: {
                 text: strings('bridge.points'),
-                variant: TextVariant.BodyMDMedium,
+                variant: TextVariant.BodyMD,
               },
               tooltip: {
                 title: strings('bridge.points_tooltip'),

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/__snapshots__/QuoteDetailsCard.test.tsx.snap
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/__snapshots__/QuoteDetailsCard.test.tsx.snap
@@ -330,14 +330,11 @@ exports[`QuoteDetailsCard renders initial state 1`] = `
                             },
                             {
                               "backgroundColor": "#ffffff",
-                              "borderColor": "#b7bbc866",
-                              "borderRadius": 8,
-                              "borderWidth": 1,
                               "gap": 12,
-                              "marginBottom": 12,
                               "overflow": "hidden",
+                              "paddingBottom": 16,
                               "paddingHorizontal": 16,
-                              "paddingVertical": 12,
+                              "paddingTop": 12,
                             },
                           ]
                         }
@@ -400,7 +397,7 @@ exports[`QuoteDetailsCard renders initial state 1`] = `
                                     style={
                                       {
                                         "color": "#121314",
-                                        "fontFamily": "Geist Medium",
+                                        "fontFamily": "Geist Regular",
                                         "fontSize": 16,
                                         "letterSpacing": 0,
                                         "lineHeight": 24,
@@ -433,7 +430,7 @@ exports[`QuoteDetailsCard renders initial state 1`] = `
                                         }
                                       }
                                     >
-                                      (30s)
+                                      0:30
                                     </Text>
                                   </View>
                                 </View>
@@ -565,7 +562,7 @@ exports[`QuoteDetailsCard renders initial state 1`] = `
                                   style={
                                     {
                                       "color": "#121314",
-                                      "fontFamily": "Geist Medium",
+                                      "fontFamily": "Geist Regular",
                                       "fontSize": 16,
                                       "letterSpacing": 0,
                                       "lineHeight": 24,
@@ -701,7 +698,7 @@ exports[`QuoteDetailsCard renders initial state 1`] = `
                                   style={
                                     {
                                       "color": "#121314",
-                                      "fontFamily": "Geist Medium",
+                                      "fontFamily": "Geist Regular",
                                       "fontSize": 16,
                                       "letterSpacing": 0,
                                       "lineHeight": 24,
@@ -862,7 +859,7 @@ exports[`QuoteDetailsCard renders initial state 1`] = `
                                   style={
                                     {
                                       "color": "#121314",
-                                      "fontFamily": "Geist Medium",
+                                      "fontFamily": "Geist Regular",
                                       "fontSize": 16,
                                       "letterSpacing": 0,
                                       "lineHeight": 24,
@@ -985,7 +982,7 @@ exports[`QuoteDetailsCard renders initial state 1`] = `
                               style={
                                 {
                                   "color": "#121314",
-                                  "fontFamily": "Geist Medium",
+                                  "fontFamily": "Geist Regular",
                                   "fontSize": 16,
                                   "letterSpacing": 0,
                                   "lineHeight": 24,

--- a/app/components/UI/Bridge/components/QuoteDetailsRecipientKeyValueRow/QuoteDetailsRecipientKeyValueRow.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsRecipientKeyValueRow/QuoteDetailsRecipientKeyValueRow.tsx
@@ -48,9 +48,7 @@ const QuoteDetailsRecipientKeyValueRow = () => {
   return (
     <KeyValueRowStubs.Root>
       <Box style={styles.recipientFieldSection}>
-        <Text variant={TextVariant.BodyMDMedium}>
-          {strings('bridge.recipient')}
-        </Text>
+        <Text variant={TextVariant.BodyMD}>{strings('bridge.recipient')}</Text>
       </Box>
       <Box
         style={styles.recipientValueSection}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Update `QuoteDetailsCard` designs to improve UX.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Update `QuoteDetailsCard` designs to improve UX.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3305

## **Manual testing steps**

```gherkin
Ensure that the implementation matches the new designs for both ios and android platforms.

```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="431" height="889" alt="Screenshot 2025-10-26 at 2 55 46 PM" src="https://github.com/user-attachments/assets/b5f83a1e-5790-454d-830c-1b56d49bf0c2" />

<img width="451" height="908" alt="Screenshot 2025-10-26 at 2 54 47 PM" src="https://github.com/user-attachments/assets/8b5e07aa-84eb-48a9-b41e-92ed4522680d" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines QuoteDetailsCard styling/typography, updates countdown to 0:SS format, and reorders BridgeView confirm button above disclaimer with layout tweaks.
> 
> - **BridgeView**:
>   - Reorder primary `Button` above disclaimer text; keep hidden when keypad is shown.
>   - Layout tweaks: remove `paddingTop` in `buttonContainer`, make `quoteContainer` flex and bottom-aligned, simplify `dynamicContent` spacing.
> - **QuoteDetailsCard**:
>   - Restyle `container` (remove border/margin, adjust padding; keep background); unify labels to `TextVariant.BodyMD` (rate, network fee, slippage, minimum received, price impact, recipient).
>   - Use updated countdown display with zero-padded seconds.
> - **QuoteCountdownTimer**:
>   - Format timer as `0:SS` with zero padding (was `(Ss)`), maintain fixed width.
> - **Tests**:
>   - Update snapshots to reflect new styles, typography, and timer format.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a00aa24099c41c40873e2ce948611c8845e5e322. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->