### PR TITLE
fix: cp-7.58.0 formatTimeRemaining to correctly display time remaining

### DIFF
--- a/app/components/UI/Rewards/utils/formatUtils.test.ts
+++ b/app/components/UI/Rewards/utils/formatUtils.test.ts
@@ -88,7 +88,7 @@ describe('formatUtils', () => {
   });
 
   describe('formatTimeRemaining', () => {
-    it('should return formatted time with days and hours when hours > 0', () => {
+    it('returns formatted time with days, hours, and minutes when all are positive', () => {
       // Given: 2 days, 5 hours, 30 minutes remaining
       mockGetTimeDifferenceFromNow.mockReturnValue({
         days: 2,
@@ -101,14 +101,14 @@ describe('formatUtils', () => {
       // When: formatting time remaining
       const result = formatTimeRemaining(endDate);
 
-      // Then: should return days and hours format
-      expect(result).toBe('2d 5h');
+      // Then: should return days, hours, and minutes format
+      expect(result).toBe('2d 5h 30m');
       expect(mockGetTimeDifferenceFromNow).toHaveBeenCalledWith(
         endDate.getTime(),
       );
     });
 
-    it('should return formatted time with only minutes when hours = 0 and minutes > 0', () => {
+    it('returns formatted time with only minutes when hours and days are zero', () => {
       // Given: 0 hours, 45 minutes remaining
       mockGetTimeDifferenceFromNow.mockReturnValue({
         days: 0,
@@ -125,7 +125,7 @@ describe('formatUtils', () => {
       expect(result).toBe('45m');
     });
 
-    it('should return null when both hours and minutes are 0', () => {
+    it('returns null when days, hours, and minutes are all zero', () => {
       // Given: 0 hours, 0 minutes remaining
       mockGetTimeDifferenceFromNow.mockReturnValue({
         days: 0,
@@ -142,7 +142,7 @@ describe('formatUtils', () => {
       expect(result).toBeNull();
     });
 
-    it('should return null when minutes are negative (past date)', () => {
+    it('returns null when time values are negative for past date', () => {
       // Given: negative minutes (past date)
       mockGetTimeDifferenceFromNow.mockReturnValue({
         days: 0,
@@ -159,7 +159,7 @@ describe('formatUtils', () => {
       expect(result).toBeNull();
     });
 
-    it('should handle edge case with 0 days, 1 hour, 0 minutes', () => {
+    it('returns only hours when days and minutes are zero', () => {
       // Given: exactly 1 hour remaining
       mockGetTimeDifferenceFromNow.mockReturnValue({
         days: 0,
@@ -172,11 +172,11 @@ describe('formatUtils', () => {
       // When: formatting time remaining
       const result = formatTimeRemaining(endDate);
 
-      // Then: should return days and hours format
-      expect(result).toBe('0d 1h');
+      // Then: should return hours format only
+      expect(result).toBe('1h');
     });
 
-    it('should handle large time differences correctly', () => {
+    it('returns days, hours, and minutes for large time differences', () => {
       // Given: 365 days, 23 hours, 59 minutes remaining
       mockGetTimeDifferenceFromNow.mockReturnValue({
         days: 365,
@@ -189,11 +189,11 @@ describe('formatUtils', () => {
       // When: formatting time remaining
       const result = formatTimeRemaining(endDate);
 
-      // Then: should return days and hours format
-      expect(result).toBe('365d 23h');
+      // Then: should return days, hours, and minutes format
+      expect(result).toBe('365d 23h 59m');
     });
 
-    it('should handle single digit values correctly', () => {
+    it('returns single digit values without padding', () => {
       // Given: 1 day, 1 hour, 1 minute remaining
       mockGetTimeDifferenceFromNow.mockReturnValue({
         days: 1,
@@ -206,11 +206,11 @@ describe('formatUtils', () => {
       // When: formatting time remaining
       const result = formatTimeRemaining(endDate);
 
-      // Then: should return days and hours format without padding
-      expect(result).toBe('1d 1h');
+      // Then: should return days, hours, and minutes format without padding
+      expect(result).toBe('1d 1h 1m');
     });
 
-    it('should prioritize hours over minutes when hours > 0', () => {
+    it('returns hours and minutes when days are zero', () => {
       // Given: 0 days, 2 hours, 59 minutes remaining
       mockGetTimeDifferenceFromNow.mockReturnValue({
         days: 0,
@@ -223,11 +223,11 @@ describe('formatUtils', () => {
       // When: formatting time remaining
       const result = formatTimeRemaining(endDate);
 
-      // Then: should return days and hours format (ignoring minutes)
-      expect(result).toBe('0d 2h');
+      // Then: should return hours and minutes format
+      expect(result).toBe('2h 59m');
     });
 
-    it('should handle exactly 1 minute remaining', () => {
+    it('returns exactly 1 minute when only minutes remain', () => {
       // Given: exactly 1 minute remaining
       mockGetTimeDifferenceFromNow.mockReturnValue({
         days: 0,
@@ -244,7 +244,7 @@ describe('formatUtils', () => {
       expect(result).toBe('1m');
     });
 
-    it('should handle zero days with hours correctly', () => {
+    it('returns hours and minutes when days are zero', () => {
       // Given: 0 days, 12 hours, 30 minutes remaining
       mockGetTimeDifferenceFromNow.mockReturnValue({
         days: 0,
@@ -257,11 +257,11 @@ describe('formatUtils', () => {
       // When: formatting time remaining
       const result = formatTimeRemaining(endDate);
 
-      // Then: should return days and hours format with 0 days
-      expect(result).toBe('0d 12h');
+      // Then: should return hours and minutes format
+      expect(result).toBe('12h 30m');
     });
 
-    it('should call getTimeDifferenceFromNow with correct timestamp', () => {
+    it('calls getTimeDifferenceFromNow with correct timestamp', () => {
       // Given: a specific end date
       const endDate = new Date('2024-06-15T10:30:00Z');
       const expectedTimestamp = endDate.getTime();
@@ -280,6 +280,57 @@ describe('formatUtils', () => {
         expectedTimestamp,
       );
       expect(mockGetTimeDifferenceFromNow).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns days and minutes when hours are zero', () => {
+      // Given: 3 days, 0 hours, 15 minutes remaining
+      mockGetTimeDifferenceFromNow.mockReturnValue({
+        days: 3,
+        hours: 0,
+        minutes: 15,
+      });
+
+      const endDate = new Date('2024-01-04T12:15:00Z');
+
+      // When: formatting time remaining
+      const result = formatTimeRemaining(endDate);
+
+      // Then: should return days and minutes format
+      expect(result).toBe('3d 15m');
+    });
+
+    it('returns only days when hours and minutes are zero', () => {
+      // Given: 5 days, 0 hours, 0 minutes remaining
+      mockGetTimeDifferenceFromNow.mockReturnValue({
+        days: 5,
+        hours: 0,
+        minutes: 0,
+      });
+
+      const endDate = new Date('2024-01-06T12:00:00Z');
+
+      // When: formatting time remaining
+      const result = formatTimeRemaining(endDate);
+
+      // Then: should return days format only
+      expect(result).toBe('5d');
+    });
+
+    it('trims trailing space when minutes are zero', () => {
+      // Given: 2 days, 3 hours, 0 minutes remaining
+      mockGetTimeDifferenceFromNow.mockReturnValue({
+        days: 2,
+        hours: 3,
+        minutes: 0,
+      });
+
+      const endDate = new Date('2024-12-31T15:00:00Z');
+
+      // When: formatting time remaining
+      const result = formatTimeRemaining(endDate);
+
+      // Then: should return days and hours format without trailing space
+      expect(result).toBe('2d 3h');
     });
   });
 

--- a/app/components/UI/Rewards/utils/formatUtils.ts
+++ b/app/components/UI/Rewards/utils/formatUtils.ts
@@ -45,17 +45,15 @@ export const formatTimeRemaining = (endDate: Date): string | null => {
   const { days, hours, minutes } = getTimeDifferenceFromNow(endDate.getTime());
 
   // No time remaining
-  if (hours <= 0 && minutes <= 0) {
+  if (hours <= 0 && minutes <= 0 && days <= 0) {
     return null;
   }
 
-  // Only minutes remaining
-  if (hours <= 0) {
-    return `${minutes}m`;
-  }
+  const dayString = days > 0 ? `${days}d ` : '';
+  const hourString = hours > 0 ? `${hours}h ` : '';
+  const minuteString = minutes > 0 ? `${minutes}m` : '';
 
-  // Hours and days remaining
-  return `${days}d ${hours}h`;
+  return `${dayString}${hourString}${minuteString}`?.trim();
 };
 
 // Get icon name with fallback to Star if invalid


### PR DESCRIPTION
## **Description**

Right now the rewards component that displays the number of time left is incorrectly showing the time left if the hours value returned by `getTimeDifferenceFromNow` is 0. (it will only show minutes left in this case) This will happen if the end date of the season versus the current time on the app is X day(s) 0 hours and X minute(s).

## **Changelog**

CHANGELOG entry: fix rewards season time remaining

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/21842

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="654" height="206" alt="image" src="https://github.com/user-attachments/assets/353da666-7a10-4433-b6fd-1e08bf88309d" />

### **After**

<img width="656" height="273" alt="image" src="https://github.com/user-attachments/assets/3a36bfa3-6c26-4966-b4ab-c9c09f865fc4" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjust time-remaining formatting to include days/hours/minutes with stricter null conditions and update tests, plus locale checks for rewards date formatting.
> 
> - **Utilities**:
>   - Update `formatTimeRemaining` to compose output from `days`, `hours`, and `minutes`, trim trailing space, and return `null` only when all are non-positive.
> - **Tests**:
>   - Revise and expand `formatUtils.test.ts` for new `formatTimeRemaining` behavior (e.g., days+minutes, hours-only, minutes-only, large diffs, zero/negative cases, trimming).
>   - Add locale-aware checks for `formatRewardsDate` (default and custom locales).
>   - Maintain number formatting fallback test using mocked `getIntlNumberFormatter`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a87305acbaf79825c23537d12e47196218216622. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->