### PR TITLE
chore: Improved error catching block to know when feature flag update fails cp-7.58.0

### DIFF
--- a/app/core/Engine/controllers/remote-feature-flag-controller-init.test.ts
+++ b/app/core/Engine/controllers/remote-feature-flag-controller-init.test.ts
@@ -9,6 +9,11 @@ import { getRemoteFeatureFlagControllerMessenger } from '../messengers/remote-fe
 import { ExtendedMessenger } from '../../ExtendedMessenger';
 import { buildControllerInitRequestMock } from '../utils/test-utils';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
+import Logger from '../../../util/Logger';
+
+jest.mock('../../../util/Logger', () => ({
+  log: jest.fn(),
+}));
 
 jest.mock('@metamask/remote-feature-flag-controller', () => ({
   ...jest.requireActual('@metamask/remote-feature-flag-controller'),
@@ -99,5 +104,36 @@ describe('remoteFeatureFlagControllerInit', () => {
     expect(
       controllerMock.mock.results[0].value.updateRemoteFeatureFlags,
     ).not.toHaveBeenCalled();
+  });
+
+  it('logs success message when feature flags update successfully', async () => {
+    const initRequestMock = getInitRequestMock();
+
+    remoteFeatureFlagControllerInit(initRequestMock);
+
+    await new Promise(process.nextTick);
+
+    expect(Logger.log).toHaveBeenCalledWith('Feature flags updated');
+  });
+
+  it('logs error message when feature flags update fails', async () => {
+    const initRequestMock = getInitRequestMock();
+    const mockError = new Error('Network error');
+    const controllerMock = jest.mocked(RemoteFeatureFlagController);
+    controllerMock.mockImplementationOnce(
+      () =>
+        ({
+          updateRemoteFeatureFlags: jest.fn().mockRejectedValue(mockError),
+        }) as unknown as RemoteFeatureFlagController,
+    );
+
+    remoteFeatureFlagControllerInit(initRequestMock);
+
+    await new Promise(process.nextTick);
+
+    expect(Logger.log).toHaveBeenCalledWith(
+      'Feature flags update failed: ',
+      mockError,
+    );
   });
 });

--- a/app/core/Engine/controllers/remote-feature-flag-controller-init.ts
+++ b/app/core/Engine/controllers/remote-feature-flag-controller-init.ts
@@ -53,7 +53,7 @@ export const remoteFeatureFlagControllerInit: ControllerInitFunction<
       .then(() => {
         Logger.log('Feature flags updated');
       })
-      .catch((error) => Logger.log(error));
+      .catch((error) => Logger.log('Feature flags update failed: ', error));
   }
 
   return {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Improved error catching block to know when feature flag update fails
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improve feature flag update error logging and update onboarding tests to handle security modal and use the “I Agree” CTA.
> 
> - **Engine**:
>   - Refine error handling in `app/core/Engine/controllers/remote-feature-flag-controller-init.ts` to log a clearer message on failure: `Logger.log('Feature flags update failed: ', error)`; retain success log `Feature flags updated`.
> - **Tests**:
>   - `remote-feature-flag-controller-init.test.ts`:
>     - Mock `Logger` and add assertions for success and failure logs when `updateRemoteFeatureFlags` resolves/rejects.
>     - Preserve checks for controller initialization, arguments, and disabled behavior.
> - **Onboarding E2E/Appwright**:
>   - `appwright/tests/performance/onboarding/new-wallet-account-creation.spec.js`: handle `SkipAccountSecurityModal` and switch from `tapContinueButton` to `tapIAgreeButton`.
>   - `wdio/screen-objects/Onboarding/MetaMetricsScreen.js`: remove `continueButton`/`tapContinueButton`; use `iAgreeButton` and `tapIAgreeButton`.
>   - `wdio/screen-objects/Onboarding/OnboardingScreen.js`: remove unused `isScreenTitleVisible` method.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 854f2a858d3277179b18a0fcf1ccdf0fcc9d19e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->