### PR TITLE
feat: Updated DefiPositionsList to no longer use FlatList

### DIFF
--- a/app/components/UI/DeFiPositions/DeFiPositionsList.tsx
+++ b/app/components/UI/DeFiPositions/DeFiPositionsList.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { View, FlatList } from 'react-native';
+import { View, ScrollView } from 'react-native';
 import { strings } from '../../../../locales/i18n';
 import { useSelector } from 'react-redux';
 import {
@@ -106,18 +106,6 @@ const DeFiPositionsList: React.FC<DeFiPositionsListProps> = () => {
     defiPositionsByEnabledNetworks,
   ]);
 
-  const estimatedItemHeight = 72;
-  const calculatedListHeight = useMemo(() => {
-    if (!isHomepageRedesignV1Enabled) return undefined;
-
-    const itemCount = formattedDeFiPositions?.length || 0;
-    const contentHeight = itemCount * estimatedItemHeight;
-    const emptyStateHeight = itemCount === 0 ? 200 : 0;
-    const padding = 20;
-
-    return contentHeight + emptyStateHeight + padding;
-  }, [isHomepageRedesignV1Enabled, formattedDeFiPositions?.length]);
-
   if (!formattedDeFiPositions) {
     if (formattedDeFiPositions === undefined) {
       // Position data is still loading
@@ -149,38 +137,35 @@ const DeFiPositionsList: React.FC<DeFiPositionsListProps> = () => {
   }
 
   const flatListContent = (
-    <FlatList
-      testID={WalletViewSelectorsIDs.DEFI_POSITIONS_LIST}
-      data={formattedDeFiPositions}
-      renderItem={({ item: { chainId, protocolId, protocolAggregate } }) => (
-        <DeFiPositionsListItem
-          chainId={chainId}
-          protocolId={protocolId}
-          protocolAggregate={protocolAggregate}
-          privacyMode={privacyMode}
-        />
+    <View testID={WalletViewSelectorsIDs.DEFI_POSITIONS_LIST}>
+      {formattedDeFiPositions.map(
+        ({ chainId, protocolId, protocolAggregate }) => (
+          <DeFiPositionsListItem
+            key={`${chainId}-${protocolAggregate.protocolDetails.name}`}
+            chainId={chainId}
+            protocolId={protocolId}
+            protocolAggregate={protocolAggregate}
+            privacyMode={privacyMode}
+          />
+        ),
       )}
-      keyExtractor={(protocolChainAggregate) =>
-        `${protocolChainAggregate.chainId}-${protocolChainAggregate.protocolAggregate.protocolDetails.name}`
-      }
-      scrollEnabled={!isHomepageRedesignV1Enabled}
-      ListEmptyComponent={<DefiEmptyState twClassName="mx-auto mt-4" />}
-    />
+    </View>
   );
 
   return (
     <View
-      style={[
-        styles.wrapper,
-        isHomepageRedesignV1Enabled && { flex: undefined },
-      ]}
+      style={!isHomepageRedesignV1Enabled ? styles.wrapper : undefined}
       testID={WalletViewSelectorsIDs.DEFI_POSITIONS_CONTAINER}
     >
       <DeFiPositionsControlBar />
-      {isHomepageRedesignV1Enabled && calculatedListHeight ? (
-        <View style={{ height: calculatedListHeight }}>{flatListContent}</View>
+      {formattedDeFiPositions.length > 0 ? (
+        isHomepageRedesignV1Enabled ? (
+          flatListContent
+        ) : (
+          <ScrollView>{flatListContent}</ScrollView>
+        )
       ) : (
-        flatListContent
+        <DefiEmptyState twClassName="mx-auto mt-4" />
       )}
     </View>
   );


### PR DESCRIPTION
## **Description**

This PR refactors the `DeFiPositionsList` component to improve scrolling behavior and simplify the rendering logic for the homepage redesign.

**What is the reason for the change?**
The previous implementation used `FlatList` with a fixed calculated height when the homepage redesign flag was enabled. This approach was complex and could cause layout issues when the list content didn't match the estimated height calculations.

**What is the improvement/solution?**
- Replaced `FlatList` with a simpler `.map()` approach for rendering DeFi positions
- Removed the fixed height calculation logic (`calculatedListHeight` and `estimatedItemHeight`)
- Added conditional `ScrollView` wrapper that only applies when the homepage redesign flag is disabled
- Simplified empty state handling by moving it from `ListEmptyComponent` prop to inline conditional rendering
- Streamlined the styles logic for the container

This makes the component more maintainable and allows the content to naturally size itself when the homepage redesign is enabled, while maintaining scrollability for the legacy view.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: 

## **Manual testing steps**

```gherkin
Feature: DeFi Positions List rendering

  Scenario: user views DeFi positions with homepage redesign enabled
    Given the homepage redesign feature flag is enabled
    And user has DeFi positions in their wallet

    When user navigates to the DeFi positions tab
    Then the list should render without a ScrollView wrapper
    And the content should naturally size to fit all positions

  Scenario: user views DeFi positions with homepage redesign disabled
    Given the homepage redesign feature flag is disabled
    And user has DeFi positions in their wallet

    When user navigates to the DeFi positions tab
    Then the list should render within a ScrollView
    And user should be able to scroll through their positions

  Scenario: user views empty DeFi positions
    Given user has no DeFi positions

    When user navigates to the DeFi positions tab
    Then the empty state component should display
```

## **Screenshots/Recordings**

### **Before**

### **After**
When feature flag is false 
https://github.com/user-attachments/assets/03ddb844-213b-4876-b081-a0e9ff22940f

When feature flag is true
https://github.com/user-attachments/assets/5f3aded7-ff9c-4bf3-997c-b7002a50809b

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces auto-height behavior to Tabs, refactors DeFi positions to simple mapped rendering, and updates Tokens/NFT/Perps/Predict and Wallet to honor the homepage redesign (fixed-height sections, capped items, scroll behavior).
> 
> - **Tabs**:
>   - Add `autoHeight` mode to `TabsList` with content height measurement, caching, debounce, RAF, and timer cleanup.
>   - Defer tab loading until scroll settles; preload adjacent tabs; handle programmatic scroll flags; preserve active tab by key across reorders.
>   - Expose common scroll handlers, index mapping between tabs/content; refine disabled-tab handling; centralize ScrollView props; support `tabsListContentTwClassName`.
>   - Extensive new test coverage for height, scrolling, timing, edge cases, and ref APIs.
> - **Homepage Redesign Integration**:
>   - Wallet: wrap main content in `ScrollView` and enable `TabsList autoHeight` when flag is on.
>   - Tokens: add maxItems (10), fixed-height calculation, non-scroll FlashList in redesign; footer “View all tokens”; keep full-view scrollable.
>   - NFT Grid: cap items (18), compute container height, disable scroll in redesign; show “View all NFTs”.
>   - Perps: adjust containers to non-flex and disable scrolling in redesign; tweak loading skeleton min-height.
>   - Predict: compute fixed heights for active/claimable lists and wrap in sized containers in redesign; disable scroll in tab view.
> - **DeFi Positions**:
>   - Replace `FlatList` with mapped content; conditional `ScrollView` only when redesign is off; inline empty state.
> - **Tokens Full View**:
>   - Add explicit back button testID and header styling.
> - **Tests**:
>   - Add/expand tests across Tabs, DeFi, NFT Grid, Predict, Perps, Tokens, and TokensFullView to cover new behaviors and flags.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b74b2cdd6968c9d09cd1a5fc861f2d41fae0405. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->