### PR TITLE
ci: Allow concurrent runs on `main`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
     - cron: '0 2-6 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
   cancel-in-progress: ${{ !(contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/heads/stable')) }}
 
 jobs:


### PR DESCRIPTION
## **Description**

Currently the `ci.yml` workflow only runs once per combination of workflow and branch.

Usually if a new commit is pushed to a branch, the CI run on the previous commit is no longer relevant. However that's not true on `main`. Getting a full CI run for every commit on `main` is critical for investigating CI failures that somehow make their way to `main` (e.g. flaky test failures).

The concurrency group ID has been updated to use the SHA as the ID on just the `main` branch, ensuring new commits don't cancel CI workflows for previous commits.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allow concurrent CI runs on main by including the commit SHA in the concurrency group key.
> 
> - **CI Workflow (`.github/workflows/ci.yml`)**:
>   - Adjust `concurrency.group` to `${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}` to allow concurrent runs per commit on `main` without canceling earlier runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98861c0172abd091ef4baa47f8536f3769dc25ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->