### PR TITLE
feat: use new asset comparisson

### DIFF
--- a/app/components/UI/Tokens/util/sortAssets.ts
+++ b/app/components/UI/Tokens/util/sortAssets.ts
@@ -1,9 +1,10 @@
 import { get } from 'lodash';
 
 export type SortOrder = 'asc' | 'dsc';
+
 export interface SortCriteria {
   key: string;
-  order: string;
+  order: SortOrder;
   sortCallback: string;
 }
 
@@ -30,10 +31,7 @@ function getNestedValue<T>(obj: T, keyPath: string): SortingType {
   return get(obj, keyPath) as SortingType;
 }
 
-export function sortAssets<T>(
-  array: T[],
-  criteria: Record<string, string>,
-): T[] {
+export function sortAssets<T>(array: T[], criteria: SortCriteria): T[] {
   const { key, order = 'asc', sortCallback } = criteria;
 
   return [...array].sort((a, b) => {

--- a/app/components/UI/Tokens/util/sortAssets.ts
+++ b/app/components/UI/Tokens/util/sortAssets.ts
@@ -1,7 +1,6 @@
 import { get } from 'lodash';
 
 export type SortOrder = 'asc' | 'dsc';
-
 export interface SortCriteria {
   key: string;
   order: string;

--- a/app/components/UI/Tokens/util/sortAssets.ts
+++ b/app/components/UI/Tokens/util/sortAssets.ts
@@ -4,7 +4,7 @@ export type SortOrder = 'asc' | 'dsc';
 
 export interface SortCriteria {
   key: string;
-  order: SortOrder;
+  order: string;
   sortCallback: string;
 }
 
@@ -31,7 +31,10 @@ function getNestedValue<T>(obj: T, keyPath: string): SortingType {
   return get(obj, keyPath) as SortingType;
 }
 
-export function sortAssets<T>(array: T[], criteria: SortCriteria): T[] {
+export function sortAssets<T>(
+  array: T[],
+  criteria: Record<string, string>,
+): T[] {
   const { key, order = 'asc', sortCallback } = criteria;
 
   return [...array].sort((a, b) => {

--- a/app/components/UI/Tokens/util/sortAssetsWithPriority.test.ts
+++ b/app/components/UI/Tokens/util/sortAssetsWithPriority.test.ts
@@ -19,7 +19,7 @@ function createMockAsset({
 }): Asset {
   return {
     name,
-    fiat: fiatBalance !== undefined ? { balance: fiatBalance } : undefined,
+    fiat: fiatBalance === undefined ? undefined : { balance: fiatBalance },
     isNative,
     chainId,
   } as unknown as Asset;

--- a/app/components/UI/Tokens/util/sortAssetsWithPriority.test.ts
+++ b/app/components/UI/Tokens/util/sortAssetsWithPriority.test.ts
@@ -1,0 +1,185 @@
+import { Asset } from '@metamask/assets-controllers';
+import {
+  compareFiatBalanceWithPriority,
+  sortAssetsWithPriority,
+} from './sortAssetsWithPriority';
+import { CaipChainId, Hex } from '@metamask/utils';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+
+function createMockAsset({
+  name,
+  fiatBalance,
+  isNative = true,
+  chainId = CHAIN_IDS.MAINNET,
+}: {
+  name: string;
+  fiatBalance?: number;
+  isNative?: boolean;
+  chainId?: Hex | CaipChainId;
+}): Asset {
+  return {
+    name,
+    fiat: fiatBalance ? { balance: fiatBalance } : undefined,
+    isNative,
+    chainId,
+  } as unknown as Asset;
+}
+
+describe('sortAssetsWithPriority', () => {
+  function extractAssetNames(assets: Asset[]): string[] {
+    return assets.map((asset) => asset.name);
+  }
+
+  it('sorts by name when key is "name"', () => {
+    const assets = [
+      createMockAsset({ name: 'Asset B', fiatBalance: 400 }),
+      createMockAsset({ name: 'Asset A', fiatBalance: 600 }),
+      createMockAsset({ name: 'Asset Z', fiatBalance: 500 }),
+    ];
+
+    const sortedAssets = sortAssetsWithPriority(assets, {
+      key: 'name',
+      order: 'asc',
+      sortCallback: 'alphaNumeric',
+    });
+
+    expect(extractAssetNames(sortedAssets)).toStrictEqual([
+      'Asset A',
+      'Asset B',
+      'Asset Z',
+    ]);
+  });
+
+  it('sorts by fiat balance when key is "tokenFiatAmount"', () => {
+    const assets = [
+      createMockAsset({ name: 'Asset B', fiatBalance: 400 }),
+      createMockAsset({ name: 'Asset A', fiatBalance: 600 }),
+      createMockAsset({ name: 'Asset Z', fiatBalance: 500 }),
+    ];
+
+    const sortedAssets = sortAssetsWithPriority(assets, {
+      key: 'tokenFiatAmount',
+      order: 'dsc',
+      sortCallback: 'stringNumeric',
+    });
+
+    expect(extractAssetNames(sortedAssets)).toStrictEqual([
+      'Asset A',
+      'Asset Z',
+      'Asset B',
+    ]);
+  });
+});
+
+describe('compareFiatBalanceWithPriority', () => {
+  describe('fiat balance comparison', () => {
+    it('returns -1 if the first asset has a fiat balance and the second asset does not', () => {
+      const assetA = createMockAsset({ name: 'Asset A', fiatBalance: 400 });
+      const assetB = createMockAsset({
+        name: 'Asset B',
+        fiatBalance: undefined,
+      });
+
+      const result = compareFiatBalanceWithPriority(assetA, assetB);
+
+      expect(result).toBe(-1);
+    });
+
+    it('returns 1 if the second asset has a fiat balance and the first asset does not', () => {
+      const assetA = createMockAsset({
+        name: 'Asset A',
+        fiatBalance: undefined,
+      });
+      const assetB = createMockAsset({ name: 'Asset B', fiatBalance: 400 });
+
+      const result = compareFiatBalanceWithPriority(assetA, assetB);
+
+      expect(result).toBe(1);
+    });
+
+    it('compares first value above the second value if both assets have fiat balances and the first value is greater', () => {
+      const assetA = createMockAsset({ name: 'Asset A', fiatBalance: 400 });
+      const assetB = createMockAsset({ name: 'Asset B', fiatBalance: 300 });
+
+      const result = compareFiatBalanceWithPriority(assetA, assetB);
+
+      expect(result).toBeLessThan(0);
+    });
+  });
+
+  describe('non-native asset comparison', () => {
+    it('returns -1 if the first asset is native and the second asset is not', () => {
+      const assetA = createMockAsset({ name: 'Asset A', isNative: true });
+      const assetB = createMockAsset({ name: 'Asset B', isNative: false });
+
+      const result = compareFiatBalanceWithPriority(assetA, assetB);
+
+      expect(result).toBe(-1);
+    });
+
+    it('returns 1 if the second asset is native and the first asset is not', () => {
+      const assetA = createMockAsset({ name: 'Asset A', isNative: false });
+      const assetB = createMockAsset({ name: 'Asset B', isNative: true });
+
+      const result = compareFiatBalanceWithPriority(assetA, assetB);
+
+      expect(result).toBe(1);
+    });
+
+    it('compares name values if neither asset is native', () => {
+      const assetA = createMockAsset({ name: 'Asset A', isNative: false });
+      const assetB = createMockAsset({ name: 'Asset B', isNative: false });
+
+      const result = compareFiatBalanceWithPriority(assetA, assetB);
+
+      expect(result).toBe(-1);
+    });
+  });
+
+  describe('native asset comparison', () => {
+    it('compares first value above second if the first asset is in the defaultNativeAssetOrder and the second asset is not', () => {
+      const assetA = createMockAsset({
+        name: 'Asset A',
+        chainId: CHAIN_IDS.BASE,
+      });
+      const assetB = createMockAsset({
+        name: 'Asset B',
+        chainId: '0xeeeeeeeeeeeee1',
+      });
+
+      const result = compareFiatBalanceWithPriority(assetA, assetB);
+
+      expect(result).toBeLessThan(0);
+    });
+
+    it('compares first value above second if both assets are in the defaultNativeAssetOrder and the first value has higher priority', () => {
+      const assetA = createMockAsset({
+        name: 'Asset A',
+        chainId: CHAIN_IDS.LINEA_MAINNET,
+      });
+      const assetB = createMockAsset({
+        name: 'Asset B',
+        chainId: CHAIN_IDS.ARBITRUM,
+      });
+
+      const result = compareFiatBalanceWithPriority(assetA, assetB);
+
+      expect(result).toBeLessThan(0);
+    });
+
+    it('compares name values if neither asset is in the defaultNativeAssetOrder', () => {
+      const assetA = createMockAsset({
+        name: 'Asset A',
+        chainId: '0xeeeeeeeeeeeee1',
+      });
+      const assetB = createMockAsset({
+        name: 'Asset B',
+        chainId: '0xeeeeeeeeeeeee2',
+      });
+
+      const result = compareFiatBalanceWithPriority(assetA, assetB);
+
+      expect(result).toBeLessThan(0);
+    });
+  });
+});

--- a/app/components/UI/Tokens/util/sortAssetsWithPriority.test.ts
+++ b/app/components/UI/Tokens/util/sortAssetsWithPriority.test.ts
@@ -1,10 +1,10 @@
-import { Asset } from '@metamask/assets-controllers';
+import type { Asset } from '@metamask/assets-controllers';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import type { CaipChainId, Hex } from '@metamask/utils';
 import {
   compareFiatBalanceWithPriority,
   sortAssetsWithPriority,
 } from './sortAssetsWithPriority';
-import { CaipChainId, Hex } from '@metamask/utils';
-import { CHAIN_IDS } from '@metamask/transaction-controller';
 
 function createMockAsset({
   name,

--- a/app/components/UI/Tokens/util/sortAssetsWithPriority.ts
+++ b/app/components/UI/Tokens/util/sortAssetsWithPriority.ts
@@ -7,10 +7,10 @@ import { sortAssets, type SortCriteria } from './sortAssets';
 // These are the only two options for sorting assets
 // {"key": "name", "order": "asc", "sortCallback": "alphaNumeric"}
 // {"key": "tokenFiatAmount", "order": "dsc", "sortCallback": "stringNumeric"}
-export function sortAssetsWithPriority<T extends Asset>(
-  array: T[],
+export function sortAssetsWithPriority(
+  array: Asset[],
   criteria: SortCriteria,
-): T[] {
+): Asset[] {
   if (criteria.key === 'name') {
     return sortAssets(array, {
       key: 'name',

--- a/app/components/UI/Tokens/util/sortAssetsWithPriority.ts
+++ b/app/components/UI/Tokens/util/sortAssetsWithPriority.ts
@@ -1,5 +1,6 @@
-import { CaipChainId, Hex } from '@metamask/utils';
+import type { Asset } from '@metamask/assets-controllers';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
+import type { CaipChainId, Hex } from '@metamask/utils';
 import {
   BtcScope,
   SolScope,
@@ -7,8 +8,7 @@ import {
   TrxScope,
   ///: END:ONLY_INCLUDE_IF
 } from '@metamask/keyring-api';
-import { Asset } from '@metamask/assets-controllers';
-import { sortAssets, SortCriteria } from './sortAssets';
+import { sortAssets, type SortCriteria } from './sortAssets';
 
 // These are the only two options for sorting assets
 // {"key": "name", "order": "asc", "sortCallback": "alphaNumeric"}

--- a/app/components/UI/Tokens/util/sortAssetsWithPriority.ts
+++ b/app/components/UI/Tokens/util/sortAssetsWithPriority.ts
@@ -1,13 +1,7 @@
 import type { Asset } from '@metamask/assets-controllers';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import type { CaipChainId, Hex } from '@metamask/utils';
-import {
-  BtcScope,
-  SolScope,
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
-  TrxScope,
-  ///: END:ONLY_INCLUDE_IF
-} from '@metamask/keyring-api';
+import { BtcScope, SolScope, TrxScope } from '@metamask/keyring-api';
 import { sortAssets, type SortCriteria } from './sortAssets';
 
 // These are the only two options for sorting assets
@@ -25,49 +19,7 @@ export function sortAssetsWithPriority<T extends Asset>(
     });
   }
 
-  const xxx = [...array].sort((a, b) => {
-    const comparison = compareFiatBalanceWithPriority(a, b);
-
-    if (a.name === 'Solana' || b.name === 'Solana') {
-      // eslint-disable-next-line no-console
-      console.log('XXXXX', {
-        a: {
-          name: a.name,
-          chainId: a.chainId,
-          fiatBalance: a.fiat?.balance,
-          isNative: a.isNative,
-        },
-        b: {
-          name: b.name,
-          chainId: b.chainId,
-          fiatBalance: b.fiat?.balance,
-          isNative: b.isNative,
-        },
-        comparison,
-        balanceCheck: a.fiat?.balance && b.fiat?.balance,
-      });
-    }
-
-    return comparison;
-  });
-
-  // eslint-disable-next-line no-console
-  // console.log('ARRAY', {
-  //   unsorted: array.map((asset) => ({
-  //     name: asset.name,
-  //     fiatBalance: asset.fiat?.balance,
-  //     isNative: asset.isNative,
-  //     chainId: asset.chainId,
-  //   })),
-  //   sorted: xxx.map((asset) => ({
-  //     name: asset.name,
-  //     fiatBalance: asset.fiat?.balance,
-  //     isNative: asset.isNative,
-  //     chainId: asset.chainId,
-  //   })),
-  // });
-
-  return xxx;
+  return [...array].sort(compareFiatBalanceWithPriority);
 }
 
 // Higher priority assets are last in the array to facilitate sorting
@@ -77,9 +29,7 @@ const defaultNativeAssetOrder: (Hex | CaipChainId)[] = [
   CHAIN_IDS.BSC,
   CHAIN_IDS.ARBITRUM,
   CHAIN_IDS.BASE,
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   TrxScope.Mainnet,
-  ///: END:ONLY_INCLUDE_IF
   BtcScope.Mainnet,
   SolScope.Mainnet,
   CHAIN_IDS.LINEA_MAINNET,

--- a/app/components/UI/Tokens/util/sortAssetsWithPriority.ts
+++ b/app/components/UI/Tokens/util/sortAssetsWithPriority.ts
@@ -1,0 +1,100 @@
+import { CaipChainId, Hex } from '@metamask/utils';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import {
+  BtcScope,
+  SolScope,
+  ///: BEGIN:ONLY_INCLUDE_IF(tron)
+  TrxScope,
+  ///: END:ONLY_INCLUDE_IF
+} from '@metamask/keyring-api';
+import { Asset } from '@metamask/assets-controllers';
+import { sortAssets, SortCriteria } from './sortAssets';
+
+// These are the only two options for sorting assets
+// {"key": "name", "order": "asc", "sortCallback": "alphaNumeric"}
+// {"key": "tokenFiatAmount", "order": "dsc", "sortCallback": "stringNumeric"}
+export function sortAssetsWithPriority<T extends Asset>(
+  array: T[],
+  criteria: SortCriteria,
+): T[] {
+  if (criteria.key === 'name') {
+    return sortAssets(array, {
+      key: 'name',
+      order: 'asc',
+      sortCallback: 'alphaNumeric',
+    });
+  }
+
+  return [...array].sort(compareFiatBalanceWithPriority);
+}
+
+// Higher priority assets are last in the array to facilitate sorting
+const defaultNativeAssetOrder: (Hex | CaipChainId)[] = [
+  CHAIN_IDS.POLYGON,
+  CHAIN_IDS.OPTIMISM,
+  CHAIN_IDS.BSC,
+  CHAIN_IDS.ARBITRUM,
+  CHAIN_IDS.BASE,
+  ///: BEGIN:ONLY_INCLUDE_IF(tron)
+  TrxScope.Mainnet,
+  ///: END:ONLY_INCLUDE_IF
+  BtcScope.Mainnet,
+  SolScope.Mainnet,
+  CHAIN_IDS.LINEA_MAINNET,
+  CHAIN_IDS.MAINNET,
+];
+
+/**
+ * Compares assets by fiat balance with priority sorting.
+ *
+ * @param a - The first asset to compare.
+ * @param b - The second asset to compare.
+ * @returns A negative number if the first asset should appear before the second, a positive number if the first asset should appear after the second, or 0 if they are equal.
+ */
+export function compareFiatBalanceWithPriority(a: Asset, b: Asset) {
+  // If one of the fiat balances is greater than the other, return the comparison
+  if (a.fiat?.balance && b.fiat?.balance === undefined) {
+    return -1;
+  }
+
+  if (b.fiat?.balance && a.fiat?.balance === undefined) {
+    return 1;
+  }
+
+  let comparison = 0;
+  if (a.fiat?.balance && b.fiat?.balance) {
+    comparison = b.fiat.balance - a.fiat.balance;
+  }
+
+  if (comparison) {
+    return comparison;
+  }
+
+  // With equal fiat balances
+  // Always return native assets before token assets
+  // Apply the priority defined in defaultNativeAssetOrder if both are native assets
+  // If both assets are tokens or none is in the defaultNativeAssetOrder, compare by name
+  if (a.isNative && !b.isNative) {
+    return -1;
+  }
+
+  if (b.isNative && !a.isNative) {
+    return 1;
+  }
+
+  if (!a.isNative && !b.isNative) {
+    return a.name.localeCompare(b.name);
+  }
+
+  const nativeAssetOrderA = defaultNativeAssetOrder.indexOf(a.chainId);
+  const nativeAssetOrderB = defaultNativeAssetOrder.indexOf(b.chainId);
+
+  comparison = nativeAssetOrderB - nativeAssetOrderA;
+
+  if (comparison) {
+    return comparison;
+  }
+
+  // If neither asset is in the defaultNativeAssetOrder, compare by name
+  return a.name.localeCompare(b.name);
+}

--- a/app/components/UI/Tokens/util/sortAssetsWithPriority.ts
+++ b/app/components/UI/Tokens/util/sortAssetsWithPriority.ts
@@ -25,7 +25,49 @@ export function sortAssetsWithPriority<T extends Asset>(
     });
   }
 
-  return [...array].sort(compareFiatBalanceWithPriority);
+  const xxx = [...array].sort((a, b) => {
+    const comparison = compareFiatBalanceWithPriority(a, b);
+
+    if (a.name === 'Solana' || b.name === 'Solana') {
+      // eslint-disable-next-line no-console
+      console.log('XXXXX', {
+        a: {
+          name: a.name,
+          chainId: a.chainId,
+          fiatBalance: a.fiat?.balance,
+          isNative: a.isNative,
+        },
+        b: {
+          name: b.name,
+          chainId: b.chainId,
+          fiatBalance: b.fiat?.balance,
+          isNative: b.isNative,
+        },
+        comparison,
+        balanceCheck: a.fiat?.balance && b.fiat?.balance,
+      });
+    }
+
+    return comparison;
+  });
+
+  // eslint-disable-next-line no-console
+  // console.log('ARRAY', {
+  //   unsorted: array.map((asset) => ({
+  //     name: asset.name,
+  //     fiatBalance: asset.fiat?.balance,
+  //     isNative: asset.isNative,
+  //     chainId: asset.chainId,
+  //   })),
+  //   sorted: xxx.map((asset) => ({
+  //     name: asset.name,
+  //     fiatBalance: asset.fiat?.balance,
+  //     isNative: asset.isNative,
+  //     chainId: asset.chainId,
+  //   })),
+  // });
+
+  return xxx;
 }
 
 // Higher priority assets are last in the array to facilitate sorting
@@ -53,21 +95,11 @@ const defaultNativeAssetOrder: (Hex | CaipChainId)[] = [
  */
 export function compareFiatBalanceWithPriority(a: Asset, b: Asset) {
   // If one of the fiat balances is greater than the other, return the comparison
-  if (a.fiat?.balance && b.fiat?.balance === undefined) {
-    return -1;
-  }
+  const fiatBalanceComparison = (b.fiat?.balance ?? 0) - (a.fiat?.balance ?? 0);
 
-  if (b.fiat?.balance && a.fiat?.balance === undefined) {
-    return 1;
-  }
-
-  let comparison = 0;
-  if (a.fiat?.balance && b.fiat?.balance) {
-    comparison = b.fiat.balance - a.fiat.balance;
-  }
-
-  if (comparison) {
-    return comparison;
+  // Only return comparison if it is not zero
+  if (fiatBalanceComparison) {
+    return fiatBalanceComparison;
   }
 
   // With equal fiat balances
@@ -89,10 +121,10 @@ export function compareFiatBalanceWithPriority(a: Asset, b: Asset) {
   const nativeAssetOrderA = defaultNativeAssetOrder.indexOf(a.chainId);
   const nativeAssetOrderB = defaultNativeAssetOrder.indexOf(b.chainId);
 
-  comparison = nativeAssetOrderB - nativeAssetOrderA;
+  const nativeAssetOrderComparison = nativeAssetOrderB - nativeAssetOrderA;
 
-  if (comparison) {
-    return comparison;
+  if (nativeAssetOrderComparison) {
+    return nativeAssetOrderComparison;
   }
 
   // If neither asset is in the defaultNativeAssetOrder, compare by name

--- a/app/selectors/assets/assets-list.ts
+++ b/app/selectors/assets/assets-list.ts
@@ -10,7 +10,6 @@ import { createSelector } from 'reselect';
 
 import I18n from '../../../locales/i18n';
 import { TokenI } from '../../components/UI/Tokens/types';
-import { sortAssets } from '../../components/UI/Tokens/util';
 import { RootState } from '../../reducers';
 import { formatWithThreshold } from '../../util/assets';
 import { selectEvmNetworkConfigurationsByChainId } from '../networkController';
@@ -27,6 +26,7 @@ import {
   TRON_RESOURCE_SYMBOLS_SET,
   TronResourceSymbol,
 } from '../../core/Multichain/constants';
+import { sortAssetsWithPriority } from '../../components/UI/Tokens/util/sortAssetsWithPriority';
 
 export const selectAssetsBySelectedAccountGroup = createDeepEqualSelector(
   (state: RootState) => {
@@ -234,7 +234,7 @@ export const selectSortedAssetsBySelectedAccountGroup = createDeepEqualSelector(
     // Current sorting options
     // {"key": "name", "order": "asc", "sortCallback": "alphaNumeric"}
     // {"key": "tokenFiatAmount", "order": "dsc", "sortCallback": "stringNumeric"}
-    const tokensSorted = sortAssets(
+    const tokensSorted = sortAssetsWithPriority(
       assets.map((asset) => ({
         ...asset,
         tokenFiatAmount: asset.fiat?.balance.toString(),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Use new asset sorting when balances are the same (or $0):
ETH Mainnet
ETH Linea
SOL Solana
BTC Bitcoin
TRX Tron
ETH Base
ETH Arbitrum
BNB Binance
ETH Optimism
POL Polygon

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Changed order of assets when their fiat balances are the same

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-1259

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/e8474a20-740f-4503-831f-17f0747d0183


### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/64b7f149-b5f5-45ca-9b68-fc9a4b23a417


## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds priority-based asset sorting (fiat desc with native/network tie-breakers) and integrates it into the assets selector with tests.
> 
> - **Assets Sorting**:
>   - Introduces `sortAssetsWithPriority` with `compareFiatBalanceWithPriority` to sort by fiat desc, then prioritize native assets and a default native chain order; fall back to name.
>   - Defines `defaultNativeAssetOrder` (e.g., `POLYGON`, `OPTIMISM`, `BSC`, `ARBITRUM`, `BASE`, `TRX`, `BTC`, `SOL`, `LINEA_MAINNET`, `MAINNET`).
> - **Integration**:
>   - Replaces `sortAssets` with `sortAssetsWithPriority` in `app/selectors/assets/assets-list.ts` when applying `tokenSortConfig`.
> - **Tests**:
>   - Adds `sortAssetsWithPriority.test.ts` covering name sort, fiat balance sort, native vs token handling, and chain priority tie-breakers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f0a9dd2bd5f629a1f0e85fe8fef8088839352cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->