### PR TITLE
fix: limit price bottom sheet input decimal not showing

### DIFF
--- a/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.test.tsx
@@ -91,42 +91,6 @@ jest.mock('@metamask/design-system-twrnc-preset', () => ({
   })),
 }));
 
-// Mock format utilities
-jest.mock('../../utils/formatUtils', () => ({
-  formatPerpsFiat: jest.fn((value, options = {}) => {
-    const num = typeof value === 'string' ? parseFloat(value) : value;
-    if (isNaN(num)) return '$0.00';
-    // Handle dynamic decimals from ranges config - match component behavior
-    if (options.ranges && options.ranges.length > 0) {
-      const range = options.ranges[0];
-      if (
-        range.minimumDecimals !== undefined &&
-        range.maximumDecimals !== undefined
-      ) {
-        // Use the minimumDecimals as set by the component logic
-        return `$${num.toFixed(range.minimumDecimals)}`;
-      }
-    }
-    return `$${num.toFixed(2)}`;
-  }),
-  formatWithSignificantDigits: jest.fn((value, significantDigits) => {
-    const num = typeof value === 'number' ? value : parseFloat(value);
-    if (isNaN(num)) return { value: '0', formatted: '$0.00' };
-    return {
-      value: num.toFixed(significantDigits || 2),
-      formatted: `$${num.toFixed(significantDigits || 2)}`,
-    };
-  }),
-  PRICE_RANGES_UNIVERSAL: [
-    {
-      condition: () => true,
-      minimumDecimals: 2,
-      maximumDecimals: 2,
-      threshold: 0.01,
-    },
-  ],
-}));
-
 // Mock strings
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: jest.fn((key) => key),
@@ -384,7 +348,7 @@ describe('PerpsLimitPriceBottomSheet', () => {
         screen.getByText('perps.order.limit_price_modal.title'),
       ).toBeOnTheScreen();
       expect(screen.getByText(/ETH/)).toBeOnTheScreen();
-      expect(screen.getByText(/\$3000/)).toBeOnTheScreen();
+      expect(screen.getByText(/\$3,000/)).toBeOnTheScreen();
     });
 
     it('returns null when not visible', () => {
@@ -404,7 +368,7 @@ describe('PerpsLimitPriceBottomSheet', () => {
       render(<PerpsLimitPriceBottomSheet {...defaultProps} />);
 
       // Assert - prices are rendered somewhere in the component
-      expect(screen.getByText(/\$3000/)).toBeOnTheScreen(); // Current price
+      expect(screen.getByText(/\$3,000/)).toBeOnTheScreen(); // Current price with thousands separator
     });
 
     it('displays placeholder when no limit price is set', () => {
@@ -425,7 +389,7 @@ describe('PerpsLimitPriceBottomSheet', () => {
       render(<PerpsLimitPriceBottomSheet {...props} />);
 
       // Assert
-      expect(screen.getByText(/\$3100/)).toBeOnTheScreen(); // Formatted limit price display
+      expect(screen.getByText(/\$3,100/)).toBeOnTheScreen(); // Formatted limit price display with thousands separator
       expect(screen.getByText('3100')).toBeOnTheScreen(); // Keypad value
     });
 
@@ -724,6 +688,124 @@ describe('PerpsLimitPriceBottomSheet', () => {
       expect(screen.getByTestId('keypad-component')).toBeOnTheScreen();
       expect(screen.getByTestId('keypad-button-1')).toBeOnTheScreen();
       expect(screen.getByTestId('keypad-button-clear')).toBeOnTheScreen();
+    });
+  });
+
+  describe('Decimal Point and Trailing Zero Display', () => {
+    it('displays decimal point immediately when typed', () => {
+      // Arrange
+      render(<PerpsLimitPriceBottomSheet {...defaultProps} limitPrice="0." />);
+
+      // Act - Component should render the raw value with decimal point
+
+      // Assert
+      expect(screen.getByText('$0.')).toBeOnTheScreen();
+    });
+
+    it('displays single trailing zero after decimal point', () => {
+      // Arrange
+      render(<PerpsLimitPriceBottomSheet {...defaultProps} limitPrice="0.0" />);
+
+      // Act - Component should preserve the trailing zero
+
+      // Assert
+      expect(screen.getByText('$0.0')).toBeOnTheScreen();
+    });
+
+    it('displays multiple trailing zeros after decimal point', () => {
+      // Arrange
+      render(
+        <PerpsLimitPriceBottomSheet {...defaultProps} limitPrice="0.00" />,
+      );
+
+      // Act - Component should preserve trailing zeros
+
+      // Assert
+      expect(screen.getByText('$0.00')).toBeOnTheScreen();
+    });
+
+    it('displays decimal point with integer value and preserves currency formatting', () => {
+      // Arrange
+      render(
+        <PerpsLimitPriceBottomSheet {...defaultProps} limitPrice="345." />,
+      );
+
+      // Act - Should format integer part with currency, append decimal
+
+      // Assert
+      expect(screen.getByText('$345.')).toBeOnTheScreen();
+    });
+
+    it('displays trailing zero with integer value', () => {
+      // Arrange
+      render(
+        <PerpsLimitPriceBottomSheet {...defaultProps} limitPrice="345.0" />,
+      );
+
+      // Act - Should show integer with decimal and trailing zero
+
+      // Assert
+      expect(screen.getByText('$345.0')).toBeOnTheScreen();
+    });
+
+    it('displays multiple trailing zeros with integer value', () => {
+      // Arrange
+      render(
+        <PerpsLimitPriceBottomSheet {...defaultProps} limitPrice="345.00" />,
+      );
+
+      // Act - Should preserve all trailing zeros
+
+      // Assert
+      expect(screen.getByText('$345.00')).toBeOnTheScreen();
+    });
+
+    it('preserves thousands separator when decimal point is added', () => {
+      // Arrange
+      render(
+        <PerpsLimitPriceBottomSheet {...defaultProps} limitPrice="12345." />,
+      );
+
+      // Act - Should format with thousands separator and decimal
+
+      // Assert
+      expect(screen.getByText('$12,345.')).toBeOnTheScreen();
+    });
+
+    it('preserves thousands separator with trailing zeros', () => {
+      // Arrange
+      render(
+        <PerpsLimitPriceBottomSheet {...defaultProps} limitPrice="12345.00" />,
+      );
+
+      // Act - Should format with thousands separator and trailing zeros
+
+      // Assert
+      expect(screen.getByText('$12,345.00')).toBeOnTheScreen();
+    });
+
+    it('formats complete decimal numbers normally', () => {
+      // Arrange
+      render(
+        <PerpsLimitPriceBottomSheet {...defaultProps} limitPrice="123.45" />,
+      );
+
+      // Act - Complete numbers use normal formatting
+
+      // Assert
+      expect(screen.getByText('$123.45')).toBeOnTheScreen();
+    });
+
+    it('displays trailing zero in middle of decimal value', () => {
+      // Arrange
+      render(
+        <PerpsLimitPriceBottomSheet {...defaultProps} limitPrice="123.10" />,
+      );
+
+      // Act - Should preserve trailing zero even in middle positions
+
+      // Assert
+      expect(screen.getByText('$123.10')).toBeOnTheScreen();
     });
   });
 

--- a/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet.tsx
@@ -132,12 +132,37 @@ const PerpsLimitPriceBottomSheet: React.FC<PerpsLimitPriceBottomSheetProps> = ({
 
   /**
    * Format limit price with proper decimal handling
+   * Shows raw input during typing (preserves ".", "0.", "0.00", etc.)
+   * Only formats complete numbers
    * @param price - Price string to format
-   * @returns Formatted price string
+   * @returns Formatted price string with proper currency symbol
    */
   const formatLimitPriceValue = useCallback((price: string) => {
     if (!price || price === '0') {
       return '';
+    }
+
+    // Preserve raw input if it ends with a decimal point or has trailing zeros after decimal
+    // Format the base number to get proper currency symbol, then append the typed decimal part
+    if (price.endsWith('.') || /\.\d*0$/.test(price)) {
+      const parts = price.split('.');
+      const integerPart = parts[0] || '0';
+      const decimalPart = parts.length > 1 ? `.${parts[1]}` : '.';
+
+      // Format the integer part to get proper currency formatting
+      const formatted = formatPerpsFiat(integerPart, {
+        ranges: [
+          {
+            condition: () => true,
+            threshold: 0,
+            maximumDecimals: 0,
+            minimumDecimals: 0,
+          },
+        ],
+      });
+
+      // Append the decimal part as typed by user
+      return `${formatted}${decimalPart}`;
     }
 
     const formatConfig = {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR ensures that on the limit price bottom sheet the input allows the user to see decimal point the moment it is keyed 

User types "." → Displays "$0." immediately
User types "0.00" → Displays "$0.00" immediately
User types "345." → Displays "$345." immediately
User types "12345." → Displays "$12,345." with thousands separator
User types "123.10" → Displays "$123.10" preserving trailing zero
Complete numbers like "123.45" → Display "$123.45" with normal formatting

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1813

## **Manual testing steps**

```gherkin
Feature: Perps Limit Price Input - Immediate Decimal and Zero Display

  Scenario: Decimal point appears immediately when typed
    Given I am entering a limit price of "0"
    When I tap the "." key
    Then the display immediately shows "$0."

  Scenario: Trailing zeros display as typed
    Given I am entering a limit price of "0."
    When I tap "0" twice
    Then the display shows "$0.00"
    And both zeros are visible immediately

  Scenario: Thousands separators preserved with decimal point
    Given I am entering a limit price of "12345"
    When I tap "." then "0" then "0"
    Then the display shows "$12,345.00"
    And the thousands separator remains visible

  Scenario: Complete numbers format normally
    Given I am entering a limit price of "123.4"
    When I tap "5"
    Then the display shows "$123.45"
    And standard formatting is applied
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
https://github.com/user-attachments/assets/0a762b31-3968-402f-bda3-fae0088f9c00

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Preserves typed decimals and trailing zeros in the limit price field while keeping proper currency/thousands formatting, with tests updated accordingly.
> 
> - **Perps UI**:
>   - `PerpsLimitPriceBottomSheet.tsx`: Enhance `formatLimitPriceValue` to preserve raw decimal input (e.g., `"."`, `"0.", "0.00", "345.", "12345."`) by formatting only the integer part with `formatPerpsFiat` and appending the typed decimal portion; only fully-formed numbers are fully formatted.
> - **Tests**:
>   - `PerpsLimitPriceBottomSheet.test.tsx`:
>     - Update expectations to include thousands separators (e.g., `$3,000`, `$3,100`).
>     - Add comprehensive cases for immediate decimal point visibility and trailing zeros (e.g., `$0.`, `$0.0`, `$345.00`, `$12,345.`).
>     - Clean up mocks (remove custom `formatUtils` mock) and keep keypad/warning behavior tests intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a87a86b106ce2d53ef09ea79946275280a857a23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->