### PR TITLE
fix: navigation when send confirmation is rejected.

### DIFF
--- a/app/components/Views/confirmations/components/footer/footer.tsx
+++ b/app/components/Views/confirmations/components/footer/footer.tsx
@@ -31,7 +31,10 @@ import { isStakingConfirmation } from '../../utils/confirm';
 import styleSheet from './footer.styles';
 import Routes from '../../../../../constants/navigation/Routes';
 import { TransactionType } from '@metamask/transaction-controller';
-import { REDESIGNED_TRANSFER_TYPES } from '../../constants/confirmations';
+import {
+  MMM_ORIGIN,
+  REDESIGNED_TRANSFER_TYPES,
+} from '../../constants/confirmations';
 import { hasTransactionType } from '../../utils/transaction';
 import { PredictClaimFooter } from '../predict-confirmations/predict-claim-footer/predict-claim-footer';
 import { useIsTransactionPayLoading } from '../../hooks/pay/useIsTransactionPayLoading';
@@ -58,7 +61,9 @@ export const Footer = () => {
   const { isFullScreenConfirmation } = useFullScreenConfirmation();
   const transactionType = transactionMetadata?.type as TransactionType;
   const isStakingConfirmationBool = isStakingConfirmation(transactionType);
-  const isSendReq = REDESIGNED_TRANSFER_TYPES.includes(transactionType);
+  const isMMSendReq =
+    REDESIGNED_TRANSFER_TYPES.includes(transactionType) &&
+    transactionMetadata?.origin === MMM_ORIGIN;
   const { isLoading: isPayLoading } = useIsTransactionPayLoading();
 
   const { isFooterVisible: isFooterVisibleFlag, isTransactionValueUpdating } =
@@ -156,7 +161,7 @@ export const Footer = () => {
       label: strings('confirm.cancel'),
       size: ButtonSize.Lg,
       onPress: () =>
-        onReject(providerErrors.userRejectedRequest(), undefined, isSendReq),
+        onReject(providerErrors.userRejectedRequest(), undefined, isMMSendReq),
       testID: ConfirmationFooterSelectorIDs.CANCEL_BUTTON,
     },
     {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix navigation after send from dapp is rejected.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/21677

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**
TODO

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Scopes the redesigned transfer rejection flag to MMM-originated requests and passes it on cancel, fixing navigation after rejecting dapp-initiated sends.
> 
> - **Confirmations Footer (`app/components/Views/confirmations/components/footer/footer.tsx`)**:
>   - Introduces `isMMSendReq` computed from `REDESIGNED_TRANSFER_TYPES` and `transactionMetadata.origin === MMM_ORIGIN`.
>   - Passes `isMMSendReq` as the third arg to `onReject(providerErrors.userRejectedRequest(), undefined, isMMSendReq)` for the Cancel button.
>   - Adds import of `MMM_ORIGIN` alongside `REDESIGNED_TRANSFER_TYPES`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35123a685097547efa9b10e5142d96421fed9210. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->