### PR TITLE
feat(perps): show hip-3 markets without volume in dev

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
@@ -99,7 +99,7 @@ const PerpsMarketListView = ({
     enablePolling: false,
     showWatchlistOnly,
     defaultMarketTypeFilter,
-    showZeroVolume: true, // Show $0.00 volume markets in list view
+    showZeroVolume: __DEV__, // Only show $0.00 volume markets in development
   });
 
   // Destructure search state for easier access

--- a/app/components/UI/Perps/hooks/usePerpsHomeData.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeData.ts
@@ -82,12 +82,14 @@ export const usePerpsHomeData = ({
     });
 
   // Fetch markets data for trending section (markets don't need real-time updates)
+  // Volume filtering is handled at the data layer in usePerpsMarkets
   const {
     markets: allMarkets,
     isLoading: isMarketsLoading,
     refresh: refreshMarkets,
   } = usePerpsMarkets({
     skipInitialFetch: false,
+    showZeroVolume: __DEV__,
   });
 
   // Get watchlist symbols from Redux

--- a/app/components/UI/Perps/hooks/usePerpsMarkets.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarkets.test.ts
@@ -445,7 +445,7 @@ describe('usePerpsMarkets', () => {
           price: '$1',
           change24h: '+0%',
           change24hPercent: '0',
-          volume: '—',
+          volume: '--', // FALLBACK_DATA_DISPLAY
         },
         {
           symbol: 'F',
@@ -463,7 +463,7 @@ describe('usePerpsMarkets', () => {
           price: '$1',
           change24h: '+0%',
           change24hPercent: '0',
-          volume: '—',
+          volume: '--', // FALLBACK_DATA_DISPLAY
         },
       ];
 
@@ -480,8 +480,60 @@ describe('usePerpsMarkets', () => {
       });
 
       // Assert - should be sorted by volume descending
+      // Note: F ($0), E (—), and G (—) are filtered out by default (showZeroVolume=false)
       const sortedSymbols = result.current.markets.map((m) => m.symbol);
-      expect(sortedSymbols).toEqual(['B', 'D', 'A', 'C', 'F', 'E', 'G']);
+      expect(sortedSymbols).toEqual(['B', 'D', 'A', 'C']); // Only markets with valid volume
+    });
+
+    it('includes zero volume markets when showZeroVolume is true', async () => {
+      // Arrange - markets with various volume formats
+      const unsortedMarkets: PerpsMarketData[] = [
+        {
+          symbol: 'A',
+          name: 'A',
+          maxLeverage: '1x',
+          price: '$1',
+          change24h: '+0%',
+          change24hPercent: '0',
+          volume: '$100K',
+        },
+        {
+          symbol: 'B',
+          name: 'B',
+          maxLeverage: '1x',
+          price: '$1',
+          change24h: '+0%',
+          change24hPercent: '0',
+          volume: '$1.5B',
+        },
+        {
+          symbol: 'F',
+          name: 'F',
+          maxLeverage: '1x',
+          price: '$1',
+          change24h: '+0%',
+          change24hPercent: '0',
+          volume: '$0',
+        },
+      ];
+
+      mockSubscribe.mockImplementation(({ callback }) => {
+        setTimeout(() => callback(unsortedMarkets), 0);
+        return jest.fn();
+      });
+
+      // Act
+      const { result } = renderHook(() =>
+        usePerpsMarkets({ showZeroVolume: true }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // Assert - should include F ($0) when showZeroVolume is true
+      const sortedSymbols = result.current.markets.map((m) => m.symbol);
+      expect(sortedSymbols).toEqual(['B', 'A', 'F']);
     });
   });
 

--- a/app/components/UI/Perps/hooks/usePerpsMarkets.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarkets.ts
@@ -48,6 +48,11 @@ export interface UsePerpsMarketsOptions {
    * @default false
    */
   skipInitialFetch?: boolean;
+  /**
+   * Show markets with zero or invalid volume
+   * @default false
+   */
+  showZeroVolume?: boolean;
 }
 
 const multipliers: Record<string, number> = {
@@ -107,6 +112,7 @@ export const usePerpsMarkets = (
     enablePolling = false,
     pollingInterval = 60000, // 1 minute default
     skipInitialFetch = false,
+    showZeroVolume = false,
   } = options;
 
   const streamManager = usePerpsStream();
@@ -115,18 +121,43 @@ export const usePerpsMarkets = (
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Helper function to sort markets by volume
+  // Helper function to filter and sort markets by volume
   const sortMarketsByVolume = useCallback(
-    (marketData: PerpsMarketData[]): PerpsMarketDataWithVolumeNumber[] =>
-      marketData
-        // pregenerate volumeNumber for sorting to avoid recalculating it on every sort
-        .map((item) => ({ ...item, volumeNumber: parseVolume(item.volume) }))
-        .sort((a, b) => {
-          const volumeA = a.volumeNumber;
-          const volumeB = b.volumeNumber;
-          return volumeB - volumeA;
-        }),
-    [],
+    (marketData: PerpsMarketData[]): PerpsMarketDataWithVolumeNumber[] => {
+      // Filter out invalid volume (unless showZeroVolume is true)
+      const filteredData = !showZeroVolume
+        ? marketData.filter((market) => {
+            // Filter out fallback/error values
+            if (
+              market.volume === PERPS_CONSTANTS.FALLBACK_PRICE_DISPLAY ||
+              market.volume === PERPS_CONSTANTS.FALLBACK_DATA_DISPLAY
+            ) {
+              return false;
+            }
+            // Filter out zero and missing values
+            if (
+              !market.volume ||
+              market.volume === PERPS_CONSTANTS.ZERO_AMOUNT_DISPLAY ||
+              market.volume === PERPS_CONSTANTS.ZERO_AMOUNT_DETAILED_DISPLAY
+            ) {
+              return false;
+            }
+            return true;
+          })
+        : marketData;
+
+      return (
+        filteredData
+          // pregenerate volumeNumber for sorting to avoid recalculating it on every sort
+          .map((item) => ({ ...item, volumeNumber: parseVolume(item.volume) }))
+          .sort((a, b) => {
+            const volumeA = a.volumeNumber;
+            const volumeB = b.volumeNumber;
+            return volumeB - volumeA;
+          })
+      );
+    },
+    [showZeroVolume],
   );
 
   // Manual refresh function


### PR DESCRIPTION
## **Description**

This PR fixes an issue where HIP-3 markets (stocks and commodities) with $0.00 volume were incorrectly displayed in the Market List View and Home View.

**What was the problem?**
- Markets with zero or invalid volume data were showing up in the Stocks and Commodities tabs
- This was inconsistent with how crypto perps markets behave (they correctly hide zero-volume markets)

**What is the solution?**
- Zero-volume markets are now filtered out consistently across all market types
- Filtering logic moved to the data layer for consistency
- Both Market List View and Home View now hide markets with $0.00 volume by default

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1957

## **Manual testing steps**

```gherkin
Feature: Hide zero-volume HIP-3 markets

  Scenario: user views Market List View stocks tab
    Given app is running and Perps feature is enabled

    When user navigates to Market List View
    And user selects the "Stocks" tab
    Then user should only see stocks with valid volume data
    And user should NOT see any markets displaying "$0.00" volume

  Scenario: user views Market List View commodities tab
    Given app is running and Perps feature is enabled

    When user navigates to Market List View
    And user selects the "Commodities" tab
    Then user should only see commodities with valid volume data
    And user should NOT see any markets displaying "$0.00" volume

  Scenario: user views Perps Home View
    Given app is running and Perps feature is enabled

    When user navigates to Perps Home View
    Then user should only see markets with valid volume data in all carousels
    And user should NOT see any markets displaying "$0.00" volume
```

## **Screenshots/Recordings**

### **Before**

Markets with $0.00 volume were visible in the Stocks tab and other HIP-3 market tabs.

### **After**

Only markets with valid volume data are displayed. Zero-volume markets are filtered out consistently.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Overhauls Perps Markets and Home with searchable/sortable tabs, consistent zero‑volume filtering, bulk Close/Cancel All flows, market hours banner/tooltip, refined leverage priority, and extensive hook/test updates.
> 
> - **UI/Navigation**:
>   - **Home**: New `PerpsHomeView` with positions/orders sections, watchlist, market type sections, navigation card, and bottom sheets for Close All/Cancel All.
>   - **Market List**: Reworked `PerpsMarketListView` with tabs (All/Crypto/Stocks & Commodities), search header, sorting/filters, and reusable `PerpsMarketList`/row components.
>   - **Bulk Actions**: Added `PerpsCloseAllPositionsView`/`PerpsCancelAllOrdersView` and modal variants; shared `PerpsCloseSummary`.
>   - **Market Hours**: Added `PerpsMarketHoursBanner` and bottom-sheet tooltip content.
> - **Hooks/Logic**:
>   - **Data**: New `usePerpsHomeData`, `usePerpsMarketListView`, `usePerpsSearch`, `usePerpsSorting`; consistent zero‑volume filtering moved to `usePerpsMarkets` (opt‑in via `showZeroVolume`).
>   - **Bulk Ops**: `usePerpsCloseAllCalculations`, `usePerpsCloseAllPositions`, `usePerpsCancelAllOrders` for fees/points and execution.
>   - **Streams**: `usePerpsLiveFills` now returns `{ fills, isInitialLoading }`.
>   - **Orders**: Leverage priority: nav param > existing position > saved config > default; validation accepts `existingPositionLeverage`.
> - **Routing/Styles/Locale**:
>   - Wired Home and modal routes; various style tweaks; added i18n for market hours.
> - **Tests**: Extensive new unit tests across views, hooks, components, and styles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c712e480db4628461b73880cda39a7b1d5caa800. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->