### PR TITLE
fix(deposit): allow user to proceed with order creation when limits fetch fails cp-7.58.0

### DIFF
--- a/app/components/UI/Ramp/Deposit/hooks/useDepositRouting.test.ts
+++ b/app/components/UI/Ramp/Deposit/hooks/useDepositRouting.test.ts
@@ -1246,7 +1246,7 @@ describe('useDepositRouting', () => {
       expect(mockRequestOtt).not.toHaveBeenCalled();
     });
 
-    it('should throw error when getUserLimits returns null', async () => {
+    it('allows user to continue when getUserLimits returns null', async () => {
       const mockQuote = {
         quoteId: 'test-quote-id',
         fiatAmount: 100,
@@ -1263,13 +1263,13 @@ describe('useDepositRouting', () => {
 
       await expect(
         result.current.routeAfterAuthentication(mockQuote),
-      ).rejects.toThrow('Failed to check your deposit limits');
+      ).resolves.not.toThrow();
 
-      expect(mockCreateOrder).not.toHaveBeenCalled();
-      expect(mockRequestOtt).not.toHaveBeenCalled();
+      expect(mockRequestOtt).toHaveBeenCalled();
+      expect(mockGeneratePaymentUrl).toHaveBeenCalled();
     });
 
-    it('should throw error when any limit value is undefined', async () => {
+    it('allows user to continue when any limit value is undefined', async () => {
       const mockQuote = {
         quoteId: 'test-quote-id',
         fiatAmount: 100,
@@ -1292,10 +1292,35 @@ describe('useDepositRouting', () => {
 
       await expect(
         result.current.routeAfterAuthentication(mockQuote),
-      ).rejects.toThrow('Failed to check your deposit limits');
+      ).resolves.not.toThrow();
 
-      expect(mockCreateOrder).not.toHaveBeenCalled();
-      expect(mockRequestOtt).not.toHaveBeenCalled();
+      expect(mockRequestOtt).toHaveBeenCalled();
+      expect(mockGeneratePaymentUrl).toHaveBeenCalled();
+    });
+
+    it('allows user to continue when getUserLimits API fails', async () => {
+      const mockQuote = {
+        quoteId: 'test-quote-id',
+        fiatAmount: 100,
+      } as BuyQuote;
+
+      mockGetKycRequirement = jest.fn().mockResolvedValue({
+        status: 'APPROVED',
+        kycType: 'SIMPLE',
+      });
+
+      mockGetUserLimits = jest
+        .fn()
+        .mockRejectedValue(new Error('Network error'));
+
+      const { result } = renderHook(() => useDepositRouting());
+
+      await expect(
+        result.current.routeAfterAuthentication(mockQuote),
+      ).resolves.not.toThrow();
+
+      expect(mockRequestOtt).toHaveBeenCalled();
+      expect(mockGeneratePaymentUrl).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
We don't want to block the UI when the `user-limits` request fails.
We only want to block it when we're certain of the limits.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/21864

## **Manual testing steps**

```gherkin
Feature: Deposit Limits Validation

  Scenario: User can continue when limits data is unavailable
    Given the user is on the deposit flow
    And the limits API request fails

    When the user presses Buy
    And the user presses Deposit in the bottom sheet
    And the user selects WIRE/SEPA as payment method
    And the user inputs 20 EUR to buy
    And the user continues with the login flow
    And the user completes authentication

    Then the user should NOT see a limit exceeded error
    And the user should be able to proceed to payment
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
(Failing limits fetch blocks UI)

<img width="402" height="874" alt="Image" src="https://github.com/user-attachments/assets/c8a7a542-e411-490b-a14f-47dc29b12739" />

### **After**

<!-- [screenshots/recordings] -->
(Failing limits fetch don't block UI)

https://github.com/user-attachments/assets/d5141055-031b-4b2b-867d-a5a79fb140f1


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allows deposit flow to continue when user limits cannot be fetched or are incomplete, while still erroring when limits are explicitly exceeded.
> 
> - **Deposit routing (`useDepositRouting.ts`)**
>   - Introduces `LimitExceededError` and throws it only when deposit exceeds `daily`/`monthly`/`yearly` remaining limits.
>   - Wraps `getUserLimits` in try/catch; returns early (no block) when limits are `null`, missing, or API fails; logs non-limit errors with `Logger.error`.
> - **Tests (`useDepositRouting.test.ts`)**
>   - Updates expectations to continue flow when limits are `null`, have undefined values, or `getUserLimits` rejects.
>   - Adds test for API failure case; keeps exceed-limit tests asserting proper errors.
>   - Verifies continuation triggers OTT request and payment URL generation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0a9900d5184ed9b445a95258a374f7470f3321c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->