### PR TITLE
chore: Revert "test: removes e2e references from bitrise.yml"

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -37,7 +37,7 @@ pipelines:
       - bump_version_stage: {}
       - create_build_release: {}
       - deploy_build_release: {}
-      - create_build_qa: {}
+      - create_build_qa: {} #Generate QA builds for E2E app upgrade tests
   #Releases MetaMask beta apps and stores apk/ipa into Play(Internal Testing)/App(TestFlight) Store
   beta_builds_to_store_pipeline:
     stages:
@@ -62,7 +62,65 @@ pipelines:
       - bump_version_stage: {}
       - create_android_release: {}
       - deploy_android_release: {}
+  # TODO: Remove this workflow since it's not used anymore
+  run_e2e_ios_pipeline:
+    stages:
+      - build_e2e_ios_stage: {}
+      - run_e2e_ios_stage: {}
+      - notify: {}
+  # TODO: Remove this workflow since it's not used anymore
+  run_e2e_flask_pipeline:
+    stages:
+      - pr_cache_check_stage: {}
+      - build_e2e_flask_ios_android: {}
+      - run_e2e_flask_ios_android: {}
+      - notify: {}
   #Run single suits or test files
+  run_single_test_suite_ios_android:
+    stages:
+      - build_smoke_e2e_ios_android_stage: {}
+      - run_single_e2e_ios_android_stage: {}
+      - notify: {}
+  #Run E2E test suite for Android only
+  run_e2e_android_pipeline:
+    stages:
+      - build_e2e_android_stage: {} #builds android detox E2E
+      - run_e2e_android_stage: {} #runs android detox test E2E
+      - notify: {}
+  #PR_e2e_verfication (build ios & android), run iOS (smoke), emulator Android
+  release_e2e_pipeline:
+    stages:
+      - build_e2e_ios_android_stage: {}
+      - run_release_e2e_ios_android_stage: {}
+      - report_results_stage: {}
+      - notify: {}
+  #PR_e2e_verfication (build ios & android), run iOS (smoke), emulator Android
+  pr_smoke_e2e_pipeline:
+    stages:
+      - set_main_target_stage: {}
+      - pr_cache_check_stage: {}
+      - build_smoke_e2e_ios_android_stage: {}
+      - run_smoke_e2e_ios_android_stage: {}
+      - notify: {}
+      
+  flask_smoke_e2e_pipeline:
+    stages:
+      - set_flask_target_stage: {}
+      - pr_cache_check_stage: {}
+      - build_e2e_flask_ios_android: {}
+      - run_e2e_flask_ios_android_stage: {}
+      - notify: {}
+
+  #Performance smoke test pipeline - runs only performance tests
+  smoke_e2e_performance_pipeline:
+    stages:
+      - set_main_target_stage: {}
+      - pr_cache_check_stage: {}
+      - build_smoke_e2e_ios_android_stage: {}
+      # - run_smoke_e2e_performance_ios_android_stage: {}
+      - notify: {}
+
+  #PR_e2e_verfication (build ios & android), run iOS (regression), emulator Android
   pr_rc_rwy_pipeline:
     workflows:
       set_main_target_workflow: {}
@@ -82,6 +140,7 @@ pipelines:
   expo_dev_pipeline:
     stages:
       - create_build_qa_and_expo: {}
+      # - app_launch_times_test_stage: {}
   #Main expo pipeline
   expo_main_pipeline:
     stages:
@@ -98,6 +157,11 @@ pipelines:
   app_upgrade_pipeline:
     stages:
       - create_build_qa_android: {}
+      - app_upgrade_test_stage: {}
+  # multichain_permissions_e2e_pipeline:
+  #   stages:
+  #     - build_multichain_permissions_e2e_ios_android_stage: {}
+  #     - run_multichain_permissions_e2e_ios_android_stage: {}
   # Pipeline for Flask
   create_flask_release_builds_pipeline:
     stages:
@@ -228,9 +292,11 @@ stages:
       - build_android_main_beta: {}
       - build_android_main_exp: {}
       - build_android_main_test: {}
+      - build_android_main_e2e: {}
       - build_android_main_dev: {}
       - build_android_flask_prod: {}
       - build_android_flask_test: {}
+      - build_android_flask_e2e: {}
       - build_android_flask_dev: {}
   create_build_qa_android:
     workflows:
@@ -238,20 +304,205 @@ stages:
   create_build_qa_ios:
     workflows:
       - build_ios_qa: {}
+  # TODO: Remove this workflow since it's not used anymore
+  build_e2e_ios_stage:
+    workflows:
+      - ios_e2e_build: {}
+  # TODO: Remove this workflow since it's not used anymore
+  run_e2e_ios_stage:
+    workflows:
+      - ios_e2e_test: {}
   pr_cache_check_stage:
     abort_on_fail: true
     workflows:
       - pr_check_build_cache: {}
+  # Sets the METAMASK_BUILD_TYPE variable to the main target
+  set_main_target_stage:
+    workflows:
+      - set_main_target_workflow: {}
   # Sets the METAMASK_BUILD_TYPE variable to the flask target
   set_flask_target_stage:
     workflows:
       - set_flask_target_workflow: {}
+  build_smoke_e2e_ios_android_stage:
+    abort_on_fail: true
+    workflows:
+      - build_ios_main_e2e:
+          run_if: '{{getenv "SKIP_IOS_BUILD" | eq "false"}}'
+      # Disabling in CI to allow GHA runs
+      # - build_android_main_e2e:
+      #     run_if: '{{getenv "SKIP_ANDROID_BUILD" | eq "false"}}'
+  build_multichain_permissions_e2e_ios_android_stage:
+    abort_on_fail: true
+    workflows:
+      - build_ios_multichain_permissions_e2e: {}
+      - build_android_multichain_permissions_e2e: {}
+  # run_multichain_permissions_e2e_ios_android_stage:
+  #   workflows:
+  #     - run_tag_multichain_permissions_ios: {}
+  #     - run_tag_multichain_permissions_android: {}
+  run_e2e_flask_ios_android_stage:
+    workflows:
+      - run_ios_api_specs: {}
+      - run_trade_swimlane_ios_smoke: {}
+      - run_trade_swimlane_android_smoke: {}
+      - run_network_abstraction_swimlane_ios_smoke: {}
+      - run_network_abstraction_swimlane_android_smoke: {}
+      - run_network_expansion_swimlane_ios_smoke: {}
+      - run_network_expansion_swimlane_android_smoke: {}
+      - run_wallet_platform_swimlane_ios_smoke: {}
+      - run_wallet_platform_swimlane_android_smoke: {}
+      - run_tag_smoke_confirmations_redesigned_android: {}
+      - run_tag_smoke_confirmations_redesigned_ios: {}
+      - run_tag_flask_build_tests_ios: {}
+      - run_tag_flask_build_tests_android: {}
+      - run_tag_smoke_accounts_ios: {}
+      - run_tag_smoke_accounts_android: {}
+  run_single_e2e_ios_android_stage:
+    workflows:
+      - run_single_ios_e2e_test: {}
+      - run_single_android_e2e_test: {}
+  run_smoke_e2e_ios_android_stage:
+    workflows:
+      - run_ios_api_specs: {}
+      - run_trade_swimlane_ios_smoke: {}
+      # - run_trade_swimlane_android_smoke: {}
+      - run_network_abstraction_swimlane_ios_smoke: {}
+      # - run_network_abstraction_swimlane_android_smoke: {}
+      - run_network_expansion_swimlane_ios_smoke: {}
+      # - run_network_expansion_swimlane_android_smoke: {}
+      - run_wallet_platform_swimlane_ios_smoke: {}
+      # - run_wallet_platform_swimlane_android_smoke: {}
+      # - run_tag_smoke_confirmations_android: {}
+      - run_tag_smoke_identity_ios: {}
+      # - run_tag_smoke_identity_android: {}
+      - run_tag_smoke_confirmations_redesigned_ios: {}
+      - run_tag_smoke_multichain_api_ios: {}
+      - run_tag_smoke_accounts_ios: {}
+      # - run_tag_smoke_accounts_android: {}
+      # - run_tag_smoke_performance_ios: {}
+      # - run_tag_smoke_performance_android: {}
+      - run_tag_smoke_card_ios: {}
+      # - run_tag_smoke_card_android: {}
+  # The entire workflow is disabled as Android runs on GHA and iOS was already skipped due to a regression
+  # run_smoke_e2e_performance_ios_android_stage:
+    # workflows:
+      # - run_tag_smoke_performance_ios: {}
+      #- run_tag_smoke_performance_android: {}
+  # TODO: This stage does the same thing as build_smoke_e2e_ios_android_stage
+  build_regression_e2e_ios_android_stage:
+    abort_on_fail: true
+    workflows:
+      - build_ios_main_e2e:
+          run_if: '{{getenv "SKIP_IOS_BUILD" | eq "false"}}'
+      - build_android_main_e2e:
+          run_if: '{{getenv "SKIP_ANDROID_BUILD" | eq "false"}}'
+  run_regression_e2e_ios_android_stage:
+    workflows:
+      - ios_run_regression_confirmations_tests: {}
+      - ios_run_regression_wallet_platform_tests: {}
+      - ios_run_regression_trade_tests: {}
+      - ios_run_regression_network_abstraction_tests: {}
+      - ios_run_regression_network_expansion_tests: {}
+      - ios_run_regression_accounts_tests: {}
+      - ios_run_regression_ux_tests: {}
+      - ios_run_regression_assets_tests: {}
+      - android_run_regression_confirmations_tests: {}
+      - android_run_regression_wallet_platform_tests: {}
+      - android_run_regression_trade_tests: {}
+      - android_run_regression_network_abstraction_tests: {}
+      - android_run_regression_network_expansion_tests: {}
+      - android_run_regression_performance_tests: {}
+      - android_run_regression_assets_tests: {}
+      - android_run_regression_accounts_tests: {}
+      - android_run_regression_ux_tests: {}
+  run_release_e2e_ios_android_stage:
+    workflows:
+      - ios_run_regression_confirmations_tests: {}
+      - ios_run_regression_wallet_platform_tests: {}
+      - ios_run_regression_trade_tests: {}
+      - ios_run_regression_network_abstraction_tests: {}
+      - ios_run_regression_network_expansion_tests: {}
+      - ios_run_regression_accounts_tests: {}
+      - ios_run_regression_ux_tests: {}
+      - ios_run_regression_assets_tests: {}
+      - android_run_regression_confirmations_tests: {}
+      - android_run_regression_wallet_platform_tests: {}
+      - android_run_regression_trade_tests: {}
+      - android_run_regression_network_abstraction_tests: {}
+      - android_run_regression_network_expansion_tests: {}
+      - android_run_regression_performance_tests: {}
+      - android_run_regression_assets_tests: {}
+      - android_run_regression_accounts_tests: {}
+      - android_run_regression_ux_tests: {}
+      - run_ios_api_specs: {}
+      - run_trade_swimlane_ios_smoke: {}
+      - run_trade_swimlane_android_smoke: {}
+      - run_network_expansion_swimlane_ios_smoke: {}
+      - run_network_expansion_swimlane_android_smoke: {}
+      - run_network_abstraction_swimlane_ios_smoke: {}
+      - run_network_abstraction_swimlane_android_smoke: {}
+      - run_wallet_platform_swimlane_ios_smoke: {}
+      - run_wallet_platform_swimlane_android_smoke: {}
+      - run_tag_smoke_confirmations_redesigned_android: {}
+      - run_tag_smoke_confirmations_redesigned_ios: {}
+      - run_tag_upgrade_android: {}
+      - run_android_app_launch_times_appium_test: {}
+      - run_tag_smoke_multichain_api_ios: {}
+      - run_tag_smoke_accounts_ios: {}
+      - run_tag_smoke_accounts_android: {}
+      - run_tag_smoke_card_ios: {}
+      - run_tag_smoke_card_android: {}
+  build_regression_e2e_ios_gns_disabled_stage:
+    abort_on_fail: true
+    workflows:
+      - build_ios_main_e2e_gns_disabled:
+          run_if: '{{getenv "SKIP_IOS_BUILD" | eq "false"}}'
+  run_regression_e2e_ios_gns_disabled_stage:
+    workflows:
+      - ios_run_regression_network_abstraction_tests_gns_disabled: {}
+
+  report_results_stage:
+    workflows:
+      - run_testrail_update_automated_test_results: {}
+  # TODO: Remove this stage since it's not used anymore
+  run_e2e_ios_android_stage:
+    workflows:
+      - ios_e2e_test: {}
+      - android_e2e_test: {}
+  build_e2e_ios_android_stage:
+    workflows:
+      - build_android_qa: {}
+      - ios_e2e_build: {}
+      - android_e2e_build: {}
+  build_e2e_android_stage:
+    workflows:
+      - android_e2e_build: {}
+  run_e2e_android_stage:
+    workflows:
+      - android_e2e_test: {}
   notify:
     workflows:
       - notify_success: {}
+  app_launch_times_test_stage:
+    workflows:
+      - run_android_app_launch_times_appium_test: {}
+      # - run_ios_app_launch_times_appium_test: {}
+  app_upgrade_test_stage:
+    workflows:
+      - run_tag_upgrade_android: {}
   release_notify:
     workflows:
       - release_announcing_stores: {}
+  build_e2e_flask_ios_android:
+    workflows:
+      - build_android_flask_e2e: {}
+      - build_ios_flask_e2e: {}
+  # TODO: Remove this workflow since it's not used anymore
+  run_e2e_flask_ios_android:
+    workflows:
+      - run_flask_e2e_android: {}
+      - run_flask_e2e_ios: {}
   create_build_flask_release:
     workflows:
       - build_android_flask_release: {}
@@ -642,7 +893,152 @@ workflows:
                 echo 'weew - everything passed!'
           title: All Tests Passed
           is_always_run: false
-        
+  # E2E Steps
+  ### This workflow uses a flag (TEST_SUITE) that defines the specific set of tests to be run.
+  ## in this instance Regression. In future iterations we can rename to ios_test_suite_selection & android_test_suite_selection
+  ios_build_regression_tests:
+    after_run:
+      - ios_e2e_build
+  ios_run_regression_confirmations_tests:
+    envs:
+      - TEST_SUITE_TAG: 'RegressionConfirmations'
+    after_run:
+      - ios_e2e_test
+  ios_run_regression_wallet_platform_tests:
+    envs:
+      - TEST_SUITE_TAG: 'RegressionWalletPlatform'
+    after_run:
+      - ios_e2e_test
+  ios_run_regression_trade_tests:
+    envs:
+      - TEST_SUITE_TAG: 'RegressionTrade'
+    after_run:
+      - ios_e2e_test
+  ios_run_regression_network_abstraction_tests:
+    envs:
+      - TEST_SUITE_TAG: 'RegressionNetworkAbstractions'
+      - MM_REMOVE_GLOBAL_NETWORK_SELECTOR: 'true'
+    after_run:
+      - ios_e2e_test
+  ios_run_regression_network_abstraction_tests_gns_disabled:
+    envs:
+      - TEST_SUITE_TAG: 'RegressionNetworkAbstractions'
+      - MM_REMOVE_GLOBAL_NETWORK_SELECTOR: 'false'
+    after_run:
+      - ios_e2e_test
+  ios_run_regression_network_expansion_tests:
+    envs:
+      - TEST_SUITE_TAG: 'RegressionNetworkExpansion'
+    after_run:
+      - ios_e2e_test
+  ios_run_regression_performance_tests:
+    envs:
+      - TEST_SUITE_TAG: 'RegressionPerformance'
+    after_run:
+      - ios_e2e_test
+  ios_run_regression_accounts_tests:
+    envs:
+      - TEST_SUITE_TAG: 'RegressionAccounts'
+    after_run:
+      - ios_e2e_test
+  ios_run_regression_assets_tests:
+    envs:
+      - TEST_SUITE_TAG: 'RegressionAssets'
+    after_run:
+      - ios_e2e_test
+  ios_run_regression_ux_tests:
+    envs:
+      - TEST_SUITE_TAG: 'RegressionWalletUX'
+    after_run:
+      - ios_e2e_test
+  android_build_regression_tests:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: elite-xl
+    after_run:
+      - android_e2e_build
+  android_run_regression_confirmations_tests:
+    meta:
+        bitrise.io:
+          stack: linux-docker-android-22.04
+          machine_type_id: elite-xl
+    envs:
+      - TEST_SUITE_TAG: 'RegressionConfirmations'
+    after_run:
+      - android_e2e_test
+  android_run_regression_wallet_platform_tests:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: elite-xl
+    envs:
+      - TEST_SUITE_TAG: 'RegressionWalletPlatform'
+    after_run:
+      - android_e2e_test
+  android_run_regression_trade_tests:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: elite-xl
+    envs:
+      - TEST_SUITE_TAG: 'RegressionTrade'
+    after_run:
+      - android_e2e_test
+  android_run_regression_network_abstraction_tests:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: elite-xl
+    envs:
+      - TEST_SUITE_TAG: 'RegressionNetworkAbstractions'
+    after_run:
+      - android_e2e_test
+  android_run_regression_network_expansion_tests:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: elite-xl
+    envs:
+      - TEST_SUITE_TAG: 'RegressionNetworkExpansion'
+    after_run:
+      - android_e2e_test
+  android_run_regression_performance_tests:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: elite-xl
+    envs:
+      - TEST_SUITE_TAG: 'RegressionPerformance'
+    after_run:
+      - android_e2e_test
+  android_run_regression_accounts_tests:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: elite-xl
+    envs:
+      - TEST_SUITE_TAG: 'RegressionAccounts'
+    after_run:
+      - android_e2e_test
+  android_run_regression_ux_tests:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: elite-xl
+    envs:
+      - TEST_SUITE_TAG: 'RegressionWalletUX'
+    after_run:
+      - android_e2e_test
+  android_run_regression_assets_tests:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: elite-xl
+    envs:
+      - TEST_SUITE_TAG: 'RegressionAssets'
+    after_run:
+      - android_e2e_test
   download_production_qa_apk:
     steps:
       - script@1:
@@ -652,6 +1048,717 @@ workflows:
                 #!/usr/bin/env bash
                 ./scripts/download-android-qa-app.sh
                 # APK_PATH is already set by the download script using envman
+  build_flask_e2e_android:
+    after_run:
+      - android_flask_e2e_build
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: elite-xl
+  # TODO: Remove this workflow since it's not used anymore
+  run_flask_e2e_android:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: elite-xl
+    envs:
+      - METAMASK_BUILD_TYPE: 'flask'
+    after_run:
+      - android_e2e_test
+  build_flask_e2e_ios:
+    envs:
+      - COMMAND_YARN: 'build:ios:flask:e2e'
+    after_run:
+      - ios_e2e_build
+  # TODO: Remove this workflow since it's not used anymore
+  run_flask_e2e_ios:
+    envs:
+      - METAMASK_BUILD_TYPE: 'flask'
+    after_run:
+      - ios_e2e_test
+  run_tag_upgrade_android:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: elite-xl
+    before_run:
+      - setup
+      - prep_environment
+      - download_production_qa_apk
+    after_run:
+      -  wdio_android_e2e_test
+    envs:
+      - CUCUMBER_TAG_EXPRESSION: '@upgrade and @androidApp'
+      - TEST_TYPE: 'upgrade'
+      - NEW_BUILD_STRING: 'MetaMask v$VERSION_NAME ($VERSION_NUMBER)' # this is the build string for the new build that was generated by build_android_qa
+    steps:
+      - script@1:
+          title: Set Build Strings
+          inputs:
+            - content: |
+                envman add --key PRODUCTION_BUILD_STRING --value "MetaMask v${PRODUCTION_BUILD_NAME} (${PRODUCTION_BUILD_NUMBER})"
+
+                BITRISE_GIT_BRANCH="qa-release"
+                VERSION_NAME="$PRODUCTION_BUILD_NAME" #  This value (PRODUCTION_BUILD_NAME) comes from the script to download the production build
+                VERSION_NUMBER="$PRODUCTION_BUILD_NUMBER" # This value (PRODUCTION_BUILD_NUMBER) comes from the script to download the production build
+                echo "Using qa-release with production version: $VERSION_NAME ($VERSION_NUMBER)"
+
+                CUSTOM_ID="$BITRISE_GIT_BRANCH-$VERSION_NAME-$VERSION_NUMBER"
+                CUSTOM_ID=${CUSTOM_ID////-}
+
+                #### The UPLOAD_APK_PATH is the path to the apk file that was downloaded by the download_production_qa_apk step
+                echo "apk path: $UPLOAD_APK_PATH"
+                RESPONSE=$(curl -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" \
+                    -X POST "https://api-cloud.browserstack.com/app-automate/upload" \
+                    -F "file=@$UPLOAD_APK_PATH" \
+                    -F 'data={"custom_id": "'$CUSTOM_ID'"}')
+
+                # Extract app_url
+                APP_URL=$(echo "$RESPONSE" | jq -r '.app_url')
+
+                # Set the environment variable
+                envman add --key PRODUCTION_APP_URL --value "$APP_URL"
+
+                # Debug output
+                echo "Response: $RESPONSE"
+                echo "APP_URL: $APP_URL"
+                echo "PRODUCTION_APP_URL: $PRODUCTION_APP_URL"
+
+  build_ios_multichain_permissions_e2e:
+    after_run:
+      - ios_e2e_build
+      # - android_e2e_build
+  build_android_multichain_permissions_e2e:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: elite-xl
+    after_run:
+      - android_e2e_build
+  run_android_app_launch_times_appium_test:
+    envs:
+      - TEST_SUITE_FOLDER: './wdio/features/Performance/*'
+      - TEST_TYPE: 'performance'
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: elite-xl
+    after_run:
+      - wdio_android_e2e_test
+
+  ### Report automated test results to TestRail
+  run_testrail_update_automated_test_results:
+    before_run:
+      - code_setup
+    steps:
+      - script@1:
+          title: 'Add Automated Test Results to TestRail'
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                echo 'REPORT AUTOMATED TEST RESULTS TO TESTRAIL'
+                node ./scripts/testrail/testrail.api.js
+
+  run_ios_app_launch_times_appium_test:
+    envs:
+      - TEST_SUITE_FOLDER: './wdio/features/Performance/*'
+      - TEST_TYPE: 'performance'
+    after_run:
+      - wdio_ios_e2e_test
+
+  ### Separating workflows so they run concurrently during smoke runs
+  run_tag_smoke_multichain_api_ios:
+    envs:
+      - TEST_SUITE_TAG: '.*SmokeMultiChainAPI.*'
+    after_run:
+      - ios_e2e_test
+
+  run_network_expansion_swimlane_ios_smoke:
+    envs:
+      - TEST_SUITE_TAG: '.*NetworkExpansion.*'
+    after_run:
+      - ios_e2e_test
+  run_network_expansion_swimlane_android_smoke:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: elite-xl
+    envs:
+      - TEST_SUITE_TAG: '.*NetworkExpansion.*'
+    after_run:
+      - android_e2e_test
+
+  run_wallet_platform_swimlane_ios_smoke:
+    envs:
+      - TEST_SUITE_TAG: '.*SmokeWalletPlatform.*'
+    after_run:
+      - ios_e2e_test
+  run_wallet_platform_swimlane_android_smoke:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: elite-xl
+    envs:
+      - TEST_SUITE_TAG: '.*SmokeWalletPlatform.*'
+    after_run:
+      - android_e2e_test
+
+  run_network_abstraction_swimlane_ios_smoke:
+    envs:
+      - TEST_SUITE_TAG: '.*SmokeNetworkAbstraction.*'
+    after_run:
+      - ios_e2e_test
+  run_network_abstraction_swimlane_android_smoke:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: elite-xl
+    envs:
+      - TEST_SUITE_TAG: '.*SmokeNetworkAbstraction.*'
+    after_run:
+      - android_e2e_test
+  run_trade_swimlane_ios_smoke:
+    envs:
+      - TEST_SUITE_TAG: '.*SmokeTrade.*'
+    after_run:
+      - ios_e2e_test
+  run_trade_swimlane_android_smoke:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: elite-xl
+    envs:
+      - TEST_SUITE_TAG: '.*SmokeTrade.*'
+    after_run:
+      - android_e2e_test
+  run_ios_api_specs:
+    after_run:
+      - ios_api_specs
+  run_tag_smoke_confirmations_redesigned_android:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: elite-xl
+    envs:
+      - TEST_SUITE_TAG: 'SmokeConfirmationsRedesigned '
+    after_run:
+      - android_e2e_test
+  run_tag_smoke_confirmations_redesigned_ios:
+    envs:
+      - TEST_SUITE_TAG: 'SmokeConfirmationsRedesigned'
+    after_run:
+      - ios_e2e_test
+  run_tag_smoke_performance_ios:
+    envs:
+      - TEST_SUITE_TAG: '.*SmokePerformance.*'
+    after_run:
+      - ios_e2e_test
+  run_tag_smoke_performance_android:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: elite-xl
+    envs:
+      - TEST_SUITE_TAG: '.*SmokePerformance.*'
+    after_run:
+      - android_e2e_test
+  run_tag_multichain_permissions_ios:
+    envs:
+      - TEST_SUITE_TAG: '.*SmokeMultiChainPermissions.*'
+    after_run:
+      - ios_e2e_test
+  run_tag_multichain_permissions_android:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: elite-xl
+    envs:
+      - TEST_SUITE_TAG: '.*SmokeMultiChainPermissions.*'
+    after_run:
+      - android_e2e_test
+  run_tag_flask_build_tests_ios:
+    envs:
+      - TEST_SUITE_TAG: '.*FlaskBuildTests.*'
+    after_run:
+      - ios_e2e_test
+  run_tag_flask_build_tests_android:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: elite-xl
+    envs:
+      - TEST_SUITE_TAG: '.*FlaskBuildTests.*'
+    after_run:
+      - android_e2e_test
+  run_tag_smoke_identity_ios:
+    envs:
+      - TEST_SUITE_TAG: 'SmokeIdentity'
+    after_run:
+      - ios_e2e_test
+  run_tag_smoke_identity_android:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: elite-xl
+    envs:
+      - TEST_SUITE_TAG: 'SmokeIdentity'
+    after_run:
+      - android_e2e_test
+  run_tag_smoke_accounts_ios:
+    envs:
+      - TEST_SUITE_TAG: 'SmokeAccounts'
+    after_run:
+      - ios_e2e_test
+  run_tag_smoke_accounts_android:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: elite-xl
+    envs:
+      - TEST_SUITE_TAG: 'SmokeAccounts'
+    after_run:
+      - android_e2e_test
+  run_tag_smoke_card_ios:
+    envs:
+      - TEST_SUITE_TAG: 'SmokeCard'
+    after_run:
+      - ios_e2e_test
+  run_tag_smoke_card_android:
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: elite-xl
+    envs:
+      - TEST_SUITE_TAG: 'SmokeCard'
+    after_run:
+      - android_e2e_test
+  android_e2e_build:
+    envs:
+      - KEYSTORE_URL: $BITRISEIO_ANDROID_KEYSTORE_URL
+      - KEYSTORE_PATH: 'android/keystores/release.keystore'
+      - BUILD_COMMAND: 'yarn build:android:main:e2e'
+    after_run:
+      - _android_e2e_build_template
+    meta:
+      bitrise.io:
+        machine_type_id: elite-xl
+        stack: linux-docker-android-22.04
+  # TODO: Consolidate android_e2e_build and android_flask_e2e_build once _android_e2e_build_template and _android_build_template is consolidated
+  android_flask_e2e_build:
+    envs:
+      - KEYSTORE_URL: $BITRISEIO_ANDROID_FLASK_KEYSTORE_URL_URL
+      - KEYSTORE_PATH: 'android/keystores/flaskRelease.keystore'
+      - BUILD_COMMAND: 'yarn build:android:flask:e2e'
+    after_run:
+      - _android_e2e_build_template
+    meta:
+      bitrise.io:
+        machine_type_id: elite-xl
+        stack: linux-docker-android-22.04
+  run_single_android_e2e_test:
+    run_if: '{{ or (ne "$E2E_TEST_FILE" "") (ne "$TEST_SUITE_TAG" "") }}'
+    after_run:
+      - android_e2e_test
+    meta:
+      bitrise.io:
+        machine_type_id: elite-xl
+        stack: linux-docker-android-22.04
+
+  run_single_ios_e2e_test:
+    run_if: '{{ or (ne "$E2E_TEST_FILE" "") (ne "$TEST_SUITE_TAG" "") }}'
+    after_run:
+      - ios_e2e_test
+
+  android_e2e_test:
+    before_run:
+      - setup
+      - prep_environment
+    after_run:
+      - notify_failure
+    steps:
+      - restore-gradle-cache@2: {}
+      - restore-cache@2:
+          title: Restore Android PR Build Cache (if build was skipped)
+          run_if: '{{getenv "SKIP_ANDROID_BUILD" | eq "true"}}'
+          inputs:
+            - key: '{{ getenv "ANDROID_PR_BUILD_CACHE_KEY" }}'
+      - script@1:
+          title: Copy Android build from cache (if build was skipped)
+          run_if: '{{getenv "SKIP_ANDROID_BUILD" | eq "true"}}'
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                echo "Copying Android build from cache..."
+                
+                if [ -d "/tmp/android-cache/build/outputs" ]; then
+                    echo "Restoring Android build outputs from cache..."
+                    mkdir -p android/app/build/outputs
+                    cp -r /tmp/android-cache/build/outputs/* android/app/build/outputs/
+                    echo "✅ Android build artifacts restored from cache"
+                    
+                    echo "Restored files:"
+                    find android/app/build/outputs -type f -name "*.apk" -o -name "*.aab" | head -5
+                else
+                    echo "❌ Cache directory /tmp/android-cache/build/outputs not found"
+                    echo "Cache may not have been restored properly"
+                fi
+      - pull-intermediate-files@1:
+          inputs:
+            - artifact_sources: .*
+          title: Pull Android build
+      - script@1:
+          title: Copy Android build for Detox
+          run_if: '{{getenv "SKIP_ANDROID_BUILD" | eq "false"}}'
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -ex
+
+                # Create directories for Detox
+                mkdir -p "$BITRISE_SOURCE_DIR/android/app/build/outputs"
+
+                # Copy saved files for Detox usage
+                # INTERMEDIATE_ANDROID_BUILD_DIR is the cached directory from android_e2e_build's "Save Android build" step
+                cp -r "$INTERMEDIATE_ANDROID_BUILD_DIR" "$BITRISE_SOURCE_DIR/android/app/build"
+      - restore-cache@2:
+          title: Restore cache node_modules
+          inputs:
+            - key: node_modules-{{ .OS }}-{{ .Arch }}-{{ getenv "BRANCH_COMMIT_HASH" }}
+      - script@1:
+          title: Install foundry
+          inputs:
+            - content: |-
+                #!/bin/bash
+                yarn install:foundryup
+      - avd-manager@1:
+          inputs:
+            - api_level: '34'
+            - abi: 'x86_64'
+            - create_command_flags: --sdcard 8192M
+            - start_command_flags: -read-only
+            - profile: pixel_5
+      - wait-for-android-emulator@1: {}
+      - script@1:
+          title: Run detox test
+          timeout: 1800
+          is_always_run: false
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                export METAMASK_ENVIRONMENT='dev'
+                 node -v
+                if [ -n "${E2E_TEST_FILE:-}" ]; then
+                  echo "[INFO] Running only specified E2E_TEST_FILE(s): $E2E_TEST_FILE"
+                  IGNORE_BOXLOGS_DEVELOPMENT="true" yarn test:e2e:android:run:qa-release $E2E_TEST_FILE
+                elif [ -n "${TEST_SUITE_TAG:-}" ]; then
+                  echo "[INFO] Running tests matching TEST_SUITE_TAG: $TEST_SUITE_TAG"
+                  ./scripts/run-e2e-tags.sh
+                fi
+      - custom-test-results-export@1:
+          title: Export test results
+          is_always_run: true
+          is_skippable: true
+          inputs:
+            - base_path: $BITRISE_SOURCE_DIR/e2e/reports/
+            - test_name: E2E Tests
+            - search_pattern: $BITRISE_SOURCE_DIR/e2e/reports/junit.xml
+      - deploy-to-bitrise-io@2.2.3:
+          title: Deploy test report files
+          is_always_run: true
+          is_skippable: true
+      - script@1:
+          title: Copy screenshot files
+          is_always_run: true
+          run_if: .IsBuildFailed
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -ex
+                cp -r "$BITRISE_SOURCE_DIR/artifacts"  "$BITRISE_DEPLOY_DIR"
+      - deploy-to-bitrise-io@2.3:
+          title: Deploy test screenshots
+          is_always_run: true
+          run_if: .IsBuildFailed
+          inputs:
+            - deploy_path: $BITRISE_DEPLOY_DIR
+            - is_compress: true
+            - zip_name: E2E_Android_Failure_Artifacts
+      - script@1:
+          title: Copy performance results
+          is_always_run: true
+          run_if: '{{getenv "TEST_SUITE_TAG" | eq ".*SmokePerformance.*"}}'
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -ex
+                # Create performance results directory
+                mkdir -p "$BITRISE_DEPLOY_DIR/performance-results"
+                
+                # Copy performance JSON files if they exist
+                if [ -f "$BITRISE_SOURCE_DIR/e2e/specs/performance/reports/account-list-load-testing-performance-results.json" ]; then
+                  cp "$BITRISE_SOURCE_DIR/e2e/specs/performance/reports/account-list-load-testing-performance-results.json" "$BITRISE_DEPLOY_DIR/performance-results/"
+                  echo "Copied account-list-load-testing-performance-results.json"
+                fi
+                
+                if [ -f "$BITRISE_SOURCE_DIR/e2e/specs/performance/reports/network-list-load-testing-performance-results.json" ]; then
+                  cp "$BITRISE_SOURCE_DIR/e2e/specs/performance/reports/network-list-load-testing-performance-results.json" "$BITRISE_DEPLOY_DIR/performance-results/"
+                  echo "Copied network-list-load-testing-performance-results.json"
+                fi
+                
+                if [ -f "$BITRISE_SOURCE_DIR/e2e/specs/performance/reports/switching-accounts-to-dismiss-load-testing-performance-results.json" ]; then
+                  cp "$BITRISE_SOURCE_DIR/e2e/specs/performance/reports/switching-accounts-to-dismiss-load-testing-performance-results.json" "$BITRISE_DEPLOY_DIR/performance-results/"
+                  echo "Copied switching-accounts-to-dismiss-load-testing-performance-results.json"
+                fi
+      - deploy-to-bitrise-io@2.3:
+          title: Deploy performance results
+          is_always_run: true
+          run_if: '{{getenv "TEST_SUITE_TAG" | eq ".*SmokePerformance.*"}}'
+          inputs:
+            - deploy_path: $BITRISE_DEPLOY_DIR/performance-results
+            - is_compress: true
+            - zip_name: E2E_Performance_Results
+    meta:
+      bitrise.io:
+        machine_type_id: elite-xl
+        stack: linux-docker-android-22.04
+
+  # Performance-specific Android E2E test workflow
+  android_e2e_test_performance:
+    before_run:
+      - setup
+      - prep_environment
+    after_run:
+      - notify_failure
+    steps:
+      - restore-gradle-cache@2: {}
+      - pull-intermediate-files@1:
+          inputs:
+            - artifact_sources: .*
+          title: Pull Android build
+      - script@1:
+          title: Copy Android build for Detox
+          run_if: '{{getenv "SKIP_ANDROID_BUILD" | eq "false"}}'
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -ex
+
+                # Create directories for Detox
+                mkdir -p "$BITRISE_SOURCE_DIR/android/app/build/outputs"
+
+                # Copy saved files for Detox usage
+                # INTERMEDIATE_ANDROID_BUILD_DIR is the cached directory from android_e2e_build's "Save Android build" step
+                cp -r "$INTERMEDIATE_ANDROID_BUILD_DIR" "$BITRISE_SOURCE_DIR/android/app/build"
+      - restore-cache@2:
+          title: Restore cache node_modules
+          inputs:
+            - key: node_modules-{{ .OS }}-{{ .Arch }}-{{ getenv "BRANCH_COMMIT_HASH" }}
+      - script@1:
+          title: Install foundry
+          inputs:
+            - content: |-
+                #!/bin/bash
+                yarn install:foundryup
+      - avd-manager@1:
+          inputs:
+            - api_level: '34'
+            - abi: 'x86_64'
+            - create_command_flags: --sdcard 8192M
+            - start_command_flags: -read-only
+            - profile: pixel_5
+      - wait-for-android-emulator@1: {}
+      - script@1:
+          title: Run detox test
+          timeout: 1200
+          is_always_run: false
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+
+                export METAMASK_ENVIRONMENT='e2e'
+
+                if [ -n "${E2E_TEST_FILE:-}" ]; then
+                  echo "[INFO] Running only specified E2E_TEST_FILE(s): $E2E_TEST_FILE"
+                  IGNORE_BOXLOGS_DEVELOPMENT="true" yarn test:e2e:android:$METAMASK_BUILD_TYPE:prod $E2E_TEST_FILE
+                elif [ -n "${TEST_SUITE_TAG:-}" ]; then
+                  echo "[INFO] Running tests matching TEST_SUITE_TAG: $TEST_SUITE_TAG"
+                  ./scripts/run-e2e-tags.sh
+                fi
+      - custom-test-results-export@1:
+          title: Export test results
+          is_always_run: true
+          is_skippable: true
+          inputs:
+            - base_path: $BITRISE_SOURCE_DIR/e2e/reports/
+            - test_name: E2E Tests
+            - search_pattern: $BITRISE_SOURCE_DIR/e2e/reports/junit.xml
+      - deploy-to-bitrise-io@2.2.3:
+          title: Deploy test report files
+          is_always_run: true
+          is_skippable: true
+      - script@1:
+          title: Copy screenshot files
+          is_always_run: true
+          run_if: .IsBuildFailed
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -ex
+                cp -r "$BITRISE_SOURCE_DIR/artifacts"  "$BITRISE_DEPLOY_DIR"
+      - deploy-to-bitrise-io@2.3:
+          title: Deploy test screenshots
+          is_always_run: true
+          run_if: .IsBuildFailed
+          inputs:
+            - deploy_path: $BITRISE_DEPLOY_DIR
+            - is_compress: true
+            - zip_name: E2E_Android_Failure_Artifacts
+      - script@1:
+          title: Copy performance results
+          is_always_run: true
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -ex
+                # Create performance results directory
+                mkdir -p "$BITRISE_DEPLOY_DIR/performance-results"
+                
+                # Copy performance JSON files if they exist
+                if [ -f "$BITRISE_SOURCE_DIR/e2e/specs/performance/reports/account-list-load-testing-performance-results.json" ]; then
+                  cp "$BITRISE_SOURCE_DIR/e2e/specs/performance/reports/account-list-load-testing-performance-results.json" "$BITRISE_DEPLOY_DIR/performance-results/"
+                  echo "Copied account-list-load-testing-performance-results.json"
+                fi
+                
+                if [ -f "$BITRISE_SOURCE_DIR/e2e/specs/performance/reports/network-list-load-testing-performance-results.json" ]; then
+                  cp "$BITRISE_SOURCE_DIR/e2e/specs/performance/reports/network-list-load-testing-performance-results.json" "$BITRISE_DEPLOY_DIR/performance-results/"
+                  echo "Copied network-list-load-testing-performance-results.json"
+                fi
+                
+                if [ -f "$BITRISE_SOURCE_DIR/e2e/specs/performance/reports/switching-accounts-to-dismiss-load-testing-performance-results.json" ]; then
+                  cp "$BITRISE_SOURCE_DIR/e2e/specs/performance/reports/switching-accounts-to-dismiss-load-testing-performance-results.json" "$BITRISE_DEPLOY_DIR/performance-results/"
+                  echo "Copied switching-accounts-to-dismiss-load-testing-performance-results.json"
+                fi
+      - deploy-to-bitrise-io@2.3:
+          title: Deploy performance results
+          is_always_run: true
+          inputs:
+            - deploy_path: $BITRISE_DEPLOY_DIR/performance-results
+            - is_compress: true
+            - zip_name: E2E_Performance_Results
+    meta:
+      bitrise.io:
+        machine_type_id: elite-xl
+        stack: linux-docker-android-22.04
+
+  ios_api_specs:
+    before_run:
+      - setup
+      - code_setup
+      - install_applesimutils
+      - prep_environment
+    after_run:
+      - notify_failure
+    steps:
+      - restore-cache@2:
+          title: Restore iOS PR Build Cache (if build was skipped)
+          run_if: '{{getenv "SKIP_IOS_BUILD" | eq "true"}}'
+          inputs:
+            - key: '{{ getenv "IOS_PR_BUILD_CACHE_KEY" }}'
+      - script@1:
+          title: Copy iOS build from cache (if build was skipped)
+          run_if: '{{getenv "SKIP_IOS_BUILD" | eq "true"}}'
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                echo "Copying iOS build from cache..."
+                
+                # Check if cached build products exist
+                if [ -d "ios/build/Build/Products/Release-iphonesimulator" ]; then
+                    echo "✅ iOS build artifacts found in cache"
+                    echo "Build products directory contents:"
+                    ls -la ios/build/Build/Products/Release-iphonesimulator/ | head -5
+                else
+                    echo "❌ iOS build products not found in cache"
+                    mkdir -p ios/build/Build/Products/Release-iphonesimulator
+                fi
+                
+                # Check if cached Detox artifacts exist
+                if [ -d "../Library/Detox/ios" ]; then
+                    echo "✅ Detox iOS artifacts found in cache"
+                    echo "Detox directory contents:"
+                    ls -la ../Library/Detox/ios/ | head -5
+                else
+                    echo "❌ Detox iOS artifacts not found in cache"
+                    mkdir -p ../Library/Detox/ios
+                fi
+                
+                echo "iOS build artifacts restored from cache"
+      - pull-intermediate-files@1:
+          inputs:
+            - artifact_sources: .*
+          title: Pull iOS build
+      - script@1:
+          title: Copy iOS build for Detox
+          run_if: '{{getenv "SKIP_IOS_BUILD" | eq "false"}}'
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -ex
+
+                # Create directories for Detox
+                mkdir -p "$BITRISE_SOURCE_DIR/ios/build/Build/Products"
+                mkdir -p "$BITRISE_SOURCE_DIR/../Library/Detox/ios"
+
+                # Copy saved files for Detox usage
+                # INTERMEDIATE_IOS_BUILD_DIR & INTERMEDIATE_IOS_DETOX_DIR are the cached directories by ios_e2e_build's "Save iOS build" step
+                cp -r "$INTERMEDIATE_IOS_BUILD_DIR" "$BITRISE_SOURCE_DIR/ios/build/Build/Products"
+                cp -r "$INTERMEDIATE_IOS_DETOX_DIR" "$BITRISE_SOURCE_DIR/../Library/Detox"
+      # - restore-cocoapods-cache@2: {}
+      - restore-cache@2:
+          title: Restore cache node_modules
+          inputs:
+            - key: node_modules-{{ .OS }}-{{ .Arch }}-{{ getenv "BRANCH_COMMIT_HASH" }}
+      - script@1:
+          title: Install foundry
+          inputs:
+            - content: |-
+                #!/bin/bash
+                yarn install:foundryup
+      - certificate-and-profile-installer@1: {}
+      - set-xcode-build-number@1:
+          inputs:
+            - build_short_version_string: $VERSION_NAME
+            - plist_path: $PROJECT_LOCATION_IOS/MetaMask/Info.plist
+      - script:
+          inputs:
+            - content: |-
+                # Add cache directory to environment variable
+                envman add --key BREW_APPLESIMUTILS --value "$(brew --cellar)/applesimutils"
+                envman add --key BREW_OPT_APPLESIMUTILS --value "/usr/local/opt/applesimutils"
+                brew tap wix/brew
+          title: Set Env Path for caching deps
+      - script@1:
+          title: Run detox test
+          timeout: 1800
+          is_always_run: false
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                yarn test:api-specs --retries 1
+      - script@1:
+          is_always_run: true
+          is_skippable: false
+          title: Add tests reports to Bitrise
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                cp -r $BITRISE_SOURCE_DIR/html-report/index.html $BITRISE_HTML_REPORT_DIR/
+      - deploy-to-bitrise-io@2.2.3:
+          is_always_run: true
+          is_skippable: false
+          inputs:
+            - deploy_path: $BITRISE_HTML_REPORT_DIR
+          title: Deploy test report files
 
   pr_check_build_cache:
     steps:
@@ -742,9 +1849,444 @@ workflows:
                 IOS_PR_BUILD_CACHE_KEY
                 ANDROID_PR_BUILD_CACHE_KEY
 
+  ios_e2e_build:
+    before_run:
+      - install_applesimutils
+      - code_setup
+      - set_commit_hash
+    after_run:
+      - notify_failure
+    steps:
+      - script@1:
+          title: Generating ccache key using native folder checksum
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                ./scripts/cache/set-cache-envs.sh ios
+      - certificate-and-profile-installer@1: {}
+      - script:
+          inputs:
+            - content: |-
+                # Add cache directory to environment variable
+                envman add --key BREW_APPLESIMUTILS --value "$(brew --cellar)/applesimutils"
+                envman add --key BREW_OPT_APPLESIMUTILS --value "/usr/local/opt/applesimutils"
+                brew tap wix/brew
+          title: Set Env Path for caching deps
+      - script@1:
+          title: Install CCache & symlink
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                brew install ccache with HOMEBREW_NO_DEPENDENTS_CHECK=1
+                ln -s $(which ccache) /usr/local/bin/gcc
+                ln -s $(which ccache) /usr/local/bin/g++
+                ln -s $(which ccache) /usr/local/bin/cc
+                ln -s $(which ccache) /usr/local/bin/c++
+                ln -s $(which ccache) /usr/local/bin/clang
+                ln -s $(which ccache) /usr/local/bin/clang++
+      - restore-cache@2:
+          title: Restore CCache
+          inputs:
+            - key: '{{ getenv "CCACHE_KEY" }}'
+      - script@1:
+          title: Set skip ccache upload
+          run_if: '{{ enveq "BITRISE_CACHE_HIT" "exact" }}'
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                envman add --key SKIP_CCACHE_UPLOAD --value "true"
+      - script@1:
+          title: Run detox build
+          timeout: 1800
+          is_always_run: true
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                ./scripts/cache/setup-ccache.sh
+                node -v
+                if [ -n "$COMMAND_YARN" ]; then
+                    GIT_BRANCH=$BITRISE_GIT_BRANCH yarn "$COMMAND_YARN"
+                else
+                    echo "No COMMAND_YARN provided. Running yarn build:ios:main:e2e..."
+                    yarn build:ios:main:e2e
+                fi
+      - save-cocoapods-cache@1: {}
+      - save-cache@1:
+          title: Save CCache
+          run_if: '{{not (enveq "SKIP_CCACHE_UPLOAD" "true")}}'
+          inputs:
+            - key: '{{ getenv "CCACHE_KEY" }}'
+            - paths: |-
+                ccache
+      - save-cache@1:
+          title: Save iOS PR Build Cache
+          inputs:
+            - key: '{{ getenv "IOS_PR_BUILD_CACHE_KEY" }}'
+            - paths: |-
+                ios/build/Build/Products/Release-iphonesimulator
+                ../Library/Detox/ios
+      - script@1:
+          title: Save last successful build commit
+          run_if: '{{getenv "GITHUB_PR_NUMBER" | ne ""}}'
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                # Create a marker file with the current commit
+                mkdir -p /tmp/last-build-commit
+                echo "$(git rev-parse HEAD 2>/dev/null || echo ${BITRISE_GIT_COMMIT})" > /tmp/last-build-commit/commit
+                echo "Build completed successfully at $(date)" >> /tmp/last-build-commit/commit
+      - save-cache@1:
+          title: Save last successful build commit marker
+          run_if: '{{getenv "GITHUB_PR_NUMBER" | ne ""}}'
+          inputs:
+            - key: 'last-e2e-build-commit-pr-{{ getenv "GITHUB_PR_NUMBER" }}'
+            - paths: /tmp/last-build-commit
+      - deploy-to-bitrise-io@2.2.3:
+          inputs:
+            - pipeline_intermediate_files: |-
+                ios/build/Build/Products/Release-iphonesimulator:INTERMEDIATE_IOS_BUILD_DIR
+                ../Library/Detox/ios:INTERMEDIATE_IOS_DETOX_DIR
+          title: Save iOS build
+      - save-cache@1:
+          title: Save node_modules
+          inputs:
+            - key: node_modules-{{ .OS }}-{{ .Arch }}-{{ getenv "BRANCH_COMMIT_HASH" }}
+            - paths: node_modules
+  ios_e2e_test:
+    before_run:
+      - setup
+      - code_setup
+      - install_applesimutils
+      - prep_environment
+    after_run:
+      - notify_failure
+    steps:
+      - restore-cache@2:
+          title: Restore iOS PR Build Cache (if build was skipped)
+          run_if: '{{getenv "SKIP_IOS_BUILD" | eq "true"}}'
+          inputs:
+            - key: '{{ getenv "IOS_PR_BUILD_CACHE_KEY" }}'
+      - script@1:
+          title: Copy iOS build from cache (if build was skipped)
+          run_if: '{{getenv "SKIP_IOS_BUILD" | eq "true"}}'
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                echo "Copying iOS build from cache..."
+                
+                # Check if cached build products exist
+                if [ -d "ios/build/Build/Products/Release-iphonesimulator" ]; then
+                    echo "✅ iOS build artifacts found in cache"
+                    echo "Build products directory contents:"
+                    ls -la ios/build/Build/Products/Release-iphonesimulator/ | head -5
+                else
+                    echo "❌ iOS build products not found in cache"
+                    mkdir -p ios/build/Build/Products/Release-iphonesimulator
+                fi
+                
+                # Check if cached Detox artifacts exist
+                if [ -d "../Library/Detox/ios" ]; then
+                    echo "✅ Detox iOS artifacts found in cache"
+                    echo "Detox directory contents:"
+                    ls -la ../Library/Detox/ios/ | head -5
+                else
+                    echo "❌ Detox iOS artifacts not found in cache"
+                    mkdir -p ../Library/Detox/ios
+                fi
+                
+                echo "iOS build artifacts restored from cache"
+      - pull-intermediate-files@1:
+          inputs:
+            - artifact_sources: .*
+          title: Pull iOS build
+      - script@1:
+          title: Copy iOS build for Detox
+          run_if: '{{getenv "SKIP_IOS_BUILD" | eq "false"}}'
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -ex
+
+                # Create directories for Detox
+                mkdir -p "$BITRISE_SOURCE_DIR/ios/build/Build/Products"
+                mkdir -p "$BITRISE_SOURCE_DIR/../Library/Detox/ios"
+
+                # Copy saved files for Detox usage
+                # INTERMEDIATE_IOS_BUILD_DIR & INTERMEDIATE_IOS_DETOX_DIR are the cached directories by ios_e2e_build's "Save iOS build" step
+                cp -r "$INTERMEDIATE_IOS_BUILD_DIR" "$BITRISE_SOURCE_DIR/ios/build/Build/Products"
+                cp -r "$INTERMEDIATE_IOS_DETOX_DIR" "$BITRISE_SOURCE_DIR/../Library/Detox"
+      # - restore-cocoapods-cache@2: {}
+      - restore-cache@2:
+          title: Restore cache node_modules
+          inputs:
+            - key: node_modules-{{ .OS }}-{{ .Arch }}-{{ getenv "BRANCH_COMMIT_HASH" }}
+      - script@1:
+          title: Install foundry
+          inputs:
+            - content: |-
+                #!/bin/bash
+                yarn install:foundryup
+      - certificate-and-profile-installer@1: {}
+      - set-xcode-build-number@1:
+          inputs:
+            - build_short_version_string: $VERSION_NAME
+            - plist_path: $PROJECT_LOCATION_IOS/MetaMask/Info.plist
+      - script:
+          inputs:
+            - content: |-
+                # Add cache directory to environment variable
+                envman add --key BREW_APPLESIMUTILS --value "$(brew --cellar)/applesimutils"
+                envman add --key BREW_OPT_APPLESIMUTILS --value "/usr/local/opt/applesimutils"
+                brew tap wix/brew
+          title: Set Env Path for caching deps
+      - script@1:
+          title: Boot up simulator
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                xcrun simctl boot "iPhone 15 Pro" || true
+                xcrun simctl list | grep Booted
+      - script@1:
+          title: Run detox test
+          timeout: 1800
+          is_always_run: false
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+
+                # node -v
+                export METAMASK_ENVIRONMENT='dev'
+                export METAMASK_BUILD_TYPE=${METAMASK_BUILD_TYPE:-'main'}
+                # if [ "$METAMASK_BUILD_TYPE" = "flask" ]; then
+                # IS_TEST='true' METAMASK_BUILD_TYPE='flask' yarn test:e2e:ios:run:qa-release e2e/specs/flask/
+                # else
+                # ./scripts/run-e2e-tags.sh
+                # fi
+                if [ -n "${E2E_TEST_FILE:-}" ]; then
+                  echo "[INFO] Running only specified E2E_TEST_FILE(s): $E2E_TEST_FILE"
+                  IGNORE_BOXLOGS_DEVELOPMENT="true" yarn test:e2e:ios:run:qa-release $E2E_TEST_FILE
+                elif [ -n "${TEST_SUITE_TAG:-}" ]; then
+                  echo "[INFO] Running tests matching TEST_SUITE_TAG: $TEST_SUITE_TAG"
+                  ./scripts/run-e2e-tags.sh
+                fi
+      - custom-test-results-export@1:
+          is_always_run: true
+          is_skippable: false
+          title: Export test results
+          inputs:
+            - base_path: $BITRISE_SOURCE_DIR/e2e/reports/
+            - test_name: E2E Tests
+            - search_pattern: $BITRISE_SOURCE_DIR/e2e/reports/junit.xml
+      - deploy-to-bitrise-io@2.2.3:
+          is_always_run: true
+          is_skippable: true
+          title: Deploy test report files
+      - script@1:
+          is_always_run: true
+          run_if: .IsBuildFailed
+          title: Copy screenshot files
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -ex
+                cp -r "$BITRISE_SOURCE_DIR/artifacts"  "$BITRISE_DEPLOY_DIR"
+      - deploy-to-bitrise-io@2.3:
+          is_always_run: true
+          run_if: .IsBuildFailed
+          title: Deploy test screenshots
+          inputs:
+            - deploy_path: $BITRISE_DEPLOY_DIR
+            - is_compress: true
+            - zip_name: 'E2E_IOS_Failure_Artifacts'
+      - script@1:
+          title: Copy performance results
+          is_always_run: true
+          run_if: '{{getenv "TEST_SUITE_TAG" | eq ".*SmokePerformance.*"}}'
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -ex
+                # Create performance results directory
+                mkdir -p "$BITRISE_DEPLOY_DIR/performance-results"
+                
+                # Copy performance JSON files if they exist
+                if [ -f "$BITRISE_SOURCE_DIR/e2e/specs/performance/reports/account-list-load-testing-performance-results.json" ]; then
+                  cp "$BITRISE_SOURCE_DIR/e2e/specs/performance/reports/account-list-load-testing-performance-results.json" "$BITRISE_DEPLOY_DIR/performance-results/"
+                  echo "Copied account-list-load-testing-performance-results.json"
+                fi
+                
+                if [ -f "$BITRISE_SOURCE_DIR/e2e/specs/performance/reports/network-list-load-testing-performance-results.json" ]; then
+                  cp "$BITRISE_SOURCE_DIR/e2e/specs/performance/reports/network-list-load-testing-performance-results.json" "$BITRISE_DEPLOY_DIR/performance-results/"
+                  echo "Copied network-list-load-testing-performance-results.json"
+                fi
+                
+                if [ -f "$BITRISE_SOURCE_DIR/e2e/specs/performance/reports/switching-accounts-to-dismiss-load-testing-performance-results.json" ]; then
+                  cp "$BITRISE_SOURCE_DIR/e2e/specs/performance/reports/switching-accounts-to-dismiss-load-testing-performance-results.json" "$BITRISE_DEPLOY_DIR/performance-results/"
+                  echo "Copied switching-accounts-to-dismiss-load-testing-performance-results.json"
+                fi
+      - deploy-to-bitrise-io@2.3:
+          title: Deploy performance results
+          is_always_run: true
+          run_if: '{{getenv "TEST_SUITE_TAG" | eq ".*SmokePerformance.*"}}'
+          inputs:
+            - deploy_path: $BITRISE_DEPLOY_DIR/performance-results
+            - is_compress: true
+            - zip_name: E2E_Performance_Results
+    meta:
+      bitrise.io:
+        machine_type_id: elite-xl
+        stack: linux-docker-android-22.04
+
+  # Performance-specific iOS E2E test workflow
+  ios_e2e_test_performance:
+    before_run:
+      - setup
+      - install_applesimutils
+      - prep_environment
+    after_run:
+      - notify_failure
+    steps:
+      - pull-intermediate-files@1:
+          inputs:
+            - artifact_sources: .*
+          title: Pull iOS build
+      - script@1:
+          title: Copy iOS build for Detox
+          run_if: '{{getenv "SKIP_IOS_BUILD" | eq "false"}}'
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -ex
+
+                # Create directories for Detox
+                mkdir -p "$BITRISE_SOURCE_DIR/ios/build/Build/Products"
+                mkdir -p "$BITRISE_SOURCE_DIR/../Library/Detox/ios"
+
+                # Copy saved files for Detox usage
+                # INTERMEDIATE_IOS_BUILD_DIR & INTERMEDIATE_IOS_DETOX_DIR are the cached directories by ios_e2e_build's "Save iOS build" step
+                cp -r "$INTERMEDIATE_IOS_BUILD_DIR" "$BITRISE_SOURCE_DIR/ios/build/Build/Products"
+                cp -r "$INTERMEDIATE_IOS_DETOX_DIR" "$BITRISE_SOURCE_DIR/../Library/Detox"
+      # - restore-cocoapods-cache@2: {}
+      - restore-cache@2:
+          title: Restore cache node_modules
+          inputs:
+            - key: node_modules-{{ .OS }}-{{ .Arch }}-{{ getenv "BRANCH_COMMIT_HASH" }}
+      - script@1:
+          title: Install foundry
+          inputs:
+            - content: |-
+                #!/bin/bash
+                yarn install:foundryup
+      - certificate-and-profile-installer@1: {}
+      - set-xcode-build-number@1:
+          inputs:
+            - build_short_version_string: $VERSION_NAME
+            - plist_path: $PROJECT_LOCATION_IOS/MetaMask/MetaMask-QA-Info.plist
+      - script:
+          inputs:
+            - content: |-
+                # Add cache directory to environment variable
+                envman add --key BREW_APPLESIMUTILS --value "$(brew --cellar)/applesimutils"
+                envman add --key BREW_OPT_APPLESIMUTILS --value "/usr/local/opt/applesimutils"
+                brew tap wix/brew
+          title: Set Env Path for caching deps
+      - script@1:
+          title: Boot up simulator
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                xcrun simctl boot "iPhone 15 Pro" || true
+                xcrun simctl list | grep Booted
+      - script@1:
+          title: Run detox test
+          timeout: 1200
+          is_always_run: false
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+
+                export METAMASK_ENVIRONMENT='e2e'
+
+                if [ -n "${E2E_TEST_FILE:-}" ]; then
+                  echo "[INFO] Running only specified E2E_TEST_FILE(s): $E2E_TEST_FILE"
+                  IGNORE_BOXLOGS_DEVELOPMENT="true" yarn test:e2e:ios:$METAMASK_BUILD_TYPE:prod $E2E_TEST_FILE
+                elif [ -n "${TEST_SUITE_TAG:-}" ]; then
+                  echo "[INFO] Running tests matching TEST_SUITE_TAG: $TEST_SUITE_TAG"
+                  ./scripts/run-e2e-tags.sh
+                fi
+      - custom-test-results-export@1:
+          is_always_run: true
+          is_skippable: false
+          title: Export test results
+          inputs:
+            - base_path: $BITRISE_SOURCE_DIR/e2e/reports/
+            - test_name: E2E Tests
+            - search_pattern: $BITRISE_SOURCE_DIR/e2e/reports/junit.xml
+      - deploy-to-bitrise-io@2.2.3:
+          is_always_run: true
+          is_skippable: true
+          title: Deploy test report files
+      - script@1:
+          is_always_run: true
+          run_if: .IsBuildFailed
+          title: Copy screenshot files
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -ex
+                cp -r "$BITRISE_SOURCE_DIR/artifacts"  "$BITRISE_DEPLOY_DIR"
+      - deploy-to-bitrise-io@2.3:
+          is_always_run: true
+          run_if: .IsBuildFailed
+          title: Deploy test screenshots
+          inputs:
+            - deploy_path: $BITRISE_DEPLOY_DIR
+            - is_compress: true
+            - zip_name: 'E2E_IOS_Failure_Artifacts'
+      - script@1:
+          title: Copy performance results
+          is_always_run: true
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -ex
+                # Create performance results directory
+                mkdir -p "$BITRISE_DEPLOY_DIR/performance-results"
+                
+                # Copy performance JSON files if they exist
+                if [ -f "$BITRISE_SOURCE_DIR/e2e/specs/performance/reports/account-list-load-testing-performance-results.json" ]; then
+                  cp "$BITRISE_SOURCE_DIR/e2e/specs/performance/reports/account-list-load-testing-performance-results.json" "$BITRISE_DEPLOY_DIR/performance-results/"
+                  echo "Copied account-list-load-testing-performance-results.json"
+                fi
+                
+                if [ -f "$BITRISE_SOURCE_DIR/e2e/specs/performance/reports/network-list-load-testing-performance-results.json" ]; then
+                  cp "$BITRISE_SOURCE_DIR/e2e/specs/performance/reports/network-list-load-testing-performance-results.json" "$BITRISE_DEPLOY_DIR/performance-results/"
+                  echo "Copied network-list-load-testing-performance-results.json"
+                fi
+                
+                if [ -f "$BITRISE_SOURCE_DIR/e2e/specs/performance/reports/switching-accounts-to-dismiss-load-testing-performance-results.json" ]; then
+                  cp "$BITRISE_SOURCE_DIR/e2e/specs/performance/reports/switching-accounts-to-dismiss-load-testing-performance-results.json" "$BITRISE_DEPLOY_DIR/performance-results/"
+                  echo "Copied switching-accounts-to-dismiss-load-testing-performance-results.json"
+                fi
+      - deploy-to-bitrise-io@2.3:
+          title: Deploy performance results
+          is_always_run: true
+          inputs:
+            - deploy_path: $BITRISE_DEPLOY_DIR/performance-results
+            - is_compress: true
+            - zip_name: E2E_Performance_Results
+    meta:
+      bitrise.io:
+        machine_type_id: elite-xl
+        stack: linux-docker-android-22.04
+
+  start_e2e_tests:
     steps:
       - build-router-start@0:
           inputs:
+            - workflows: |-
+                ios_e2e_test
+                wdio_android_e2e_test
             - wait_for_builds: 'true'
             - access_token: $BITRISE_START_BUILD_ACCESS_TOKEN
       - build-router-wait@0:
@@ -946,6 +2488,7 @@ workflows:
 
   # Template for E2E Android builds
 
+  _android_e2e_build_template:
     before_run:
       - code_setup
       - set_commit_hash
@@ -1121,6 +2664,7 @@ workflows:
       bitrise.io:
         stack: linux-docker-android-22.04
         machine_type_id: elite-xl
+  build_android_flask_e2e:
     envs:
       - COMMAND_YARN: 'build:android:flask:e2e'
       - NAME: $FLASK_VERSION_NAME
@@ -1196,6 +2740,7 @@ workflows:
       bitrise.io:
         stack: linux-docker-android-22.04
         machine_type_id: elite-xl
+  build_android_main_e2e:
     envs:
       - COMMAND_YARN: 'build:android:main:e2e'
       - NAME: $VERSION_NAME
@@ -1275,6 +2820,8 @@ workflows:
       - NUMBER: $VERSION_NUMBER
       - APP_NAME: 'prod'
       - BUILD_COMMAND: 'yarn build:android:main:dev'
+    after_run:
+      - _android_e2e_build_template
     meta:
       bitrise.io:
         stack: linux-docker-android-22.04
@@ -1294,6 +2841,8 @@ workflows:
       - NUMBER: $FLASK_VERSION_NUMBER
       - APP_NAME: 'flask'
       - BUILD_COMMAND: 'yarn build:android:flask:dev'
+    after_run:
+      - _android_e2e_build_template
     meta:
       bitrise.io:
         stack: linux-docker-android-22.04
@@ -1313,6 +2862,8 @@ workflows:
       - NUMBER: $VERSION_NUMBER
       - APP_NAME: 'qa'
       - BUILD_COMMAND: 'yarn build:android:qa:dev'
+    after_run:
+      - _android_e2e_build_template
     meta:
       bitrise.io:
         stack: linux-docker-android-22.04
@@ -1344,10 +2895,12 @@ workflows:
   build_android_qa:
       after_run:
         - build_android_qa_prod
+        - _upload_apk_to_browserstack_qa
   build_android_qa_flask:
     before_run:
       - code_setup
     after_run:
+      - _upload_apk_to_browserstack_flask
       - notify_failure
     steps:
       - change-android-versioncode-and-versionname@1:
@@ -1409,6 +2962,7 @@ workflows:
       bitrise.io:
         stack: linux-docker-android-22.04
         machine_type_id: elite-xl
+  _upload_apk_to_browserstack_flask:
     steps:
       - script@1:
           title: Upload Flask APK to Browserstack
@@ -1432,6 +2986,144 @@ workflows:
           inputs:
             - pipeline_intermediate_files: $BITRISE_SOURCE_DIR/browserstack_uploaded_flask_apps.json:BROWSERSTACK_UPLOADED_FLASK_APPS_LIST
           title: Save Browserstack uploaded Flask apps JSON
+  _upload_apk_to_browserstack_qa:
+    steps:
+      - script@1:
+          title: Upload APK to Browserstack
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -e
+                set -x
+                set -o pipefail
+                APK_DIR="$PROJECT_LOCATION/app/build/outputs/apk/qa/release"
+                ORIGINAL_APK="$APK_DIR/app-qa-release.apk"
+
+                CUSTOM_ID="$BITRISE_GIT_BRANCH-$VERSION_NAME-$VERSION_NUMBER"
+                CUSTOM_ID=${CUSTOM_ID////-}
+
+                cp "$ORIGINAL_APK" "$APK_DIR/$CUSTOM_ID.apk"
+                APK_PATH="$APK_DIR/$CUSTOM_ID.apk"
+
+                # Upload to app-automate
+                curl -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" \
+                    -X POST "https://api-cloud.browserstack.com/app-automate/upload" \
+                    -F "file=@$APK_PATH" \
+                    -F 'data={"custom_id": "'$CUSTOM_ID'"}' \
+                    | jq -j '.app_url' \
+                    | envman add --key BROWSERSTACK_ANDROID_APP_URL
+
+                # Upload to app-live
+                curl -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" \
+                    -X POST "https://api-cloud.browserstack.com/app-live/upload" \
+                    -F "file=@$APK_PATH" \
+                    -F 'data={"custom_id": "'$CUSTOM_ID'"}'
+
+                # Get recent apps
+                curl -u "$BROWSERSTACK_USERNAME:$BROWSERSTACK_ACCESS_KEY" \
+                    -X GET https://api-cloud.browserstack.com/app-automate/recent_apps \
+                    | jq > browserstack_uploaded_apps.json
+      - share-pipeline-variable@1:
+          title: Persist BROWSERSTACK_ANDROID_APP_URL across all stages
+          inputs:
+            - variables: |-
+                BROWSERSTACK_ANDROID_APP_URL
+      - deploy-to-bitrise-io@2.2.3:
+          is_always_run: false
+          is_skippable: true
+          inputs:
+            - pipeline_intermediate_files: $BITRISE_SOURCE_DIR/browserstack_uploaded_apps.json:BROWSERSTACK_UPLOADED_APPS_LIST
+          title: Save Browserstack uploaded apps JSON
+  wdio_android_e2e_test:
+    before_run:
+      - code_setup
+    after_run:
+      - notify_failure
+    steps:
+      - script@1:
+          title: Debug Env Variables
+          inputs:
+            - content: |
+                echo "PRODUCTION_BUILD_NAME: $PRODUCTION_BUILD_NAME"
+                echo "PRODUCTION_BUILD_NUMBER: $PRODUCTION_BUILD_NUMBER"
+                echo "PRODUCTION_APP_URL from tag upgrade workflow: $PRODUCTION_APP_URL"
+                echo "BROWSERSTACK_ANDROID_APP_URL: $BROWSERSTACK_ANDROID_APP_URL"
+      - script@1:
+          title: Run Android E2E tests on Browserstack
+          is_always_run: true
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+
+                # Check if TEST_TYPE is set to upgrade
+                if [ "$TEST_TYPE" = "upgrade" ]; then
+                  TEST_TYPE="--upgrade"
+
+                # Check if TEST_TYPE is set to performance
+                elif [ "$TEST_TYPE" = "performance" ]; then
+                  TEST_TYPE="--performance"
+                fi
+                yarn test:wdio:android:browserstack "$TEST_SUITE_FOLDER" "$TEST_TYPE"
+      - script@1:
+          is_always_run: true
+          is_skippable: false
+          title: Package test reports
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                cd $BITRISE_SOURCE_DIR/wdio/reports/
+                zip -r test-report.zip html/
+                mv test-report.zip $BITRISE_DEPLOY_DIR/
+      - deploy-to-bitrise-io@2.2.3:
+          is_always_run: true
+          is_skippable: false
+          inputs:
+            - deploy_path: $BITRISE_DEPLOY_DIR/test-report.zip
+          title: Deploy test report
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: standard
+  wdio_ios_e2e_test:
+    before_run:
+      - code_setup
+    after_run:
+      - notify_failure
+    steps:
+      - script@1:
+          title: Run iOS E2E tests on Browserstack
+          is_always_run: true
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                # Check if TEST_TYPE is set to upgrade
+                if [ "$TEST_TYPE" = "upgrade" ]; then
+                  TEST_TYPE="--upgrade"
+                # Check if TEST_TYPE is set to performance
+                elif [ "$TEST_TYPE" = "performance" ]; then
+                  TEST_TYPE="--performance"
+                fi
+                yarn test:wdio:ios:browserstack "$TEST_SUITE_FOLDER" "$TEST_TYPE"
+      - script@1:
+          is_always_run: true
+          is_skippable: false
+          title: Package test reports
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                cd $BITRISE_SOURCE_DIR/wdio/reports/
+                zip -r test-report.zip html/
+                mv test-report.zip $BITRISE_DEPLOY_DIR/
+      - deploy-to-bitrise-io@2.2.3:
+          is_always_run: true
+          is_skippable: false
+          inputs:
+            - deploy_path: $BITRISE_DEPLOY_DIR/test-report.zip
+          title: Deploy test report
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-22.04
+        machine_type_id: standard
   deploy_android_to_store:
     steps:
       - pull-intermediate-files@1:
@@ -1645,6 +3337,28 @@ workflows:
   build_ios_main_test:
     envs:
       - CONFIGURATION: 'Release'
+      - COMMAND_YARN: 'build:ios:main:test'
+      - NAME: $VERSION_NAME
+      - NUMBER: $VERSION_NUMBER
+      - APP_NAME: "MetaMask"
+      - INFO_PLIST_NAME: "Info.plist"
+    after_run:
+      - _ios_build_template
+  build_ios_main_e2e:
+    envs:
+      - CONFIGURATION: 'Release'
+      - IS_SIM_BUILD: 'true'
+      - SHARE_WITH_DETOX: 'true'
+      - NAME: $VERSION_NAME
+      - NUMBER: $VERSION_NUMBER
+      - APP_NAME: "MetaMask"
+      - INFO_PLIST_NAME: "Info.plist"
+      - COMMAND_YARN: 'build:ios:main:e2e'
+    after_run:
+      - _ios_build_template
+  build_ios_main_e2e_gns_disabled:
+    envs:
+      - CONFIGURATION: 'Release'
       - IS_SIM_BUILD: 'true'
       - SHARE_WITH_DETOX: 'true'
       - NAME: $VERSION_NAME
@@ -1700,6 +3414,7 @@ workflows:
       - COMMAND_YARN: 'build:ios:flask:test'
     after_run:
       - _ios_build_template
+  build_ios_flask_e2e:
     envs:
       - CONFIGURATION: 'Release'
       - IS_SIM_BUILD: 'true'


### PR DESCRIPTION
Reverts MetaMask/metamask-mobile#21684

CHANGELOG entry: null

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores and expands Bitrise E2E pipelines for iOS/Android with smoke/regression/performance suites, caching, BrowserStack uploads/tests, QA build for upgrades, and TestRail reporting.
> 
> - **CI/Bitrise (`bitrise.yml`)**:
>   - **E2E Pipelines Restored/Expanded**:
>     - Reintroduces iOS/Android E2E pipelines (smoke, regression, release, Flask, single-suite) and a `start_e2e_tests` dispatcher.
>     - Adds performance-specific E2E workflows and app-upgrade tests via BrowserStack.
>   - **Stages/Orchestration**:
>     - New/updated stages for `set_main_target_stage`, `pr_cache_check_stage`, build/run E2E (smoke/regression/release), Flask E2E, results reporting, and notifications.
>   - **Build/Cache Templates**:
>     - New `_android_e2e_build_template` and expanded `ios_e2e_build` with ccache, PR build caching, intermediate artifact sharing, and cache-based build skipping.
>   - **BrowserStack Integration**:
>     - Workflows to upload QA/Flask `APK`/`IPA`, persist app URLs, and run WDIO tests (`wdio_android_e2e_test`, `wdio_ios_e2e_test`).
>   - **Release/QA Adjustments**:
>     - `release_builds_to_store_pipeline` now also generates QA builds for E2E app upgrade tests.
>   - **Reporting**:
>     - Adds TestRail automated results workflow.
>   - **Build Matrix Additions**:
>     - Adds/updates Android/iOS `main`/`flask`/`qa` E2E build workflows (e.g., `build_android_main_e2e`, `build_ios_main_e2e`, `build_ios_flask_e2e`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ff1a8030ad99e67b385b144e2858026ac692621. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/512b83aa-4128-47ac-af81-7fe985f9c563