### PR TITLE
chore: fix typo in isPortfolioViewEnabled property name

### DIFF
--- a/app/components/Views/confirmations/components/rows/account-network-info-row/account-network-info-expanded/account-network-info-expanded.test.tsx
+++ b/app/components/Views/confirmations/components/rows/account-network-info-row/account-network-info-expanded/account-network-info-expanded.test.tsx
@@ -46,7 +46,7 @@ describe('AccountNetworkInfoExpanded', () => {
         nativeTokenUnit: 'ETH',
         tokenFiatBalancesCrossChains: [],
         shouldShowAggregatedPercentage: false,
-        isPortfolioVieEnabled: true,
+        isPortfolioViewEnabled: true,
         aggregatedBalance: {
           ethFiat: 0,
           tokenFiat: 0,

--- a/app/components/hooks/useMultichainBalances/useMultichainBalances.types.ts
+++ b/app/components/hooks/useMultichainBalances/useMultichainBalances.types.ts
@@ -10,7 +10,7 @@ export interface MultichainBalancesData {
   totalNativeTokenBalance: string | undefined;
   nativeTokenUnit: string;
   shouldShowAggregatedPercentage: boolean;
-  isPortfolioVieEnabled: boolean;
+  isPortfolioViewEnabled: boolean;
   aggregatedBalance: AggregatedPercentageProps;
   isLoadingAccount: boolean;
 }

--- a/app/components/hooks/useMultichainBalances/useSelectedAccountMultichainBalances.test.ts
+++ b/app/components/hooks/useMultichainBalances/useSelectedAccountMultichainBalances.test.ts
@@ -124,7 +124,7 @@ describe('useSelectedAccountMultichainBalances', () => {
       totalNativeTokenBalance: '0',
       nativeTokenUnit: 'ETH',
       shouldShowAggregatedPercentage: true,
-      isPortfolioVieEnabled: false,
+      isPortfolioViewEnabled: false,
       aggregatedBalance,
     });
   });
@@ -216,7 +216,7 @@ describe('useSelectedAccountMultichainBalances', () => {
     const { result } = renderHook(() => useSelectedAccountMultichainBalances());
 
     expect(
-      result.current.selectedAccountMultichainBalance?.isPortfolioVieEnabled,
+      result.current.selectedAccountMultichainBalance?.isPortfolioViewEnabled,
     ).toBe(true);
     expect(
       result.current.selectedAccountMultichainBalance?.totalFiatBalance,

--- a/app/components/hooks/useMultichainBalances/useSelectedAccountMultichainBalances.ts
+++ b/app/components/hooks/useMultichainBalances/useSelectedAccountMultichainBalances.ts
@@ -116,7 +116,7 @@ const useSelectedAccountMultichainBalances =
           shouldShowAggregatedPercentage: getShouldShowAggregatedPercentage(
             chainId as SupportedCaipChainId,
           ),
-          isPortfolioVieEnabled: isPortfolioEnabled,
+          isPortfolioViewEnabled: isPortfolioEnabled,
           aggregatedBalance: getAggregatedBalance(selectedInternalAccount),
           isLoadingAccount:
             accountBalanceData.totalNativeTokenBalance === undefined,


### PR DESCRIPTION
## **Description**

This PR fixes a typo in the multichain balances hook where the property name was incorrectly spelled as `isPortfolioVieEnabled` instead of `isPortfolioViewEnabled`.

**What is the reason for the change?**
The property name `isPortfolioVieEnabled` contained a typo ("Vie" instead of "View"), which reduced code readability and could cause confusion for developers.

**What is the improvement/solution?**
Renamed the property to `isPortfolioViewEnabled` consistently across all files including:
- TypeScript type definitions
- Implementation in the useSelectedAccountMultichainBalances hook
- All related unit tests

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Portfolio view functionality

  Scenario: user views portfolio with multichain balances
    Given the app is running with portfolio view enabled
    
    When user navigates to account network info
    And user views their multichain balances
    Then the portfolio view displays correctly with no console errors or TypeScript errors
```

## **Screenshots/Recordings**

N/A - This is an internal refactoring with no visual changes

### **Before**

Property named `isPortfolioVieEnabled` (typo)

<img width="313" height="412" alt="Screenshot 2025-10-28 at 11 29 59 AM" src="https://github.com/user-attachments/assets/da5ea743-9eb7-4caf-b0c7-de31f2f5c047" />

### **After**

Property named `isPortfolioViewEnabled` (corrected)

<img width="300" height="266" alt="Screenshot 2025-10-28 at 11 30 29 AM" src="https://github.com/user-attachments/assets/363734a1-99f9-4f11-9274-3a47e697414c" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rename `isPortfolioVieEnabled` to `isPortfolioViewEnabled` across types, implementation, and tests.
> 
> - **Multichain Balances**:
>   - Rename `isPortfolioVieEnabled` -> `isPortfolioViewEnabled` in:
>     - `useMultichainBalances.types.ts` interface `MultichainBalancesData`.
>     - `useSelectedAccountMultichainBalances.ts` returned data.
> - **Tests**:
>   - Update all references and expectations in:
>     - `useSelectedAccountMultichainBalances.test.ts`.
>     - `account-network-info-expanded.test.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6db3cff80cf98be4c764aa14af4fc7b4c0df55a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->