### PR TITLE
chore(predict): ui bug bash 2

### DIFF
--- a/app/components/UI/Predict/components/PredictAmountDisplay/PredictAmountDisplay.tsx
+++ b/app/components/UI/Predict/components/PredictAmountDisplay/PredictAmountDisplay.tsx
@@ -1,17 +1,17 @@
-import React, { useEffect, useRef } from 'react';
-import { Animated, Platform, TouchableOpacity } from 'react-native';
-import { PerpsAmountDisplaySelectorsIDs } from '../../../../../../e2e/selectors/Perps/Perps.selectors';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
-import { formatPrice, formatPositionSize } from '../../utils/format';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
   BoxAlignItems,
   BoxFlexDirection,
 } from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import React, { useEffect, useRef } from 'react';
+import { Animated, TouchableOpacity } from 'react-native';
+import { PerpsAmountDisplaySelectorsIDs } from '../../../../../../e2e/selectors/Perps/Perps.selectors';
+import Text, {
+  TextColor,
+  TextVariant,
+} from '../../../../../component-library/components/Texts/Text';
+import { formatPositionSize, formatPrice } from '../../utils/format';
 
 interface PredictAmountDisplayProps {
   amount: string;
@@ -69,7 +69,7 @@ const PredictAmountDisplay: React.FC<PredictAmountDisplayProps> = ({
   const content = (
     <Box
       alignItems={BoxAlignItems.Center}
-      twClassName="pt-12 px-6"
+      twClassName="px-6"
       testID={PerpsAmountDisplaySelectorsIDs.CONTAINER}
     >
       {label && (
@@ -89,10 +89,9 @@ const PredictAmountDisplay: React.FC<PredictAmountDisplayProps> = ({
         <Text
           testID={PerpsAmountDisplaySelectorsIDs.AMOUNT_LABEL}
           color={hasError ? TextColor.Error : TextColor.Default}
-          variant={TextVariant.BodyMDBold}
+          variant={TextVariant.BodyMDMedium}
           style={tw.style(
-            'text-[54px] tracking-tight leading-[74px]',
-            Platform.OS === 'android' ? 'font-medium' : 'font-black',
+            'text-[64px] tracking-tight leading-[74px] font-medium',
           )}
         >
           {showTokenAmount && tokenAmount && tokenSymbol

--- a/app/components/UI/Predict/components/PredictFeeSummary/PredictFeeSummary.tsx
+++ b/app/components/UI/Predict/components/PredictFeeSummary/PredictFeeSummary.tsx
@@ -1,13 +1,18 @@
 import React from 'react';
-import {
-  Box,
-  ButtonIcon,
-  IconName,
-} from '@metamask/design-system-react-native';
+import { Box } from '@metamask/design-system-react-native';
 import Text, {
   TextColor,
+  TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
 import { formatPrice } from '../../utils/format';
+import ButtonIcon, {
+  ButtonIconSizes,
+} from '../../../../../component-library/components/Buttons/ButtonIcon';
+import {
+  IconColor,
+  IconName,
+} from '../../../../../component-library/components/Icons/Icon';
+import { strings } from '../../../../../../locales/i18n';
 
 interface PredictFeeSummaryProps {
   disabled: boolean;
@@ -26,11 +31,17 @@ const PredictFeeSummary: React.FC<PredictFeeSummaryProps> = ({
     return null;
   }
   return (
-    <Box twClassName="p-4 flex-col gap-2">
+    <Box twClassName="pt-4 px-4 pb-6 flex-col gap-4">
       <Box twClassName="flex-row justify-between items-center">
         <Box twClassName=" flex-row gap-2 items-center">
-          <Text color={TextColor.Alternative}>Provider fee</Text>
-          <ButtonIcon iconName={IconName.Info} twClassName="text-alternative" />
+          <Text color={TextColor.Alternative} variant={TextVariant.BodyMD}>
+            {strings('predict.fee_summary.provider_fee')}
+          </Text>
+          <ButtonIcon
+            iconName={IconName.Info}
+            size={ButtonIconSizes.Sm}
+            iconColor={IconColor.Alternative}
+          />
         </Box>
         <Text color={TextColor.Alternative}>
           {formatPrice(providerFee, {
@@ -40,8 +51,14 @@ const PredictFeeSummary: React.FC<PredictFeeSummaryProps> = ({
       </Box>
       <Box twClassName="flex-row justify-between items-center">
         <Box twClassName="flex-row gap-2 items-center">
-          <Text color={TextColor.Alternative}>MetaMask fee</Text>
-          <ButtonIcon iconName={IconName.Info} />
+          <Text color={TextColor.Alternative} variant={TextVariant.BodyMD}>
+            {strings('predict.fee_summary.metamask_fee')}
+          </Text>
+          <ButtonIcon
+            iconName={IconName.Info}
+            size={ButtonIconSizes.Sm}
+            iconColor={IconColor.Alternative}
+          />
         </Box>
         <Text color={TextColor.Alternative}>
           {formatPrice(metamaskFee, {
@@ -51,8 +68,14 @@ const PredictFeeSummary: React.FC<PredictFeeSummaryProps> = ({
       </Box>
       <Box twClassName="flex-row justify-between items-center">
         <Box twClassName="flex-row gap-2 items-center">
-          <Text color={TextColor.Alternative}>Total</Text>
-          <ButtonIcon iconName={IconName.Info} />
+          <Text color={TextColor.Alternative} variant={TextVariant.BodyMD}>
+            {strings('predict.fee_summary.total')}
+          </Text>
+          <ButtonIcon
+            iconName={IconName.Info}
+            size={ButtonIconSizes.Sm}
+            iconColor={IconColor.Alternative}
+          />
         </Box>
         <Text color={TextColor.Alternative}>
           {formatPrice(total, {

--- a/app/components/UI/Predict/components/PredictKeypad/PredictKeypad.tsx
+++ b/app/components/UI/Predict/components/PredictKeypad/PredictKeypad.tsx
@@ -128,8 +128,8 @@ const PredictKeypad = forwardRef<PredictKeypadHandles, PredictKeypadProps>(
     if (!isInputFocused) return null;
 
     return (
-      <View style={tw.style('pt-4 bg-background-section pb-8 rounded-t-3xl')}>
-        <View style={tw.style('px-4 mb-3')}>
+      <View style={tw.style('py-4')}>
+        <View style={tw.style('px-4 mb-4')}>
           {hasInsufficientFunds && onAddFunds ? (
             <Button
               variant={ButtonVariants.Primary}

--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
@@ -5,8 +5,6 @@ import {
   BoxJustifyContent,
   Button,
   ButtonVariant,
-  Text,
-  TextVariant,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { NavigationProp, useNavigation } from '@react-navigation/native';
@@ -40,6 +38,10 @@ import {
 } from '../../types';
 import { PredictNavigationParamList } from '../../types/navigation';
 import { formatPrice } from '../../utils/format';
+import Text, {
+  TextColor,
+  TextVariant,
+} from '../../../../../component-library/components/Texts/Text';
 
 // NOTE For some reason bg-primary-default and theme.colors.primary.default displaying #8b99ff
 const BUTTON_COLOR = '#4459FF';
@@ -163,7 +165,7 @@ const PredictPositionsHeader = forwardRef<PredictPositionsHeaderHandle>(
               justifyContent={BoxJustifyContent.Center}
               twClassName="gap-2"
             >
-              <Text variant={TextVariant.BodyMd}>
+              <Text variant={TextVariant.BodyMD} color={TextColor.Inverse}>
                 {strings('predict.claim_amount_text', {
                   amount: totalClaimableAmount.toFixed(2),
                 })}
@@ -193,8 +195,8 @@ const PredictPositionsHeader = forwardRef<PredictPositionsHeaderHandle>(
                     alignItems={BoxAlignItems.Center}
                   >
                     <Text
-                      variant={TextVariant.BodyMd}
-                      twClassName="text-alternative"
+                      variant={TextVariant.BodyMD}
+                      color={TextColor.Alternative}
                       testID="markets-won-count"
                     >
                       {strings('predict.available_balance')}
@@ -206,8 +208,9 @@ const PredictPositionsHeader = forwardRef<PredictPositionsHeaderHandle>(
                     twClassName="flex-row items-center"
                   >
                     <Text
-                      variant={TextVariant.BodyMd}
-                      twClassName="text-primary mr-1"
+                      variant={TextVariant.BodyMD}
+                      color={TextColor.Primary}
+                      className="mr-1"
                       testID="claimable-amount"
                     >
                       {formatPrice(balance, { maximumDecimals: 2 })}
@@ -223,7 +226,7 @@ const PredictPositionsHeader = forwardRef<PredictPositionsHeaderHandle>(
             )}
             {hasUnrealizedPnL && (
               <>
-                <Box twClassName="h-px bg-alternative" />
+                <Box twClassName="h-[2px] bg-default" />
                 <Box
                   twClassName="px-4 pb-3 mt-3"
                   flexDirection={BoxFlexDirection.Row}
@@ -235,18 +238,18 @@ const PredictPositionsHeader = forwardRef<PredictPositionsHeaderHandle>(
                     alignItems={BoxAlignItems.Center}
                   >
                     <Text
-                      variant={TextVariant.BodyMd}
-                      twClassName="text-alternative"
+                      variant={TextVariant.BodyMD}
+                      color={TextColor.Alternative}
                     >
                       {strings('predict.unrealized_pnl_label')}
                     </Text>
                   </Box>
                   <Text
-                    variant={TextVariant.BodyMd}
-                    twClassName={
+                    variant={TextVariant.BodyMD}
+                    color={
                       unrealizedAmount >= 0
-                        ? 'text-success-default'
-                        : 'text-error-default'
+                        ? TextColor.Success
+                        : TextColor.Error
                     }
                   >
                     {strings('predict.unrealized_pnl_value', {

--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
@@ -5,6 +5,8 @@ import {
   BoxJustifyContent,
   Button,
   ButtonVariant,
+  Text,
+  TextVariant,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { NavigationProp, useNavigation } from '@react-navigation/native';
@@ -38,10 +40,6 @@ import {
 } from '../../types';
 import { PredictNavigationParamList } from '../../types/navigation';
 import { formatPrice } from '../../utils/format';
-import Text, {
-  TextColor,
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 
 // NOTE For some reason bg-primary-default and theme.colors.primary.default displaying #8b99ff
 const BUTTON_COLOR = '#4459FF';
@@ -165,7 +163,7 @@ const PredictPositionsHeader = forwardRef<PredictPositionsHeaderHandle>(
               justifyContent={BoxJustifyContent.Center}
               twClassName="gap-2"
             >
-              <Text variant={TextVariant.BodyMD} color={TextColor.Inverse}>
+              <Text variant={TextVariant.BodyMd}>
                 {strings('predict.claim_amount_text', {
                   amount: totalClaimableAmount.toFixed(2),
                 })}
@@ -195,8 +193,8 @@ const PredictPositionsHeader = forwardRef<PredictPositionsHeaderHandle>(
                     alignItems={BoxAlignItems.Center}
                   >
                     <Text
-                      variant={TextVariant.BodyMD}
-                      color={TextColor.Alternative}
+                      variant={TextVariant.BodyMd}
+                      twClassName="text-alternative"
                       testID="markets-won-count"
                     >
                       {strings('predict.available_balance')}
@@ -208,9 +206,8 @@ const PredictPositionsHeader = forwardRef<PredictPositionsHeaderHandle>(
                     twClassName="flex-row items-center"
                   >
                     <Text
-                      variant={TextVariant.BodyMD}
-                      color={TextColor.Primary}
-                      className="mr-1"
+                      variant={TextVariant.BodyMd}
+                      twClassName="text-primary mr-1"
                       testID="claimable-amount"
                     >
                       {formatPrice(balance, { maximumDecimals: 2 })}
@@ -226,7 +223,7 @@ const PredictPositionsHeader = forwardRef<PredictPositionsHeaderHandle>(
             )}
             {hasUnrealizedPnL && (
               <>
-                <Box twClassName="h-[2px] bg-default" />
+                <Box twClassName="h-px bg-alternative" />
                 <Box
                   twClassName="px-4 pb-3 mt-3"
                   flexDirection={BoxFlexDirection.Row}
@@ -238,18 +235,18 @@ const PredictPositionsHeader = forwardRef<PredictPositionsHeaderHandle>(
                     alignItems={BoxAlignItems.Center}
                   >
                     <Text
-                      variant={TextVariant.BodyMD}
-                      color={TextColor.Alternative}
+                      variant={TextVariant.BodyMd}
+                      twClassName="text-alternative"
                     >
                       {strings('predict.unrealized_pnl_label')}
                     </Text>
                   </Box>
                   <Text
-                    variant={TextVariant.BodyMD}
-                    color={
+                    variant={TextVariant.BodyMd}
+                    twClassName={
                       unrealizedAmount >= 0
-                        ? TextColor.Success
-                        : TextColor.Error
+                        ? 'text-success-default'
+                        : 'text-error-default'
                     }
                   >
                     {strings('predict.unrealized_pnl_value', {

--- a/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.test.tsx
@@ -441,7 +441,7 @@ describe('PredictBuyPreview', () => {
       const doneButton = getByText('Done');
       fireEvent.press(doneButton);
 
-      const placeBetButton = getByText('Yes • 50¢');
+      const placeBetButton = getByText('Yes · 50¢');
       fireEvent.press(placeBetButton);
 
       expect(mockPlaceOrder).toHaveBeenCalledWith({
@@ -477,7 +477,7 @@ describe('PredictBuyPreview', () => {
       const doneButton = getByText('Done');
       fireEvent.press(doneButton);
 
-      const placeBetButton = getByText('Yes • 50¢');
+      const placeBetButton = getByText('Yes · 50¢');
       fireEvent.press(placeBetButton);
 
       // Wait for the timeout in onPlaceBet
@@ -636,7 +636,7 @@ describe('PredictBuyPreview', () => {
         state: initialState,
       });
 
-      expect(getByText('Bitcoin Price •')).toBeOnTheScreen();
+      expect(getByText('Bitcoin Price ·')).toBeOnTheScreen();
       expect(getByText('Yes at 50¢')).toBeOnTheScreen();
     });
 
@@ -902,7 +902,7 @@ describe('PredictBuyPreview', () => {
       const doneButton = getByText('Done');
       fireEvent.press(doneButton);
 
-      const placeBetButton = getByText('Yes • 50¢');
+      const placeBetButton = getByText('Yes · 50¢');
 
       // The dispatch now throws and is not caught, so expect the error
       expect(() => {
@@ -1463,7 +1463,7 @@ describe('PredictBuyPreview', () => {
       fireEvent.press(doneButton);
 
       // Should show place bet button
-      expect(getByText('Yes • 50¢')).toBeOnTheScreen();
+      expect(getByText('Yes · 50¢')).toBeOnTheScreen();
 
       // Now enter amount that exceeds balance
       const amountDisplay = getByText('10');
@@ -1504,7 +1504,7 @@ describe('PredictBuyPreview', () => {
       const doneButton = getByText('Done');
       fireEvent.press(doneButton);
 
-      const placeBetButton = getByText('Yes • 50¢');
+      const placeBetButton = getByText('Yes · 50¢');
       expect(placeBetButton).toBeOnTheScreen();
 
       // Verify it's not disabled by trying to press it
@@ -1572,7 +1572,7 @@ describe('PredictBuyPreview', () => {
       fireEvent.press(doneButton);
 
       // Verify button works with valid amount
-      const placeBetButton = getByText('Yes • 50¢');
+      const placeBetButton = getByText('Yes · 50¢');
       fireEvent.press(placeBetButton);
 
       expect(mockPlaceOrder).toHaveBeenCalled();
@@ -1600,7 +1600,7 @@ describe('PredictBuyPreview', () => {
       const doneButton = getByText('Done');
       fireEvent.press(doneButton);
 
-      const placeBetButton = getByText('Yes • 50¢');
+      const placeBetButton = getByText('Yes · 50¢');
       fireEvent.press(placeBetButton);
 
       // Button should work (backward compatibility)
@@ -1628,7 +1628,7 @@ describe('PredictBuyPreview', () => {
       fireEvent.press(doneButton);
 
       // With default mocks (no rateLimited), button should work
-      const placeBetButton = getByText('Yes • 50¢');
+      const placeBetButton = getByText('Yes · 50¢');
       fireEvent.press(placeBetButton);
       expect(mockPlaceOrder).toHaveBeenCalled();
     });
@@ -1876,7 +1876,7 @@ describe('PredictBuyPreview', () => {
       fireEvent.press(doneButton);
 
       // Click place bet
-      const placeBetButton = getByText('Yes • 50¢');
+      const placeBetButton = getByText('Yes · 50¢');
       fireEvent.press(placeBetButton);
 
       expect(mockPlaceOrder).toHaveBeenCalled();
@@ -1959,7 +1959,7 @@ describe('PredictBuyPreview', () => {
       expect(queryByText('Minimum bet is $1.00')).not.toBeOnTheScreen();
 
       // Should show place bet button
-      expect(getByText('Yes • 50¢')).toBeOnTheScreen();
+      expect(getByText('Yes · 50¢')).toBeOnTheScreen();
     });
 
     it('handles amount $0.99', () => {

--- a/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
+++ b/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
@@ -133,7 +133,7 @@ const PredictBuyPreview = () => {
 
   const title = market.title;
   const outcomeGroupTitle = outcome.groupItemTitle
-    ? `${outcome.groupItemTitle} • `
+    ? `${outcome.groupItemTitle} · `
     : '';
   const outcomeTokenLabel = `${outcomeToken?.title} at ${formatCents(
     preview?.sharePrice ?? outcomeToken?.price ?? 0,
@@ -154,7 +154,7 @@ const PredictBuyPreview = () => {
     <Box
       flexDirection={BoxFlexDirection.Row}
       alignItems={BoxAlignItems.Center}
-      twClassName="w-full gap-4 p-4 border-b border-muted"
+      twClassName="w-full gap-4 p-4"
     >
       <TouchableOpacity testID="back-button" onPress={() => goBack()}>
         <Icon name={IconName.ArrowLeft} size={IconSize.Md} />
@@ -170,7 +170,7 @@ const PredictBuyPreview = () => {
         <Box flexDirection={BoxFlexDirection.Row} twClassName="min-w-0 gap-4">
           <Box twClassName="flex-1 min-w-0">
             <Text
-              variant={TextVariant.BodyMDMedium}
+              variant={TextVariant.HeadingSM}
               numberOfLines={1}
               ellipsizeMode="tail"
             >
@@ -315,9 +315,15 @@ const PredictBuyPreview = () => {
               />
             ) : (
               <Button
-                label={`${outcomeToken?.title} • ${formatCents(
-                  outcomeToken?.price ?? 0,
-                )}`}
+                label={
+                  <Text
+                    variant={TextVariant.BodyLGMedium}
+                    color={TextColor.Success}
+                  >
+                    {outcomeToken?.title} ·{' '}
+                    {formatCents(outcomeToken?.price ?? 0)}
+                  </Text>
+                }
                 variant={ButtonVariants.Secondary}
                 onPress={onPlaceBet}
                 style={tw.style(
@@ -333,11 +339,12 @@ const PredictBuyPreview = () => {
                 loading={isLoading}
                 size={ButtonSize.Lg}
                 width={ButtonWidthTypes.Full}
+                labelTextVariant={TextVariant.BodyMD}
               />
             )}
           </Box>
           <Box twClassName="text-center items-center">
-            <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+            <Text variant={TextVariant.BodyXS} color={TextColor.Alternative}>
               {strings('predict.order.payments_made_in_usdc')}
             </Text>
           </Box>

--- a/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.styles.ts
+++ b/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.styles.ts
@@ -21,14 +21,14 @@ const styleSheet = (params: { theme: Theme }) => {
     currentValue: {
       fontSize: 64,
       fontWeight: '500',
-      lineHeight: 72,
+      lineHeight: 74,
       letterSpacing: 0,
       textAlign: 'center',
       verticalAlign: 'middle',
     },
     percentPnl: {
-      fontSize: 20,
-      lineHeight: 28,
+      fontSize: 16,
+      lineHeight: 24,
       letterSpacing: 0,
       textAlign: 'center',
       ...fontStyles.bold,
@@ -61,17 +61,11 @@ const styleSheet = (params: { theme: Theme }) => {
     detailsLeft: {
       flex: 1,
       minWidth: 0,
-      fontSize: 16,
-      fontWeight: '500',
-      letterSpacing: 0,
     },
     detailsResolves: {
       flex: 1,
       minWidth: 0,
       color: theme.colors.text.alternative,
-      fontSize: 14,
-      fontWeight: '500',
-      letterSpacing: 0,
     },
     detailsRight: {
       flexShrink: 0,
@@ -82,7 +76,7 @@ const styleSheet = (params: { theme: Theme }) => {
     positionIcon: {
       width: 40,
       height: 40,
-      borderRadius: 4.4,
+      borderRadius: 4,
     },
     cashOutButtonContainer: {
       justifyContent: 'center',
@@ -90,7 +84,6 @@ const styleSheet = (params: { theme: Theme }) => {
     },
     cashOutButton: {
       width: '100%',
-      color: theme.colors.primary.inverse,
       height: 48,
       opacity: 1,
     },

--- a/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.tsx
+++ b/app/components/UI/Predict/views/PredictSellPreview/PredictSellPreview.tsx
@@ -31,6 +31,7 @@ import styleSheet from './PredictSellPreview.styles';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { PredictCashOutSelectorsIDs } from '../../../../../../e2e/selectors/Predict/Predict.selectors';
+import { strings } from '../../../../../../locales/i18n';
 
 const PredictSellPreview = () => {
   const tw = useTailwind();
@@ -114,12 +115,13 @@ const PredictSellPreview = () => {
         style={styles.container}
       >
         <View style={styles.cashOutContainer}>
-          <Text style={styles.currentValue}>
+          <Text style={styles.currentValue} variant={TextVariant.BodyMDMedium}>
             {formatPrice(currentValue, { maximumDecimals: 2 })}
           </Text>
           <Text
             style={styles.percentPnl}
             color={percentPnl > 0 ? TextColor.Success : TextColor.Error}
+            variant={TextVariant.BodyMDMedium}
           >
             {`${signal}${formatPrice(Math.abs(cashPnl), {
               maximumDecimals: 2,
@@ -136,6 +138,7 @@ const PredictSellPreview = () => {
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 style={styles.detailsLeft}
+                variant={TextVariant.HeadingSM}
               >
                 {outcomeTitle}
               </Text>
@@ -143,6 +146,7 @@ const PredictSellPreview = () => {
                 numberOfLines={1}
                 ellipsizeMode="tail"
                 style={styles.detailsResolves}
+                variant={TextVariant.BodySMMedium}
               >
                 {formatPrice(initialValue, { maximumDecimals: 2 })} on{' '}
                 {outcomeSideText}
@@ -152,7 +156,14 @@ const PredictSellPreview = () => {
           <View style={styles.cashOutButtonContainer}>
             <Button
               testID={PredictCashOutSelectorsIDs.SELL_PREVIEW_CASH_OUT_BUTTON}
-              label="Cash out"
+              label={
+                <Text
+                  variant={TextVariant.BodyMDMedium}
+                  color={TextColor.Inverse}
+                >
+                  {strings('predict.cash_out')}
+                </Text>
+              }
               variant={ButtonVariants.Secondary}
               disabled={!preview || isCalculating || isLoading}
               onPress={onCashOut}
@@ -162,8 +173,8 @@ const PredictSellPreview = () => {
               }}
               loading={isLoading}
             />
-            <Text variant={TextVariant.BodySM} style={styles.cashOutButtonText}>
-              Funds will be added to your available balance
+            <Text variant={TextVariant.BodyXS} style={styles.cashOutButtonText}>
+              {strings('predict.cash_out_info')}
             </Text>
           </View>
         </View>

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1651,6 +1651,7 @@
     },
     "sell_position": "Sell Position",
     "cash_out": "Cash out",
+    "cash_out_info": "Funds will be added to your available balance",
     "buy_yes": "Yes",
     "buy_no": "No",
     "outcomes": "outcomes",
@@ -1767,6 +1768,11 @@
       "error_title": "Something went wrong",
       "error_description": "Failed to proceed with withdraw",
       "try_again": "Try again"
+    },
+    "fee_summary": {
+      "provider_fee": "Provider fee",
+      "metamask_fee": "MetaMask fee",
+      "total": "Total"
     }
   },
   "receive": {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Fixed UI bugs from Buy/Sell Preview

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines Predict buy/sell previews with typography/spacing tweaks, replaces separators (• → ·), localizes fee labels, adjusts keypad/button visuals, and updates tests/locales.
> 
> - **Predict UI**:
>   - **Buy Preview (`PredictBuyPreview.tsx`)**:
>     - Header title variant to `HeadingSM`; remove bottom border.
>     - Outcome group separator changed to `·` and styled; dynamic outcome color.
>     - Place bet button now renders colored `Text` label; payments note to `BodyXS`.
>   - **Sell Preview (`PredictSellPreview.tsx`/`.styles.ts`)**:
>     - Typography/line-height tweaks; smaller PnL text; rounded image radius.
>     - Cash out button label via `strings('predict.cash_out')`; info note moved to `BodyXS`.
>   - **Components**:
>     - `PredictAmountDisplay`: larger amount (`text-[64px]`, `BodyMDMedium`), spacing cleanup.
>     - `PredictFeeSummary`: i18n labels via `strings('predict.fee_summary.*')`, small `Info` icons, spacing.
>     - `PredictKeypad`: compact padding/margins.
> - **Tests** (`PredictBuyPreview.test.tsx`):
>   - Expect text updates for `·` separator and UI changes across flows.
> - **Localization** (`locales/languages/en.json`):
>   - Add `predict.fee_summary` keys and `predict.cash_out_info`; reuse `predict.cash_out`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 356f33cc5a5a17378ac9698b4c8c9afd851361e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->