### PR TITLE
fix: addresses styling on transaction details

### DIFF
--- a/app/components/UI/TransactionElement/TransactionDetails/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/TransactionElement/TransactionDetails/__snapshots__/index.test.tsx.snap
@@ -615,19 +615,19 @@ exports[`TransactionDetails should render correctly 1`] = `
                                   style={
                                     {
                                       "backgroundColor": "#ffffff",
-                                      "borderRadius": 8,
-                                      "height": 32,
+                                      "borderRadius": 6,
+                                      "height": 24,
                                       "marginRight": 8,
                                       "overflow": "hidden",
-                                      "width": 32,
+                                      "width": 24,
                                     }
                                   }
                                 >
                                   <View
                                     style={
                                       {
-                                        "height": 32,
-                                        "width": 32,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
                                   />
@@ -635,14 +635,13 @@ exports[`TransactionDetails should render correctly 1`] = `
                                 <Text
                                   accessibilityRole="text"
                                   primary={true}
-                                  small={true}
                                   style={
                                     {
                                       "color": "#121314",
                                       "fontFamily": "Geist Regular",
-                                      "fontSize": 16,
+                                      "fontSize": 14,
                                       "letterSpacing": 0,
-                                      "lineHeight": 24,
+                                      "lineHeight": 22,
                                     }
                                   }
                                   testID="account-label"
@@ -746,19 +745,19 @@ exports[`TransactionDetails should render correctly 1`] = `
                                   style={
                                     {
                                       "backgroundColor": "#ffffff",
-                                      "borderRadius": 8,
-                                      "height": 32,
+                                      "borderRadius": 6,
+                                      "height": 24,
                                       "marginRight": 8,
                                       "overflow": "hidden",
-                                      "width": 32,
+                                      "width": 24,
                                     }
                                   }
                                 >
                                   <View
                                     style={
                                       {
-                                        "height": 32,
-                                        "width": 32,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
                                   />
@@ -766,14 +765,13 @@ exports[`TransactionDetails should render correctly 1`] = `
                                 <Text
                                   accessibilityRole="text"
                                   primary={true}
-                                  small={true}
                                   style={
                                     {
                                       "color": "#121314",
                                       "fontFamily": "Geist Regular",
-                                      "fontSize": 16,
+                                      "fontSize": 14,
                                       "letterSpacing": 0,
-                                      "lineHeight": 24,
+                                      "lineHeight": 22,
                                     }
                                   }
                                   testID="account-label"
@@ -1891,19 +1889,19 @@ exports[`TransactionDetails should render correctly for multi-layer fee network 
                                   style={
                                     {
                                       "backgroundColor": "#ffffff",
-                                      "borderRadius": 8,
-                                      "height": 32,
+                                      "borderRadius": 6,
+                                      "height": 24,
                                       "marginRight": 8,
                                       "overflow": "hidden",
-                                      "width": 32,
+                                      "width": 24,
                                     }
                                   }
                                 >
                                   <View
                                     style={
                                       {
-                                        "height": 32,
-                                        "width": 32,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
                                   />
@@ -1911,14 +1909,13 @@ exports[`TransactionDetails should render correctly for multi-layer fee network 
                                 <Text
                                   accessibilityRole="text"
                                   primary={true}
-                                  small={true}
                                   style={
                                     {
                                       "color": "#121314",
                                       "fontFamily": "Geist Regular",
-                                      "fontSize": 16,
+                                      "fontSize": 14,
                                       "letterSpacing": 0,
-                                      "lineHeight": 24,
+                                      "lineHeight": 22,
                                     }
                                   }
                                   testID="account-label"
@@ -2022,19 +2019,19 @@ exports[`TransactionDetails should render correctly for multi-layer fee network 
                                   style={
                                     {
                                       "backgroundColor": "#ffffff",
-                                      "borderRadius": 8,
-                                      "height": 32,
+                                      "borderRadius": 6,
+                                      "height": 24,
                                       "marginRight": 8,
                                       "overflow": "hidden",
-                                      "width": 32,
+                                      "width": 24,
                                     }
                                   }
                                 >
                                   <View
                                     style={
                                       {
-                                        "height": 32,
-                                        "width": 32,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
                                   />
@@ -2042,14 +2039,13 @@ exports[`TransactionDetails should render correctly for multi-layer fee network 
                                 <Text
                                   accessibilityRole="text"
                                   primary={true}
-                                  small={true}
                                   style={
                                     {
                                       "color": "#121314",
                                       "fontFamily": "Geist Regular",
-                                      "fontSize": 16,
+                                      "fontSize": 14,
                                       "letterSpacing": 0,
-                                      "lineHeight": 24,
+                                      "lineHeight": 22,
                                     }
                                   }
                                   testID="account-label"
@@ -3167,19 +3163,19 @@ exports[`TransactionDetails should render correctly for multi-layer fee network 
                                   style={
                                     {
                                       "backgroundColor": "#ffffff",
-                                      "borderRadius": 8,
-                                      "height": 32,
+                                      "borderRadius": 6,
+                                      "height": 24,
                                       "marginRight": 8,
                                       "overflow": "hidden",
-                                      "width": 32,
+                                      "width": 24,
                                     }
                                   }
                                 >
                                   <View
                                     style={
                                       {
-                                        "height": 32,
-                                        "width": 32,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
                                   />
@@ -3187,14 +3183,13 @@ exports[`TransactionDetails should render correctly for multi-layer fee network 
                                 <Text
                                   accessibilityRole="text"
                                   primary={true}
-                                  small={true}
                                   style={
                                     {
                                       "color": "#121314",
                                       "fontFamily": "Geist Regular",
-                                      "fontSize": 16,
+                                      "fontSize": 14,
                                       "letterSpacing": 0,
-                                      "lineHeight": 24,
+                                      "lineHeight": 22,
                                     }
                                   }
                                   testID="account-label"
@@ -3298,19 +3293,19 @@ exports[`TransactionDetails should render correctly for multi-layer fee network 
                                   style={
                                     {
                                       "backgroundColor": "#ffffff",
-                                      "borderRadius": 8,
-                                      "height": 32,
+                                      "borderRadius": 6,
+                                      "height": 24,
                                       "marginRight": 8,
                                       "overflow": "hidden",
-                                      "width": 32,
+                                      "width": 24,
                                     }
                                   }
                                 >
                                   <View
                                     style={
                                       {
-                                        "height": 32,
-                                        "width": 32,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
                                   />
@@ -3318,14 +3313,13 @@ exports[`TransactionDetails should render correctly for multi-layer fee network 
                                 <Text
                                   accessibilityRole="text"
                                   primary={true}
-                                  small={true}
                                   style={
                                     {
                                       "color": "#121314",
                                       "fontFamily": "Geist Regular",
-                                      "fontSize": 16,
+                                      "fontSize": 14,
                                       "letterSpacing": 0,
-                                      "lineHeight": 24,
+                                      "lineHeight": 22,
                                     }
                                   }
                                   testID="account-label"

--- a/app/components/UI/TransactionElement/TransactionDetails/index.js
+++ b/app/components/UI/TransactionElement/TransactionDetails/index.js
@@ -449,11 +449,11 @@ class TransactionDetails extends PureComponent {
                       this.props.avatarAccountType || AvatarAccountType.Maskicon
                     }
                     accountAddress={updatedTransactionDetails.renderFrom}
-                    size={AvatarSize.Md}
+                    size={AvatarSize.Sm}
                     style={styles.accountAvatar}
                   />
                   <Text
-                    small
+                    variant={TextVariant.BodySM}
                     primary
                     testID={WalletViewSelectorsIDs.ACCOUNT_NAME_LABEL_TEXT}
                   >
@@ -479,11 +479,11 @@ class TransactionDetails extends PureComponent {
                       this.props.avatarAccountType || AvatarAccountType.Maskicon
                     }
                     accountAddress={updatedTransactionDetails.renderTo}
-                    size={AvatarSize.Md}
+                    size={AvatarSize.Sm}
                     style={styles.accountAvatar}
                   />
                   <Text
-                    small
+                    variant={TextVariant.BodySM}
                     primary
                     testID={WalletViewSelectorsIDs.ACCOUNT_NAME_LABEL_TEXT}
                   >


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR fixes addresses styling on transaction details view.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed styling on transaction details view

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/15603
https://consensyssoftware.atlassian.net/browse/TMCU-138

## **Manual testing steps**

```gherkin
Feature: Show transaction details

  Scenario: user opens transaction details
    Given user has any transactions in activity view

    When user clicks transaction item to open details
    Then transaction details view has smaller addresses styling
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="412" height="909" alt="Screenshot 2025-10-30 at 16 33 39" src="https://github.com/user-attachments/assets/82cb6219-542d-4ee5-8d39-c363c73b03ea" />

### **After**

<!-- [screenshots/recordings] -->
<img width="407" height="915" alt="Screenshot 2025-10-31 at 09 16 40" src="https://github.com/user-attachments/assets/104bb565-5294-4658-ba84-2cae2953348d" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shrinks the from/to address avatar and label typography in Transaction Details and updates snapshots.
> 
> - **UI — Transaction Details (`app/components/UI/TransactionElement/TransactionDetails/index.js`)**:
>   - Reduce `Avatar` size from `AvatarSize.Md` to `AvatarSize.Sm` for `renderFrom` and `renderTo`.
>   - Replace `Text small` with `Text variant={TextVariant.BodySM}` for address labels.
> - **Tests — Snapshots**:
>   - Update `__snapshots__/index.test.tsx.snap` to reflect smaller avatar container (32→24, radius 8→6) and smaller text (fontSize 16→14, lineHeight 24→22).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcceec7bd5c78253e2a7ad6356ada78314338c95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->