### PR TITLE
fix: cp-7.59.0 explorer url for Monad

### DIFF
--- a/app/util/networks/customNetworks.tsx
+++ b/app/util/networks/customNetworks.tsx
@@ -156,7 +156,7 @@ export const PopularList = [
     ticker: 'MON',
     warning: true,
     rpcPrefs: {
-      blockExplorerUrl: 'http://monadscan.com/',
+      blockExplorerUrl: 'https://monadscan.com/',
       imageUrl: 'MON',
       imageSource: require('../../images/monad-mainnet-logo.png'),
     },

--- a/e2e/api-mocking/mock-responses/defaults/index.ts
+++ b/e2e/api-mocking/mock-responses/defaults/index.ts
@@ -165,7 +165,7 @@ export const DEFAULT_MOCKS = {
             decimals: 18,
           },
           network: 'monad-mainnet',
-          explorer: 'http://monadscan.com/',
+          explorer: 'https://monadscan.com/',
           confirmations: true,
           smartTransactions: false,
           relayTransactions: false,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR changes the explorer url of the upcoming monad network (launch expected on 24th of nov), from `http://monadscan.com` to `https://monadscan.com`. The url is not yet active, but will be activated for the launch.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed url for monda explorer url 

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Monad explorer URL to https://monadscan.com/ in app config and e2e mocks.
> 
> - **Networks configuration**:
>   - Update `rpcPrefs.blockExplorerUrl` for `Monad` in `app/util/networks/customNetworks.tsx` to `https://monadscan.com/`.
> - **E2E mocks**:
>   - Update `explorer` for `Monad Mainnet (143)` in `e2e/api-mocking/mock-responses/defaults/index.ts` to `https://monadscan.com/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a40e37ede6fbcc38ff8bd379c320b8c8c768097e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->