### PR TITLE
fix: Update Hip3 risk disclaimer

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
@@ -1422,8 +1422,8 @@ describe('PerpsMarketDetailsView', () => {
         },
       );
 
-      // Find and press the Trading View link
-      const tradingViewLink = getByText('Trading View.');
+      // Find and press the TradingView link
+      const tradingViewLink = getByText('TradingView.');
       fireEvent.press(tradingViewLink);
 
       // Verify Linking.openURL was called with correct URL
@@ -1452,8 +1452,8 @@ describe('PerpsMarketDetailsView', () => {
         },
       );
 
-      // Find and press the Trading View link
-      const tradingViewLink = getByText('Trading View.');
+      // Find and press the TradingView link
+      const tradingViewLink = getByText('TradingView.');
       fireEvent.press(tradingViewLink);
 
       // Wait for the error to be logged

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -566,6 +566,14 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
     return status.isOpen ? 'market_hours' : 'after_hours_trading';
   })();
 
+  // Determine risk disclaimer source and HIP type based on market
+  const riskDisclaimerParams = useMemo(() => {
+    const isHip3 = !!market?.marketSource;
+    return {
+      source: isHip3 ? market.marketSource : 'Hyperliquid',
+    };
+  }, [market?.marketSource]);
+
   // Determine if any action buttons will be visible
   const hasLongShortButtons = useMemo(
     () => !isLoadingPosition && !hasZeroBalance,
@@ -713,13 +721,13 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
               variant={TextVariant.BodyXS}
               color={TextColor.Alternative}
             >
-              {strings('perps.risk_disclaimer')}{' '}
+              {strings('perps.risk_disclaimer', riskDisclaimerParams)}{' '}
               <Text
                 variant={TextVariant.BodyXS}
                 color={TextColor.Alternative}
                 onPress={handleTradingViewPress}
               >
-                Trading View.
+                TradingView.
               </Text>
             </Text>
           </View>

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1680,7 +1680,7 @@
         "history_will_appear": "Your trading history will appear here"
       }
     },
-    "risk_disclaimer": "Perpetual contracts are very risky, and you could suddenly and without notice lose your entire investment. You trade entirely at your own risk. Market data provided by Hyperliquid. Price chart powered by",
+    "risk_disclaimer": "Perpetual contracts are very risky, and you could suddenly and without notice lose your entire investment. You trade entirely at your own risk. Powered by {{source}}. Price chart powered by",
     "tutorial": {
       "continue": "Continue",
       "skip": "Skip",


### PR DESCRIPTION
## **Description**

Updates Hip3 risk disclaimer.

## **Changelog**

CHANGELOG entry: Updates Hip3 risk disclaimer.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes the perps risk disclaimer source dynamic (based on market), updates copy to "TradingView.", and adjusts i18n and tests accordingly.
> 
> - **Perps UI (`PerpsMarketDetailsView.tsx`)**:
>   - Add `riskDisclaimerParams` (from `market.marketSource` fallback to `"Hyperliquid"`) and pass to `strings('perps.risk_disclaimer', ...)`.
>   - Update link label text to `TradingView.`
> - **i18n (`locales/languages/en.json`)**:
>   - Change `perps.risk_disclaimer` to use `Powered by {{source}}. Price chart powered by`.
> - **Tests (`PerpsMarketDetailsView.test.tsx`)**:
>   - Expect `TradingView.` label and keep URL `https://www.tradingview.com/` in link-open assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dae3aa880b6e852e781d53400d672139cf2aecb3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->