### PR TITLE
ci: Fix merge queue checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -470,10 +470,9 @@ jobs:
       - name: Check workflow files
         run: ${{ steps.download-actionlint.outputs.executable }} -color -config-file .github/actionlint.yaml
         shell: bash
-  all-jobs-pass-merge-pr:
+  all-jobs-pass:
     name: All jobs pass
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'merge_group' }}
     needs:
       [
         check-diff,
@@ -490,39 +489,19 @@ jobs:
       - name: Set jobs passed status
         id: jobs-passed-status
         run: echo "ALL_JOBS_PASSED=true" >> "$GITHUB_OUTPUT"
-  all-jobs-pass:
-    name: All jobs pass (merge_group)
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'merge_group' }}
-    needs:
-      [
-        check-diff,
-        dedupe,
-        scripts,
-        unit-tests,
-        check-workflows,
-        js-bundle-size-check,
-        sonar-cloud-quality-gate-status,
-      ]
-    outputs:
-      ALL_JOBS_PASSED: ${{ steps.jobs-passed-status.outputs.ALL_JOBS_PASSED }}
-    steps:
-      - name: Set jobs passed status
-        id: jobs-passed-status
-        run: echo "ALL_JOBS_PASSED=true" >> "$GITHUB_OUTPUT"
-  check-all-jobs-pass-merge-pr:
+  check-all-jobs-pass:
     name: Check all jobs pass
-    if: ${{ github.event_name != 'merge_group' && always() }}
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     needs:
-      - all-jobs-pass-merge-pr
+      - all-jobs-pass
       - needs_e2e_build
       - e2e-smoke-tests-android
       - e2e-smoke-tests-ios
     steps:
       - run: |
           # Check if all non-E2E jobs passed
-          if [[ "${{ needs.all-jobs-pass-merge-pr.outputs.ALL_JOBS_PASSED }}" != "true" ]]; then
+          if [[ "${{ needs.all-jobs-pass.outputs.ALL_JOBS_PASSED }}" != "true" ]]; then
             echo "Non-E2E jobs failed"
             exit 1
           fi
@@ -540,19 +519,6 @@ jobs:
           fi
 
           echo "All required jobs passed"
-  check-all-jobs-pass:
-    name: Check all jobs pass (merge_group)
-    runs-on: ubuntu-latest
-    needs: all-jobs-pass
-    if: ${{ github.event_name == 'merge_group' && always() }}
-    steps:
-      - run: |
-          if [[ "${{ needs.all-jobs-pass.outputs.ALL_JOBS_PASSED }}" == "true" ]]; then
-            echo "All jobs passed. Unblock PR."
-          else
-            echo "All jobs passed step skipped. Block PR."
-            exit 1
-          fi
 
   log-merge-group-failure:
     name: Log merge group failure


### PR DESCRIPTION
## **Description**

Status checks in the merge queue were always passing because the required status check was always skipped. This entirely defeats the purpose of having a merge queue.

The `ci.yml` workflow has been updated to ensure the required status check "Check all jobs passed" is always run.

It seems that this workflow change was originally made in #18919. The intent appears to have been to skip E2E tests in the merge queue, but run them in PRs. A separate merge-queue specific version of the "Check all jobs passed" job was created to create two separate conditions, but this was both ineffective and unnecessary.

The changes in this PR bring us back to a single "Check all jobs passed" job, (matching the current required status check), and it still allows the check to pass when E2E tests are skipped (as in the merge queue).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Consolidates CI jobs to a single `all-jobs-pass` and makes `check-all-jobs-pass` always run, fixing merge-queue status checks.
> 
> - **CI workflow (`.github/workflows/ci.yml`)**
>   - Consolidate to a single `all-jobs-pass` job; remove merge_group-specific variants.
>   - Make `check-all-jobs-pass` always run with `if: ${{ always() }}` and depend on `all-jobs-pass` plus E2E jobs.
>   - Update `needs`/references from `all-jobs-pass-merge-pr` to `all-jobs-pass`; streamline job names.
>   - Preserve E2E conditional validation (only checks Android/iOS E2E when `needs_e2e_build.outputs.builds == 'true'`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d347109f7fab7bda1a6b16e6eb9d67d0cd01f8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->