### PR TITLE
chore: update balance empty state to use primary button and buy flow

### DIFF
--- a/app/components/UI/BalanceEmptyState/BalanceEmptyState.test.tsx
+++ b/app/components/UI/BalanceEmptyState/BalanceEmptyState.test.tsx
@@ -14,6 +14,17 @@ jest.mock('@react-navigation/native', () => ({
   }),
 }));
 
+// Mock buy navigation details
+const mockBuyNavigationDetails = ['RampBuy', { screen: 'GetStarted' }];
+jest.mock('../Ramp/Aggregator/routes/utils', () => ({
+  createBuyNavigationDetails: jest.fn(() => mockBuyNavigationDetails),
+}));
+
+// Get the mock function to verify calls
+const { createBuyNavigationDetails } = jest.requireMock(
+  '../Ramp/Aggregator/routes/utils',
+);
+
 describe('BalanceEmptyState', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -43,7 +54,7 @@ describe('BalanceEmptyState', () => {
     });
   });
 
-  it('has action button that can be pressed', () => {
+  it('navigates to buy flow when action button is pressed', () => {
     const { getByTestId } = renderComponent();
     const actionButton = getByTestId('balance-empty-state-action-button');
 
@@ -52,7 +63,12 @@ describe('BalanceEmptyState', () => {
     // Press the button
     fireEvent.press(actionButton);
 
-    // Verify that navigation was triggered
-    expect(mockNavigate).toHaveBeenCalled();
+    // Verify that buy navigation details are created
+    expect(createBuyNavigationDetails).toHaveBeenCalled();
+
+    // Verify that navigation was triggered with buy flow parameters
+    expect(mockNavigate).toHaveBeenCalledWith('RampBuy', {
+      screen: 'GetStarted',
+    });
   });
 });

--- a/app/components/UI/BalanceEmptyState/BalanceEmptyState.tsx
+++ b/app/components/UI/BalanceEmptyState/BalanceEmptyState.tsx
@@ -4,6 +4,8 @@ import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import {
   Box,
+  Button,
+  ButtonSize,
   Text,
   TextVariant,
   TextColor,
@@ -14,13 +16,12 @@ import {
   FontWeight,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import ButtonHero from '../../../component-library/components-temp/Buttons/ButtonHero';
 import { strings } from '../../../../locales/i18n';
 import { MetaMetricsEvents, useMetrics } from '../../hooks/useMetrics';
 import { getDecimalChainId } from '../../../util/networks';
 import { selectChainId } from '../../../selectors/networkController';
 import { trace, TraceName } from '../../../util/trace';
-import { createDepositNavigationDetails } from '../Ramp/Deposit/routes/utils';
+import { createBuyNavigationDetails } from '../Ramp/Aggregator/routes/utils';
 import { BalanceEmptyStateProps } from './BalanceEmptyState.types';
 import bankTransferImage from '../../../images/bank-transfer.png';
 
@@ -38,12 +39,10 @@ const BalanceEmptyState: React.FC<BalanceEmptyStateProps> = ({
   const { trackEvent, createEventBuilder } = useMetrics();
 
   const handleAction = () => {
-    navigation.navigate(...createDepositNavigationDetails());
+    navigation.navigate(...createBuyNavigationDetails());
 
     trackEvent(
-      createEventBuilder(
-        MetaMetricsEvents.CARD_ADD_FUNDS_DEPOSIT_CLICKED,
-      ).build(),
+      createEventBuilder(MetaMetricsEvents.BUY_BUTTON_CLICKED).build(),
     );
 
     trackEvent(
@@ -52,13 +51,13 @@ const BalanceEmptyState: React.FC<BalanceEmptyStateProps> = ({
           text: 'Add funds',
           location: 'BalanceEmptyState',
           chain_id_destination: getDecimalChainId(chainId),
-          ramp_type: 'DEPOSIT',
+          ramp_type: 'BUY',
         })
         .build(),
     );
 
     trace({
-      name: TraceName.LoadDepositExperience,
+      name: TraceName.LoadRampExperience,
     });
   };
 
@@ -104,13 +103,14 @@ const BalanceEmptyState: React.FC<BalanceEmptyStateProps> = ({
           {strings('wallet.get_ready_for_web3')}
         </Text>
       </Box>
-      <ButtonHero
+      <Button
+        size={ButtonSize.Lg}
         onPress={handleAction}
         isFullWidth
         testID={`${testID}-action-button`}
       >
         {strings('wallet.add_funds')}
-      </ButtonHero>
+      </Button>
     </Box>
   );
 };


### PR DESCRIPTION
## **Description**

Updates the balance empty state component:

1. Replaced `ButtonHero` with standard `Button` component
2. Updated routing from deposit flow to buy flow

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: Internal design system alignment and user flow optimization

## **Manual testing steps**

```gherkin
Feature: Balance Empty State Updates

  Scenario: User views balance empty state with new button styling in storybook
    When user navigates to BalanceEmptyState in storybook
    Then they should see the balance empty state with a primary button styled "Add funds" button
```

## **Screenshots/Recordings**

### **Before**
ButtonHero component

<img width="350" height="402" alt="Screenshot 2025-10-28 at 1 08 55 PM" src="https://github.com/user-attachments/assets/f4a581e7-4190-4f86-bb3c-b791cb59ce1e" /><img width="350" height="385" alt="Screenshot 2025-10-28 at 1 08 59 PM" src="https://github.com/user-attachments/assets/665e6274-71b4-46e6-ae8b-f5c57172d134" />


### **After**  
Button component with primary styling

<img width="350" height="407" alt="Screenshot 2025-10-28 at 12 04 48 PM" src="https://github.com/user-attachments/assets/e04ff8a5-ec4c-42b8-8153-f5f427031056" /><img width="350" height="375" alt="Screenshot 2025-10-28 at 12 04 57 PM" src="https://github.com/user-attachments/assets/2ea46b53-b3be-4658-afb7-c9c3e16e0bd6" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches BalanceEmptyState from deposit to buy flow and replaces ButtonHero with design-system Button, updating analytics/trace and tests accordingly.
> 
> - **UI**:
>   - Replace `ButtonHero` with design-system `Button` (`ButtonSize.Lg`) in `BalanceEmptyState.tsx`.
>   - Change action to navigate via `createBuyNavigationDetails()` instead of deposit flow.
> - **Analytics/Tracing**:
>   - Update events to `BUY_BUTTON_CLICKED` and `RAMPS_BUTTON_CLICKED` with `ramp_type: 'BUY'`.
>   - Switch trace to `TraceName.LoadRampExperience`.
> - **Tests**:
>   - Update `BalanceEmptyState.test.tsx` to mock `createBuyNavigationDetails` and assert navigation to `RampBuy` with `{ screen: 'GetStarted' }`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f3432666d1f7d536caabaaa755f80f31d16a521. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->