### PR TITLE
docs: fix wrong label in the UI

### DIFF
--- a/locales/languages/ru-ru.json
+++ b/locales/languages/ru-ru.json
@@ -259,7 +259,7 @@
     "confirm": "Подтвердить"
   },
   "deposit": {
-    "title": "Депонировать"
+    "title": "Пополнить"
   },
   "receive": {
     "title": "Получить"
@@ -277,7 +277,7 @@
     "add_collectibles": "ДОБАВИТЬ не взаимозаменяемые токены",
     "no_transactions": "У вас нет транзакций!",
     "send_button": "Отправить",
-    "deposit_button": "Депонировать",
+    "deposit_button": "Пополнить",
     "copy_address": "Копировать",
     "remove_token_title": "Вы хотите удалить этот токен?",
     "remove_collectible_title": "Вы хотите удалить этот предмет коллекционирования?",


### PR DESCRIPTION
## **Description**

replaced “Депонировать” with “Пополнить” - that’s the proper wording in Russian.

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces Russian "Депонировать" with "Пополнить" for deposit title and wallet deposit button.
> 
> - **Localization (ru-ru)**:
>   - Update `deposit.title` to `"Пополнить"`.
>   - Update `wallet.deposit_button` to `"Пополнить"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 452c224081333fb6c078eb91232481a64c7bd4a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->