### PR TITLE
fix: regeneration of metametrics id when it is an empty string cp-7.58.0

### DIFF
--- a/app/core/Analytics/MetaMetrics.test.ts
+++ b/app/core/Analytics/MetaMetrics.test.ts
@@ -745,7 +745,7 @@ describe('MetaMetrics', () => {
         const metricsId = await metaMetrics.getMetaMetricsId();
         expect(metricsId).not.toEqual('""');
         expect(metricsId).not.toEqual('');
-        expect(metricsId.length).toBeGreaterThan(10);
+        expect(metricsId?.length).toBeGreaterThan(10);
         expect(StorageWrapper.setItem).toHaveBeenCalledWith(
           METAMETRICS_ID,
           metricsId,
@@ -762,7 +762,7 @@ describe('MetaMetrics', () => {
 
         const metricsId = await metaMetrics.getMetaMetricsId();
         expect(metricsId).not.toEqual('abc');
-        expect(metricsId.length).toBeGreaterThan(10);
+        expect(metricsId?.length).toBeGreaterThan(10);
         expect(StorageWrapper.setItem).toHaveBeenCalledWith(
           METAMETRICS_ID,
           metricsId,

--- a/app/core/Analytics/MetaMetrics.ts
+++ b/app/core/Analytics/MetaMetrics.ts
@@ -41,6 +41,7 @@ import { isE2E } from '../../util/test/utils';
 import MetaMetricsPrivacySegmentPlugin from './MetaMetricsPrivacySegmentPlugin';
 import MetaMetricsTestUtils from './MetaMetricsTestUtils';
 import { segmentPersistor } from './SegmentPersistor';
+import { isHexAddress } from '@metamask/utils';
 
 /**
  * MetaMetrics using Segment as the analytics provider.
@@ -298,7 +299,7 @@ class MetaMetrics implements IMetaMetrics {
     // this same ID should be retrieved from preferences and reused.
     // look for a legacy ID from MixPanel integration and use it
     const legacyId = await StorageWrapper.getItem(MIXPANEL_METAMETRICS_ID);
-    if (legacyId) {
+    if (legacyId && isHexAddress(legacyId.toLowerCase())) {
       this.metametricsId = legacyId;
       await StorageWrapper.setItem(METAMETRICS_ID, legacyId);
       return legacyId;

--- a/app/core/Analytics/MetaMetrics.ts
+++ b/app/core/Analytics/MetaMetrics.ts
@@ -33,7 +33,7 @@ import {
   ISegmentClient,
   ITrackingEvent,
 } from './MetaMetrics.types';
-import { v4 as uuidv4 } from 'uuid';
+import { v4 as uuidv4, validate } from 'uuid';
 import { Config } from '@segment/analytics-react-native/lib/typescript/src/types';
 import generateDeviceAnalyticsMetaData from '../../util/metrics/DeviceAnalyticsMetaData/generateDeviceAnalyticsMetaData';
 import generateUserSettingsAnalyticsMetaData from '../../util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData';
@@ -298,7 +298,7 @@ class MetaMetrics implements IMetaMetrics {
     // this same ID should be retrieved from preferences and reused.
     // look for a legacy ID from MixPanel integration and use it
     const legacyId = await StorageWrapper.getItem(MIXPANEL_METAMETRICS_ID);
-    if (legacyId && legacyId.length >= 32) {
+    if (legacyId) {
       this.metametricsId = legacyId;
       await StorageWrapper.setItem(METAMETRICS_ID, legacyId);
       return legacyId;
@@ -308,10 +308,8 @@ class MetaMetrics implements IMetaMetrics {
     const metametricsId: string | undefined =
       await StorageWrapper.getItem(METAMETRICS_ID);
 
-    // Validate the stored ID - regenerate if corrupted or too short
-    // Valid IDs are at least 32 chars (UUIDv4=36, Hex=66)
     // This catches '""', 'null', 'undefined', and other corruptions
-    if (!metametricsId || metametricsId.length < 32) {
+    if (!metametricsId || !validate(metametricsId)) {
       if (metametricsId) {
         // Log corruption for monitoring
         Logger.log(


### PR DESCRIPTION
<!--

Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.

-->

## **Description**

**What is the reason for the change?**

Users with corrupted `metaMetricsId` values (such as `""`, `"null"`, or other invalid strings) were experiencing empty remote feature flags, preventing them from receiving A/B test variants, gradual rollouts, and platform-specific configurations.

**Root Cause:**
The `#getMetaMetricsId` method in `MetaMetrics.ts` only checked for falsy values (`!metametricsId`), which failed to catch corrupted strings like `""` (2-character string containing two double-quotes). This corrupted ID would then be passed to `RemoteFeatureFlagController`, where `generateDeterministicRandomNumber("")` would throw an error during user segmentation processing, preventing feature flags from being cached.

**What is the improvement/solution?**

Added a simple length validation check (`metametricsId.length < 32`) to detect and regenerate corrupted IDs. Valid IDs are at least 32 characters (UUIDv4 = 36 chars, Hex = 66 chars), so this single check catches all known corruptions:
- `""` (length 2)
- `"null"` (length 4)  
- `"undefined"` (length 9)
- Any other short corrupted strings

The fix applies the same validation to both legacy Mixpanel IDs and new MetaMetrics IDs, ensuring consistency and preventing crashes in `RemoteFeatureFlagController`.

## **Changelog**

CHANGELOG entry: Fixed a bug where corrupted analytics IDs prevented users from receiving remote feature flags

## **Related issues**

Fixes: #[ISSUE_NUMBER]

## **Manual testing steps**

```gherkin
Feature: MetaMetrics ID corruption recovery

  Scenario: user with corrupted metaMetricsId gets feature flags
    Given the user has a corrupted metaMetricsId stored (e.g., '""')
    When the app initializes MetaMetrics
    Then a new valid UUID is generated and stored
    And remote feature flags are successfully fetched and cached
    And the corruption is logged for monitoring

  Scenario: user with valid metaMetricsId continues normally
    Given the user has a valid metaMetricsId (length >= 32)
    When the app initializes MetaMetrics
    Then the existing ID is preserved
    And remote feature flags work correctly

  Scenario: legacy Mixpanel ID validation
    Given the user has a legacy Mixpanel ID
    When the ID length is >= 32
    Then the legacy ID is migrated to MetaMetrics storage
    When the ID length is < 32
    Then a new UUID is generated instead
```

### **Unit Test Coverage**

Run the following to verify all corrupted ID scenarios are handled:

```bash
yarn jest app/core/Analytics/MetaMetrics.test.ts -t "corrupted ID validation"
```

Tests cover:
- ✅ JSON-stringified empty string (`""`)
- ✅ Too short IDs (`"abc"`)
- ✅ String literals (`"null"`, `"undefined"`)
- ✅ Invalid UUID formats
- ✅ Valid UUID acceptance
- ✅ Valid hex format acceptance
- ✅ Corrupted legacy Mixpanel ID rejection

## **Screenshots/Recordings**
This record goest over a branch switch from main to this branch with the metametrics hardcoded to a string inside of a string
https://github.com/user-attachments/assets/9fc5bb8f-d61c-461d-8b6a-6315de36c6b8



### **Before**

User state with corrupted ID:
```json
{
  "metaMetricsId": "\"\"",
  "RemoteFeatureFlagController": {
    "remoteFeatureFlags": {},
    "cacheTimestamp": 0
  }
}
```

Console logs would show silent failures in feature flag processing, with users missing out on:
- A/B test variants
- Gradual feature rollouts
- Platform-specific configurations

### **After**

With the fix applied:
```
MetaMetrics: Corrupted metaMetricsId detected and regenerated. Invalid value: ""
```

User state after fix:
```json
{
  "metaMetricsId": "12345678-1234-4567-89ab-123456789012",
  "RemoteFeatureFlagController": {
    "remoteFeatureFlags": {
      "backendWebSocketConnection": { "value": true },
      "perpsPerpTradingGeoBlockedCountriesV2": { "blockedRegions": [...] }
    },
    "cacheTimestamp": 1699564800000
  }
}
```

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---

## **Additional Context**

### **Files Changed**
- `app/core/Analytics/MetaMetrics.ts`: Added length validation to `#getMetaMetricsId` method
- `app/core/Analytics/MetaMetrics.test.ts`: Added comprehensive test suite for corrupted ID scenarios

### **Performance Impact**
- Negligible: Single length check is O(1) operation
- No additional API calls or storage operations

### **Backward Compatibility**
- ✅ Fully backward compatible
- ✅ Automatically heals users with existing corrupted IDs
- ✅ No migration required
- ✅ No user action needed

### **Monitoring**
The fix includes logging when corrupted IDs are detected:
```typescript
Logger.log(
  `MetaMetrics: Corrupted metaMetricsId detected and regenerated. Invalid value: ${metametricsId}`,
);
```

This allows us to:
- Track how many users are affected
- Identify potential sources of corruption
- Monitor if the issue persists or is resolved

### **Security Considerations**
- No security implications
- Corrupted ID values are logged (for debugging), but they contain no PII
- New generated UUIDs follow existing security practices



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds strict ID validation (UUIDv4 or legacy hex) for MetaMetrics, regenerating corrupted IDs and migrating valid Mixpanel hex IDs.
> 
> - **Analytics (`app/core/Analytics/MetaMetrics.ts`)**:
>   - Validate stored `metaMetricsId` using `uuid.validate`; regenerate with `uuidv4()` and log when invalid or corrupted.
>   - Accept legacy Mixpanel ID only if it’s a valid hex address (`isHexAddress(legacyId.toLowerCase())`); migrate to `METAMETRICS_ID`.
>   - Import `validate` (uuid) and `isHexAddress` for the above checks.
> - **Tests (`app/core/Analytics/MetaMetrics.test.ts`)**:
>   - Add cases covering valid hex Mixpanel IDs (including uppercase), rejection of non-hex Mixpanel IDs, and multiple corruption scenarios (`""`, short strings, `"null"`, `"undefined"`, invalid UUID), plus acceptance of valid UUIDv4.
>   - Use `uuid.validate` and `isHexAddress` assertions; update expectations for storage interactions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bddd52f20633e6cca3ffcea76552e190c21bed3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->