### PR TITLE
chore: Remove unused option

### DIFF
--- a/scripts/generate-fingerprint.js
+++ b/scripts/generate-fingerprint.js
@@ -2,7 +2,7 @@ const { createFingerprintAsync } = require('@expo/fingerprint');
 
 async function generateFingerprint() {
   try {
-    const { hash } = await createFingerprintAsync(process.cwd(), { mode: 'prebuild' });
+    const { hash } = await createFingerprintAsync(process.cwd());
     // Only output the hash to stdout, with no extra output, to ensure that scripts or tools consuming this output receive only the hash value and are not affected by additional text.
     process.stdout.write(hash);
   } catch (error) {


### PR DESCRIPTION
## **Description**

The `mode` option we're passing into `createFingerprintAsync` does not exist. It has been removed to reduce confusion.


## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the unsupported mode option from the fingerprint generation script.
> 
> - **Scripts**:
>   - Update `scripts/generate-fingerprint.js` to call `createFingerprintAsync(process.cwd())` without the unsupported `mode: 'prebuild'` option.
>   - Preserves existing stdout/stderr behavior for hash output and errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99224eea3634f2565a98083e1146458357f8bba9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->