### PR TITLE
fix: predict transaction type metrics

### DIFF
--- a/app/core/Engine/controllers/transaction-controller/utils.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/utils.test.ts
@@ -147,6 +147,25 @@ describe('getTransactionTypeValue', () => {
       'unknown',
     );
   });
+
+  it.each([
+    ['predict_claim', TransactionType.predictClaim],
+    ['predict_deposit', TransactionType.predictDeposit],
+    ['predict_withdraw', TransactionType.predictWithdraw],
+  ])('returns %s if nested transaction type is %s', (expected, nestedType) => {
+    const mockTransactionMeta = {
+      type: TransactionType.simpleSend,
+      nestedTransactions: [
+        {
+          type: nestedType,
+        },
+      ],
+    } as TransactionMeta;
+
+    expect(
+      getTransactionTypeValue(mockTransactionMeta.type, mockTransactionMeta),
+    ).toBe(expected);
+  });
 });
 
 describe('generateRPCProperties', () => {

--- a/app/core/Engine/controllers/transaction-controller/utils.ts
+++ b/app/core/Engine/controllers/transaction-controller/utils.ts
@@ -29,6 +29,7 @@ import {
   getAddressAccountType,
   isValidHexAddress,
 } from '../../../../util/address';
+import { hasTransactionType } from '../../../../components/Views/confirmations/utils/transaction';
 
 const BATCHED_MESSAGE_TYPE = {
   WALLET_SEND_CALLS: 'wallet_sendCalls',
@@ -37,7 +38,20 @@ const BATCHED_MESSAGE_TYPE = {
 
 export function getTransactionTypeValue(
   transactionType: TransactionType | undefined,
+  transactionMeta?: TransactionMeta,
 ) {
+  if (hasTransactionType(transactionMeta, [TransactionType.predictDeposit])) {
+    return 'predict_deposit';
+  }
+
+  if (hasTransactionType(transactionMeta, [TransactionType.predictWithdraw])) {
+    return 'predict_withdraw';
+  }
+
+  if (hasTransactionType(transactionMeta, [TransactionType.predictClaim])) {
+    return 'predict_claim';
+  }
+
   switch (transactionType) {
     case TransactionType.bridgeApproval:
       return 'bridge_approval';
@@ -49,12 +63,6 @@ export function getTransactionTypeValue(
       return 'eth_get_encryption_public_key';
     case TransactionType.perpsDeposit:
       return 'perps_deposit';
-    case TransactionType.predictDeposit:
-      return 'predict_deposit';
-    case TransactionType.predictClaim:
-      return 'predict_claim';
-    case TransactionType.predictWithdraw:
-      return 'predict_withdraw';
     case TransactionType.signTypedData:
       return 'eth_sign_typed_data';
     case TransactionType.simpleSend:
@@ -210,7 +218,7 @@ export async function generateDefaultTransactionMetrics(
           await getTransactionContractMethod(transactionMeta),
         transaction_envelope_type: transactionMeta.txParams.type,
         transaction_internal_id: id,
-        transaction_type: getTransactionTypeValue(type),
+        transaction_type: getTransactionTypeValue(type, transactionMeta),
       },
     },
     getConfirmationMetricProperties(


### PR DESCRIPTION
## **Description**

Derive the transaction type metric from the nested calls in the Predict transactions.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Derives `transaction_type` for Predict flows from `nestedTransactions` and updates metrics/tests accordingly.
> 
> - **Engine/Transaction Metrics**:
>   - Enhance `getTransactionTypeValue` to accept `transactionMeta` and resolve `predict_deposit`, `predict_withdraw`, `predict_claim` via `hasTransactionType` on `nestedTransactions`.
>   - Remove direct switch cases for Predict types; keep other mappings unchanged.
>   - Update `generateDefaultTransactionMetrics` to pass `transactionMeta` into `getTransactionTypeValue`.
>   - Import `hasTransactionType` utility.
> - **Tests**:
>   - Add parameterized tests to assert Predict types are derived from nested transaction data.
>   - Keep existing RPC/gas/batch metrics tests intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9f16dd1c205ff55132d4ba48f901b82c5871f35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->