### PR TITLE
fix: add navigation lock on home screen buttons click

### DIFF
--- a/app/components/UI/AssetOverview/AssetOverview.test.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.test.tsx
@@ -179,6 +179,10 @@ jest.mock('@react-navigation/native', () => {
     useNavigation: () => ({
       navigate: mockNavigate,
     }),
+    useFocusEffect: jest.fn((callback) => {
+      // Call the callback immediately to simulate focus
+      callback();
+    }),
   };
 });
 

--- a/app/components/UI/AssetOverview/AssetOverview.test.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.test.tsx
@@ -178,6 +178,7 @@ jest.mock('@react-navigation/native', () => {
     ...actualNav,
     useNavigation: () => ({
       navigate: mockNavigate,
+      addListener: jest.fn(() => jest.fn()), // Returns unsubscribe function
     }),
     useFocusEffect: jest.fn((callback) => {
       // Call the callback immediately to simulate focus

--- a/app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.test.tsx
+++ b/app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.test.tsx
@@ -15,11 +15,15 @@ import { selectIsSwapsEnabled } from '../../../../core/redux/slices/bridge';
 
 // Mock the navigation hook
 const mockNavigate = jest.fn();
+const mockAddListener = jest.fn(() => jest.fn()); // Returns unsubscribe function
 jest.mock('@react-navigation/native', () => {
   const actualNav = jest.requireActual('@react-navigation/native');
   return {
     ...actualNav,
-    useNavigation: jest.fn(() => ({ navigate: mockNavigate })),
+    useNavigation: jest.fn(() => ({
+      navigate: mockNavigate,
+      addListener: mockAddListener,
+    })),
     useFocusEffect: jest.fn((callback) => {
       // Call the callback immediately to simulate focus
       callback();
@@ -92,6 +96,7 @@ describe('AssetDetailsActions', () => {
   afterEach(() => {
     jest.clearAllMocks();
     mockNavigate.mockClear();
+    mockAddListener.mockClear();
     mockTrackEvent.mockClear();
     mockCreateEventBuilder.mockClear();
     jest.mocked(selectIsSwapsEnabled).mockReset();

--- a/app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.test.tsx
+++ b/app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.test.tsx
@@ -20,6 +20,10 @@ jest.mock('@react-navigation/native', () => {
   return {
     ...actualNav,
     useNavigation: jest.fn(() => ({ navigate: mockNavigate })),
+    useFocusEffect: jest.fn((callback) => {
+      // Call the callback immediately to simulate focus
+      callback();
+    }),
   };
 });
 

--- a/app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.tsx
+++ b/app/components/Views/AssetDetails/AssetDetailsActions/AssetDetailsActions.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useCallback } from 'react';
+import React, { useRef, useCallback, useEffect } from 'react';
 import { View } from 'react-native';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import styleSheet from './AssetDetailsActions.styles';
@@ -59,7 +59,8 @@ export const AssetDetailsActions: React.FC<AssetDetailsActionsProps> = ({
   const isSwapsEnabled = useSelector((state: RootState) =>
     selectIsSwapsEnabled(state),
   );
-  const { navigate } = useNavigation();
+  const navigation = useNavigation();
+  const { navigate } = navigation;
   const { trackEvent, createEventBuilder } = useMetrics();
 
   // Prevent rapid navigation clicks - locks all buttons during navigation
@@ -71,6 +72,14 @@ export const AssetDetailsActions: React.FC<AssetDetailsActionsProps> = ({
       navigationLockRef.current = false;
     }, []),
   );
+
+  // Listen to navigation state changes to unlock when navigation completes or fails
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('state', () => {
+      navigationLockRef.current = false;
+    });
+    return unsubscribe;
+  }, [navigation]);
 
   // Check if FundActionMenu would be empty
   const { isDepositEnabled } = useDepositEnabled();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR fixes an issue when user tries to quickly click Swap and then Send buttons on the main page, causing views to stack, instead of transitioning to initially clicked button.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug causing navigation stack up on quickly clicking main page buttons

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-119
https://github.com/MetaMask/metamask-mobile/issues/18650

## **Manual testing steps**

```gherkin
Feature: Click home page buttons

  Scenario: user opens Swap and then Send
    Given user unlocked the app

    When user clicks quickly Swap and then Send
    Then only Swap is displayed and Send click is ignored
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/2e9dc23b-2d0a-4636-8440-39560dfb7126


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/d39b187a-9fd1-4d6c-a128-63b648e86669


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a navigation lock and focus/state listeners to prevent rapid multi-press stacking on asset action buttons, with corresponding test updates.
> 
> - **UI/Navigation**:
>   - `AssetDetailsActions.tsx`:
>     - Add navigation lock (`useRef`) and `withNavigationLock` wrapper for button handlers (`Buy/Swap/Send/Receive`).
>     - Reset lock on focus via `useFocusEffect` and on navigation state changes via `navigation.addListener('state', ...)`.
>     - Minor refactor to use full `navigation` object.
> - **Tests**:
>   - `AssetDetailsActions.test.tsx` and `AssetOverview.test.tsx`:
>     - Mock `useFocusEffect` (invoke immediately) and `navigation.addListener` (return unsubscribe fn).
>     - Update navigation mocks, clear mocks, and assertions to align with new locking/listener behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1833351114dfcee097cfd27ed984d4ee68142530. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->