### PR TITLE
fix: Investigate perf regression in Perps 7.59

### DIFF
--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -70,7 +70,6 @@ abstract class StreamChannel<T> {
       // Store pending update
       subscriber.pendingUpdate = updates;
 
-      // CRITICAL FIX: Clear existing timer before creating new one
       // This prevents timer accumulation and memory leaks, especially on Android devices
       if (subscriber.timer) {
         clearTimeout(subscriber.timer);
@@ -133,7 +132,6 @@ abstract class StreamChannel<T> {
   }
 
   public disconnect() {
-    // CRITICAL FIX: Clear all pending timers before disconnecting
     // This prevents orphaned timers from continuing to run after disconnect
     this.subscribers.forEach((subscriber) => {
       if (subscriber.timer) {
@@ -174,7 +172,6 @@ abstract class StreamChannel<T> {
   }
 
   public clearCache(): void {
-    // CRITICAL FIX: Clear all timers BEFORE disconnecting
     // This ensures no timers are orphaned during the disconnect/reconnect cycle
     this.subscribers.forEach((subscriber) => {
       // Clear any pending updates and timers

--- a/app/components/UI/Perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/components/UI/Perps/services/HyperLiquidSubscriptionService.ts
@@ -1230,8 +1230,6 @@ export class HyperLiquidSubscriptionService {
         // Initialize cache if needed
         this.cachedPriceData ??= new Map<string, PriceUpdate>();
 
-        // OPTIMIZATION: Only process symbols that have active subscribers
-        // This reduces processing from 200-300 symbols to typically 5-20
         const subscribedSymbols = new Set<string>();
 
         // Collect all symbols that have subscribers
@@ -1244,7 +1242,6 @@ export class HyperLiquidSubscriptionService {
         // Track if any subscribed symbol was updated
         let hasUpdates = false;
 
-        // OPTIMIZATION: Use for...in to avoid Object.entries() array allocation
         // Only process symbols that are actually subscribed to
         for (const symbol in data.mids) {
           // Skip if nobody is subscribed to this symbol
@@ -1255,7 +1252,7 @@ export class HyperLiquidSubscriptionService {
           const price = data.mids[symbol].toString();
           const cachedPrice = this.cachedPriceData.get(symbol);
 
-          // OPTIMIZATION: Skip if price hasn't changed
+          // Skip if price hasn't changed
           if (cachedPrice && cachedPrice.price === price) {
             continue;
           }


### PR DESCRIPTION
## **Description**

We noticed a performance regression on low end Android devices. It's unclear if this is a regression in 7.59, or if it was introduced earlier, and made more obvious in 7.59 with the latest controller changes and hip-3 support.

This PR proposes two performance improvements to the `PerpsStreamManager` and `HyperLiquidSubscriptionService` to address a potential memory leak caused by uncleared timers, and further optimizing our websocket subscription message processing.

1. `PerpsStreamManager`: The first change is to clear timers before we ever disconnect a stream connection. Without this we run the risk of exponentially maintaining orphaned timers that aren't closed before socket disconnection. This could be the reason for the memory creep that we were seeing, where performance on low end devices with limited memory would degrade over time.

2. `HyperLiquidSubscriptionService`: Based on what I could tell, we are currently subscribed to ALL market symbols (200-300+) on every websocket message, even when only 5-10 symbols actually need to be displayed or subscribed to. This should reduce the amount of data getting processed per websocket message by only subscribing to symbols that we care about.

## **Changelog**

CHANGELOG entry: Performance optimizations to `PerpsStreamManager` and `HyperLiquidSubscriptionService`

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
