### PR TITLE
test: Refactors e2eBridgePerps to use CommandQueueServer polling instead of deeplinks

### DIFF
--- a/app/components/UI/Perps/utils/e2eBridgePerps.ts
+++ b/app/components/UI/Perps/utils/e2eBridgePerps.ts
@@ -173,14 +173,21 @@ function startE2EPerpsCommandPolling(): void {
 
       DevLogger.log('[E2E Perps Bridge - HTTP Polling] Poll URL', baseUrl);
 
-      const response = await new Promise((resolve, reject) => {
-        axios
-          .get(baseUrl)
-          .then((res) => resolve(res))
-          .catch((error) => reject(error));
-        setTimeout(() => {
+      const response = await new Promise<AxiosResponse>((resolve, reject) => {
+        const timeoutId = setTimeout(() => {
           reject(new Error('Request timeout'));
         }, FETCH_TIMEOUT);
+
+        axios
+          .get(baseUrl)
+          .then((res) => {
+            clearTimeout(timeoutId);
+            resolve(res);
+          })
+          .catch((error) => {
+            clearTimeout(timeoutId);
+            reject(error);
+          });
       });
 
       if ((response as AxiosResponse).status !== 200) {

--- a/app/components/UI/Perps/utils/e2eBridgePerps.ts
+++ b/app/components/UI/Perps/utils/e2eBridgePerps.ts
@@ -150,7 +150,11 @@ function startE2EPerpsCommandPolling(): void {
   const pollIntervalMs = Number(process.env.E2E_POLL_INTERVAL_MS || 2000);
   const host = getLocalHost();
   const port = getCommandQueueServerPort();
-  const baseUrl = `http://${host}:${port}/queue.json`;
+  // Change isDebug while developing E2E for Perps to avoid emptying out the queue
+  const isDebug = false;
+  const baseUrl = isDebug
+    ? `http://${host}:${port}/debug.json`
+    : `http://${host}:${port}/queue.json`;
   const FETCH_TIMEOUT = 40000; // Timeout in milliseconds
 
   function scheduleNext(delay: number): void {

--- a/app/components/UI/Perps/utils/e2eBridgePerps.ts
+++ b/app/components/UI/Perps/utils/e2eBridgePerps.ts
@@ -8,6 +8,11 @@
 import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
 import { isE2E } from '../../../../util/test/utils';
 import { Linking } from 'react-native';
+import axios, { AxiosResponse } from 'axios';
+import {
+  getCommandQueueServerPort,
+  getLocalHost,
+} from '../../../../../e2e/framework/fixtures/FixtureUtils';
 
 // Global bridge for E2E mock injection
 export interface E2EBridgePerpsStreaming {
@@ -23,10 +28,18 @@ let hasRegisteredDeepLinkHandler = false;
 // Track processed URLs to avoid duplicate handling when both initial URL and event fire
 const processedDeepLinks = new Set<string>();
 
+// E2E HTTP polling state
+let hasStartedPolling = false;
+let pollTimeout: ReturnType<typeof setTimeout> | null = null;
+let consecutivePollFailures = 0;
+let pollingDisabled = false;
+const MAX_CONSECUTIVE_POLL_FAILURES = 2;
+
 /**
  * Register a lightweight deep link handler for E2E-only schema (e2e://perps/*)
  * This avoids touching production deeplink parsing while enabling deterministic
  * E2E commands like price push and forced liquidation.
+ * !! TODO: E2E perps deeplink handler can be later removed if HTTP polling is stable !!
  */
 function registerE2EPerpsDeepLinkHandler(): void {
   if (hasRegisteredDeepLinkHandler || !isE2E) {
@@ -122,6 +135,156 @@ function registerE2EPerpsDeepLinkHandler(): void {
 }
 
 /**
+ * E2E-only: Poll external command API to apply mock updates
+ * Avoids deep links; relies on tests posting commands to a standalone service
+ *
+ * @returns void
+ */
+function startE2EPerpsCommandPolling(): void {
+  if (!isE2E || hasStartedPolling) {
+    return;
+  }
+
+  hasStartedPolling = true;
+
+  const pollIntervalMs = Number(process.env.E2E_POLL_INTERVAL_MS || 2000);
+  const host = getLocalHost();
+  const port = getCommandQueueServerPort();
+  const baseUrl = `http://${host}:${port}/queue.json`;
+  const FETCH_TIMEOUT = 40000; // Timeout in milliseconds
+
+  function scheduleNext(delay: number): void {
+    if (!isE2E || pollingDisabled) return;
+    if (pollTimeout) clearTimeout(pollTimeout);
+    pollTimeout = setTimeout(pollOnce, delay);
+  }
+
+  async function pollOnce(): Promise<void> {
+    try {
+      // Lazy require to keep bridge tree-shakeable in prod and avoid ESM import in Jest
+      /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
+      const mod = require('../../../../../e2e/controller-mocking/mock-responses/perps/perps-e2e-mocks');
+      const service = mod?.PerpsE2EMockService?.getInstance?.();
+      /* eslint-enable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
+      if (!service) {
+        scheduleNext(pollIntervalMs);
+        return;
+      }
+
+      DevLogger.log('[E2E Perps Bridge - HTTP Polling] Poll URL', baseUrl);
+
+      const response = await new Promise((resolve, reject) => {
+        axios
+          .get(baseUrl)
+          .then((res) => resolve(res))
+          .catch((error) => reject(error));
+        setTimeout(() => {
+          reject(new Error('Request timeout'));
+        }, FETCH_TIMEOUT);
+      });
+
+      if ((response as AxiosResponse).status !== 200) {
+        DevLogger.log(
+          '[E2E Perps Bridge - HTTP Polling] Poll non-200',
+          (response as AxiosResponse).status,
+        );
+        consecutivePollFailures += 1;
+        if (consecutivePollFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
+          pollingDisabled = true;
+          DevLogger.log(
+            '[E2E Perps Bridge - HTTP Polling] Disabling polling due to repeated non-200 responses',
+          );
+          return;
+        }
+        scheduleNext(pollIntervalMs);
+        return;
+      }
+
+      const data = ((await response) as AxiosResponse).data as
+        | (
+            | {
+                type: 'push-price';
+                symbol: string;
+                price: string | number;
+              }
+            | {
+                type: 'force-liquidation';
+                symbol: string;
+              }
+            | {
+                type: 'mock-deposit';
+                amount: string;
+              }
+          )[]
+        | null
+        | undefined;
+
+      if (!Array.isArray(data) || data.length === 0) {
+        consecutivePollFailures = 0;
+        scheduleNext(pollIntervalMs);
+        return;
+      }
+
+      consecutivePollFailures = 0;
+      DevLogger.log('[E2E Perps Bridge - HTTP Polling] Poll data', data);
+
+      for (const item of data) {
+        if (!item || typeof item !== 'object') continue;
+        if (item.type === 'push-price') {
+          const sym = (item as { symbol: string }).symbol;
+          const price = String((item as { price: string | number }).price);
+          try {
+            if (typeof service.mockPushPrice === 'function') {
+              service.mockPushPrice(sym, price);
+            }
+          } catch (e) {
+            // no-op
+          }
+        } else if (item.type === 'force-liquidation') {
+          const sym = (item as { symbol: string }).symbol;
+          try {
+            if (typeof service.mockForceLiquidation === 'function') {
+              service.mockForceLiquidation(sym);
+            }
+          } catch (e) {
+            // no-op
+          }
+        } else if (item.type === 'mock-deposit') {
+          const amount = (item as { amount: string }).amount;
+          try {
+            if (typeof service.mockDepositUSD === 'function') {
+              service.mockDepositUSD(amount);
+            }
+          } catch (e) {
+            // no-op
+          }
+        }
+
+        // no cursor handling
+      }
+
+      scheduleNext(0);
+    } catch (err) {
+      DevLogger.log('[E2E Perps Bridge - HTTP Polling] Poll error', err);
+      consecutivePollFailures += 1;
+      if (consecutivePollFailures >= MAX_CONSECUTIVE_POLL_FAILURES) {
+        pollingDisabled = true;
+        DevLogger.log(
+          '[E2E Perps Bridge - HTTP Polling] Disabling polling due to repeated errors',
+        );
+        return;
+      }
+      scheduleNext(pollIntervalMs);
+    }
+  }
+
+  DevLogger.log(
+    '[E2E Perps Bridge - HTTP Polling] Starting E2E perps HTTP polling',
+  );
+  scheduleNext(0);
+}
+
+/**
  * Auto-configure E2E bridge when isE2E is true
  */
 function autoConfigureE2EBridge(): void {
@@ -158,9 +321,15 @@ function autoConfigureE2EBridge(): void {
     };
 
     // Register E2E deep link handler for price/liq commands
+    // TODO: E2E perps deeplink handler can be later removed if HTTP polling is stable
     registerE2EPerpsDeepLinkHandler();
 
-    DevLogger.log('E2E Bridge auto-configured successfully');
+    // Start E2E HTTP polling for commands (replaces deeplink handler)
+    startE2EPerpsCommandPolling();
+
+    DevLogger.log(
+      '[E2E Perps Bridge - HTTP Polling] E2E Bridge auto-configured successfully',
+    );
     DevLogger.log('Mock state:', {
       accountBalance: mockService.getMockAccountState().availableBalance,
       positionsCount: mockService.getMockPositions().length,

--- a/app/components/UI/Perps/utils/e2eBridgePerps.ts
+++ b/app/components/UI/Perps/utils/e2eBridgePerps.ts
@@ -200,7 +200,7 @@ function startE2EPerpsCommandPolling(): void {
         return;
       }
 
-      const data = ((await response) as AxiosResponse).data as
+      const data = ((await response) as AxiosResponse).data?.queue as
         | (
             | {
                 type: 'push-price';

--- a/e2e/framework/fixtures/CommandQueueServer.ts
+++ b/e2e/framework/fixtures/CommandQueueServer.ts
@@ -7,7 +7,13 @@ const logger = createLogger({
   name: 'CommandQueueServer',
 });
 
-interface CommandQueueItem {
+/**
+ * The command queue item to add to the command queue server
+ *
+ * @param type - The type of command to add to the command queue
+ * @param args - The arguments to add to the command queue
+ */
+export interface CommandQueueItem {
   type: CommandType;
   args: Record<string, unknown>;
 }
@@ -35,6 +41,12 @@ class CommandQueueServer {
         this._queue.length = 0;
         ctx.body = {
           queue: newQueue,
+        };
+      }
+
+      if (this._isDebugRequest(ctx)) {
+        ctx.body = {
+          queue: this._queue,
         };
       }
     });
@@ -90,6 +102,10 @@ class CommandQueueServer {
 
   private _isQueueRequest(ctx: Context) {
     return ctx.method === 'GET' && ctx.path === '/queue.json';
+  }
+
+  private _isDebugRequest(ctx: Context) {
+    return ctx.method === 'GET' && ctx.path === '/debug.json';
   }
 }
 

--- a/e2e/specs/perps/helpers/perps-modifiers.ts
+++ b/e2e/specs/perps/helpers/perps-modifiers.ts
@@ -1,5 +1,14 @@
 import { openE2EUrl } from '../../../framework/DeepLink';
 import { E2EDeeplinkSchemes } from '../../../framework/Constants';
+import { createLogger } from '../../../framework/logger';
+import CommandQueueServer, {
+  CommandQueueItem,
+} from '../../../framework/fixtures/CommandQueueServer';
+import { PerpsModifiersCommandTypes } from '../../../framework/types';
+
+const logger = createLogger({
+  name: 'PerpsE2EModifiers',
+});
 
 class PerpsE2EModifiers {
   static async updateMarketPrice(symbol: string, price: string): Promise<void> {
@@ -20,8 +29,66 @@ class PerpsE2EModifiers {
 
   static async applyDepositUSD(amount: string): Promise<void> {
     await openE2EUrl(
-      `${E2EDeeplinkSchemes.PERPS}mock-deposit?amount=${encodeURIComponent(amount)}`,
+      `${E2EDeeplinkSchemes.PERPS}mock-deposit?amount=${encodeURIComponent(
+        amount,
+      )}`,
     );
+  }
+
+  /**
+   *
+   * @param commandQueueServer - The command queue server to add the command to
+   * @param symbol - The symbol to update the price for
+   * @param price - The price to update the symbol to
+   * @returns void
+   */
+  static async updateMarketPriceServer(
+    commandQueueServer: CommandQueueServer,
+    symbol: string,
+    price: string,
+  ): Promise<void> {
+    logger.debug('Updating market price for symbol', symbol, 'to price', price);
+    const command: CommandQueueItem = {
+      type: PerpsModifiersCommandTypes.pushPrice,
+      args: { symbol, price },
+    };
+    await commandQueueServer.addToQueue(command);
+  }
+
+  /**
+   *
+   * @param commandQueueServer - The command queue server to add the command to
+   * @param symbol - The symbol to trigger the liquidation for
+   * @returns void
+   */
+  static async triggerLiquidationServer(
+    commandQueueServer: CommandQueueServer,
+    symbol: string,
+  ): Promise<void> {
+    logger.debug('Triggering liquidation for symbol', symbol);
+    const command: CommandQueueItem = {
+      type: PerpsModifiersCommandTypes.forceLiquidation,
+      args: { symbol },
+    };
+    await commandQueueServer.addToQueue(command);
+  }
+
+  /**
+   *
+   * @param commandQueueServer - The command queue server to add the command to
+   * @param amount - The amount to apply the deposit for
+   * @returns void
+   */
+  static async applyDepositUSDServer(
+    commandQueueServer: CommandQueueServer,
+    amount: string,
+  ): Promise<void> {
+    logger.debug('Applying deposit USD for amount', amount);
+    const command: CommandQueueItem = {
+      type: PerpsModifiersCommandTypes.mockDeposit,
+      args: { amount },
+    };
+    await commandQueueServer.addToQueue(command);
   }
 }
 

--- a/e2e/specs/perps/perps-add-funds.spec.ts
+++ b/e2e/specs/perps/perps-add-funds.spec.ts
@@ -1,6 +1,6 @@
 import { withFixtures } from '../../framework/fixtures/FixtureHelper';
 import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
-import { LocalNodeType } from '../../framework/types';
+import { LocalNodeType, TestSuiteParams } from '../../framework/types';
 import { Hardfork } from '../../seeder/anvil-manager';
 import { SmokeTrade } from '../../tags';
 import { loginToApp } from '../../viewHelper';
@@ -61,7 +61,10 @@ describe(SmokeTrade('Perps - Add funds (has funds, not first time)'), () => {
           },
         ],
       },
-      async () => {
+      async ({ commandQueueServer }: TestSuiteParams) => {
+        if (!commandQueueServer) {
+          throw new Error('Command queue server not found');
+        }
         await loginToApp();
         await device.disableSynchronization();
         await Assertions.expectElementToBeVisible(
@@ -106,7 +109,7 @@ describe(SmokeTrade('Perps - Add funds (has funds, not first time)'), () => {
 
         await PerpsDepositProcessingView.expectProcessingVisible();
         // Apply deposit mock and verify balance update
-        await PerpsE2EModifiers.applyDepositUSD('80');
+        await PerpsE2EModifiers.applyDepositUSDServer(commandQueueServer, '80');
         logger.info('🔥 E2E Mock: Deposit applied');
         await Utilities.executeWithRetry(
           async () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR refactors e2eBridgePerps to use the CommandQueueServer polling instead of deeplinks.
All references to deeplinks in this context were kept.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches Perps E2E control from deeplinks to an HTTP-polled CommandQueueServer queue and updates helpers/specs to enqueue commands.
> 
> - **E2E Bridge (Perps)**:
>   - Add HTTP polling with axios to read commands from `http://<host>:<port>/queue.json` (and `/debug.json`) and apply `push-price`, `force-liquidation`, and `mock-deposit` via the Perps mock service.
>   - Start polling during `autoConfigureE2EBridge`; retain lightweight deeplink handler as fallback.
> - **E2E Framework**:
>   - `e2e/framework/fixtures/CommandQueueServer.ts`: export `CommandQueueItem`; add `GET /debug.json` (non-destructive) alongside existing `GET /queue.json` (clears queue).
> - **Test Helpers**:
>   - `e2e/specs/perps/helpers/perps-modifiers.ts`: add server-backed methods (`updateMarketPriceServer`, `triggerLiquidationServer`, `applyDepositUSDServer`) that enqueue `PerpsModifiersCommandTypes`; keep deeplink methods.
> - **Specs**:
>   - `e2e/specs/perps/perps-add-funds.spec.ts`: use `TestSuiteParams.commandQueueServer` and switch deposit mock to `applyDepositUSDServer`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e3a527cfd1f8d9e697cb00efd79e297d98eb8ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->