### PR TITLE
fix: fix SnapKeyring events forwarding

### DIFF
--- a/app/core/Engine/messengers/snap-keyring-builder-messenger.ts
+++ b/app/core/Engine/messengers/snap-keyring-builder-messenger.ts
@@ -18,12 +18,12 @@ export function getSnapKeyringBuilderMessenger(
   rootMessenger: RootMessenger,
 ): SnapKeyringBuilderMessenger {
   const messenger = new Messenger<
-    'SnapKeyringBuilder',
+    'SnapKeyring',
     MessengerActions<SnapKeyringBuilderMessenger>,
     MessengerEvents<SnapKeyringBuilderMessenger>,
     RootMessenger
   >({
-    namespace: 'SnapKeyringBuilder',
+    namespace: 'SnapKeyring',
     parent: rootMessenger,
   });
   rootMessenger.delegate({
@@ -71,12 +71,12 @@ export function getSnapKeyringBuilderInitMessenger(
   rootMessenger: RootMessenger,
 ) {
   const messenger = new Messenger<
-    'SnapKeyringBuilderInit',
+    'SnapKeyringInit',
     AllowedInitializationActions,
     never,
     RootMessenger
   >({
-    namespace: 'SnapKeyringBuilderInit',
+    namespace: 'SnapKeyringInit',
     parent: rootMessenger,
   });
   rootMessenger.delegate({


### PR DESCRIPTION
## **Description**

The namespace used by the `SnapKeyring` builder was wrong and was preventing the actual `SnapKeyring` instance from using its own events (which are consumed by the `AccountsController`).

Maybe there's a cleaner way to delegate those events with the new messaging system, but for now I went with the same logic that we have on the extension and that solves the issue.

> [!CAUTION]
> Without those events, most of the Snap account data are missing (balances, transactions history, assets data).

This should fix non-EVM Snap integration!

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

```gherkin
Feature: loads non-EVM account info

  Scenario: user has some Solana accounts
    Given some of those accounts have funds

    When user select any multichain accounts (with Solana funds)
    Then he should see the right token balances
```

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Align Snap keyring messenger namespaces to `SnapKeyring`/`SnapKeyringInit` for correct event/action routing.
> 
> - **Engine/messengers**:
>   - Update `getSnapKeyringBuilderMessenger` to use `SnapKeyring` namespace (type and `namespace` option) for proper event/action scoping.
>   - Update `getSnapKeyringBuilderInitMessenger` to use `SnapKeyringInit` namespace (type and `namespace` option).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1d74993c2593b34343b556878099c0f2de4aa30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->