### PR TITLE
feat: OTA update exp workflow

### DIFF
--- a/.github/workflows/push-eas-update.yml
+++ b/.github/workflows/push-eas-update.yml
@@ -1,0 +1,269 @@
+name: Push OTA Update (Test)
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull request number to publish'
+        required: true
+        type: string
+      base_branch:
+        description: 'Base branch ref to compare fingerprints against (e.g., main)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  TARGET_PR_NUMBER: ${{ inputs.pr_number }}
+  BASE_BRANCH_REF: ${{ inputs.base_branch }}
+
+jobs:
+  fingerprint-comparison:
+    name: Compare Expo Fingerprints
+    runs-on: ubuntu-latest
+    outputs:
+      branch_fingerprint: ${{ steps.branch_fingerprint.outputs.fingerprint }}
+      main_fingerprint: ${{ steps.main_fingerprint.outputs.fingerprint }}
+      fingerprints_equal: ${{ steps.compare.outputs.equal }}
+    steps:
+      - name: Checkout target PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ env.TARGET_PR_NUMBER }}/head
+          fetch-depth: 0
+
+      - name: Checkout base branch snapshot
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.BASE_BRANCH_REF }}
+          path: main
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+
+      - name: Install dependencies (workflow branch)
+        run: |
+          echo "📦 Installing dependencies for current branch..."
+          yarn install --immutable
+
+      - name: Generate fingerprint (workflow branch)
+        id: branch_fingerprint
+        run: |
+          echo "🧬 Generating fingerprint for current branch..."
+          FINGERPRINT=$(yarn fingerprint:generate)
+          echo "fingerprint=$FINGERPRINT" >> "$GITHUB_OUTPUT"
+          echo "Target PR fingerprint: $FINGERPRINT"
+          echo "Writing detailed fingerprint file to fingerprint-pr.json"
+          npx @expo/fingerprint ./ > fingerprint-pr.json
+
+      - name: Install dependencies (base branch)
+        working-directory: main
+        run: |
+          echo "📦 Installing dependencies for base branch snapshot (${BASE_BRANCH_REF})..."
+          yarn install --immutable
+
+      - name: Generate fingerprint (base branch)
+        id: main_fingerprint
+        working-directory: main
+        run: |
+          echo "🧬 Generating fingerprint for base branch (${BASE_BRANCH_REF})..."
+          FINGERPRINT=$(yarn fingerprint:generate)
+          echo "fingerprint=$FINGERPRINT" >> "$GITHUB_OUTPUT"
+          echo "Base branch fingerprint: $FINGERPRINT"
+          echo "Writing detailed fingerprint file to ../fingerprint-base.json"
+          npx @expo/fingerprint ./ > ../fingerprint-base.json
+
+      - name: Compare fingerprints
+        id: compare
+        env:
+          BRANCH_FP: ${{ steps.branch_fingerprint.outputs.fingerprint }}
+          MAIN_FP: ${{ steps.main_fingerprint.outputs.fingerprint }}
+        run: |
+          if [ -z "$BRANCH_FP" ] || [ -z "$MAIN_FP" ]; then
+            echo "❌ Fingerprint generation failed." >&2
+            exit 1
+          fi
+
+          echo "Target PR fingerprint: $BRANCH_FP"
+          echo "Base branch fingerprint: $MAIN_FP"
+
+          if [ "$BRANCH_FP" = "$MAIN_FP" ]; then
+            echo "✅ Fingerprints match. No native changes detected."
+            echo "equal=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "⚠️ Fingerprints differ. Native changes detected."
+            echo "equal=false" >> "$GITHUB_OUTPUT"
+            if [ -f fingerprint-base.json ] && [ -f fingerprint-pr.json ]; then
+              echo "Fingerprint differences:"
+              npx @expo/fingerprint ./ fingerprint-base.json fingerprint-pr.json || true
+            else
+              echo "Detailed fingerprint files not found; skipping diff."
+            fi
+          fi
+
+      - name: Record fingerprint summary
+        env:
+          BRANCH_FP: ${{ steps.branch_fingerprint.outputs.fingerprint }}
+          MAIN_FP: ${{ steps.main_fingerprint.outputs.fingerprint }}
+          MATCHES: ${{ steps.compare.outputs.equal }}
+          TARGET_PR_NUMBER: ${{ env.TARGET_PR_NUMBER }}
+          BASE_BRANCH_REF: ${{ env.BASE_BRANCH_REF }}
+        run: |
+          {
+            echo "### Expo Fingerprint Comparison"
+            echo ""
+            echo "- Target PR (#$TARGET_PR_NUMBER) fingerprint: \`$BRANCH_FP\`"
+            echo "- Base branch (\`$BASE_BRANCH_REF\`) fingerprint: \`$MAIN_FP\`"
+            echo "- Match: \`$MATCHES\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  approval:
+    name: Require OTA Update Approval
+    needs: fingerprint-comparison
+    if: ${{ needs.fingerprint-comparison.outputs.fingerprints_equal == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Await approval from mobile platform team
+        uses: op5dev/require-team-approval@dfd7b8b9a88bf82a955c103f7e19642b0411aecd
+        with:
+          team: mobile-platform
+          pr-number: ${{ env.TARGET_PR_NUMBER }}
+          token: ${{ secrets.METAMASK_MOBILE_ORG_READ_TOKEN }}
+
+  push-update:
+    name: Push EAS Update
+    runs-on: ubuntu-latest
+    environment: expo-update
+    needs:
+      - fingerprint-comparison
+      - approval
+    if: ${{ needs.fingerprint-comparison.outputs.fingerprints_equal == 'true' }}
+    env:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      EXPO_PROJECT_ID: ${{ secrets.EXPO_PROJECT_ID }}
+      EXPO_CHANNEL: ${{ vars.EXPO_CHANNEL }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ env.TARGET_PR_NUMBER }}/head
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: |
+          echo "📦 Installing dependencies..."
+          yarn install --immutable
+
+      - name: Setup project
+        run: |
+          echo "🔧 Running setup for GitHub CI..."
+          yarn setup:github-ci
+
+      - name: Display configuration
+        run: |
+          TARGET_RUNTIME_VERSION=$(node -p "require('./package.json').version")
+          TARGET_PROJECT_ID=$(node -p "require('./ota.config.js').PROJECT_ID")
+          echo "🔧 Configuration:"
+          echo "  Channel: ${EXPO_CHANNEL:-<not set>}"
+          echo "  Channel (vars.EXPO_CHANNEL): ${{ vars.EXPO_CHANNEL }}"
+          echo "  Message: test eas update workflow"
+          echo "  Runtime Version (target): ${TARGET_RUNTIME_VERSION}"
+          # Fingerprint comparison temporarily disabled
+          echo ""
+          echo "📱 Project Info:"
+          echo "  Project ID (target branch): ${TARGET_PROJECT_ID}"
+          echo "  EXPO_PROJECT_ID (from secrets): $EXPO_PROJECT_ID"
+          echo "  EXPO_TOKEN (from secrets): $EXPO_TOKEN"
+
+      - name: Prepare Expo update signing key
+        env:
+          EXPO_KEY_PRIV: ${{ secrets.EXPO_KEY_PRIV }}
+        run: |
+          if [ -z "${EXPO_KEY_PRIV}" ]; then
+            echo "::error title=Missing EXPO_KEY_PRIV::EXPO_KEY_PRIV secret is not configured. Cannot sign update." >&2
+            exit 1
+          fi
+          mkdir -p keys
+          echo "Writing Expo private key to ./keys/private-key.pem"
+          printf '%s' "${EXPO_KEY_PRIV}" > keys/private-key.pem
+
+      - name: Push EAS Update
+        env:
+          # Skip linting during Metro transform in CI (linting already done separately)
+          SKIP_TRANSFORM_LINT: 'true'
+          # Increase Node heap to avoid OOM during Expo export in CI
+          NODE_OPTIONS: '--max_old_space_size=8192'
+          # Disable LavaMoat sandbox to prevent duplicate bundle executions in CI
+          EXPO_NO_LAVAMOAT: '1'
+        run: |
+          echo "🚀 Publishing EAS update..."
+
+          if [ -z "${EXPO_CHANNEL}" ]; then
+            echo "::error title=Missing EXPO_CHANNEL::EXPO_CHANNEL environment variable is not set. Cannot publish update." >&2
+            exit 1
+          fi
+
+          if [ ! -f keys/private-key.pem ]; then
+            echo "::error title=Missing signing key::keys/private-key.pem not found. Ensure the signing key step ran successfully." >&2
+            exit 1
+          fi
+
+          echo "ℹ️ Git head: $(git rev-parse HEAD)"
+          echo "ℹ️ Checking for eas script in package.json..."
+          if ! grep -q '"eas": "eas"' package.json; then
+            echo "::error title=Missing eas script::package.json does not include an \"eas\" script. Commit hash: $(git rev-parse HEAD)." >&2
+            exit 1
+          fi
+
+          echo "ℹ️ Available yarn scripts containing eas:"
+          yarn run --json | grep '"name":"eas"' || true
+
+          yarn run eas update \
+            --channel "${EXPO_CHANNEL}" \
+            --private-key-path "./keys/private-key.pem" \
+            --message "test eas update workflow" \
+            --non-interactive
+
+      - name: Update summary
+        if: success()
+        run: |
+          echo "### ✅ EAS Update Published Successfully" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Channel:** \`${EXPO_CHANNEL:-<not set>}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Message:** test eas update workflow" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Users on the \`${EXPO_CHANNEL:-<not set>}\` channel will receive this update on their next app launch." >> $GITHUB_STEP_SUMMARY
+
+      - name: Update summary on failure
+        if: failure()
+        run: |
+          echo "### ❌ EAS Update Failed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Check the logs above for error details." >> $GITHUB_STEP_SUMMARY
+
+  fingerprint-mismatch:
+    name: Fingerprint Mismatch Guard
+    needs: fingerprint-comparison
+    if: ${{ needs.fingerprint-comparison.outputs.fingerprints_equal != 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail on native changes
+        run: |
+          echo "::error title=Fingerprint mismatch::Current branch fingerprint differs from main. Native changes detected; aborting workflow."
+          echo "Current fingerprint: ${{ needs.fingerprint-comparison.outputs.branch_fingerprint }}"
+          echo "Main fingerprint:    ${{ needs.fingerprint-comparison.outputs.main_fingerprint }}"
+          exit 1

--- a/.github/workflows/push-eas-update.yml
+++ b/.github/workflows/push-eas-update.yml
@@ -241,19 +241,23 @@ jobs:
       - name: Update summary
         if: success()
         run: |
-          echo "### ✅ EAS Update Published Successfully" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Channel:** \`${EXPO_CHANNEL:-<not set>}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Message:** test eas update workflow" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Users on the \`${EXPO_CHANNEL:-<not set>}\` channel will receive this update on their next app launch." >> $GITHUB_STEP_SUMMARY
+          {
+            echo "### ✅ EAS Update Published Successfully"
+            echo
+            echo "**Channel:** \`${EXPO_CHANNEL:-<not set>}\`"
+            echo "**Message:** test eas update workflow"
+            echo
+            echo "Users on the \`${EXPO_CHANNEL:-<not set>}\` channel will receive this update on their next app launch."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Update summary on failure
         if: failure()
         run: |
-          echo "### ❌ EAS Update Failed" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Check the logs above for error details." >> $GITHUB_STEP_SUMMARY
+          {
+            echo "### ❌ EAS Update Failed"
+            echo
+            echo "Check the logs above for error details."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   fingerprint-mismatch:
     name: Fingerprint Mismatch Guard


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
New OTA updates workflow:
<img width="1550" height="391" alt="Screenshot 2025-11-18 at 2 14 29 PM" src="https://github.com/user-attachments/assets/d73c5978-ad00-4487-a94c-cf36cfeea044" />


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added OTA updates workflow 

## **Related issues**

Fixes: [21215](https://github.com/MetaMask/metamask-mobile/issues/21215)

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
I was testing it with on pushing my branch. It was working from checking fingerprints to deploying EAS updates. 
I haven't tested the part where we input PR number and branch name but I hardcoded these before so they should work with inputs as well. This can only be tested when this PR is merged into main.
<img width="813" height="378" alt="Screenshot 2025-11-18 at 2 23 41 PM" src="https://github.com/user-attachments/assets/a12c4f04-c0d3-4ccc-9ef7-a3581bfe8be5" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a GitHub Actions workflow to publish Expo EAS OTA updates gated by fingerprint comparison and team approval.
> 
> - **CI / GitHub Actions**:
>   - **New workflow** `/.github/workflows/push-eas-update.yml` for Expo EAS OTA updates:
>     - `fingerprint-comparison`: checks out PR and base branch, installs deps, generates Expo fingerprints, compares, and records summary.
>     - `approval`: requires `mobile-platform` team approval for OTA when fingerprints match.
>     - `push-update`: verifies `eas` script and required secrets/vars, prepares signing key, and publishes `eas update` to the configured `EXPO_CHANNEL`, adding success/failure summaries.
>     - `fingerprint-mismatch`: fails the run if fingerprints differ (native changes detected).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf2fc085e6618972eecf606e9959f8c894ae7fd7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->