### PR TITLE
fix(snaps): Only trigger `onActive` and `onInactive` when client is unlocked

### DIFF
--- a/app/core/Engine/Engine.test.ts
+++ b/app/core/Engine/Engine.test.ts
@@ -822,7 +822,15 @@ describe('Engine', () => {
         return { remove: jest.fn() };
       },
     );
-    const engine = Engine.init(backgroundState);
+
+    const engine = Engine.init({
+      ...backgroundState,
+      KeyringController: {
+        ...backgroundState.KeyringController,
+        isUnlocked: true,
+      },
+    });
+
     const messengerSpy = jest.spyOn(engine.controllerMessenger, 'call');
 
     // Simulate app state change to active
@@ -841,7 +849,15 @@ describe('Engine', () => {
         return { remove: jest.fn() };
       },
     );
-    const engine = Engine.init(backgroundState);
+
+    const engine = Engine.init({
+      ...backgroundState,
+      KeyringController: {
+        ...backgroundState.KeyringController,
+        isUnlocked: true,
+      },
+    });
+
     const messengerSpy = jest.spyOn(engine.controllerMessenger, 'call');
 
     // Simulate app state change to background
@@ -865,6 +881,33 @@ describe('Engine', () => {
 
     // Simulate app state change to inactive
     mockAppStateListener('inactive');
+
+    expect(messengerSpy).not.toHaveBeenCalledWith(
+      'SnapController:setClientActive',
+      expect.anything(),
+    );
+  });
+
+  it('does not call `SnapController:setClientActive` when the app is locked', () => {
+    (AppState.addEventListener as jest.Mock).mockImplementation(
+      (_, listener) => {
+        mockAppStateListener = listener;
+        return { remove: jest.fn() };
+      },
+    );
+
+    const engine = Engine.init({
+      ...backgroundState,
+      KeyringController: {
+        ...backgroundState.KeyringController,
+        isUnlocked: false,
+      },
+    });
+
+    const messengerSpy = jest.spyOn(engine.controllerMessenger, 'call');
+
+    // Simulate app state change to active
+    mockAppStateListener('active');
 
     expect(messengerSpy).not.toHaveBeenCalledWith(
       'SnapController:setClientActive',

--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -466,8 +466,6 @@ export class Engine {
     cronjobController.init();
     // Notification Setup
     notificationServicesController.init();
-    // Notify Snaps that the app is active when the Engine is initialized.
-    this.controllerMessenger.call('SnapController:setClientActive', true);
     ///: END:ONLY_INCLUDE_IF
 
     this.context = {
@@ -661,12 +659,19 @@ export class Engine {
         if (state !== 'active' && state !== 'background') {
           return;
         }
+
+        const { isUnlocked } = this.controllerMessenger.call(
+          'KeyringController:getState',
+        );
+
         // Notifies Snaps that the app may be in the background.
         // This is best effort as we cannot guarantee the messages are received in time.
-        return this.controllerMessenger.call(
-          'SnapController:setClientActive',
-          state === 'active',
-        );
+        if (isUnlocked) {
+          return this.controllerMessenger.call(
+            'SnapController:setClientActive',
+            state === 'active',
+          );
+        }
       },
     );
     ///: END:ONLY_INCLUDE_IF

--- a/app/core/Engine/controllers/snaps/snap-controller-init.test.ts
+++ b/app/core/Engine/controllers/snaps/snap-controller-init.test.ts
@@ -9,7 +9,11 @@ import {
 import { snapControllerInit } from './snap-controller-init';
 import { buildControllerInitRequestMock } from '../../utils/test-utils';
 import { ExtendedControllerMessenger } from '../../../ExtendedControllerMessenger';
-import { KeyringControllerGetKeyringsByTypeAction } from '@metamask/keyring-controller';
+import {
+  KeyringControllerGetKeyringsByTypeAction,
+  KeyringControllerLockEvent,
+  KeyringControllerUnlockEvent,
+} from '@metamask/keyring-controller';
 import { store } from '../../../../store';
 import { MetaMetrics } from '../../../Analytics';
 
@@ -73,6 +77,40 @@ describe('SnapControllerInit', () => {
       preinstalledSnaps: expect.any(Array),
       trackEvent: expect.any(Function),
     });
+  });
+
+  it('calls `SnapController:setClientActive` when the client is locked', () => {
+    const baseMessenger = new ExtendedControllerMessenger<
+      never,
+      KeyringControllerLockEvent
+    >();
+
+    const request = getInitRequestMock(baseMessenger);
+    const { initMessenger } = request;
+
+    const spy = jest.spyOn(initMessenger, 'call');
+
+    snapControllerInit(request);
+    baseMessenger.publish('KeyringController:lock');
+
+    expect(spy).toHaveBeenCalledWith('SnapController:setClientActive', false);
+  });
+
+  it('calls `SnapController:setClientActive` when the client is unlocked', () => {
+    const baseMessenger = new ExtendedControllerMessenger<
+      never,
+      KeyringControllerUnlockEvent
+    >();
+
+    const request = getInitRequestMock(baseMessenger);
+    const { initMessenger } = request;
+
+    const spy = jest.spyOn(initMessenger, 'call');
+
+    snapControllerInit(request);
+    baseMessenger.publish('KeyringController:unlock');
+
+    expect(spy).toHaveBeenCalledWith('SnapController:setClientActive', true);
   });
 
   describe('getMnemonicSeed', () => {

--- a/app/core/Engine/controllers/snaps/snap-controller-init.test.ts
+++ b/app/core/Engine/controllers/snaps/snap-controller-init.test.ts
@@ -88,7 +88,7 @@ describe('SnapControllerInit', () => {
     const request = getInitRequestMock(baseMessenger);
     const { initMessenger } = request;
 
-    const spy = jest.spyOn(initMessenger, 'call');
+    const spy = jest.spyOn(initMessenger, 'call').mockImplementation();
 
     snapControllerInit(request);
     baseMessenger.publish('KeyringController:lock');
@@ -105,7 +105,7 @@ describe('SnapControllerInit', () => {
     const request = getInitRequestMock(baseMessenger);
     const { initMessenger } = request;
 
-    const spy = jest.spyOn(initMessenger, 'call');
+    const spy = jest.spyOn(initMessenger, 'call').mockImplementation();
 
     snapControllerInit(request);
     baseMessenger.publish('KeyringController:unlock');

--- a/app/core/Engine/controllers/snaps/snap-controller-init.ts
+++ b/app/core/Engine/controllers/snaps/snap-controller-init.ts
@@ -142,6 +142,14 @@ export const snapControllerInit: ControllerInitFunction<
       ),
   });
 
+  initMessenger.subscribe('KeyringController:lock', () => {
+    initMessenger.call('SnapController:setClientActive', false);
+  });
+
+  initMessenger.subscribe('KeyringController:unlock', () => {
+    initMessenger.call('SnapController:setClientActive', true);
+  });
+
   return {
     controller,
   };

--- a/app/core/Engine/messengers/snaps/snap-controller-messenger.ts
+++ b/app/core/Engine/messengers/snaps/snap-controller-messenger.ts
@@ -13,6 +13,7 @@ import {
   ErrorMessageEvent,
   OutboundRequest,
   OutboundResponse,
+  SetClientActive,
 } from '@metamask/snaps-controllers';
 import {
   GetEndowments,
@@ -36,6 +37,7 @@ import {
 import {
   KeyringControllerGetKeyringsByTypeAction,
   KeyringControllerLockEvent,
+  KeyringControllerUnlockEvent,
 } from '@metamask/keyring-controller';
 import { PreferencesControllerGetStateAction } from '@metamask/preferences-controller';
 import { NetworkControllerGetNetworkClientByIdAction } from '@metamask/network-controller';
@@ -132,7 +134,10 @@ export function getSnapControllerMessenger(
 
 type InitActions =
   | KeyringControllerGetKeyringsByTypeAction
-  | PreferencesControllerGetStateAction;
+  | PreferencesControllerGetStateAction
+  | SetClientActive;
+
+type InitEvents = KeyringControllerLockEvent | KeyringControllerUnlockEvent;
 
 export type SnapControllerInitMessenger = ReturnType<
   typeof getSnapControllerInitMessenger
@@ -146,14 +151,15 @@ export type SnapControllerInitMessenger = ReturnType<
  * @returns The restricted messenger.
  */
 export function getSnapControllerInitMessenger(
-  messenger: Messenger<InitActions, never>,
+  messenger: Messenger<InitActions, InitEvents>,
 ) {
   return messenger.getRestricted({
     name: 'SnapControllerInit',
-    allowedEvents: [],
     allowedActions: [
       'KeyringController:getKeyringsByType',
       'PreferencesController:getState',
+      'SnapController:setClientActive',
     ],
+    allowedEvents: ['KeyringController:lock', 'KeyringController:unlock'],
   });
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This fixes an issue where Snaps may try to call APIs that are only available when the client is unlocked in the `onActive` handler. After this change, `onActive` is only called when the client is being unlocked, or when the client is already in the unlocked state and is opened. `onInactive` is only called when the client is in the unlocked state and closed, or when the client is being locked.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Only trigger `onActive` and `onInactive` Snap lifecycle hooks when client is unlocked

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Only notify Snaps of client active state when the wallet is unlocked, and propagate lock/unlock via Keyring events; update messengers and tests accordingly.
> 
> - **Snaps lifecycle**:
>   - Gate `SnapController:setClientActive` on app state changes behind `KeyringController:isUnlocked` in `Engine` (`app/core/Engine/Engine.ts`).
>   - Remove initial active notification on Engine init.
>   - Subscribe to `KeyringController:lock`/`unlock` in `snap-controller-init` to call `SnapController:setClientActive` with `false`/`true` (`app/core/Engine/controllers/snaps/snap-controller-init.ts`).
> - **Messengers**:
>   - Allow `SetClientActive` action and `KeyringController:unlock` event in Snap init messenger (`app/core/Engine/messengers/snaps/snap-controller-messenger.ts`).
> - **Tests**:
>   - Update `Engine.test.ts` to require unlocked state for active/background notifications and add locked-state assertion.
>   - Add tests for lock/unlock triggering `setClientActive` in `snap-controller-init.test.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbd8190299e1e102667cb65af474f2460c0466c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->