### PR TITLE
fix: flickering on dapp connection permissions page

### DIFF
--- a/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.styles.ts
+++ b/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.styles.ts
@@ -17,6 +17,25 @@ const styleSheet = (params: { theme: Theme }) => {
       backgroundColor: colors.background.default,
       paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0,
     },
+    // We use absolute positioning with opacity instead of display: 'none' or conditional rendering
+    // to keep all screens mounted while preventing visual flickering during transitions.
+    screenVisible: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      zIndex: 1,
+    },
+    screenHidden: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      zIndex: 0,
+      opacity: 0,
+    },
   });
 };
 

--- a/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.tsx
@@ -102,6 +102,28 @@ import { Box } from '@metamask/design-system-react-native';
 import { TESTNET_CAIP_IDS } from '../../../../constants/network.js';
 import { getCaip25AccountIdsFromAccountGroupAndScope } from '../../../../util/multichain/getCaip25AccountIdsFromAccountGroupAndScope.ts';
 
+interface ScreenContainerProps {
+  isVisible: boolean;
+  children: React.ReactNode;
+  styles: {
+    screenVisible: object;
+    screenHidden: object;
+  };
+}
+
+const ScreenContainer: React.FC<ScreenContainerProps> = ({
+  isVisible,
+  children,
+  styles,
+}) => (
+  <Box
+    style={isVisible ? styles.screenVisible : styles.screenHidden}
+    pointerEvents={isVisible ? 'auto' : 'none'}
+  >
+    {children}
+  </Box>
+);
+
 const MultichainAccountConnect = (props: AccountConnectProps) => {
   const { colors } = useTheme();
   const { styles } = useStyles(styleSheet, {});
@@ -855,25 +877,26 @@ const MultichainAccountConnect = (props: AccountConnectProps) => {
     ],
   );
 
-  const renderConnectScreens = useCallback(() => {
-    switch (screen) {
-      case AccountConnectScreens.SingleConnect:
-        return renderPermissionsSummaryScreen();
-      case AccountConnectScreens.MultiConnectSelector:
-        return renderMultiConnectSelectorScreen();
-      case AccountConnectScreens.MultiConnectNetworkSelector:
-        return renderMultiConnectNetworkSelectorScreen();
-    }
-  }, [
-    screen,
-    renderPermissionsSummaryScreen,
-    renderMultiConnectSelectorScreen,
-    renderMultiConnectNetworkSelectorScreen,
-  ]);
-
   return (
     <Box style={styles.container}>
-      {renderConnectScreens()}
+      <ScreenContainer
+        isVisible={screen === AccountConnectScreens.SingleConnect}
+        styles={styles}
+      >
+        {renderPermissionsSummaryScreen()}
+      </ScreenContainer>
+      <ScreenContainer
+        isVisible={screen === AccountConnectScreens.MultiConnectSelector}
+        styles={styles}
+      >
+        {renderMultiConnectSelectorScreen()}
+      </ScreenContainer>
+      <ScreenContainer
+        isVisible={screen === AccountConnectScreens.MultiConnectNetworkSelector}
+        styles={styles}
+      >
+        {renderMultiConnectNetworkSelectorScreen()}
+      </ScreenContainer>
       {renderPhishingModal()}
     </Box>
   );

--- a/app/components/Views/NetworkConnect/NetworkConnectMultiSelector/NetworkConnectMultiSelector.tsx
+++ b/app/components/Views/NetworkConnect/NetworkConnectMultiSelector/NetworkConnectMultiSelector.tsx
@@ -39,14 +39,16 @@ const NetworkConnectMultiSelector = ({
   defaultSelectedChainIds,
 }: NetworkConnectMultiSelectorProps) => {
   const { styles } = useStyles(styleSheet, { isRenderedAsBottomSheet });
-  const [selectedChainIds, setSelectedChainIds] = useState<CaipChainId[]>([]);
+  const [selectedChainIds, setSelectedChainIds] = useState<CaipChainId[]>(
+    defaultSelectedChainIds,
+  );
   const networkConfigurations = useSelector(
     selectNetworkConfigurationsByCaipChainId,
   );
 
   useEffect(() => {
     setSelectedChainIds(defaultSelectedChainIds);
-  }, [setSelectedChainIds, defaultSelectedChainIds]);
+  }, [defaultSelectedChainIds]);
 
   const handleUpdateNetworkPermissions = useCallback(async () => {
     onSubmit(selectedChainIds);

--- a/app/components/Views/NetworkConnect/NetworkConnectMultiSelector/__snapshots__/NetworkConnectMultiSelector.test.tsx.snap
+++ b/app/components/Views/NetworkConnect/NetworkConnectMultiSelector/__snapshots__/NetworkConnectMultiSelector.test.tsx.snap
@@ -189,7 +189,7 @@ exports[`NetworkConnectMultiSelector renders correctly 1`] = `
       }
       getItem={[Function]}
       getItemCount={[Function]}
-      handlerTag={1}
+      handlerTag={-1}
       handlerType="NativeViewGestureHandler"
       initialNumToRender={999}
       keyExtractor={[Function]}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR fixes a bug causing a flickering when transitioning between views on the dapp connection modal
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug causing a flickering when transitioning between views on the dapp connection modal

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-38
https://consensyssoftware.atlassian.net/browse/TMCU-37

## **Manual testing steps**

```gherkin
Feature: Edit accounts or network pemissions

  Scenario: user edits network pemissions
    Given user is trying to connect to the dapp

    When user goes to permissions, clicks edit next to the networks row and then clicks back button
    Then there is no flickering of the screen
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/f767fa34-d8ba-43ef-858c-83856b7975aa


<!-- [screenshots/recordings] -->

### **After**
https://github.com/user-attachments/assets/bd8a6afb-6db2-4561-a99f-1050a0316a40
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents view flicker in the dapp connection modal by keeping screens mounted with absolute-positioned containers and aligns network selector state with provided defaults.
> 
> - **Multichain connect UI**:
>   - Introduces `ScreenContainer` and always mounts screens (`SingleConnect`, `MultiConnectSelector`, `MultiConnectNetworkSelector`) with layered styles (`styles.screenVisible`/`styles.screenHidden`) and `pointerEvents` to avoid flicker.
>   - Adds `screenVisible`/`screenHidden` styles in `MultichainAccountConnect.styles.ts` using absolute positioning and opacity.
> - **Network selector**:
>   - Initializes `selectedChainIds` from `defaultSelectedChainIds` and simplifies effect deps; updates snapshot accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd6022fecca438aaafb1403b0e6eb686ab668750. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->