### PR TITLE
chore: update tutorial to redirect to the home markets list on last page

### DIFF
--- a/app/components/UI/Perps/components/PerpsTutorialCarousel/PerpsTutorialCarousel.test.tsx
+++ b/app/components/UI/Perps/components/PerpsTutorialCarousel/PerpsTutorialCarousel.test.tsx
@@ -1,11 +1,5 @@
 import React from 'react';
-import {
-  render,
-  screen,
-  fireEvent,
-  act,
-  waitFor,
-} from '@testing-library/react-native';
+import { render, screen, fireEvent, act } from '@testing-library/react-native';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Routes from '../../../../../constants/navigation/Routes';
@@ -228,7 +222,7 @@ describe('PerpsTutorialCarousel', () => {
   });
 
   describe('Navigation', () => {
-    it('should navigate to deposit screen when on last screen and pressing continue', async () => {
+    it('should navigate to perps home when on last screen and pressing continue', async () => {
       render(<PerpsTutorialCarousel />);
 
       // Navigate through all screens by pressing Continue 5 times (6 screens total)
@@ -239,25 +233,26 @@ describe('PerpsTutorialCarousel', () => {
         screen.getByText(strings('perps.tutorial.ready_to_trade.title')),
       ).toBeOnTheScreen();
 
-      // Button should say "Add funds" on last screen
-      expect(
-        screen.getByText(strings('perps.tutorial.add_funds')),
-      ).toBeOnTheScreen();
+      // Button should say "Got it" on last screen
+      const continueButton = screen.getByTestId(
+        'perps-tutorial-continue-button',
+      );
+      expect(continueButton).toBeOnTheScreen();
 
-      // Press the "Add funds" button
+      // Press the "Got it" button
       await act(async () => {
-        fireEvent.press(screen.getByText(strings('perps.tutorial.add_funds')));
+        fireEvent.press(continueButton);
       });
 
-      // Should mark tutorial as completed and navigate to add funds screen
+      // Should mark tutorial as completed and navigate to perps home screen
       expect(mockMarkTutorialCompleted).toHaveBeenCalled();
-      expect(mockNavigation.navigate).toHaveBeenCalledWith(
+      expect(mockNavigationServiceMethods.navigate).toHaveBeenCalledWith(
         Routes.PERPS.ROOT,
-        expect.objectContaining({
-          screen: Routes.FULL_SCREEN_CONFIRMATIONS.REDESIGNED_CONFIRMATIONS,
-        }),
+        {
+          screen: Routes.PERPS.PERPS_HOME,
+        },
       );
-      expect(mockDepositWithConfirmation).toHaveBeenCalled();
+      expect(mockDepositWithConfirmation).not.toHaveBeenCalled();
     });
 
     it('should navigate to markets list when pressing Skip on first screen', () => {
@@ -277,7 +272,7 @@ describe('PerpsTutorialCarousel', () => {
       expect(mockDepositWithConfirmation).not.toHaveBeenCalled();
     });
 
-    it('should mark tutorial as completed and navigate to markets list when pressing Skip on last screen', async () => {
+    it('hides skip button on last screen', async () => {
       render(<PerpsTutorialCarousel />);
 
       // Navigate to the last screen
@@ -288,25 +283,15 @@ describe('PerpsTutorialCarousel', () => {
         screen.getByText(strings('perps.tutorial.ready_to_trade.title')),
       ).toBeOnTheScreen();
 
-      // Skip button should say "Got it" on last screen
-      expect(
-        screen.getByText(strings('perps.tutorial.got_it')),
-      ).toBeOnTheScreen();
+      // Skip button should be disabled on last screen
+      const skipButton = screen.getByTestId('perps-tutorial-skip-button');
+      expect(skipButton.props.disabled).toBe(true);
 
-      // Press the "Got it" button
-      act(() => {
-        fireEvent.press(screen.getByText(strings('perps.tutorial.got_it')));
-      });
-
-      // Should mark tutorial as completed and navigate to markets list, but NOT initialize deposit
-      expect(mockMarkTutorialCompleted).toHaveBeenCalled();
-      expect(mockNavigationServiceMethods.navigate).toHaveBeenCalledWith(
-        Routes.PERPS.ROOT,
-        {
-          screen: Routes.PERPS.PERPS_HOME,
-        },
+      // Main "Let's go" button should be visible
+      const continueButton = screen.getByTestId(
+        'perps-tutorial-continue-button',
       );
-      expect(mockDepositWithConfirmation).not.toHaveBeenCalled();
+      expect(continueButton).toBeOnTheScreen();
     });
 
     it('should mark tutorial as completed when finishing tutorial', async () => {
@@ -315,65 +300,35 @@ describe('PerpsTutorialCarousel', () => {
       // Navigate through all screens by pressing Continue 5 times to get to last screen
       await navigateToScreen(5);
 
-      // Press Add funds button on last screen
+      // Press Got it button on last screen
       await act(async () => {
-        fireEvent.press(screen.getByText(strings('perps.tutorial.add_funds')));
+        fireEvent.press(screen.getByTestId('perps-tutorial-continue-button'));
       });
 
-      // Should mark tutorial as completed and initialize deposit
+      // Should mark tutorial as completed and navigate to perps home
       expect(mockMarkTutorialCompleted).toHaveBeenCalled();
-      expect(mockDepositWithConfirmation).toHaveBeenCalled();
+      expect(mockDepositWithConfirmation).not.toHaveBeenCalled();
     });
 
-    it('should navigate to add funds screen when on last screen', async () => {
+    it('should navigate to perps home screen when on last screen', async () => {
       render(<PerpsTutorialCarousel />);
 
       // Navigate through all screens by pressing Continue 5 times
       await navigateToScreen(5);
 
-      // Press Add funds button on last screen
+      // Press Got it button on last screen
       await act(async () => {
-        fireEvent.press(screen.getByText(strings('perps.tutorial.add_funds')));
+        fireEvent.press(screen.getByTestId('perps-tutorial-continue-button'));
       });
 
-      // Should navigate to add funds screen and initialize deposit
-      expect(mockNavigation.navigate).toHaveBeenCalledWith(
+      // Should navigate to perps home screen
+      expect(mockNavigationServiceMethods.navigate).toHaveBeenCalledWith(
         Routes.PERPS.ROOT,
-        expect.objectContaining({
-          screen: Routes.FULL_SCREEN_CONFIRMATIONS.REDESIGNED_CONFIRMATIONS,
-        }),
+        {
+          screen: Routes.PERPS.PERPS_HOME,
+        },
       );
-      expect(mockDepositWithConfirmation).toHaveBeenCalled();
-    });
-  });
-
-  describe('Error Handling', () => {
-    it('should handle deposit confirmation error gracefully', async () => {
-      // Mock deposit failure
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
-      mockDepositWithConfirmation.mockRejectedValue(
-        new Error('Deposit failed'),
-      );
-
-      render(<PerpsTutorialCarousel />);
-
-      // Navigate to last screen and press Add funds
-      await navigateToScreen(5);
-
-      // Press Add funds button
-      await act(async () => {
-        fireEvent.press(screen.getByText(strings('perps.tutorial.add_funds')));
-      });
-
-      // Wait for the async operation to complete and error to be logged
-      await waitFor(() => {
-        expect(consoleErrorSpy).toHaveBeenCalledWith(
-          'Failed to initialize deposit:',
-          expect.any(Error),
-        );
-      });
-
-      consoleErrorSpy.mockRestore();
+      expect(mockDepositWithConfirmation).not.toHaveBeenCalled();
     });
   });
 
@@ -432,7 +387,7 @@ describe('PerpsTutorialCarousel', () => {
         }
       });
 
-      it('shows "Add funds" button on last screen for eligible users', async () => {
+      it('shows "Got it" button on last screen for eligible users', async () => {
         render(<PerpsTutorialCarousel />);
 
         // Navigate through all screens to get to last screen
@@ -443,42 +398,45 @@ describe('PerpsTutorialCarousel', () => {
           screen.getByText(strings('perps.tutorial.ready_to_trade.title')),
         ).toBeOnTheScreen();
 
-        // Button should say "Add funds" on last screen for eligible users
-        expect(
-          screen.getByText(strings('perps.tutorial.add_funds')),
-        ).toBeOnTheScreen();
+        // Button should say "Let's go" on last screen for eligible users
+        const continueButton = screen.getByTestId(
+          'perps-tutorial-continue-button',
+        );
+        expect(continueButton).toBeOnTheScreen();
+
+        // Skip button should be disabled on last screen
+        const skipButton = screen.getByTestId('perps-tutorial-skip-button');
+        expect(skipButton.props.disabled).toBe(true);
       });
 
-      it('navigates to deposit screen when eligible user completes tutorial', async () => {
+      it('navigates to perps home when eligible user completes tutorial', async () => {
         render(<PerpsTutorialCarousel />);
 
         // Navigate through all screens by pressing Continue 5 times
         await navigateToScreen(5);
 
-        // Press the "Add funds" button
+        // Press the "Got it" button
         await act(async () => {
-          fireEvent.press(
-            screen.getByText(strings('perps.tutorial.add_funds')),
-          );
+          fireEvent.press(screen.getByTestId('perps-tutorial-continue-button'));
         });
 
-        // Should mark tutorial as completed and navigate to add funds screen
+        // Should mark tutorial as completed and navigate to perps home
         expect(mockMarkTutorialCompleted).toHaveBeenCalled();
-        expect(mockNavigation.navigate).toHaveBeenCalledWith(
+        expect(mockNavigationServiceMethods.navigate).toHaveBeenCalledWith(
           Routes.PERPS.ROOT,
-          expect.objectContaining({
-            screen: Routes.FULL_SCREEN_CONFIRMATIONS.REDESIGNED_CONFIRMATIONS,
-          }),
+          {
+            screen: Routes.PERPS.PERPS_HOME,
+          },
         );
-        expect(mockDepositWithConfirmation).toHaveBeenCalled();
+        expect(mockDepositWithConfirmation).not.toHaveBeenCalled();
       });
 
-      it('enables skip button for eligible users', () => {
+      it('shows skip button for eligible users on non-last screens', () => {
         render(<PerpsTutorialCarousel />);
 
-        // Skip button should be enabled for eligible users
+        // Skip button should be visible and enabled for eligible users on first screen
         const skipButton = screen.getByTestId('perps-tutorial-skip-button');
-        expect(skipButton.props.disabled).toBe(false);
+        expect(skipButton).toBeOnTheScreen();
       });
 
       it('allows eligible users to skip tutorial', () => {
@@ -565,7 +523,7 @@ describe('PerpsTutorialCarousel', () => {
         ).not.toBeOnTheScreen();
       });
 
-      it('shows "Got it" button on last screen for non-eligible users', async () => {
+      it('shows "Let\'s go" button and disables skip button on last screen for non-eligible users', async () => {
         render(<PerpsTutorialCarousel />);
 
         // Navigate through all screens to get to last screen (4 clicks for 5 screens)
@@ -576,44 +534,23 @@ describe('PerpsTutorialCarousel', () => {
           screen.getByText(strings('perps.tutorial.close_anytime.title')),
         ).toBeOnTheScreen();
 
-        // Should show "Got it" buttons (both main button and skip button show this text)
-        const gotItButtons = screen.getAllByText(
-          strings('perps.tutorial.got_it'),
+        // Should show "Let's go" button
+        const continueButton = screen.getByTestId(
+          'perps-tutorial-continue-button',
         );
-        expect(gotItButtons).toHaveLength(2); // Main button and skip button
+        expect(continueButton).toBeOnTheScreen();
 
-        // Should NOT show "Add funds" button
-        expect(
-          screen.queryByText(strings('perps.tutorial.add_funds')),
-        ).not.toBeOnTheScreen();
+        // Skip button should be disabled on last screen
+        const skipButton = screen.getByTestId('perps-tutorial-skip-button');
+        expect(skipButton.props.disabled).toBe(true);
       });
 
       it('shows skip button for non-eligible users on non-last screens', () => {
         render(<PerpsTutorialCarousel />);
 
-        // Skip button should be visible and enabled for non-eligible users on first screen
+        // Skip button should be visible for non-eligible users on first screen
         const skipButton = screen.getByTestId('perps-tutorial-skip-button');
         expect(skipButton).toBeOnTheScreen();
-        expect(skipButton.props.disabled).toBe(false);
-      });
-
-      it('disables skip button for non-eligible users on last screen', async () => {
-        render(<PerpsTutorialCarousel />);
-
-        // Navigate through all screens to get to last screen (4 clicks for 5 screens)
-        await navigateToScreen(4);
-
-        // Verify we're on the last screen (close_anytime screen for non-eligible users)
-        expect(
-          screen.getByText(strings('perps.tutorial.close_anytime.title')),
-        ).toBeOnTheScreen();
-
-        // Skip button should be present but disabled for non-eligible users on last screen
-        const skipButton = screen.getByTestId('perps-tutorial-skip-button');
-        expect(skipButton).toBeOnTheScreen();
-
-        // The button should be disabled for non-eligible users on last screen
-        expect(skipButton.props.disabled).toBe(true);
       });
 
       it('navigates to markets list when non-eligible user completes tutorial', async () => {

--- a/app/components/UI/Perps/components/PerpsTutorialCarousel/PerpsTutorialCarousel.test.tsx
+++ b/app/components/UI/Perps/components/PerpsTutorialCarousel/PerpsTutorialCarousel.test.tsx
@@ -81,7 +81,6 @@ jest.mock('../../../../../core/NavigationService', () => ({
 // Mock hooks
 const mockMarkTutorialCompleted = jest.fn();
 const mockTrack = jest.fn();
-const mockDepositWithConfirmation = jest.fn().mockResolvedValue(undefined);
 
 // Mock the selector module first
 jest.mock('../../selectors/perpsController', () => ({
@@ -97,12 +96,6 @@ jest.mock('react-redux', () => ({
 jest.mock('../../hooks', () => ({
   usePerpsFirstTimeUser: () => ({
     markTutorialCompleted: mockMarkTutorialCompleted,
-  }),
-  usePerpsTrading: () => ({
-    depositWithConfirmation: mockDepositWithConfirmation,
-  }),
-  usePerpsNetworkManagement: () => ({
-    ensureArbitrumNetworkExists: jest.fn().mockResolvedValue(undefined),
   }),
 }));
 
@@ -179,7 +172,6 @@ describe('PerpsTutorialCarousel', () => {
     jest.useFakeTimers();
     mockMarkTutorialCompleted.mockClear();
     mockTrack.mockClear();
-    mockDepositWithConfirmation.mockClear();
     mockNavigationServiceMethods.navigate.mockClear();
     mockNavigationServiceMethods.setParams.mockClear();
     (useNavigation as jest.Mock).mockReturnValue(mockNavigation);
@@ -252,7 +244,6 @@ describe('PerpsTutorialCarousel', () => {
           screen: Routes.PERPS.PERPS_HOME,
         },
       );
-      expect(mockDepositWithConfirmation).not.toHaveBeenCalled();
     });
 
     it('should navigate to markets list when pressing Skip on first screen', () => {
@@ -269,10 +260,9 @@ describe('PerpsTutorialCarousel', () => {
         },
       );
       expect(mockMarkTutorialCompleted).toHaveBeenCalled();
-      expect(mockDepositWithConfirmation).not.toHaveBeenCalled();
     });
 
-    it('hides skip button on last screen', async () => {
+    it('enables skip button on last screen for eligible users', async () => {
       render(<PerpsTutorialCarousel />);
 
       // Navigate to the last screen
@@ -283,9 +273,9 @@ describe('PerpsTutorialCarousel', () => {
         screen.getByText(strings('perps.tutorial.ready_to_trade.title')),
       ).toBeOnTheScreen();
 
-      // Skip button should be disabled on last screen
+      // Skip button should be enabled on last screen for eligible users
       const skipButton = screen.getByTestId('perps-tutorial-skip-button');
-      expect(skipButton.props.disabled).toBe(true);
+      expect(skipButton.props.disabled).toBe(false);
 
       // Main "Let's go" button should be visible
       const continueButton = screen.getByTestId(
@@ -307,7 +297,6 @@ describe('PerpsTutorialCarousel', () => {
 
       // Should mark tutorial as completed and navigate to perps home
       expect(mockMarkTutorialCompleted).toHaveBeenCalled();
-      expect(mockDepositWithConfirmation).not.toHaveBeenCalled();
     });
 
     it('should navigate to perps home screen when on last screen', async () => {
@@ -328,7 +317,6 @@ describe('PerpsTutorialCarousel', () => {
           screen: Routes.PERPS.PERPS_HOME,
         },
       );
-      expect(mockDepositWithConfirmation).not.toHaveBeenCalled();
     });
   });
 
@@ -404,9 +392,9 @@ describe('PerpsTutorialCarousel', () => {
         );
         expect(continueButton).toBeOnTheScreen();
 
-        // Skip button should be disabled on last screen
+        // Skip button should be enabled for eligible users on last screen
         const skipButton = screen.getByTestId('perps-tutorial-skip-button');
-        expect(skipButton.props.disabled).toBe(true);
+        expect(skipButton.props.disabled).toBe(false);
       });
 
       it('navigates to perps home when eligible user completes tutorial', async () => {
@@ -428,7 +416,6 @@ describe('PerpsTutorialCarousel', () => {
             screen: Routes.PERPS.PERPS_HOME,
           },
         );
-        expect(mockDepositWithConfirmation).not.toHaveBeenCalled();
       });
 
       it('shows skip button for eligible users on non-last screens', () => {
@@ -455,7 +442,6 @@ describe('PerpsTutorialCarousel', () => {
             screen: Routes.PERPS.PERPS_HOME,
           },
         );
-        expect(mockDepositWithConfirmation).not.toHaveBeenCalled();
       });
     });
 
@@ -572,9 +558,8 @@ describe('PerpsTutorialCarousel', () => {
             screen: Routes.PERPS.PERPS_HOME,
           },
         );
-        // Should NOT navigate to deposit screen or call deposit
+        // Should NOT navigate using the mocked navigation (uses NavigationService instead)
         expect(mockNavigation.navigate).not.toHaveBeenCalled();
-        expect(mockDepositWithConfirmation).not.toHaveBeenCalled();
       });
     });
   });

--- a/app/components/UI/Perps/components/PerpsTutorialCarousel/PerpsTutorialCarousel.tsx
+++ b/app/components/UI/Perps/components/PerpsTutorialCarousel/PerpsTutorialCarousel.tsx
@@ -32,11 +32,7 @@ import {
   PerpsEventValues,
 } from '../../constants/eventNames';
 
-import {
-  usePerpsFirstTimeUser,
-  usePerpsTrading,
-  usePerpsNetworkManagement,
-} from '../../hooks';
+import { usePerpsFirstTimeUser, usePerpsNetworkManagement } from '../../hooks';
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
 import { PerpsConnectionManager } from '../../services/PerpsConnectionManager';
 import createStyles from './PerpsTutorialCarousel.styles';
@@ -48,7 +44,6 @@ const PerpsOnboardingAnimationDark = require('../../animations/perps-onboarding-
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, import/no-commonjs
 import Character from '../../../../../images/character_3x.png';
 import { PerpsTutorialSelectorsIDs } from '../../../../../../e2e/selectors/Perps/Perps.selectors';
-import { useConfirmNavigation } from '../../../../Views/confirmations/hooks/useConfirmNavigation';
 import { selectPerpsEligibility } from '../../selectors/perpsController';
 import { useSelector } from 'react-redux';
 import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
@@ -137,7 +132,6 @@ const getTutorialScreens = (isEligible: boolean): TutorialScreen[] => {
 const PerpsTutorialCarousel: React.FC = () => {
   const { markTutorialCompleted } = usePerpsFirstTimeUser();
   const { track } = usePerpsEventTracking();
-  const { depositWithConfirmation } = usePerpsTrading();
   const { ensureArbitrumNetworkExists } = usePerpsNetworkManagement();
   const [currentTab, setCurrentTab] = useState(0);
   const safeAreaInsets = useSafeAreaInsets();
@@ -151,7 +145,6 @@ const PerpsTutorialCarousel: React.FC = () => {
   const continueDebounceRef = useRef<NodeJS.Timeout | null>(null);
   const previousTabRef = useRef(0);
   const isProgrammaticNavigationRef = useRef(false);
-  const { navigateToConfirmation } = useConfirmNavigation();
 
   const isEligible = useSelector(selectPerpsEligibility);
 
@@ -167,10 +160,7 @@ const PerpsTutorialCarousel: React.FC = () => {
     [currentTab, tutorialScreens.length],
   );
 
-  const shouldShowSkipButton = useMemo(
-    () => !isLastScreen || isEligible,
-    [isLastScreen, isEligible],
-  );
+  const shouldShowSkipButton = useMemo(() => !isLastScreen, [isLastScreen]);
 
   const { styles } = useStyles(createStyles, {
     shouldShowSkipButton,
@@ -302,20 +292,7 @@ const PerpsTutorialCarousel: React.FC = () => {
       // For devs on testnet, Arbitrum Sepolia will be added/enabled
       await ensureArbitrumNetworkExists();
 
-      if (isEligible) {
-        // Navigate immediately to confirmations screen for instant UI response
-        // Note: When from deeplink, user will go through deposit flow
-        // and should return to markets after completion
-        navigateToConfirmation({ stack: Routes.PERPS.ROOT });
-
-        // Initialize deposit in the background without blocking
-        depositWithConfirmation().catch((error) => {
-          console.error('Failed to initialize deposit:', error);
-        });
-
-        return;
-      }
-
+      // Navigate all users to perps home screen for a more natural experience
       navigateToMarketsList();
     } else {
       // Go to next screen using the ref
@@ -358,9 +335,6 @@ const PerpsTutorialCarousel: React.FC = () => {
     currentTab,
     tutorialScreens,
     markTutorialCompleted,
-    isEligible,
-    navigateToConfirmation,
-    depositWithConfirmation,
     ensureArbitrumNetworkExists,
     navigateToMarketsList,
   ]);
@@ -394,20 +368,12 @@ const PerpsTutorialCarousel: React.FC = () => {
   const renderTabBar = () => <View />;
 
   const buttonLabel = useMemo(() => {
-    if (!isEligible && isLastScreen) {
-      return strings('perps.tutorial.got_it');
-    }
-
     if (isLastScreen) {
-      return strings('perps.tutorial.add_funds');
+      return strings('perps.tutorial.lets_go');
     }
 
     return strings('perps.tutorial.continue');
-  }, [isEligible, isLastScreen]);
-
-  const skipLabel = isLastScreen
-    ? strings('perps.tutorial.got_it')
-    : strings('perps.tutorial.skip');
+  }, [isLastScreen]);
 
   return (
     <View style={[styles.container, { paddingTop: safeAreaInsets.top }]}>
@@ -524,7 +490,7 @@ const PerpsTutorialCarousel: React.FC = () => {
                 variant={TextVariant.BodyMDMedium}
                 color={TextColor.Alternative}
               >
-                {skipLabel}
+                {strings('perps.tutorial.skip')}
               </Text>
             </TouchableOpacity>
           </View>

--- a/app/components/UI/Perps/components/PerpsTutorialCarousel/PerpsTutorialCarousel.tsx
+++ b/app/components/UI/Perps/components/PerpsTutorialCarousel/PerpsTutorialCarousel.tsx
@@ -32,7 +32,7 @@ import {
   PerpsEventValues,
 } from '../../constants/eventNames';
 
-import { usePerpsFirstTimeUser, usePerpsNetworkManagement } from '../../hooks';
+import { usePerpsFirstTimeUser } from '../../hooks';
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
 import { PerpsConnectionManager } from '../../services/PerpsConnectionManager';
 import createStyles from './PerpsTutorialCarousel.styles';
@@ -132,7 +132,6 @@ const getTutorialScreens = (isEligible: boolean): TutorialScreen[] => {
 const PerpsTutorialCarousel: React.FC = () => {
   const { markTutorialCompleted } = usePerpsFirstTimeUser();
   const { track } = usePerpsEventTracking();
-  const { ensureArbitrumNetworkExists } = usePerpsNetworkManagement();
   const [currentTab, setCurrentTab] = useState(0);
   const safeAreaInsets = useSafeAreaInsets();
 
@@ -286,12 +285,6 @@ const PerpsTutorialCarousel: React.FC = () => {
 
       // Mark tutorial as completed
       markTutorialCompleted();
-
-      // We need to enable Arbitrum for deposits to work
-      // Arbitrum One is already added for all users as a default network
-      // For devs on testnet, Arbitrum Sepolia will be added/enabled
-      await ensureArbitrumNetworkExists();
-
       // Navigate all users to perps home screen for a more natural experience
       navigateToMarketsList();
     } else {
@@ -335,7 +328,6 @@ const PerpsTutorialCarousel: React.FC = () => {
     currentTab,
     tutorialScreens,
     markTutorialCompleted,
-    ensureArbitrumNetworkExists,
     navigateToMarketsList,
   ]);
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1713,6 +1713,7 @@
         "footer_text": "MetaMask will swap your funds to USDC on Arbitrum, and deposit them onto HyperCore for no added fee."
       },
       "got_it": "Got it",
+      "lets_go": "Let's go",
       "card": {
         "title": "Learn the basics of perps"
       }

--- a/wdio/screen-objects/PerpsTutorialScreen.js
+++ b/wdio/screen-objects/PerpsTutorialScreen.js
@@ -9,7 +9,7 @@ class PerpsTutorialScreen {
 
   }
 
-  get addFundsButton() {
+  get continueButton() {
     return AppwrightSelectors.getElementByID(this._device, 'perps-tutorial-continue-button');
   }
 
@@ -21,20 +21,26 @@ class PerpsTutorialScreen {
     return AppwrightSelectors.getElementByCatchAll(this._device, 'What are perps?');
   }
 
-  get continueButton() {
-    return AppwrightSelectors.getElementByID(this._device, 'perps-tutorial-continue-button');
+  // Legacy alias for backward compatibility
+  get addFundsButton() {
+    return this.continueButton;
   }
 
   get skipButtonTutorial() {
-    return AppwrightSelectors.getElementByID(this._device, 'perps-tutorial-skip-button');
+    return this.skipButton;
   }
 
+  async tapContinue() {
+    await AppwrightGestures.tap(this.continueButton); // Use static tap method with retry logic
+  }
+
+  // Legacy alias for backward compatibility
   async tapAddFunds() {
-    await AppwrightGestures.tap(this.addFundsButton); // Use static tap method with retry logic
+    await this.tapContinue();
   }
 
   async tapSkip() {
-    await AppwrightGestures.tap(this.skipButtonTutorial); // Use static tap method with retry logic
+    await AppwrightGestures.tap(this.skipButton); // Use static tap method with retry logic
   }
 
   async expectFirstScreenVisible() {
@@ -43,7 +49,7 @@ class PerpsTutorialScreen {
   }
 
   async flowTapContinueTutorial(times = 1) {
-    const btn = await this.addFundsButton;
+    const btn = await this.continueButton;
     for (let i = 0; i < times; i++) {
       await AppwrightGestures.tap(btn); // Use static tap method with retry logic
     }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Updated PerpsTutorialCarousel.test.tsx to align with latest component changes where all users (eligible and non-eligible) are redirected to the Perps home screen after completing or skipping the tutorial. Removed deprecated depositWithConfirmation functionality and updated skip button behavior assertions to match the current implementation.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Update Tutorial Perps Intro to redirect to the markets home screen view

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1845
 
## **Manual testing steps**

```gherkin
Scenario: Eligible user completes tutorial and navigates to perps home
  Given I am an eligible user viewing the tutorial
  When I navigate through all 6 tutorial screens
  And I press the "Let's go" button on the final screen
  Then the tutorial should be marked as completed
  And I should be redirected to the Perps home screen

Scenario: Non-eligible user completes tutorial and navigates to perps home
  Given I am a non-eligible user viewing the tutorial
  When I navigate through all 5 tutorial screens
  And I press the "Let's go" button on the final screen
  Then the tutorial should be marked as completed
  And I should be redirected to the Perps home screen

Scenario: Eligible user skips tutorial from last screen
  Given I am an eligible user on the last tutorial screen
  When I view the ready_to_trade screen
  Then the skip button should be enabled
  And I can press skip to navigate to Perps home screen

Scenario: Non-eligible user cannot skip from last screen
  Given I am a non-eligible user on the last tutorial screen
  When I view the close_anytime screen
  Then the skip button should be disabled
  And I must use the "Let's go" button to proceed
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/19943a7a-8b73-4377-be68-d03accde2b16

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Perps tutorial now completes by navigating to Perps home for all users, removes deposit initiation, updates last-screen button to “Let’s go,” adjusts skip behavior, and refreshes tests/e2e selectors and i18n.
> 
> - **Perps Tutorial UX**
>   - Completion now navigates to `Routes.PERPS.ROOT` → `Routes.PERPS.PERPS_HOME` for all users; deposit flow removed.
>   - Replaces last-screen primary label with `strings('perps.tutorial.lets_go')` and always shows Skip (disabled on last screen for non‑eligible users).
>   - Removes `usePerpsTrading`/`depositWithConfirmation`, `usePerpsNetworkManagement`, and confirmation navigation logic.
> - **Tracking/Logic**
>   - Keeps metrics events; simplifies `shouldShowSkipButton`; refactors continue/skip handlers accordingly.
> - **Tests** (`PerpsTutorialCarousel.test.tsx`)
>   - Updates expectations for navigation, button labels, skip enablement, and removes deposit-related assertions and error case.
> - **E2E** (`wdio/screen-objects/PerpsTutorialScreen.js`)
>   - Introduces `continueButton` and `tapContinue`; keeps legacy `addFundsButton`/`tapAddFunds` as aliases.
> - **i18n** (`locales/languages/en.json`)
>   - Adds `perps.tutorial.lets_go` string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8bd52bd7a889a08950bfb5b4471e7b9aad6f246. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->