### PR TITLE
fix: accountStatus page UI top padding

### DIFF
--- a/app/components/Views/AccountStatus/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/AccountStatus/__snapshots__/index.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`AccountStatus Snapshots android renders correctly with accountName in r
       {
         "flex": 1,
         "paddingHorizontal": 16,
-        "paddingTop": 24,
+        "paddingTop": 40,
       }
     }
   >
@@ -208,7 +208,7 @@ exports[`AccountStatus Snapshots android renders correctly with type="found and 
       {
         "flex": 1,
         "paddingHorizontal": 16,
-        "paddingTop": 24,
+        "paddingTop": 40,
       }
     }
   >
@@ -395,7 +395,7 @@ exports[`AccountStatus Snapshots android renders correctly with type="not_exist"
       {
         "flex": 1,
         "paddingHorizontal": 16,
-        "paddingTop": 24,
+        "paddingTop": 40,
       }
     }
   >
@@ -582,7 +582,7 @@ exports[`AccountStatus Snapshots iOS renders correctly with accountName in route
       {
         "flex": 1,
         "paddingHorizontal": 16,
-        "paddingTop": 24,
+        "paddingTop": 40,
       }
     }
   >
@@ -769,7 +769,7 @@ exports[`AccountStatus Snapshots iOS renders correctly with type="found" 1`] = `
       {
         "flex": 1,
         "paddingHorizontal": 16,
-        "paddingTop": 24,
+        "paddingTop": 40,
       }
     }
   >
@@ -956,7 +956,7 @@ exports[`AccountStatus Snapshots iOS renders correctly with type="not_exist" 1`]
       {
         "flex": 1,
         "paddingHorizontal": 16,
-        "paddingTop": 24,
+        "paddingTop": 40,
       }
     }
   >

--- a/app/components/Views/AccountStatus/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/AccountStatus/__snapshots__/index.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`AccountStatus Snapshots android renders correctly with accountName in r
       "bottom": "additive",
       "left": "off",
       "right": "off",
-      "top": "off",
+      "top": "additive",
     }
   }
   style={
@@ -21,7 +21,7 @@ exports[`AccountStatus Snapshots android renders correctly with accountName in r
       {
         "flex": 1,
         "paddingHorizontal": 16,
-        "paddingTop": 40,
+        "paddingTop": 16,
       }
     }
   >
@@ -187,14 +187,14 @@ exports[`AccountStatus Snapshots android renders correctly with accountName in r
 </RNCSafeAreaView>
 `;
 
-exports[`AccountStatus Snapshots android renders correctly with type="not_exist" 1`] = `
+exports[`AccountStatus Snapshots android renders correctly with type="found" 1`] = `
 <RNCSafeAreaView
   edges={
     {
       "bottom": "additive",
       "left": "off",
       "right": "off",
-      "top": "off",
+      "top": "additive",
     }
   }
   style={
@@ -208,194 +208,7 @@ exports[`AccountStatus Snapshots android renders correctly with type="not_exist"
       {
         "flex": 1,
         "paddingHorizontal": 16,
-        "paddingTop": 40,
-      }
-    }
-  >
-    <RCTScrollView
-      style={
-        {
-          "marginBottom": 0,
-        }
-      }
-    >
-      <View>
-        <View
-          style={
-            {
-              "alignItems": "flex-start",
-              "flex": 1,
-              "justifyContent": "flex-start",
-              "paddingBottom": 24,
-            }
-          }
-        >
-          <Text
-            accessibilityRole="text"
-            style={
-              {
-                "color": "#121314",
-                "fontFamily": "Geist Bold",
-                "fontSize": 32,
-                "letterSpacing": 0,
-                "lineHeight": 40,
-              }
-            }
-          >
-            Wallet not found
-          </Text>
-          <Image
-            resizeMode="contain"
-            source={1}
-            style={
-              {
-                "alignSelf": "center",
-                "height": 302,
-                "marginHorizontal": "auto",
-                "marginVertical": 16,
-                "width": 343,
-              }
-            }
-          />
-          <View
-            style={
-              {
-                "flexDirection": "column",
-                "rowGap": 20,
-                "width": "100%",
-              }
-            }
-          >
-            <Text
-              accessibilityRole="text"
-              style={
-                {
-                  "color": "#686e7d",
-                  "fontFamily": "Geist Regular",
-                  "fontSize": 16,
-                  "letterSpacing": 0,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              We couldn’t find a wallet for "[missing {{accountName}} value]". Do you want to create a new one with this login?
-            </Text>
-          </View>
-        </View>
-      </View>
-    </RCTScrollView>
-    <View
-      style={
-        {
-          "display": "flex",
-          "flexDirection": "column",
-          "marginBottom": 16,
-          "marginTop": "auto",
-          "rowGap": 16,
-        }
-      }
-    >
-      <TouchableOpacity
-        accessibilityRole="button"
-        accessible={true}
-        activeOpacity={1}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
-        style={
-          {
-            "alignItems": "center",
-            "alignSelf": "stretch",
-            "backgroundColor": "#121314",
-            "borderRadius": 12,
-            "flexDirection": "row",
-            "height": 48,
-            "justifyContent": "center",
-            "overflow": "hidden",
-            "paddingHorizontal": 16,
-          }
-        }
-      >
-        <Text
-          accessibilityRole="text"
-          style={
-            {
-              "color": "#ffffff",
-              "fontFamily": "Geist Medium",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
-            }
-          }
-        >
-          Create a new wallet
-        </Text>
-      </TouchableOpacity>
-      <TouchableOpacity
-        accessibilityRole="button"
-        accessible={true}
-        activeOpacity={1}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
-        style={
-          {
-            "alignItems": "center",
-            "alignSelf": "stretch",
-            "backgroundColor": "#3c4d9d0f",
-            "borderColor": "transparent",
-            "borderRadius": 12,
-            "borderWidth": 1,
-            "flexDirection": "row",
-            "height": 48,
-            "justifyContent": "center",
-            "overflow": "hidden",
-            "paddingHorizontal": 16,
-          }
-        }
-      >
-        <Text
-          accessibilityRole="text"
-          style={
-            {
-              "color": "#121314",
-              "fontFamily": "Geist Medium",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
-            }
-          }
-        >
-          Use a different login method
-        </Text>
-      </TouchableOpacity>
-    </View>
-  </View>
-</RNCSafeAreaView>
-`;
-
-exports[`AccountStatus Snapshots android renders with type="found" 1`] = `
-<RNCSafeAreaView
-  edges={
-    {
-      "bottom": "additive",
-      "left": "off",
-      "right": "off",
-      "top": "off",
-    }
-  }
-  style={
-    {
-      "flex": 1,
-    }
-  }
->
-  <View
-    style={
-      {
-        "flex": 1,
-        "paddingHorizontal": 16,
-        "paddingTop": 40,
+        "paddingTop": 16,
       }
     }
   >
@@ -561,14 +374,14 @@ exports[`AccountStatus Snapshots android renders with type="found" 1`] = `
 </RNCSafeAreaView>
 `;
 
-exports[`AccountStatus Snapshots iOS renders correctly with accountName in route params 1`] = `
+exports[`AccountStatus Snapshots android renders correctly with type="not_exist" 1`] = `
 <RNCSafeAreaView
   edges={
     {
       "bottom": "additive",
       "left": "off",
       "right": "off",
-      "top": "off",
+      "top": "additive",
     }
   }
   style={
@@ -582,7 +395,194 @@ exports[`AccountStatus Snapshots iOS renders correctly with accountName in route
       {
         "flex": 1,
         "paddingHorizontal": 16,
-        "paddingTop": 40,
+        "paddingTop": 16,
+      }
+    }
+  >
+    <RCTScrollView
+      style={
+        {
+          "marginBottom": 0,
+        }
+      }
+    >
+      <View>
+        <View
+          style={
+            {
+              "alignItems": "flex-start",
+              "flex": 1,
+              "justifyContent": "flex-start",
+              "paddingBottom": 24,
+            }
+          }
+        >
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#121314",
+                "fontFamily": "Geist Bold",
+                "fontSize": 32,
+                "letterSpacing": 0,
+                "lineHeight": 40,
+              }
+            }
+          >
+            Wallet not found
+          </Text>
+          <Image
+            resizeMode="contain"
+            source={1}
+            style={
+              {
+                "alignSelf": "center",
+                "height": 302,
+                "marginHorizontal": "auto",
+                "marginVertical": 16,
+                "width": 343,
+              }
+            }
+          />
+          <View
+            style={
+              {
+                "flexDirection": "column",
+                "rowGap": 20,
+                "width": "100%",
+              }
+            }
+          >
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#686e7d",
+                  "fontFamily": "Geist Regular",
+                  "fontSize": 16,
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                }
+              }
+            >
+              We couldn’t find a wallet for "[missing {{accountName}} value]". Do you want to create a new one with this login?
+            </Text>
+          </View>
+        </View>
+      </View>
+    </RCTScrollView>
+    <View
+      style={
+        {
+          "display": "flex",
+          "flexDirection": "column",
+          "marginBottom": 16,
+          "marginTop": "auto",
+          "rowGap": 16,
+        }
+      }
+    >
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        activeOpacity={1}
+        onPress={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "alignSelf": "stretch",
+            "backgroundColor": "#121314",
+            "borderRadius": 12,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "overflow": "hidden",
+            "paddingHorizontal": 16,
+          }
+        }
+      >
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#ffffff",
+              "fontFamily": "Geist Medium",
+              "fontSize": 16,
+              "letterSpacing": 0,
+              "lineHeight": 24,
+            }
+          }
+        >
+          Create a new wallet
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        activeOpacity={1}
+        onPress={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "alignSelf": "stretch",
+            "backgroundColor": "#3c4d9d0f",
+            "borderColor": "transparent",
+            "borderRadius": 12,
+            "borderWidth": 1,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "overflow": "hidden",
+            "paddingHorizontal": 16,
+          }
+        }
+      >
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#121314",
+              "fontFamily": "Geist Medium",
+              "fontSize": 16,
+              "letterSpacing": 0,
+              "lineHeight": 24,
+            }
+          }
+        >
+          Use a different login method
+        </Text>
+      </TouchableOpacity>
+    </View>
+  </View>
+</RNCSafeAreaView>
+`;
+
+exports[`AccountStatus Snapshots iOS renders correctly with accountName in route params 1`] = `
+<RNCSafeAreaView
+  edges={
+    {
+      "bottom": "additive",
+      "left": "off",
+      "right": "off",
+      "top": "additive",
+    }
+  }
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <View
+    style={
+      {
+        "flex": 1,
+        "paddingHorizontal": 16,
+        "paddingTop": 16,
       }
     }
   >
@@ -755,7 +755,7 @@ exports[`AccountStatus Snapshots iOS renders correctly with type="found" 1`] = `
       "bottom": "additive",
       "left": "off",
       "right": "off",
-      "top": "off",
+      "top": "additive",
     }
   }
   style={
@@ -769,7 +769,7 @@ exports[`AccountStatus Snapshots iOS renders correctly with type="found" 1`] = `
       {
         "flex": 1,
         "paddingHorizontal": 16,
-        "paddingTop": 40,
+        "paddingTop": 16,
       }
     }
   >
@@ -942,7 +942,7 @@ exports[`AccountStatus Snapshots iOS renders correctly with type="not_exist" 1`]
       "bottom": "additive",
       "left": "off",
       "right": "off",
-      "top": "off",
+      "top": "additive",
     }
   }
   style={
@@ -956,7 +956,7 @@ exports[`AccountStatus Snapshots iOS renders correctly with type="not_exist" 1`]
       {
         "flex": 1,
         "paddingHorizontal": 16,
-        "paddingTop": 40,
+        "paddingTop": 16,
       }
     }
   >

--- a/app/components/Views/AccountStatus/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/AccountStatus/__snapshots__/index.test.tsx.snap
@@ -187,193 +187,6 @@ exports[`AccountStatus Snapshots android renders correctly with accountName in r
 </RNCSafeAreaView>
 `;
 
-exports[`AccountStatus Snapshots android renders correctly with type="found and statusbar current height to zero" 1`] = `
-<RNCSafeAreaView
-  edges={
-    {
-      "bottom": "additive",
-      "left": "off",
-      "right": "off",
-      "top": "off",
-    }
-  }
-  style={
-    {
-      "flex": 1,
-    }
-  }
->
-  <View
-    style={
-      {
-        "flex": 1,
-        "paddingHorizontal": 16,
-        "paddingTop": 40,
-      }
-    }
-  >
-    <RCTScrollView
-      style={
-        {
-          "marginBottom": 0,
-        }
-      }
-    >
-      <View>
-        <View
-          style={
-            {
-              "alignItems": "flex-start",
-              "flex": 1,
-              "justifyContent": "flex-start",
-              "paddingBottom": 24,
-            }
-          }
-        >
-          <Text
-            accessibilityRole="text"
-            style={
-              {
-                "color": "#121314",
-                "fontFamily": "Geist Bold",
-                "fontSize": 32,
-                "letterSpacing": 0,
-                "lineHeight": 40,
-              }
-            }
-          >
-            Wallet already exists
-          </Text>
-          <Image
-            resizeMode="contain"
-            source={1}
-            style={
-              {
-                "alignSelf": "center",
-                "height": 302,
-                "marginHorizontal": "auto",
-                "marginVertical": 16,
-                "width": 343,
-              }
-            }
-          />
-          <View
-            style={
-              {
-                "flexDirection": "column",
-                "rowGap": 20,
-                "width": "100%",
-              }
-            }
-          >
-            <Text
-              accessibilityRole="text"
-              style={
-                {
-                  "color": "#686e7d",
-                  "fontFamily": "Geist Regular",
-                  "fontSize": 16,
-                  "letterSpacing": 0,
-                  "lineHeight": 24,
-                }
-              }
-            >
-              A wallet using "[missing {{accountName}} value]" already exists. Do you want to try logging in instead?
-            </Text>
-          </View>
-        </View>
-      </View>
-    </RCTScrollView>
-    <View
-      style={
-        {
-          "display": "flex",
-          "flexDirection": "column",
-          "marginBottom": 16,
-          "marginTop": "auto",
-          "rowGap": 16,
-        }
-      }
-    >
-      <TouchableOpacity
-        accessibilityRole="button"
-        accessible={true}
-        activeOpacity={1}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
-        style={
-          {
-            "alignItems": "center",
-            "alignSelf": "stretch",
-            "backgroundColor": "#121314",
-            "borderRadius": 12,
-            "flexDirection": "row",
-            "height": 48,
-            "justifyContent": "center",
-            "overflow": "hidden",
-            "paddingHorizontal": 16,
-          }
-        }
-      >
-        <Text
-          accessibilityRole="text"
-          style={
-            {
-              "color": "#ffffff",
-              "fontFamily": "Geist Medium",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
-            }
-          }
-        >
-          Log in
-        </Text>
-      </TouchableOpacity>
-      <TouchableOpacity
-        accessibilityRole="button"
-        accessible={true}
-        activeOpacity={1}
-        onPress={[Function]}
-        onPressIn={[Function]}
-        onPressOut={[Function]}
-        style={
-          {
-            "alignItems": "center",
-            "alignSelf": "stretch",
-            "backgroundColor": "#3c4d9d0f",
-            "borderColor": "transparent",
-            "borderRadius": 12,
-            "borderWidth": 1,
-            "flexDirection": "row",
-            "height": 48,
-            "justifyContent": "center",
-            "overflow": "hidden",
-            "paddingHorizontal": 16,
-          }
-        }
-      >
-        <Text
-          accessibilityRole="text"
-          style={
-            {
-              "color": "#121314",
-              "fontFamily": "Geist Medium",
-              "fontSize": 16,
-              "letterSpacing": 0,
-              "lineHeight": 24,
-            }
-          }
-        >
-          Use a different login method
-        </Text>
-      </TouchableOpacity>
-    </View>
-  </View>
-</RNCSafeAreaView>
-`;
-
 exports[`AccountStatus Snapshots android renders correctly with type="not_exist" 1`] = `
 <RNCSafeAreaView
   edges={
@@ -516,6 +329,193 @@ exports[`AccountStatus Snapshots android renders correctly with type="not_exist"
           }
         >
           Create a new wallet
+        </Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        activeOpacity={1}
+        onPress={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "alignSelf": "stretch",
+            "backgroundColor": "#3c4d9d0f",
+            "borderColor": "transparent",
+            "borderRadius": 12,
+            "borderWidth": 1,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "overflow": "hidden",
+            "paddingHorizontal": 16,
+          }
+        }
+      >
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#121314",
+              "fontFamily": "Geist Medium",
+              "fontSize": 16,
+              "letterSpacing": 0,
+              "lineHeight": 24,
+            }
+          }
+        >
+          Use a different login method
+        </Text>
+      </TouchableOpacity>
+    </View>
+  </View>
+</RNCSafeAreaView>
+`;
+
+exports[`AccountStatus Snapshots android renders with type="found" 1`] = `
+<RNCSafeAreaView
+  edges={
+    {
+      "bottom": "additive",
+      "left": "off",
+      "right": "off",
+      "top": "off",
+    }
+  }
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <View
+    style={
+      {
+        "flex": 1,
+        "paddingHorizontal": 16,
+        "paddingTop": 40,
+      }
+    }
+  >
+    <RCTScrollView
+      style={
+        {
+          "marginBottom": 0,
+        }
+      }
+    >
+      <View>
+        <View
+          style={
+            {
+              "alignItems": "flex-start",
+              "flex": 1,
+              "justifyContent": "flex-start",
+              "paddingBottom": 24,
+            }
+          }
+        >
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#121314",
+                "fontFamily": "Geist Bold",
+                "fontSize": 32,
+                "letterSpacing": 0,
+                "lineHeight": 40,
+              }
+            }
+          >
+            Wallet already exists
+          </Text>
+          <Image
+            resizeMode="contain"
+            source={1}
+            style={
+              {
+                "alignSelf": "center",
+                "height": 302,
+                "marginHorizontal": "auto",
+                "marginVertical": 16,
+                "width": 343,
+              }
+            }
+          />
+          <View
+            style={
+              {
+                "flexDirection": "column",
+                "rowGap": 20,
+                "width": "100%",
+              }
+            }
+          >
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#686e7d",
+                  "fontFamily": "Geist Regular",
+                  "fontSize": 16,
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                }
+              }
+            >
+              A wallet using "[missing {{accountName}} value]" already exists. Do you want to try logging in instead?
+            </Text>
+          </View>
+        </View>
+      </View>
+    </RCTScrollView>
+    <View
+      style={
+        {
+          "display": "flex",
+          "flexDirection": "column",
+          "marginBottom": 16,
+          "marginTop": "auto",
+          "rowGap": 16,
+        }
+      }
+    >
+      <TouchableOpacity
+        accessibilityRole="button"
+        accessible={true}
+        activeOpacity={1}
+        onPress={[Function]}
+        onPressIn={[Function]}
+        onPressOut={[Function]}
+        style={
+          {
+            "alignItems": "center",
+            "alignSelf": "stretch",
+            "backgroundColor": "#121314",
+            "borderRadius": 12,
+            "flexDirection": "row",
+            "height": 48,
+            "justifyContent": "center",
+            "overflow": "hidden",
+            "paddingHorizontal": 16,
+          }
+        }
+      >
+        <Text
+          accessibilityRole="text"
+          style={
+            {
+              "color": "#ffffff",
+              "fontFamily": "Geist Medium",
+              "fontSize": 16,
+              "letterSpacing": 0,
+              "lineHeight": 24,
+            }
+          }
+        >
+          Log in
         </Text>
       </TouchableOpacity>
       <TouchableOpacity

--- a/app/components/Views/AccountStatus/index.styles.ts
+++ b/app/components/Views/AccountStatus/index.styles.ts
@@ -1,13 +1,10 @@
-import { StyleSheet, Platform, StatusBar, Dimensions } from 'react-native';
+import { StyleSheet, Platform, Dimensions } from 'react-native';
 
 const IMAGE_MAX_WIDTH = 343;
 const IMAGE_ASPECT_RATIO = 343 / 302;
 const HORIZONTAL_PADDING = 16;
 const CONTAINER_WIDTH = Dimensions.get('window').width - HORIZONTAL_PADDING * 2;
 const WALLET_IMAGE_WIDTH = Math.min(CONTAINER_WIDTH, IMAGE_MAX_WIDTH);
-
-const statusBarHeight = StatusBar.currentHeight ?? 0;
-const androidPaddingTopWithStatusBar = statusBarHeight + 24;
 
 const styles = StyleSheet.create({
   safeArea: {
@@ -19,10 +16,7 @@ const styles = StyleSheet.create({
   root: {
     flex: 1,
     paddingHorizontal: 16,
-    paddingTop: Platform.select({
-      ios: 40,
-      android: androidPaddingTopWithStatusBar,
-    }),
+    paddingTop: 16,
   },
   content: {
     flex: 1,

--- a/app/components/Views/AccountStatus/index.styles.ts
+++ b/app/components/Views/AccountStatus/index.styles.ts
@@ -19,7 +19,10 @@ const styles = StyleSheet.create({
   root: {
     flex: 1,
     paddingHorizontal: 16,
-    paddingTop: Platform.OS === 'android' ? androidPaddingTopWithStatusBar : 40,
+    paddingTop: Platform.select({
+      ios: 40,
+      android: androidPaddingTopWithStatusBar,
+    }),
   },
   content: {
     flex: 1,

--- a/app/components/Views/AccountStatus/index.styles.ts
+++ b/app/components/Views/AccountStatus/index.styles.ts
@@ -19,7 +19,7 @@ const styles = StyleSheet.create({
   root: {
     flex: 1,
     paddingHorizontal: 16,
-    paddingTop: Platform.OS === 'android' ? androidPaddingTopWithStatusBar : 24,
+    paddingTop: Platform.OS === 'android' ? androidPaddingTopWithStatusBar : 40,
   },
   content: {
     flex: 1,

--- a/app/components/Views/AccountStatus/index.test.tsx
+++ b/app/components/Views/AccountStatus/index.test.tsx
@@ -49,17 +49,6 @@ jest.mock('../../../core/Analytics/MetricsEventBuilder', () => ({
   },
 }));
 
-// Use dynamic mocking to avoid native module conflicts
-jest.doMock('react-native', () => {
-  const originalRN = jest.requireActual('react-native');
-  return {
-    ...originalRN,
-    StatusBar: {
-      currentHeight: 42,
-    },
-  };
-});
-
 describe('AccountStatus', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -98,13 +87,9 @@ describe('AccountStatus', () => {
       expect(toJSON()).toMatchSnapshot();
     });
 
-    it('renders correctly with type="found and statusbar current height to zero"', () => {
-      const { StatusBar } = jest.requireMock('react-native');
-      const originalCurrentHeight = StatusBar.currentHeight;
-      StatusBar.currentHeight = 0;
+    it('renders with type="found"', () => {
       const { toJSON } = renderWithProvider(<AccountStatus type="found" />);
       expect(toJSON()).toMatchSnapshot();
-      StatusBar.currentHeight = originalCurrentHeight;
     });
 
     it('renders correctly with accountName in route params', () => {

--- a/app/components/Views/AccountStatus/index.test.tsx
+++ b/app/components/Views/AccountStatus/index.test.tsx
@@ -87,7 +87,7 @@ describe('AccountStatus', () => {
       expect(toJSON()).toMatchSnapshot();
     });
 
-    it('renders with type="found"', () => {
+    it('renders correctly with type="found"', () => {
       const { toJSON } = renderWithProvider(<AccountStatus type="found" />);
       expect(toJSON()).toMatchSnapshot();
     });
@@ -237,6 +237,17 @@ describe('AccountStatus', () => {
       fireEvent.press(primaryButton);
 
       expect(trackOnboarding).toHaveBeenCalled();
+    });
+  });
+
+  describe('SafeAreaView Configuration', () => {
+    it('uses SafeAreaView with top and bottom edges', () => {
+      const { toJSON } = renderWithProvider(<AccountStatus type="not_exist" />);
+      const tree = toJSON();
+
+      expect(tree).toBeTruthy();
+      expect(JSON.stringify(tree)).toContain('top');
+      expect(JSON.stringify(tree)).toContain('bottom');
     });
   });
 });

--- a/app/components/Views/AccountStatus/index.tsx
+++ b/app/components/Views/AccountStatus/index.tsx
@@ -152,7 +152,7 @@ const AccountStatus = ({
   }, []);
 
   return (
-    <SafeAreaView style={styles.safeArea} edges={['bottom']}>
+    <SafeAreaView style={styles.safeArea} edges={['top', 'bottom']}>
       <View style={styles.root}>
         <ScrollView style={styles.scrollView}>
           <View style={styles.content}>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
* fix: accountStatus page UI top padding
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: accountStatus page UI top padding

## **Related issues**

Fixes: accountStatus page UI top padding

## **Manual testing steps**

```gherkin
Feature: my feature name
1)Open the App.
2)Login with existing wallet using social login.
3)Go to account already exists page and observe the changes in ios device.
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="415" height="924" alt="wallet" src="https://github.com/user-attachments/assets/fce35448-17c6-4c86-b8d4-790b9a6c7685" />

<!-- [screenshots/recordings] -->

### **After**
<img width="366" height="772" alt="Screenshot 2025-10-31 at 7 24 25 PM" src="https://github.com/user-attachments/assets/17f3802c-a8f4-464e-8150-b6c380cf31d0" />

![android](https://github.com/user-attachments/assets/72cc4b18-0131-4719-99c4-aa725c813a57)



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase iOS top padding in AccountStatus view to 40 and refresh related snapshots.
> 
> - **UI**:
>   - Increase `paddingTop` in `app/components/Views/AccountStatus/index.styles.ts` `root` from `24` to `40` for iOS (Android still uses `StatusBar.currentHeight + 24`).
> - **Tests**:
>   - Update `app/components/Views/AccountStatus/__snapshots__/index.test.tsx.snap` to reflect new `paddingTop: 40`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7dcb09cc2ac04aced1c09313a5f2a18d543c8ab. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->