### PR TITLE
ci: Prevent Gradle cache size from expanding

### DIFF
--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -61,45 +61,6 @@ jobs:
           configure-keystores: true
           target: ${{ inputs.keystore_target }} # qa for taget=main and flask for target=flask
 
-      - name: Check Gradle cache directories
-        run: |
-          if [ -d '/home/admin' ]; then
-            if [ -d '/home/admin/_work/.gradle' ]; then
-              echo "check 1"
-              ls -Al /home/admin/_work/.gradle
-            fi
-
-            if [ -d '/home/admin/.gradle' ]; then
-              echo "check 2"
-              ls -Al /home/admin/.gradle
-            fi
-          fi
-          if [ -d '/home/runner' ]; then
-            if [ -d '/home/runner/_work/.gradle' ]; then
-              echo "check 3"
-              ls -Al /home/runner/_work/.gradle
-            fi
-
-            if [ -d '/home/runner/.gradle' ]; then
-              echo "check 4"
-              ls -Al /home/runner/.gradle
-            fi
-          fi
-
-          echo "HOME: ${HOME}"
-
-          if [ -d "${HOME}" ]; then
-            if [ -d "${HOME}/_work/.gradle" ]; then
-              echo "check 5"
-              ls -Al "${HOME}/_work/.gradle"
-            fi
-
-            if [ -d "${HOME}/.gradle" ]; then
-              echo "check 6"
-              ls -Al "${HOME}/.gradle"
-            fi
-          fi
-
       - name: Cache Gradle dependencies
         uses: cirruslabs/cache@v4
         id: gradle-cache-restore
@@ -107,9 +68,8 @@ jobs:
           GRADLE_CACHE_VERSION: 1
         with:
           path: |
-            /home/admin/_work/.gradle/caches
-            /home/admin/_work/.gradle/wrapper
-            android/.gradle
+            ~/_work/.gradle/caches
+            ~/_work/.gradle/wrapper
           key: gradle-${{ env.GRADLE_CACHE_VERSION }}-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
 
       - name: Setup project dependencies with retry
@@ -215,46 +175,6 @@ jobs:
           GOOGLE_SERVICES_B64_IOS: ${{ secrets.GOOGLE_SERVICES_B64_IOS }}
           GOOGLE_SERVICES_B64_ANDROID: ${{ secrets.GOOGLE_SERVICES_B64_ANDROID }}
           MM_INFURA_PROJECT_ID: ${{ secrets.MM_INFURA_PROJECT_ID }}
-
-      - name: Check Gradle cache directories again after setup+build
-        run: |
-
-          if [ -d '/home/admin' ]; then
-            if [ -d '/home/admin/_work/.gradle' ]; then
-              echo "check 1"
-              ls -Al /home/admin/_work/.gradle
-            fi
-
-            if [ -d '/home/admin/.gradle' ]; then
-              echo "check 2"
-              ls -Al /home/admin/.gradle
-            fi
-          fi
-          if [ -d '/home/runner' ]; then
-            if [ -d '/home/runner/_work/.gradle' ]; then
-              echo "check 3"
-              ls -Al /home/runner/_work/.gradle
-            fi
-
-            if [ -d '/home/runner/.gradle' ]; then
-              echo "check 4"
-              ls -Al /home/runner/.gradle
-            fi
-          fi
-
-          echo "HOME: ${HOME}"
-
-          if [ -d "${HOME}" ]; then
-            if [ -d "${HOME}/_work/.gradle" ]; then
-              echo "check 5"
-              ls -Al "${HOME}/_work/.gradle"
-            fi
-
-            if [ -d "${HOME}/.gradle" ]; then
-              echo "check 6"
-              ls -Al "${HOME}/.gradle"
-            fi
-          fi
 
       - name: Repack APK with JS updates using @expo/repack-app
         if: ${{ steps.apk-cache-restore.outputs.cache-hit == 'true' && steps.gradle-cache-restore.outputs.cache-hit == 'true' }}

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -63,8 +63,11 @@ jobs:
 
       - name: Check Gradle cache directories
         run: |
+          echo "check 1"
           ls -Al /home/admin/_work/.gradle/caches
+          echo "check 2"
           ls -Al /home/runner/_work/.gradle/caches
+          echo "check 2"
           ls -Al /home/admin/.gradle/caches
 
       - name: Cache Gradle dependencies
@@ -90,8 +93,11 @@ jobs:
 
       - name: Check Gradle cache directories again after setup
         run: |
+          echo "check 1"
           ls -Al /home/admin/_work/.gradle/caches
+          echo "check 2"
           ls -Al /home/runner/_work/.gradle/caches
+          echo "check 2"
           ls -Al /home/admin/.gradle/caches
 
       # Generate fingerprint AFTER setup but BEFORE any build modifications (the fingerprint now is fake we do not want the cached apk)

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -67,8 +67,8 @@ jobs:
           GRADLE_CACHE_VERSION: 1
         with:
           path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
+            /home/admin/_work/.gradle/caches
+            /home/admin/_work/.gradle/wrapper
             android/.gradle
           key: gradle-${{ env.GRADLE_CACHE_VERSION }}-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
 

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -126,7 +126,7 @@ jobs:
             android-apk-
 
       - name: Build Android E2E APKs
-        # if: ${{ steps.apk-cache-restore.outputs.cache-hit != 'true' || steps.gradle-cache-restore.outputs.cache-hit != 'true' }}
+        if: ${{ steps.apk-cache-restore.outputs.cache-hit != 'true' || steps.gradle-cache-restore.outputs.cache-hit != 'true' }}
         run: |
           echo "🏗 Building Android E2E APKs..."
           export NODE_OPTIONS="--max-old-space-size=8192"
@@ -176,59 +176,59 @@ jobs:
           GOOGLE_SERVICES_B64_ANDROID: ${{ secrets.GOOGLE_SERVICES_B64_ANDROID }}
           MM_INFURA_PROJECT_ID: ${{ secrets.MM_INFURA_PROJECT_ID }}
 
-      # - name: Repack APK with JS updates using @expo/repack-app
-        # if: ${{ steps.apk-cache-restore.outputs.cache-hit == 'true' && steps.gradle-cache-restore.outputs.cache-hit == 'true' }}
-        # run: |
-        #   echo "📦 Repacking APK with updated JavaScript bundle using @expo/repack-app..."
-        #   # Use the optimized repack script which uses @expo/repack-app
-        #   yarn build:repack:android
-        #   echo "📦 Final APK size: $(du -h "${{ steps.determine-target-paths.outputs.apk-target-path }}/${{ steps.determine-target-paths.outputs.artifact_name }}.apk" | cut -f1)"
-        # env:
-        #   PLATFORM: android
-        #   METAMASK_ENVIRONMENT: ${{ inputs.metamask_environment }}
-        #   METAMASK_BUILD_TYPE: ${{ inputs.build_type }}
-        #   IS_TEST: true
-        #   E2E: 'true'
-        #   IGNORE_BOXLOGS_DEVELOPMENT: true
-        #   GITHUB_CI: 'true'
-        #   CI: 'true'
-        #   NODE_OPTIONS: '--max-old-space-size=8192'
-        #   BRIDGE_USE_DEV_APIS: 'true'
-        #   RAMP_INTERNAL_BUILD: 'true'
-        #   SEEDLESS_ONBOARDING_ENABLED: 'true'
-        #   MM_NOTIFICATIONS_UI_ENABLED: 'true'
-        #   MM_SECURITY_ALERTS_API_ENABLED: 'true'
-        #   MM_REMOVE_GLOBAL_NETWORK_SELECTOR: 'true'
-        #   BLOCKAID_FILE_CDN: 'static.cx.metamask.io/api/v1/confirmations/ppom'
-        #   FEATURES_ANNOUNCEMENTS_ACCESS_TOKEN: ${{ secrets.FEATURES_ANNOUNCEMENTS_ACCESS_TOKEN }}
-        #   FEATURES_ANNOUNCEMENTS_SPACE_ID: ${{ secrets.FEATURES_ANNOUNCEMENTS_SPACE_ID }}
-        #   SEGMENT_WRITE_KEY_QA: ${{ secrets.SEGMENT_WRITE_KEY_QA }}
-        #   SEGMENT_WRITE_KEY_FLASK: ${{ secrets.SEGMENT_WRITE_KEY_FLASK }}
-        #   SEGMENT_PROXY_URL_QA: ${{ secrets.SEGMENT_PROXY_URL_QA }}
-        #   SEGMENT_PROXY_URL_FLASK: ${{ secrets.SEGMENT_PROXY_URL_FLASK }}
-        #   SEGMENT_DELETE_API_SOURCE_ID_QA: ${{ secrets.SEGMENT_DELETE_API_SOURCE_ID_QA }}
-        #   SEGMENT_DELETE_API_SOURCE_ID_FLASK: ${{ secrets.SEGMENT_DELETE_API_SOURCE_ID_FLASK }}
-        #   SEGMENT_REGULATIONS_ENDPOINT_QA: ${{ secrets.SEGMENT_REGULATIONS_ENDPOINT_QA }}
-        #   SEGMENT_REGULATIONS_ENDPOINT_FLASK: ${{ secrets.SEGMENT_REGULATIONS_ENDPOINT_FLASK }}
-        #   MM_SENTRY_DSN_TEST: ${{ secrets.MM_SENTRY_DSN_TEST }}
-        #   MM_SENTRY_AUTH_TOKEN: ${{ secrets.MM_SENTRY_AUTH_TOKEN }}
-        #   MAIN_IOS_GOOGLE_CLIENT_ID_UAT: ${{ secrets.MAIN_IOS_GOOGLE_CLIENT_ID_UAT }}
-        #   FLASK_IOS_GOOGLE_CLIENT_ID_PROD: ${{ secrets.FLASK_IOS_GOOGLE_CLIENT_ID_PROD }}
-        #   MAIN_IOS_GOOGLE_REDIRECT_URI_UAT: ${{ secrets.MAIN_IOS_GOOGLE_REDIRECT_URI_UAT }}
-        #   FLASK_IOS_GOOGLE_REDIRECT_URI_PROD: ${{ secrets.FLASK_IOS_GOOGLE_REDIRECT_URI_PROD }}
-        #   MAIN_ANDROID_APPLE_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_APPLE_CLIENT_ID_UAT }}
-        #   FLASK_ANDROID_APPLE_CLIENT_ID_PROD: ${{ secrets.FLASK_ANDROID_APPLE_CLIENT_ID_PROD }}
-        #   MAIN_ANDROID_GOOGLE_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_GOOGLE_CLIENT_ID_UAT }}
-        #   FLASK_ANDROID_GOOGLE_CLIENT_ID_PROD: ${{ secrets.FLASK_ANDROID_GOOGLE_CLIENT_ID_PROD }}
-        #   MAIN_ANDROID_GOOGLE_SERVER_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_GOOGLE_SERVER_CLIENT_ID_UAT }}
-        #   FLASK_ANDROID_GOOGLE_SERVER_CLIENT_ID_PROD: ${{ secrets.FLASK_ANDROID_GOOGLE_SERVER_CLIENT_ID_PROD }}
-        #   GOOGLE_SERVICES_B64_IOS: ${{ secrets.GOOGLE_SERVICES_B64_IOS }}
-        #   GOOGLE_SERVICES_B64_ANDROID: ${{ secrets.GOOGLE_SERVICES_B64_ANDROID }}
-        #   MM_INFURA_PROJECT_ID: ${{ secrets.MM_INFURA_PROJECT_ID }}
+      - name: Repack APK with JS updates using @expo/repack-app
+        if: ${{ steps.apk-cache-restore.outputs.cache-hit == 'true' && steps.gradle-cache-restore.outputs.cache-hit == 'true' }}
+        run: |
+          echo "📦 Repacking APK with updated JavaScript bundle using @expo/repack-app..."
+          # Use the optimized repack script which uses @expo/repack-app
+          yarn build:repack:android
+          echo "📦 Final APK size: $(du -h "${{ steps.determine-target-paths.outputs.apk-target-path }}/${{ steps.determine-target-paths.outputs.artifact_name }}.apk" | cut -f1)"
+        env:
+          PLATFORM: android
+          METAMASK_ENVIRONMENT: ${{ inputs.metamask_environment }}
+          METAMASK_BUILD_TYPE: ${{ inputs.build_type }}
+          IS_TEST: true
+          E2E: 'true'
+          IGNORE_BOXLOGS_DEVELOPMENT: true
+          GITHUB_CI: 'true'
+          CI: 'true'
+          NODE_OPTIONS: '--max-old-space-size=8192'
+          BRIDGE_USE_DEV_APIS: 'true'
+          RAMP_INTERNAL_BUILD: 'true'
+          SEEDLESS_ONBOARDING_ENABLED: 'true'
+          MM_NOTIFICATIONS_UI_ENABLED: 'true'
+          MM_SECURITY_ALERTS_API_ENABLED: 'true'
+          MM_REMOVE_GLOBAL_NETWORK_SELECTOR: 'true'
+          BLOCKAID_FILE_CDN: 'static.cx.metamask.io/api/v1/confirmations/ppom'
+          FEATURES_ANNOUNCEMENTS_ACCESS_TOKEN: ${{ secrets.FEATURES_ANNOUNCEMENTS_ACCESS_TOKEN }}
+          FEATURES_ANNOUNCEMENTS_SPACE_ID: ${{ secrets.FEATURES_ANNOUNCEMENTS_SPACE_ID }}
+          SEGMENT_WRITE_KEY_QA: ${{ secrets.SEGMENT_WRITE_KEY_QA }}
+          SEGMENT_WRITE_KEY_FLASK: ${{ secrets.SEGMENT_WRITE_KEY_FLASK }}
+          SEGMENT_PROXY_URL_QA: ${{ secrets.SEGMENT_PROXY_URL_QA }}
+          SEGMENT_PROXY_URL_FLASK: ${{ secrets.SEGMENT_PROXY_URL_FLASK }}
+          SEGMENT_DELETE_API_SOURCE_ID_QA: ${{ secrets.SEGMENT_DELETE_API_SOURCE_ID_QA }}
+          SEGMENT_DELETE_API_SOURCE_ID_FLASK: ${{ secrets.SEGMENT_DELETE_API_SOURCE_ID_FLASK }}
+          SEGMENT_REGULATIONS_ENDPOINT_QA: ${{ secrets.SEGMENT_REGULATIONS_ENDPOINT_QA }}
+          SEGMENT_REGULATIONS_ENDPOINT_FLASK: ${{ secrets.SEGMENT_REGULATIONS_ENDPOINT_FLASK }}
+          MM_SENTRY_DSN_TEST: ${{ secrets.MM_SENTRY_DSN_TEST }}
+          MM_SENTRY_AUTH_TOKEN: ${{ secrets.MM_SENTRY_AUTH_TOKEN }}
+          MAIN_IOS_GOOGLE_CLIENT_ID_UAT: ${{ secrets.MAIN_IOS_GOOGLE_CLIENT_ID_UAT }}
+          FLASK_IOS_GOOGLE_CLIENT_ID_PROD: ${{ secrets.FLASK_IOS_GOOGLE_CLIENT_ID_PROD }}
+          MAIN_IOS_GOOGLE_REDIRECT_URI_UAT: ${{ secrets.MAIN_IOS_GOOGLE_REDIRECT_URI_UAT }}
+          FLASK_IOS_GOOGLE_REDIRECT_URI_PROD: ${{ secrets.FLASK_IOS_GOOGLE_REDIRECT_URI_PROD }}
+          MAIN_ANDROID_APPLE_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_APPLE_CLIENT_ID_UAT }}
+          FLASK_ANDROID_APPLE_CLIENT_ID_PROD: ${{ secrets.FLASK_ANDROID_APPLE_CLIENT_ID_PROD }}
+          MAIN_ANDROID_GOOGLE_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_GOOGLE_CLIENT_ID_UAT }}
+          FLASK_ANDROID_GOOGLE_CLIENT_ID_PROD: ${{ secrets.FLASK_ANDROID_GOOGLE_CLIENT_ID_PROD }}
+          MAIN_ANDROID_GOOGLE_SERVER_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_GOOGLE_SERVER_CLIENT_ID_UAT }}
+          FLASK_ANDROID_GOOGLE_SERVER_CLIENT_ID_PROD: ${{ secrets.FLASK_ANDROID_GOOGLE_SERVER_CLIENT_ID_PROD }}
+          GOOGLE_SERVICES_B64_IOS: ${{ secrets.GOOGLE_SERVICES_B64_IOS }}
+          GOOGLE_SERVICES_B64_ANDROID: ${{ secrets.GOOGLE_SERVICES_B64_ANDROID }}
+          MM_INFURA_PROJECT_ID: ${{ secrets.MM_INFURA_PROJECT_ID }}
 
       # Cache build artifacts with the pre-build fingerprint
       - name: Cache build artifacts
-        # if: ${{ steps.apk-cache-restore.outputs.cache-hit != 'true' || steps.gradle-cache-restore.outputs.cache-hit != 'true' }}
+        if: ${{ steps.apk-cache-restore.outputs.cache-hit != 'true' || steps.gradle-cache-restore.outputs.cache-hit != 'true' }}
         uses: cirruslabs/cache@v4
         with:
           path: |

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -61,6 +61,12 @@ jobs:
           configure-keystores: true
           target: ${{ inputs.keystore_target }} # qa for taget=main and flask for target=flask
 
+      - name: Check Gradle cache directories
+        run: |
+          ls -Al /home/admin/_work/.gradle/caches
+          ls -Al /home/runner/_work/.gradle/caches
+          ls -Al /home/admin/.gradle/caches
+
       - name: Cache Gradle dependencies
         uses: cirruslabs/cache@v4
         env:
@@ -81,6 +87,12 @@ jobs:
           command: |
             echo "🚀 Setting up project..."
             yarn setup:github-ci --no-build-ios
+
+      - name: Check Gradle cache directories again after setup
+        run: |
+          ls -Al /home/admin/_work/.gradle/caches
+          ls -Al /home/runner/_work/.gradle/caches
+          ls -Al /home/admin/.gradle/caches
 
       # Generate fingerprint AFTER setup but BEFORE any build modifications (the fingerprint now is fake we do not want the cached apk)
       - name: Generate current fingerprint

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -126,7 +126,7 @@ jobs:
             android-apk-
 
       - name: Build Android E2E APKs
-        if: ${{ steps.apk-cache-restore.outputs.cache-hit != 'true' || steps.gradle-cache-restore.outputs.cache-hit != 'true' }}
+        # if: ${{ steps.apk-cache-restore.outputs.cache-hit != 'true' || steps.gradle-cache-restore.outputs.cache-hit != 'true' }}
         run: |
           echo "🏗 Building Android E2E APKs..."
           export NODE_OPTIONS="--max-old-space-size=8192"
@@ -176,59 +176,59 @@ jobs:
           GOOGLE_SERVICES_B64_ANDROID: ${{ secrets.GOOGLE_SERVICES_B64_ANDROID }}
           MM_INFURA_PROJECT_ID: ${{ secrets.MM_INFURA_PROJECT_ID }}
 
-      - name: Repack APK with JS updates using @expo/repack-app
-        if: ${{ steps.apk-cache-restore.outputs.cache-hit == 'true' && steps.gradle-cache-restore.outputs.cache-hit == 'true' }}
-        run: |
-          echo "📦 Repacking APK with updated JavaScript bundle using @expo/repack-app..."
-          # Use the optimized repack script which uses @expo/repack-app
-          yarn build:repack:android
-          echo "📦 Final APK size: $(du -h "${{ steps.determine-target-paths.outputs.apk-target-path }}/${{ steps.determine-target-paths.outputs.artifact_name }}.apk" | cut -f1)"
-        env:
-          PLATFORM: android
-          METAMASK_ENVIRONMENT: ${{ inputs.metamask_environment }}
-          METAMASK_BUILD_TYPE: ${{ inputs.build_type }}
-          IS_TEST: true
-          E2E: 'true'
-          IGNORE_BOXLOGS_DEVELOPMENT: true
-          GITHUB_CI: 'true'
-          CI: 'true'
-          NODE_OPTIONS: '--max-old-space-size=8192'
-          BRIDGE_USE_DEV_APIS: 'true'
-          RAMP_INTERNAL_BUILD: 'true'
-          SEEDLESS_ONBOARDING_ENABLED: 'true'
-          MM_NOTIFICATIONS_UI_ENABLED: 'true'
-          MM_SECURITY_ALERTS_API_ENABLED: 'true'
-          MM_REMOVE_GLOBAL_NETWORK_SELECTOR: 'true'
-          BLOCKAID_FILE_CDN: 'static.cx.metamask.io/api/v1/confirmations/ppom'
-          FEATURES_ANNOUNCEMENTS_ACCESS_TOKEN: ${{ secrets.FEATURES_ANNOUNCEMENTS_ACCESS_TOKEN }}
-          FEATURES_ANNOUNCEMENTS_SPACE_ID: ${{ secrets.FEATURES_ANNOUNCEMENTS_SPACE_ID }}
-          SEGMENT_WRITE_KEY_QA: ${{ secrets.SEGMENT_WRITE_KEY_QA }}
-          SEGMENT_WRITE_KEY_FLASK: ${{ secrets.SEGMENT_WRITE_KEY_FLASK }}
-          SEGMENT_PROXY_URL_QA: ${{ secrets.SEGMENT_PROXY_URL_QA }}
-          SEGMENT_PROXY_URL_FLASK: ${{ secrets.SEGMENT_PROXY_URL_FLASK }}
-          SEGMENT_DELETE_API_SOURCE_ID_QA: ${{ secrets.SEGMENT_DELETE_API_SOURCE_ID_QA }}
-          SEGMENT_DELETE_API_SOURCE_ID_FLASK: ${{ secrets.SEGMENT_DELETE_API_SOURCE_ID_FLASK }}
-          SEGMENT_REGULATIONS_ENDPOINT_QA: ${{ secrets.SEGMENT_REGULATIONS_ENDPOINT_QA }}
-          SEGMENT_REGULATIONS_ENDPOINT_FLASK: ${{ secrets.SEGMENT_REGULATIONS_ENDPOINT_FLASK }}
-          MM_SENTRY_DSN_TEST: ${{ secrets.MM_SENTRY_DSN_TEST }}
-          MM_SENTRY_AUTH_TOKEN: ${{ secrets.MM_SENTRY_AUTH_TOKEN }}
-          MAIN_IOS_GOOGLE_CLIENT_ID_UAT: ${{ secrets.MAIN_IOS_GOOGLE_CLIENT_ID_UAT }}
-          FLASK_IOS_GOOGLE_CLIENT_ID_PROD: ${{ secrets.FLASK_IOS_GOOGLE_CLIENT_ID_PROD }}
-          MAIN_IOS_GOOGLE_REDIRECT_URI_UAT: ${{ secrets.MAIN_IOS_GOOGLE_REDIRECT_URI_UAT }}
-          FLASK_IOS_GOOGLE_REDIRECT_URI_PROD: ${{ secrets.FLASK_IOS_GOOGLE_REDIRECT_URI_PROD }}
-          MAIN_ANDROID_APPLE_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_APPLE_CLIENT_ID_UAT }}
-          FLASK_ANDROID_APPLE_CLIENT_ID_PROD: ${{ secrets.FLASK_ANDROID_APPLE_CLIENT_ID_PROD }}
-          MAIN_ANDROID_GOOGLE_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_GOOGLE_CLIENT_ID_UAT }}
-          FLASK_ANDROID_GOOGLE_CLIENT_ID_PROD: ${{ secrets.FLASK_ANDROID_GOOGLE_CLIENT_ID_PROD }}
-          MAIN_ANDROID_GOOGLE_SERVER_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_GOOGLE_SERVER_CLIENT_ID_UAT }}
-          FLASK_ANDROID_GOOGLE_SERVER_CLIENT_ID_PROD: ${{ secrets.FLASK_ANDROID_GOOGLE_SERVER_CLIENT_ID_PROD }}
-          GOOGLE_SERVICES_B64_IOS: ${{ secrets.GOOGLE_SERVICES_B64_IOS }}
-          GOOGLE_SERVICES_B64_ANDROID: ${{ secrets.GOOGLE_SERVICES_B64_ANDROID }}
-          MM_INFURA_PROJECT_ID: ${{ secrets.MM_INFURA_PROJECT_ID }}
+      # - name: Repack APK with JS updates using @expo/repack-app
+        # if: ${{ steps.apk-cache-restore.outputs.cache-hit == 'true' && steps.gradle-cache-restore.outputs.cache-hit == 'true' }}
+        # run: |
+        #   echo "📦 Repacking APK with updated JavaScript bundle using @expo/repack-app..."
+        #   # Use the optimized repack script which uses @expo/repack-app
+        #   yarn build:repack:android
+        #   echo "📦 Final APK size: $(du -h "${{ steps.determine-target-paths.outputs.apk-target-path }}/${{ steps.determine-target-paths.outputs.artifact_name }}.apk" | cut -f1)"
+        # env:
+        #   PLATFORM: android
+        #   METAMASK_ENVIRONMENT: ${{ inputs.metamask_environment }}
+        #   METAMASK_BUILD_TYPE: ${{ inputs.build_type }}
+        #   IS_TEST: true
+        #   E2E: 'true'
+        #   IGNORE_BOXLOGS_DEVELOPMENT: true
+        #   GITHUB_CI: 'true'
+        #   CI: 'true'
+        #   NODE_OPTIONS: '--max-old-space-size=8192'
+        #   BRIDGE_USE_DEV_APIS: 'true'
+        #   RAMP_INTERNAL_BUILD: 'true'
+        #   SEEDLESS_ONBOARDING_ENABLED: 'true'
+        #   MM_NOTIFICATIONS_UI_ENABLED: 'true'
+        #   MM_SECURITY_ALERTS_API_ENABLED: 'true'
+        #   MM_REMOVE_GLOBAL_NETWORK_SELECTOR: 'true'
+        #   BLOCKAID_FILE_CDN: 'static.cx.metamask.io/api/v1/confirmations/ppom'
+        #   FEATURES_ANNOUNCEMENTS_ACCESS_TOKEN: ${{ secrets.FEATURES_ANNOUNCEMENTS_ACCESS_TOKEN }}
+        #   FEATURES_ANNOUNCEMENTS_SPACE_ID: ${{ secrets.FEATURES_ANNOUNCEMENTS_SPACE_ID }}
+        #   SEGMENT_WRITE_KEY_QA: ${{ secrets.SEGMENT_WRITE_KEY_QA }}
+        #   SEGMENT_WRITE_KEY_FLASK: ${{ secrets.SEGMENT_WRITE_KEY_FLASK }}
+        #   SEGMENT_PROXY_URL_QA: ${{ secrets.SEGMENT_PROXY_URL_QA }}
+        #   SEGMENT_PROXY_URL_FLASK: ${{ secrets.SEGMENT_PROXY_URL_FLASK }}
+        #   SEGMENT_DELETE_API_SOURCE_ID_QA: ${{ secrets.SEGMENT_DELETE_API_SOURCE_ID_QA }}
+        #   SEGMENT_DELETE_API_SOURCE_ID_FLASK: ${{ secrets.SEGMENT_DELETE_API_SOURCE_ID_FLASK }}
+        #   SEGMENT_REGULATIONS_ENDPOINT_QA: ${{ secrets.SEGMENT_REGULATIONS_ENDPOINT_QA }}
+        #   SEGMENT_REGULATIONS_ENDPOINT_FLASK: ${{ secrets.SEGMENT_REGULATIONS_ENDPOINT_FLASK }}
+        #   MM_SENTRY_DSN_TEST: ${{ secrets.MM_SENTRY_DSN_TEST }}
+        #   MM_SENTRY_AUTH_TOKEN: ${{ secrets.MM_SENTRY_AUTH_TOKEN }}
+        #   MAIN_IOS_GOOGLE_CLIENT_ID_UAT: ${{ secrets.MAIN_IOS_GOOGLE_CLIENT_ID_UAT }}
+        #   FLASK_IOS_GOOGLE_CLIENT_ID_PROD: ${{ secrets.FLASK_IOS_GOOGLE_CLIENT_ID_PROD }}
+        #   MAIN_IOS_GOOGLE_REDIRECT_URI_UAT: ${{ secrets.MAIN_IOS_GOOGLE_REDIRECT_URI_UAT }}
+        #   FLASK_IOS_GOOGLE_REDIRECT_URI_PROD: ${{ secrets.FLASK_IOS_GOOGLE_REDIRECT_URI_PROD }}
+        #   MAIN_ANDROID_APPLE_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_APPLE_CLIENT_ID_UAT }}
+        #   FLASK_ANDROID_APPLE_CLIENT_ID_PROD: ${{ secrets.FLASK_ANDROID_APPLE_CLIENT_ID_PROD }}
+        #   MAIN_ANDROID_GOOGLE_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_GOOGLE_CLIENT_ID_UAT }}
+        #   FLASK_ANDROID_GOOGLE_CLIENT_ID_PROD: ${{ secrets.FLASK_ANDROID_GOOGLE_CLIENT_ID_PROD }}
+        #   MAIN_ANDROID_GOOGLE_SERVER_CLIENT_ID_UAT: ${{ secrets.MAIN_ANDROID_GOOGLE_SERVER_CLIENT_ID_UAT }}
+        #   FLASK_ANDROID_GOOGLE_SERVER_CLIENT_ID_PROD: ${{ secrets.FLASK_ANDROID_GOOGLE_SERVER_CLIENT_ID_PROD }}
+        #   GOOGLE_SERVICES_B64_IOS: ${{ secrets.GOOGLE_SERVICES_B64_IOS }}
+        #   GOOGLE_SERVICES_B64_ANDROID: ${{ secrets.GOOGLE_SERVICES_B64_ANDROID }}
+        #   MM_INFURA_PROJECT_ID: ${{ secrets.MM_INFURA_PROJECT_ID }}
 
       # Cache build artifacts with the pre-build fingerprint
       - name: Cache build artifacts
-        if: ${{ steps.apk-cache-restore.outputs.cache-hit != 'true' || steps.gradle-cache-restore.outputs.cache-hit != 'true' }}
+        # if: ${{ steps.apk-cache-restore.outputs.cache-hit != 'true' || steps.gradle-cache-restore.outputs.cache-hit != 'true' }}
         uses: cirruslabs/cache@v4
         with:
           path: |

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -63,12 +63,42 @@ jobs:
 
       - name: Check Gradle cache directories
         run: |
-          echo "check 1"
-          ls -Al /home/admin/_work/.gradle/caches
-          echo "check 2"
-          ls -Al /home/runner/_work/.gradle/caches
-          echo "check 2"
-          ls -Al /home/admin/.gradle/caches
+          if [ -d '/home/admin' ]; then
+            if [ -d '/home/admin/_work/.gradle' ]; then
+              echo "check 1"
+              ls -Al /home/admin/_work/.gradle
+            fi
+
+            if [ -d '/home/admin/.gradle' ]; then
+              echo "check 2"
+              ls -Al /home/admin/.gradle
+            fi
+          fi
+          if [ -d '/home/runner' ]; then
+            if [ -d '/home/runner/_work/.gradle' ]; then
+              echo "check 3"
+              ls -Al /home/runner/_work/.gradle
+            fi
+
+            if [ -d '/home/runner/.gradle' ]; then
+              echo "check 4"
+              ls -Al /home/runner/.gradle
+            fi
+          fi
+
+          echo "HOME: ${HOME}"
+
+          if [ -d "${HOME}" ]; then
+            if [ -d "${HOME}/_work/.gradle" ]; then
+              echo "check 5"
+              ls -Al "${HOME}/_work/.gradle"
+            fi
+
+            if [ -d "${HOME}/.gradle" ]; then
+              echo "check 6"
+              ls -Al "${HOME}/.gradle"
+            fi
+          fi
 
       - name: Cache Gradle dependencies
         uses: cirruslabs/cache@v4
@@ -93,12 +123,43 @@ jobs:
 
       - name: Check Gradle cache directories again after setup
         run: |
-          echo "check 1"
-          ls -Al /home/admin/_work/.gradle/caches
-          echo "check 2"
-          ls -Al /home/runner/_work/.gradle/caches
-          echo "check 2"
-          ls -Al /home/admin/.gradle/caches
+
+          if [ -d '/home/admin' ]; then
+            if [ -d '/home/admin/_work/.gradle' ]; then
+              echo "check 1"
+              ls -Al /home/admin/_work/.gradle
+            fi
+
+            if [ -d '/home/admin/.gradle' ]; then
+              echo "check 2"
+              ls -Al /home/admin/.gradle
+            fi
+          fi
+          if [ -d '/home/runner' ]; then
+            if [ -d '/home/runner/_work/.gradle' ]; then
+              echo "check 3"
+              ls -Al /home/runner/_work/.gradle
+            fi
+
+            if [ -d '/home/runner/.gradle' ]; then
+              echo "check 4"
+              ls -Al /home/runner/.gradle
+            fi
+          fi
+
+          echo "HOME: ${HOME}"
+
+          if [ -d "${HOME}" ]; then
+            if [ -d "${HOME}/_work/.gradle" ]; then
+              echo "check 5"
+              ls -Al "${HOME}/_work/.gradle"
+            fi
+
+            if [ -d "${HOME}/.gradle" ]; then
+              echo "check 6"
+              ls -Al "${HOME}/.gradle"
+            fi
+          fi
 
       # Generate fingerprint AFTER setup but BEFORE any build modifications (the fingerprint now is fake we do not want the cached apk)
       - name: Generate current fingerprint

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -63,6 +63,8 @@ jobs:
 
       - name: Cache Gradle dependencies
         uses: cirruslabs/cache@v4
+        env:
+          GRADLE_CACHE_VERSION: 1
         with:
           path: |
             /home/runner/_work/.gradle/caches
@@ -70,9 +72,7 @@ jobs:
             /home/admin/_work/.gradle/caches
             /home/admin/_work/.gradle/wrapper
             android/.gradle
-          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-
+          key: gradle-${{ env.GRADLE_CACHE_VERSION }}-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
 
       - name: Setup project dependencies with retry
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
@@ -132,7 +132,7 @@ jobs:
         run: |
           echo "🏗 Building Android E2E APKs..."
           export NODE_OPTIONS="--max-old-space-size=8192"
-          # cp android/gradle.properties.github android/gradle.properties - Build for all apps to stabilize e2e 
+          # cp android/gradle.properties.github android/gradle.properties - Build for all apps to stabilize e2e
           yarn build:android:${{ inputs.build_type }}:e2e
         shell: bash
         env:

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -122,46 +122,6 @@ jobs:
             echo "🚀 Setting up project..."
             yarn setup:github-ci --no-build-ios
 
-      - name: Check Gradle cache directories again after setup
-        run: |
-
-          if [ -d '/home/admin' ]; then
-            if [ -d '/home/admin/_work/.gradle' ]; then
-              echo "check 1"
-              ls -Al /home/admin/_work/.gradle
-            fi
-
-            if [ -d '/home/admin/.gradle' ]; then
-              echo "check 2"
-              ls -Al /home/admin/.gradle
-            fi
-          fi
-          if [ -d '/home/runner' ]; then
-            if [ -d '/home/runner/_work/.gradle' ]; then
-              echo "check 3"
-              ls -Al /home/runner/_work/.gradle
-            fi
-
-            if [ -d '/home/runner/.gradle' ]; then
-              echo "check 4"
-              ls -Al /home/runner/.gradle
-            fi
-          fi
-
-          echo "HOME: ${HOME}"
-
-          if [ -d "${HOME}" ]; then
-            if [ -d "${HOME}/_work/.gradle" ]; then
-              echo "check 5"
-              ls -Al "${HOME}/_work/.gradle"
-            fi
-
-            if [ -d "${HOME}/.gradle" ]; then
-              echo "check 6"
-              ls -Al "${HOME}/.gradle"
-            fi
-          fi
-
       # Generate fingerprint AFTER setup but BEFORE any build modifications (the fingerprint now is fake we do not want the cached apk)
       - name: Generate current fingerprint
         id: generate-fingerprint
@@ -255,6 +215,46 @@ jobs:
           GOOGLE_SERVICES_B64_IOS: ${{ secrets.GOOGLE_SERVICES_B64_IOS }}
           GOOGLE_SERVICES_B64_ANDROID: ${{ secrets.GOOGLE_SERVICES_B64_ANDROID }}
           MM_INFURA_PROJECT_ID: ${{ secrets.MM_INFURA_PROJECT_ID }}
+
+      - name: Check Gradle cache directories again after setup+build
+        run: |
+
+          if [ -d '/home/admin' ]; then
+            if [ -d '/home/admin/_work/.gradle' ]; then
+              echo "check 1"
+              ls -Al /home/admin/_work/.gradle
+            fi
+
+            if [ -d '/home/admin/.gradle' ]; then
+              echo "check 2"
+              ls -Al /home/admin/.gradle
+            fi
+          fi
+          if [ -d '/home/runner' ]; then
+            if [ -d '/home/runner/_work/.gradle' ]; then
+              echo "check 3"
+              ls -Al /home/runner/_work/.gradle
+            fi
+
+            if [ -d '/home/runner/.gradle' ]; then
+              echo "check 4"
+              ls -Al /home/runner/.gradle
+            fi
+          fi
+
+          echo "HOME: ${HOME}"
+
+          if [ -d "${HOME}" ]; then
+            if [ -d "${HOME}/_work/.gradle" ]; then
+              echo "check 5"
+              ls -Al "${HOME}/_work/.gradle"
+            fi
+
+            if [ -d "${HOME}/.gradle" ]; then
+              echo "check 6"
+              ls -Al "${HOME}/.gradle"
+            fi
+          fi
 
       - name: Repack APK with JS updates using @expo/repack-app
         if: ${{ steps.apk-cache-restore.outputs.cache-hit == 'true' && steps.gradle-cache-restore.outputs.cache-hit == 'true' }}

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -102,6 +102,7 @@ jobs:
 
       - name: Cache Gradle dependencies
         uses: cirruslabs/cache@v4
+        id: gradle-cache-restore
         env:
           GRADLE_CACHE_VERSION: 1
         with:
@@ -192,7 +193,7 @@ jobs:
           fi
 
       - name: Check and restore cached APKs if Fingerprint is found
-        id: cache-restore
+        id: apk-cache-restore
         uses: cirruslabs/cache@v4
         with:
           path: |
@@ -205,7 +206,7 @@ jobs:
             android-apk-
 
       - name: Build Android E2E APKs
-        if: ${{ steps.cache-restore.outputs.cache-hit != 'true' }}
+        if: ${{ steps.apk-cache-restore.outputs.cache-hit != 'true' || steps.gradle-cache-restore.outputs.cache-hit != 'true' }}
         run: |
           echo "🏗 Building Android E2E APKs..."
           export NODE_OPTIONS="--max-old-space-size=8192"
@@ -256,7 +257,7 @@ jobs:
           MM_INFURA_PROJECT_ID: ${{ secrets.MM_INFURA_PROJECT_ID }}
 
       - name: Repack APK with JS updates using @expo/repack-app
-        if: ${{ steps.cache-restore.outputs.cache-hit == 'true' }}
+        if: ${{ steps.apk-cache-restore.outputs.cache-hit == 'true' && steps.gradle-cache-restore.outputs.cache-hit == 'true' }}
         run: |
           echo "📦 Repacking APK with updated JavaScript bundle using @expo/repack-app..."
           # Use the optimized repack script which uses @expo/repack-app
@@ -307,7 +308,7 @@ jobs:
 
       # Cache build artifacts with the pre-build fingerprint
       - name: Cache build artifacts
-        if: ${{ steps.cache-restore.outputs.cache-hit != 'true' }}
+        if: ${{ steps.apk-cache-restore.outputs.cache-hit != 'true' || steps.gradle-cache-restore.outputs.cache-hit != 'true' }}
         uses: cirruslabs/cache@v4
         with:
           path: |

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -67,10 +67,8 @@ jobs:
           GRADLE_CACHE_VERSION: 1
         with:
           path: |
-            /home/runner/_work/.gradle/caches
-            /home/runner/_work/.gradle/wrapper
-            /home/admin/_work/.gradle/caches
-            /home/admin/_work/.gradle/wrapper
+            ~/.gradle/caches
+            ~/.gradle/wrapper
             android/.gradle
           key: gradle-${{ env.GRADLE_CACHE_VERSION }}-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
 

--- a/.github/workflows/needs-e2e-build.yml
+++ b/.github/workflows/needs-e2e-build.yml
@@ -102,12 +102,11 @@ jobs:
               - 'wdio.conf.js'                     # WebDriver config
               - 'appwright/**'                     # Appwright test files
               - 'scripts/build.sh'                 # Build script triggers rebuilds
+              - '.github/**'                       # GitHub workflow changes
 
             ignore:
               - '**/*.md'                          # Documentation files
               - 'docs/**'                          # Documentation directory
-              - '**/*.yml'                         # Workflow files
-              - '.github/**'                       # GitHub workflow changes
               - 'LICENSE'                          # License file
               - 'README.md'                        # Main README
               - 'RELEASE.MD'                       # Release notes

--- a/.github/workflows/needs-e2e-build.yml
+++ b/.github/workflows/needs-e2e-build.yml
@@ -102,11 +102,12 @@ jobs:
               - 'wdio.conf.js'                     # WebDriver config
               - 'appwright/**'                     # Appwright test files
               - 'scripts/build.sh'                 # Build script triggers rebuilds
-              - '.github/**'                       # GitHub workflow changes
 
             ignore:
               - '**/*.md'                          # Documentation files
               - 'docs/**'                          # Documentation directory
+              - '**/*.yml'                         # Workflow files
+              - '.github/**'                       # GitHub workflow changes
               - 'LICENSE'                          # License file
               - 'README.md'                        # Main README
               - 'RELEASE.MD'                       # Release notes


### PR DESCRIPTION
## **Description**

The Gradle cache was continuously expanding in size because upon a cache miss, the previous cache was still restored and combined with the new updated dependencies.

The workflow has been updated to no longer restore Gradle dependencies upon cache miss. This should prevent us from storing all of these extra unused dependencies, and it saves an enormous amount of time per build (>6 minutes)

Additionally, the check for when a manual build occurs has been updated to run upon a Gradle cache miss. This was done for two reasons:
* If Gradle settings/properties change, we want to force a rebuild to ensure they take effect
* We need to rebuild in order to test and repopulate this new cache key, because Gradle dependencies are only downloaded as part of the build

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

This workflow log shows a cache miss, with some debug logs added to confirm what the cache directory is: https://github.com/MetaMask/metamask-mobile/actions/runs/18971705909/job/54180826012

Here is a run with a cache hit + repack: https://github.com/MetaMask/metamask-mobile/actions/runs/18972284601/job/54186170098

Here is a run with a cache hit + rebuild: https://github.com/MetaMask/metamask-mobile/actions/runs/18973679409/job/54187589018

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines Android E2E workflow caching by versioning and scoping Gradle cache, renaming APK cache step, and adjusting build/repack conditions based on cache hits.
> 
> - **CI/CD — Android E2E workflow (`.github/workflows/build-android-e2e.yml`)**:
>   - **Gradle caching**:
>     - Add `id: gradle-cache-restore` with `GRADLE_CACHE_VERSION` and updated cache paths (`~/_work/.gradle/{caches,wrapper}`).
>     - Update cache key to include version for controlled busting.
>   - **APK artifact cache**:
>     - Rename step `cache-restore` ➜ `apk-cache-restore`.
>   - **Build flow conditions**:
>     - Build APKs when `apk-cache-restore` miss OR `gradle-cache-restore` miss.
>     - Repack only when both caches hit.
>     - Cache artifacts when either cache misses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f2699ae426b7acd593efa16d611865e8ebe620c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->