### PR TITLE
refactor: update alignment in PerpsMarketListView

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.test.tsx
@@ -149,6 +149,7 @@ jest.mock('@metamask/design-system-react-native', () => {
     },
     BoxAlignItems: {
       Center: 'center',
+      End: 'flex-end',
     },
   };
 });

--- a/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
@@ -401,8 +401,8 @@ const PerpsMarketListView = ({
       <View>
         <Box
           flexDirection={BoxFlexDirection.Row}
-          alignItems={BoxAlignItems.Center}
-          twClassName="w-full pt-3 px-2 bg-default border-t border-muted gap-x-2"
+          alignItems={BoxAlignItems.End}
+          twClassName="w-full pt-3 mb-1 px-2 bg-default border-t border-muted"
           style={[tw.style(`pb-[${insets.bottom}px]`)]}
         >
           <View style={tw.style('flex-1')}>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR fixes Perps footer/tap bar style misalignement.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug that was causing footer/tap bar to have different style

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-159

## **Manual testing steps**

```gherkin
Feature: Open perps

  Scenario: user opens perps
    Given user onboarded

    When user navigates to perps
    Then footer/tap bar does not change
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/ea3e144d-c01c-49e0-9cae-53410af3a52a


<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/e1472444-b807-44cf-9bcc-276b7292fbf9


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
