### PR TITLE
fix: cp-7.58.0 fix layout issues on iOS by adding SafeAreaView and padding in onboarding screens 

### DIFF
--- a/app/components/Views/AccountBackupStep1/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/AccountBackupStep1/__snapshots__/index.test.tsx.snap
@@ -516,7 +516,7 @@ exports[`AccountBackupStep1 Snapshots iOS render matches snapshot 1`] = `
     {
       "backgroundColor": "#ffffff",
       "flex": 1,
-      "paddingTop": 0,
+      "paddingTop": 8,
     }
   }
 >
@@ -530,7 +530,7 @@ exports[`AccountBackupStep1 Snapshots iOS render matches snapshot 1`] = `
       {
         "backgroundColor": "#ffffff",
         "flex": 1,
-        "paddingTop": 0,
+        "paddingTop": 8,
       }
     }
     testID="protect-your-account-screen"

--- a/app/components/Views/AccountBackupStep1/index.js
+++ b/app/components/Views/AccountBackupStep1/index.js
@@ -47,7 +47,7 @@ const createStyles = (colors) =>
     mainWrapper: {
       backgroundColor: colors.background.default,
       flex: 1,
-      paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight || 24 : 0,
+      paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight || 24 : 8,
     },
     scrollviewWrapper: {
       flexGrow: 1,

--- a/app/components/Views/AccountStatus/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/AccountStatus/__snapshots__/index.test.tsx.snap
@@ -1,11 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AccountStatus Snapshots android renders correctly with accountName in route params 1`] = `
-<RCTSafeAreaView>
+<RNCSafeAreaView
+  edges={
+    {
+      "bottom": "additive",
+      "left": "off",
+      "right": "off",
+      "top": "off",
+    }
+  }
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
   <View
     style={
       {
-        "height": "100%",
+        "flex": 1,
         "paddingHorizontal": 16,
         "paddingTop": 24,
       }
@@ -170,15 +184,29 @@ exports[`AccountStatus Snapshots android renders correctly with accountName in r
       </TouchableOpacity>
     </View>
   </View>
-</RCTSafeAreaView>
+</RNCSafeAreaView>
 `;
 
 exports[`AccountStatus Snapshots android renders correctly with type="found and statusbar current height to zero" 1`] = `
-<RCTSafeAreaView>
+<RNCSafeAreaView
+  edges={
+    {
+      "bottom": "additive",
+      "left": "off",
+      "right": "off",
+      "top": "off",
+    }
+  }
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
   <View
     style={
       {
-        "height": "100%",
+        "flex": 1,
         "paddingHorizontal": 16,
         "paddingTop": 24,
       }
@@ -343,15 +371,29 @@ exports[`AccountStatus Snapshots android renders correctly with type="found and 
       </TouchableOpacity>
     </View>
   </View>
-</RCTSafeAreaView>
+</RNCSafeAreaView>
 `;
 
 exports[`AccountStatus Snapshots android renders correctly with type="not_exist" 1`] = `
-<RCTSafeAreaView>
+<RNCSafeAreaView
+  edges={
+    {
+      "bottom": "additive",
+      "left": "off",
+      "right": "off",
+      "top": "off",
+    }
+  }
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
   <View
     style={
       {
-        "height": "100%",
+        "flex": 1,
         "paddingHorizontal": 16,
         "paddingTop": 24,
       }
@@ -516,15 +558,29 @@ exports[`AccountStatus Snapshots android renders correctly with type="not_exist"
       </TouchableOpacity>
     </View>
   </View>
-</RCTSafeAreaView>
+</RNCSafeAreaView>
 `;
 
 exports[`AccountStatus Snapshots iOS renders correctly with accountName in route params 1`] = `
-<RCTSafeAreaView>
+<RNCSafeAreaView
+  edges={
+    {
+      "bottom": "additive",
+      "left": "off",
+      "right": "off",
+      "top": "off",
+    }
+  }
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
   <View
     style={
       {
-        "height": "100%",
+        "flex": 1,
         "paddingHorizontal": 16,
         "paddingTop": 24,
       }
@@ -689,15 +745,29 @@ exports[`AccountStatus Snapshots iOS renders correctly with accountName in route
       </TouchableOpacity>
     </View>
   </View>
-</RCTSafeAreaView>
+</RNCSafeAreaView>
 `;
 
 exports[`AccountStatus Snapshots iOS renders correctly with type="found" 1`] = `
-<RCTSafeAreaView>
+<RNCSafeAreaView
+  edges={
+    {
+      "bottom": "additive",
+      "left": "off",
+      "right": "off",
+      "top": "off",
+    }
+  }
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
   <View
     style={
       {
-        "height": "100%",
+        "flex": 1,
         "paddingHorizontal": 16,
         "paddingTop": 24,
       }
@@ -862,15 +932,29 @@ exports[`AccountStatus Snapshots iOS renders correctly with type="found" 1`] = `
       </TouchableOpacity>
     </View>
   </View>
-</RCTSafeAreaView>
+</RNCSafeAreaView>
 `;
 
 exports[`AccountStatus Snapshots iOS renders correctly with type="not_exist" 1`] = `
-<RCTSafeAreaView>
+<RNCSafeAreaView
+  edges={
+    {
+      "bottom": "additive",
+      "left": "off",
+      "right": "off",
+      "top": "off",
+    }
+  }
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
   <View
     style={
       {
-        "height": "100%",
+        "flex": 1,
         "paddingHorizontal": 16,
         "paddingTop": 24,
       }
@@ -1035,5 +1119,5 @@ exports[`AccountStatus Snapshots iOS renders correctly with type="not_exist" 1`]
       </TouchableOpacity>
     </View>
   </View>
-</RCTSafeAreaView>
+</RNCSafeAreaView>
 `;

--- a/app/components/Views/AccountStatus/index.styles.ts
+++ b/app/components/Views/AccountStatus/index.styles.ts
@@ -10,11 +10,14 @@ const statusBarHeight = StatusBar.currentHeight ?? 0;
 const androidPaddingTopWithStatusBar = statusBarHeight + 24;
 
 const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+  },
   scrollView: {
     marginBottom: 0,
   },
   root: {
-    height: '100%',
+    flex: 1,
     paddingHorizontal: 16,
     paddingTop: Platform.OS === 'android' ? androidPaddingTopWithStatusBar : 24,
   },

--- a/app/components/Views/AccountStatus/index.tsx
+++ b/app/components/Views/AccountStatus/index.tsx
@@ -1,12 +1,6 @@
 import React, { useEffect, useCallback } from 'react';
-import {
-  View,
-  Image,
-  ScrollView,
-  Dimensions,
-  SafeAreaView,
-  Platform,
-} from 'react-native';
+import { View, Image, ScrollView, Dimensions, Platform } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Dispatch } from 'redux';
 import { connect } from 'react-redux';
 import Text from '../../../component-library/components/Texts/Text';
@@ -158,7 +152,7 @@ const AccountStatus = ({
   }, []);
 
   return (
-    <SafeAreaView>
+    <SafeAreaView style={styles.safeArea} edges={['bottom']}>
       <View style={styles.root}>
         <ScrollView style={styles.scrollView}>
           <View style={styles.content}>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
* Add top padding in "Secure your wallet" screen for ios.
* Add SafeAreaView in AccountStatus page.
* Bug: https://github.com/MetaMask/metamask-mobile/issues/21844
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fix ui bugs

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/21844
* Add top padding in "Secure your wallet" screen for ios.
* Add SafeAreaView in AccountStatus page.
## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="391" height="876" alt="Screenshot 2025-10-29 at 9 11 45 AM" src="https://github.com/user-attachments/assets/3a7e4935-919e-4c93-80c5-583a44ae0522" />
<img width="366" height="789" alt="Screenshot 2025-10-29 at 10 17 59 AM" src="https://github.com/user-attachments/assets/a6602218-b620-4484-8aab-3471dd8ce7e2" />
<!-- [screenshots/recordings] -->

### **After**
<img width="369" height="847" alt="Screenshot 2025-10-29 at 7 34 11 AM" src="https://github.com/user-attachments/assets/7c5aa1dc-a7c5-4d4a-9d17-dd7ff5ebcef7" />
<img width="342" height="714" alt="Screenshot 2025-10-29 at 9 00 38 AM" src="https://github.com/user-attachments/assets/78d8ae58-14a8-490a-b019-110e22b766af" />
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch AccountStatus to react-native-safe-area-context SafeAreaView with bottom edges and flex, and add 8px top padding on iOS for AccountBackupStep1.
> 
> - **UI**:
>   - **AccountStatus (`app/components/Views/AccountStatus/`)**:
>     - Replace `SafeAreaView` with `react-native-safe-area-context` `SafeAreaView` using `edges=['bottom']` and new `styles.safeArea` (`flex: 1`).
>     - Update layout to use `flex: 1` instead of `height: '100%'`; keep platform-specific top padding (Android includes status bar height).
>     - Snapshots updated to reflect `RNCSafeAreaView` and layout changes.
>   - **AccountBackupStep1 (`app/components/Views/AccountBackupStep1/`)**:
>     - Add iOS top padding (`paddingTop: 8`) in `mainWrapper` and matching `ScrollView` style.
>     - Snapshots updated for new top padding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d3f69eabd1305d9256c3872fe0ba6b8fcab779e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->