### PR TITLE
fix: remove padding and border radius from order type bottom sheet

### DIFF
--- a/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheet.styles.ts
+++ b/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheet.styles.ts
@@ -4,13 +4,11 @@ import { Theme } from '../../../../../util/theme/models';
 export const createStyles = (colors: Theme['colors']) =>
   StyleSheet.create({
     container: {
-      paddingHorizontal: 16,
       paddingVertical: 24,
     },
     option: {
       paddingVertical: 16,
       paddingHorizontal: 16,
-      borderRadius: 12,
       marginBottom: 16,
     },
     optionSelected: {


### PR DESCRIPTION
## **Description**

Remove padding and border radius from order type bottom sheet

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-392

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

`~`

### **Before**

<img width="500" alt="image" src="https://github.com/user-attachments/assets/2662e9b0-adaa-4fc3-b89d-128b32f2c478" />

### **After**

<img width="500" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-11-04 at 11 22 56" src="https://github.com/user-attachments/assets/84b8a77e-5512-4a6c-9876-13c9a4f8e7ae" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes container horizontal padding and option border radius in `PerpsOrderTypeBottomSheet` styles.
> 
> - **UI/Styles** (`app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheet.styles.ts`):
>   - Remove `container` `paddingHorizontal`.
>   - Remove `option` `borderRadius`.
>   - Keep spacing and selection colors unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99111f77cbce8e4a4d99b6449981ee2cc481574e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->