### PR TITLE
feat(perps): handle hip-3 token icon

### DIFF
--- a/app/components/UI/Perps/components/PerpsTokenLogo/PerpsTokenLogo.tsx
+++ b/app/components/UI/Perps/components/PerpsTokenLogo/PerpsTokenLogo.tsx
@@ -7,7 +7,7 @@ import Avatar, {
 import { useTheme } from '../../../../../util/theme';
 import { PerpsTokenLogoProps } from './PerpsTokenLogo.types';
 import { Image } from 'expo-image';
-import { HYPERLIQUID_ASSET_ICONS_BASE_URL } from '../../constants/hyperLiquidConfig';
+import { getAssetIconUrl } from '../../utils/marketUtils';
 import {
   ASSETS_REQUIRING_LIGHT_BG,
   ASSETS_REQUIRING_DARK_BG,
@@ -85,14 +85,7 @@ const PerpsTokenLogo: React.FC<PerpsTokenLogoProps> = ({
   // SVG URL - expo-image handles SVG rendering properly
   const imageUri = useMemo(() => {
     if (!symbol) return null;
-    let upperSymbol = symbol.toUpperCase();
-
-    // Remove 'k' prefix only for specific assets like kBONK, kPEPE
-    if (K_PREFIX_ASSETS.has(upperSymbol)) {
-      upperSymbol = upperSymbol.substring(1);
-    }
-
-    return `${HYPERLIQUID_ASSET_ICONS_BASE_URL}${upperSymbol}.svg`;
+    return getAssetIconUrl(symbol, K_PREFIX_ASSETS);
   }, [symbol]);
 
   const handleLoadStart = () => {

--- a/app/components/UI/Perps/constants/hyperLiquidConfig.ts
+++ b/app/components/UI/Perps/constants/hyperLiquidConfig.ts
@@ -58,6 +58,10 @@ export const HYPERLIQUID_ENDPOINTS: HyperLiquidEndpoints = {
 export const HYPERLIQUID_ASSET_ICONS_BASE_URL =
   'https://app.hyperliquid.xyz/coins/';
 
+// HIP-3 asset icons base URL (for assets with dex:symbol format)
+export const HIP3_ASSET_ICONS_BASE_URL =
+  'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/icons/eip155:999/';
+
 // Asset configurations for multichain abstraction
 export const HYPERLIQUID_ASSET_CONFIGS: HyperLiquidAssetConfigs = {
   USDC: {

--- a/app/components/UI/Perps/constants/hyperLiquidConfig.ts
+++ b/app/components/UI/Perps/constants/hyperLiquidConfig.ts
@@ -60,7 +60,7 @@ export const HYPERLIQUID_ASSET_ICONS_BASE_URL =
 
 // HIP-3 asset icons base URL (for assets with dex:symbol format)
 export const HIP3_ASSET_ICONS_BASE_URL =
-  'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/icons/eip155:999/';
+  'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/icons/eip155%3A999/';
 
 // Asset configurations for multichain abstraction
 export const HYPERLIQUID_ASSET_CONFIGS: HyperLiquidAssetConfigs = {

--- a/app/components/UI/Perps/hooks/usePerpsAssetsMetadata.ts
+++ b/app/components/UI/Perps/hooks/usePerpsAssetsMetadata.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { HYPERLIQUID_ASSET_ICONS_BASE_URL } from '../constants/hyperLiquidConfig';
+import { getAssetIconUrl } from '../utils/marketUtils';
 import { PERFORMANCE_CONFIG } from '../constants/perpsConfig';
 
 // Cache for validated asset URLs to prevent repeated HEAD requests
@@ -18,7 +18,7 @@ export const usePerpsAssetMetadata = (assetSymbol: string | undefined) => {
     // For now, we use the same SVG for both themes
     // In the future, we could add logic here to use different URLs based on theme
     // e.g., `${base}${symbol}_${isDarkMode ? 'dark' : 'light'}.svg`
-    return `${HYPERLIQUID_ASSET_ICONS_BASE_URL}${assetSymbol.toUpperCase()}.svg`;
+    return getAssetIconUrl(assetSymbol);
   }, [assetSymbol]);
 
   useEffect(() => {

--- a/app/components/UI/Perps/hooks/usePerpsImagePrefetch.ts
+++ b/app/components/UI/Perps/hooks/usePerpsImagePrefetch.ts
@@ -1,7 +1,7 @@
 import { Image } from 'expo-image';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
-import { HYPERLIQUID_ASSET_ICONS_BASE_URL } from '../constants/hyperLiquidConfig';
+import { getAssetIconUrl } from '../utils/marketUtils';
 
 /**
  * Hook to prefetch Perps market icons for better performance
@@ -37,10 +37,7 @@ export const usePerpsImagePrefetch = (
             .filter(
               (symbol) => symbol && typeof symbol === 'string' && symbol.trim(),
             )
-            .map(
-              (symbol) =>
-                `${HYPERLIQUID_ASSET_ICONS_BASE_URL}${symbol.toUpperCase()}.svg`,
-            );
+            .map((symbol) => getAssetIconUrl(symbol));
 
           // Prefetch with persistent disk caching
           // expo-image handles all caching internally, no need for HTTP headers

--- a/app/components/UI/Perps/utils/marketUtils.test.ts
+++ b/app/components/UI/Perps/utils/marketUtils.test.ts
@@ -1,6 +1,16 @@
-import { calculateFundingCountdown, calculate24hHighLow } from './marketUtils';
+import {
+  calculateFundingCountdown,
+  calculate24hHighLow,
+  getAssetIconUrl,
+} from './marketUtils';
 import type { CandleData } from '../types/perps-types';
 import { CandlePeriod } from '../constants/chartConfig';
+
+jest.mock('../constants/hyperLiquidConfig', () => ({
+  HYPERLIQUID_ASSET_ICONS_BASE_URL: 'https://app.hyperliquid.xyz/coins/',
+  HIP3_ASSET_ICONS_BASE_URL:
+    'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/icons/eip155:999/',
+}));
 
 describe('marketUtils', () => {
   describe('calculateFundingCountdown', () => {
@@ -324,6 +334,80 @@ describe('marketUtils', () => {
       };
       const result = calculate24hHighLow(singleCandleData);
       expect(result).toEqual({ high: 120, low: 80 });
+    });
+  });
+
+  describe('getAssetIconUrl', () => {
+    it('returns Hyperliquid URL for regular asset', () => {
+      const symbol = 'BTC';
+
+      const result = getAssetIconUrl(symbol);
+
+      expect(result).toBe('https://app.hyperliquid.xyz/coins/BTC.svg');
+    });
+
+    it('returns GitHub URL for HIP-3 asset with colon replaced by underscore', () => {
+      const symbol = 'xyz:TSLA';
+
+      const result = getAssetIconUrl(symbol);
+
+      expect(result).toBe(
+        'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/icons/eip155:999/hip3:XYZ_TSLA.svg',
+      );
+    });
+
+    it('returns GitHub URL for HIP-3 asset with different DEX prefix', () => {
+      const symbol = 'abc:XYZ100';
+
+      const result = getAssetIconUrl(symbol);
+
+      expect(result).toBe(
+        'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/icons/eip155:999/hip3:ABC_XYZ100.svg',
+      );
+    });
+
+    it('removes k prefix for specified assets', () => {
+      const symbol = 'kBONK';
+      const kPrefixAssets = new Set(['KBONK']);
+
+      const result = getAssetIconUrl(symbol, kPrefixAssets);
+
+      expect(result).toBe('https://app.hyperliquid.xyz/coins/BONK.svg');
+    });
+
+    it('does not remove k prefix for assets not in the set', () => {
+      const symbol = 'kBONK';
+      const kPrefixAssets = new Set(['KPEPE']);
+
+      const result = getAssetIconUrl(symbol, kPrefixAssets);
+
+      expect(result).toBe('https://app.hyperliquid.xyz/coins/KBONK.svg');
+    });
+
+    it('returns empty string for empty symbol', () => {
+      const symbol = '';
+
+      const result = getAssetIconUrl(symbol);
+
+      expect(result).toBe('');
+    });
+
+    it('uppercases lowercase symbols for regular assets', () => {
+      const symbol = 'btc';
+
+      const result = getAssetIconUrl(symbol);
+
+      expect(result).toBe('https://app.hyperliquid.xyz/coins/BTC.svg');
+    });
+
+    it('uppercases lowercase symbols for HIP-3 assets', () => {
+      const symbol = 'xyz:tsla';
+
+      const result = getAssetIconUrl(symbol);
+
+      expect(result).toBe(
+        'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/icons/eip155:999/hip3:XYZ_TSLA.svg',
+      );
     });
   });
 });

--- a/app/components/UI/Perps/utils/marketUtils.test.ts
+++ b/app/components/UI/Perps/utils/marketUtils.test.ts
@@ -352,7 +352,7 @@ describe('marketUtils', () => {
       const result = getAssetIconUrl(symbol);
 
       expect(result).toBe(
-        'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/icons/eip155:999/hip3:XYZ_TSLA.svg',
+        'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/icons/eip155:999/hip3%3Axyz_TSLA.svg',
       );
     });
 
@@ -362,7 +362,7 @@ describe('marketUtils', () => {
       const result = getAssetIconUrl(symbol);
 
       expect(result).toBe(
-        'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/icons/eip155:999/hip3:ABC_XYZ100.svg',
+        'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/icons/eip155:999/hip3%3Aabc_XYZ100.svg',
       );
     });
 
@@ -406,7 +406,7 @@ describe('marketUtils', () => {
       const result = getAssetIconUrl(symbol);
 
       expect(result).toBe(
-        'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/icons/eip155:999/hip3:XYZ_TSLA.svg',
+        'https://raw.githubusercontent.com/MetaMask/contract-metadata/master/icons/eip155:999/hip3%3Axyz_TSLA.svg',
       );
     });
   });

--- a/app/components/UI/Perps/utils/marketUtils.ts
+++ b/app/components/UI/Perps/utils/marketUtils.ts
@@ -202,7 +202,7 @@ export const getMarketBadgeType = (
  * getAssetIconUrl('BTC') // → 'https://app.hyperliquid.xyz/coins/BTC.svg'
  *
  * @example HIP-3 asset
- * getAssetIconUrl('xyz:TSLA') // → 'https://raw.githubusercontent.com/.../hip3:xyz_TSLA.svg'
+ * getAssetIconUrl('xyz:TSLA') // → 'https://raw.githubusercontent.com/.../hip3%3Axyz_TSLA.svg'
  *
  * @example With k-prefix handling
  * getAssetIconUrl('kBONK', new Set(['KBONK'])) // → 'https://app.hyperliquid.xyz/coins/BONK.svg'
@@ -213,14 +213,16 @@ export const getAssetIconUrl = (
 ): string => {
   if (!symbol) return '';
 
-  let processedSymbol = symbol.toUpperCase();
-
-  // Check for HIP-3 asset (contains colon)
-  if (processedSymbol.includes(':')) {
-    // Replace colon with underscore: xyz:TSLA -> xyz_TSLA
-    const hip3Symbol = processedSymbol.replace(':', '_');
-    return `${HIP3_ASSET_ICONS_BASE_URL}hip3:${hip3Symbol}.svg`;
+  // Check for HIP-3 asset (contains colon) BEFORE uppercasing
+  if (symbol.includes(':')) {
+    const [dex, assetSymbol] = symbol.split(':');
+    // Keep DEX lowercase, uppercase asset: xyz:XYZ100 -> xyz_XYZ100
+    const hip3Symbol = `${dex.toLowerCase()}_${assetSymbol.toUpperCase()}`;
+    return `${HIP3_ASSET_ICONS_BASE_URL}hip3%3A${hip3Symbol}.svg`;
   }
+
+  // For regular assets, uppercase the entire symbol
+  let processedSymbol = symbol.toUpperCase();
 
   // Remove 'k' prefix only for specific assets if provided
   if (kPrefixAssets?.has(processedSymbol)) {

--- a/app/components/UI/Perps/utils/marketUtils.ts
+++ b/app/components/UI/Perps/utils/marketUtils.ts
@@ -1,6 +1,10 @@
 import type { CandleData, CandleStick } from '../types/perps-types';
 import type { PerpsMarketData } from '../controllers/types';
 import type { BadgeType } from '../components/PerpsBadge/PerpsBadge.types';
+import {
+  HYPERLIQUID_ASSET_ICONS_BASE_URL,
+  HIP3_ASSET_ICONS_BASE_URL,
+} from '../constants/hyperLiquidConfig';
 
 /**
  * Extract the display symbol from a full symbol string
@@ -185,3 +189,44 @@ export const getMarketBadgeType = (
   // Fall back to 'experimental' for unmapped HIP-3 DEXs
   // Main DEX markets without marketType show no badge
   market.marketType || (market.marketSource ? 'experimental' : undefined);
+
+/**
+ * Generate the appropriate icon URL for an asset symbol
+ * Handles both regular assets and HIP-3 assets (dex:symbol format)
+ *
+ * @param symbol - Asset symbol (e.g., "BTC" or "xyz:TSLA")
+ * @param kPrefixAssets - Optional set of assets that have a 'k' prefix to remove
+ * @returns Icon URL for the asset
+ *
+ * @example Regular asset
+ * getAssetIconUrl('BTC') // → 'https://app.hyperliquid.xyz/coins/BTC.svg'
+ *
+ * @example HIP-3 asset
+ * getAssetIconUrl('xyz:TSLA') // → 'https://raw.githubusercontent.com/.../hip3:xyz_TSLA.svg'
+ *
+ * @example With k-prefix handling
+ * getAssetIconUrl('kBONK', new Set(['KBONK'])) // → 'https://app.hyperliquid.xyz/coins/BONK.svg'
+ */
+export const getAssetIconUrl = (
+  symbol: string,
+  kPrefixAssets?: Set<string>,
+): string => {
+  if (!symbol) return '';
+
+  let processedSymbol = symbol.toUpperCase();
+
+  // Check for HIP-3 asset (contains colon)
+  if (processedSymbol.includes(':')) {
+    // Replace colon with underscore: xyz:TSLA -> xyz_TSLA
+    const hip3Symbol = processedSymbol.replace(':', '_');
+    return `${HIP3_ASSET_ICONS_BASE_URL}hip3:${hip3Symbol}.svg`;
+  }
+
+  // Remove 'k' prefix only for specific assets if provided
+  if (kPrefixAssets?.has(processedSymbol)) {
+    processedSymbol = processedSymbol.substring(1);
+  }
+
+  // Regular asset
+  return `${HYPERLIQUID_ASSET_ICONS_BASE_URL}${processedSymbol}.svg`;
+};


### PR DESCRIPTION
## **Description**

Adds support for HIP-3 asset icons (e.g., `xyz:TSLA`, `abc:XYZ100`) using GitHub-based URLs while maintaining backward compatibility with regular Hyperliquid assets (e.g., `BTC`, `ETH`).

**What changed:**
- Added `HIP3_ASSET_ICONS_BASE_URL` constant for GitHub contract metadata repository
- Created centralized `getAssetIconUrl()` utility function that:
  - Detects HIP-3 assets by colon presence in symbol
  - Transforms colon to underscore (`xyz:TSLA` -> `hip3:XYZ_TSLA.svg`)
  - Routes to appropriate base URL based on asset type
- Updated 3 components to use the new utility (net -14 lines of code)

**URL format:**
- Regular: `BTC` -> `https://app.hyperliquid.xyz/coins/BTC.svg`
- HIP-3: `xyz:TSLA` -> `https://raw.githubusercontent.com/MetaMask/contract-metadata/master/icons/eip155:999/hip3:xyz_TSLA.svg`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1952

## **Manual testing steps**

```gherkin
Feature: HIP-3 Asset Icon Display

  Scenario: user views HIP-3 asset in Perps markets
    Given the Perps markets list contains HIP-3 assets (xyz:TSLA)

    When user scrolls through the markets
    Then HIP-3 asset icons load from GitHub URL
    And regular asset icons load from Hyperliquid URL
    And all icons display correctly

  Scenario: user views mixed asset types
    Given markets list contains BTC and xyz:TSLA

    When user views the markets
    Then both icon types load and render correctly
```

## **Screenshots/Recordings**

### **Before**
HIP-3 assets failed to load icons (incorrect URL format)

### **After**
HIP-3 assets load correctly from GitHub with proper URL transformation
<img width="536" height="936" alt="image" src="https://github.com/user-attachments/assets/067bdc24-3576-46c4-8772-42190db765ec" />

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR
- [ ] I confirm that this PR addresses all acceptance criteria

---

## **Files Changed**

1. `app/components/UI/Perps/constants/hyperLiquidConfig.ts` (+3)
   - Added HIP3_ASSET_ICONS_BASE_URL constant

2. `app/components/UI/Perps/utils/marketUtils.ts` (+38)
   - Added getAssetIconUrl() utility with JSDoc

3. `app/components/UI/Perps/components/PerpsTokenLogo/PerpsTokenLogo.tsx` (-9)
   - Replaced URL construction with utility call

4. `app/components/UI/Perps/hooks/usePerpsAssetsMetadata.ts` (-2)
   - Replaced URL construction with utility call

5. `app/components/UI/Perps/hooks/usePerpsImagePrefetch.ts` (-3)
   - Replaced URL construction with utility call

6. `app/components/UI/Perps/utils/marketUtils.test.ts` (+83)
   - Added unit test coverage


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a utility to generate asset icon URLs (including HIP-3 dex:symbol) and refactors components/hooks to use it, with new tests and constants.
> 
> - **Utils**:
>   - Add `getAssetIconUrl` to generate icon URLs for regular and HIP-3 assets (handles `dex:symbol`, colon→underscore, k-prefix trimming).
> - **Constants**:
>   - Introduce `HIP3_ASSET_ICONS_BASE_URL` alongside existing `HYPERLIQUID_ASSET_ICONS_BASE_URL`.
> - **Components/Hooks**:
>   - Refactor `PerpsTokenLogo`, `usePerpsAssetsMetadata`, and `usePerpsImagePrefetch` to use `getAssetIconUrl`.
> - **Tests**:
>   - Add unit tests for `getAssetIconUrl` with mocked base URLs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f35385618a6035ea9a3b4ad41de4b26f7090b5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->