### PR TITLE
fix: Remove test task for android release builds

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -470,6 +470,20 @@ generateIosBinary() {
 	scheme="$1"
 	configuration="${CONFIGURATION:-"Release"}"
 
+	# Check if configuration is valid
+	if [ "$configuration" != "Debug" ] && [ "$configuration" != "Release" ] ; then
+		# Configuration is not recognized
+		echo "Configuration $configuration is not recognized! Only Debug and Release are supported"
+		exit 1
+	fi
+
+	# Check if scheme is valid
+	if [ "$scheme" != "MetaMask" ] && [ "$scheme" != "MetaMask-QA" ] && [ "$scheme" != "MetaMask-Flask" ] ; then
+		# Scheme is not recognized
+		echo "Scheme $scheme is not recognized! Only MetaMask, MetaMask-QA, and MetaMask-Flask are supported"
+		exit 1
+	fi
+
 	if [ "$scheme" = "MetaMask" ] ; then
 		# Main target
 		if [ "$configuration" = "Debug" ] ; then
@@ -520,6 +534,20 @@ generateAndroidBinary() {
 	# Debug or Release
 	configuration="${CONFIGURATION:-"Release"}"
 
+	# Check if configuration is valid
+	if [ "$configuration" != "Debug" ] && [ "$configuration" != "Release" ] ; then
+		# Configuration is not recognized
+		echo "Configuration $configuration is not recognized! Only Debug and Release are supported"
+		exit 1
+	fi
+
+	# Check if flavor is valid
+	if [ "$flavor" != "Prod" ] && [ "$flavor" != "Flask" ] && [ "$flavor" != "Qa" ] ; then
+		# Flavor is not recognized
+		echo "Flavor $flavor is not recognized! Only Prod, Flask, and Qa (Deprecated - Do not use) are supported"
+		exit 1
+	fi
+
 	# Create flavor configuration
 	flavorConfiguration="app:assemble${flavor}${configuration}"
 
@@ -542,10 +570,6 @@ generateAndroidBinary() {
 		testConfiguration="app:assemble${flavor}DebugAndroidTest"
 		# Generate Android binary
 		./gradlew $flavorConfiguration $testConfiguration --build-cache --parallel
-	else 
-		#configuration is not supported
-		echo "Configuration $configuration is not recognized! Only Release and Debug are supported"
-		exit 1
 	fi
 
 	# Change directory back out

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -522,15 +522,11 @@ generateAndroidBinary() {
 
 	# Create flavor configuration
 	flavorConfiguration="app:assemble${flavor}${configuration}"
-	# Create test configuration
-	testConfiguration="app:assemble${flavor}${configuration}AndroidTest"
 
-	# Generate Android binary
 	echo "Generating Android binary for ($flavor) flavor with ($configuration) configuration"
-	./gradlew $flavorConfiguration $testConfiguration --build-cache --parallel
-
-
 	if [ "$configuration" = "Release" ] ; then
+		# Generate Android binary
+		./gradlew $flavorConfiguration --build-cache --parallel
 		# Generate AAB bundle
 		bundleConfiguration="bundle${flavor}Release"
 		echo "Generating AAB bundle for ($flavor) flavor with ($configuration) configuration"
@@ -541,6 +537,15 @@ generateAndroidBinary() {
 		checkSumCommand="build:android:checksum:${lowerCaseFlavor}"
 		echo "Generating checksum for ($flavor) flavor with ($configuration) configuration"
 		yarn $checkSumCommand
+	elif [ "$configuration" = "Debug" ] ; then
+		# Create test configuration
+		testConfiguration="app:assemble${flavor}DebugAndroidTest"
+		# Generate Android binary
+		./gradlew $flavorConfiguration $testConfiguration --build-cache --parallel
+	else 
+		#configuration is not supported
+		echo "Configuration $configuration is not recognized! Only Release and Debug are supported"
+		exit 1
 	fi
 
 	# Change directory back out


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This fix removes Android's test task for release builds since it doesn't exist and is not needed for those variants. Tests remains intact for debug builds. Also added check on generate binary helpers to validate scheme, flavor, and configuration.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

nightly_exp_builds_pipeline - https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/db618aea-1aee-4596-84c4-53487bac4ef4
nightly_rc_builds_pipeline - https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/4e3bb45e-e7af-41a4-8ded-c46e0b35797e
expo_dev_pipeline - https://app.bitrise.io/app/be69d4368ee7e86d/pipelines/d0247767-59dd-4ffe-a5fe-e9b405e1bfa0

When an invalid scheme is passed to iOS - 
<img width="738" height="457" alt="image" src="https://github.com/user-attachments/assets/2eda72cf-9e3e-4f20-9c83-893e5f53f427" />

When an invalid configuration is passed to iOS - 
<img width="716" height="444" alt="image" src="https://github.com/user-attachments/assets/55fa8099-c754-48c8-9d69-c4759b3ea575" />

When an invalid configuration is passed to Android - 
<img width="633" height="540" alt="image" src="https://github.com/user-attachments/assets/49011063-7d41-49a1-bb54-830dcd72641a" />

When an invalid flavor is passed to Android - 
<img width="754" height="491" alt="image" src="https://github.com/user-attachments/assets/61cdfd89-0ea2-4b3d-82db-2edce0c7b44a" />


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add strict build param validation and remove Android release AndroidTest task while keeping debug tests and release AAB/checksum steps.
> 
> - **scripts/build.sh**:
>   - **Build parameter validation**:
>     - `generateIosBinary`: Validate `configuration` (`Debug|Release`) and `scheme` (`MetaMask|MetaMask-QA|MetaMask-Flask`).
>     - `generateAndroidBinary`: Validate `configuration` (`Debug|Release`) and `flavor` (`Prod|Flask|Qa`).
>   - **Android build behavior**:
>     - Release: stop assembling `AndroidTest`; only assemble app, then build AAB and generate checksum.
>     - Debug: continue assembling `AndroidTest` alongside app.
>   - Minor: clearer echo messages and branching for gradle tasks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8dd18f2ede8c6b55af47fd30e7f9eda00c2c6be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->