### PR TITLE
fix: update toast background color from muted to section

### DIFF
--- a/app/component-library/components/Toast/Toast.stories.tsx
+++ b/app/component-library/components/Toast/Toast.stories.tsx
@@ -1,33 +1,35 @@
-/* eslint-disable react-native/no-inline-styles */
-/* eslint-disable react/display-name */
 // Third party dependencies.
 import React, { useContext } from 'react';
-import { Alert } from 'react-native';
+import { Alert, View } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
+import type { Meta } from '@storybook/react-native';
 
 // External dependencies.
 import Button, { ButtonVariants } from '../Buttons/Button';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
 
 // Internal dependencies.
 import { default as ToastComponent } from './Toast';
 import { ToastContext, ToastContextWrapper } from './Toast.context';
-import { ToastVariants } from './Toast.types';
+import { ToastOptions, ToastVariants } from './Toast.types';
 import {
   TEST_ACCOUNT_ADDRESS,
   TEST_AVATAR_TYPE,
   TEST_NETWORK_IMAGE_URL,
 } from './Toast.constants';
 
-const ToastMeta = {
+interface ToastStoryArgs {
+  variant: ToastVariants;
+}
+
+export default {
   title: 'Component Library / Toast',
   component: ToastComponent,
   decorators: [
-    // TODO: Replace "any" with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (Story: any) => (
+    (StoryComponent) => (
       <SafeAreaProvider>
         <ToastContextWrapper>
-          <Story />
+          <StoryComponent />
         </ToastContextWrapper>
       </SafeAreaProvider>
     ),
@@ -41,27 +43,30 @@ const ToastMeta = {
       defaultValue: ToastVariants.Plain,
     },
   },
-};
-export default ToastMeta;
+} as Meta;
 
-export const Toast = {
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  render: (args: any) => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
+export const Default = {
+  args: {
+    variant: ToastVariants.Plain,
+  },
+  render: function Render(args: ToastStoryArgs) {
     const { toastRef } = useContext(ToastContext);
-    // TODO: Replace "any" with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let otherToastProps: any;
+    const tw = useTailwind();
+
+    let toastOptions: ToastOptions;
 
     switch (args.variant) {
       case ToastVariants.Plain:
-        otherToastProps = {
+        toastOptions = {
+          variant: ToastVariants.Plain,
+          hasNoTimeout: false,
           labelOptions: [{ label: 'This is a Toast message.' }],
         };
         break;
       case ToastVariants.Account:
-        otherToastProps = {
+        toastOptions = {
+          variant: ToastVariants.Account,
+          hasNoTimeout: false,
           labelOptions: [
             { label: 'Switching to' },
             { label: ' Account 2.', isBold: true },
@@ -71,7 +76,9 @@ export const Toast = {
         };
         break;
       case ToastVariants.Network:
-        otherToastProps = {
+        toastOptions = {
+          variant: ToastVariants.Network,
+          hasNoTimeout: false,
           labelOptions: [
             { label: 'Added' },
             { label: ' Mainnet', isBold: true },
@@ -90,25 +97,24 @@ export const Toast = {
         };
         break;
       default:
-        otherToastProps = {
+        toastOptions = {
+          variant: ToastVariants.Plain,
+          hasNoTimeout: false,
           labelOptions: [{ label: 'This is a Toast message.' }],
         };
     }
 
     return (
-      <>
+      <View style={tw.style('min-h-[300px] relative')}>
         <Button
           variant={ButtonVariants.Secondary}
           label={`Show ${args.variant} Toast`}
           onPress={() => {
-            toastRef?.current?.showToast({
-              variant: args.variant,
-              ...otherToastProps,
-            });
+            toastRef?.current?.showToast(toastOptions);
           }}
         />
         <ToastComponent ref={toastRef} />
-      </>
+      </View>
     );
   },
 };

--- a/app/component-library/components/Toast/Toast.styles.ts
+++ b/app/component-library/components/Toast/Toast.styles.ts
@@ -20,7 +20,7 @@ const styleSheet = (params: { theme: Theme }) => {
       width: toastWidth,
       left: marginWidth,
       bottom: 0,
-      backgroundColor: colors.background.muted,
+      backgroundColor: colors.background.section,
       borderWidth: 1,
       borderColor: colors.border.muted,
       borderRadius: 12,


### PR DESCRIPTION
## **Description**

Updated the Toast component background color from `background.muted` (transparent) to `background.section` (opaque) to improve visibility and match design specifications. This was introduced in [21942](https://github.com/MetaMask/metamask-mobile/pull/21942/files#diff-3a77a02f68287c5db97fcab49cee7ca3303235de3cfc9ec9d7fd36e2c7853f11R23). This change ensures toasts have proper contrast against different backgrounds.

The transparent background was causing readability issues when toasts appeared over various content.

## **Changelog**

CHANGELOG entry: Fixed toast background color to improve visibility

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Toast visibility

  Scenario: User views a toast notification
    Given the app is open on any screen
    When a toast notification appears
    Then the toast should have an opaque background
    And the toast content should be clearly visible against any background content
```

## **Screenshots/Recordings**

### **Before**

Toast had transparent background (background.muted) which could cause visibility issues

<img width="476" height="436" alt="Screenshot 2025-11-04 at 2 32 37 PM" src="https://github.com/user-attachments/assets/d0611093-1a6b-49da-b0dc-e264ab0f6575" />


### **After**

Toast now has opaque background (background.section) ensuring consistent visibility

https://github.com/user-attachments/assets/3720778b-7bd4-4386-a08c-7d0ecdf25c96

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches Toast background to `colors.background.section` and updates the Storybook story to use typed `ToastOptions` with a Tailwind-wrapped container.
> 
> - **Toast styles (`Toast.styles.ts`)**:
>   - Change background from `colors.background.muted` to `colors.background.section`.
> - **Storybook (`Toast.stories.tsx`)**:
>   - Use typed `ToastOptions` and pass a single `toastOptions` object (includes `variant` and `hasNoTimeout`).
>   - Wrap story UI in a Tailwind-styled `View` container for layout.
>   - Modernize story config: type with `Meta`, rename to `Default`, and clean up decorators.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2817a6c67807d207af342cce9da849595b2f0aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->