### PR TITLE
fix: the network badges for the tokens are missing a border

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/__snapshots__/BridgeView.test.tsx.snap
+++ b/app/components/UI/Bridge/Views/BridgeView/__snapshots__/BridgeView.test.tsx.snap
@@ -575,7 +575,7 @@ exports[`BridgeView Bottom Content blurs input when opening QuoteExpiredModal 1`
                                                   {
                                                     "alignItems": "center",
                                                     "backgroundColor": "#ffffff",
-                                                    "borderColor": "#3c4d9d0f",
+                                                    "borderColor": "#ffffff",
                                                     "borderRadius": 8,
                                                     "borderWidth": 2,
                                                     "height": 32,
@@ -2234,7 +2234,7 @@ exports[`BridgeView renders 1`] = `
                                                   {
                                                     "alignItems": "center",
                                                     "backgroundColor": "#ffffff",
-                                                    "borderColor": "#3c4d9d0f",
+                                                    "borderColor": "#ffffff",
                                                     "borderRadius": 8,
                                                     "borderWidth": 2,
                                                     "height": 32,

--- a/app/components/UI/Bridge/components/TokenButton.tsx
+++ b/app/components/UI/Bridge/components/TokenButton.tsx
@@ -53,9 +53,6 @@ const createStyles = (params: StylesParams) => {
       color: theme.colors.text.default,
       fontSize: 24,
     },
-    networkBadge: {
-      borderColor: theme.colors.background.muted,
-    },
   });
 };
 
@@ -84,7 +81,6 @@ export const TokenButton: React.FC<TokenProps> = ({
               variant={BadgeVariant.Network}
               imageSource={networkImageSource}
               name={networkName}
-              style={styles.networkBadge}
             />
           }
         >


### PR DESCRIPTION
## **Description**

The network badges for the tokens are missing a border

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MDP-381

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

`~`

### **Before**

<img width="500" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-11-04 at 11 57 17" src="https://github.com/user-attachments/assets/27f35526-db30-4ee3-85cf-61554fa38bda" />

### **After**
<img width="500" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-11-04 at 12 08 40" src="https://github.com/user-attachments/assets/97ae6d44-cdb7-4b2a-b642-5a2ac5e5fc36" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set the token network badge border to white and update BridgeView snapshots accordingly.
> 
> - **UI**:
>   - `TokenButton`: Remove custom `networkBadge` style and stop passing it to `Badge`, resulting in a white (`#ffffff`) border for `BadgeVariant.Network`.
> - **Tests**:
>   - Update `BridgeView` snapshots to reflect the white network badge border.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad56eed0d2207a91ddd9f14531888c8e52ea8dc8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->