### PR TITLE
fix: cp-7.58.0 percentage buttons in perps deposit

### DIFF
--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
@@ -53,6 +53,22 @@ function runHook({
             },
           }
         : {},
+      {
+        engine: {
+          backgroundState: {
+            CurrencyRateController: {
+              currentCurrency: 'tst',
+              currencyRates: {
+                ETH: {
+                  conversionDate: 1732887955.694,
+                  conversionRate: 1,
+                  usdConversionRate: 2,
+                },
+              },
+            },
+          },
+        },
+      },
     ),
   });
 }
@@ -261,6 +277,18 @@ describe('useTransactionCustomAmount', () => {
       });
 
       expect(result.current.amountFiat).toBe('530.86');
+    });
+
+    it('to percentage of token balance converted to usd if overridden', async () => {
+      const { result } = runHook({
+        transactionMeta: { type: TransactionType.perpsDeposit },
+      });
+
+      await act(async () => {
+        result.current.updatePendingAmountPercentage(43);
+      });
+
+      expect(result.current.amountFiat).toBe('1061.72');
     });
 
     it('minus buffers if 100', async () => {

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -19,6 +19,7 @@ import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { selectPredictBalanceByAddress } from '../../components/predict-confirmations/predict-temp';
 import { RootState } from '../../../../../reducers';
 import { hasTransactionType } from '../../utils/transaction';
+import { useTransactionPayFiat } from '../pay/useTransactionPayFiat';
 
 export const MAX_LENGTH = 28;
 const DEBOUNCE_DELAY = 500;
@@ -174,9 +175,10 @@ function getTokenAddress(transactionMeta: TransactionMeta | undefined): Hex {
 function useTokenBalance() {
   const transactionMeta = useTransactionMetadataRequest() as TransactionMeta;
   const from = (transactionMeta?.txParams?.from ?? '0x0') as Hex;
+  const { convertFiat } = useTransactionPayFiat();
 
   const { payToken } = useTransactionPayToken();
-  const payTokenBalance = payToken?.tokenFiatAmount ?? 0;
+  const payTokenBalance = convertFiat(payToken?.tokenFiatAmount ?? 0);
 
   const predictBalance = useSelector((state: RootState) =>
     selectPredictBalanceByAddress(state, from),


### PR DESCRIPTION
## **Description**

Fix percentage buttons in Perps deposit, by converting balance to USD if required.

Partial cherry-pick of #21529 for `7.58.0`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #21751 

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Percentage buttons now compute amounts from fiat-converted balance (handles USD override for perps deposits) with supporting tests.
> 
> - **Hooks**:
>   - `useTransactionCustomAmount`: use `useTransactionPayFiat.convertFiat` to derive `payTokenBalance` in `useTokenBalance`, ensuring percentage calculations use the selected fiat (e.g., USD override for perps deposits).
> - **Tests**:
>   - `useTransactionCustomAmount.test.ts`: add `CurrencyRateController` mock data and a test verifying percentage calculation converts to USD for `TransactionType.perpsDeposit`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9561b323ba7b74eb027e91905e3e0e81f2baa223. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->