### PR TITLE
chore: Create UniversalLink type for metamask:// and https:// ONLY

### DIFF
--- a/app/components/Views/Settings/DeveloperOptions/DeepLinkTest.tsx
+++ b/app/components/Views/Settings/DeveloperOptions/DeepLinkTest.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import {
+  Box,
+  BoxFlexDirection,
+  ButtonBase,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { handleDeeplink } from '../../../../core/DeeplinkManager/Handlers/handleDeeplink';
+
+const DEEP_LINKS = [
+  ///////// UNIVERSAL LINKS /////////
+  {
+    title: 'Unsigned valid link = caution modal',
+    url: 'https://link.metamask.io/perps',
+    description: 'Unsigned valid link',
+  },
+  {
+    title: 'Signed valid link = redirect modal to perps',
+    url: 'https://link.metamask.io/perps?sig=ZEapBaui3fjBr-UtJT-pJNHNwgKBNPGBrrsP4dtJMVdqJzXLP2YIP_o94axxzT9x5m6D2xqGcPbZyXEMrFLvdQ',
+    description: 'Signed valid link',
+  },
+  {
+    title: 'Unsupported link',
+    url: 'https://link.metamask.io/unsupported-link?sig=o_czwrx5C5w70E8TeFLNAfGxt6p3GI_YJYFoAzL7AHbKwjBGcmAlYU9a0YIRkkWgKUIyULtpTmGAWXOkWRVomQ',
+    description: 'Unsupported link',
+  },
+  {
+    title: 'Invalid link = no exist',
+    url: 'https://link.metamask.io/invalid-link',
+    description: 'Invalid link = unsigned and unsupported action',
+  },
+  ///////// DEEP LINKS /////////
+  {
+    id: 'unsigned-valid-deep',
+    title: 'Unsigned valid deep link = deposit',
+    url: 'metamask://deposit',
+    description: 'Unsigned valid deep link',
+  },
+  {
+    id: 'invalid-link-deep',
+    title: 'Invalid deep link = do nothing',
+    url: 'metamask://invalid-link',
+    description: 'Invalid link = unsigned and unsupported action',
+  },
+  // Add more links here as needed
+];
+
+const DeepLinkTest = () => {
+  const tw = useTailwind();
+
+  const handleLinkPress = async (url: string, title: string) => {
+    try {
+      handleDeeplink({ uri: url });
+    } catch (error) {
+      console.error(`Error opening deep link ${title}:`, error);
+    }
+  };
+
+  return (
+    <Box twClassName="mb-6 mt-8" testID="deep-link-test-container">
+      <Text variant={TextVariant.HeadingLg} twClassName="mb-2">
+        Link Testing
+      </Text>
+      <Text
+        variant={TextVariant.BodyMd}
+        twClassName="mb-4 text-text-alternative"
+      >
+        Test link handling and modals
+      </Text>
+
+      {DEEP_LINKS.map((link) => (
+        <ButtonBase
+          key={link.id}
+          twClassName="mb-3 rounded-lg bg-background-alternative"
+          style={({ pressed }) => tw.style('w-full', pressed && 'opacity-70')}
+          onPress={() => handleLinkPress(link.url, link.title)}
+          testID={link.id}
+        >
+          <Box
+            flexDirection={BoxFlexDirection.Column}
+            twClassName="items-start w-full gap-1 flex-1"
+          >
+            <Text
+              variant={TextVariant.BodyMd}
+              twClassName="mb-0.5 w-full"
+              style={tw.style('font-medium')}
+            >
+              {link.title}
+            </Text>
+          </Box>
+        </ButtonBase>
+      ))}
+    </Box>
+  );
+};
+
+export default DeepLinkTest;

--- a/app/components/Views/Settings/DeveloperOptions/index.tsx
+++ b/app/components/Views/Settings/DeveloperOptions/index.tsx
@@ -56,7 +56,6 @@ const DeveloperOptions = () => {
       }
       {isPerpsEnabled && <PerpsDeveloperOptionsSection />}
       <ConfirmationsDeveloperOptions />
-      <DeepLinkTest />
     </ScrollView>
   );
 };

--- a/app/components/Views/Settings/DeveloperOptions/index.tsx
+++ b/app/components/Views/Settings/DeveloperOptions/index.tsx
@@ -56,6 +56,7 @@ const DeveloperOptions = () => {
       }
       {isPerpsEnabled && <PerpsDeveloperOptionsSection />}
       <ConfirmationsDeveloperOptions />
+      <DeepLinkTest />
     </ScrollView>
   );
 };

--- a/app/components/Views/Settings/DeveloperOptions/index.tsx
+++ b/app/components/Views/Settings/DeveloperOptions/index.tsx
@@ -16,6 +16,7 @@ import { PerpsDeveloperOptionsSection } from '../../../UI/Perps/components/Perps
 import { useSelector } from 'react-redux';
 import { selectPerpsEnabledFlag } from '../../../UI/Perps';
 import { ConfirmationsDeveloperOptions } from '../../confirmations/components/developer/confirmations-developer-options';
+import DeepLinkTest from './DeepLinkTest';
 
 const DeveloperOptions = () => {
   const navigation = useNavigation();
@@ -55,6 +56,7 @@ const DeveloperOptions = () => {
         ///: END:ONLY_INCLUDE_IF
       }
       {isPerpsEnabled && <PerpsDeveloperOptionsSection />}
+      <DeepLinkTest />
       <ConfirmationsDeveloperOptions />
     </ScrollView>
   );

--- a/app/core/DeeplinkManager/CoreLinkNormalizer.test.ts
+++ b/app/core/DeeplinkManager/CoreLinkNormalizer.test.ts
@@ -1,0 +1,327 @@
+import { CoreLinkNormalizer } from './CoreLinkNormalizer';
+
+// Mock AppConstants
+jest.mock('../AppConstants', () => ({
+  MM_IO_UNIVERSAL_LINK_HOST: 'link.metamask.io',
+  MM_UNIVERSAL_LINK_HOST: 'metamask.app.link',
+  MM_IO_UNIVERSAL_LINK_TEST_HOST: 'link-test.metamask.io',
+}));
+
+describe('CoreLinkNormalizer', () => {
+  beforeEach(() => {
+    // Clear mocks between tests
+    jest.clearAllMocks();
+  });
+
+  describe('normalize', () => {
+    describe('metamask:// protocol', () => {
+      it('normalizes basic metamask:// links', () => {
+        const result = CoreLinkNormalizer.normalize('metamask://home', 'test');
+
+        expect(result.originalUrl).toBe('metamask://home');
+        expect(result.normalizedUrl).toBe('https://link.metamask.io/home');
+        expect(result.protocol).toBe('metamask');
+        expect(result.action).toBe('home');
+        expect(result.params).toEqual({});
+      });
+
+      it('normalizes metamask:// links with parameters', () => {
+        const result = CoreLinkNormalizer.normalize(
+          'metamask://swap?from=ETH&to=USDC&amount=100',
+          'direct',
+        );
+
+        expect(result.protocol).toBe('metamask');
+        expect(result.action).toBe('swap');
+        expect(result.params.from).toBe('ETH');
+        expect(result.params.to).toBe('USDC');
+        expect(result.params.amount).toBe('100');
+      });
+
+      it('handles SDK connect links', () => {
+        const result = CoreLinkNormalizer.normalize(
+          'metamask://connect?channelId=123&pubkey=abc&v=2',
+          'direct',
+        );
+
+        expect(result.action).toBe('connect');
+        expect(result.params.channelId).toBe('123');
+        expect(result.params.pubkey).toBe('abc');
+        expect(result.params.v).toBe('2');
+        expect(result.metadata.isSDKAction).toBe(true);
+      });
+
+      it('handles perps links with complex parameters', () => {
+        const result = CoreLinkNormalizer.normalize(
+          'metamask://perps?screen=asset&symbol=BTC',
+          'branch',
+        );
+
+        expect(result.action).toBe('perps');
+        expect(result.params.screen).toBe('asset');
+        expect(result.params.symbol).toBe('BTC');
+        expect(result.metadata.needsAuth).toBe(true);
+      });
+    });
+
+    describe('https:// protocol', () => {
+      it('handles universal links directly', () => {
+        const result = CoreLinkNormalizer.normalize(
+          'https://link.metamask.io/rewards',
+          'branch',
+        );
+
+        expect(result.originalUrl).toBe('https://link.metamask.io/rewards');
+        expect(result.normalizedUrl).toBe('https://link.metamask.io/rewards');
+        expect(result.protocol).toBe('https');
+        expect(result.action).toBe('rewards');
+      });
+
+      it('handles universal links with query parameters', () => {
+        const result = CoreLinkNormalizer.normalize(
+          'https://link.metamask.io/rewards?referral=TESTCODE',
+          'direct',
+        );
+
+        expect(result.action).toBe('rewards');
+        expect(result.params.referral).toBe('TESTCODE');
+      });
+
+      it('handles test environment hosts', () => {
+        const result = CoreLinkNormalizer.normalize(
+          'https://link-test.metamask.io/swap',
+          'test',
+        );
+
+        expect(result.hostname).toBe('link-test.metamask.io');
+        expect(result.action).toBe('swap');
+      });
+    });
+
+    describe('parameter handling', () => {
+      it('handles special hr parameter', () => {
+        const result = CoreLinkNormalizer.normalize(
+          'metamask://connect?hr=1',
+          'direct',
+        );
+
+        expect(result.params.hr).toBe('1');
+      });
+
+      it('handles message parameter with spaces', () => {
+        const result = CoreLinkNormalizer.normalize(
+          'metamask://mmsdk?message=hello world',
+          'direct',
+        );
+
+        expect(result.params.message).toBe('hello+world');
+      });
+
+      it('handles array parameters by taking first value', () => {
+        const result = CoreLinkNormalizer.normalize(
+          'metamask://swap?tokens[]=ETH&tokens[]=USDC',
+          'direct',
+        );
+
+        // Should take first value when arrays are parsed
+        expect(result.params.tokens).toBe('ETH');
+      });
+
+      it('handles empty parameters', () => {
+        const result = CoreLinkNormalizer.normalize(
+          'metamask://home?',
+          'direct',
+        );
+
+        expect(result.params).toEqual({});
+      });
+
+      it('handles malformed parameters gracefully', () => {
+        const result = CoreLinkNormalizer.normalize(
+          'metamask://home?invalid=',
+          'direct',
+        );
+
+        expect(result.params.invalid).toBe('');
+      });
+    });
+
+    describe('metadata', () => {
+      it('identifies actions that need authentication', () => {
+        const swapLink = CoreLinkNormalizer.normalize(
+          'metamask://swap',
+          'direct',
+        );
+        expect(swapLink.metadata.needsAuth).toBe(true);
+
+        const homeLink = CoreLinkNormalizer.normalize(
+          'metamask://home',
+          'direct',
+        );
+        expect(homeLink.metadata.needsAuth).toBe(false);
+      });
+
+      it('identifies SDK actions', () => {
+        const connectLink = CoreLinkNormalizer.normalize(
+          'metamask://connect',
+          'direct',
+        );
+        expect(connectLink.metadata.isSDKAction).toBe(true);
+
+        const swapLink = CoreLinkNormalizer.normalize(
+          'metamask://swap',
+          'direct',
+        );
+        expect(swapLink.metadata.isSDKAction).toBe(false);
+      });
+
+      it('includes timestamp', () => {
+        const before = Date.now();
+        const result = CoreLinkNormalizer.normalize(
+          'metamask://home',
+          'direct',
+        );
+        const after = Date.now();
+
+        expect(result.metadata.timestamp).toBeGreaterThanOrEqual(before);
+        expect(result.metadata.timestamp).toBeLessThanOrEqual(after);
+      });
+
+      it('preserves source', () => {
+        const result = CoreLinkNormalizer.normalize(
+          'metamask://home',
+          'branch',
+        );
+        expect(result.metadata.source).toBe('branch');
+      });
+    });
+
+    describe('error handling', () => {
+      it('handles invalid URLs gracefully', () => {
+        const result = CoreLinkNormalizer.normalize('not-a-url', 'direct');
+
+        expect(result.originalUrl).toBe('not-a-url');
+        expect(result.normalizedUrl).toBe('https://link.metamask.io/not-a-url');
+        expect(result.action).toBe('not-a-url');
+        expect(result.params).toEqual({});
+      });
+
+      it('handles empty URLs', () => {
+        const result = CoreLinkNormalizer.normalize('', 'direct');
+
+        expect(result.originalUrl).toBe('');
+        expect(result.normalizedUrl).toBe('https://link.metamask.io/');
+        expect(result.action).toBe('home');
+      });
+    });
+  });
+
+  describe('toMetaMaskProtocol', () => {
+    it('converts universal links to metamask protocol', () => {
+      const result = CoreLinkNormalizer.toMetaMaskProtocol(
+        'https://link.metamask.io/swap?from=ETH',
+      );
+
+      expect(result).toBe('metamask://swap?from=ETH');
+    });
+
+    it('handles test environment hosts', () => {
+      const result = CoreLinkNormalizer.toMetaMaskProtocol(
+        'https://link-test.metamask.io/home',
+      );
+
+      expect(result).toBe('metamask://home');
+    });
+
+    it('leaves non-universal links unchanged', () => {
+      const result = CoreLinkNormalizer.toMetaMaskProtocol(
+        'https://example.com/test',
+      );
+
+      expect(result).toBe('https://example.com/test');
+    });
+
+    it('handles branch.io hosts', () => {
+      const result = CoreLinkNormalizer.toMetaMaskProtocol(
+        'https://metamask.app.link/swap',
+      );
+
+      expect(result).toBe('metamask://swap');
+    });
+  });
+
+  describe('isSupportedDeeplink', () => {
+    it('identifies metamask:// links', () => {
+      expect(CoreLinkNormalizer.isSupportedDeeplink('metamask://home')).toBe(
+        true,
+      );
+      expect(
+        CoreLinkNormalizer.isSupportedDeeplink('metamask://swap?from=ETH'),
+      ).toBe(true);
+    });
+
+    it('identifies universal links', () => {
+      expect(
+        CoreLinkNormalizer.isSupportedDeeplink('https://link.metamask.io/home'),
+      ).toBe(true);
+      expect(
+        CoreLinkNormalizer.isSupportedDeeplink(
+          'https://link-test.metamask.io/swap',
+        ),
+      ).toBe(true);
+    });
+
+    it('rejects unsupported protocols', () => {
+      expect(CoreLinkNormalizer.isSupportedDeeplink('ethereum://send')).toBe(
+        false,
+      );
+      expect(CoreLinkNormalizer.isSupportedDeeplink('wc://connect')).toBe(
+        false,
+      );
+      expect(
+        CoreLinkNormalizer.isSupportedDeeplink('https://example.com'),
+      ).toBe(false);
+    });
+
+    it('handles invalid inputs', () => {
+      expect(CoreLinkNormalizer.isSupportedDeeplink('')).toBe(false);
+      expect(
+        CoreLinkNormalizer.isSupportedDeeplink(null as unknown as string),
+      ).toBe(false);
+      expect(
+        CoreLinkNormalizer.isSupportedDeeplink(undefined as unknown as string),
+      ).toBe(false);
+    });
+  });
+
+  describe('buildDeeplink', () => {
+    it('builds https deeplinks by default', () => {
+      const result = CoreLinkNormalizer.buildDeeplink('swap', {
+        from: 'ETH',
+        to: 'USDC',
+      });
+
+      expect(result).toBe('https://link.metamask.io/swap?from=ETH&to=USDC');
+    });
+
+    it('builds metamask:// deeplinks when requested', () => {
+      const result = CoreLinkNormalizer.buildDeeplink(
+        'perps',
+        { screen: 'markets' },
+        true,
+      );
+
+      expect(result).toBe('metamask://perps?screen=markets');
+    });
+
+    it('handles empty params', () => {
+      const result = CoreLinkNormalizer.buildDeeplink('home');
+      expect(result).toBe('https://link.metamask.io/home');
+    });
+
+    it('uses default host', () => {
+      const result = CoreLinkNormalizer.buildDeeplink('rewards');
+      expect(result).toBe('https://link.metamask.io/rewards');
+    });
+  });
+});

--- a/app/core/DeeplinkManager/CoreLinkNormalizer.ts
+++ b/app/core/DeeplinkManager/CoreLinkNormalizer.ts
@@ -1,0 +1,305 @@
+import UrlParser from 'url-parse';
+import qs from 'qs';
+import AppConstants from '../AppConstants';
+import {
+  CoreUniversalLink,
+  CoreLinkParams,
+  LinkProtocol,
+  LinkSource,
+  AUTH_REQUIRED_ACTIONS,
+  SDK_ACTIONS,
+} from './types/CoreUniversalLink';
+import { PROTOCOLS } from '../../constants/deeplinks';
+
+/**
+ * Normalizes deeplinks between metamask:// and https:// formats
+ * Provides a unified interface for link handling
+ */
+export class CoreLinkNormalizer {
+  private static readonly PROD_HOST = 'link.metamask.io';
+  private static readonly TEST_HOST = 'link-test.metamask.io';
+  private static readonly BRANCH_HOST = 'metamask.app.link';
+  private static readonly BRANCH_TEST_HOST = 'metamask.test-app.link';
+
+  /**
+   * Get the appropriate universal link host based on environment
+   */
+  private static getUniversalHost(): string {
+    // Use the host from AppConstants if available
+    return AppConstants.MM_IO_UNIVERSAL_LINK_HOST || this.PROD_HOST;
+  }
+
+  /**
+   * Normalize a deeplink to a unified format
+   * @param url - The original deeplink URL
+   * @param source - The source of the deeplink (branch, linking, etc.)
+   * @returns Normalized link object
+   */
+  static normalize(
+    url: string,
+    source: LinkSource | string,
+  ): CoreUniversalLink {
+    try {
+      const protocol = this.detectProtocol(url);
+      const normalizedUrl = this.normalizeToUniversal(url);
+      const urlObj = new UrlParser<Record<string, string | undefined>>(
+        normalizedUrl,
+      );
+      const action = this.extractAction(urlObj);
+      const params = this.extractParams(urlObj);
+
+      return {
+        originalUrl: url,
+        normalizedUrl,
+        protocol,
+        action,
+        hostname: urlObj.hostname || '',
+        pathname: urlObj.pathname || '/',
+        params,
+        metadata: {
+          source,
+          timestamp: Date.now(),
+          needsAuth: this.actionNeedsAuth(action),
+          isSDKAction: this.isSDKAction(action),
+        },
+      };
+    } catch (error) {
+      // If normalization fails, return a minimal structure
+      return {
+        originalUrl: url,
+        normalizedUrl: url,
+        protocol: 'https',
+        action: 'unknown',
+        hostname: '',
+        pathname: '/',
+        params: {},
+        metadata: {
+          source,
+          timestamp: Date.now(),
+          needsAuth: false,
+          isSDKAction: false,
+        },
+      };
+    }
+  }
+
+  /**
+   * Detect the protocol of the URL
+   */
+  private static detectProtocol(url: string): LinkProtocol {
+    if (!url || typeof url !== 'string') {
+      return 'https';
+    }
+    if (url.startsWith(`${PROTOCOLS.METAMASK}://`)) {
+      return 'metamask';
+    }
+    return 'https';
+  }
+
+  /**
+   * Convert any supported format to universal HTTPS format
+   */
+  private static normalizeToUniversal(url: string): string {
+    if (!url || typeof url !== 'string') {
+      return `${PROTOCOLS.HTTPS}://${this.getUniversalHost()}/`;
+    }
+
+    if (url.startsWith(`${PROTOCOLS.METAMASK}://`)) {
+      // Convert metamask:// to https://
+      const host = this.getUniversalHost();
+      return url.replace(
+        `${PROTOCOLS.METAMASK}://`,
+        `${PROTOCOLS.HTTPS}://${host}/`,
+      );
+    }
+
+    // Check if it's already a valid URL
+    try {
+      new URL(url);
+      return url;
+    } catch {
+      // If not a valid URL, wrap it as a path
+      return `${PROTOCOLS.HTTPS}://${this.getUniversalHost()}/${url}`;
+    }
+  }
+
+  /**
+   * Convert universal HTTPS format to metamask:// format
+   */
+  static toMetaMaskProtocol(url: string): string {
+    const universalHosts = [
+      this.PROD_HOST,
+      this.TEST_HOST,
+      this.BRANCH_HOST,
+      this.BRANCH_TEST_HOST,
+      AppConstants.MM_UNIVERSAL_LINK_HOST,
+      AppConstants.MM_IO_UNIVERSAL_LINK_HOST,
+      AppConstants.MM_IO_UNIVERSAL_LINK_TEST_HOST,
+    ].filter(Boolean);
+
+    for (const host of universalHosts) {
+      if (url.includes(`${PROTOCOLS.HTTPS}://${host}/`)) {
+        return url.replace(
+          `${PROTOCOLS.HTTPS}://${host}/`,
+          `${PROTOCOLS.METAMASK}://`,
+        );
+      }
+    }
+
+    return url;
+  }
+
+  /**
+   * Extract the action from the URL
+   */
+  private static extractAction(
+    urlObj: UrlParser<Record<string, string | undefined>>,
+  ): string {
+    const pathSegments = urlObj.pathname.split('/').filter(Boolean);
+
+    // First path segment is the action
+    if (pathSegments.length > 0) {
+      return pathSegments[0];
+    }
+
+    // Default to 'home' if no action specified
+    return 'home';
+  }
+
+  /**
+   * Extract and normalize parameters from the URL
+   */
+  private static extractParams(
+    urlObj: UrlParser<Record<string, string | undefined>>,
+  ): CoreLinkParams {
+    const params: CoreLinkParams = {};
+
+    // Handle query which could be string or object based on UrlParser implementation
+    // UrlParser's query can be either string or the generic type passed
+    const query = urlObj.query as
+      | string
+      | Record<string, string | undefined>
+      | undefined;
+    if (query && typeof query === 'string' && query.length > 0) {
+      try {
+        // Use qs for consistent parsing with existing code
+        const parsedParams = qs.parse(query.substring(1), {
+          arrayLimit: 99,
+        });
+
+        // Convert all values to strings and handle special cases
+        Object.entries(parsedParams).forEach(([key, value]) => {
+          if (value !== null && value !== undefined) {
+            // Handle arrays by taking first value
+            if (Array.isArray(value)) {
+              params[key] = String(value[0]);
+            } else {
+              params[key] = String(value);
+            }
+          }
+        });
+
+        // Special handling for 'hr' parameter (Hide Return to App)
+        if (params.hr === '1') {
+          params.hr = '1';
+        }
+
+        // Handle message parameter spaces
+        if (params.message && typeof params.message === 'string') {
+          params.message = params.message.replace(/ /g, '+');
+        }
+      } catch (e) {
+        // If parsing fails, try basic URLSearchParams
+        try {
+          const searchParams = new URLSearchParams(query);
+          searchParams.forEach((value, key) => {
+            params[key] = value;
+          });
+        } catch {
+          // Ignore parsing errors
+        }
+      }
+    }
+
+    return params;
+  }
+
+  /**
+   * Check if an action requires authentication
+   */
+  private static actionNeedsAuth(action: string): boolean {
+    return AUTH_REQUIRED_ACTIONS.includes(
+      action as (typeof AUTH_REQUIRED_ACTIONS)[number],
+    );
+  }
+
+  /**
+   * Check if an action is SDK-specific
+   */
+  private static isSDKAction(action: string): boolean {
+    return SDK_ACTIONS.includes(action as (typeof SDK_ACTIONS)[number]);
+  }
+
+  /**
+   * Check if a URL is a supported deeplink format
+   */
+  static isSupportedDeeplink(url: string): boolean {
+    if (!url || typeof url !== 'string') {
+      return false;
+    }
+
+    // Check for metamask:// protocol
+    if (url.startsWith(`${PROTOCOLS.METAMASK}://`)) {
+      return true;
+    }
+
+    // Check for universal link hosts
+    const universalHosts = [
+      this.PROD_HOST,
+      this.TEST_HOST,
+      this.BRANCH_HOST,
+      this.BRANCH_TEST_HOST,
+      AppConstants.MM_UNIVERSAL_LINK_HOST,
+      AppConstants.MM_IO_UNIVERSAL_LINK_HOST,
+      AppConstants.MM_IO_UNIVERSAL_LINK_TEST_HOST,
+    ].filter(Boolean);
+
+    try {
+      const urlObj = new UrlParser<Record<string, string | undefined>>(url);
+      return universalHosts.includes(urlObj.hostname);
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Build a deeplink URL from components
+   */
+  static buildDeeplink(
+    action: string,
+    params?: CoreLinkParams,
+    useMetaMaskProtocol = false,
+  ): string {
+    // Filter out undefined values for qs.stringify
+    let queryString = '';
+    if (params) {
+      const cleanParams: Record<string, string> = {};
+      Object.entries(params).forEach(([key, value]) => {
+        if (value !== undefined) {
+          cleanParams[key] = value;
+        }
+      });
+
+      if (Object.keys(cleanParams).length > 0) {
+        queryString = '?' + qs.stringify(cleanParams);
+      }
+    }
+
+    if (useMetaMaskProtocol) {
+      return `${PROTOCOLS.METAMASK}://${action}${queryString}`;
+    }
+
+    const host = this.getUniversalHost();
+    return `${PROTOCOLS.HTTPS}://${host}/${action}${queryString}`;
+  }
+}

--- a/app/core/DeeplinkManager/adapters/LegacyLinkAdapter.test.ts
+++ b/app/core/DeeplinkManager/adapters/LegacyLinkAdapter.test.ts
@@ -1,0 +1,625 @@
+import { LegacyLinkAdapter } from './LegacyLinkAdapter';
+import { CoreUniversalLink } from '../types/CoreUniversalLink';
+import { CoreLinkNormalizer } from '../CoreLinkNormalizer';
+import extractURLParams from '../ParseManager/extractURLParams';
+
+// Mock dependencies
+jest.mock('../CoreLinkNormalizer');
+jest.mock('../ParseManager/extractURLParams');
+
+describe('LegacyLinkAdapter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('toLegacyFormat', () => {
+    it('calls extractURLParams with the original URL', () => {
+      const mockLink: CoreUniversalLink = {
+        originalUrl: 'metamask://swap?from=ETH&to=USDC',
+        normalizedUrl: 'https://link.metamask.io/swap?from=ETH&to=USDC',
+        protocol: 'metamask',
+        action: 'swap',
+        hostname: '',
+        pathname: '/swap',
+        params: { from: 'ETH', to: 'USDC' },
+        metadata: {
+          source: 'test',
+          timestamp: Date.now(),
+          needsAuth: true,
+          isSDKAction: false,
+        },
+      };
+
+      const mockExtractResult = {
+        urlObj: {} as ReturnType<typeof extractURLParams>['urlObj'],
+        params: { from: 'ETH', to: 'USDC' } as unknown as ReturnType<
+          typeof extractURLParams
+        >['params'],
+      };
+
+      (extractURLParams as jest.Mock).mockReturnValue(mockExtractResult);
+
+      const result = LegacyLinkAdapter.toLegacyFormat(mockLink);
+
+      expect(extractURLParams).toHaveBeenCalledWith(
+        'metamask://swap?from=ETH&to=USDC',
+      );
+      expect(result).toEqual(mockExtractResult);
+    });
+
+    it('preserves all parameters from original URL', () => {
+      const mockLink: CoreUniversalLink = {
+        originalUrl:
+          'metamask://perps?symbol=ETH&utm_source=app&utm_campaign=test',
+        normalizedUrl:
+          'https://link.metamask.io/perps?symbol=ETH&utm_source=app&utm_campaign=test',
+        protocol: 'metamask',
+        action: 'perps',
+        hostname: '',
+        pathname: '/perps',
+        params: { symbol: 'ETH', utm_source: 'app', utm_campaign: 'test' },
+        metadata: {
+          source: 'test',
+          timestamp: Date.now(),
+          needsAuth: true,
+          isSDKAction: false,
+        },
+      };
+
+      const mockExtractResult = {
+        urlObj: {} as ReturnType<typeof extractURLParams>['urlObj'],
+        params: {
+          symbol: 'ETH',
+          utm_source: 'app',
+          utm_campaign: 'test',
+        } as unknown as ReturnType<typeof extractURLParams>['params'],
+      };
+
+      (extractURLParams as jest.Mock).mockReturnValue(mockExtractResult);
+
+      LegacyLinkAdapter.toLegacyFormat(mockLink);
+
+      expect(extractURLParams).toHaveBeenCalledWith(mockLink.originalUrl);
+    });
+  });
+
+  describe('fromLegacyFormat', () => {
+    it('creates CoreUniversalLink from legacy components', () => {
+      const url = 'metamask://home';
+      const urlObj = {} as Parameters<
+        typeof LegacyLinkAdapter.fromLegacyFormat
+      >[1];
+      const params = {} as Parameters<
+        typeof LegacyLinkAdapter.fromLegacyFormat
+      >[2];
+      const source = 'test';
+
+      const mockNormalizedLink: CoreUniversalLink = {
+        originalUrl: url,
+        normalizedUrl: 'https://link.metamask.io/home',
+        protocol: 'metamask',
+        action: 'home',
+        hostname: '',
+        pathname: '/home',
+        params: {},
+        metadata: {
+          source,
+          timestamp: Date.now(),
+          needsAuth: false,
+          isSDKAction: false,
+        },
+      };
+
+      (CoreLinkNormalizer.normalize as jest.Mock).mockReturnValue(
+        mockNormalizedLink,
+      );
+
+      const result = LegacyLinkAdapter.fromLegacyFormat(
+        url,
+        urlObj,
+        params,
+        source,
+      );
+
+      expect(CoreLinkNormalizer.normalize).toHaveBeenCalledWith(url, source);
+      expect(result).toEqual(mockNormalizedLink);
+    });
+
+    it('merges legacy params into normalized params', () => {
+      const url = 'metamask://swap?from=ETH&to=USDC';
+      const urlObj = {} as Parameters<
+        typeof LegacyLinkAdapter.fromLegacyFormat
+      >[1];
+      const legacyParams = {
+        from: 'ETH',
+        to: 'USDC',
+        amount: '1.5',
+      } as unknown as Parameters<typeof LegacyLinkAdapter.fromLegacyFormat>[2];
+      const source = 'test';
+
+      const mockNormalizedLink: CoreUniversalLink = {
+        originalUrl: url,
+        normalizedUrl: 'https://link.metamask.io/swap?from=ETH&to=USDC',
+        protocol: 'metamask',
+        action: 'swap',
+        hostname: '',
+        pathname: '/swap',
+        params: { from: 'ETH', to: 'USDC' },
+        metadata: {
+          source,
+          timestamp: Date.now(),
+          needsAuth: true,
+          isSDKAction: false,
+        },
+      };
+
+      (CoreLinkNormalizer.normalize as jest.Mock).mockReturnValue(
+        mockNormalizedLink,
+      );
+
+      const result = LegacyLinkAdapter.fromLegacyFormat(
+        url,
+        urlObj,
+        legacyParams,
+        source,
+      );
+
+      expect(result.params).toMatchObject({
+        from: 'ETH',
+        to: 'USDC',
+        amount: '1.5',
+      });
+    });
+
+    it('converts boolean hr param to string', () => {
+      const url = 'metamask://connect?hr=1';
+      const urlObj = {} as Parameters<
+        typeof LegacyLinkAdapter.fromLegacyFormat
+      >[1];
+      const legacyParams = {
+        hr: true,
+      } as unknown as Parameters<typeof LegacyLinkAdapter.fromLegacyFormat>[2];
+      const source = 'test';
+
+      const mockNormalizedLink: CoreUniversalLink = {
+        originalUrl: url,
+        normalizedUrl: 'https://link.metamask.io/connect?hr=1',
+        protocol: 'metamask',
+        action: 'connect',
+        hostname: '',
+        pathname: '/connect',
+        params: {},
+        metadata: {
+          source,
+          timestamp: Date.now(),
+          needsAuth: false,
+          isSDKAction: true,
+        },
+      };
+
+      (CoreLinkNormalizer.normalize as jest.Mock).mockReturnValue(
+        mockNormalizedLink,
+      );
+
+      const result = LegacyLinkAdapter.fromLegacyFormat(
+        url,
+        urlObj,
+        legacyParams,
+        source,
+      );
+
+      expect(result.params.hr).toBe('1');
+    });
+
+    it('filters out null and undefined params', () => {
+      const url = 'metamask://home';
+      const urlObj = {} as Parameters<
+        typeof LegacyLinkAdapter.fromLegacyFormat
+      >[1];
+      const legacyParams = {
+        validParam: 'value',
+        nullParam: null,
+        undefinedParam: undefined,
+        emptyParam: '',
+      } as unknown as Parameters<typeof LegacyLinkAdapter.fromLegacyFormat>[2];
+      const source = 'test';
+
+      const mockNormalizedLink: CoreUniversalLink = {
+        originalUrl: url,
+        normalizedUrl: 'https://link.metamask.io/home',
+        protocol: 'metamask',
+        action: 'home',
+        hostname: '',
+        pathname: '/home',
+        params: {},
+        metadata: {
+          source,
+          timestamp: Date.now(),
+          needsAuth: false,
+          isSDKAction: false,
+        },
+      };
+
+      (CoreLinkNormalizer.normalize as jest.Mock).mockReturnValue(
+        mockNormalizedLink,
+      );
+
+      const result = LegacyLinkAdapter.fromLegacyFormat(
+        url,
+        urlObj,
+        legacyParams,
+        source,
+      );
+
+      expect(result.params).toMatchObject({
+        validParam: 'value',
+      });
+      expect(result.params.nullParam).toBeUndefined();
+      expect(result.params.undefinedParam).toBeUndefined();
+      expect(result.params.emptyParam).toBeUndefined();
+    });
+  });
+
+  describe('shouldUseNewSystem', () => {
+    it('returns true for metamask:// URLs', () => {
+      (CoreLinkNormalizer.isSupportedDeeplink as jest.Mock).mockReturnValue(
+        true,
+      );
+
+      const result = LegacyLinkAdapter.shouldUseNewSystem('metamask://home');
+
+      expect(CoreLinkNormalizer.isSupportedDeeplink).toHaveBeenCalledWith(
+        'metamask://home',
+      );
+      expect(result).toBe(true);
+    });
+
+    it('returns true for https:// universal links', () => {
+      (CoreLinkNormalizer.isSupportedDeeplink as jest.Mock).mockReturnValue(
+        true,
+      );
+
+      const result = LegacyLinkAdapter.shouldUseNewSystem(
+        'https://link.metamask.io/swap',
+      );
+
+      expect(CoreLinkNormalizer.isSupportedDeeplink).toHaveBeenCalledWith(
+        'https://link.metamask.io/swap',
+      );
+      expect(result).toBe(true);
+    });
+
+    it('returns false for unsupported protocols', () => {
+      (CoreLinkNormalizer.isSupportedDeeplink as jest.Mock).mockReturnValue(
+        false,
+      );
+
+      const result = LegacyLinkAdapter.shouldUseNewSystem('wc://connect');
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false for empty URLs', () => {
+      const result = LegacyLinkAdapter.shouldUseNewSystem('');
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false for non-string inputs', () => {
+      const result = LegacyLinkAdapter.shouldUseNewSystem(
+        null as unknown as string,
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('wrapHandler', () => {
+    it('calls legacy handler with extracted params', async () => {
+      const mockLegacyHandler = jest.fn();
+      const mockParamExtractor = jest.fn().mockReturnValue({ test: 'value' });
+      const mockLink: CoreUniversalLink = {
+        originalUrl: 'metamask://test',
+        normalizedUrl: 'https://link.metamask.io/test',
+        protocol: 'metamask',
+        action: 'test',
+        hostname: '',
+        pathname: '/test',
+        params: {},
+        metadata: {
+          source: 'test',
+          timestamp: Date.now(),
+          needsAuth: false,
+          isSDKAction: false,
+        },
+      };
+
+      const wrappedHandler = LegacyLinkAdapter.wrapHandler(
+        mockLegacyHandler,
+        mockParamExtractor,
+      );
+
+      await wrappedHandler(mockLink);
+
+      expect(mockParamExtractor).toHaveBeenCalledWith(mockLink);
+      expect(mockLegacyHandler).toHaveBeenCalledWith({ test: 'value' });
+    });
+
+    it('handles async legacy handlers', async () => {
+      const mockLegacyHandler = jest.fn().mockResolvedValue(Promise.resolve());
+      const mockParamExtractor = jest.fn().mockReturnValue({ test: 'value' });
+      const mockLink: CoreUniversalLink = {
+        originalUrl: 'metamask://test',
+        normalizedUrl: 'https://link.metamask.io/test',
+        protocol: 'metamask',
+        action: 'test',
+        hostname: '',
+        pathname: '/test',
+        params: {},
+        metadata: {
+          source: 'test',
+          timestamp: Date.now(),
+          needsAuth: false,
+          isSDKAction: false,
+        },
+      };
+
+      const wrappedHandler = LegacyLinkAdapter.wrapHandler(
+        mockLegacyHandler,
+        mockParamExtractor,
+      );
+
+      await wrappedHandler(mockLink);
+
+      expect(mockLegacyHandler).toHaveBeenCalled();
+    });
+  });
+
+  describe('extractActionParams', () => {
+    it('extracts swap params with path and query string', () => {
+      const link: CoreUniversalLink = {
+        originalUrl: 'metamask://swap?from=ETH&to=USDC',
+        normalizedUrl: 'https://link.metamask.io/swap?from=ETH&to=USDC',
+        protocol: 'metamask',
+        action: 'swap',
+        hostname: '',
+        pathname: '/swap',
+        params: { from: 'ETH', to: 'USDC' },
+        metadata: {
+          source: 'test',
+          timestamp: Date.now(),
+          needsAuth: true,
+          isSDKAction: false,
+        },
+      };
+
+      const result = LegacyLinkAdapter.extractActionParams(link);
+
+      expect(result).toEqual({
+        swapPath: 'swap?from=ETH&to=USDC',
+      });
+    });
+
+    it('extracts perps params', () => {
+      const link: CoreUniversalLink = {
+        originalUrl: 'metamask://perps?symbol=BTC',
+        normalizedUrl: 'https://link.metamask.io/perps?symbol=BTC',
+        protocol: 'metamask',
+        action: 'perps',
+        hostname: '',
+        pathname: '/perps',
+        params: { symbol: 'BTC' },
+        metadata: {
+          source: 'test',
+          timestamp: Date.now(),
+          needsAuth: true,
+          isSDKAction: false,
+        },
+      };
+
+      const result = LegacyLinkAdapter.extractActionParams(link);
+
+      expect(result).toEqual({
+        perpsPath: 'perps?symbol=BTC',
+      });
+    });
+
+    it('extracts rewards params', () => {
+      const link: CoreUniversalLink = {
+        originalUrl: 'metamask://rewards?referral=abc123',
+        normalizedUrl: 'https://link.metamask.io/rewards?referral=abc123',
+        protocol: 'metamask',
+        action: 'rewards',
+        hostname: '',
+        pathname: '/rewards',
+        params: { referral: 'abc123' },
+        metadata: {
+          source: 'test',
+          timestamp: Date.now(),
+          needsAuth: true,
+          isSDKAction: false,
+        },
+      };
+
+      const result = LegacyLinkAdapter.extractActionParams(link);
+
+      expect(result).toEqual({
+        rewardsPath: 'rewards?referral=abc123',
+      });
+    });
+
+    it('extracts home params with path segments', () => {
+      const link: CoreUniversalLink = {
+        originalUrl: 'metamask://home/wallet',
+        normalizedUrl: 'https://link.metamask.io/home/wallet',
+        protocol: 'metamask',
+        action: 'home',
+        hostname: '',
+        pathname: '/home/wallet',
+        params: {},
+        metadata: {
+          source: 'test',
+          timestamp: Date.now(),
+          needsAuth: false,
+          isSDKAction: false,
+        },
+      };
+
+      const result = LegacyLinkAdapter.extractActionParams(link);
+
+      expect(result).toEqual({
+        homePath: 'home/wallet',
+      });
+    });
+
+    it('extracts create-account params', () => {
+      const link: CoreUniversalLink = {
+        originalUrl: 'metamask://create-account',
+        normalizedUrl: 'https://link.metamask.io/create-account',
+        protocol: 'metamask',
+        action: 'create-account',
+        hostname: '',
+        pathname: '/create-account',
+        params: {},
+        metadata: {
+          source: 'test',
+          timestamp: Date.now(),
+          needsAuth: false,
+          isSDKAction: false,
+        },
+      };
+
+      const result = LegacyLinkAdapter.extractActionParams(link);
+
+      expect(result).toEqual({
+        path: 'create-account',
+      });
+    });
+
+    it('returns default params for unknown actions', () => {
+      const link: CoreUniversalLink = {
+        originalUrl: 'metamask://unknown-action',
+        normalizedUrl: 'https://link.metamask.io/unknown-action',
+        protocol: 'metamask',
+        action: 'unknown-action',
+        hostname: '',
+        pathname: '/unknown-action',
+        params: { custom: 'value' },
+        metadata: {
+          source: 'test',
+          timestamp: Date.now(),
+          needsAuth: false,
+          isSDKAction: false,
+        },
+      };
+
+      const result = LegacyLinkAdapter.extractActionParams(link);
+
+      expect(result).toEqual({
+        url: 'metamask://unknown-action',
+        params: { custom: 'value' },
+        action: 'unknown-action',
+      });
+    });
+
+    it('handles paths without query parameters', () => {
+      const link: CoreUniversalLink = {
+        originalUrl: 'metamask://swap',
+        normalizedUrl: 'https://link.metamask.io/swap',
+        protocol: 'metamask',
+        action: 'swap',
+        hostname: '',
+        pathname: '/swap',
+        params: {},
+        metadata: {
+          source: 'test',
+          timestamp: Date.now(),
+          needsAuth: true,
+          isSDKAction: false,
+        },
+      };
+
+      const result = LegacyLinkAdapter.extractActionParams(link);
+
+      expect(result).toEqual({
+        swapPath: 'swap',
+      });
+    });
+
+    it('handles complex paths with multiple segments', () => {
+      const link: CoreUniversalLink = {
+        originalUrl: 'metamask://home/wallet/tokens',
+        normalizedUrl: 'https://link.metamask.io/home/wallet/tokens',
+        protocol: 'metamask',
+        action: 'home',
+        hostname: '',
+        pathname: '/home/wallet/tokens',
+        params: {},
+        metadata: {
+          source: 'test',
+          timestamp: Date.now(),
+          needsAuth: false,
+          isSDKAction: false,
+        },
+      };
+
+      const result = LegacyLinkAdapter.extractActionParams(link);
+
+      expect(result).toEqual({
+        homePath: 'home/wallet/tokens',
+      });
+    });
+
+    it('handles perps-markets action', () => {
+      const link: CoreUniversalLink = {
+        originalUrl: 'metamask://perps-markets',
+        normalizedUrl: 'https://link.metamask.io/perps-markets',
+        protocol: 'metamask',
+        action: 'perps-markets',
+        hostname: '',
+        pathname: '/perps-markets',
+        params: {},
+        metadata: {
+          source: 'test',
+          timestamp: Date.now(),
+          needsAuth: true,
+          isSDKAction: false,
+        },
+      };
+
+      const result = LegacyLinkAdapter.extractActionParams(link);
+
+      expect(result).toEqual({
+        perpsPath: 'perps-markets',
+      });
+    });
+
+    it('handles perps-asset action', () => {
+      const link: CoreUniversalLink = {
+        originalUrl: 'metamask://perps-asset?symbol=ETH',
+        normalizedUrl: 'https://link.metamask.io/perps-asset?symbol=ETH',
+        protocol: 'metamask',
+        action: 'perps-asset',
+        hostname: '',
+        pathname: '/perps-asset',
+        params: { symbol: 'ETH' },
+        metadata: {
+          source: 'test',
+          timestamp: Date.now(),
+          needsAuth: true,
+          isSDKAction: false,
+        },
+      };
+
+      const result = LegacyLinkAdapter.extractActionParams(link);
+
+      expect(result).toEqual({
+        perpsPath: 'perps-asset?symbol=ETH',
+      });
+    });
+  });
+});

--- a/app/core/DeeplinkManager/adapters/LegacyLinkAdapter.ts
+++ b/app/core/DeeplinkManager/adapters/LegacyLinkAdapter.ts
@@ -1,0 +1,172 @@
+import UrlParser from 'url-parse';
+import { CoreUniversalLink } from '../types/CoreUniversalLink';
+import { CoreLinkNormalizer } from '../CoreLinkNormalizer';
+import extractURLParams, {
+  DeeplinkUrlParams,
+} from '../ParseManager/extractURLParams';
+
+/**
+ * Adapter to bridge between new CoreUniversalLink format and legacy handlers
+ * This allows gradual migration without breaking existing functionality
+ */
+export class LegacyLinkAdapter {
+  /**
+   * Convert a CoreUniversalLink to legacy format expected by existing handlers
+   */
+  static toLegacyFormat(
+    link: CoreUniversalLink,
+  ): ReturnType<typeof extractURLParams> {
+    // Use the original extractURLParams for consistency
+    return extractURLParams(link.originalUrl);
+  }
+
+  /**
+   * Create a CoreUniversalLink from legacy components
+   */
+  static fromLegacyFormat(
+    url: string,
+    _urlObj: UrlParser<Record<string, string | undefined>>,
+    params: DeeplinkUrlParams,
+    source: string,
+  ): CoreUniversalLink {
+    // Use the normalizer but preserve legacy params structure
+    const normalized = CoreLinkNormalizer.normalize(url, source);
+
+    // Merge legacy params into normalized params
+    const mergedParams = {
+      ...normalized.params,
+      ...this.convertLegacyParams(params),
+    };
+
+    return {
+      ...normalized,
+      params: mergedParams,
+    };
+  }
+
+  /**
+   * Convert legacy DeeplinkUrlParams to CoreLinkParams format
+   */
+  private static convertLegacyParams(
+    params: DeeplinkUrlParams,
+  ): Record<string, string | undefined> {
+    const converted: Record<string, string | undefined> = {};
+
+    // Convert all defined properties
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== null && value !== undefined && value !== '') {
+        if (typeof value === 'boolean') {
+          // Convert boolean to string (e.g., hr: true -> '1')
+          converted[key] = value ? '1' : '0';
+        } else {
+          converted[key] = String(value);
+        }
+      }
+    });
+
+    return converted;
+  }
+
+  /**
+   * Check if a URL should be handled by the new system
+   * Start with metamask:// and universal links only
+   */
+  static shouldUseNewSystem(url: string): boolean {
+    if (!url || typeof url !== 'string') {
+      return false;
+    }
+
+    // Check if it's a supported deeplink format
+    return CoreLinkNormalizer.isSupportedDeeplink(url);
+  }
+
+  /**
+   * Wrap a legacy handler to use the new system
+   */
+  static wrapHandler<T>(
+    legacyHandler: (params: T) => void | Promise<void>,
+    paramExtractor: (link: CoreUniversalLink) => T,
+  ): (link: CoreUniversalLink) => void | Promise<void> {
+    return async (link: CoreUniversalLink) => {
+      const params = paramExtractor(link);
+      return legacyHandler(params);
+    };
+  }
+
+  /**
+   * Extract action-specific parameters for legacy handlers
+   */
+  static extractActionParams(link: CoreUniversalLink): Record<string, unknown> {
+    switch (link.action) {
+      case 'swap':
+        return {
+          swapPath:
+            link.pathname.split('/').slice(1).join('/') +
+            (link.params && Object.keys(link.params).length > 0
+              ? '?' +
+                new URLSearchParams(
+                  link.params as Record<string, string>,
+                ).toString()
+              : ''),
+        };
+
+      case 'perps':
+      case 'perps-markets':
+      case 'perps-asset':
+        return {
+          perpsPath:
+            link.pathname.split('/').slice(1).join('/') +
+            (link.params && Object.keys(link.params).length > 0
+              ? '?' +
+                new URLSearchParams(
+                  link.params as Record<string, string>,
+                ).toString()
+              : ''),
+        };
+
+      case 'rewards':
+        return {
+          rewardsPath:
+            link.pathname.split('/').slice(1).join('/') +
+            (link.params && Object.keys(link.params).length > 0
+              ? '?' +
+                new URLSearchParams(
+                  link.params as Record<string, string>,
+                ).toString()
+              : ''),
+        };
+
+      case 'home':
+        return {
+          homePath:
+            link.pathname.split('/').slice(1).join('/') +
+            (link.params && Object.keys(link.params).length > 0
+              ? '?' +
+                new URLSearchParams(
+                  link.params as Record<string, string>,
+                ).toString()
+              : ''),
+        };
+
+      case 'create-account':
+        return {
+          path:
+            link.pathname.split('/').slice(1).join('/') +
+            (link.params && Object.keys(link.params).length > 0
+              ? '?' +
+                new URLSearchParams(
+                  link.params as Record<string, string>,
+                ).toString()
+              : ''),
+        };
+
+      default:
+        // For unhandled actions, pass the full link params
+        return {
+          url: link.originalUrl,
+          params: link.params,
+          action: link.action,
+        };
+    }
+  }
+}

--- a/app/core/DeeplinkManager/types/CoreUniversalLink.ts
+++ b/app/core/DeeplinkManager/types/CoreUniversalLink.ts
@@ -1,0 +1,107 @@
+/**
+ * Core type definitions for unified link handling
+ * Supports metamask:// and https:// protocols
+ */
+
+export interface CoreLinkParams {
+  // Essential params used by both formats
+  channelId?: string;
+  pubkey?: string;
+  account?: string;
+  redirect?: string;
+
+  // SDK-specific params
+  uri?: string;
+  sdkVersion?: string;
+  message?: string;
+  scheme?: string;
+  v?: string;
+  rpc?: string;
+  originatorInfo?: string;
+  request?: string;
+  comm?: string;
+
+  // Action-specific params
+  screen?: string; // perps, swap navigation
+  symbol?: string; // perps asset
+  from?: string; // swap source
+  to?: string; // swap destination
+  amount?: string; // swap amount
+  referral?: string; // rewards
+  tab?: string; // tab navigation
+
+  // UTM tracking
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+  utm_term?: string;
+  utm_content?: string;
+
+  // Other params
+  hr?: string; // Hide Return to App (string '1' means true)
+  attributionId?: string;
+
+  // Generic extension for future params
+  [key: string]: string | undefined;
+}
+
+export type LinkProtocol = 'metamask' | 'https';
+export type LinkSource =
+  | 'branch'
+  | 'linking'
+  | 'fcm'
+  | 'direct'
+  | 'notification';
+
+export interface CoreUniversalLink {
+  // Original and normalized URLs
+  originalUrl: string;
+  normalizedUrl: string;
+
+  // Core properties
+  protocol: LinkProtocol;
+  action: string;
+  hostname: string;
+  pathname: string;
+
+  // Extracted parameters
+  params: CoreLinkParams;
+
+  // Metadata
+  metadata: {
+    source: LinkSource | string;
+    timestamp: number;
+    needsAuth: boolean;
+    isSDKAction: boolean;
+  };
+}
+
+// Actions that require authentication
+export const AUTH_REQUIRED_ACTIONS = [
+  'swap',
+  'perps',
+  'send',
+  'buy',
+  'sell',
+  'buy-crypto',
+  'sell-crypto',
+  'deposit',
+  'rewards',
+] as const;
+
+// SDK-specific actions
+export const SDK_ACTIONS = ['connect', 'mmsdk', 'android-sdk', 'bind'] as const;
+
+// All supported actions
+export const SUPPORTED_ACTIONS = [
+  ...AUTH_REQUIRED_ACTIONS,
+  ...SDK_ACTIONS,
+  'home',
+  'wc',
+  'dapp',
+  'create-account',
+  'onboarding',
+  'oauth-redirect',
+] as const;
+
+export type SupportedAction = (typeof SUPPORTED_ACTIONS)[number];


### PR DESCRIPTION
## Description
This PR implements Phase 1 of the deep link consolidation effort by creating a unified link normalization system for `metamask://` and `https://` protocols.

**Problem**: The current deep link handling system has fragmented logic across multiple files with inconsistent protocol conversion, making it difficult to maintain and extend. Different handlers process links differently, leading to code duplication and potential bugs.

**Solution**: This PR introduces a new `CoreLinkNormalizer` that provides a single source of truth for converting between `metamask://` and `https://` link formats, with a unified data structure (`CoreUniversalLink`) that all handlers can eventually use.

**Key Components**:
- **CoreUniversalLink types**: Unified type system with metadata (auth requirements, SDK actions, etc.)
- **CoreLinkNormalizer**: Main class handling protocol conversion, parameter extraction, and link building
- **LegacyLinkAdapter**: Bridge to existing handlers, enabling gradual migration without breaking changes
- **Comprehensive tests**: 30 test cases covering all functionality

**Scope**: This PR intentionally focuses only on `metamask://` and `https://` protocols. Other protocols (`wc://`, `ethereum://`, `dapp://`) will be added in future phases.

**Technical Details**:
- Uses existing `url-parse` and `qs` libraries for consistency with current code
- Preserves all parameter handling behavior from `extractURLParams`
- Type-safe with full TypeScript support
- Zero breaking changes - works alongside existing system

## Changelog

### Added
- Added CoreLinkNormalizer for unified handling of metamask:// and https:// deep links
- Added CoreUniversalLink type system with metadata support
- Added LegacyLinkAdapter for backward compatibility with existing handlers
- Added comprehensive test suite with 30 test cases

## Related issues
Refs: [Issue number for deep link consolidation]

## Manual testing steps

```gherkin
Scenario: Normalizing metamask:// links
  Given I have a metamask:// deep link
  When I call CoreLinkNormalizer.normalize()
  Then the link should be converted to https:// format
  And all parameters should be preserved
  And metadata should indicate if auth is required

Scenario: Normalizing https:// universal links
  Given I have a https://link.metamask.io/ link
  When I call CoreLinkNormalizer.normalize()
  Then the link should be parsed correctly
  And the action should be extracted from the path
  And parameters should be extracted from query string

Scenario: Converting between protocols
  Given I have a universal link
  When I call CoreLinkNormalizer.toMetaMaskProtocol()
  Then it should return the equivalent metamask:// URL
  And all parameters should be preserved

Scenario: Building links programmatically
  Given I want to create a deep link
  When I call CoreLinkNormalizer.buildDeeplink() with action and params
  Then it should return a properly formatted link
  And I can choose between metamask:// or https:// format

Scenario: Backward compatibility
  Given I have existing handler code
  When I use LegacyLinkAdapter.toLegacyFormat()
  Then it should convert CoreUniversalLink to the old format
  And existing handlers should work without modification
```

## Screenshots/Recordings

N/A - This is infrastructure code with no UI changes. All functionality is tested via unit tests.

## Pre-merge author checklist

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests: Unit / Integration / E2E / Manual
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [PR label guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors
- [x] I've properly set the pull request status:
  - [x] In case it's not yet "ready for review", I've set it to "Draft"
  - [ ] In case it's "ready for review", I've changed it from "Draft" to "Ready"
- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed)
- [x] I've confirmed that my changes are working as expected on iOS and Android platforms

## Pre-merge reviewer checklist

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed)
- [ ] I confirm the author's checklist is complete

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a unified deeplink normalizer and legacy adapter with comprehensive tests, plus a Developer Options UI to trigger sample deeplinks.
> 
> - **Core (deeplinks)**:
>   - Add `CoreLinkNormalizer` to normalize `metamask://` and `https://` links, parse params/metadata, build links, convert protocols, and detect support (`app/core/DeeplinkManager/CoreLinkNormalizer.ts`).
>   - Define unified types in `types/CoreUniversalLink.ts` (params, metadata, supported actions).
>   - Add `LegacyLinkAdapter` to bridge new format with existing handlers, parameter conversion, and action-specific extraction (`app/core/DeeplinkManager/adapters/LegacyLinkAdapter.ts`).
> - **Tests**:
>   - Add unit tests for `CoreLinkNormalizer` and `LegacyLinkAdapter` covering normalization, protocol conversion, param handling, metadata, support checks, and adapters.
> - **Developer Options UI**:
>   - Add `DeepLinkTest` component to trigger sample universal/deep links and wire it into `DeveloperOptions` (`app/components/Views/Settings/DeveloperOptions/DeepLinkTest.tsx`, `index.tsx`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2640c06235acaa9a2f1e0a1fdbdc66a06de1f018. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->