### PR TITLE
fix: inconsistent top padding in networks list

### DIFF
--- a/app/components/UI/CustomNetworkSelector/CustomNetworkSelector.styles.ts
+++ b/app/components/UI/CustomNetworkSelector/CustomNetworkSelector.styles.ts
@@ -5,6 +5,7 @@ const createStyles = () =>
     // custom network styles
     container: {
       flex: 1,
+      paddingVertical: 12,
     },
     scrollContentContainer: {
       paddingBottom: 100,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR fixes inconsistent top padding in networks list
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed inconsistent top padding in networks list

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-70

## **Manual testing steps**

```gherkin
Feature: Open custom networks list

  Scenario: user opens custom networks list
    Given user onboarded

    When user navigates to activity and clicks networks selector and them "Custom" tab
    Then padding between tabs header and first item is consistent with paddings between items
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="414" height="866" alt="Screenshot 2025-11-03 at 12 44 18" src="https://github.com/user-attachments/assets/67f81fb1-3c6f-4c8e-ac88-c12149bcbac4" />

<!-- [screenshots/recordings] -->

### **After**
<img width="409" height="855" alt="Screenshot 2025-11-03 at 12 44 08" src="https://github.com/user-attachments/assets/51301eec-eda2-4d03-81ea-0f5a910482ea" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `paddingVertical: 12` to `CustomNetworkSelector` `container` style to standardize top spacing in the custom networks list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7a0255a4f997d125e83f9ffedb5a25ed5441bf1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->