### PR TITLE
feat: Await simulation results before disclosing gas fees

### DIFF
--- a/app/components/Views/confirmations/components/info/contract-interaction/contract-interaction.test.tsx
+++ b/app/components/Views/confirmations/components/info/contract-interaction/contract-interaction.test.tsx
@@ -10,6 +10,7 @@ import {
   upgradeAccountConfirmation,
 } from '../../../../../../util/test/confirm-data-helpers';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
+import useBalanceChanges from '../../../../../UI/SimulationDetails/useBalanceChanges';
 // eslint-disable-next-line import/no-namespace
 import * as EditNonceHook from '../../../../../../components/hooks/useEditNonce';
 import { useConfirmActions } from '../../../hooks/useConfirmActions';
@@ -36,6 +37,7 @@ jest.mock('../../../hooks/useAutomaticGasFeeTokenSelect');
 jest.mock('../../../hooks/alerts/useInsufficientBalanceAlert', () => ({
   useInsufficientBalanceAlert: jest.fn().mockReturnValue([]),
 }));
+jest.mock('../../../../../UI/SimulationDetails/useBalanceChanges');
 
 jest.mock('../../../hooks/7702/use7702TransactionType', () => ({
   use7702TransactionType: jest
@@ -111,6 +113,7 @@ describe('ContractInteraction', () => {
   const mockUseConfirmationMetricEvents = jest.mocked(
     useConfirmationMetricEvents,
   );
+  const mockUseBalanceChanges = jest.mocked(useBalanceChanges);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -122,6 +125,10 @@ describe('ContractInteraction', () => {
     mockUseConfirmationMetricEvents.mockReturnValue({
       trackPageViewedEvent: mockTrackPageViewedEvent,
     } as unknown as ReturnType<typeof useConfirmationMetricEvents>);
+    mockUseBalanceChanges.mockReturnValue({
+      pending: false,
+      value: [],
+    });
 
     const mockTxId = '7e62bcb1-a4e9-11ef-9b51-ddf21c91a998';
     jest

--- a/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.test.tsx
@@ -9,10 +9,12 @@ import { useConfirmationMetricEvents } from '../../../../hooks/metrics/useConfir
 import { TOOLTIP_TYPES } from '../../../../../../../core/Analytics/events/confirmations';
 import GasFeesDetailsRow from './gas-fee-details-row';
 import { toHex } from '@metamask/controller-utils';
+import { SimulationData } from '@metamask/transaction-controller';
 import { useSelectedGasFeeToken } from '../../../../hooks/gas/useGasFeeToken';
 import { useIsGaslessSupported } from '../../../../hooks/gas/useIsGaslessSupported';
 import { useInsufficientBalanceAlert } from '../../../../hooks/alerts/useInsufficientBalanceAlert';
 import useHideFiatForTestnet from '../../../../../../hooks/useHideFiatForTestnet';
+import useBalanceChanges from '../../../../../../UI/SimulationDetails/useBalanceChanges';
 
 jest.mock('../../../gas/gas-speed', () => ({
   GasSpeed: () => null,
@@ -34,6 +36,7 @@ jest.mock('../../../../hooks/gas/useIsGaslessSupported');
 jest.mock('../../../../hooks/alerts/useInsufficientBalanceAlert');
 jest.mock('../../../../../../hooks/useHideFiatForTestnet');
 jest.mock('../../../../hooks/tokens/useTokenWithBalance');
+jest.mock('../../../../../../UI/SimulationDetails/useBalanceChanges');
 
 const GAS_FEE_TOKEN_MOCK: ReturnType<typeof useSelectedGasFeeToken> = {
   amount: toHex(10000),
@@ -56,6 +59,31 @@ const GAS_FEE_TOKEN_MOCK: ReturnType<typeof useSelectedGasFeeToken> = {
   transferTransaction: {},
 };
 
+const SIMULATION_DATA_MOCK: SimulationData = {
+  nativeBalanceChange: {
+    previousBalance: '0x0',
+    newBalance: '0x0',
+    difference: '0x0',
+    isDecrease: false,
+  },
+  tokenBalanceChanges: [],
+};
+
+const createStateWithSimulationData = (
+  baseState = stakingDepositConfirmationState,
+) => {
+  const stateWithSimulation = cloneDeep(baseState);
+  const transactions =
+    stateWithSimulation.engine.backgroundState.TransactionController
+      .transactions;
+
+  if (transactions?.[0]) {
+    transactions[0].simulationData = cloneDeep(SIMULATION_DATA_MOCK);
+  }
+
+  return stateWithSimulation;
+};
+
 describe('GasFeesDetailsRow', () => {
   const useConfirmationMetricEventsMock = jest.mocked(
     useConfirmationMetricEvents,
@@ -67,6 +95,7 @@ describe('GasFeesDetailsRow', () => {
     useInsufficientBalanceAlert,
   );
   const mockUseHideFiatForTestnet = jest.mocked(useHideFiatForTestnet);
+  const mockUseBalanceChanges = jest.mocked(useBalanceChanges);
 
   beforeEach(() => {
     useConfirmationMetricEventsMock.mockReturnValue({
@@ -79,11 +108,15 @@ describe('GasFeesDetailsRow', () => {
     });
     mockUseInsufficientBalanceAlert.mockReturnValue([]);
     mockUseHideFiatForTestnet.mockReturnValue(false);
+    mockUseBalanceChanges.mockReturnValue({
+      pending: false,
+      value: [],
+    });
   });
 
   it('contains required text', async () => {
     const { getByText } = renderWithProvider(<GasFeesDetailsRow />, {
-      state: stakingDepositConfirmationState,
+      state: createStateWithSimulationData(),
     });
     expect(getByText('Network Fee')).toBeDefined();
     expect(getByText('$0.34')).toBeDefined();
@@ -91,9 +124,8 @@ describe('GasFeesDetailsRow', () => {
   });
 
   it('shows fiat if showFiatOnTestnets is true', async () => {
-    const clonedStakingDepositConfirmationState = cloneDeep(
-      stakingDepositConfirmationState,
-    );
+    const clonedStakingDepositConfirmationState =
+      createStateWithSimulationData();
     clonedStakingDepositConfirmationState.engine.backgroundState.TransactionController.transactions[0].chainId =
       NETWORKS_CHAIN_ID.SEPOLIA;
 
@@ -104,9 +136,8 @@ describe('GasFeesDetailsRow', () => {
   });
 
   it('hides fiat if showFiatOnTestnets is false', async () => {
-    const clonedStakingDepositConfirmationState = cloneDeep(
-      stakingDepositConfirmationState,
-    );
+    const clonedStakingDepositConfirmationState =
+      createStateWithSimulationData();
     clonedStakingDepositConfirmationState.engine.backgroundState.TransactionController.transactions[0].chainId =
       NETWORKS_CHAIN_ID.SEPOLIA;
     clonedStakingDepositConfirmationState.settings.showFiatOnTestnets = false;
@@ -118,9 +149,8 @@ describe('GasFeesDetailsRow', () => {
   });
 
   it('hides fiat if nativeConversionRate is undefined', async () => {
-    const clonedStakingDepositConfirmationState = cloneDeep(
-      stakingDepositConfirmationState,
-    );
+    const clonedStakingDepositConfirmationState =
+      createStateWithSimulationData();
 
     // No type is exported for CurrencyRate, so we need to cast it to the correct type
     clonedStakingDepositConfirmationState.engine.backgroundState.CurrencyRateController.currencyRates.ETH =
@@ -138,7 +168,7 @@ describe('GasFeesDetailsRow', () => {
 
   it('tracks tooltip clicked event', async () => {
     const { getByTestId } = renderWithProvider(<GasFeesDetailsRow />, {
-      state: stakingDepositConfirmationState,
+      state: createStateWithSimulationData(),
     });
 
     fireEvent.press(getByTestId('info-row-tooltip-open-btn'));
@@ -153,7 +183,7 @@ describe('GasFeesDetailsRow', () => {
 
   it('shows gas speed row', async () => {
     const { getByText } = renderWithProvider(<GasFeesDetailsRow />, {
-      state: stakingDepositConfirmationState,
+      state: createStateWithSimulationData(),
     });
     expect(getByText('Speed')).toBeDefined();
   });
@@ -162,7 +192,7 @@ describe('GasFeesDetailsRow', () => {
     const { queryByText } = renderWithProvider(
       <GasFeesDetailsRow hideSpeed />,
       {
-        state: stakingDepositConfirmationState,
+        state: createStateWithSimulationData(),
       },
     );
 
@@ -173,7 +203,7 @@ describe('GasFeesDetailsRow', () => {
     const { getByText, queryByText } = renderWithProvider(
       <GasFeesDetailsRow fiatOnly />,
       {
-        state: stakingDepositConfirmationState,
+        state: createStateWithSimulationData(),
       },
     );
 
@@ -188,7 +218,7 @@ describe('GasFeesDetailsRow', () => {
       >,
     );
     const { getByText } = renderWithProvider(<GasFeesDetailsRow />, {
-      state: stakingDepositConfirmationState,
+      state: createStateWithSimulationData(),
     });
 
     expect(getByText('USDC')).toBeDefined();
@@ -197,9 +227,8 @@ describe('GasFeesDetailsRow', () => {
 
   it('shows native amount when is a testnet', async () => {
     mockUseHideFiatForTestnet.mockReturnValue(true);
-    const clonedStakingDepositConfirmationState = cloneDeep(
-      stakingDepositConfirmationState,
-    );
+    const clonedStakingDepositConfirmationState =
+      createStateWithSimulationData();
     clonedStakingDepositConfirmationState.engine.backgroundState.TransactionController.transactions[0].chainId =
       NETWORKS_CHAIN_ID.SEPOLIA;
 
@@ -212,9 +241,8 @@ describe('GasFeesDetailsRow', () => {
   });
 
   it(`shows 'Paid by MetaMask' when gas is sponsored`, async () => {
-    const clonedStakingDepositConfirmationState = cloneDeep(
-      stakingDepositConfirmationState,
-    );
+    const clonedStakingDepositConfirmationState =
+      createStateWithSimulationData();
     clonedStakingDepositConfirmationState.engine.backgroundState.TransactionController.transactions[0].isGasFeeSponsored = true;
     const { getByText, queryByText } = renderWithProvider(
       <GasFeesDetailsRow />,
@@ -239,7 +267,7 @@ describe('GasFeesDetailsRow', () => {
     );
 
     const { queryByText } = renderWithProvider(<GasFeesDetailsRow />, {
-      state: stakingDepositConfirmationState,
+      state: createStateWithSimulationData(),
     });
 
     expect(queryByText('MetaMask fee: $0.12')).toBeNull();
@@ -259,7 +287,7 @@ describe('GasFeesDetailsRow', () => {
     const { getByTestId, getByText } = renderWithProvider(
       <GasFeesDetailsRow />,
       {
-        state: stakingDepositConfirmationState,
+        state: createStateWithSimulationData(),
       },
     );
 

--- a/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.tsx
@@ -4,41 +4,55 @@ import {
 } from '@metamask/transaction-controller';
 import React, { useState } from 'react';
 import { TouchableOpacity, View } from 'react-native';
+import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import { ConfirmationRowComponentIDs } from '../../../../../../../../e2e/selectors/Confirmation/ConfirmationView.selectors';
 import { strings } from '../../../../../../../../locales/i18n';
 import Icon, {
   IconName,
   IconSize,
 } from '../../../../../../../component-library/components/Icons/Icon';
+import {
+  TextColor,
+  TextVariant,
+} from '../../../../../../../component-library/components/Texts/Text';
 import Text from '../../../../../../../component-library/components/Texts/Text/Text';
 import { useStyles } from '../../../../../../../component-library/hooks';
 import { TOOLTIP_TYPES } from '../../../../../../../core/Analytics/events/confirmations';
 import useHideFiatForTestnet from '../../../../../../hooks/useHideFiatForTestnet';
+import useBalanceChanges from '../../../../../../UI/SimulationDetails/useBalanceChanges';
 import { useFeeCalculations } from '../../../../hooks/gas/useFeeCalculations';
 import { useFeeCalculationsTransactionBatch } from '../../../../hooks/gas/useFeeCalculationsTransactionBatch';
+import { useSelectedGasFeeToken } from '../../../../hooks/gas/useGasFeeToken';
 import { useConfirmationMetricEvents } from '../../../../hooks/metrics/useConfirmationMetricEvents';
 import { useTransactionBatchesMetadata } from '../../../../hooks/transactions/useTransactionBatchesMetadata';
 import { useTransactionMetadataRequest } from '../../../../hooks/transactions/useTransactionMetadataRequest';
+import { useAutomaticGasFeeTokenSelect } from '../../../../hooks/useAutomaticGasFeeTokenSelect';
+import { GasFeeTokenToast } from '../../../gas/gas-fee-token-toast';
 import { GasSpeed } from '../../../gas/gas-speed';
+import { SelectedGasFeeToken } from '../../../gas/selected-gas-fee-token';
 import { GasFeeModal } from '../../../modals/gas-fee-modal';
 import AlertRow from '../../../UI/info-row/alert-row';
 import { RowAlertKey } from '../../../UI/info-row/alert-row/constants';
 import InfoSection from '../../../UI/info-row/info-section';
 import styleSheet from './gas-fee-details-row.styles';
-import { SelectedGasFeeToken } from '../../../gas/selected-gas-fee-token';
-import { useSelectedGasFeeToken } from '../../../../hooks/gas/useGasFeeToken';
-import {
-  TextColor,
-  TextVariant,
-} from '../../../../../../../component-library/components/Texts/Text';
-import { GasFeeTokenToast } from '../../../gas/gas-fee-token-toast';
-import { useAutomaticGasFeeTokenSelect } from '../../../../hooks/useAutomaticGasFeeTokenSelect';
 
 const PaidByMetaMask = () => (
   <Text variant={TextVariant.BodyMD} testID="paid-by-metamask">
     {strings('transactions.paid_by_metamask')}
   </Text>
 );
+
+const SkeletonEstimationInfo = () => (
+  <SkeletonPlaceholder>
+    <SkeletonPlaceholder.Item
+      width={120}
+      height={24}
+      borderRadius={8}
+      marginTop={2}
+    />
+  </SkeletonPlaceholder>
+);
+
 const EstimationInfo = ({
   hideFiatForTestnet,
   feeCalculations,
@@ -64,11 +78,22 @@ const EstimationInfo = ({
     hideFiatForTestnet || !fiatValue
       ? styles.primaryValue
       : styles.secondaryValue;
+  const transactionMetadata = useTransactionMetadataRequest();
+  const { chainId, simulationData, networkClientId } =
+    (transactionMetadata as TransactionMeta) ?? {};
+  const balanceChangesResult = useBalanceChanges({
+    chainId,
+    simulationData,
+    networkClientId,
+  });
+  const isSimulationLoading = !simulationData || balanceChangesResult.pending;
 
   return (
     <View style={styles.estimationContainer}>
       {isGasFeeSponsored ? (
         <PaidByMetaMask />
+      ) : isSimulationLoading ? (
+        <SkeletonEstimationInfo />
       ) : (
         <>
           {displayValue && <Text style={displayStyle}>{displayValue}</Text>}
@@ -228,6 +253,15 @@ const GasFeesDetailsRow = ({
     : strings('transactions.network_fee_tooltip');
 
   const Container = noSection ? View : InfoSection;
+
+  const { chainId, simulationData, networkClientId } =
+    (transactionMetadata as TransactionMeta) ?? {};
+  const balanceChangesResult = useBalanceChanges({
+    chainId,
+    simulationData,
+    networkClientId,
+  });
+  const isSimulationLoading = !simulationData || balanceChangesResult.pending;
   return (
     <>
       <Container testID={ConfirmationRowComponentIDs.GAS_FEES_DETAILS}>
@@ -238,7 +272,10 @@ const GasFeesDetailsRow = ({
           onTooltipPress={handleNetworkFeeTooltipClickedEvent}
         >
           <View style={styles.valueContainer}>
-            {disableUpdate || gasFeeToken || isGasFeeSponsored ? (
+            {disableUpdate ||
+            gasFeeToken ||
+            isGasFeeSponsored ||
+            isSimulationLoading ? (
               <RenderEstimationInfo
                 transactionBatchesMetadata={transactionBatchesMetadata}
                 hideFiatForTestnet={hideFiatForTestnet}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds a skeleton loader to hide the gas fees indicator until simulation details are determined and gasUsed can be shown.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="419" height="895" alt="Screenshot 2025-10-31 at 15 51 06" src="https://github.com/user-attachments/assets/1ba89f82-8398-4893-a084-a67b8ec2f651" />


## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a skeleton loader and waits for simulation results before showing/editing gas fees in confirmations.
> 
> - **UI (Gas Fees)**
>   - Adds `SkeletonPlaceholder` and `SkeletonEstimationInfo` and defers gas fee display until simulation data is available (`isSimulationLoading`).
>   - Integrates `useBalanceChanges` with `simulationData`, `chainId`, and `networkClientId` from `useTransactionMetadataRequest` to gate rendering.
>   - Updates `EstimationInfo`/`RenderEstimationInfo` logic to show skeleton or "Paid by MetaMask" when sponsored; otherwise display fiat/native and `SelectedGasFeeToken`.
>   - Disables clickable edit state while simulation is loading.
> - **Tests**
>   - Mocks `useBalanceChanges` and injects `simulationData` into test state; adjusts expectations across gas-fee row tests.
>   - Updates contract interaction test to mock `useBalanceChanges` and maintain existing assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce0b2fb07890b26b232ca5532b765f357fbddca4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->