### PR TITLE
feat: Updated predictions tab on wallet to no longer use FlashList

### DIFF
--- a/app/components/UI/Predict/components/PredictPositionEmpty/PredictPositionEmpty.styles.ts
+++ b/app/components/UI/Predict/components/PredictPositionEmpty/PredictPositionEmpty.styles.ts
@@ -3,7 +3,6 @@ import { StyleSheet } from 'react-native';
 const styleSheet = () =>
   StyleSheet.create({
     emptyState: {
-      flex: 1,
       justifyContent: 'center',
       alignItems: 'center',
       paddingHorizontal: 24,

--- a/app/components/UI/Predict/components/PredictPositions/PredictPositions.tsx
+++ b/app/components/UI/Predict/components/PredictPositions/PredictPositions.tsx
@@ -3,14 +3,11 @@ import React, {
   useCallback,
   useEffect,
   useImperativeHandle,
-  useMemo,
-  useRef,
 } from 'react';
 
 import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { NavigationProp, useNavigation } from '@react-navigation/native';
-import { FlashList, FlashListRef } from '@shopify/flash-list';
 import { ActivityIndicator, View } from 'react-native';
 import { useSelector } from 'react-redux';
 import { strings } from '../../../../../../locales/i18n';
@@ -64,21 +61,6 @@ const PredictPositions = forwardRef<
     loadOnMount: true,
     refreshOnFocus: true,
   });
-  const listRef = useRef<FlashListRef<PredictPositionType>>(null);
-
-  const estimatedPositionItemHeight = 92;
-
-  const activePositionsHeight = useMemo(() => {
-    if (!isHomepageRedesignV1Enabled) return undefined;
-    if (positions.length === 0) return undefined;
-    return positions.length * estimatedPositionItemHeight + 92;
-  }, [isHomepageRedesignV1Enabled, positions.length]);
-
-  const claimablePositionsHeight = useMemo(() => {
-    if (!isHomepageRedesignV1Enabled) return undefined;
-    if (claimablePositions.length === 0) return undefined;
-    return claimablePositions.length * estimatedPositionItemHeight + 48;
-  }, [isHomepageRedesignV1Enabled, claimablePositions.length]);
 
   // Notify parent of errors while keeping state isolated
   useEffect(() => {
@@ -171,72 +153,46 @@ const PredictPositions = forwardRef<
 
   return (
     <>
-      {activePositionsHeight ? (
-        <View style={{ height: activePositionsHeight }}>
-          <FlashList
-            testID={PredictPositionsSelectorsIDs.ACTIVE_POSITIONS_LIST}
-            ref={listRef}
-            data={positions}
-            renderItem={renderPosition}
-            scrollEnabled={false}
-            keyExtractor={(item) => `${item.outcomeId}:${item.outcomeIndex}`}
-            removeClippedSubviews
-            decelerationRate={0}
-            ListEmptyComponent={isTrulyEmpty ? <PredictPositionEmpty /> : null}
-            ListFooterComponent={isTrulyEmpty ? null : <PredictNewButton />}
-          />
-        </View>
+      {isTrulyEmpty ? (
+        <PredictPositionEmpty />
       ) : (
-        <FlashList
-          testID={PredictPositionsSelectorsIDs.ACTIVE_POSITIONS_LIST}
-          ref={listRef}
-          data={positions}
-          renderItem={renderPosition}
-          scrollEnabled={false}
-          keyExtractor={(item) => `${item.outcomeId}:${item.outcomeIndex}`}
-          removeClippedSubviews
-          decelerationRate={0}
-          ListEmptyComponent={isTrulyEmpty ? <PredictPositionEmpty /> : null}
-          ListFooterComponent={isTrulyEmpty ? null : <PredictNewButton />}
-        />
-      )}
-      {claimablePositions.length > 0 && (
         <>
-          <Box>
-            <Text
-              variant={TextVariant.BodyMd}
-              twClassName="text-alternative mb-4"
-            >
-              {strings('predict.tab.resolved_markets')}
-            </Text>
-          </Box>
-          {claimablePositionsHeight ? (
-            <View style={{ height: claimablePositionsHeight }}>
-              <FlashList
+          <View testID={PredictPositionsSelectorsIDs.ACTIVE_POSITIONS_LIST}>
+            {positions.map((item) => (
+              <React.Fragment key={`${item.outcomeId}:${item.outcomeIndex}`}>
+                {renderPosition({ item })}
+              </React.Fragment>
+            ))}
+          </View>
+          <PredictNewButton />
+          {claimablePositions.length > 0 && (
+            <>
+              <Box>
+                <Text
+                  variant={TextVariant.BodyMd}
+                  twClassName="text-alternative mb-4"
+                >
+                  {strings('predict.tab.resolved_markets')}
+                </Text>
+              </Box>
+              <View
                 testID={PredictPositionsSelectorsIDs.CLAIMABLE_POSITIONS_LIST}
-                data={claimablePositions.sort(
-                  (a, b) =>
-                    new Date(b.endDate).getTime() -
-                    new Date(a.endDate).getTime(),
-                )}
-                renderItem={renderResolvedPosition}
-                scrollEnabled={false}
-                keyExtractor={(item) =>
-                  `${item.outcomeId}:${item.outcomeIndex}`
-                }
-              />
-            </View>
-          ) : (
-            <FlashList
-              testID={PredictPositionsSelectorsIDs.CLAIMABLE_POSITIONS_LIST}
-              data={claimablePositions.sort(
-                (a, b) =>
-                  new Date(b.endDate).getTime() - new Date(a.endDate).getTime(),
-              )}
-              renderItem={renderResolvedPosition}
-              scrollEnabled={false}
-              keyExtractor={(item) => `${item.outcomeId}:${item.outcomeIndex}`}
-            />
+              >
+                {claimablePositions
+                  .sort(
+                    (a, b) =>
+                      new Date(b.endDate).getTime() -
+                      new Date(a.endDate).getTime(),
+                  )
+                  .map((item) => (
+                    <React.Fragment
+                      key={`${item.outcomeId}:${item.outcomeIndex}`}
+                    >
+                      {renderResolvedPosition({ item })}
+                    </React.Fragment>
+                  ))}
+              </View>
+            </>
           )}
         </>
       )}

--- a/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
+++ b/app/components/UI/Predict/components/PredictPositionsHeader/PredictPositionsHeader.tsx
@@ -154,7 +154,11 @@ const PredictPositionsHeader = forwardRef<
     });
   };
 
-  if (isBalanceLoading || isUnrealizedPnLLoading) {
+  if (
+    isBalanceLoading ||
+    isUnrealizedPnLLoading ||
+    (!hasClaimableAmount && !shouldShowMainCard)
+  ) {
     return null;
   }
 

--- a/app/components/UI/Predict/views/PredictTabView/PredictTabView.tsx
+++ b/app/components/UI/Predict/views/PredictTabView/PredictTabView.tsx
@@ -62,6 +62,21 @@ const PredictTabView: React.FC<PredictTabViewProps> = ({ isVisible }) => {
     setHeaderError(error);
   }, []);
 
+  const content = (
+    <>
+      <PredictPositionsHeader
+        ref={predictPositionsHeaderRef}
+        onError={handleHeaderError}
+      />
+      <PredictPositions
+        ref={predictPositionsRef}
+        onError={handlePositionsError}
+        isVisible={isVisible}
+      />
+      <PredictAddFundsSheet />
+    </>
+  );
+
   return (
     <View
       style={tw.style(
@@ -70,10 +85,11 @@ const PredictTabView: React.FC<PredictTabViewProps> = ({ isVisible }) => {
     >
       {hasError ? (
         <PredictOffline onRetry={handleRefresh} />
+      ) : isHomepageRedesignV1Enabled ? (
+        <View testID={PredictTabViewSelectorsIDs.SCROLL_VIEW}>{content}</View>
       ) : (
         <ScrollView
           testID={PredictTabViewSelectorsIDs.SCROLL_VIEW}
-          scrollEnabled={!isHomepageRedesignV1Enabled}
           refreshControl={
             <RefreshControl
               refreshing={isRefreshing}
@@ -81,16 +97,7 @@ const PredictTabView: React.FC<PredictTabViewProps> = ({ isVisible }) => {
             />
           }
         >
-          <PredictPositionsHeader
-            ref={predictPositionsHeaderRef}
-            onError={handleHeaderError}
-          />
-          <PredictPositions
-            ref={predictPositionsRef}
-            onError={handlePositionsError}
-            isVisible={isVisible}
-          />
-          <PredictAddFundsSheet />
+          {content}
         </ScrollView>
       )}
     </View>


### PR DESCRIPTION
## **Description**

This PR refactors the Predictions tab components to simplify rendering logic and improve scrolling behavior for the homepage redesign.

**What is the reason for the change?**
The previous implementation used FlashList with complex fixed height calculations that could cause layout issues when content didn't match estimated heights. Additionally, the scrolling behavior was disabled when the homepage redesign flag was enabled, making it difficult to view all content.

**What is the improvement/solution?**
- Replaced FlashList with simpler `.map()` rendering for both active positions and claimable positions
- Removed all fixed height calculations (`activePositionsHeight`, `claimablePositionsHeight`) and estimated item heights
- Updated `PredictTabView` to conditionally render ScrollView (legacy) or View (redesign) based on the feature flag
- Simplified `PredictPositionsHeader` by consolidating early return conditions
- Removed `flex: 1` from empty state to prevent layout conflicts
- Moved `PredictNewButton` out of FlashList footer to always render when positions exist

This makes the components more maintainable and allows content to naturally size itself when the homepage redesign is enabled, while maintaining proper scrollability for the legacy view.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: 

## **Manual testing steps**

```gherkin
Feature: Predictions tab rendering and scrolling

  Scenario: user views predictions with homepage redesign enabled
    Given the homepage redesign feature flag is enabled
    And user has active prediction positions

    When user navigates to the predictions tab
    Then all positions should render without height constraints
    And content should naturally size to fit all positions
    And parent scrollview should allow scrolling through all content

  Scenario: user views predictions with homepage redesign disabled
    Given the homepage redesign feature flag is disabled
    And user has multiple prediction positions

    When user navigates to the predictions tab
    Then positions should render within a ScrollView
    And user should be able to scroll through all positions
    And pull-to-refresh should work

  Scenario: user views empty predictions state
    Given user has no active or claimable positions

    When user navigates to the predictions tab
    Then the empty state component should display correctly
    And the new trade button should be visible

  Scenario: user views claimable positions
    Given user has resolved/claimable positions

    When user navigates to the predictions tab
    Then the "Resolved Markets" section should display
    And all claimable positions should be visible and scrollable
```

## **Screenshots/Recordings**

### **Before**

### **After**
When feature flag is off
https://github.com/user-attachments/assets/0cca3d8a-4f2c-4bc1-a45e-c473cd6571bd

When feature flag is on
https://github.com/user-attachments/assets/333657c8-b105-4e8e-961f-ce555bb1bfc1

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace FlashList with direct map rendering, simplify header visibility, conditionally use ScrollView based on feature flag, and adjust empty state styles.
> 
> - **Predict Tab Rendering**:
>   - Replace `FlashList` with direct `.map()` rendering for active and claimable positions; remove refs, memos, and fixed height calculations.
>   - Always render `PredictNewButton` after active positions; keep resolved section with sorted claimables.
> - **Header**:
>   - Consolidate early-return conditions to hide when loading or when no balance/UPnL/claimables.
> - **Layout/Navigation**:
>   - In `PredictTabView`, factor shared `content`; use `View` for redesign and `ScrollView` (with pull-to-refresh) for legacy.
> - **Styles**:
>   - Remove `flex: 1` from `PredictPositionEmpty` container to avoid layout conflicts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d206578860ded569ec62ef8eeaf86b9c4181baf5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->