### PR TITLE
fix(card): cp-7.58.0 fix non-gated feature flag

### DIFF
--- a/app/selectors/featureFlagController/card/index.ts
+++ b/app/selectors/featureFlagController/card/index.ts
@@ -149,7 +149,7 @@ const defaultCardSupportedCountries: CardSupportedCountries = {
 
 export type CardSupportedCountries = Record<string, boolean>;
 
-export interface DisplayCardButtonFeatureFlag {
+export interface GateVersionedFeatureFlag {
   enabled: boolean;
   minimumVersion: string;
 }
@@ -188,7 +188,7 @@ export const selectDisplayCardButtonFeatureFlag = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags) => {
     const remoteFlag =
-      remoteFeatureFlags?.displayCardButton as unknown as DisplayCardButtonFeatureFlag;
+      remoteFeatureFlags?.displayCardButton as unknown as GateVersionedFeatureFlag;
 
     return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
   },
@@ -196,7 +196,12 @@ export const selectDisplayCardButtonFeatureFlag = createSelector(
 
 export const selectCardExperimentalSwitch = createSelector(
   selectRemoteFeatureFlags,
-  (remoteFeatureFlags) => remoteFeatureFlags?.cardExperimentalSwitch ?? false,
+  (remoteFeatureFlags) => {
+    const remoteFlag =
+      remoteFeatureFlags?.cardExperimentalSwitch2 as unknown as GateVersionedFeatureFlag;
+
+    return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
+  },
 );
 
 export const selectCardFeatureFlag = createSelector(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR updates the Card Experimental Switch feature flag to include version gating.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds version-gated evaluation for the card experimental switch (`cardExperimentalSwitch2`) using `validatedVersionGatedFeatureFlag`, updates typing to `GateVersionedFeatureFlag`, and adjusts tests accordingly.
> 
> - **Feature Flags**:
>   - Implement version-gated logic for `selectCardExperimentalSwitch` using `validatedVersionGatedFeatureFlag` and new remote flag `cardExperimentalSwitch2`.
>   - Rename/standardize flag type to `GateVersionedFeatureFlag` and apply to `displayCardButton` and experimental switch selectors.
> - **Tests**:
>   - Add/adjust tests for version-gated behaviors (enabled/disabled/version unmet/malformed) for both `displayCardButton` and `cardExperimentalSwitch2`.
>   - Mock `validatedVersionGatedFeatureFlag` and `core/Engine/controllers/remote-feature-flag-controller` override.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24824b045b976475c039accd410709dd4cce1209. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->