### PR TITLE
chore(predict): remove and change predict states

### DIFF
--- a/app/components/UI/Predict/components/PredictBalance/PredictBalance.test.tsx
+++ b/app/components/UI/Predict/components/PredictBalance/PredictBalance.test.tsx
@@ -26,12 +26,6 @@ jest.mock('../../hooks/usePredictBalance', () => ({
 const mockUsePredictDeposit = jest.fn();
 jest.mock('../../hooks/usePredictDeposit', () => ({
   usePredictDeposit: () => mockUsePredictDeposit(),
-  PredictDepositStatus: {
-    IDLE: 'idle',
-    PENDING: 'pending',
-    CONFIRMED: 'confirmed',
-    FAILED: 'failed',
-  },
 }));
 
 // Mock usePredictActionGuard hook
@@ -77,7 +71,7 @@ describe('PredictBalance', () => {
 
     mockUsePredictDeposit.mockReturnValue({
       deposit: jest.fn(),
-      status: 'idle',
+      isDepositPending: false,
     });
 
     mockUsePredictWithdraw.mockReturnValue({
@@ -313,7 +307,7 @@ describe('PredictBalance', () => {
       });
       mockUsePredictDeposit.mockReturnValue({
         deposit: mockDeposit,
-        status: 'idle',
+        isDepositPending: false,
       });
 
       // Act
@@ -340,7 +334,7 @@ describe('PredictBalance', () => {
       });
       mockUsePredictDeposit.mockReturnValue({
         deposit: mockDeposit,
-        status: 'idle',
+        isDepositPending: false,
       });
 
       // Act
@@ -383,10 +377,10 @@ describe('PredictBalance', () => {
 
   describe('balance refresh', () => {
     it('component renders with adding funds state when deposit is pending', () => {
-      // Arrange - set up CONFIRMED status to test the adding funds UI
+      // Arrange - set up pending deposit to test the adding funds UI
       mockUsePredictDeposit.mockReturnValue({
         deposit: jest.fn(),
-        status: 'pending',
+        isDepositPending: true,
       });
 
       // Act
@@ -400,11 +394,11 @@ describe('PredictBalance', () => {
       ).toBeOnTheScreen();
     });
 
-    it('component renders normally when deposit status is idle', () => {
-      // Arrange - set up IDLE status
+    it('component renders normally when deposit is not pending', () => {
+      // Arrange - set up no pending deposit
       mockUsePredictDeposit.mockReturnValue({
         deposit: jest.fn(),
-        status: 'idle',
+        isDepositPending: false,
       });
 
       // Act
@@ -525,7 +519,7 @@ describe('PredictBalance', () => {
       });
       mockUsePredictDeposit.mockReturnValue({
         deposit: jest.fn(),
-        status: 'pending',
+        isDepositPending: true,
       });
 
       // Act

--- a/app/components/UI/Predict/components/PredictBalance/PredictBalance.tsx
+++ b/app/components/UI/Predict/components/PredictBalance/PredictBalance.tsx
@@ -30,7 +30,6 @@ import {
 } from '../../../Perps/constants/hyperLiquidConfig';
 import { usePredictBalance } from '../../hooks/usePredictBalance';
 import { usePredictDeposit } from '../../hooks/usePredictDeposit';
-import { PredictDepositStatus } from '../../types';
 import { formatPrice } from '../../utils/format';
 import { usePredictActionGuard } from '../../hooks/usePredictActionGuard';
 import { NavigationProp, useNavigation } from '@react-navigation/native';
@@ -52,21 +51,21 @@ const PredictBalance: React.FC<PredictBalanceProps> = ({ onLayout }) => {
     loadOnMount: true,
     refreshOnFocus: true,
   });
-  const { deposit, status } = usePredictDeposit();
+  const { deposit, isDepositPending } = usePredictDeposit();
   const { withdraw } = usePredictWithdraw();
   const { executeGuardedAction } = usePredictActionGuard({
     providerId: 'polymarket',
     navigation,
   });
 
-  const isAddingFunds = status === PredictDepositStatus.PENDING;
+  const isAddingFunds = isDepositPending;
   const hasBalance = balance > 0;
 
   useEffect(() => {
-    if (status === PredictDepositStatus.CONFIRMED) {
+    if (!isDepositPending) {
       loadBalance({ isRefresh: true });
     }
-  }, [status, loadBalance]);
+  }, [isDepositPending, loadBalance]);
 
   const handleAddFunds = useCallback(() => {
     executeGuardedAction(() => {

--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
@@ -33,11 +33,7 @@ import { useUnrealizedPnL } from '../../hooks/useUnrealizedPnL';
 import { usePredictActionGuard } from '../../hooks/usePredictActionGuard';
 import { POLYMARKET_PROVIDER_ID } from '../../providers/polymarket/constants';
 import { selectPredictClaimablePositions } from '../../selectors/predictController';
-import {
-  PredictDepositStatus,
-  PredictPosition,
-  PredictPositionStatus,
-} from '../../types';
+import { PredictPosition, PredictPositionStatus } from '../../types';
 import { PredictNavigationParamList } from '../../types/navigation';
 import { formatPrice } from '../../utils/format';
 
@@ -77,7 +73,7 @@ const PredictPositionsHeader = forwardRef<
     loadOnMount: true,
     refreshOnFocus: true,
   });
-  const { status } = usePredictDeposit();
+  const { isDepositPending } = usePredictDeposit();
   const claimablePositions = useSelector(selectPredictClaimablePositions);
 
   const {
@@ -96,10 +92,10 @@ const PredictPositionsHeader = forwardRef<
   }, [balanceError, pnlError, onError]);
 
   useEffect(() => {
-    if (status === PredictDepositStatus.CONFIRMED) {
+    if (!isDepositPending) {
       loadBalance({ isRefresh: true });
     }
-  }, [status, loadBalance]);
+  }, [isDepositPending, loadBalance]);
 
   const handleBalanceTouch = () => {
     navigation.navigate(Routes.PREDICT.ROOT, {

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -1066,7 +1066,7 @@ export class PredictController extends BaseController<
 
       // Prepare claim transaction - can fail if safe address not found, signing fails, etc.
       const prepareClaimResult = await provider.prepareClaim({
-        positions: claimablePositions.splice(0, 1),
+        positions: claimablePositions,
         signer,
       });
 

--- a/app/components/UI/Predict/hooks/usePredictClaim.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictClaim.test.ts
@@ -1,7 +1,6 @@
 import { NavigationProp } from '@react-navigation/native';
 import { renderHook } from '@testing-library/react-hooks';
 import React from 'react';
-import { useSelector } from 'react-redux';
 import { captureException } from '@sentry/react-native';
 import { strings } from '../../../../../locales/i18n';
 import { IconName } from '../../../../component-library/components/Icons/Icon';
@@ -23,12 +22,6 @@ const mockShowToast = jest.fn();
 // Mock dependencies
 jest.mock('@sentry/react-native', () => ({
   captureException: jest.fn(),
-}));
-
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: jest.fn(),
-  connect: jest.fn(() => (component: unknown) => component),
 }));
 
 jest.mock('./usePredictEligibility');
@@ -56,7 +49,6 @@ jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(),
 }));
 
-const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 const mockUsePredictTrading = usePredictTrading as jest.MockedFunction<
   typeof usePredictTrading
 >;
@@ -104,10 +96,6 @@ describe('usePredictClaim', () => {
     mockUseConfirmNavigation.mockReturnValue({
       navigateToConfirmation: mockNavigateToConfirmation,
     } as ReturnType<typeof useConfirmNavigation>);
-
-    mockUseSelector.mockReturnValue({
-      status: 'pending',
-    });
   });
 
   afterEach(() => {
@@ -129,13 +117,12 @@ describe('usePredictClaim', () => {
     );
 
   describe('initialization', () => {
-    it('returns claim function and status', () => {
+    it('returns claim function', () => {
       // Arrange & Act
       const { result } = renderHook(() => usePredictClaim(), { wrapper });
 
       // Assert
       expect(result.current.claim).toBeInstanceOf(Function);
-      expect(result.current.status).toBe('pending');
     });
   });
 
@@ -363,72 +350,6 @@ describe('usePredictClaim', () => {
           },
         },
       );
-    });
-  });
-
-  describe('status', () => {
-    it('returns status from claimTransaction selector', () => {
-      // Arrange
-      mockUseSelector.mockReturnValue({
-        status: 'completed',
-      });
-
-      // Act
-      const { result } = renderHook(() => usePredictClaim(), { wrapper });
-
-      // Assert
-      expect(result.current.status).toBe('completed');
-    });
-
-    it('returns undefined when claimTransaction is not available', () => {
-      // Arrange
-      mockUseSelector.mockReturnValue(undefined);
-
-      // Act
-      const { result } = renderHook(() => usePredictClaim(), { wrapper });
-
-      // Assert
-      expect(result.current.status).toBeUndefined();
-    });
-
-    it('returns different status values from claimTransaction', () => {
-      // Arrange
-      mockUseSelector.mockReturnValue({
-        status: 'processing',
-      });
-
-      // Act
-      const { result } = renderHook(() => usePredictClaim(), { wrapper });
-
-      // Assert
-      expect(result.current.status).toBe('processing');
-    });
-
-    it('selects claimTransaction from Redux state', () => {
-      // Arrange
-      const mockClaimTransaction = {
-        status: 'failed',
-        error: 'Transaction failed',
-      };
-
-      mockUseSelector.mockImplementation((selector) => {
-        const mockState = {
-          engine: {
-            backgroundState: {
-              PredictController: {
-                claimTransaction: mockClaimTransaction,
-              },
-            },
-          },
-        };
-        return selector(mockState);
-      });
-
-      // Act
-      const { result } = renderHook(() => usePredictClaim(), { wrapper });
-
-      // Assert
-      expect(result.current.status).toBe('failed');
     });
   });
 

--- a/app/components/UI/Predict/hooks/usePredictClaim.ts
+++ b/app/components/UI/Predict/hooks/usePredictClaim.ts
@@ -1,18 +1,15 @@
-import { useCallback, useContext } from 'react';
-import { useSelector } from 'react-redux';
-import { createSelector } from 'reselect';
+import { useNavigation } from '@react-navigation/native';
 import { captureException } from '@sentry/react-native';
+import { useCallback, useContext } from 'react';
+import { strings } from '../../../../../locales/i18n';
 import { IconName } from '../../../../component-library/components/Icons/Icon';
 import { ToastVariants } from '../../../../component-library/components/Toast';
 import { ToastContext } from '../../../../component-library/components/Toast/Toast.context';
 import Routes from '../../../../constants/navigation/Routes';
-import { RootState } from '../../../../reducers';
+import { useAppThemeFromContext } from '../../../../util/theme';
+import { useConfirmNavigation } from '../../../Views/confirmations/hooks/useConfirmNavigation';
 import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
 import { usePredictTrading } from './usePredictTrading';
-import { useAppThemeFromContext } from '../../../../util/theme';
-import { strings } from '../../../../../locales/i18n';
-import { useConfirmNavigation } from '../../../Views/confirmations/hooks/useConfirmNavigation';
-import { useNavigation } from '@react-navigation/native';
 
 interface UsePredictClaimParams {
   providerId?: string;
@@ -26,12 +23,6 @@ export const usePredictClaim = ({
   const theme = useAppThemeFromContext();
   const { toastRef } = useContext(ToastContext);
   const navigation = useNavigation();
-
-  const selectClaimTransaction = createSelector(
-    (state: RootState) => state.engine.backgroundState.PredictController,
-    (predictState) => predictState.claimTransaction,
-  );
-  const claimTransaction = useSelector(selectClaimTransaction);
 
   const claim = useCallback(async () => {
     try {
@@ -92,6 +83,5 @@ export const usePredictClaim = ({
 
   return {
     claim,
-    status: claimTransaction?.status,
   };
 };

--- a/app/components/UI/Predict/hooks/usePredictClaimToasts.test.tsx
+++ b/app/components/UI/Predict/hooks/usePredictClaimToasts.test.tsx
@@ -58,9 +58,7 @@ jest.mock('../../../../util/theme', () => ({
 // Mock Engine
 jest.mock('../../../../core/Engine', () => ({
   context: {
-    PredictController: {
-      clearClaimTransaction: jest.fn(),
-    },
+    PredictController: {},
   },
   controllerMessenger: {
     subscribe: jest.fn(),
@@ -130,9 +128,6 @@ describe('usePredictClaimToasts', () => {
     jest.clearAllMocks();
     mockToastRef.current.showToast.mockClear();
     mockClaim.mockClear();
-    (
-      Engine.context.PredictController.clearClaimTransaction as jest.Mock
-    ).mockClear();
 
     // Capture the subscribe callback
     mockSubscribeCallback = null;
@@ -214,9 +209,6 @@ describe('usePredictClaimToasts', () => {
       });
 
       // Assert
-      expect(
-        Engine.context.PredictController.clearClaimTransaction,
-      ).not.toHaveBeenCalled();
       expect(mockToastRef.current.showToast).not.toHaveBeenCalled();
     });
 
@@ -289,9 +281,6 @@ describe('usePredictClaimToasts', () => {
       });
 
       // Assert
-      expect(
-        Engine.context.PredictController.clearClaimTransaction,
-      ).toHaveBeenCalled();
       expect(mockToastRef.current.showToast).toHaveBeenCalledWith(
         expect.objectContaining({
           variant: expect.anything(),
@@ -321,9 +310,6 @@ describe('usePredictClaimToasts', () => {
       });
 
       // Assert
-      expect(
-        Engine.context.PredictController.clearClaimTransaction,
-      ).toHaveBeenCalled();
       expect(mockToastRef.current.showToast).toHaveBeenCalledWith(
         expect.objectContaining({
           variant: expect.anything(),
@@ -336,46 +322,6 @@ describe('usePredictClaimToasts', () => {
           }),
         }),
       );
-    });
-
-    it('clears claim transaction when transaction is confirmed', async () => {
-      // Arrange
-      renderHook(() => usePredictClaimToasts(), { wrapper });
-
-      // Act
-      await act(async () => {
-        mockSubscribeCallback?.({
-          transactionMeta: {
-            status: TransactionStatus.confirmed,
-            nestedTransactions: [{ type: TransactionType.predictClaim }],
-          },
-        });
-      });
-
-      // Assert
-      expect(
-        Engine.context.PredictController.clearClaimTransaction,
-      ).toHaveBeenCalled();
-    });
-
-    it('clears claim transaction when transaction fails', async () => {
-      // Arrange
-      renderHook(() => usePredictClaimToasts(), { wrapper });
-
-      // Act
-      await act(async () => {
-        mockSubscribeCallback?.({
-          transactionMeta: {
-            status: TransactionStatus.failed,
-            nestedTransactions: [{ type: TransactionType.predictClaim }],
-          },
-        });
-      });
-
-      // Assert
-      expect(
-        Engine.context.PredictController.clearClaimTransaction,
-      ).toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Predict/hooks/usePredictClaimToasts.tsx
+++ b/app/components/UI/Predict/hooks/usePredictClaimToasts.tsx
@@ -2,7 +2,6 @@ import { TransactionType } from '@metamask/transaction-controller';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { strings } from '../../../../../locales/i18n';
-import Engine from '../../../../core/Engine';
 import { selectPredictClaimablePositions } from '../selectors/predictController';
 import { PredictPosition, PredictPositionStatus } from '../types';
 import { formatPrice } from '../utils/format';
@@ -63,8 +62,6 @@ export const usePredictClaimToasts = () => {
       retryLabel: strings('predict.claim.toasts.error.try_again'),
       onRetry: claim,
     },
-    clearTransaction: () =>
-      Engine.context.PredictController.clearClaimTransaction(),
     onConfirmed: () => {
       loadPositions({ isRefresh: true }).catch(() => {
         // Ignore errors when refreshing positions

--- a/app/components/UI/Predict/hooks/usePredictDeposit.ts
+++ b/app/components/UI/Predict/hooks/usePredictDeposit.ts
@@ -2,16 +2,16 @@ import { NavigationProp, useNavigation } from '@react-navigation/native';
 import { captureException } from '@sentry/react-native';
 import { useCallback, useContext } from 'react';
 import { useSelector } from 'react-redux';
-import { createSelector } from 'reselect';
 import { strings } from '../../../../../locales/i18n';
 import { IconName } from '../../../../component-library/components/Icons/Icon';
 import { ToastContext } from '../../../../component-library/components/Toast';
 import { ToastVariants } from '../../../../component-library/components/Toast/Toast.types';
 import Routes from '../../../../constants/navigation/Routes';
-import { RootState } from '../../../../reducers';
+import { selectSelectedInternalAccountAddress } from '../../../../selectors/accountsController';
 import { useAppThemeFromContext } from '../../../../util/theme';
 import { ConfirmationLoader } from '../../../Views/confirmations/components/confirm/confirm-component';
 import { useConfirmNavigation } from '../../../Views/confirmations/hooks/useConfirmNavigation';
+import { selectPredictPendingDepositByAddress } from '../selectors/predictController';
 import { PredictNavigationParamList } from '../types/navigation';
 import { usePredictTrading } from './usePredictTrading';
 
@@ -28,14 +28,18 @@ export const usePredictDeposit = ({
   const navigation =
     useNavigation<NavigationProp<PredictNavigationParamList>>();
 
-  const { deposit: depositWithConfirmation } = usePredictTrading();
-
-  const selectDepositTransaction = createSelector(
-    (state: RootState) => state.engine.backgroundState.PredictController,
-    (predictState) => predictState.depositTransaction,
+  const selectedInternalAccountAddress = useSelector(
+    selectSelectedInternalAccountAddress,
   );
 
-  const depositTransaction = useSelector(selectDepositTransaction);
+  const { deposit: depositWithConfirmation } = usePredictTrading();
+
+  const isDepositPending = useSelector(
+    selectPredictPendingDepositByAddress({
+      providerId,
+      address: selectedInternalAccountAddress ?? '',
+    }),
+  );
 
   const deposit = useCallback(async () => {
     try {
@@ -133,6 +137,6 @@ export const usePredictDeposit = ({
 
   return {
     deposit,
-    status: depositTransaction?.status,
+    isDepositPending,
   };
 };

--- a/app/components/UI/Predict/hooks/usePredictDepositToasts.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictDepositToasts.test.ts
@@ -78,7 +78,7 @@ jest.mock('../../../../util/theme', () => ({
 jest.mock('../../../../core/Engine', () => ({
   context: {
     PredictController: {
-      clearDepositTransaction: jest.fn(),
+      clearPendingDeposit: jest.fn(),
       depositWithConfirmation: jest.fn(() => Promise.resolve()),
     },
   },
@@ -94,7 +94,17 @@ let mockState: any = {
   engine: {
     backgroundState: {
       PredictController: {
-        depositTransaction: null,
+        pendingDeposits: {},
+      },
+      AccountsController: {
+        internalAccounts: {
+          selectedAccount: 'account1',
+          accounts: {
+            account1: {
+              address: '0x1234567890123456789012345678901234567890',
+            },
+          },
+        },
       },
     },
   },
@@ -130,10 +140,7 @@ describe('usePredictDepositToasts', () => {
     jest.clearAllMocks();
     mockToastRef.current.showToast.mockClear();
     (
-      Engine.context.PredictController.clearDepositTransaction as jest.Mock
-    ).mockClear();
-    (
-      Engine.context.PredictController.clearDepositTransaction as jest.Mock
+      Engine.context.PredictController.clearPendingDeposit as jest.Mock
     ).mockClear();
 
     // Capture the subscribe callback
@@ -149,7 +156,17 @@ describe('usePredictDepositToasts', () => {
       engine: {
         backgroundState: {
           PredictController: {
-            depositTransaction: null,
+            pendingDeposits: {},
+          },
+          AccountsController: {
+            internalAccounts: {
+              selectedAccount: 'account1',
+              accounts: {
+                account1: {
+                  address: '0x1234567890123456789012345678901234567890',
+                },
+              },
+            },
           },
         },
       },
@@ -199,7 +216,7 @@ describe('usePredictDepositToasts', () => {
       });
 
       expect(
-        Engine.context.PredictController.clearDepositTransaction,
+        Engine.context.PredictController.clearPendingDeposit,
       ).not.toHaveBeenCalled();
       expect(mockToastRef.current.showToast).not.toHaveBeenCalled();
     });
@@ -217,7 +234,7 @@ describe('usePredictDepositToasts', () => {
       });
 
       expect(
-        Engine.context.PredictController.clearDepositTransaction,
+        Engine.context.PredictController.clearPendingDeposit,
       ).toHaveBeenCalled();
       expect(mockToastRef.current.showToast).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -245,7 +262,7 @@ describe('usePredictDepositToasts', () => {
       });
 
       expect(
-        Engine.context.PredictController.clearDepositTransaction,
+        Engine.context.PredictController.clearPendingDeposit,
       ).toHaveBeenCalled();
       expect(mockToastRef.current.showToast).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -268,7 +285,7 @@ describe('usePredictDepositToasts', () => {
       });
 
       expect(
-        Engine.context.PredictController.clearDepositTransaction,
+        Engine.context.PredictController.clearPendingDeposit,
       ).toHaveBeenCalled();
       expect(mockToastRef.current.showToast).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/app/components/UI/Predict/hooks/usePredictDepositToasts.tsx
+++ b/app/components/UI/Predict/hooks/usePredictDepositToasts.tsx
@@ -4,8 +4,15 @@ import Engine from '../../../../core/Engine';
 import { usePredictDeposit } from './usePredictDeposit';
 import { usePredictToasts } from './usePredictToasts';
 import { usePredictBalance } from './usePredictBalance';
+import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
 
-export const usePredictDepositToasts = () => {
+interface UsePredictDepositToastsParams {
+  providerId?: string;
+}
+
+export const usePredictDepositToasts = ({
+  providerId = POLYMARKET_PROVIDER_ID,
+}: UsePredictDepositToastsParams = {}) => {
   const { loadBalance } = usePredictBalance();
   const { deposit } = usePredictDeposit();
 
@@ -35,6 +42,8 @@ export const usePredictDepositToasts = () => {
       onRetry: deposit,
     },
     clearTransaction: () =>
-      Engine.context.PredictController.clearDepositTransaction(),
+      Engine.context.PredictController.clearPendingDeposit({
+        providerId,
+      }),
   });
 };

--- a/app/components/UI/Predict/hooks/usePredictToasts.tsx
+++ b/app/components/UI/Predict/hooks/usePredictToasts.tsx
@@ -48,7 +48,7 @@ interface UsePredictToastsParams {
   pendingToastConfig?: PendingToastConfig;
   confirmedToastConfig: ConfirmedToastConfig;
   errorToastConfig: ErrorToastConfig;
-  clearTransaction: () => void;
+  clearTransaction?: () => void;
   onConfirmed?: () => void;
 }
 
@@ -174,7 +174,7 @@ export const usePredictToasts = ({
       }
 
       if (transactionMeta.status === TransactionStatus.rejected) {
-        clearTransaction();
+        clearTransaction?.();
       } else if (
         transactionMeta.status === TransactionStatus.approved &&
         pendingToastConfig
@@ -182,12 +182,12 @@ export const usePredictToasts = ({
         const amount = pendingToastConfig.getAmount?.(transactionMeta);
         showPendingToast({ amount, config: pendingToastConfig });
       } else if (transactionMeta.status === TransactionStatus.confirmed) {
-        clearTransaction();
+        clearTransaction?.();
         const amount = confirmedToastConfig.getAmount(transactionMeta);
         showConfirmedToast(amount);
         onConfirmed?.();
       } else if (transactionMeta.status === TransactionStatus.failed) {
-        clearTransaction();
+        clearTransaction?.();
         showErrorToast();
       }
     };

--- a/app/components/UI/Predict/selectors/predictController/index.test.ts
+++ b/app/components/UI/Predict/selectors/predictController/index.test.ts
@@ -1,7 +1,6 @@
 import {
   selectPredictControllerState,
   selectPredictDepositTransaction,
-  selectPredictClaimTransaction,
   selectPredictClaimablePositions,
   selectPredictWonPositions,
   selectPredictWinFiat,
@@ -9,11 +8,7 @@ import {
   selectPredictBalances,
   selectPredictBalanceByAddress,
 } from './index';
-import {
-  PredictDepositStatus,
-  PredictClaimStatus,
-  PredictPositionStatus,
-} from '../../types';
+import { PredictDepositStatus, PredictPositionStatus } from '../../types';
 
 describe('Predict Controller Selectors', () => {
   describe('selectPredictControllerState', () => {
@@ -95,68 +90,6 @@ describe('Predict Controller Selectors', () => {
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const result = selectPredictDepositTransaction(mockState as any);
-
-      expect(result).toBeNull();
-    });
-  });
-
-  describe('selectPredictClaimTransaction', () => {
-    it('returns claim transaction when it exists', () => {
-      const claimTransaction = {
-        transactionId: 'tx-123',
-        chainId: 137,
-        status: PredictClaimStatus.PENDING,
-        txParams: {
-          to: '0x123' as `0x${string}`,
-          data: '0xabc' as `0x${string}`,
-          value: '0x0' as `0x${string}`,
-        },
-      };
-
-      const mockState = {
-        engine: {
-          backgroundState: {
-            PredictController: {
-              claimTransaction,
-            },
-          },
-        },
-      };
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result = selectPredictClaimTransaction(mockState as any);
-
-      expect(result).toEqual(claimTransaction);
-    });
-
-    it('returns null when claim transaction does not exist', () => {
-      const mockState = {
-        engine: {
-          backgroundState: {
-            PredictController: {
-              claimTransaction: null,
-            },
-          },
-        },
-      };
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result = selectPredictClaimTransaction(mockState as any);
-
-      expect(result).toBeNull();
-    });
-
-    it('returns null when PredictController state is undefined', () => {
-      const mockState = {
-        engine: {
-          backgroundState: {
-            PredictController: undefined,
-          },
-        },
-      };
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result = selectPredictClaimTransaction(mockState as any);
 
       expect(result).toBeNull();
     });

--- a/app/components/UI/Predict/selectors/predictController/index.test.ts
+++ b/app/components/UI/Predict/selectors/predictController/index.test.ts
@@ -1,14 +1,14 @@
 import {
   selectPredictControllerState,
-  selectPredictDepositTransaction,
   selectPredictClaimablePositions,
+  selectPredictPendingDeposits,
   selectPredictWonPositions,
   selectPredictWinFiat,
   selectPredictWinPnl,
   selectPredictBalances,
   selectPredictBalanceByAddress,
 } from './index';
-import { PredictDepositStatus, PredictPositionStatus } from '../../types';
+import { PredictPositionStatus } from '../../types';
 
 describe('Predict Controller Selectors', () => {
   describe('selectPredictControllerState', () => {
@@ -37,49 +37,48 @@ describe('Predict Controller Selectors', () => {
     });
   });
 
-  describe('selectPredictDepositTransaction', () => {
+  describe('selectPredictPendingDeposits', () => {
     it('returns deposit transaction when it exists', () => {
-      const depositTransaction = {
-        batchId: 'batch-123',
-        chainId: 137,
-        status: PredictDepositStatus.PENDING,
-        providerId: 'polymarket',
+      const pendingDeposits = {
+        polymarket: {
+          '0x123': true,
+        },
       };
 
       const mockState = {
         engine: {
           backgroundState: {
             PredictController: {
-              depositTransaction,
+              pendingDeposits,
             },
           },
         },
       };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result = selectPredictDepositTransaction(mockState as any);
+      const result = selectPredictPendingDeposits(mockState as any);
 
-      expect(result).toEqual(depositTransaction);
+      expect(result).toEqual(pendingDeposits);
     });
 
-    it('returns null when deposit transaction does not exist', () => {
+    it('returns empty object when pending deposits do not exist', () => {
       const mockState = {
         engine: {
           backgroundState: {
             PredictController: {
-              depositTransaction: null,
+              pendingDeposits: {},
             },
           },
         },
       };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result = selectPredictDepositTransaction(mockState as any);
+      const result = selectPredictPendingDeposits(mockState as any);
 
-      expect(result).toBeNull();
+      expect(result).toEqual({});
     });
 
-    it('returns null when PredictController state is undefined', () => {
+    it('returns empty object when PredictController state is undefined', () => {
       const mockState = {
         engine: {
           backgroundState: {
@@ -89,9 +88,9 @@ describe('Predict Controller Selectors', () => {
       };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const result = selectPredictDepositTransaction(mockState as any);
+      const result = selectPredictPendingDeposits(mockState as any);
 
-      expect(result).toBeNull();
+      expect(result).toEqual({});
     });
   });
 

--- a/app/components/UI/Predict/selectors/predictController/index.ts
+++ b/app/components/UI/Predict/selectors/predictController/index.ts
@@ -5,10 +5,9 @@ import { PredictPositionStatus } from '../../types';
 const selectPredictControllerState = (state: RootState) =>
   state.engine.backgroundState.PredictController;
 
-const selectPredictDepositTransaction = createSelector(
+const selectPredictPendingDeposits = createSelector(
   selectPredictControllerState,
-  (predictControllerState) =>
-    predictControllerState?.depositTransaction || null,
+  (predictControllerState) => predictControllerState?.pendingDeposits || {},
 );
 
 const selectPredictClaimablePositions = createSelector(
@@ -53,13 +52,26 @@ const selectPredictBalanceByAddress = ({
     (balances) => balances[providerId]?.[address] || 0,
   );
 
+const selectPredictPendingDepositByAddress = ({
+  providerId,
+  address,
+}: {
+  providerId: string;
+  address: string;
+}) =>
+  createSelector(
+    selectPredictPendingDeposits,
+    (pendingDeposits) => pendingDeposits[providerId]?.[address] || false,
+  );
+
 export {
   selectPredictControllerState,
-  selectPredictDepositTransaction,
+  selectPredictPendingDeposits,
   selectPredictClaimablePositions,
   selectPredictWonPositions,
   selectPredictWinFiat,
   selectPredictWinPnl,
   selectPredictBalances,
   selectPredictBalanceByAddress,
+  selectPredictPendingDepositByAddress,
 };

--- a/app/components/UI/Predict/selectors/predictController/index.ts
+++ b/app/components/UI/Predict/selectors/predictController/index.ts
@@ -11,11 +11,6 @@ const selectPredictDepositTransaction = createSelector(
     predictControllerState?.depositTransaction || null,
 );
 
-const selectPredictClaimTransaction = createSelector(
-  selectPredictControllerState,
-  (predictControllerState) => predictControllerState?.claimTransaction || null,
-);
-
 const selectPredictClaimablePositions = createSelector(
   selectPredictControllerState,
   (predictControllerState) => predictControllerState?.claimablePositions || [],
@@ -61,7 +56,6 @@ const selectPredictBalanceByAddress = ({
 export {
   selectPredictControllerState,
   selectPredictDepositTransaction,
-  selectPredictClaimTransaction,
   selectPredictClaimablePositions,
   selectPredictWonPositions,
   selectPredictWinFiat,

--- a/app/core/Engine/Engine.test.ts
+++ b/app/core/Engine/Engine.test.ts
@@ -227,7 +227,6 @@ describe('Engine', () => {
         lastError: null,
         lastUpdateTimestamp: 0,
         balances: {},
-        claimTransaction: null,
         claimablePositions: [],
         depositTransaction: null,
         withdrawTransaction: null,

--- a/app/core/Engine/Engine.test.ts
+++ b/app/core/Engine/Engine.test.ts
@@ -228,7 +228,7 @@ describe('Engine', () => {
         lastUpdateTimestamp: 0,
         balances: {},
         claimablePositions: [],
-        depositTransaction: null,
+        pendingDeposits: {},
         withdrawTransaction: null,
         isOnboarded: {},
       },

--- a/app/core/Engine/controllers/predict-controller/index.test.ts
+++ b/app/core/Engine/controllers/predict-controller/index.test.ts
@@ -67,7 +67,6 @@ describe('predict controller init', () => {
       lastError: null,
       lastUpdateTimestamp: Date.now(),
       balances: {},
-      claimTransaction: null,
       claimablePositions: [],
       depositTransaction: null,
       withdrawTransaction: null,

--- a/app/core/Engine/controllers/predict-controller/index.test.ts
+++ b/app/core/Engine/controllers/predict-controller/index.test.ts
@@ -68,7 +68,7 @@ describe('predict controller init', () => {
       lastUpdateTimestamp: Date.now(),
       balances: {},
       claimablePositions: [],
-      depositTransaction: null,
+      pendingDeposits: {},
       withdrawTransaction: null,
       isOnboarded: {},
     };

--- a/app/util/test/initial-background-state.json
+++ b/app/util/test/initial-background-state.json
@@ -660,7 +660,6 @@
     "eligibility": {},
     "lastError": null,
     "lastUpdateTimestamp": 0,
-    "claimTransaction": null,
     "depositTransaction": null,
     "isOnboarded": {}
   }

--- a/app/util/test/initial-background-state.json
+++ b/app/util/test/initial-background-state.json
@@ -660,7 +660,7 @@
     "eligibility": {},
     "lastError": null,
     "lastUpdateTimestamp": 0,
-    "depositTransaction": null,
+    "pendingDeposits": {},
     "isOnboarded": {}
   }
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- remove claimTransaction state
- change depositTransaction to pendingDeposits

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces deposit tracking with per-account `pendingDeposits`, removes `claimTransaction`, and updates hooks/components/toasts/selectors and tests accordingly.
> 
> - **Controller (state + API)**
>   - Remove `claimTransaction`; replace `depositTransaction` with per-provider/address map `pendingDeposits` and add `clearPendingDeposit`.
>   - Update `depositWithConfirmation` to manage `pendingDeposits` and validation; no claim state stored.
> - **Hooks/Toasts**
>   - `usePredictDeposit`: expose `isDepositPending` via `selectPredictPendingDepositByAddress`; error handling unchanged.
>   - `usePredictDepositToasts`: clear via `clearPendingDeposit({ providerId })`; supports provider param.
>   - `usePredictToasts`: make `clearTransaction` optional; guard calls.
>   - `usePredictClaim`: remove Redux status usage; keep `claim` and error toast.
>   - `usePredictClaimToasts`: drop controller clearing; refresh positions on confirm.
> - **Selectors**
>   - Add `selectPredictPendingDeposits` and `selectPredictPendingDepositByAddress`; remove deposit/claim transaction selectors.
> - **UI**
>   - `PredictBalance` and `PredictPositionsHeader`: use `isDepositPending` to show “adding funds” and refresh balance when not pending.
> - **Tests/Fixtures**
>   - Update unit tests to new state shape and behaviors; engine initial state JSON reflects `pendingDeposits` and removed claim/deposit transactions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84b9c87efb45b3e7a5de254883a3ad4385e8e442. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->