### PR TITLE
fix: input cursor jump sometime in ios

### DIFF
--- a/app/components/Views/SrpInput/index.test.tsx
+++ b/app/components/Views/SrpInput/index.test.tsx
@@ -11,9 +11,15 @@ import {
 } from '../../../component-library/components/Form/TextField/TextField.constants';
 import { TextFieldSize } from '../../../component-library/components/Form/TextField/TextField.types';
 import { act, fireEvent, render } from '@testing-library/react-native';
+import Device from '../../../util/device';
+
+jest.mock('../../../util/device');
 
 const INPUT_TEST_ID = 'testingInputID';
 describe('SrpInput', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   it('renders default settings correctly', () => {
     const wrapper = render(<SrpInput />);
 
@@ -61,111 +67,161 @@ describe('SrpInput', () => {
   });
 
   describe('selection updates', () => {
-    it('sets selection to end of value on focus', () => {
-      const testValue = 'test recovery phrase';
-      const wrapper = render(
-        <SrpInput value={testValue} testID={INPUT_TEST_ID} />,
-      );
-
-      const input = wrapper.getByTestId(INPUT_TEST_ID);
-
-      act(() => {
-        fireEvent(input, 'focus');
+    describe('Android', () => {
+      beforeEach(() => {
+        (Device.isAndroid as jest.Mock).mockReturnValue(true);
       });
 
-      act(() => {
-        fireEvent(input, 'blur');
-      });
+      it('sets selection to end of value on focus', () => {
+        const testValue = 'test recovery phrase';
+        const wrapper = render(
+          <SrpInput value={testValue} testID={INPUT_TEST_ID} />,
+        );
+        const input = wrapper.getByTestId(INPUT_TEST_ID);
 
-      act(() => {
-        fireEvent(input, 'focus');
-      });
+        act(() => {
+          fireEvent(input, 'focus');
+        });
 
-      // wrapper.rerender(<SrpInput value={testValue} testID={INPUT_TEST_ID} />);
-
-      expect(input.props.selection).toEqual({
-        start: testValue.length,
-        end: testValue.length,
-      });
-    });
-
-    it('sets selection to beginning on blur', () => {
-      const wrapper = render(
-        <SrpInput value="test value" testID={INPUT_TEST_ID} />,
-      );
-      const input = wrapper.getByTestId(INPUT_TEST_ID);
-
-      act(() => {
-        fireEvent(input, 'focus');
-      });
-
-      act(() => {
-        fireEvent(input, 'blur');
-      });
-
-      expect(input.props.selection).toEqual({
-        start: 0,
-        end: 0,
-      });
-    });
-
-    it('calls provided onFocus callback when focused', () => {
-      const mockOnFocus = jest.fn();
-      const wrapper = render(
-        <SrpInput onFocus={mockOnFocus} testID={INPUT_TEST_ID} />,
-      );
-      const input = wrapper.getByTestId(INPUT_TEST_ID);
-
-      act(() => {
-        fireEvent(input, 'focus');
-      });
-
-      expect(mockOnFocus).toHaveBeenCalledTimes(1);
-    });
-
-    it('calls provided onBlur callback when blurred', () => {
-      const mockOnBlur = jest.fn();
-      const wrapper = render(
-        <SrpInput onBlur={mockOnBlur} testID={INPUT_TEST_ID} />,
-      );
-      const input = wrapper.getByTestId(INPUT_TEST_ID);
-
-      act(() => {
-        fireEvent(input, 'blur');
-      });
-
-      expect(mockOnBlur).toHaveBeenCalledTimes(1);
-    });
-
-    it('does not update selection when disabled on focus', () => {
-      const wrapper = render(
-        <SrpInput value="test" isDisabled testID={INPUT_TEST_ID} />,
-      );
-      const input = wrapper.getByTestId(INPUT_TEST_ID);
-
-      const initialSelection = input.props.selection;
-
-      act(() => {
-        fireEvent(input, 'focus');
-      });
-
-      expect(input.props.selection).toBe(initialSelection);
-    });
-
-    it('updates selection state on selection change', () => {
-      const wrapper = render(
-        <SrpInput value="test value" testID={INPUT_TEST_ID} />,
-      );
-      const input = wrapper.getByTestId(INPUT_TEST_ID);
-      const mockSelection = { start: 5, end: 5 };
-
-      act(() => {
-        fireEvent(input, 'selectionChange', {
-          nativeEvent: { selection: mockSelection },
+        expect(input.props.selection).toEqual({
+          start: testValue.length,
+          end: testValue.length,
         });
       });
 
-      expect(input.props.selection).toEqual(mockSelection);
+      it('sets selection to beginning on blur', () => {
+        const wrapper = render(
+          <SrpInput value="test value" testID={INPUT_TEST_ID} />,
+        );
+        const input = wrapper.getByTestId(INPUT_TEST_ID);
+
+        act(() => {
+          fireEvent(input, 'focus');
+        });
+
+        act(() => {
+          fireEvent(input, 'blur');
+        });
+
+        expect(input.props.selection).toEqual({
+          start: 0,
+          end: 0,
+        });
+      });
+
+      it('updates selection state on selection change', () => {
+        const wrapper = render(
+          <SrpInput value="test value" testID={INPUT_TEST_ID} />,
+        );
+        const input = wrapper.getByTestId(INPUT_TEST_ID);
+        const mockSelection = { start: 5, end: 5 };
+
+        act(() => {
+          fireEvent(input, 'selectionChange', {
+            nativeEvent: { selection: mockSelection },
+          });
+        });
+
+        expect(input.props.selection).toEqual(mockSelection);
+      });
+
+      it('does not update selection when disabled on focus', () => {
+        const wrapper = render(
+          <SrpInput value="test" isDisabled testID={INPUT_TEST_ID} />,
+        );
+        const input = wrapper.getByTestId(INPUT_TEST_ID);
+
+        const initialSelection = input.props.selection;
+
+        act(() => {
+          fireEvent(input, 'focus');
+        });
+
+        expect(input.props.selection).toBe(initialSelection);
+      });
+    });
+
+    describe('iOS', () => {
+      beforeEach(() => {
+        (Device.isAndroid as jest.Mock).mockReturnValue(false);
+      });
+
+      it('does not set selection on focus', () => {
+        const testValue = 'test recovery phrase';
+        const wrapper = render(
+          <SrpInput value={testValue} testID={INPUT_TEST_ID} />,
+        );
+        const input = wrapper.getByTestId(INPUT_TEST_ID);
+
+        act(() => {
+          fireEvent(input, 'focus');
+        });
+
+        expect(input.props.selection).toBeUndefined();
+      });
+
+      it('does not set selection on blur', () => {
+        const wrapper = render(
+          <SrpInput value="test value" testID={INPUT_TEST_ID} />,
+        );
+        const input = wrapper.getByTestId(INPUT_TEST_ID);
+
+        act(() => {
+          fireEvent(input, 'focus');
+        });
+
+        act(() => {
+          fireEvent(input, 'blur');
+        });
+
+        expect(input.props.selection).toBeUndefined();
+      });
+
+      it('does not update selection on selection change', () => {
+        const wrapper = render(
+          <SrpInput value="test value" testID={INPUT_TEST_ID} />,
+        );
+        const input = wrapper.getByTestId(INPUT_TEST_ID);
+        const mockSelection = { start: 5, end: 5 };
+
+        act(() => {
+          fireEvent(input, 'selectionChange', {
+            nativeEvent: { selection: mockSelection },
+          });
+        });
+
+        expect(input.props.selection).toBeUndefined();
+      });
+    });
+
+    describe('callbacks', () => {
+      it('calls provided onFocus callback when focused', () => {
+        const mockOnFocus = jest.fn();
+        const wrapper = render(
+          <SrpInput onFocus={mockOnFocus} testID={INPUT_TEST_ID} />,
+        );
+        const input = wrapper.getByTestId(INPUT_TEST_ID);
+
+        act(() => {
+          fireEvent(input, 'focus');
+        });
+
+        expect(mockOnFocus).toHaveBeenCalledTimes(1);
+      });
+
+      it('calls provided onBlur callback when blurred', () => {
+        const mockOnBlur = jest.fn();
+        const wrapper = render(
+          <SrpInput onBlur={mockOnBlur} testID={INPUT_TEST_ID} />,
+        );
+        const input = wrapper.getByTestId(INPUT_TEST_ID);
+
+        act(() => {
+          fireEvent(input, 'blur');
+        });
+
+        expect(mockOnBlur).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/app/components/Views/SrpInput/index.tsx
+++ b/app/components/Views/SrpInput/index.tsx
@@ -27,6 +27,7 @@ import {
   TEXTFIELD_STARTACCESSORY_TEST_ID,
   TEXTFIELD_ENDACCESSORY_TEST_ID,
 } from '../../../component-library/components/Form/TextField/TextField.constants';
+import Device from '../../../util/device';
 
 const TextField = React.forwardRef<
   TextInput,
@@ -74,7 +75,9 @@ const TextField = React.forwardRef<
           setIsFocused(false);
           onBlur?.(e);
         }
-        setInputSelection({ start: 0, end: 0 });
+        if (Device.isAndroid()) {
+          setInputSelection({ start: 0, end: 0 });
+        }
       },
       [isDisabled, setIsFocused, onBlur],
     );
@@ -85,10 +88,12 @@ const TextField = React.forwardRef<
           setIsFocused(true);
           onFocus?.(e);
 
-          setInputSelection({
-            start: value?.length ?? 0,
-            end: value?.length ?? 0,
-          });
+          if (Device.isAndroid()) {
+            setInputSelection({
+              start: value?.length ?? 0,
+              end: value?.length ?? 0,
+            });
+          }
         }
       },
       [isDisabled, setIsFocused, onFocus, value],
@@ -98,7 +103,9 @@ const TextField = React.forwardRef<
       event: NativeSyntheticEvent<TextInputSelectionChangeEventData>,
     ) => {
       // Update selection state when user manually changes cursor position
-      setInputSelection(event.nativeEvent.selection);
+      if (Device.isAndroid()) {
+        setInputSelection(event.nativeEvent.selection);
+      }
     };
 
     return (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Manual typing a seed phrase on iPhone makes the text cursor jump back sometimes
Only applicable to iPhone, can’t trigger it on Android

Previous pr https://github.com/MetaMask/metamask-mobile/pull/21250 fix selection issue on android onblur 
This pr exclude the fix for iOS

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:
https://consensys.slack.com/archives/C08AG8ARL3V/p1761742637575009

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/a7184eba-ea4a-4689-a3d3-29dae27fd44c


### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/63a6a41f-d897-4e8a-8b7c-906d6e6ec200




## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Limits SRP input cursor selection updates to Android and updates tests to validate platform-specific behavior.
> 
> - **SrpInput (`app/components/Views/SrpInput/index.tsx`)**:
>   - Gate cursor selection updates behind `Device.isAndroid()`:
>     - On focus: set selection to end only on Android.
>     - On blur: reset selection to `{ start: 0, end: 0 }` only on Android.
>     - On `selectionChange`: update internal selection only on Android.
> - **Tests (`app/components/Views/SrpInput/index.test.tsx`)**:
>   - Mock `Device` and add platform-specific suites for Android and iOS.
>   - Assert Android sets/updates selection; iOS leaves selection undefined.
>   - Retain and validate `onFocus`/`onBlur` callbacks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef180379b8959a22eb0528cd047d8b9da15cf4a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->