### PR TITLE
feat(ramp): add state for detected geolocation

### DIFF
--- a/app/components/UI/Ramp/hooks/useDetectGeolocation.test.ts
+++ b/app/components/UI/Ramp/hooks/useDetectGeolocation.test.ts
@@ -1,0 +1,262 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+import useDetectGeolocation from './useDetectGeolocation';
+import { SdkEnvironment } from '@consensys/native-ramps-sdk';
+import Logger from '../../../../util/Logger';
+
+const mockDispatch = jest.fn();
+
+jest.mock('react-redux', () => ({
+  useDispatch: () => mockDispatch,
+}));
+
+const mockGetSdkEnvironment = jest.fn();
+jest.mock('../Deposit/sdk/getSdkEnvironment', () => ({
+  getSdkEnvironment: () => mockGetSdkEnvironment(),
+}));
+
+global.fetch = jest.fn();
+const mockFetch = global.fetch as jest.Mock;
+
+describe('useDetecGeolocation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('URL selection based on environment', () => {
+    it('uses production URL when getSdkEnvironment returns Production', async () => {
+      mockGetSdkEnvironment.mockReturnValue(SdkEnvironment.Production);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: jest.fn().mockResolvedValue('US'),
+      });
+
+      renderHook(() => useDetectGeolocation());
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://on-ramp.api.cx.metamask.io/geolocation',
+      );
+    });
+
+    it('uses development URL when getSdkEnvironment returns Staging', async () => {
+      mockGetSdkEnvironment.mockReturnValue(SdkEnvironment.Staging);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: jest.fn().mockResolvedValue('US'),
+      });
+
+      renderHook(() => useDetectGeolocation());
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://on-ramp.dev-api.cx.metamask.io/geolocation',
+      );
+    });
+
+    it('uses development URL for any non-production environment', async () => {
+      mockGetSdkEnvironment.mockReturnValue('unknown-environment');
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: jest.fn().mockResolvedValue('US'),
+      });
+
+      renderHook(() => useDetectGeolocation());
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://on-ramp.dev-api.cx.metamask.io/geolocation',
+      );
+    });
+  });
+
+  describe('Successful geolocation detection', () => {
+    it('dispatches setDetectedGeolocation with returned geolocation when fetch succeeds', async () => {
+      const mockGeolocation = 'US';
+      mockGetSdkEnvironment.mockReturnValue(SdkEnvironment.Production);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: jest.fn().mockResolvedValue(mockGeolocation),
+      });
+
+      renderHook(() => useDetectGeolocation());
+
+      await waitFor(() =>
+        expect(mockDispatch).toHaveBeenCalledWith({
+          type: 'FIAT_SET_DETECTED_GEOLOCATION',
+          payload: mockGeolocation,
+        }),
+      );
+    });
+
+    it('dispatches setDetectedGeolocation with undefined when response text is empty', async () => {
+      mockGetSdkEnvironment.mockReturnValue(SdkEnvironment.Production);
+      const mockGeolocation = '';
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: jest.fn().mockResolvedValue(mockGeolocation),
+      });
+
+      renderHook(() => useDetectGeolocation());
+
+      await waitFor(() =>
+        expect(mockDispatch).toHaveBeenCalledWith({
+          type: 'FIAT_SET_DETECTED_GEOLOCATION',
+          payload: undefined,
+        }),
+      );
+    });
+
+    it('dispatches setDetectedGeolocation with undefined when response text is null', async () => {
+      mockGetSdkEnvironment.mockReturnValue(SdkEnvironment.Production);
+      const mockGeolocation = null;
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: jest.fn().mockResolvedValue(mockGeolocation),
+      });
+
+      renderHook(() => useDetectGeolocation());
+
+      await waitFor(() =>
+        expect(mockDispatch).toHaveBeenCalledWith({
+          type: 'FIAT_SET_DETECTED_GEOLOCATION',
+          payload: undefined,
+        }),
+      );
+    });
+  });
+
+  describe('Failed geolocation detection', () => {
+    it('logs error when fetch response is not ok', async () => {
+      mockGetSdkEnvironment.mockReturnValue(SdkEnvironment.Production);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        statusText: 'Not Found',
+      });
+
+      renderHook(() => useDetectGeolocation());
+      const mockLoggerError = jest.spyOn(Logger, 'error');
+
+      await waitFor(() =>
+        expect(mockLoggerError).toHaveBeenCalledWith(
+          expect.any(Error),
+          'useDetectedGeolocation: Failed to detect geolocation',
+        ),
+      );
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+
+    it('logs error when fetch throws network error', async () => {
+      const mockLoggerError = jest.spyOn(Logger, 'error');
+      const networkError = new Error('Network error');
+      mockGetSdkEnvironment.mockReturnValue(SdkEnvironment.Production);
+
+      mockFetch.mockRejectedValueOnce(networkError);
+
+      renderHook(() => useDetectGeolocation());
+      await waitFor(() =>
+        expect(mockLoggerError).toHaveBeenCalledWith(
+          networkError,
+          'useDetectedGeolocation: Failed to detect geolocation',
+        ),
+      );
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+
+    it('logs error when response.text() throws', async () => {
+      const mockLoggerError = jest.spyOn(Logger, 'error');
+      const textError = new Error('Text parsing error');
+      mockGetSdkEnvironment.mockReturnValue(SdkEnvironment.Production);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: jest.fn().mockRejectedValue(textError),
+      });
+
+      renderHook(() => useDetectGeolocation());
+
+      await waitFor(() =>
+        expect(mockLoggerError).toHaveBeenCalledWith(
+          textError,
+          'useDetectedGeolocation: Failed to detect geolocation',
+        ),
+      );
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Hook lifecycle', () => {
+    it('calls detectGeolocation on mount', async () => {
+      mockGetSdkEnvironment.mockReturnValue(SdkEnvironment.Production);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: jest.fn().mockResolvedValue('US'),
+      });
+
+      renderHook(() => useDetectGeolocation());
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('calls detectGeolocation again when URL changes due to environment change', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        text: jest.fn().mockResolvedValue('US'),
+      });
+
+      mockGetSdkEnvironment.mockReturnValue(SdkEnvironment.Production);
+      const { rerender } = renderHook(() => useDetectGeolocation());
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          'https://on-ramp.api.cx.metamask.io/geolocation',
+        );
+      });
+
+      mockGetSdkEnvironment.mockReturnValue(SdkEnvironment.Staging);
+      rerender([]);
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          'https://on-ramp.dev-api.cx.metamask.io/geolocation',
+        );
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  describe('Error handling edge cases', () => {
+    it('handles undefined response from fetch', async () => {
+      const mockLoggerError = jest.spyOn(Logger, 'error');
+      mockGetSdkEnvironment.mockReturnValue(SdkEnvironment.Production);
+
+      mockFetch.mockResolvedValueOnce(undefined);
+
+      renderHook(() => useDetectGeolocation());
+
+      await waitFor(() => {
+        expect(mockLoggerError).toHaveBeenCalledWith(
+          expect.any(Error),
+          'useDetectedGeolocation: Failed to detect geolocation',
+        );
+      });
+    });
+
+    it('handles response with missing text method', async () => {
+      const mockLoggerError = jest.spyOn(Logger, 'error');
+      mockGetSdkEnvironment.mockReturnValue(SdkEnvironment.Production);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+      });
+
+      renderHook(() => useDetectGeolocation());
+
+      await waitFor(() => {
+        expect(mockLoggerError).toHaveBeenCalledWith(
+          expect.any(Error),
+          'useDetectedGeolocation: Failed to detect geolocation',
+        );
+      });
+    });
+  });
+});

--- a/app/components/UI/Ramp/hooks/useDetectGeolocation.ts
+++ b/app/components/UI/Ramp/hooks/useDetectGeolocation.ts
@@ -1,0 +1,41 @@
+import { useCallback, useEffect } from 'react';
+import { getSdkEnvironment } from '../Deposit/sdk/getSdkEnvironment';
+import { SdkEnvironment } from '@consensys/native-ramps-sdk';
+import { useDispatch } from 'react-redux';
+import { setDetectedGeolocation } from '../../../../reducers/fiatOrders';
+import Logger from '../../../../util/Logger';
+
+const GEOLOCATION_URLS = {
+  DEV: 'https://on-ramp.dev-api.cx.metamask.io/geolocation',
+  PROD: 'https://on-ramp.api.cx.metamask.io/geolocation',
+};
+
+export default function useDetectGeolocation() {
+  const nativeRampEnvironment = getSdkEnvironment();
+  const dispatch = useDispatch();
+  const url =
+    nativeRampEnvironment === SdkEnvironment.Production
+      ? GEOLOCATION_URLS.PROD
+      : GEOLOCATION_URLS.DEV;
+
+  const detectGeolocation = useCallback(async () => {
+    try {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`Network response was not ok: ${response.statusText}`);
+      }
+      const geolocation = await response.text();
+
+      dispatch(setDetectedGeolocation(geolocation || undefined));
+    } catch (error) {
+      Logger.error(
+        error as Error,
+        'useDetectedGeolocation: Failed to detect geolocation',
+      );
+    }
+  }, [dispatch, url]);
+
+  useEffect(() => {
+    detectGeolocation();
+  }, [detectGeolocation]);
+}

--- a/app/components/UI/Ramp/index.tsx
+++ b/app/components/UI/Ramp/index.tsx
@@ -33,6 +33,7 @@ import stateHasOrder from './utils/stateHasOrder';
 import Routes from '../../../constants/navigation/Routes';
 import getOrderAnalyticsPayload from './utils/getOrderAnalyticsPayload';
 import { NativeRampsSdk } from '@consensys/native-ramps-sdk';
+import useDetectGeolocation from './hooks/useDetectGeolocation';
 
 const POLLING_FREQUENCY = AppConstants.FIAT_ORDERS.POLLING_FREQUENCY;
 
@@ -81,9 +82,8 @@ async function processCustomOrderId(
     dispatchThunk: (thunk: ThunkAction) => void;
   },
 ) {
-  const [customOrderId, fiatOrderResponse] = await processCustomOrderIdData(
-    customOrderIdData,
-  );
+  const [customOrderId, fiatOrderResponse] =
+    await processCustomOrderIdData(customOrderIdData);
 
   if (fiatOrderResponse) {
     const fiatOrder = aggregatorOrderToFiatOrder(fiatOrderResponse);
@@ -117,6 +117,7 @@ const styles = StyleSheet.create({
 
 function FiatOrders() {
   useFetchRampNetworks();
+  useDetectGeolocation();
   const dispatch = useDispatch();
   const dispatchThunk = useThunkDispatch();
   const navigation = useNavigation();

--- a/app/reducers/fiatOrders/index.test.ts
+++ b/app/reducers/fiatOrders/index.test.ts
@@ -56,6 +56,8 @@ import fiatOrderReducer, {
   setFiatSellTxHash,
   removeFiatSellTxHash,
   getOrdersProviders,
+  getDetectedGeolocation,
+  setDetectedGeolocation,
 } from '.';
 import { FIAT_ORDER_PROVIDERS } from '../../constants/on-ramp';
 import { CustomIdData, Action, FiatOrder, Region } from './types';
@@ -839,6 +841,28 @@ describe('fiatOrderReducer', () => {
     );
 
     expect(stateWithoutChanges).toEqual(stateWithOrder1);
+  });
+
+  it('sets the detected geolocation', () => {
+    const stateWithGeolocation = fiatOrderReducer(
+      initialState,
+      setDetectedGeolocation('US'),
+    );
+    expect(stateWithGeolocation.detectedGeolocation).toBe('US');
+
+    const otherStateWithGeolocation = fiatOrderReducer(
+      stateWithGeolocation,
+      setDetectedGeolocation('CL'),
+    );
+    expect(otherStateWithGeolocation.detectedGeolocation).toBe('CL');
+  });
+
+  it('sets the detected geolocation to undefined', () => {
+    const stateWithGeolocation = fiatOrderReducer(
+      initialState,
+      setDetectedGeolocation(undefined),
+    );
+    expect(stateWithGeolocation.detectedGeolocation).toBeUndefined();
   });
 });
 
@@ -2527,6 +2551,24 @@ describe('selectors', () => {
           {} as FiatOrder['data'],
         ),
       ).toEqual('...');
+    });
+  });
+
+  describe('getDetectedGeolocation', () => {
+    it('should return the detected geolocation', () => {
+      const state = merge({}, initialRootState, {
+        fiatOrders: {
+          detectedGeolocation: 'US',
+        },
+      });
+      expect(getDetectedGeolocation(state)).toBe('US');
+    });
+
+    it('should return undefined if detected geolocation is not set', () => {
+      const state = merge({}, initialRootState, {
+        fiatOrders: {},
+      });
+      expect(getDetectedGeolocation(state)).toBeUndefined();
     });
   });
 });

--- a/app/reducers/fiatOrders/index.ts
+++ b/app/reducers/fiatOrders/index.ts
@@ -134,6 +134,11 @@ export const removeFiatSellTxHash = (orderId: string) => ({
   payload: orderId,
 });
 
+export const setDetectedGeolocation = (geolocation: string | undefined) => ({
+  type: ACTIONS.FIAT_SET_DETECTED_GEOLOCATION,
+  payload: geolocation,
+});
+
 /**
  * Selectors
  */
@@ -298,6 +303,11 @@ export const networkShortNameSelector = createSelector(
   },
 );
 
+export const getDetectedGeolocation: (
+  state: RootState,
+) => string | undefined = (state: RootState) =>
+  state.fiatOrders.detectedGeolocation;
+
 export const initialState: FiatOrdersState = {
   orders: [],
   customOrderIds: [],
@@ -312,6 +322,7 @@ export const initialState: FiatOrdersState = {
   getStartedDeposit: false,
   authenticationUrls: [],
   activationKeys: [],
+  detectedGeolocation: undefined,
 };
 
 const findOrderIndex = (
@@ -598,6 +609,12 @@ const fiatOrderReducer: (
           },
           ...orders.slice(index + 1),
         ],
+      };
+    }
+    case ACTIONS.FIAT_SET_DETECTED_GEOLOCATION: {
+      return {
+        ...state,
+        detectedGeolocation: action.payload,
       };
     }
 

--- a/app/reducers/fiatOrders/types.ts
+++ b/app/reducers/fiatOrders/types.ts
@@ -34,6 +34,7 @@ import {
   updateOnRampNetworks,
   setFiatSellTxHash,
   removeFiatSellTxHash,
+  setDetectedGeolocation,
 } from '.';
 import {
   FIAT_ORDER_PROVIDERS,
@@ -103,6 +104,7 @@ export interface FiatOrdersState {
   getStartedDeposit: boolean;
   authenticationUrls: string[];
   activationKeys: ActivationKey[];
+  detectedGeolocation?: string;
 }
 
 export const ACTIONS = {
@@ -131,6 +133,7 @@ export const ACTIONS = {
   FIAT_UPDATE_NETWORKS: 'FIAT_UPDATE_NETWORKS',
   FIAT_SET_SELL_TX_HASH: 'FIAT_SET_SELL_TX_HASH',
   FIAT_REMOVE_SELL_TX_HASH: 'FIAT_REMOVE_SELL_TX_HASH',
+  FIAT_SET_DETECTED_GEOLOCATION: 'FIAT_SET_DETECTED_GEOLOCATION',
 } as const;
 
 export type Action =
@@ -156,7 +159,8 @@ export type Action =
   | ReturnType<typeof removeActivationKey>
   | ReturnType<typeof updateOnRampNetworks>
   | ReturnType<typeof setFiatSellTxHash>
-  | ReturnType<typeof removeFiatSellTxHash>;
+  | ReturnType<typeof removeFiatSellTxHash>
+  | ReturnType<typeof setDetectedGeolocation>;
 
 export type Region = Country & State;
 


### PR DESCRIPTION


## **Description**

This pull request introduces geolocation detection to the Ramp UI, allowing the app to determine and store the user's country code for fiat on-ramp flows. The main changes include a new `useDetectGeolocation` hook, updates to the fiat orders reducer to support storing and retrieving the detected geolocation, and comprehensive tests for both the hook and the reducer.

**Geolocation detection and state management:**

- Added a new hook, `useDetectGeolocation`, which fetches the user's geolocation from an API endpoint based on the current SDK environment and dispatches the result to the Redux store. The hook includes robust error handling and is automatically invoked in the `FiatOrders` component. [[1]](diffhunk://#diff-cf98b9695f077d572a04cbc9119718411fafbe9ab9a93bc05041c1ea62a7b756R1-R41) [[2]](diffhunk://#diff-5cce1901aeaf11c1c102232f718b93a0c59e379ccb61a5702e164e6a722e110cR36) [[3]](diffhunk://#diff-5cce1901aeaf11c1c102232f718b93a0c59e379ccb61a5702e164e6a722e110cR120)

- Updated the fiat orders Redux state (`FiatOrdersState`) to include a new `detectedGeolocation` field, along with a new action (`FIAT_SET_DETECTED_GEOLOCATION`), action creator (`setDetectedGeolocation`), and selector (`getDetectedGeolocation`) for managing and accessing this value. [[1]](diffhunk://#diff-e90e723a44ecff022a0428a9f2244a5527737efc7b34cb9c6efb246addc29577R137-R141) [[2]](diffhunk://#diff-e90e723a44ecff022a0428a9f2244a5527737efc7b34cb9c6efb246addc29577R306-R310) [[3]](diffhunk://#diff-e90e723a44ecff022a0428a9f2244a5527737efc7b34cb9c6efb246addc29577R325) [[4]](diffhunk://#diff-e90e723a44ecff022a0428a9f2244a5527737efc7b34cb9c6efb246addc29577R614-R619) [[5]](diffhunk://#diff-ee673394f0b41f57ddc3901229482bec289064897ff3cf6c3e7a5b3c20f936b0R107) [[6]](diffhunk://#diff-ee673394f0b41f57ddc3901229482bec289064897ff3cf6c3e7a5b3c20f936b0R136) [[7]](diffhunk://#diff-ee673394f0b41f57ddc3901229482bec289064897ff3cf6c3e7a5b3c20f936b0L159-R163)

**Testing improvements:**

- Added a comprehensive test suite for the `useDetectGeolocation` hook, covering environment-based URL selection, successful and failed geolocation detection, error handling, and hook lifecycle behaviors.

- Extended the fiat orders reducer tests to cover setting, updating, and unsetting the detected geolocation, as well as verifying the selector behavior. [[1]](diffhunk://#diff-57993aac9713d455248b3d92f0201d5eaff6b3f8b5ea84889147073be786e2ffR59-R60) [[2]](diffhunk://#diff-57993aac9713d455248b3d92f0201d5eaff6b3f8b5ea84889147073be786e2ffR845-R866) [[3]](diffhunk://#diff-57993aac9713d455248b3d92f0201d5eaff6b3f8b5ea84889147073be786e2ffR2556-R2573)

**Other minor improvements:**

- Minor code formatting and cleanup in the Ramp UI component.

These changes collectively enable the app to detect and persist a user's geolocation for use in fiat on-ramp flows, with robust error handling and full test coverage.
## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added a piece of state for the detected geolocation 

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-2768

## **Manual testing steps**

```gherkin
Feature: Ramps geodectection

  Scenario: user opens the app
    Given the app rendered

    When user loads the app
    Then the detected region gets stored in the state
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a geolocation detection hook wired to Redux and integrates it into Ramp, with state, actions, selector, and tests.
> 
> - **Ramp UI**:
>   - Adds `useDetectGeolocation` hook to fetch country code from env-based endpoint and dispatch `setDetectedGeolocation` (error-handled; auto-invoked in `FiatOrders`).
> - **State/Redux**:
>   - Extends `FiatOrdersState` with `detectedGeolocation`.
>   - Adds action `FIAT_SET_DETECTED_GEOLOCATION`, creator `setDetectedGeolocation`, and selector `getDetectedGeolocation`.
> - **Tests**:
>   - New hook tests covering env URL selection, success/empty/null responses, network/text errors, lifecycle, and edge cases.
>   - Reducer tests for setting/unsetting `detectedGeolocation` and selector behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 019a4156ca0d35efa5c53fefca5e9cf7e276f414. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->