### PR TITLE
fix: cp-7.58.0 Make burn and null address sending a blocking alert

### DIFF
--- a/app/components/Views/confirmations/hooks/alerts/useBurnAddressAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useBurnAddressAlert.test.ts
@@ -56,7 +56,7 @@ describe('useBurnAddressAlert', () => {
       key: AlertKeys.BurnAddress,
       field: RowAlertKey.BurnAddress,
       severity: Severity.Danger,
-      isBlocking: false,
+      isBlocking: true,
     });
     expect(result.current[0].title).toBeDefined();
     expect(result.current[0].message).toBeDefined();
@@ -72,7 +72,7 @@ describe('useBurnAddressAlert', () => {
       key: AlertKeys.BurnAddress,
       field: RowAlertKey.BurnAddress,
       severity: Severity.Danger,
-      isBlocking: false,
+      isBlocking: true,
     });
   });
 
@@ -100,7 +100,7 @@ describe('useBurnAddressAlert', () => {
       key: AlertKeys.BurnAddress,
       field: RowAlertKey.BurnAddress,
       severity: Severity.Danger,
-      isBlocking: false,
+      isBlocking: true,
     });
   });
 

--- a/app/components/Views/confirmations/hooks/alerts/useBurnAddressAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useBurnAddressAlert.ts
@@ -41,7 +41,7 @@ export function useBurnAddressAlert(): Alert[] {
         message: strings('alert_system.burn_address.message'),
         title: strings('alert_system.burn_address.title'),
         severity: Severity.Danger,
-        isBlocking: false,
+        isBlocking: true,
       },
     ];
   }, [hasBurnAddressRecipient]);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to make burn/null address sending alert to be a blocking alert. 

See the task details for further information

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Make burn and null address sending a blocking alert

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/22046

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make burn/null address alerts blocking and update tests accordingly.
> 
> - **Alerts**:
>   - `useBurnAddressAlert`: Set `isBlocking: true` for `BurnAddress` alert in `Severity.Danger`.
> - **Tests**:
>   - Update `useBurnAddressAlert.test.ts` to expect `isBlocking: true` for burn/null address cases (direct and nested recipients, mixed/uppercase casing).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9093654edde09d3d7ba119e51e058b936e77404f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->