### PR TITLE
fix: ensure that close position screen uses correct decimals

### DIFF
--- a/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
@@ -564,8 +564,8 @@ const PerpsClosePositionView: React.FC = () => {
         {/* Filter the errors and only show minimum $10 error */}
         {filteredErrors.length > 0 && (
           <View style={styles.validationSection}>
-            {filteredErrors.map((error) => (
-              <View key={error} style={styles.errorMessage}>
+            {filteredErrors.map((error, index) => (
+              <View key={`error-${index}`} style={styles.errorMessage}>
                 <Icon
                   name={IconName.Danger}
                   size={IconSize.Sm}

--- a/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
@@ -44,6 +44,7 @@ import {
   usePerpsOrderFees,
   usePerpsRewards,
   usePerpsToasts,
+  usePerpsMarketData,
 } from '../../hooks';
 import { usePerpsLivePrices } from '../../hooks/stream';
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
@@ -81,6 +82,9 @@ const PerpsClosePositionView: React.FC = () => {
   const inputMethodRef = useRef<InputMethod>('default');
 
   const { showToast, PerpsToastOptions } = usePerpsToasts();
+
+  // Get market data for szDecimals
+  const { marketData } = usePerpsMarketData(position.coin);
 
   // Track screen load performance with unified hook (immediate measurement)
   usePerpsMeasurement({
@@ -492,7 +496,7 @@ const PerpsClosePositionView: React.FC = () => {
           showWarning={false}
           onPress={handleAmountPress}
           isActive={isInputFocused}
-          tokenAmount={formatPositionSize(closeAmount)}
+          tokenAmount={formatPositionSize(closeAmount, marketData?.szDecimals)}
           hasError={filteredErrors.length > 0}
           tokenSymbol={position.coin}
           showMaxAmount={false}
@@ -501,7 +505,7 @@ const PerpsClosePositionView: React.FC = () => {
         {/* Toggle Button for USD/Token Display */}
         <View style={styles.toggleContainer}>
           <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
-            {`${formatPositionSize(closeAmount)} ${position.coin}`}
+            {`${formatPositionSize(closeAmount, marketData?.szDecimals)} ${position.coin}`}
           </Text>
         </View>
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixed the decimal precision issue for token amounts displayed in the Perps Close Position screen. The component now uses asset-specific szDecimals from market metadata to format position sizes correctly, ensuring proper display across different cryptocurrencies.

🐛 Problem
Previously, formatPositionSize was called without the szDecimals parameter, causing inconsistent decimal precision across different assets. This resulted in either too many or too few decimal places being displayed for token amounts (e.g., BTC showing too many decimals, DOGE showing unnecessary precision).

✅ Solution
Added usePerpsMarketData hook to fetch market metadata for the position's asset
Passed marketData?.szDecimals to both formatPositionSize calls:
Token amount display in PerpsAmountDisplay component
Token amount in the toggle container text
The formatting now respects asset-specific decimal precision

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1922

## **Manual testing steps**

```gherkin
Feature: Position Close Token Amount Formatting

  Background:
    Given the user has an open position
    And the user navigates to the Close Position screen

  Scenario: Display token amounts with asset-specific decimal precision
    Given the position is for <asset> with szDecimals of <decimals>
    When the close amount is calculated
    Then the token amount displays with <decimals> decimal places
    And no unnecessary trailing zeros are shown

  Scenario: Update token display when close percentage changes
    Given the position has specific szDecimals
    When the user adjusts the close percentage slider
    Then the token amount updates in real-time
    And maintains correct decimal precision

  Scenario: Handle missing market data gracefully
    Given the market data is unavailable
    When the close position screen loads
    Then the token amount displays with fallback formatting
    And the component does not crash

  Scenario: Format partial close amounts correctly
    Given the user selects a partial close percentage
    When the token amount is calculated
    Then the display uses asset-specific decimal precision
    And shows accurate fractional token amounts
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="300" height="auto" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-30 at 18 47 36" src="https://github.com/user-attachments/assets/a31311f6-7593-48d5-93ca-3052e1676b8a" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Uses asset-specific szDecimals from market data to format token amounts in Close Position and adds focused tests; minor key fix in error list rendering.
> 
> - **Perps Close Position (UI)**:
>   - Integrate `usePerpsMarketData(position.coin)` and pass `marketData?.szDecimals` to `formatPositionSize` for `tokenAmount` and the toggle text.
>   - Use stable keys for validation messages (`error-${index}`).
> - **Tests**:
>   - Add comprehensive coverage for szDecimals/market data integration (varying assets/precisions, loading, errors, missing data, small/large sizes) and hook invocation with correct coin.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ace779dbe3c1d9bfb1b1c8823dbad709739bbc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->