### PR TITLE
fix: perps not reconnecting on account switch

### DIFF
--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -260,8 +260,8 @@ class PerpsConnectionManagerClass {
             // Clean up preloaded subscriptions
             this.cleanupPreloadedSubscriptions();
 
-            // Clean up state monitoring when leaving Perps
-            this.cleanupStateMonitoring();
+            // Keep state monitoring active to detect account changes even when disconnected
+            // This ensures we can reconnect with the correct account context when user returns
 
             // Reset state before disconnecting to prevent race conditions
             this.isConnected = false;
@@ -286,10 +286,8 @@ class PerpsConnectionManagerClass {
         })();
 
         await this.disconnectPromise;
-      } else {
-        // Even if not connected, clean up monitoring when leaving Perps
-        this.cleanupStateMonitoring();
       }
+      // Note: We no longer clean up state monitoring here to ensure account changes are detected
     } else {
       DevLogger.log(
         `PerpsConnectionManager: Grace period expired but refCount is now ${this.connectionRefCount}, skipping disconnection`,
@@ -359,6 +357,7 @@ class PerpsConnectionManagerClass {
     }
 
     // Set up monitoring when first entering Perps (refCount 0 -> 1)
+    // Keep monitoring active throughout app lifecycle to detect account changes even when disconnected
     if (this.connectionRefCount === 0) {
       this.setupStateMonitoring();
     }
@@ -819,10 +818,8 @@ class PerpsConnectionManagerClass {
           'PerpsConnectionManager: Starting grace period before disconnection',
         );
         this.scheduleGracePeriodDisconnection();
-      } else {
-        // Even if not connected, clean up monitoring when leaving Perps
-        this.cleanupStateMonitoring();
       }
+      // Note: Keep state monitoring active even when not connected to detect account changes
     }
   }
 

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -260,9 +260,6 @@ class PerpsConnectionManagerClass {
             // Clean up preloaded subscriptions
             this.cleanupPreloadedSubscriptions();
 
-            // Keep state monitoring active to detect account changes even when disconnected
-            // This ensures we can reconnect with the correct account context when user returns
-
             // Reset state before disconnecting to prevent race conditions
             this.isConnected = false;
             this.isInitialized = false;
@@ -287,7 +284,6 @@ class PerpsConnectionManagerClass {
 
         await this.disconnectPromise;
       }
-      // Note: We no longer clean up state monitoring here to ensure account changes are detected
     } else {
       DevLogger.log(
         `PerpsConnectionManager: Grace period expired but refCount is now ${this.connectionRefCount}, skipping disconnection`,
@@ -357,7 +353,6 @@ class PerpsConnectionManagerClass {
     }
 
     // Set up monitoring when first entering Perps (refCount 0 -> 1)
-    // Keep monitoring active throughout app lifecycle to detect account changes even when disconnected
     if (this.connectionRefCount === 0) {
       this.setupStateMonitoring();
     }
@@ -819,7 +814,6 @@ class PerpsConnectionManagerClass {
         );
         this.scheduleGracePeriodDisconnection();
       }
-      // Note: Keep state monitoring active even when not connected to detect account changes
     }
   }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR introduces a change that keeps the Perps redux subscription active throughout the app lifecycle. This ensures that things like `reconnectWithNewContext()` gets triggered automatically when things like account switches get called. We were noticing that this reconnection was regressing on some [PerpsTab](https://github.com/MetaMask/metamask-mobile/pull/22044) refactoring for full page scroll, so this should help mitigate this type of regression.

I don't think this will introduce any major performance regression. The Redux subscription is pretty lightweight, and I think we can keep it alive throughout the app lifecycle. Worth reviewing with @abretonc7s here though.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Maintain Perps redux state monitoring throughout app lifecycle

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Keeps Perps Redux monitoring active by eliminating `cleanupStateMonitoring()` during disconnect/grace paths and only cleaning preloaded subscriptions.
> 
> - **PerpsConnectionManager (`app/components/UI/Perps/services/PerpsConnectionManager.ts`)**:
>   - **Disconnection flow**:
>     - Remove calls to `cleanupStateMonitoring()` during actual/grace-period disconnection.
>     - Keep Redux monitoring active even when disconnecting or not connected.
>     - Continue cleaning only preloaded subscriptions via `cleanupPreloadedSubscriptions()`.
>   - **Grace period handling**:
>     - Drop redundant else-branches that previously cleaned up monitoring when not connected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b9269993b410e40bc42e2ceffeb8b2a945f89ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->