### PR TITLE
chore: Add legacy adapter for backwards compatibility

### DIFF
--- a/app/core/DeeplinkManager/adapters/LegacyLinkAdapter.test.ts
+++ b/app/core/DeeplinkManager/adapters/LegacyLinkAdapter.test.ts
@@ -1,0 +1,665 @@
+import { LegacyLinkAdapter } from './LegacyLinkAdapter';
+import { CoreUniversalLink } from '../types/CoreUniversalLink';
+import { DeeplinkUrlParams } from '../ParseManager/extractURLParams';
+import { CoreLinkNormalizer } from '../CoreLinkNormalizer';
+import AppConstants from '../../AppConstants';
+import { ACTIONS } from '../../../constants/deeplinks';
+
+jest.mock('../CoreLinkNormalizer');
+
+describe('LegacyLinkAdapter', () => {
+  const mockTimestamp = 1234567890;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('toLegacyFormat', () => {
+    it('converts CoreUniversalLink to legacy format with all parameters', () => {
+      const link: CoreUniversalLink = {
+        protocol: 'metamask',
+        action: 'connect',
+        params: {
+          channelId: '123',
+          comm: 'socket',
+          pubkey: 'abc',
+          v: '2',
+          hr: true,
+          utm_source: 'twitter',
+          message: 'Hello',
+        },
+        source: 'test',
+        timestamp: mockTimestamp,
+        originalUrl: 'metamask://connect?channelId=123',
+        normalizedUrl: 'metamask://connect?channelId=123',
+        isValid: true,
+        isSupportedAction: true,
+        isPrivateLink: false,
+        requiresAuth: false,
+      };
+
+      const result = LegacyLinkAdapter.toLegacyFormat(link);
+
+      expect(result.params.channelId).toBe('123');
+      expect(result.params.comm).toBe('socket');
+      expect(result.params.pubkey).toBe('abc');
+      expect(result.params.v).toBe('2');
+      expect(result.params.hr).toBe(true);
+      expect(result.params.utm_source).toBe('twitter');
+      expect(result.params.message).toBe('Hello');
+      expect(result.urlObj).toBeDefined();
+    });
+
+    it('converts hr boolean to boolean in legacy format', () => {
+      const link: CoreUniversalLink = {
+        protocol: 'metamask',
+        action: 'home',
+        params: {
+          hr: false,
+        },
+        source: 'test',
+        timestamp: mockTimestamp,
+        originalUrl: 'metamask://home',
+        normalizedUrl: 'metamask://home',
+        isValid: true,
+        isSupportedAction: true,
+        isPrivateLink: false,
+        requiresAuth: false,
+      };
+
+      const result = LegacyLinkAdapter.toLegacyFormat(link);
+
+      expect(result.params.hr).toBe(false);
+    });
+
+    it('handles empty parameters gracefully', () => {
+      const link: CoreUniversalLink = {
+        protocol: 'metamask',
+        action: 'home',
+        params: {},
+        source: 'test',
+        timestamp: mockTimestamp,
+        originalUrl: 'metamask://home',
+        normalizedUrl: 'metamask://home',
+        isValid: true,
+        isSupportedAction: true,
+        isPrivateLink: false,
+        requiresAuth: false,
+      };
+
+      const result = LegacyLinkAdapter.toLegacyFormat(link);
+
+      expect(result.params.uri).toBe('');
+      expect(result.params.redirect).toBe('');
+      expect(result.params.channelId).toBe('');
+      expect(result.params.comm).toBe('');
+      expect(result.params.pubkey).toBe('');
+      expect(result.params.hr).toBe(false);
+    });
+
+    it('converts https protocol links correctly', () => {
+      const link: CoreUniversalLink = {
+        protocol: 'https',
+        host: AppConstants.MM_IO_UNIVERSAL_LINK_HOST,
+        action: 'swap',
+        params: {
+          from: 'ETH',
+          to: 'DAI',
+        },
+        source: 'test',
+        timestamp: mockTimestamp,
+        originalUrl: `https://${AppConstants.MM_IO_UNIVERSAL_LINK_HOST}/swap`,
+        normalizedUrl: `https://${AppConstants.MM_IO_UNIVERSAL_LINK_HOST}/swap`,
+        isValid: true,
+        isSupportedAction: true,
+        isPrivateLink: false,
+        requiresAuth: false,
+      };
+
+      const result = LegacyLinkAdapter.toLegacyFormat(link);
+
+      expect(result.urlObj.hostname).toBe(
+        AppConstants.MM_IO_UNIVERSAL_LINK_HOST,
+      );
+      expect(result.urlObj.pathname).toBe('/swap');
+    });
+  });
+
+  describe('fromLegacyFormat', () => {
+    beforeEach(() => {
+      (CoreLinkNormalizer.normalize as jest.Mock).mockImplementation(
+        (url, source) => ({
+          protocol: url.startsWith('metamask://') ? 'metamask' : 'https',
+          action: 'test-action',
+          params: {},
+          source,
+          timestamp: mockTimestamp,
+          originalUrl: url,
+          normalizedUrl: url,
+          isValid: true,
+          isSupportedAction: true,
+          isPrivateLink: false,
+          requiresAuth: false,
+        }),
+      );
+    });
+
+    it('converts legacy format to CoreUniversalLink', () => {
+      const url = 'metamask://connect?channelId=123';
+      const params: DeeplinkUrlParams = {
+        uri: 'test-uri',
+        redirect: 'test-redirect',
+        channelId: '123',
+        comm: 'socket',
+        pubkey: 'abc',
+        hr: true,
+        scheme: 'test-scheme',
+        v: '2',
+        rpc: 'test-rpc',
+        sdkVersion: '1.0',
+        message: 'Hello',
+        originatorInfo: 'test-info',
+        request: 'test-request',
+        attributionId: 'test-attr',
+        utm_source: 'twitter',
+        utm_medium: 'social',
+        utm_campaign: 'launch',
+        utm_term: 'test',
+        utm_content: 'content',
+        account: '0x123@1',
+      };
+      const source = 'test';
+
+      const result = LegacyLinkAdapter.fromLegacyFormat(url, params, source);
+
+      expect(result.params.channelId).toBe('123');
+      expect(result.params.comm).toBe('socket');
+      expect(result.params.pubkey).toBe('abc');
+      expect(result.params.hr).toBe(true);
+      expect(result.params.utm_source).toBe('twitter');
+      expect(result.params.account).toBe('0x123@1');
+      expect(result.source).toBe(source);
+    });
+
+    it('handles undefined optional parameters', () => {
+      const url = 'metamask://home';
+      const params: DeeplinkUrlParams = {
+        uri: '',
+        redirect: '',
+        channelId: '',
+        comm: '',
+        pubkey: '',
+        hr: false,
+        utm_source: '',
+        utm_medium: '',
+        utm_campaign: '',
+        utm_term: '',
+        utm_content: '',
+        attributionId: '',
+      };
+      const source = 'test';
+
+      const result = LegacyLinkAdapter.fromLegacyFormat(url, params, source);
+
+      expect(result.params.uri).toBeUndefined();
+      expect(result.params.hr).toBe(false);
+    });
+
+    it('preserves hr boolean value', () => {
+      const url = 'metamask://home';
+      const params: DeeplinkUrlParams = {
+        uri: '',
+        redirect: '',
+        channelId: '',
+        comm: '',
+        pubkey: '',
+        hr: true,
+        utm_source: '',
+        utm_medium: '',
+        utm_campaign: '',
+        utm_term: '',
+        utm_content: '',
+        attributionId: '',
+      };
+      const source = 'test';
+
+      const result = LegacyLinkAdapter.fromLegacyFormat(url, params, source);
+
+      expect(result.params.hr).toBe(true);
+    });
+  });
+
+  describe('shouldUseNewSystem', () => {
+    it('returns false by default for backward compatibility', () => {
+      const link: CoreUniversalLink = {
+        protocol: 'metamask',
+        action: 'swap',
+        params: {},
+        source: 'test',
+        timestamp: mockTimestamp,
+        originalUrl: 'metamask://swap',
+        normalizedUrl: 'metamask://swap',
+        isValid: true,
+        isSupportedAction: true,
+        isPrivateLink: false,
+        requiresAuth: false,
+      };
+
+      const result = LegacyLinkAdapter.shouldUseNewSystem(link);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false for all action types currently', () => {
+      const actions = ['home', 'swap', 'send', 'dapp', 'perps'];
+
+      actions.forEach((action) => {
+        const link: CoreUniversalLink = {
+          protocol: 'metamask',
+          action,
+          params: {},
+          source: 'test',
+          timestamp: mockTimestamp,
+          originalUrl: `metamask://${action}`,
+          normalizedUrl: `metamask://${action}`,
+          isValid: true,
+          isSupportedAction: true,
+          isPrivateLink: false,
+          requiresAuth: false,
+        };
+
+        expect(LegacyLinkAdapter.shouldUseNewSystem(link)).toBe(false);
+      });
+    });
+  });
+
+  describe('wrapHandler', () => {
+    it('wraps a synchronous handler function', () => {
+      const mockHandler = jest.fn();
+      const paramExtractor = (link: CoreUniversalLink) => ({
+        swapPath: link.params.swapPath || '',
+      });
+
+      const wrappedHandler = LegacyLinkAdapter.wrapHandler(
+        mockHandler,
+        paramExtractor,
+      );
+
+      const link: CoreUniversalLink = {
+        protocol: 'metamask',
+        action: 'swap',
+        params: {
+          swapPath: 'swap?from=ETH&to=DAI',
+        },
+        source: 'test',
+        timestamp: mockTimestamp,
+        originalUrl: 'metamask://swap',
+        normalizedUrl: 'metamask://swap',
+        isValid: true,
+        isSupportedAction: true,
+        isPrivateLink: false,
+        requiresAuth: false,
+      };
+
+      wrappedHandler(link);
+
+      expect(mockHandler).toHaveBeenCalledWith({
+        swapPath: 'swap?from=ETH&to=DAI',
+      });
+    });
+
+    it('wraps an asynchronous handler function', async () => {
+      const mockHandler = jest.fn().mockResolvedValue(undefined);
+      const paramExtractor = (link: CoreUniversalLink) => ({
+        perpsPath: link.params.perpsPath || '',
+      });
+
+      const wrappedHandler = LegacyLinkAdapter.wrapHandler(
+        mockHandler,
+        paramExtractor,
+      );
+
+      const link: CoreUniversalLink = {
+        protocol: 'https',
+        action: 'perps',
+        params: {
+          perpsPath: 'perps/markets',
+        },
+        source: 'test',
+        timestamp: mockTimestamp,
+        originalUrl: 'https://example.com/perps',
+        normalizedUrl: 'https://example.com/perps',
+        isValid: true,
+        isSupportedAction: true,
+        isPrivateLink: false,
+        requiresAuth: false,
+      };
+
+      await wrappedHandler(link);
+
+      expect(mockHandler).toHaveBeenCalledWith({
+        perpsPath: 'perps/markets',
+      });
+    });
+
+    it('passes through errors from wrapped handler', async () => {
+      const error = new Error('Handler error');
+      const mockHandler = jest.fn().mockRejectedValue(error);
+      const paramExtractor = (_link: CoreUniversalLink) => ({ test: 'value' });
+
+      const wrappedHandler = LegacyLinkAdapter.wrapHandler(
+        mockHandler,
+        paramExtractor,
+      );
+
+      const link: CoreUniversalLink = {
+        protocol: 'metamask',
+        action: 'test',
+        params: {},
+        source: 'test',
+        timestamp: mockTimestamp,
+        originalUrl: 'metamask://test',
+        normalizedUrl: 'metamask://test',
+        isValid: true,
+        isSupportedAction: true,
+        isPrivateLink: false,
+        requiresAuth: false,
+      };
+
+      await expect(wrappedHandler(link)).rejects.toThrow(error);
+    });
+  });
+
+  describe('extractActionParams', () => {
+    it('extracts swap path parameters', () => {
+      const link: CoreUniversalLink = {
+        protocol: 'metamask',
+        action: ACTIONS.SWAP,
+        params: {
+          swapPath: 'swap?from=ETH&to=DAI',
+        },
+        source: 'test',
+        timestamp: mockTimestamp,
+        originalUrl: 'metamask://swap',
+        normalizedUrl: 'metamask://swap',
+        isValid: true,
+        isSupportedAction: true,
+        isPrivateLink: false,
+        requiresAuth: false,
+      };
+
+      const result = LegacyLinkAdapter.extractActionParams(link);
+
+      expect(result.swapPath).toBe('swap?from=ETH&to=DAI');
+      expect(result.perpsPath).toBeUndefined();
+    });
+
+    it('extracts perps path parameters', () => {
+      const link: CoreUniversalLink = {
+        protocol: 'https',
+        action: ACTIONS.PERPS,
+        params: {
+          perpsPath: 'perps/markets',
+        },
+        source: 'test',
+        timestamp: mockTimestamp,
+        originalUrl: 'https://example.com/perps',
+        normalizedUrl: 'https://example.com/perps',
+        isValid: true,
+        isSupportedAction: true,
+        isPrivateLink: false,
+        requiresAuth: false,
+      };
+
+      const result = LegacyLinkAdapter.extractActionParams(link);
+
+      expect(result.perpsPath).toBe('perps/markets');
+      expect(result.swapPath).toBeUndefined();
+    });
+
+    it('extracts ramp-related path parameters', () => {
+      const link: CoreUniversalLink = {
+        protocol: 'metamask',
+        action: ACTIONS.BUY_CRYPTO,
+        params: {
+          rampPath: 'buy-crypto?amount=100',
+        },
+        source: 'test',
+        timestamp: mockTimestamp,
+        originalUrl: 'metamask://buy-crypto',
+        normalizedUrl: 'metamask://buy-crypto',
+        isValid: true,
+        isSupportedAction: true,
+        isPrivateLink: false,
+        requiresAuth: false,
+      };
+
+      const result = LegacyLinkAdapter.extractActionParams(link);
+
+      expect(result.rampPath).toBe('buy-crypto?amount=100');
+    });
+
+    it('extracts dapp path parameters', () => {
+      const link: CoreUniversalLink = {
+        protocol: 'metamask',
+        action: ACTIONS.DAPP,
+        params: {
+          dappPath: 'dapp/app.uniswap.org',
+        },
+        source: 'test',
+        timestamp: mockTimestamp,
+        originalUrl: 'metamask://dapp',
+        normalizedUrl: 'metamask://dapp',
+        isValid: true,
+        isSupportedAction: true,
+        isPrivateLink: false,
+        requiresAuth: false,
+      };
+
+      const result = LegacyLinkAdapter.extractActionParams(link);
+
+      expect(result.dappPath).toBe('dapp/app.uniswap.org');
+    });
+
+    it('returns empty object for unsupported actions', () => {
+      const link: CoreUniversalLink = {
+        protocol: 'metamask',
+        action: 'unknown',
+        params: {},
+        source: 'test',
+        timestamp: mockTimestamp,
+        originalUrl: 'metamask://unknown',
+        normalizedUrl: 'metamask://unknown',
+        isValid: false,
+        isSupportedAction: false,
+        isPrivateLink: false,
+        requiresAuth: false,
+      };
+
+      const result = LegacyLinkAdapter.extractActionParams(link);
+
+      expect(result).toEqual({});
+    });
+
+    it('extracts multiple path parameters for perps actions', () => {
+      const link: CoreUniversalLink = {
+        protocol: 'metamask',
+        action: ACTIONS.PERPS_ASSET,
+        params: {
+          perpsPath: 'perps-asset/ETH-USD',
+          perpsAssetPath: 'perps-asset/ETH-USD',
+        },
+        source: 'test',
+        timestamp: mockTimestamp,
+        originalUrl: 'metamask://perps-asset',
+        normalizedUrl: 'metamask://perps-asset',
+        isValid: true,
+        isSupportedAction: true,
+        isPrivateLink: false,
+        requiresAuth: false,
+      };
+
+      const result = LegacyLinkAdapter.extractActionParams(link);
+
+      expect(result.perpsPath).toBe('perps-asset/ETH-USD');
+      expect(result.perpsAssetPath).toBe('perps-asset/ETH-USD');
+    });
+  });
+
+  describe('buildLegacyUrl', () => {
+    it('builds metamask protocol URLs', () => {
+      const link: CoreUniversalLink = {
+        protocol: 'metamask',
+        action: 'swap',
+        params: {
+          from: 'ETH',
+          to: 'DAI',
+          amount: '100',
+        },
+        source: 'test',
+        timestamp: mockTimestamp,
+        originalUrl: 'metamask://swap',
+        normalizedUrl: 'metamask://swap',
+        isValid: true,
+        isSupportedAction: true,
+        isPrivateLink: false,
+        requiresAuth: false,
+      };
+
+      const result = LegacyLinkAdapter.buildLegacyUrl(link);
+
+      expect(result).toBe('metamask://swap?from=ETH&to=DAI&amount=100');
+    });
+
+    it('builds https protocol URLs', () => {
+      const link: CoreUniversalLink = {
+        protocol: 'https',
+        host: AppConstants.MM_IO_UNIVERSAL_LINK_HOST,
+        action: 'send',
+        params: {
+          to: '0x123',
+          value: '1',
+        },
+        source: 'test',
+        timestamp: mockTimestamp,
+        originalUrl: `https://${AppConstants.MM_IO_UNIVERSAL_LINK_HOST}/send`,
+        normalizedUrl: `https://${AppConstants.MM_IO_UNIVERSAL_LINK_HOST}/send`,
+        isValid: true,
+        isSupportedAction: true,
+        isPrivateLink: false,
+        requiresAuth: true,
+      };
+
+      const result = LegacyLinkAdapter.buildLegacyUrl(link);
+
+      expect(result).toBe(
+        `https://${AppConstants.MM_IO_UNIVERSAL_LINK_HOST}/send?to=0x123&value=1`,
+      );
+    });
+
+    it('converts boolean hr parameter to string', () => {
+      const link: CoreUniversalLink = {
+        protocol: 'metamask',
+        action: 'home',
+        params: {
+          hr: true,
+        },
+        source: 'test',
+        timestamp: mockTimestamp,
+        originalUrl: 'metamask://home',
+        normalizedUrl: 'metamask://home',
+        isValid: true,
+        isSupportedAction: true,
+        isPrivateLink: false,
+        requiresAuth: false,
+      };
+
+      const result = LegacyLinkAdapter.buildLegacyUrl(link);
+
+      expect(result).toBe('metamask://home?hr=1');
+    });
+
+    it('filters out action-specific path parameters', () => {
+      const link: CoreUniversalLink = {
+        protocol: 'metamask',
+        action: 'swap',
+        params: {
+          swapPath: 'swap?from=ETH',
+          from: 'ETH',
+          to: 'DAI',
+        },
+        source: 'test',
+        timestamp: mockTimestamp,
+        originalUrl: 'metamask://swap',
+        normalizedUrl: 'metamask://swap',
+        isValid: true,
+        isSupportedAction: true,
+        isPrivateLink: false,
+        requiresAuth: false,
+      };
+
+      const result = LegacyLinkAdapter.buildLegacyUrl(link);
+
+      expect(result).toBe('metamask://swap?from=ETH&to=DAI');
+      expect(result).not.toContain('swapPath');
+    });
+
+    it('handles empty parameters', () => {
+      const link: CoreUniversalLink = {
+        protocol: 'metamask',
+        action: 'home',
+        params: {},
+        source: 'test',
+        timestamp: mockTimestamp,
+        originalUrl: 'metamask://home',
+        normalizedUrl: 'metamask://home',
+        isValid: true,
+        isSupportedAction: true,
+        isPrivateLink: false,
+        requiresAuth: false,
+      };
+
+      const result = LegacyLinkAdapter.buildLegacyUrl(link);
+
+      expect(result).toBe('metamask://home');
+    });
+  });
+
+  describe('extractPathFromUrl', () => {
+    it('extracts path with query parameters', () => {
+      const url = 'https://example.com/swap/test?from=ETH&to=DAI';
+      const action = 'swap';
+
+      const result = LegacyLinkAdapter.extractPathFromUrl(url, action);
+
+      expect(result).toBe('swap/test?from=ETH&to=DAI');
+    });
+
+    it('extracts path without query parameters', () => {
+      const url = 'https://example.com/perps/markets';
+      const action = 'perps';
+
+      const result = LegacyLinkAdapter.extractPathFromUrl(url, action);
+
+      expect(result).toBe('perps/markets');
+    });
+
+    it('returns action when no additional path', () => {
+      const url = 'metamask://home';
+      const action = 'home';
+
+      const result = LegacyLinkAdapter.extractPathFromUrl(url, action);
+
+      expect(result).toBe('home');
+    });
+
+    it('handles action not in path', () => {
+      const url = 'https://example.com/other/path';
+      const action = 'swap';
+
+      const result = LegacyLinkAdapter.extractPathFromUrl(url, action);
+
+      expect(result).toBe('swap/other/path');
+    });
+  });
+});

--- a/app/core/DeeplinkManager/adapters/LegacyLinkAdapter.ts
+++ b/app/core/DeeplinkManager/adapters/LegacyLinkAdapter.ts
@@ -1,0 +1,323 @@
+/**
+ * LegacyLinkAdapter - Bridge between CoreUniversalLink and legacy deeplink format
+ *
+ * Provides compatibility layer for gradual migration from legacy deeplink handling
+ * to the new unified CoreUniversalLink format
+ */
+import UrlParser from 'url-parse';
+import qs from 'qs';
+import { PROTOCOLS, ACTIONS } from '../../../constants/deeplinks';
+import { CoreUniversalLink, CoreLinkParams } from '../types/CoreUniversalLink';
+import { DeeplinkUrlParams } from '../ParseManager/extractURLParams';
+import { CoreLinkNormalizer } from '../CoreLinkNormalizer';
+import AppConstants from '../../AppConstants';
+
+/**
+ * Parameters for action-specific handlers
+ */
+export interface ActionParams {
+  swapPath?: string;
+  perpsPath?: string;
+  rampPath?: string;
+  dappPath?: string;
+  sendPath?: string;
+  homePath?: string;
+  onboardingPath?: string;
+  createAccountPath?: string;
+  depositCashPath?: string;
+  rewardsPath?: string;
+  perpsMarketsPath?: string;
+  perpsAssetPath?: string;
+  buyPath?: string;
+  sellPath?: string;
+  buyCryptoPath?: string;
+  sellCryptoPath?: string;
+}
+
+export class LegacyLinkAdapter {
+  /**
+   * Convert CoreUniversalLink to legacy format (DeeplinkUrlParams)
+   * @param link - The CoreUniversalLink to convert
+   * @returns Legacy format with urlObj and params
+   */
+  static toLegacyFormat(link: CoreUniversalLink): {
+    urlObj: UrlParser<string>;
+    params: DeeplinkUrlParams;
+  } {
+    // Build URL string from CoreUniversalLink
+    const urlString = this.buildLegacyUrl(link);
+    const urlObj = new UrlParser(urlString);
+
+    // Map CoreLinkParams to DeeplinkUrlParams
+    const params: DeeplinkUrlParams = {
+      uri: link.params.uri || '',
+      redirect: link.params.redirect || '',
+      channelId: link.params.channelId || '',
+      comm: link.params.comm || '',
+      pubkey: link.params.pubkey || '',
+      scheme: link.params.scheme,
+      v: link.params.v,
+      rpc: link.params.rpc,
+      sdkVersion: link.params.sdkVersion,
+      message: link.params.message,
+      originatorInfo: link.params.originatorInfo,
+      request: link.params.request,
+      attributionId: link.params.attributionId,
+      utm_source: link.params.utm_source,
+      utm_medium: link.params.utm_medium,
+      utm_campaign: link.params.utm_campaign,
+      utm_term: link.params.utm_term,
+      utm_content: link.params.utm_content,
+      account: link.params.account,
+      hr: link.params.hr === true,
+    };
+
+    return { urlObj, params };
+  }
+
+  /**
+   * Convert legacy format to CoreUniversalLink
+   * @param url - The original URL string
+   * @param params - Legacy DeeplinkUrlParams
+   * @param source - The source of the deeplink
+   * @returns CoreUniversalLink object
+   */
+  static fromLegacyFormat(
+    url: string,
+    params: DeeplinkUrlParams,
+    source: string,
+  ): CoreUniversalLink {
+    // Map legacy params to CoreLinkParams
+    const coreParams: CoreLinkParams = {};
+
+    // Map all parameters
+    if (params.uri) coreParams.uri = params.uri;
+    if (params.redirect) coreParams.redirect = params.redirect;
+    if (params.channelId) coreParams.channelId = params.channelId;
+    if (params.comm) coreParams.comm = params.comm;
+    if (params.pubkey) coreParams.pubkey = params.pubkey;
+    if (params.scheme) coreParams.scheme = params.scheme;
+    if (params.v) coreParams.v = params.v;
+    if (params.rpc) coreParams.rpc = params.rpc;
+    if (params.sdkVersion) coreParams.sdkVersion = params.sdkVersion;
+    if (params.message) coreParams.message = params.message;
+    if (params.originatorInfo)
+      coreParams.originatorInfo = params.originatorInfo;
+    if (params.request) coreParams.request = params.request;
+    if (params.attributionId) coreParams.attributionId = params.attributionId;
+    if (params.utm_source) coreParams.utm_source = params.utm_source;
+    if (params.utm_medium) coreParams.utm_medium = params.utm_medium;
+    if (params.utm_campaign) coreParams.utm_campaign = params.utm_campaign;
+    if (params.utm_term) coreParams.utm_term = params.utm_term;
+    if (params.utm_content) coreParams.utm_content = params.utm_content;
+    if (params.account) coreParams.account = params.account;
+
+    // Convert hr from boolean to boolean (it's already boolean in DeeplinkUrlParams)
+    coreParams.hr = params.hr;
+
+    // Use normalizer to create a proper CoreUniversalLink, then override params
+    const normalizedLink = CoreLinkNormalizer.normalize(url, source);
+
+    // Merge the mapped params with normalized params
+    return {
+      ...normalizedLink,
+      params: {
+        ...normalizedLink.params,
+        ...coreParams,
+      },
+    };
+  }
+
+  /**
+   * Check if a link should use the new routing system
+   * @param link - The CoreUniversalLink to check
+   * @returns Whether to use the new system (default: false for backward compatibility)
+   */
+  static shouldUseNewSystem(_link: CoreUniversalLink): boolean {
+    // Initially returns false to maintain legacy behavior
+    // Can be modified to gradually enable new system per action type
+    // Example future implementation:
+    // if (featureFlag.isEnabled('new-routing-system')) {
+    //   const enabledActions = ['home', 'swap'];
+    //   return enabledActions.includes(link.action);
+    // }
+
+    // For now, always use legacy system
+    return false;
+  }
+
+  /**
+   * Wrap a legacy handler to work with CoreUniversalLink
+   * @param handler - The legacy handler function
+   * @param paramExtractor - Function to extract params for the handler
+   * @returns Wrapped handler that accepts CoreUniversalLink
+   */
+  static wrapHandler<T extends Record<string, unknown>>(
+    handler: (params: T) => void | Promise<void>,
+    paramExtractor: (link: CoreUniversalLink) => T,
+  ): (link: CoreUniversalLink) => void | Promise<void> {
+    return async (link: CoreUniversalLink) => {
+      const params = paramExtractor(link);
+      return handler(params);
+    };
+  }
+
+  /**
+   * Extract action-specific parameters for handlers
+   * @param link - The CoreUniversalLink
+   * @returns Object with action-specific path parameters
+   */
+  static extractActionParams(link: CoreUniversalLink): ActionParams {
+    const params: ActionParams = {};
+
+    // Helper to ensure string type for paths
+    const getStringParam = (
+      value: string | boolean | undefined,
+    ): string | undefined => {
+      if (typeof value === 'string') return value;
+      return undefined;
+    };
+
+    // Extract path based on action
+    switch (link.action) {
+      case ACTIONS.SWAP:
+        params.swapPath = getStringParam(link.params.swapPath);
+        break;
+      case ACTIONS.PERPS:
+      case ACTIONS.PERPS_MARKETS:
+      case ACTIONS.PERPS_ASSET:
+        params.perpsPath = getStringParam(link.params.perpsPath);
+        params.perpsMarketsPath = getStringParam(link.params.perpsMarketsPath);
+        params.perpsAssetPath = getStringParam(link.params.perpsAssetPath);
+        break;
+      case ACTIONS.BUY:
+      case ACTIONS.SELL:
+      case ACTIONS.BUY_CRYPTO:
+      case ACTIONS.SELL_CRYPTO:
+        params.rampPath = getStringParam(link.params.rampPath);
+        params.buyPath = getStringParam(link.params.buyPath);
+        params.sellPath = getStringParam(link.params.sellPath);
+        params.buyCryptoPath = getStringParam(link.params.buyCryptoPath);
+        params.sellCryptoPath = getStringParam(link.params.sellCryptoPath);
+        break;
+      case ACTIONS.DAPP:
+        params.dappPath = getStringParam(link.params.dappPath);
+        break;
+      case ACTIONS.SEND:
+        params.sendPath = getStringParam(link.params.sendPath);
+        break;
+      case ACTIONS.HOME:
+        params.homePath = getStringParam(link.params.homePath);
+        break;
+      case ACTIONS.ONBOARDING:
+        params.onboardingPath = getStringParam(link.params.onboardingPath);
+        break;
+      case ACTIONS.CREATE_ACCOUNT:
+        params.createAccountPath = getStringParam(
+          link.params.createAccountPath,
+        );
+        break;
+      case ACTIONS.DEPOSIT:
+        params.depositCashPath = getStringParam(link.params.depositCashPath);
+        break;
+      case ACTIONS.REWARDS:
+        params.rewardsPath = getStringParam(link.params.rewardsPath);
+        break;
+      default:
+        // No specific path for this action
+        break;
+    }
+
+    return params;
+  }
+
+  /**
+   * Build legacy URL format from CoreUniversalLink
+   * @param link - The CoreUniversalLink
+   * @returns URL string in legacy format
+   */
+  static buildLegacyUrl(link: CoreUniversalLink): string {
+    let baseUrl: string;
+
+    if (link.protocol === 'metamask') {
+      baseUrl = `${PROTOCOLS.METAMASK}://${link.action}`;
+    } else {
+      const host = link.host || AppConstants.MM_IO_UNIVERSAL_LINK_HOST;
+      baseUrl = `${PROTOCOLS.HTTPS}://${host}/${link.action}`;
+    }
+
+    // Build query string from params, excluding action-specific paths
+    const queryParams: Record<string, string> = {};
+    const pathKeys = [
+      'swapPath',
+      'perpsPath',
+      'rampPath',
+      'dappPath',
+      'sendPath',
+      'homePath',
+      'onboardingPath',
+      'createAccountPath',
+      'depositCashPath',
+      'rewardsPath',
+      'perpsMarketsPath',
+      'perpsAssetPath',
+      'buyPath',
+      'sellPath',
+      'buyCryptoPath',
+      'sellCryptoPath',
+    ];
+
+    Object.entries(link.params).forEach(([key, value]) => {
+      if (
+        !pathKeys.includes(key) &&
+        value !== undefined &&
+        value !== null &&
+        value !== ''
+      ) {
+        if (key === 'hr' && typeof value === 'boolean') {
+          queryParams[key] = value ? '1' : '0';
+        } else {
+          queryParams[key] = String(value);
+        }
+      }
+    });
+
+    const queryString =
+      Object.keys(queryParams).length > 0
+        ? `?${qs.stringify(queryParams)}`
+        : '';
+
+    return `${baseUrl}${queryString}`;
+  }
+
+  /**
+   * Extract path from URL based on action
+   * Helper method for reconstructing action-specific paths
+   * @param url - The URL to extract path from
+   * @param action - The action name
+   * @returns The extracted path with query parameters
+   */
+  static extractPathFromUrl(url: string, action: string): string {
+    const urlObj = new UrlParser(url);
+    const pathSegments = urlObj.pathname.split('/').filter(Boolean);
+
+    // Find action index and get remaining path
+    const actionIndex = pathSegments.indexOf(action);
+    if (actionIndex >= 0) {
+      pathSegments.splice(0, actionIndex + 1);
+    }
+
+    const remainingPath = pathSegments.join('/');
+    const queryString = urlObj.query;
+
+    let result = action;
+    if (remainingPath) {
+      result += `/${remainingPath}`;
+    }
+    if (queryString) {
+      result += queryString;
+    }
+
+    return result;
+  }
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR implements the Legacy Adapter as part of Phase 1 of the deep link consolidation project. The adapter creates a bridge between the new `CoreUniversalLink` format (introduced in PR #1) and the existing legacy deep link handlers, enabling a gradual migration without breaking existing functionality.

**What is the reason for the change?**
The current deep link handling system is fragmented with routing logic spread across multiple files. To consolidate this system, we need a compatibility layer that allows both old and new systems to coexist during the migration period.

**What is the improvement/solution?**
The `LegacyLinkAdapter` provides bidirectional conversion between `CoreUniversalLink` and legacy `DeeplinkUrlParams` formats, along with utilities for wrapping existing handlers and extracting action-specific parameters. This enables us to gradually migrate to the new unified system without disrupting existing deep link flows.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [Issue number for deep link consolidation project]

## **Manual testing steps**

```gherkin
Feature: Legacy Adapter Compatibility

  Scenario: Convert CoreUniversalLink to legacy format
    Given a CoreUniversalLink object with metamask:// protocol
    When toLegacyFormat() is called
    Then the legacy format with urlObj and params should be returned
    And all parameters should be correctly mapped

  Scenario: Convert legacy format to CoreUniversalLink
    Given a legacy URL string and DeeplinkUrlParams
    When fromLegacyFormat() is called
    Then a CoreUniversalLink object should be returned
    And all parameters should be preserved

  Scenario: Wrap legacy handlers
    Given an existing deep link handler function
    When wrapHandler() is called with a parameter extractor
    Then the wrapped handler should accept CoreUniversalLink
    And execute the original handler with correct parameters
```

## **Screenshots/Recordings**

N/A - This is an internal infrastructure change with no UI impact.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
  - 27 test cases with 86.2% coverage
  - Tests cover all public methods and edge cases
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
  - All public methods have JSDoc comments with parameter and return type documentation
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---

## **Technical Details**

### Files Added
- `app/core/DeeplinkManager/adapters/LegacyLinkAdapter.ts` (300 lines)
- `app/core/DeeplinkManager/adapters/LegacyLinkAdapter.test.ts` (666 lines)

**Total: 966 lines** (under 1,000 line limit)

### Key Methods
1. **`toLegacyFormat()`** - Converts CoreUniversalLink → legacy format
2. **`fromLegacyFormat()`** - Converts legacy format → CoreUniversalLink
3. **`shouldUseNewSystem()`** - Feature flag support (returns false by default)
4. **`wrapHandler()`** - Wraps legacy handlers to accept CoreUniversalLink
5. **`extractActionParams()`** - Extracts action-specific path parameters
6. **`buildLegacyUrl()`** - Reconstructs legacy URL strings
7. **`extractPathFromUrl()`** - Helper for path extraction

### Test Coverage
- **Statements:** 88.67%
- **Branches:** 89.77%
- **Functions:** 100%
- **Lines:** 86.2%

### Quality Checks
- ✅ All tests pass (27/27)
- ✅ ESLint clean
- ✅ TypeScript compiles without errors
- ✅ Follows MetaMask coding standards

### Dependencies
- Requires PR #1 (Core Types & Normalizer) to be merged first
- No breaking changes to existing functionality
- Maintains 100% backward compatibility

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a LegacyLinkAdapter that converts between CoreUniversalLink and legacy params, wraps legacy handlers, extracts action-specific paths, and builds/extracts URLs, with comprehensive unit tests.
> 
> - **Core/DeeplinkManager**:
>   - Add `LegacyLinkAdapter.ts` providing:
>     - `toLegacyFormat` and `fromLegacyFormat` for bidirectional conversion with `CoreLinkNormalizer` integration.
>     - `wrapHandler` to adapt legacy handlers (supports sync/async).
>     - `extractActionParams` for `ACTIONS` (e.g., `SWAP`, `PERPS`, `BUY_CRYPTO`, `DAPP`, `SEND`, etc.).
>     - `buildLegacyUrl` (handles `metamask`/`https`, filters action-path keys, converts `hr` to `0/1`).
>     - `extractPathFromUrl` to reconstruct action paths.
>     - `shouldUseNewSystem` (defaults to `false`).
> - **Tests**:
>   - Add `LegacyLinkAdapter.test.ts` covering conversions, handler wrapping (sync/async/error), action param extraction, URL building, and path extraction (mocks `CoreLinkNormalizer`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ede44d2f2887602559fe19b87ddfade00ec832d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->