### PR TITLE
feat(card): cp-7.58.0 add card experimental deeplink

### DIFF
--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -72,6 +72,7 @@ import FundActionMenu from '../../UI/FundActionMenu';
 import NetworkSelector from '../../../components/Views/NetworkSelector';
 import ReturnToAppNotification from '../../Views/ReturnToAppNotification';
 import EditAccountName from '../../Views/EditAccountName/EditAccountName';
+import CardNotification from '../../Views/CardNotification';
 import LegacyEditMultichainAccountName from '../../Views/MultichainAccounts/sheets/EditAccountName';
 import { EditMultichainAccountName } from '../../Views/MultichainAccounts/sheets/EditMultichainAccountName';
 import { PPOMView } from '../../../lib/ppom/PPOMView';
@@ -572,6 +573,10 @@ const RootModalFlow = (props: RootModalFlowProps) => (
       name={Routes.SDK.RETURN_TO_DAPP_NOTIFICATION}
       component={ReturnToAppNotification}
       initialParams={{ ...props.route.params }}
+    />
+    <Stack.Screen
+      name={Routes.CARD.NOTIFICATION}
+      component={CardNotification}
     />
   </Stack.Navigator>
 );

--- a/app/components/Views/CardNotification/CardNotification.test.tsx
+++ b/app/components/Views/CardNotification/CardNotification.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+import CardNotification from './CardNotification';
+import { ToastContext } from '../../../component-library/components/Toast';
+import { ToastVariants } from '../../../component-library/components/Toast/Toast.types';
+import { IconName } from '../../../component-library/components/Icons/Icon';
+
+jest.mock('../../../../locales/i18n', () => ({
+  strings: jest.fn((key: string) => key),
+}));
+
+const mockGoBack = jest.fn();
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useNavigation: () => ({
+      goBack: mockGoBack,
+    }),
+  };
+});
+
+describe('CardNotification', () => {
+  const createToastRef = () => ({
+    current: { showToast: jest.fn(), closeToast: jest.fn() },
+  });
+
+  const renderWithProviders = (toastRef = createToastRef()) => {
+    const ui = (
+      <ToastContext.Provider value={{ toastRef }}>
+        <CardNotification />
+      </ToastContext.Provider>
+    );
+
+    const utils = render(ui);
+    return { ...utils, toastRef };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGoBack.mockClear();
+  });
+
+  it('renders without crashing', () => {
+    const { toastRef } = renderWithProviders();
+
+    expect(toastRef.current).toBeDefined();
+  });
+
+  it('displays toast with correct configuration when toastRef is available', async () => {
+    const { toastRef } = renderWithProviders();
+
+    await waitFor(() => {
+      expect(toastRef.current.showToast).toHaveBeenCalledWith({
+        variant: ToastVariants.Icon,
+        labelOptions: [{ label: 'card.card_home.card_button_enabled_toast' }],
+        hasNoTimeout: false,
+        iconName: IconName.Info,
+      });
+    });
+  });
+
+  it('calls navigation goBack after showing toast', async () => {
+    renderWithProviders();
+
+    await waitFor(() => {
+      expect(mockGoBack).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('does not show toast when toastRef is null', () => {
+    const nullToastRef = {
+      current: null,
+    } as unknown as {
+      current: { showToast: jest.Mock; closeToast: jest.Mock };
+    };
+    const { toastRef } = renderWithProviders(nullToastRef);
+
+    expect(toastRef.current).toBeNull();
+    expect(mockGoBack).not.toHaveBeenCalled();
+  });
+
+  it('shows toast only once on multiple renders', async () => {
+    const { toastRef, rerender } = renderWithProviders();
+
+    await waitFor(() => {
+      expect(toastRef.current.showToast).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(
+      <ToastContext.Provider value={{ toastRef }}>
+        <CardNotification />
+      </ToastContext.Provider>,
+    );
+
+    await waitFor(() => {
+      expect(toastRef.current.showToast).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('translates toast label using i18n strings', async () => {
+    const mockStrings = jest.requireMock('../../../../locales/i18n').strings;
+    const { toastRef } = renderWithProviders();
+
+    await waitFor(() => {
+      expect(mockStrings).toHaveBeenCalledWith(
+        'card.card_home.card_button_enabled_toast',
+      );
+      expect(toastRef.current.showToast).toHaveBeenCalled();
+    });
+  });
+
+  it('renders empty fragment as component output', () => {
+    const { toJSON } = renderWithProviders();
+
+    expect(toJSON()).toBeNull();
+  });
+});

--- a/app/components/Views/CardNotification/CardNotification.test.tsx
+++ b/app/components/Views/CardNotification/CardNotification.test.tsx
@@ -53,7 +53,7 @@ describe('CardNotification', () => {
     await waitFor(() => {
       expect(toastRef.current.showToast).toHaveBeenCalledWith({
         variant: ToastVariants.Icon,
-        labelOptions: [{ label: 'card.card_home.card_button_enabled_toast' }],
+        labelOptions: [{ label: 'card.card_button_enabled_toast' }],
         hasNoTimeout: false,
         iconName: IconName.Info,
       });
@@ -104,7 +104,7 @@ describe('CardNotification', () => {
 
     await waitFor(() => {
       expect(mockStrings).toHaveBeenCalledWith(
-        'card.card_home.card_button_enabled_toast',
+        'card.card_button_enabled_toast',
       );
       expect(toastRef.current.showToast).toHaveBeenCalled();
     });

--- a/app/components/Views/CardNotification/CardNotification.tsx
+++ b/app/components/Views/CardNotification/CardNotification.tsx
@@ -1,0 +1,39 @@
+import React, { useContext, useEffect, useRef } from 'react';
+import { ToastContext } from '../../../component-library/components/Toast';
+import { ToastVariants } from '../../../component-library/components/Toast/Toast.types';
+import { useNavigation } from '@react-navigation/native';
+import { IconName } from '../../../component-library/components/Icons/Icon';
+import { strings } from '../../../../locales/i18n';
+
+/**
+ * Fake modal that displays a toast for card-related deeplinks.
+ * Similar to ReturnToAppNotification but for card feature.
+ *
+ * This component is used to trigger toasts from non-React contexts (like deeplink handlers)
+ * by navigating to this route with toast parameters, then immediately going back.
+ */
+const CardNotification = () => {
+  const navigation = useNavigation();
+  const { toastRef } = useContext(ToastContext);
+  const hasExecuted = useRef<boolean>(false);
+
+  useEffect(() => {
+    if (toastRef && toastRef.current !== null && !hasExecuted.current) {
+      hasExecuted.current = true;
+
+      toastRef.current.showToast({
+        variant: ToastVariants.Icon,
+        labelOptions: [{ label: strings('card.card_button_enabled_toast') }],
+        hasNoTimeout: false,
+        iconName: IconName.Info,
+      });
+
+      // Hide the fake modal
+      navigation?.goBack();
+    }
+  }, [toastRef, navigation]);
+
+  return <></>;
+};
+
+export default CardNotification;

--- a/app/components/Views/CardNotification/index.ts
+++ b/app/components/Views/CardNotification/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CardNotification';

--- a/app/constants/deeplinks.ts
+++ b/app/constants/deeplinks.ts
@@ -13,6 +13,7 @@ export enum PROTOCOLS {
 }
 
 export enum ACTIONS {
+  ENABLE_CARD_BUTTON = 'enable-card-button',
   DAPP = 'dapp',
   SEND = 'send',
   APPROVE = 'approve',
@@ -62,5 +63,6 @@ export const PREFIXES = {
   [ACTIONS.PERPS_ASSET]: '',
   [ACTIONS.REWARDS]: '',
   [ACTIONS.ONBOARDING]: '',
+  [ACTIONS.ENABLE_CARD_BUTTON]: '',
   METAMASK: 'metamask://',
 };

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -359,6 +359,7 @@ const Routes = {
     HOME: 'CardHome',
     WELCOME: 'CardWelcome',
     AUTHENTICATION: 'CardAuthentication',
+    NOTIFICATION: 'CardNotification',
     SPENDING_LIMIT: 'CardSpendingLimit',
     CHANGE_ASSET: 'CardChangeAsset',
     ONBOARDING: {

--- a/app/core/DeeplinkManager/DeeplinkManager.ts
+++ b/app/core/DeeplinkManager/DeeplinkManager.ts
@@ -25,6 +25,7 @@ import SharedDeeplinkManager from './SharedDeeplinkManager';
 import FCMService from '../../util/notifications/services/FCMService';
 import { handleRewardsUrl } from './Handlers/handleRewardsUrl';
 import handleFastOnboarding from './Handlers/handleFastOnboarding';
+import { handleEnableCardButton } from './Handlers/handleEnableCardButton';
 
 class DeeplinkManager {
   // TODO: Replace "any" with type
@@ -144,6 +145,10 @@ class DeeplinkManager {
 
   _handleFastOnboarding(onboardingPath: string) {
     handleFastOnboarding({ onboardingPath });
+  }
+
+  _handleEnableCardButton() {
+    handleEnableCardButton();
   }
 
   async parse(

--- a/app/core/DeeplinkManager/Handlers/handleEnableCardButton.test.ts
+++ b/app/core/DeeplinkManager/Handlers/handleEnableCardButton.test.ts
@@ -1,0 +1,133 @@
+import { handleEnableCardButton } from './handleEnableCardButton';
+import { store } from '../../../store';
+import { setAlwaysShowCardButton } from '../../../core/redux/slices/card';
+import { selectCardExperimentalSwitch } from '../../../selectors/featureFlagController/card';
+import DevLogger from '../../SDKConnect/utils/DevLogger';
+import Logger from '../../../util/Logger';
+
+jest.mock('../../../store');
+jest.mock('../../../core/redux/slices/card');
+jest.mock('../../../selectors/featureFlagController/card');
+jest.mock('../../SDKConnect/utils/DevLogger');
+jest.mock('../../../util/Logger');
+
+describe('handleEnableCardButton', () => {
+  const mockGetState = jest.fn();
+  const mockDispatch = jest.fn();
+  const mockDevLogger = DevLogger.log as jest.Mock;
+  const mockLogger = Logger.log as jest.Mock;
+  const mockLoggerError = Logger.error as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (store.getState as jest.Mock) = mockGetState;
+    (store.dispatch as jest.Mock) = mockDispatch;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('when card experimental switch is enabled', () => {
+    beforeEach(() => {
+      (selectCardExperimentalSwitch as unknown as jest.Mock).mockReturnValue(
+        true,
+      );
+      mockGetState.mockReturnValue({});
+    });
+
+    it('dispatches setAlwaysShowCardButton with true', () => {
+      handleEnableCardButton();
+
+      expect(mockDispatch).toHaveBeenCalledWith(setAlwaysShowCardButton(true));
+    });
+
+    it('logs successful enablement', () => {
+      handleEnableCardButton();
+
+      expect(mockDevLogger).toHaveBeenCalledWith(
+        '[handleEnableCardButton] Successfully enabled card button',
+      );
+      expect(mockLogger).toHaveBeenCalledWith(
+        '[handleEnableCardButton] Card button enabled via deeplink',
+      );
+    });
+
+    it('logs starting message', () => {
+      handleEnableCardButton();
+
+      expect(mockDevLogger).toHaveBeenCalledWith(
+        '[handleEnableCardButton] Starting card button enable deeplink handling',
+      );
+    });
+  });
+
+  describe('when card experimental switch is disabled', () => {
+    beforeEach(() => {
+      (selectCardExperimentalSwitch as unknown as jest.Mock).mockReturnValue(
+        false,
+      );
+      mockGetState.mockReturnValue({});
+    });
+
+    it('does not dispatch setAlwaysShowCardButton', () => {
+      handleEnableCardButton();
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+
+    it('logs that feature flag is disabled', () => {
+      handleEnableCardButton();
+
+      expect(mockDevLogger).toHaveBeenCalledWith(
+        '[handleEnableCardButton] Card experimental switch is disabled, skipping',
+      );
+      expect(mockLogger).toHaveBeenCalledWith(
+        '[handleEnableCardButton] Card experimental switch feature flag is disabled',
+      );
+    });
+
+    it('logs starting message', () => {
+      handleEnableCardButton();
+
+      expect(mockDevLogger).toHaveBeenCalledWith(
+        '[handleEnableCardButton] Starting card button enable deeplink handling',
+      );
+    });
+  });
+
+  describe('when an error occurs', () => {
+    const mockError = new Error('Test error');
+
+    beforeEach(() => {
+      mockGetState.mockImplementation(() => {
+        throw mockError;
+      });
+    });
+
+    it('logs error with DevLogger', () => {
+      handleEnableCardButton();
+
+      expect(mockDevLogger).toHaveBeenCalledWith(
+        '[handleEnableCardButton] Failed to enable card button:',
+        mockError,
+      );
+    });
+
+    it('logs error with Logger', () => {
+      handleEnableCardButton();
+
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        mockError,
+        '[handleEnableCardButton] Error enabling card button',
+      );
+    });
+
+    it('does not dispatch setAlwaysShowCardButton', () => {
+      handleEnableCardButton();
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/core/DeeplinkManager/Handlers/handleEnableCardButton.ts
+++ b/app/core/DeeplinkManager/Handlers/handleEnableCardButton.ts
@@ -1,0 +1,63 @@
+import DevLogger from '../../SDKConnect/utils/DevLogger';
+import Logger from '../../../util/Logger';
+import { store } from '../../../store';
+import { setAlwaysShowCardButton } from '../../../core/redux/slices/card';
+import { selectCardExperimentalSwitch } from '../../../selectors/featureFlagController/card';
+import NavigationService from '../../NavigationService';
+import Routes from '../../../constants/navigation/Routes';
+
+/**
+ * Card deeplink handler to enable the card button
+ *
+ * This handler enables the card button by setting the alwaysShowCardButton flag
+ * to true, but only if the cardExperimentalSwitch feature flag is enabled.
+ * It shows a success toast notification after enabling the button.
+ *
+ * Supported URL formats:
+ * - https://link.metamask.io/enable-card-button
+ * - https://metamask.app.link/enable-card-button
+ */
+export const handleEnableCardButton = () => {
+  DevLogger.log(
+    '[handleEnableCardButton] Starting card button enable deeplink handling',
+  );
+
+  try {
+    const state = store.getState();
+    const cardExperimentalSwitchEnabled = selectCardExperimentalSwitch(state);
+
+    DevLogger.log(
+      '[handleEnableCardButton] Card experimental switch enabled:',
+      cardExperimentalSwitchEnabled,
+    );
+
+    if (cardExperimentalSwitchEnabled) {
+      store.dispatch(setAlwaysShowCardButton(true));
+      DevLogger.log(
+        '[handleEnableCardButton] Successfully enabled card button',
+      );
+      Logger.log('[handleEnableCardButton] Card button enabled via deeplink');
+
+      // Show success toast via navigation
+      NavigationService.navigation?.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
+        screen: Routes.CARD.NOTIFICATION,
+      });
+    } else {
+      DevLogger.log(
+        '[handleEnableCardButton] Card experimental switch is disabled, skipping',
+      );
+      Logger.log(
+        '[handleEnableCardButton] Card experimental switch feature flag is disabled',
+      );
+    }
+  } catch (error) {
+    DevLogger.log(
+      '[handleEnableCardButton] Failed to enable card button:',
+      error,
+    );
+    Logger.error(
+      error as Error,
+      '[handleEnableCardButton] Error enabling card button',
+    );
+  }
+};

--- a/app/core/DeeplinkManager/ParseManager/handleUniversalLink.test.ts
+++ b/app/core/DeeplinkManager/ParseManager/handleUniversalLink.test.ts
@@ -50,6 +50,7 @@ describe('handleUniversalLinks', () => {
   const mockHandlePerps = jest.fn();
   const mockHandleRewards = jest.fn();
   const mockHandleFastOnboarding = jest.fn();
+  const mockHandleEnableCardButton = jest.fn();
   const mockConnectToChannel = jest.fn();
   const mockGetConnections = jest.fn();
   const mockRevalidateChannel = jest.fn();
@@ -77,6 +78,7 @@ describe('handleUniversalLinks', () => {
     _handlePerps: mockHandlePerps,
     _handleRewards: mockHandleRewards,
     _handleFastOnboarding: mockHandleFastOnboarding,
+    _handleEnableCardButton: mockHandleEnableCardButton,
   } as unknown as DeeplinkManager;
 
   const handled = jest.fn();
@@ -693,6 +695,51 @@ describe('handleUniversalLinks', () => {
         expect(mockHandleFastOnboarding).toHaveBeenCalledWith(
           expectedTransformedPath,
         );
+      },
+    );
+  });
+
+  describe('ACTIONS.ENABLE_CARD_BUTTON', () => {
+    const testCases = [
+      {
+        domain: AppConstants.MM_UNIVERSAL_LINK_HOST,
+        description: 'old deeplink domain',
+      },
+      {
+        domain: AppConstants.MM_IO_UNIVERSAL_LINK_HOST,
+        description: 'new deeplink domain',
+      },
+      {
+        domain: AppConstants.MM_IO_UNIVERSAL_LINK_TEST_HOST,
+        description: 'test deeplink domain',
+      },
+    ] as const;
+
+    it.each(testCases)(
+      'calls _handleEnableCardButton without showing modal for $description',
+      async ({ domain }) => {
+        const enableCardButtonUrl = `${PROTOCOLS.HTTPS}://${domain}/${ACTIONS.ENABLE_CARD_BUTTON}`;
+        const origin = `${PROTOCOLS.HTTPS}://${domain}`;
+        const enableCardButtonUrlObj = {
+          ...urlObj,
+          hostname: domain,
+          href: enableCardButtonUrl,
+          pathname: `/${ACTIONS.ENABLE_CARD_BUTTON}`,
+          origin,
+        };
+
+        await handleUniversalLink({
+          instance,
+          handled,
+          urlObj: enableCardButtonUrlObj,
+          browserCallBack: mockBrowserCallBack,
+          url: enableCardButtonUrl,
+          source: 'test-source',
+        });
+
+        expect(mockHandleDeepLinkModalDisplay).not.toHaveBeenCalled();
+        expect(handled).toHaveBeenCalled();
+        expect(mockHandleEnableCardButton).toHaveBeenCalled();
       },
     );
   });

--- a/app/core/DeeplinkManager/ParseManager/handleUniversalLink.ts
+++ b/app/core/DeeplinkManager/ParseManager/handleUniversalLink.ts
@@ -38,6 +38,7 @@ enum SUPPORTED_ACTIONS {
   REWARDS = ACTIONS.REWARDS,
   WC = ACTIONS.WC,
   ONBOARDING = ACTIONS.ONBOARDING,
+  ENABLE_CARD_BUTTON = ACTIONS.ENABLE_CARD_BUTTON,
   // MetaMask SDK specific actions
   ANDROID_SDK = ACTIONS.ANDROID_SDK,
   CONNECT = ACTIONS.CONNECT,
@@ -47,7 +48,10 @@ enum SUPPORTED_ACTIONS {
 /**
  * Actions that should not show the deep link modal
  */
-const WHITELISTED_ACTIONS: SUPPORTED_ACTIONS[] = [SUPPORTED_ACTIONS.WC];
+const WHITELISTED_ACTIONS: SUPPORTED_ACTIONS[] = [
+  SUPPORTED_ACTIONS.WC,
+  SUPPORTED_ACTIONS.ENABLE_CARD_BUTTON,
+];
 
 /**
  * MetaMask SDK actions that should be handled by handleMetaMaskDeeplink
@@ -264,6 +268,8 @@ async function handleUniversalLink({
   } else if (action === SUPPORTED_ACTIONS.ONBOARDING) {
     const onboardingPath = urlObj.href.replace(BASE_URL_ACTION, '');
     instance._handleFastOnboarding(onboardingPath);
+  } else if (action === SUPPORTED_ACTIONS.ENABLE_CARD_BUTTON) {
+    instance._handleEnableCardButton();
   }
 }
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6083,6 +6083,7 @@
   },
   "card": {
     "card": "MetaMask Card",
+    "card_button_enabled_toast": "You can now sign up for MetaMask Card!",
     "add_funds_bottomsheet": {
       "deposit": "Fund with cash",
       "deposit_description": "Low-cost card or bank transfer",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR introduces a Deeplink handler that enables the Card button for all users who open the app through the specific Deeplink metamask://enable-card-button. The handler ensures the link is properly parsed and triggers the correct in-app action to activate the Card feature seamlessly.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added Deeplink handler for metamask://enable-card-button to enable the Card button for all users

## **Related issues**

Fixes:

## **Manual testing steps**

Run `npx uri-scheme open "metamask://enable-card-button" --ios` or `--android`

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/749e3932-d2e5-4f47-af84-2c102dcee036

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `enable-card-button` deeplink that enables the Card button (behind feature flag) and shows a confirmation toast via a new `CardNotification` route.
> 
> - **Deeplinks/Parsing**:
>   - Add action `ACTIONS.ENABLE_CARD_BUTTON` and whitelist it from the interstitial modal in `handleUniversalLink`.
>   - Wire `DeeplinkManager._handleEnableCardButton()` to process the universal link.
> - **Handler**:
>   - Implement `handleEnableCardButton`: checks `selectCardExperimentalSwitch`, dispatches `setAlwaysShowCardButton(true)`, then navigates to `Routes.MODAL.ROOT_MODAL_FLOW` → `Routes.CARD.NOTIFICATION`.
> - **Navigation/Routes**:
>   - Add `Routes.CARD.NOTIFICATION` and register `CardNotification` screen in `RootModalFlow`.
> - **UI**:
>   - New `CardNotification` component: triggers a toast (`card.card_button_enabled_toast`) and immediately `goBack()`.
> - **i18n**:
>   - Add `card.card_button_enabled_toast` copy.
> - **Tests**:
>   - Unit tests for `CardNotification`, `handleEnableCardButton`, and universal link handling of `enable-card-button`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 514972378707df8d3581461d7df330db9411c6f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->