### PR TITLE
fix: ensure that close value does not change when amount input focused

### DIFF
--- a/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
@@ -57,6 +57,7 @@ import {
 import {
   calculateCloseAmountFromPercentage,
   validateCloseAmountLimits,
+  formatCloseAmountUSD,
 } from '../../utils/positionCalculations';
 import { createStyles } from './PerpsClosePositionView.styles';
 import {
@@ -139,7 +140,7 @@ const PerpsClosePositionView: React.FC = () => {
 
     return {
       closeAmount: tokenAmount.toString(),
-      calculatedUSDString: usdValue.toFixed(2),
+      calculatedUSDString: formatCloseAmountUSD(usdValue),
     };
   }, [closePercentage, absSize, effectivePrice]);
 
@@ -277,7 +278,7 @@ const PerpsClosePositionView: React.FC = () => {
   useEffect(() => {
     if (!isAmountInitializedRef.current && absSize > 0 && effectivePrice > 0) {
       const initialUSDAmount = absSize * effectivePrice;
-      setCloseAmountUSDString(initialUSDAmount.toFixed(2));
+      setCloseAmountUSDString(formatCloseAmountUSD(initialUSDAmount));
       isAmountInitializedRef.current = true;
     }
   }, [absSize, effectivePrice]);
@@ -413,7 +414,7 @@ const PerpsClosePositionView: React.FC = () => {
 
     // Update USD input to match calculated value for keypad display consistency
     const newUSDAmount = (newPercentage / 100) * absSize * effectivePrice;
-    setCloseAmountUSDString(newUSDAmount.toFixed(2));
+    setCloseAmountUSDString(formatCloseAmountUSD(newUSDAmount));
   };
 
   const handleMaxPress = () => {
@@ -422,7 +423,7 @@ const PerpsClosePositionView: React.FC = () => {
 
     // Update USD input to match calculated value for keypad display consistency
     const newUSDAmount = absSize * effectivePrice;
-    setCloseAmountUSDString(newUSDAmount.toFixed(2));
+    setCloseAmountUSDString(formatCloseAmountUSD(newUSDAmount));
   };
 
   const handleDonePress = () => {
@@ -436,7 +437,7 @@ const PerpsClosePositionView: React.FC = () => {
 
     // Update USD input to match calculated value for keypad display consistency
     const newUSDAmount = (value / 100) * absSize * effectivePrice;
-    setCloseAmountUSDString(newUSDAmount.toFixed(2));
+    setCloseAmountUSDString(formatCloseAmountUSD(newUSDAmount));
   };
 
   // Hide provider-level limit price required error on this UI

--- a/app/components/UI/Perps/utils/positionCalculations.test.ts
+++ b/app/components/UI/Perps/utils/positionCalculations.test.ts
@@ -3,6 +3,7 @@ import {
   validateCloseAmountLimits,
   formatCloseAmountDisplay,
   calculateCloseValue,
+  formatCloseAmountUSD,
   calculatePercentageFromTokenAmount,
   calculatePercentageFromUSDAmount,
   getPositionDirection,
@@ -148,6 +149,68 @@ describe('Position Calculations Utils', () => {
       });
 
       expect(result).toBe(0);
+    });
+  });
+
+  describe('formatCloseAmountUSD', () => {
+    it('formats USD value with 2 decimal places', () => {
+      const result = formatCloseAmountUSD(1234.56);
+
+      expect(result).toBe('1234.56');
+    });
+
+    it('formats whole numbers with 2 decimal places', () => {
+      const result = formatCloseAmountUSD(500);
+
+      expect(result).toBe('500.00');
+    });
+
+    it('rounds to 2 decimal places for values with more decimals', () => {
+      const result = formatCloseAmountUSD(123.456789);
+
+      expect(result).toBe('123.46');
+    });
+
+    it('formats zero as string with 2 decimal places', () => {
+      const result = formatCloseAmountUSD(0);
+
+      expect(result).toBe('0.00');
+    });
+
+    it('returns "0" for negative values', () => {
+      const result = formatCloseAmountUSD(-100);
+
+      expect(result).toBe('0');
+    });
+
+    it('returns "0" for NaN values', () => {
+      const result = formatCloseAmountUSD(NaN);
+
+      expect(result).toBe('0');
+    });
+
+    it('formats very small positive values correctly', () => {
+      const result = formatCloseAmountUSD(0.01);
+
+      expect(result).toBe('0.01');
+    });
+
+    it('formats large values correctly', () => {
+      const result = formatCloseAmountUSD(1234567.89);
+
+      expect(result).toBe('1234567.89');
+    });
+
+    it('rounds down for values ending in .xx4', () => {
+      const result = formatCloseAmountUSD(10.004);
+
+      expect(result).toBe('10.00');
+    });
+
+    it('rounds up for values ending in .xx5', () => {
+      const result = formatCloseAmountUSD(10.005);
+
+      expect(result).toBe('10.01');
     });
   });
 

--- a/app/components/UI/Perps/utils/positionCalculations.ts
+++ b/app/components/UI/Perps/utils/positionCalculations.ts
@@ -132,6 +132,19 @@ export function calculateCloseValue(params: CloseValueParams): number {
 }
 
 /**
+ * Formats a USD value for close amount display with proper decimal places
+ * Uses the centralized USD_DECIMAL_PLACES configuration
+ * @param value - Raw USD value to format
+ * @returns Formatted string with configured decimal places
+ */
+export function formatCloseAmountUSD(value: number): string {
+  if (isNaN(value) || value < 0) {
+    return '0';
+  }
+  return value.toFixed(CLOSE_POSITION_CONFIG.USD_DECIMAL_PLACES);
+}
+
+/**
  * Calculate percentage from token amount
  * @param tokenAmount - Amount in token units
  * @param totalPositionSize - Total position size in token units


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR stops the amount from switching when the input amount is clicked. However, it allows the amount to update with price until the user actually presses the keypad. At that point the price does not update the amount until the user has clicked Done

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null
 
## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1751

## **Manual testing steps**

```gherkin
Feature: ensure amount does not change + pnl  on user input

  Scenario:  user is on the position close screen
    Given the user clicks on the amount input when they have pnl

    When the amount is focused, the price will update it until the user has pressed the keypad
    Then when clicking done, the price will be set

    When the price is at 100 percent and the user clicks done, the price will update to match what 100% actually is in amount
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/402bc2ad-5109-4de8-83de-2d04dcc23612

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes USD close amount during input by syncing only when not editing, adds centralized USD formatter, and extends tests for price sync and formatting.
> 
> - **PerpsClosePositionView**:
>   - Add `isAmountInitializedRef` and effects to initialize USD once and sync `closeAmountUSDString` with calculated value only when not actively editing.
>   - Use new `formatCloseAmountUSD` for all USD amount updates (calculated, percentage, max, slider).
>   - Ensure effective price drives calculations (incl. limit price), preventing amount jumps on focus after price updates.
> - **Utils**:
>   - Add `formatCloseAmountUSD(value)` with 2‑dp rounding and guards; export and use in view.
> - **Tests**:
>   - Add "Price Update Synchronization" suite covering init-once, focus-jump prevention, sync when not editing, and no-sync while editing.
>   - Add unit tests for `formatCloseAmountUSD` edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22b7d1f71b8015460a3e8f425a5e7383ba050074. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->