### PR TITLE
chore(predict): change keypad to remove unnecessary props and show decimal dot

### DIFF
--- a/app/components/UI/Predict/components/PredictAmountDisplay/PredictAmountDisplay.test.tsx
+++ b/app/components/UI/Predict/components/PredictAmountDisplay/PredictAmountDisplay.test.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react-native';
+import { render, fireEvent } from '@testing-library/react-native';
 import { PerpsAmountDisplaySelectorsIDs } from '../../../../../../e2e/selectors/Perps/Perps.selectors';
 import PredictAmountDisplay from './PredictAmountDisplay';
-import { formatPrice, formatPositionSize } from '../../utils/format';
 
 jest.mock('../../../../../util/theme', () => ({
   useTheme: () => ({
@@ -14,280 +13,179 @@ jest.mock('../../../../../util/theme', () => ({
       primary: {
         default: '#037DD6',
       },
-      warning: {
-        default: '#ffd33d',
-      },
     },
     themeAppearance: 'light',
   }),
 }));
 
-jest.mock('../../utils/format', () => ({
-  formatPrice: jest.fn((value, options) => {
-    const num = parseFloat(value);
-    if (options?.minimumDecimals === 0 && Number.isInteger(num)) {
-      return `$${num}`;
-    }
-    return `$${value}`;
-  }),
-  formatPositionSize: jest.fn((value) => parseFloat(value).toString()),
-}));
-
-describe('PerpsAmountDisplay', () => {
+describe('PredictAmountDisplay', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
   });
 
   describe('Rendering', () => {
-    it('displays amount with proper formatting', () => {
-      // Arrange
+    it('displays amount with dollar sign', () => {
       const amount = '1000';
 
-      // Act
       const { getByText } = render(<PredictAmountDisplay amount={amount} />);
 
-      // Assert
-      expect(getByText('$1000')).toBeTruthy();
+      expect(getByText('$1000')).toBeOnTheScreen();
     });
 
-    it('displays $0 when amount is empty', () => {
-      // Arrange
+    it('displays $ when amount is empty string', () => {
       const emptyAmount = '';
 
-      // Act
       const { getByText } = render(
         <PredictAmountDisplay amount={emptyAmount} />,
       );
 
-      // Assert
-      expect(getByText('$0')).toBeTruthy();
+      expect(getByText('$')).toBeOnTheScreen();
     });
 
-    it('displays label when provided', () => {
-      // Arrange - Testing branch coverage for line 72
-      const label = 'Enter Amount';
-      const amount = '1000';
+    it('renders container with correct test ID', () => {
+      const amount = '100';
 
-      // Act
-      const { getByText } = render(
-        <PredictAmountDisplay amount={amount} label={label} />,
-      );
+      const { getByTestId } = render(<PredictAmountDisplay amount={amount} />);
 
-      // Assert
-      expect(getByText(label)).toBeTruthy();
-    });
-
-    it('displays token amount when showTokenAmount is true', () => {
-      // Arrange - Testing branch coverage for line 85
-      const tokenAmount = '0.5';
-      const tokenSymbol = 'ETH';
-      const amount = '1000';
-
-      // Act
-      render(
-        <PredictAmountDisplay
-          amount={amount}
-          showTokenAmount
-          tokenAmount={tokenAmount}
-          tokenSymbol={tokenSymbol}
-        />,
-      );
-
-      // Assert
-      // There will be 2 elements: one in the main display and one in the token amount section
-      const tokenElements = screen.getAllByText(
-        `${tokenAmount} ${tokenSymbol}`,
-      );
-      expect(tokenElements.length).toBe(2);
-      expect(formatPositionSize).toHaveBeenCalledWith(tokenAmount);
-    });
-  });
-
-  describe('Warning States', () => {
-    it('shows default warning when showWarning is true and maxAmount is 0', () => {
-      // Arrange
-      const amount = '1000';
-
-      // Act
-      const { getByText } = render(
-        <PredictAmountDisplay amount={amount} showWarning />,
-      );
-
-      // Assert
       expect(
-        getByText('No funds available. Please deposit first.'),
-      ).toBeTruthy();
+        getByTestId(PerpsAmountDisplaySelectorsIDs.CONTAINER),
+      ).toBeOnTheScreen();
     });
 
-    it('shows custom warning message when provided', () => {
-      // Arrange
-      const customMessage = 'Insufficient balance';
-      const amount = '1000';
+    it('displays decimal amounts correctly', () => {
+      const amount = '1234.56';
 
-      // Act
-      const { getByText } = render(
-        <PredictAmountDisplay
-          amount={amount}
-          showWarning
-          warningMessage={customMessage}
-        />,
-      );
+      const { getByText } = render(<PredictAmountDisplay amount={amount} />);
 
-      // Assert
-      expect(getByText(customMessage)).toBeTruthy();
+      expect(getByText('$1234.56')).toBeOnTheScreen();
     });
   });
 
   describe('User Interactions', () => {
     it('calls onPress handler when amount is pressed', () => {
-      // Arrange
       const onPressMock = jest.fn();
       const amount = '1000';
 
-      // Act
       const { getByText } = render(
         <PredictAmountDisplay amount={amount} onPress={onPressMock} />,
       );
       fireEvent.press(getByText('$1000'));
 
-      // Assert
       expect(onPressMock).toHaveBeenCalledTimes(1);
     });
 
-    it('handles press gracefully when onPress is not provided', () => {
-      // Arrange
+    it('handles press without error when onPress is not provided', () => {
       const amount = '1000';
 
-      // Act
       const { getByText } = render(<PredictAmountDisplay amount={amount} />);
 
-      // Assert - This should not throw an error
       expect(() => fireEvent.press(getByText('$1000'))).not.toThrow();
     });
   });
 
   describe('Active State', () => {
-    it('shows cursor when isActive is true', () => {
-      // Arrange
+    it('displays cursor when isActive is true', () => {
       const amount = '1000';
 
-      // Act
       const { getByTestId } = render(
         <PredictAmountDisplay amount={amount} isActive />,
       );
 
-      // Assert
-      expect(getByTestId('cursor')).toBeTruthy();
+      expect(getByTestId('cursor')).toBeOnTheScreen();
     });
 
     it('hides cursor when isActive is false', () => {
-      // Arrange
       const amount = '1000';
 
-      // Act
       const { queryByTestId } = render(
         <PredictAmountDisplay amount={amount} isActive={false} />,
       );
 
-      // Assert
+      expect(queryByTestId('cursor')).toBeNull();
+    });
+
+    it('hides cursor by default when isActive is not specified', () => {
+      const amount = '1000';
+
+      const { queryByTestId } = render(
+        <PredictAmountDisplay amount={amount} />,
+      );
+
       expect(queryByTestId('cursor')).toBeNull();
     });
   });
 
-  describe('Token Amount Display', () => {
-    it('displays token amount when showMaxAmount is true with token data', () => {
-      // Arrange
+  describe('Error State', () => {
+    it('applies error text color when hasError is true', () => {
       const amount = '1000';
-      const tokenAmount = '0.025';
-      const tokenSymbol = 'BTC';
 
-      // Act
-      const { getByText } = render(
-        <PredictAmountDisplay
-          amount={amount}
-          showMaxAmount
-          tokenAmount={tokenAmount}
-          tokenSymbol={tokenSymbol}
-        />,
+      const { getByTestId } = render(
+        <PredictAmountDisplay amount={amount} hasError />,
       );
 
-      // Assert
-      expect(getByText('0.025 BTC')).toBeTruthy();
-      expect(formatPositionSize).toHaveBeenCalledWith(tokenAmount);
+      const amountText = getByTestId(
+        PerpsAmountDisplaySelectorsIDs.AMOUNT_LABEL,
+      );
+      expect(amountText).toBeOnTheScreen();
+      expect(amountText.props.style).toEqual(
+        expect.objectContaining({
+          color: expect.any(String),
+        }),
+      );
     });
 
-    it('does not display token amount when showMaxAmount is false', () => {
-      // Arrange
+    it('applies default text color when hasError is false', () => {
       const amount = '1000';
-      const tokenAmount = '0.025';
-      const tokenSymbol = 'BTC';
 
-      // Act
-      const { queryByText } = render(
-        <PredictAmountDisplay
-          amount={amount}
-          showMaxAmount={false}
-          tokenAmount={tokenAmount}
-          tokenSymbol={tokenSymbol}
-        />,
+      const { getByTestId } = render(
+        <PredictAmountDisplay amount={amount} hasError={false} />,
       );
 
-      // Assert
-      expect(queryByText('0.025 BTC')).toBeNull();
+      const amountText = getByTestId(
+        PerpsAmountDisplaySelectorsIDs.AMOUNT_LABEL,
+      );
+      expect(amountText).toBeOnTheScreen();
     });
 
-    it('does not display anything when showMaxAmount is true but no token data', () => {
-      // Arrange
+    it('applies default text color when hasError is not specified', () => {
       const amount = '1000';
 
-      // Act
-      const { queryByTestId } = render(
-        <PredictAmountDisplay amount={amount} showMaxAmount />,
-      );
+      const { getByTestId } = render(<PredictAmountDisplay amount={amount} />);
 
-      // Assert - The component should not show the token amount section
-      // When no token data is provided, the token amount section won't be rendered
-      // We verify by checking if the amount display is there but no token text
-      expect(
-        queryByTestId(PerpsAmountDisplaySelectorsIDs.CONTAINER),
-      ).toBeTruthy();
-      // No token amount should be displayed
-      expect(screen.queryByText(/BTC|ETH|SOL/)).toBeNull();
+      const amountText = getByTestId(
+        PerpsAmountDisplaySelectorsIDs.AMOUNT_LABEL,
+      );
+      expect(amountText).toBeOnTheScreen();
     });
   });
 
-  describe('Formatting', () => {
-    it('formats prices with correct decimal places', () => {
-      // Arrange
-      const amount = '1234.56';
+  describe('Edge Cases', () => {
+    it('handles zero amount', () => {
+      const amount = '0';
 
-      // Act
-      render(<PredictAmountDisplay amount={amount} />);
+      const { getByText } = render(<PredictAmountDisplay amount={amount} />);
 
-      // Assert
-      expect(formatPrice).toHaveBeenCalledWith('1234.56', {
-        minimumDecimals: 0,
-        maximumDecimals: 2,
-      });
-      // Note: formatPrice is no longer called with maxAmount for display
+      expect(getByText('$0')).toBeOnTheScreen();
     });
 
-    it('formats USD amounts with maximum 2 decimal places', () => {
-      // Arrange
-      const amount = '1234.5678';
+    it('handles large numbers', () => {
+      const amount = '1000000';
 
-      // Act
-      render(<PredictAmountDisplay amount={amount} />);
+      const { getByText } = render(<PredictAmountDisplay amount={amount} />);
 
-      // Assert - Verify USD amounts are limited to 2 decimal places
-      expect(formatPrice).toHaveBeenCalledWith('1234.5678', {
-        minimumDecimals: 0,
-        maximumDecimals: 2,
-      });
+      expect(getByText('$1000000')).toBeOnTheScreen();
+    });
+
+    it('handles very small decimal amounts', () => {
+      const amount = '0.01';
+
+      const { getByText } = render(<PredictAmountDisplay amount={amount} />);
+
+      expect(getByText('$0.01')).toBeOnTheScreen();
     });
   });
 });

--- a/app/components/UI/Predict/components/PredictAmountDisplay/PredictAmountDisplay.test.tsx
+++ b/app/components/UI/Predict/components/PredictAmountDisplay/PredictAmountDisplay.test.tsx
@@ -36,14 +36,14 @@ describe('PredictAmountDisplay', () => {
       expect(getByText('$1000')).toBeOnTheScreen();
     });
 
-    it('displays $ when amount is empty string', () => {
+    it('displays $0 when amount is empty string', () => {
       const emptyAmount = '';
 
       const { getByText } = render(
         <PredictAmountDisplay amount={emptyAmount} />,
       );
 
-      expect(getByText('$')).toBeOnTheScreen();
+      expect(getByText('$0')).toBeOnTheScreen();
     });
 
     it('renders container with correct test ID', () => {

--- a/app/components/UI/Predict/components/PredictAmountDisplay/PredictAmountDisplay.tsx
+++ b/app/components/UI/Predict/components/PredictAmountDisplay/PredictAmountDisplay.tsx
@@ -11,33 +11,18 @@ import Text, {
   TextColor,
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
-import { formatPositionSize, formatPrice } from '../../utils/format';
 
 interface PredictAmountDisplayProps {
   amount: string;
-  showWarning?: boolean;
-  warningMessage?: string;
   onPress?: () => void;
   isActive?: boolean;
-  label?: string;
-  showTokenAmount?: boolean;
-  tokenAmount?: string;
-  tokenSymbol?: string;
-  showMaxAmount?: boolean;
   hasError?: boolean;
 }
 
 const PredictAmountDisplay: React.FC<PredictAmountDisplayProps> = ({
   amount,
-  showWarning = false,
-  warningMessage = 'No funds available. Please deposit first.',
   onPress,
   isActive = false,
-  label,
-  showTokenAmount = false,
-  tokenAmount,
-  tokenSymbol,
-  showMaxAmount = true,
   hasError = false,
 }) => {
   const tw = useTailwind();
@@ -72,15 +57,6 @@ const PredictAmountDisplay: React.FC<PredictAmountDisplayProps> = ({
       twClassName="px-6"
       testID={PerpsAmountDisplaySelectorsIDs.CONTAINER}
     >
-      {label && (
-        <Text
-          variant={TextVariant.BodyMD}
-          color={TextColor.Alternative}
-          style={tw.style('mb-2')}
-        >
-          {label}
-        </Text>
-      )}
       <Box
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.Center}
@@ -94,11 +70,7 @@ const PredictAmountDisplay: React.FC<PredictAmountDisplayProps> = ({
             'text-[64px] tracking-tight leading-[74px] font-medium',
           )}
         >
-          {showTokenAmount && tokenAmount && tokenSymbol
-            ? `${formatPositionSize(tokenAmount)} ${tokenSymbol}`
-            : amount
-            ? formatPrice(amount, { minimumDecimals: 0, maximumDecimals: 2 })
-            : '$0'}
+          {`$${amount}` || '$0'}
         </Text>
         {isActive && (
           <Animated.View
@@ -112,26 +84,6 @@ const PredictAmountDisplay: React.FC<PredictAmountDisplayProps> = ({
           />
         )}
       </Box>
-      {/* Display token amount equivalent for current input */}
-      {showMaxAmount && tokenAmount && tokenSymbol && (
-        <Text
-          variant={TextVariant.BodyMD}
-          color={TextColor.Alternative}
-          style={tw.style('mt-1')}
-          testID={PerpsAmountDisplaySelectorsIDs.MAX_LABEL}
-        >
-          {formatPositionSize(tokenAmount)} {tokenSymbol}
-        </Text>
-      )}
-      {showWarning && (
-        <Text
-          variant={TextVariant.BodySM}
-          color={TextColor.Warning}
-          style={tw.style('mt-3')}
-        >
-          {warningMessage}
-        </Text>
-      )}
     </Box>
   );
 

--- a/app/components/UI/Predict/components/PredictAmountDisplay/PredictAmountDisplay.tsx
+++ b/app/components/UI/Predict/components/PredictAmountDisplay/PredictAmountDisplay.tsx
@@ -51,6 +51,8 @@ const PredictAmountDisplay: React.FC<PredictAmountDisplayProps> = ({
     }
   }, [isActive, fadeAnim]);
 
+  const amountValue = amount ? `$${amount}` : '$0';
+
   const content = (
     <Box
       alignItems={BoxAlignItems.Center}
@@ -70,7 +72,7 @@ const PredictAmountDisplay: React.FC<PredictAmountDisplayProps> = ({
             'text-[64px] tracking-tight leading-[74px] font-medium',
           )}
         >
-          {`$${amount}` || '$0'}
+          {amountValue}
         </Text>
         {isActive && (
           <Animated.View

--- a/app/components/UI/Predict/components/PredictKeypad/PredictKeypad.test.tsx
+++ b/app/components/UI/Predict/components/PredictKeypad/PredictKeypad.test.tsx
@@ -2,7 +2,21 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import PredictKeypad, { PredictKeypadHandles } from './PredictKeypad';
 
+// Mock the Keypad component to capture onChange callback
+let mockOnChange:
+  | ((data: { value: string; valueAsNumber: number }) => void)
+  | null = null;
+jest.mock('../../../../Base/Keypad', () =>
+  jest.fn((props) => {
+    mockOnChange = props.onChange;
+    return null;
+  }),
+);
+
 describe('PredictKeypad', () => {
+  beforeAll(() => {
+    mockOnChange = null;
+  });
   const defaultProps = {
     isInputFocused: true,
     currentValue: 1,
@@ -148,27 +162,271 @@ describe('PredictKeypad', () => {
   });
 
   describe('Keypad Integration', () => {
-    it('renders with correct props', () => {
-      // Arrange
+    it('renders Keypad component with correct currency and decimals', () => {
       const props = { ...defaultProps };
 
-      // Act
       const { toJSON } = render(<PredictKeypad {...props} />);
 
-      // Assert
       expect(toJSON()).toBeTruthy();
     });
+  });
 
-    it('handles keypad input changes internally', () => {
-      // Arrange
-      const props = { ...defaultProps };
+  describe('Add Funds Button', () => {
+    it('renders Add Funds button when hasInsufficientFunds is true and onAddFunds is provided', () => {
+      const onAddFundsMock = jest.fn();
+      const props = {
+        ...defaultProps,
+        hasInsufficientFunds: true,
+        onAddFunds: onAddFundsMock,
+      };
 
-      // Act - Component handles keypad changes internally, so we test that it renders
+      const { getByText, queryByText } = render(<PredictKeypad {...props} />);
+
+      expect(getByText('Add funds')).toBeOnTheScreen();
+      expect(queryByText('$20')).toBeNull();
+      expect(queryByText('$50')).toBeNull();
+      expect(queryByText('$100')).toBeNull();
+    });
+
+    it('calls onAddFunds when Add Funds button is pressed', () => {
+      const onAddFundsMock = jest.fn();
+      const props = {
+        ...defaultProps,
+        hasInsufficientFunds: true,
+        onAddFunds: onAddFundsMock,
+      };
+
+      const { getByText } = render(<PredictKeypad {...props} />);
+      fireEvent.press(getByText('Add funds'));
+
+      expect(onAddFundsMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders quick amount buttons when hasInsufficientFunds is false', () => {
+      const props = {
+        ...defaultProps,
+        hasInsufficientFunds: false,
+      };
+
+      const { getByText, queryByText } = render(<PredictKeypad {...props} />);
+
+      expect(getByText('$20')).toBeOnTheScreen();
+      expect(getByText('$50')).toBeOnTheScreen();
+      expect(getByText('$100')).toBeOnTheScreen();
+      expect(queryByText('predict.deposit.add_funds')).toBeNull();
+    });
+
+    it('renders quick amount buttons when onAddFunds is not provided', () => {
+      const props = {
+        ...defaultProps,
+        hasInsufficientFunds: true,
+        onAddFunds: undefined,
+      };
+
+      const { getByText, queryByText } = render(<PredictKeypad {...props} />);
+
+      expect(getByText('$20')).toBeOnTheScreen();
+      expect(queryByText('predict.deposit.add_funds')).toBeNull();
+    });
+  });
+
+  describe('handleDonePress', () => {
+    it('removes trailing decimal point when Done is pressed', () => {
+      const props = {
+        ...defaultProps,
+        currentValueUSDString: '25.',
+      };
+      const ref = React.createRef<PredictKeypadHandles>();
+
+      render(<PredictKeypad ref={ref} {...props} />);
+      ref.current?.handleDonePress();
+
+      expect(props.setCurrentValueUSDString).toHaveBeenCalledWith('25');
+      expect(props.setCurrentValue).toHaveBeenCalledWith(25);
+      expect(props.setIsInputFocused).toHaveBeenCalledWith(false);
+    });
+
+    it('handles empty string after removing decimal point', () => {
+      const props = {
+        ...defaultProps,
+        currentValueUSDString: '.',
+      };
+      const ref = React.createRef<PredictKeypadHandles>();
+
+      render(<PredictKeypad ref={ref} {...props} />);
+      ref.current?.handleDonePress();
+
+      expect(props.setCurrentValueUSDString).toHaveBeenCalledWith('');
+      expect(props.setCurrentValue).toHaveBeenCalledWith(0);
+    });
+
+    it('does not modify value when no trailing decimal point', () => {
+      const props = {
+        ...defaultProps,
+        currentValueUSDString: '25.50',
+      };
+      const ref = React.createRef<PredictKeypadHandles>();
+
+      render(<PredictKeypad ref={ref} {...props} />);
+      ref.current?.handleDonePress();
+
+      expect(props.setCurrentValueUSDString).not.toHaveBeenCalled();
+      expect(props.setIsInputFocused).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('handleKeypadChange', () => {
+    it('updates value when keypad input changes', () => {
+      const props = {
+        ...defaultProps,
+        currentValue: 0,
+        currentValueUSDString: '0',
+      };
+
       render(<PredictKeypad {...props} />);
+      mockOnChange?.({ value: '5', valueAsNumber: 5 });
 
-      // Assert - The component should render without errors and handle changes internally
-      expect(props.setCurrentValue).toBeDefined();
-      expect(props.setCurrentValueUSDString).toBeDefined();
+      expect(props.setCurrentValueUSDString).toHaveBeenCalledWith('5');
+      expect(props.setCurrentValue).toHaveBeenCalledWith(5);
+    });
+
+    it('blocks input exceeding 9 digits', () => {
+      const props = {
+        ...defaultProps,
+        currentValue: 123456789,
+        currentValueUSDString: '123456789',
+      };
+
+      render(<PredictKeypad {...props} />);
+      mockOnChange?.({ value: '1234567890', valueAsNumber: 1234567890 });
+
+      expect(props.setCurrentValueUSDString).not.toHaveBeenCalled();
+      expect(props.setCurrentValue).not.toHaveBeenCalled();
+    });
+
+    it('limits decimal places to 2 digits', () => {
+      const props = {
+        ...defaultProps,
+        currentValue: 25,
+        currentValueUSDString: '25',
+      };
+
+      render(<PredictKeypad {...props} />);
+      mockOnChange?.({ value: '25.999', valueAsNumber: 25.999 });
+
+      expect(props.setCurrentValueUSDString).toHaveBeenCalledWith('25.99');
+      expect(props.setCurrentValue).toHaveBeenCalledWith(25.99);
+    });
+
+    it('preserves decimal point when user just typed it', () => {
+      const props = {
+        ...defaultProps,
+        currentValue: 25,
+        currentValueUSDString: '25',
+      };
+
+      render(<PredictKeypad {...props} />);
+      mockOnChange?.({ value: '25.', valueAsNumber: 25 });
+
+      expect(props.setCurrentValueUSDString).toHaveBeenCalledWith('25.');
+      expect(props.setCurrentValue).toHaveBeenCalledWith(25);
+    });
+
+    it('handles value with trailing decimal remaining the same', () => {
+      const props = {
+        ...defaultProps,
+        currentValue: 25,
+        currentValueUSDString: '25.',
+      };
+
+      render(<PredictKeypad {...props} />);
+      mockOnChange?.({ value: '25.', valueAsNumber: 25 });
+
+      expect(props.setCurrentValueUSDString).toHaveBeenCalledWith('25.');
+      expect(props.setCurrentValue).toHaveBeenCalledWith(25);
+    });
+
+    it('removes decimal when deleting digit after decimal point', () => {
+      const props = {
+        ...defaultProps,
+        currentValue: 2.5,
+        currentValueUSDString: '2.5',
+      };
+
+      render(<PredictKeypad {...props} />);
+      mockOnChange?.({ value: '2.', valueAsNumber: 2 });
+
+      expect(props.setCurrentValueUSDString).toHaveBeenCalledWith('2');
+    });
+
+    it('handles empty input value', () => {
+      const props = {
+        ...defaultProps,
+        currentValue: 25,
+        currentValueUSDString: '25',
+      };
+
+      render(<PredictKeypad {...props} />);
+      mockOnChange?.({ value: '', valueAsNumber: 0 });
+
+      expect(props.setCurrentValueUSDString).toHaveBeenCalledWith('');
+      expect(props.setCurrentValue).toHaveBeenCalledWith(0);
+    });
+
+    it('handles single decimal point input', () => {
+      const props = {
+        ...defaultProps,
+        currentValue: 0,
+        currentValueUSDString: '0',
+      };
+
+      render(<PredictKeypad {...props} />);
+      mockOnChange?.({ value: '.', valueAsNumber: 0 });
+
+      expect(props.setCurrentValueUSDString).toHaveBeenCalledWith('.');
+      expect(props.setCurrentValue).toHaveBeenCalledWith(0);
+    });
+
+    it('handles decimal value with no integer part', () => {
+      const props = {
+        ...defaultProps,
+        currentValue: 0,
+        currentValueUSDString: '0',
+      };
+
+      render(<PredictKeypad {...props} />);
+      mockOnChange?.({ value: '.5', valueAsNumber: 0.5 });
+
+      expect(props.setCurrentValueUSDString).toHaveBeenCalledWith('.5');
+      expect(props.setCurrentValue).toHaveBeenCalledWith(0.5);
+    });
+
+    it('handles normal numeric input', () => {
+      const props = {
+        ...defaultProps,
+        currentValue: 0,
+        currentValueUSDString: '0',
+      };
+
+      render(<PredictKeypad {...props} />);
+      mockOnChange?.({ value: '123', valueAsNumber: 123 });
+
+      expect(props.setCurrentValueUSDString).toHaveBeenCalledWith('123');
+      expect(props.setCurrentValue).toHaveBeenCalledWith(123);
+    });
+
+    it('handles decimal input with multiple digits', () => {
+      const props = {
+        ...defaultProps,
+        currentValue: 0,
+        currentValueUSDString: '0',
+      };
+
+      render(<PredictKeypad {...props} />);
+      mockOnChange?.({ value: '123.45', valueAsNumber: 123.45 });
+
+      expect(props.setCurrentValueUSDString).toHaveBeenCalledWith('123.45');
+      expect(props.setCurrentValue).toHaveBeenCalledWith(123.45);
     });
   });
 });

--- a/app/components/UI/Predict/components/PredictKeypad/PredictKeypad.tsx
+++ b/app/components/UI/Predict/components/PredictKeypad/PredictKeypad.tsx
@@ -54,8 +54,20 @@ const PredictKeypad = forwardRef<PredictKeypadHandles, PredictKeypadProps>(
     );
 
     const handleDonePress = useCallback(() => {
+      // Clean up trailing decimal point if user finished with just a dot
+      let cleanedValue = currentValueUSDString;
+      if (cleanedValue.endsWith('.')) {
+        cleanedValue = cleanedValue.slice(0, -1);
+        setCurrentValueUSDString(cleanedValue);
+        setCurrentValue(parseFloat(cleanedValue) || 0);
+      }
       setIsInputFocused(false);
-    }, [setIsInputFocused]);
+    }, [
+      setIsInputFocused,
+      currentValueUSDString,
+      setCurrentValueUSDString,
+      setCurrentValue,
+    ]);
 
     useImperativeHandle(ref, () => ({
       handleAmountPress,
@@ -114,7 +126,9 @@ const PredictKeypad = forwardRef<PredictKeypadHandles, PredictKeypadProps>(
 
         // Update all states in batch to prevent race conditions
         setCurrentValueUSDString(formattedUSDString);
-        setCurrentValue(parseFloat(formattedUSDString));
+        // parseFloat handles "2." correctly (returns 2), and handles empty/"." as NaN
+        const numericValue = parseFloat(formattedUSDString);
+        setCurrentValue(isNaN(numericValue) ? 0 : numericValue);
       },
       [
         currentValue,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- change keypad to remove unnecessary props 
- show decimal dot

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies PredictAmountDisplay and enhances PredictKeypad input/UX (decimal handling, limits, conditional Add funds), with comprehensive test updates.
> 
> - **UI**:
>   - **`app/components/UI/Predict/components/PredictAmountDisplay/PredictAmountDisplay.tsx`**:
>     - Simplifies API and rendering: removes label/token/warning props and external formatters; always displays `$${amount}` or `$0`.
>     - Retains active cursor animation; supports error color via `hasError`.
>   - **`app/components/UI/Predict/components/PredictKeypad/PredictKeypad.tsx`**:
>     - Improves input handling: trims trailing `.` on Done, preserves typed `.`, limits to 9 digits and 2 decimals, handles deletions/NaN -> 0.
>     - Adds conditional "Add funds" button when `hasInsufficientFunds` and `onAddFunds` are provided; otherwise shows quick amounts and Done.
> - **Tests**:
>   - Overhauls tests for both components to match new behavior: simplified amount display assertions, cursor/error states, Add funds flow, quick amounts, ref handlers, and comprehensive keypad input edge cases (mocked `Keypad`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ade638d4f32ff8765e40dc39c626b7f04f567b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->