### PR TITLE
chore(predict): add loading state to place order screen and remove toasts

### DIFF
--- a/app/components/UI/Predict/components/PredictPositions/PredictPositions.tsx
+++ b/app/components/UI/Predict/components/PredictPositions/PredictPositions.tsx
@@ -138,7 +138,7 @@ const PredictPositions = forwardRef<
         removeClippedSubviews
         decelerationRate={0}
         ListEmptyComponent={isTrulyEmpty ? <PredictPositionEmpty /> : null}
-        ListFooterComponent={positions.length > 0 ? <PredictNewButton /> : null}
+        ListFooterComponent={isTrulyEmpty ? null : <PredictNewButton />}
       />
       {claimablePositions.length > 0 && (
         <>

--- a/app/components/UI/Predict/hooks/usePredictPlaceOrder.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictPlaceOrder.test.ts
@@ -160,22 +160,9 @@ describe('usePredictPlaceOrder', () => {
         await result.current.placeOrder(mockOrderParams);
       });
 
-      expect(mockToastRef.current?.showToast).toHaveBeenCalledTimes(2);
+      expect(mockToastRef.current?.showToast).toHaveBeenCalledTimes(1);
 
-      // First call - loading toast
-      expect(mockToastRef.current?.showToast).toHaveBeenNthCalledWith(
-        1,
-        expect.objectContaining({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Loading,
-          labelOptions: [{ label: 'Placing a prediction' }],
-          hasNoTimeout: false,
-        }),
-      );
-
-      // Second call - success toast
-      expect(mockToastRef.current?.showToast).toHaveBeenNthCalledWith(
-        2,
+      expect(mockToastRef.current?.showToast).toHaveBeenCalledWith(
         expect.objectContaining({
           variant: ToastVariants.Icon,
           iconName: IconName.Check,
@@ -191,7 +178,6 @@ describe('usePredictPlaceOrder', () => {
     });
 
     it('shows cashed out toast when SELL order is placed', async () => {
-      jest.useFakeTimers();
       mockPlaceOrder.mockResolvedValue(mockSuccessResult);
       const sellOrderParams = {
         ...mockOrderParams,
@@ -208,31 +194,7 @@ describe('usePredictPlaceOrder', () => {
 
       expect(mockToastRef.current?.showToast).toHaveBeenCalledTimes(1);
 
-      // First call - loading toast
-      expect(mockToastRef.current?.showToast).toHaveBeenNthCalledWith(
-        1,
-        expect.objectContaining({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Loading,
-          labelOptions: expect.arrayContaining([
-            expect.objectContaining({
-              label: expect.stringContaining('Cashing out'),
-              isBold: true,
-            }),
-          ]),
-          hasNoTimeout: false,
-        }),
-      );
-
-      await act(async () => {
-        jest.advanceTimersByTime(2000);
-      });
-
-      expect(mockToastRef.current?.showToast).toHaveBeenCalledTimes(2);
-
-      // Second call - success toast (after delay)
-      expect(mockToastRef.current?.showToast).toHaveBeenNthCalledWith(
-        2,
+      expect(mockToastRef.current?.showToast).toHaveBeenCalledWith(
         expect.objectContaining({
           variant: ToastVariants.Icon,
           iconName: IconName.Check,
@@ -245,8 +207,6 @@ describe('usePredictPlaceOrder', () => {
           hasNoTimeout: false,
         }),
       );
-
-      jest.useRealTimers();
     });
 
     it('reloads balance after order placement completes', async () => {
@@ -286,7 +246,7 @@ describe('usePredictPlaceOrder', () => {
       expect(mockOnComplete).toHaveBeenCalledTimes(1);
     });
 
-    it('logs order placement attempt and success', async () => {
+    it('logs order placement success', async () => {
       mockPlaceOrder.mockResolvedValue(mockSuccessResult);
 
       const { result } = renderHook(() => usePredictPlaceOrder());
@@ -295,10 +255,6 @@ describe('usePredictPlaceOrder', () => {
         await result.current.placeOrder(mockOrderParams);
       });
 
-      expect(mockDevLoggerLog).toHaveBeenCalledWith(
-        'usePredictPlaceOrder: Placing order',
-        mockOrderParams,
-      );
       expect(mockDevLoggerLog).toHaveBeenCalledWith(
         'usePredictPlaceOrder: Order placed successfully',
       );
@@ -344,7 +300,7 @@ describe('usePredictPlaceOrder', () => {
       expect(result.current.result).toBeNull();
     });
 
-    it('shows failure toast when order placement fails', async () => {
+    it('does not show toast when order placement fails', async () => {
       mockPlaceOrder.mockResolvedValue(mockFailureResult);
 
       const { result } = renderHook(() => usePredictPlaceOrder());
@@ -353,37 +309,7 @@ describe('usePredictPlaceOrder', () => {
         await result.current.placeOrder(mockOrderParams);
       });
 
-      expect(mockToastRef.current?.showToast).toHaveBeenCalledTimes(2);
-
-      // First call - loading toast
-      expect(mockToastRef.current?.showToast).toHaveBeenNthCalledWith(
-        1,
-        expect.objectContaining({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Loading,
-          hasNoTimeout: false,
-        }),
-      );
-
-      // Second call - error toast with detailed message
-      expect(mockToastRef.current?.showToast).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Danger,
-          labelOptions: expect.arrayContaining([
-            expect.objectContaining({
-              label: 'Order failed',
-              isBold: true,
-            }),
-            expect.objectContaining({
-              label: 'Order placement failed',
-              isBold: false,
-            }),
-          ]),
-          hasNoTimeout: false,
-        }),
-      );
+      expect(mockToastRef.current?.showToast).not.toHaveBeenCalled();
     });
 
     it('calls onError callback when provided and order fails', async () => {
@@ -415,7 +341,7 @@ describe('usePredictPlaceOrder', () => {
       expect(result.current.result).toBeNull();
     });
 
-    it('shows error toast when controller throws exception', async () => {
+    it('does not show toast when controller throws exception', async () => {
       const mockError = new Error('Network error');
       mockPlaceOrder.mockRejectedValue(mockError);
 
@@ -425,37 +351,7 @@ describe('usePredictPlaceOrder', () => {
         await result.current.placeOrder(mockOrderParams);
       });
 
-      expect(mockToastRef.current?.showToast).toHaveBeenCalledTimes(2);
-
-      // First call - loading toast
-      expect(mockToastRef.current?.showToast).toHaveBeenNthCalledWith(
-        1,
-        expect.objectContaining({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Loading,
-          hasNoTimeout: false,
-        }),
-      );
-
-      // Second call - error toast with exception message
-      expect(mockToastRef.current?.showToast).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Danger,
-          labelOptions: expect.arrayContaining([
-            expect.objectContaining({
-              label: 'Order failed',
-              isBold: true,
-            }),
-            expect.objectContaining({
-              label: 'Network error',
-              isBold: false,
-            }),
-          ]),
-          hasNoTimeout: false,
-        }),
-      );
+      expect(mockToastRef.current?.showToast).not.toHaveBeenCalled();
     });
 
     it('provides default error message for non-Error thrown values', async () => {

--- a/app/components/UI/Predict/hooks/usePredictPlaceOrder.ts
+++ b/app/components/UI/Predict/hooks/usePredictPlaceOrder.ts
@@ -50,25 +50,21 @@ export function usePredictPlaceOrder(
 
   const showCashedOutToast = useCallback(
     (amount: string) => {
-      // NOTE: When cashing out happens fast, stacking toasts messes the UX.
-      // Figure out how toast behavior can be improved to avoid this.
-      setTimeout(() => {
-        toastRef?.current?.showToast({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Check,
-          labelOptions: [
-            { label: strings('predict.order.cashed_out'), isBold: true },
-            { label: '\n', isBold: false },
-            {
-              label: strings('predict.order.cashed_out_subtitle', {
-                amount,
-              }),
-              isBold: false,
-            },
-          ],
-          hasNoTimeout: false,
-        });
-      }, 2000);
+      toastRef?.current?.showToast({
+        variant: ToastVariants.Icon,
+        iconName: IconName.Check,
+        labelOptions: [
+          { label: strings('predict.order.cashed_out'), isBold: true },
+          { label: '\n', isBold: false },
+          {
+            label: strings('predict.order.cashed_out_subtitle', {
+              amount,
+            }),
+            isBold: false,
+          },
+        ],
+        hasNoTimeout: false,
+      });
     },
     [toastRef],
   );
@@ -94,42 +90,6 @@ export function usePredictPlaceOrder(
 
       try {
         setIsLoading(true);
-
-        DevLogger.log('usePredictPlaceOrder: Placing order', orderParams);
-        if (side === Side.BUY) {
-          toastRef?.current?.showToast({
-            variant: ToastVariants.Icon,
-            iconName: IconName.Loading,
-            labelOptions: [
-              { label: strings('predict.order.placing_prediction') },
-            ],
-            hasNoTimeout: false,
-          });
-        } else {
-          toastRef?.current?.showToast({
-            variant: ToastVariants.Icon,
-            iconName: IconName.Loading,
-            labelOptions: [
-              {
-                label: strings('predict.order.cashing_out', {
-                  amount: formatPrice(minAmountReceived, {
-                    maximumDecimals: 2,
-                  }),
-                }),
-                isBold: true,
-              },
-              { label: '\n', isBold: false },
-              {
-                label: strings('predict.order.cashing_out_subtitle', {
-                  time: 5,
-                }),
-                isBold: false,
-              },
-            ],
-            hasNoTimeout: false,
-          });
-        }
-
         // Place order using Predict controller
         const orderResult = await controllerPlaceOrder(orderParams);
 
@@ -183,18 +143,6 @@ export function usePredictPlaceOrder(
 
         setError(errorMessage);
         onError?.(errorMessage);
-
-        // Show error toast to user
-        toastRef?.current?.showToast({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Danger,
-          labelOptions: [
-            { label: strings('predict.order.order_failed'), isBold: true },
-            { label: '\n', isBold: false },
-            { label: errorMessage, isBold: false },
-          ],
-          hasNoTimeout: false,
-        });
       } finally {
         setIsLoading(false);
       }
@@ -203,7 +151,6 @@ export function usePredictPlaceOrder(
       controllerPlaceOrder,
       onComplete,
       loadBalance,
-      toastRef,
       showCashedOutToast,
       showOrderPlacedToast,
       onError,

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -1956,7 +1956,7 @@ describe('PolymarketProvider', () => {
       ).rejects.toThrow('Failed to fetch unrealized P&L');
     });
 
-    it('throws error when API returns empty array', async () => {
+    it('returns undefined when API returns empty array', async () => {
       const provider = createProvider();
 
       (globalThis.fetch as jest.Mock).mockResolvedValue({
@@ -1964,11 +1964,11 @@ describe('PolymarketProvider', () => {
         json: jest.fn().mockResolvedValue([]),
       });
 
-      await expect(
-        provider.getUnrealizedPnL({
-          address: '0x1234567890123456789012345678901234567890',
-        }),
-      ).rejects.toThrow('No unrealized P&L data found');
+      const result = await provider.getUnrealizedPnL({
+        address: '0x1234567890123456789012345678901234567890',
+      });
+
+      expect(result).toBeUndefined();
     });
 
     it('throws error when API returns non-array response', async () => {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -382,7 +382,7 @@ export class PolymarketProvider implements PredictProvider {
 
     const data = (await response.json()) as UnrealizedPnL[];
 
-    if (!Array.isArray(data) || data.length === 0) {
+    if (!Array.isArray(data)) {
       throw new Error('No unrealized P&L data found');
     }
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1751,6 +1751,7 @@
       "cashed_out": "Cashed out",
       "cashed_out_subtitle": "{{amount}} added to your balance",
       "cashing_out": "Cashing out {{amount}}",
+      "cashing_out_loading": "Cashing out...",
       "cashing_out_subtitle": "Estimated {{time}} seconds",
       "placing_prediction": "Placing a prediction",
       "prediction_placed": "Prediction placed",
@@ -1758,7 +1759,8 @@
       "payments_made_in_usdc": "All payments are made in USDC",
       "prediction_insufficient_funds": "Insufficient funds. Lower the amount or add funds to continue.",
       "prediction_minimum_bet": "Minimum bet is {{amount}}",
-      "to_win": "To win"
+      "to_win": "To win",
+      "order_failed_generic": "Transaction failed. Please try again."
     },
     "withdraw": {
       "withdrawing": "Withdrawing {{amount}} USDC",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- add loading state to place order screen and remove toasts
- fixes an issue when throwing an error for accounts with no PnL.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds inline loading states and generic error messages to buy/sell previews, removes loading/error toasts from order placement, tweaks positions footer logic, and returns undefined for empty unrealized P&L.
> 
> - **Predict UI**:
>   - **Buy/Sell Previews**: Add inline button loading (spinner + text) and show generic error message on failure; navigate back via `result` effect after success.
>   - **Positions List**: Show `PredictNewButton` unless lists are truly empty.
> - **Hook**:
>   - **usePredictPlaceOrder**: Remove loading/error toasts and “placing” logs; keep success toasts; maintain loading/error/result state and balance refresh.
> - **Provider**:
>   - **PolymarketProvider.getUnrealizedPnL**: Return `undefined` when API returns an empty array; keep error on non-array.
> - **Locales**:
>   - Add `predict.order.cashing_out_loading` and `predict.order.order_failed_generic` strings.
> - **Tests**:
>   - Update unit tests to reflect new inline loading/error behavior and PnL empty handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ac887f5ff62d7208f59d28d1cd2211487eddce9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->