### PR TITLE
test(ramp): add unified ff mock

### DIFF
--- a/e2e/api-mocking/helpers/remoteFeatureFlagsHelper.ts
+++ b/e2e/api-mocking/helpers/remoteFeatureFlagsHelper.ts
@@ -270,6 +270,12 @@ const DEFAULT_FEATURE_FLAGS_ARRAY: Record<string, unknown>[] = [
   {
     additionalNetworksBlacklist: [], // Empty by default, can be overridden in tests
   },
+  {
+    rampsUnifiedBuyV1: {
+      minimumVersion: '7.61.0',
+      active: false,
+    },
+  },
 ];
 
 /**


### PR DESCRIPTION

## **Description**

This pull request adds a new default feature flag configuration for `rampsUnifiedBuyV1` in the `remoteFeatureFlagsHelper.ts` file. This feature flag is set with a minimum version and is inactive by default, allowing tests to override or activate it as needed. No other changes are included.

- Added a default feature flag entry for `rampsUnifiedBuyV1` with `minimumVersion` set to `'7.61.0'` and `active` set to `false` in `DEFAULT_FEATURE_FLAGS_ARRAY` (`e2e/api-mocking/helpers/remoteFeatureFlagsHelper.ts`).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Adds Ramps Unified buy v1 feature flag mock to e2e tests

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-2805 

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds default `rampsUnifiedBuyV1` flag (minimumVersion `7.61.0`, `active: false`) to the e2e remote feature flags helper.
> 
> - **Testing helpers**:
>   - Add default `rampsUnifiedBuyV1` flag to `DEFAULT_FEATURE_FLAGS_ARRAY` in `e2e/api-mocking/helpers/remoteFeatureFlagsHelper.ts` with `minimumVersion: '7.61.0'` and `active: false`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6df1d22a20108ea11381f544dea7b853a004c36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->