### PR TITLE
feat(multichain): update multichain accounts intro modal logic and tests

### DIFF
--- a/app/components/hooks/useMultichainAccountsIntroModal.test.ts
+++ b/app/components/hooks/useMultichainAccountsIntroModal.test.ts
@@ -73,8 +73,8 @@ describe('useMultichainAccountsIntroModal', () => {
   it('navigates on app update when feature is enabled and not seen', async () => {
     // Mock app update (has last app version different from current)
     mockStorageWrapper.getItem.mockImplementation((key: string) => {
-      if (key === CURRENT_APP_VERSION) return Promise.resolve('1.1.0');
-      if (key === LAST_APP_VERSION) return Promise.resolve('1.0.0'); // Previous version = update
+      if (key === CURRENT_APP_VERSION) return Promise.resolve('7.57.0');
+      if (key === LAST_APP_VERSION) return Promise.resolve('7.56.0'); // Previous version = update
       return Promise.resolve(null);
     });
 
@@ -110,8 +110,8 @@ describe('useMultichainAccountsIntroModal', () => {
   it('does not navigate when modal has already been seen', async () => {
     // Mock app update
     mockStorageWrapper.getItem.mockImplementation((key: string) => {
-      if (key === CURRENT_APP_VERSION) return Promise.resolve('1.1.0');
-      if (key === LAST_APP_VERSION) return Promise.resolve('1.0.0');
+      if (key === CURRENT_APP_VERSION) return Promise.resolve('7.57.0');
+      if (key === LAST_APP_VERSION) return Promise.resolve('7.56.0');
       return Promise.resolve(null);
     });
 
@@ -145,8 +145,8 @@ describe('useMultichainAccountsIntroModal', () => {
   it('does not navigate when feature is disabled', async () => {
     // Mock app update
     mockStorageWrapper.getItem.mockImplementation((key: string) => {
-      if (key === CURRENT_APP_VERSION) return Promise.resolve('1.1.0');
-      if (key === LAST_APP_VERSION) return Promise.resolve('1.0.0');
+      if (key === CURRENT_APP_VERSION) return Promise.resolve('7.57.0');
+      if (key === LAST_APP_VERSION) return Promise.resolve('7.56.0');
       return Promise.resolve(null);
     });
 
@@ -206,5 +206,79 @@ describe('useMultichainAccountsIntroModal', () => {
 
     expect(result.current.isMultichainAccountsState2Enabled).toBe(true);
     expect(result.current.hasSeenIntroModal).toBe(false);
+  });
+
+  describe('isMultichainAccountsUpdate version logic', () => {
+    const createInitialState = () => ({
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              enableMultichainAccountsState2: {
+                enabled: true,
+                featureVersion: '2',
+                minimumVersion: '1.0.0',
+              },
+            },
+          },
+        },
+      },
+      user: {
+        multichainAccountsIntroModalSeen: false,
+      },
+    });
+
+    it.each([
+      ['7.56.0', '7.57.0'], // exact boundary
+      ['7.55.0', '7.57.0'], // below boundary
+      ['6.0.0', '7.57.0'], // major version jump
+      ['7.56.0', '7.58.0'], // crossing boundary
+      ['6.99.0', '8.0.0'], // major version crossing
+      ['7', '7.57.0'], // missing minor version
+      ['7.56.0-beta', '7.57.0'], // malformed version
+    ])(
+      'navigates when updating from %s to %s',
+      async (lastVersion, currentVersion) => {
+        mockStorageWrapper.getItem.mockImplementation((key: string) => {
+          if (key === CURRENT_APP_VERSION)
+            return Promise.resolve(currentVersion);
+          if (key === LAST_APP_VERSION) return Promise.resolve(lastVersion);
+          return Promise.resolve(null);
+        });
+
+        renderHookWithProviders(createInitialState());
+
+        await new Promise(setImmediate);
+
+        expect(mockNavigate).toHaveBeenCalledWith('RootModalFlow', {
+          screen: 'MultichainAccountsIntroModal',
+        });
+      },
+    );
+
+    it.each([
+      ['7.57.0', '7.58.0'], // already past boundary
+      ['7.58.0', '7.59.0'], // both past boundary
+      ['8.0.0', '8.1.0'], // major version past
+      ['7.60.0', '8.0.0'], // both past boundary
+      ['7.56.0', '6.0.0'], // downgrade
+      ['', '7.57.0'], // empty version
+    ])(
+      'does not navigate when updating from %s to %s',
+      async (lastVersion, currentVersion) => {
+        mockStorageWrapper.getItem.mockImplementation((key: string) => {
+          if (key === CURRENT_APP_VERSION)
+            return Promise.resolve(currentVersion);
+          if (key === LAST_APP_VERSION) return Promise.resolve(lastVersion);
+          return Promise.resolve(null);
+        });
+
+        renderHookWithProviders(createInitialState());
+
+        await new Promise(setImmediate);
+
+        expect(mockNavigate).not.toHaveBeenCalled();
+      },
+    );
   });
 });

--- a/app/components/hooks/useMultichainAccountsIntroModal.ts
+++ b/app/components/hooks/useMultichainAccountsIntroModal.ts
@@ -31,12 +31,26 @@ export const useMultichainAccountsIntroModal = () => {
     const lastAppVersion = await StorageWrapper.getItem(LAST_APP_VERSION);
     const isUpdate = !!lastAppVersion && currentAppVersion !== lastAppVersion;
 
+    let isMultichainAccountsUpdate = false;
+    if (isUpdate) {
+      const toParts = (v: string = '') => v.split('.').map(Number);
+      const [lastMaj = 0, lastMin = 0] = toParts(lastAppVersion);
+      const [currMaj = 0, currMin = 0] = toParts(currentAppVersion);
+
+      isMultichainAccountsUpdate =
+        (lastMaj < 7 || (lastMaj === 7 && lastMin <= 56)) &&
+        (currMaj > 7 || (currMaj === 7 && currMin >= 57));
+    }
+
     // Only show modal if:
     // 1. Feature is enabled
     // 2. User hasn't seen the modal
     // 3. This is not a fresh install (it's an update)
     const shouldShow =
-      isMultichainAccountsState2Enabled && !hasSeenIntroModal && isUpdate;
+      isMultichainAccountsState2Enabled &&
+      !hasSeenIntroModal &&
+      isUpdate &&
+      isMultichainAccountsUpdate;
 
     if (shouldShow && !isE2ETest) {
       navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR updates multichain accounts intro modal logic so that the banner only triggers if `sourceVersion <= 7.56.xx` and `destVersion >= 7.57.xx.`, to prevent showing the modal on upgrade for every user that installs any version after 7.57.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updates multichain accounts intro modal display logic

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-164

## **Manual testing steps**

```gherkin
Feature: Update between versions >= 7.57

  Scenario: user updates app
    Given user has app with version >= 7.57

    When user updates to higher version
    Then multichain account intro modal is NOT SHOWN
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Gate the multichain accounts intro modal to only show when updating from <=7.56.x to >=7.57.x, with comprehensive tests for version-crossing scenarios.
> 
> - **Hook logic (`app/components/hooks/useMultichainAccountsIntroModal.ts`)**:
>   - Gate modal display behind a version boundary: only show on updates crossing from `<= 7.56.x` to `>= 7.57.x`.
>   - Parse major/minor from `CURRENT_APP_VERSION`/`LAST_APP_VERSION` and include `isMultichainAccountsUpdate` in `shouldShow` condition.
> - **Tests (`app/components/hooks/useMultichainAccountsIntroModal.test.ts`)**:
>   - Update test versions to `7.56.0` → `7.57.0`.
>   - Add parameterized cases validating navigation for boundary-crossing updates and non-navigation for already-past, downgrade, and empty-version scenarios.
>   - Preserve checks for fresh install, feature disabled, and modal already seen.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8c3873dfb52119bdbbc05024c92a6c1d9adf0e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->