### PR TITLE
fix(INFRA-3066): path based rebuilds

### DIFF
--- a/.github/workflows/needs-e2e-build.yml
+++ b/.github/workflows/needs-e2e-build.yml
@@ -70,6 +70,18 @@ jobs:
         id: filter
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         with:
+          # Path filtering logic:
+          # - android: Files that require Android builds only
+          # - ios: Files that require iOS builds only
+          # - shared: Files that require both Android and iOS builds
+          # - ignore: Files that should not trigger any builds
+          # - catch_all: Fallback that matches everything for conservative handling
+          #
+          # Key points:
+          # - scripts/build.sh is in 'shared' to ensure it triggers rebuilds
+          # - Native code changes (android/**, ios/**) trigger platform-specific builds
+          # - Dependency files (package.json, Podfile, etc.) trigger both platforms
+          # - Documentation and workflow files are ignored
           filters: |
             android:
               - 'android/**'                       # All Android project files
@@ -89,12 +101,12 @@ jobs:
               - 'wdio/**'                          # WebDriver test files
               - 'wdio.conf.js'                     # WebDriver config
               - 'appwright/**'                     # Appwright test files
-              - 'scripts/build.sh'                 # Build.sh
+              - 'scripts/build.sh'                 # Build script triggers rebuilds
 
             ignore:
               - '**/*.md'                          # Documentation files
               - 'docs/**'                          # Documentation directory
-              - '**/*.yml'                         # Workflow files  
+              - '**/*.yml'                         # Workflow files
               - '.github/**'                       # GitHub workflow changes
               - 'LICENSE'                          # License file
               - 'README.md'                        # Main README
@@ -107,9 +119,8 @@ jobs:
               - 'crowdin.yml'                      # Translation config
               - 'bitrise.yml'                      # CI config (non-GitHub)
               - 'sonar-project.properties'         # SonarQube config
-              - 'scripts/*'                        # Build/utility scripts
-              - 'scripts/*/**'                     # Subdirectories in scripts/   
-              - '!scripts/build.sh'                # But NOT build.sh
+              - 'scripts/*'                        # Build/utility scripts (except build.sh which is in shared)
+              - 'scripts/*/**'                     # Subdirectories in scripts/
               - 'patches/**'                       # Dependency patches
               - 'ppom/**'                          # PPOM sub-project
 


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been
completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes a critical bug in the GitHub Actions workflow that was preventing native code changes from triggering E2E test rebuilds.

**Problem:** The negation pattern `!scripts/build.sh` in the paths filter was breaking the entire filtering logic, causing the dorny/paths-filter action to incorrectly treat all files (including native Android and iOS code) as ignored. This meant that PRs with only native code changes would not trigger app rebuilds, potentially running E2E tests against stale builds.

**Solution:**
1. Moved `scripts/build.sh` from the `ignore` section (with problematic negation) to the `shared` section
2. Added comprehensive documentation explaining the intended filter logic
3. Ensured native code changes (`android/**`, `ios/**`) properly trigger platform-specific rebuilds

This fix ensures the CI workflow correctly identifies when rebuilds are needed while maintaining the intended optimization of avoiding unnecessary rebuilds for documentation-only changes.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

## **Manual testing steps**

1. Create a test PR with only Android native code changes (e.g., modify a file in `android/app/src/`)
2. Verify the `needs_e2e_build` job outputs `android_changed: true` and `builds: true`
3. Create a test PR with only iOS native code changes (e.g., modify a file in `ios/`)
4. Verify the `needs_e2e_build` job outputs `ios_changed: true` and `builds: true`
5. Create a test PR with only documentation changes (e.g., modify `README.md`)
6. Verify the `needs_e2e_build` job outputs `builds: false` (no unnecessary rebuilds)
7. Create a test PR that modifies `scripts/build.sh`
8. Verify it triggers rebuilds for both platforms (`android_changed: true`, `ios_changed: true`)

## **Screenshots/Recordings**

### **Before**

Native code changes were incorrectly flagged as ignored:

### **After**

Native code changes now properly trigger the appropriate platform builds.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines path filters in `needs-e2e-build.yml` by moving `scripts/build.sh` to `shared`, clarifying ignore rules, and adding clear documentation to ensure correct Android/iOS rebuild triggers.
> 
> - **CI Workflow (`.github/workflows/needs-e2e-build.yml`)**:
>   - **Path filtering**:
>     - Move `scripts/build.sh` from `ignore` to `shared` to trigger rebuilds on changes.
>     - Keep native paths `android/**` and `ios/**` as platform-specific triggers; group common/dependency files under `shared`.
>     - Maintain `ignore` for docs/workflow and utility scripts; refine patterns and comments for clarity.
>     - Preserve `catch_all` fallback and output listing configuration.
>   - **Documentation**: Add detailed comments explaining filter intent and key points.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ddc5d0b0b907563ded27b8f86f13d4dd575fe479. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->