### PR TITLE
feat: Updated NFT Grid to no longer using FlashList

### DIFF
--- a/app/components/UI/CollectibleMedia/CollectibleMedia.styles.ts
+++ b/app/components/UI/CollectibleMedia/CollectibleMedia.styles.ts
@@ -49,15 +49,16 @@ const styleSheet = (params: {
       borderRadius: 12,
     },
     textContainer: {
+      flex: 1,
       alignItems: 'center',
-      justifyContent: 'flex-start',
+      justifyContent: 'center',
       backgroundColor: colors.background.section,
       borderRadius: 8,
     },
     textWrapper: {
-      flex: 1,
       textAlign: 'center',
-      marginTop: 16,
+      alignItems: 'center',
+      justifyContent: 'center',
     },
     textWrapperIcon: {
       fontSize: 18,

--- a/app/components/UI/NftGrid/NftGrid.test.tsx
+++ b/app/components/UI/NftGrid/NftGrid.test.tsx
@@ -107,6 +107,10 @@ jest.mock('./NftGridHeader', () => {
     </View>
   );
 });
+jest.mock('./NftGridSkeleton', () => {
+  const { View } = jest.requireActual('react-native');
+  return () => <View testID="nft-grid-skeleton" />;
+});
 
 // Mock CollectiblesEmptyState - has complex dependencies
 jest.mock('../CollectiblesEmptyState', () => ({
@@ -167,6 +171,7 @@ jest.mock('../CollectibleMedia', () => () => null);
 jest.mock('@metamask/design-system-react-native', () => ({
   Text: ({ children }: { children: React.ReactNode }) => children,
   TextVariant: { BodyMd: 'BodyMd', BodySm: 'BodySm' },
+  FontWeight: { Medium: 'Medium' },
   Box: ({
     children,
     testID,

--- a/app/components/UI/NftGrid/NftGrid.tsx
+++ b/app/components/UI/NftGrid/NftGrid.tsx
@@ -138,15 +138,6 @@ const NftGrid = ({ isFullView = false }: NftGridProps) => {
     setIsAddNFTEnabled(true);
   }, [navigation, trackEvent, createEventBuilder]);
 
-  const additionalButtons = (
-    <ButtonIcon
-      testID={WalletViewSelectorsIDs.IMPORT_TOKEN_BUTTON}
-      size={ButtonIconSizes.Lg}
-      onPress={goToAddCollectible}
-      iconName={IconName.Add}
-    />
-  );
-
   const handleViewAllNfts = useCallback(() => {
     navigation.navigate(Routes.WALLET.NFTS_FULL_VIEW);
   }, [navigation]);
@@ -176,8 +167,7 @@ const NftGrid = ({ isFullView = false }: NftGridProps) => {
         testID={RefreshTestId}
         decelerationRate="fast"
         refreshControl={<NftGridRefreshControl />}
-        contentContainerStyle={isFullView ? tw`px-4` : undefined}
-        scrollEnabled
+        contentContainerStyle={tw`px-4`}
       />
     );
 
@@ -187,7 +177,14 @@ const NftGrid = ({ isFullView = false }: NftGridProps) => {
         networkFilterTestId={WalletViewSelectorsIDs.TOKEN_NETWORK_FILTER}
         useEvmSelectionLogic={false}
         customWrapper={'outer'}
-        additionalButtons={additionalButtons}
+        additionalButtons={
+          <ButtonIcon
+            testID={WalletViewSelectorsIDs.IMPORT_TOKEN_BUTTON}
+            size={ButtonIconSizes.Lg}
+            onPress={goToAddCollectible}
+            iconName={IconName.Add}
+          />
+        }
         hideSort
         style={isFullView ? tw`px-4 pb-4` : tw`pb-3`}
       />

--- a/app/components/UI/NftGrid/NftGrid.tsx
+++ b/app/components/UI/NftGrid/NftGrid.tsx
@@ -151,35 +151,19 @@ const NftGrid = ({ isFullView = false }: NftGridProps) => {
     navigation.navigate(Routes.WALLET.NFTS_FULL_VIEW);
   }, [navigation]);
 
-  // Determine if we should show the "View all NFTs" button
-  const shouldShowViewAllButton =
-    maxItems && allFilteredCollectibles.length > maxItems;
-
-  const flashListContent =
+  const nftRowList =
     !isFullView && isHomepageRedesignV1Enabled ? (
       <Box>
         <NftGridHeader />
-        {allFilteredCollectibles.length > 0 ? (
-          <Box twClassName="gap-3">
-            {groupedCollectibles.map((items, index) => (
-              <NftRow
-                key={`nft-row-${index}`}
-                items={items}
-                onLongPress={setLongPressedCollectible}
-              />
-            ))}
-          </Box>
-        ) : (
-          <CollectiblesEmptyState
-            onAction={goToAddCollectible}
-            actionButtonProps={{
-              testID: WalletViewSelectorsIDs.IMPORT_NFT_BUTTON,
-              isDisabled: !isAddNFTEnabled,
-            }}
-            twClassName="mx-auto mt-4"
-            testID="collectibles-empty-state"
-          />
-        )}
+        <Box twClassName="gap-3">
+          {groupedCollectibles.map((items, index) => (
+            <NftRow
+              key={`nft-row-${index}`}
+              items={items}
+              onLongPress={setLongPressedCollectible}
+            />
+          ))}
+        </Box>
       </Box>
     ) : (
       <FlashList
@@ -192,17 +176,6 @@ const NftGrid = ({ isFullView = false }: NftGridProps) => {
         testID={RefreshTestId}
         decelerationRate="fast"
         refreshControl={<NftGridRefreshControl />}
-        ListEmptyComponent={
-          <CollectiblesEmptyState
-            onAction={goToAddCollectible}
-            actionButtonProps={{
-              testID: WalletViewSelectorsIDs.IMPORT_NFT_BUTTON,
-              isDisabled: !isAddNFTEnabled,
-            }}
-            twClassName="mx-auto mt-4"
-            testID="collectibles-empty-state"
-          />
-        }
         contentContainerStyle={isFullView ? tw`px-4` : undefined}
         scrollEnabled
       />
@@ -218,15 +191,23 @@ const NftGrid = ({ isFullView = false }: NftGridProps) => {
         hideSort
         style={isFullView ? tw`px-4 pb-4` : tw`pb-3`}
       />
-      {isNftFetchingProgress ? <NftGridSkeleton /> : flashListContent}
-
-      <NftGridItemActionSheet
-        actionSheetRef={actionSheetRef}
-        longPressedCollectible={longPressedCollectible}
-      />
-
+      {isNftFetchingProgress ? (
+        <NftGridSkeleton />
+      ) : allFilteredCollectibles.length > 0 ? (
+        nftRowList
+      ) : (
+        <CollectiblesEmptyState
+          onAction={goToAddCollectible}
+          actionButtonProps={{
+            testID: WalletViewSelectorsIDs.IMPORT_NFT_BUTTON,
+            isDisabled: !isAddNFTEnabled,
+          }}
+          twClassName="mx-auto mt-4"
+          testID="collectibles-empty-state"
+        />
+      )}
       {/* View all NFTs button - shown when there are more items than maxItems */}
-      {shouldShowViewAllButton && (
+      {maxItems && allFilteredCollectibles.length > maxItems && (
         <Box twClassName="pt-5 pb-7">
           <Button
             variant={ButtonVariant.Secondary}
@@ -238,6 +219,10 @@ const NftGrid = ({ isFullView = false }: NftGridProps) => {
           </Button>
         </Box>
       )}
+      <NftGridItemActionSheet
+        actionSheetRef={actionSheetRef}
+        longPressedCollectible={longPressedCollectible}
+      />
     </>
   );
 };

--- a/app/components/UI/NftGrid/NftGrid.tsx
+++ b/app/components/UI/NftGrid/NftGrid.tsx
@@ -19,6 +19,7 @@ import NftGridItem from './NftGridItem';
 import ActionSheet from '@metamask/react-native-actionsheet';
 import NftGridItemActionSheet from './NftGridItemActionSheet';
 import NftGridHeader from './NftGridHeader';
+import NftGridSkeleton from './NftGridSkeleton';
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { MetaMetricsEvents, useMetrics } from '../../hooks/useMetrics';
@@ -158,17 +159,7 @@ const NftGrid = ({ isFullView = false }: NftGridProps) => {
     !isFullView && isHomepageRedesignV1Enabled ? (
       <Box>
         <NftGridHeader />
-        {isNftFetchingProgress ? (
-          <CollectiblesEmptyState
-            onAction={goToAddCollectible}
-            actionButtonProps={{
-              testID: WalletViewSelectorsIDs.IMPORT_NFT_BUTTON,
-              isDisabled: !isAddNFTEnabled,
-            }}
-            twClassName="mx-auto mt-4"
-            testID="collectibles-empty-state"
-          />
-        ) : (
+        {allFilteredCollectibles.length > 0 ? (
           <Box twClassName="gap-3">
             {groupedCollectibles.map((items, index) => (
               <NftRow
@@ -178,6 +169,16 @@ const NftGrid = ({ isFullView = false }: NftGridProps) => {
               />
             ))}
           </Box>
+        ) : (
+          <CollectiblesEmptyState
+            onAction={goToAddCollectible}
+            actionButtonProps={{
+              testID: WalletViewSelectorsIDs.IMPORT_NFT_BUTTON,
+              isDisabled: !isAddNFTEnabled,
+            }}
+            twClassName="mx-auto mt-4"
+            testID="collectibles-empty-state"
+          />
         )}
       </Box>
     ) : (
@@ -192,17 +193,15 @@ const NftGrid = ({ isFullView = false }: NftGridProps) => {
         decelerationRate="fast"
         refreshControl={<NftGridRefreshControl />}
         ListEmptyComponent={
-          !isNftFetchingProgress ? (
-            <CollectiblesEmptyState
-              onAction={goToAddCollectible}
-              actionButtonProps={{
-                testID: WalletViewSelectorsIDs.IMPORT_NFT_BUTTON,
-                isDisabled: !isAddNFTEnabled,
-              }}
-              twClassName="mx-auto mt-4"
-              testID="collectibles-empty-state"
-            />
-          ) : null
+          <CollectiblesEmptyState
+            onAction={goToAddCollectible}
+            actionButtonProps={{
+              testID: WalletViewSelectorsIDs.IMPORT_NFT_BUTTON,
+              isDisabled: !isAddNFTEnabled,
+            }}
+            twClassName="mx-auto mt-4"
+            testID="collectibles-empty-state"
+          />
         }
         contentContainerStyle={isFullView ? tw`px-4` : undefined}
         scrollEnabled
@@ -219,7 +218,7 @@ const NftGrid = ({ isFullView = false }: NftGridProps) => {
         hideSort
         style={isFullView ? tw`px-4 pb-4` : tw`pb-3`}
       />
-      {flashListContent}
+      {isNftFetchingProgress ? <NftGridSkeleton /> : flashListContent}
 
       <NftGridItemActionSheet
         actionSheetRef={actionSheetRef}

--- a/app/components/UI/NftGrid/NftGridItem.tsx
+++ b/app/components/UI/NftGrid/NftGridItem.tsx
@@ -2,21 +2,15 @@ import React, { useCallback } from 'react';
 import { Nft } from '@metamask/assets-controllers';
 import { debounce } from 'lodash';
 import { useNavigation } from '@react-navigation/native';
-import { StyleSheet, TouchableOpacity, View } from 'react-native';
-import { Text, TextVariant } from '@metamask/design-system-react-native';
+import { Pressable } from 'react-native';
+import {
+  Box,
+  Text,
+  TextVariant,
+  FontWeight,
+} from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import CollectibleMedia from '../CollectibleMedia';
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  collectible: {
-    aspectRatio: 1,
-  },
-  collectibleIcon: {
-    aspectRatio: 1,
-  },
-});
 
 const debouncedNavigation = debounce((navigation, collectible) => {
   navigation.navigate('NftDetails', { collectible });
@@ -30,28 +24,29 @@ const NftGridItem = ({
   onLongPress: (nft: Nft) => void;
 }) => {
   const navigation = useNavigation();
+  const tw = useTailwind();
 
   const onPress = useCallback(() => {
     debouncedNavigation(navigation, item);
   }, [navigation, item]);
 
   return (
-    <View style={styles.container}>
-      <TouchableOpacity
-        style={styles.collectible}
-        onPress={onPress}
-        onLongPress={() => onLongPress(item)}
-        testID={`collectible-${item.name}-${item.tokenId}`}
-      >
+    <Pressable
+      style={tw.style('self-stretch ')}
+      onPress={onPress}
+      onLongPress={() => onLongPress(item)}
+      testID={`collectible-${item.name}-${item.tokenId}`}
+    >
+      <Box twClassName="self-stretch aspect-square">
         <CollectibleMedia
-          style={styles.collectibleIcon}
+          style={tw.style('self-stretch aspect-square')}
           collectible={item}
           isTokenImage
         />
-      </TouchableOpacity>
-
+      </Box>
       <Text
         variant={TextVariant.BodyMd}
+        fontWeight={FontWeight.Medium}
         twClassName="mt-2 text-default"
         numberOfLines={1}
       >
@@ -61,12 +56,13 @@ const NftGridItem = ({
       {/* TODO: check if is better to use collection name from nft contract? */}
       <Text
         variant={TextVariant.BodySm}
+        fontWeight={FontWeight.Medium}
         twClassName="text-alternative"
         numberOfLines={1}
       >
         {item.collection?.name}
       </Text>
-    </View>
+    </Pressable>
   );
 };
 

--- a/app/components/UI/NftGrid/NftGridSkeleton.tsx
+++ b/app/components/UI/NftGrid/NftGridSkeleton.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
+import { Box } from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { useTheme } from '../../../util/theme';
+
+const NftGridSkeleton = () => {
+  const { colors } = useTheme();
+  const tw = useTailwind();
+
+  return (
+    <Box twClassName="flex-1 p-1">
+      <SkeletonPlaceholder
+        backgroundColor={colors.background.section}
+        highlightColor={colors.background.subsection}
+      >
+        <Box twClassName="flex-row flex-wrap justify-between gap-2">
+          {Array.from({ length: 18 }, (_, index) => (
+            <Box key={index} style={tw.style('w-[30%] mb-2')}>
+              <Box style={tw.style('w-full aspect-square rounded-xl mb-3')} />
+              <Box>
+                <Box style={tw.style('h-4 rounded-lg mb-1 w-[60%]')} />
+                <Box style={tw.style('h-3.5 rounded-md w-full')} />
+              </Box>
+            </Box>
+          ))}
+        </Box>
+      </SkeletonPlaceholder>
+    </Box>
+  );
+};
+
+export default NftGridSkeleton;


### PR DESCRIPTION
## **Description**

### What is the reason for the change?

This PR refactors the NFT grid components to improve code maintainability, consistency with the design system, and rendering performance for the homepage redesign feature.

### What is the improvement/solution?

**NFT Grid Component:**
- Optimized rendering path for homepage redesign by rendering NFT items directly when appropriate, reducing unnecessary list component overhead
- Updated conditional rendering logic for empty states and loading states to better align with homepage redesign requirements

**NFT Grid Item Component:**
- Migrated from StyleSheet to Tailwind CSS for consistent styling across the codebase
- Replaced TouchableOpacity with Pressable for better interaction handling
- Converted to use design system components (Box) and utilities (useTailwind)
- Added medium font weight to NFT name and collection text for improved readability

**Test Updates:**
- Enhanced FlashList mock to properly handle footer components in all scenarios
- Added test coverage for new homepage redesign rendering paths
- Updated useTailwind mock to support the tw.style() function pattern
- Improved test names to better describe expected behavior

## **Changelog**

CHANGELOG entry: Refactored NFT grid components to use Tailwind CSS and optimized rendering for improved performance

## **Related issues**

Fixes: 

## **Manual testing steps**

```gherkin
Feature: NFT Grid Display

  Scenario: user views NFTs on the wallet home screen
    Given the user has NFTs in their wallet
    And homepage redesign feature is enabled
    When user navigates to the NFTs tab
    Then NFTs are displayed in a grid layout
    And NFT names and collection names are clearly visible
    And tapping an NFT navigates to NFT details

  Scenario: user views NFTs in full view mode
    Given the user has NFTs in their wallet
    When user taps "View all NFTs" button
    Then NFTs are displayed in a scrollable grid
    And all NFTs load properly with correct styling

  Scenario: user interacts with NFT items
    Given NFTs are displayed in the grid
    When user presses on an NFT item
    Then the item shows visual press feedback
    And navigates to the NFT details screen
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
https://github.com/user-attachments/assets/63e58c3d-2d3e-4c96-902d-6df573adad64

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors NFT grid to render rows directly for homepage redesign, replaces spinner with a skeleton loader, migrates item to design-system/Tailwind, and updates tests accordingly.
> 
> - **UI/Rendering**:
>   - **NftGrid** (`NftGrid.tsx`):
>     - Adds direct grid rendering (bypasses `FlashList`) when homepage redesign is enabled and not in full view.
>     - Replaces footer spinner with `NftGridSkeleton` for loading state; simplifies empty-state handling.
>     - Inlines `additionalButtons` with `ButtonIcon`; keeps `FlashList` for non-redesign/full-view with `contentContainerStyle` set via Tailwind.
>     - Adjusts row layout (`NftRow`) spacing (removes `justify-between`).
>   - **NftGridItem** (`NftGridItem.tsx`):
>     - Migrates to `Pressable`, `Box`, and Tailwind (`useTailwind`); removes `StyleSheet`.
>     - Applies medium font weight for name/collection and square media layout.
>   - **CollectibleMedia styles**: centers text container/wrapper and adds `flex: 1` to `textContainer`.
>   - **New**: `NftGridSkeleton.tsx` for loading placeholders using theme colors.
> - **Tests** (`NftGrid.test.tsx`):
>   - Updates `FlashList` mock to render header/footer in all cases; adds mock for `NftGridSkeleton`.
>   - Adds/updates cases for redesign direct render, loading vs empty states, and view-all button logic.
>   - Enhances Tailwind mock to support `tw.style`; adjusts expectations for new loading/empty behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1aa4d09dff0cc080c9ec5a111334f396f5d2c8be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->