### PR TITLE
fix: align balance loaders for account group and portfolio pages

### DIFF
--- a/app/components/UI/Assets/components/Balance/AccountGroupBalance.styles.ts
+++ b/app/components/UI/Assets/components/Balance/AccountGroupBalance.styles.ts
@@ -10,7 +10,6 @@ const createStyles = () =>
     },
     skeletonContainer: {
       flexDirection: 'column',
-      alignItems: 'center',
       gap: 4,
     },
   });

--- a/app/components/UI/Tokens/TokenList/PortfolioBalance/index.tsx
+++ b/app/components/UI/Tokens/TokenList/PortfolioBalance/index.tsx
@@ -12,7 +12,7 @@ import SensitiveText, {
 import { WalletViewSelectorsIDs } from '../../../../../../e2e/selectors/wallet/WalletView.selectors';
 import AggregatedPercentageCrossChains from '../../../../../component-library/components-temp/Price/AggregatedPercentage/AggregatedPercentageCrossChains';
 import { useSelectedAccountMultichainBalances } from '../../../../hooks/useMultichainBalances';
-import Loader from '../../../../../component-library/components-temp/Loader/Loader';
+import { Skeleton } from '../../../../../component-library/components/Skeleton';
 import NonEvmAggregatedPercentage from '../../../../../component-library/components-temp/Price/AggregatedPercentage/NonEvmAggregatedPercentage';
 import { selectIsEvmNetworkSelected } from '../../../../../selectors/multichainNetworkController';
 
@@ -80,7 +80,8 @@ export const PortfolioBalance = React.memo(() => {
           </TouchableOpacity>
         ) : (
           <View style={styles.loaderWrapper}>
-            <Loader />
+            <Skeleton width={100} height={40} />
+            <Skeleton width={100} height={20} />
           </View>
         )}
       </View>

--- a/app/components/UI/Tokens/styles.ts
+++ b/app/components/UI/Tokens/styles.ts
@@ -226,7 +226,8 @@ const createStyles = (colors: Colors) =>
       marginLeft: 8,
     },
     loaderWrapper: {
-      paddingLeft: 40,
+      flexDirection: 'column',
+      gap: 4,
     },
     portfolioButtonContainer: {
       alignItems: 'center',


### PR DESCRIPTION
## **Description**

This PR aligns the balance loaders between the account group and legacy portfolio pages to ensure consistent UI/UX. Previously, the account group loader was centered while the portfolio page used a different loader component. Now both pages use the same Skeleton components with consistent alignment and styling.

**Changes made:**
- Removed center alignment from account group balance skeleton container
- Replaced portfolio page Loader component with Skeleton components to match account group
- Updated loader wrapper styling to use consistent flexDirection and gap properties

## **Changelog**

CHANGELOG entry: N/A

## **Related issues**

Fixes: N/A https://github.com/MetaMask/metamask-mobile/pull/21391#discussion_r2467169988

## **Manual testing steps**

```gherkin
Feature: Balance loader alignment

  Scenario: user views balance loaders on account group and portfolio pages
    Given the app is loaded with account balances loading
    
    When user navigates to account group page during balance loading
    Then balance loaders should be left-aligned with consistent styling
    
    When user navigates to portfolio page during balance loading  
    Then balance loaders should be left-aligned and match account group styling
```

## **Screenshots/Recordings**

### **Before**

Account group loader was centered, portfolio used different Loader component

<img width="300" height="873" alt="Screenshot 2025-10-27 at 3 41 31 PM" src="https://github.com/user-attachments/assets/e36118b6-7c75-41b9-95ab-a3bb33819678" /><img width="300" height="877" alt="Screenshot 2025-10-27 at 3 35 32 PM" src="https://github.com/user-attachments/assets/42e0bee3-13fe-4d3f-9675-afeba2ac1e1e" />

### **After**

Both pages now use consistent Skeleton components with left alignment

<img width="300" height="886" alt="Screenshot 2025-10-27 at 3 34 01 PM" src="https://github.com/user-attachments/assets/9fffa81c-949a-4082-96d5-bc1030468e78" /><img width="300" height="886" alt="Screenshot 2025-10-27 at 3 34 01 PM" src="https://github.com/user-attachments/assets/9fffa81c-949a-4082-96d5-bc1030468e78" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies balance loading UI by replacing the portfolio loader with Skeletons and aligning skeleton layouts across account group and portfolio screens.
> 
> - **UI/Styles**:
>   - `AccountGroupBalance.styles.ts`: Align skeleton vertically by removing `alignItems: 'center'` and adding `gap: 4` in `skeletonContainer`.
>   - `app/components/UI/Tokens/styles.ts`: Update `loaderWrapper` to `flexDirection: 'column'` with `gap: 4` for consistent alignment.
> - **Portfolio Balance**:
>   - `TokenList/PortfolioBalance/index.tsx`: Replace `Loader` with two `Skeleton` components and update imports; preserve balance rendering and privacy toggle.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c47e0f57ea060b3269e95483ea2d7cd864b15aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->