### PR TITLE
chore: update BottomSheetHeader close and back buttons to size LG

### DIFF
--- a/app/component-library/components/BottomSheets/BottomSheetHeader/BottomSheetHeader.tsx
+++ b/app/component-library/components/BottomSheets/BottomSheetHeader/BottomSheetHeader.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { useStyles } from '../../../hooks';
 import HeaderBase from '../../HeaderBase';
 
-import ButtonIcon from '../../Buttons/ButtonIcon';
+import ButtonIcon, { ButtonIconSizes } from '../../Buttons/ButtonIcon';
 import { IconName, IconColor } from '../../Icons/Icon';
 
 // Internal dependencies.
@@ -35,6 +35,7 @@ const BottomSheetHeader: React.FC<BottomSheetHeaderProps> = ({
       iconName={IconName.ArrowLeft}
       iconColor={IconColor.Default}
       onPress={onBack}
+      size={ButtonIconSizes.Lg}
       {...backButtonProps}
     />
   );
@@ -44,6 +45,7 @@ const BottomSheetHeader: React.FC<BottomSheetHeaderProps> = ({
       iconName={IconName.Close}
       iconColor={IconColor.Default}
       onPress={onClose}
+      size={ButtonIconSizes.Lg}
       {...closeButtonProps}
     />
   );

--- a/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
+++ b/app/components/Snaps/SnapUIRenderer/components/__snapshots__/form.test.ts.snap
@@ -967,25 +967,25 @@ exports[`SnapUIForm will render with fields 1`] = `
                                   {
                                     "alignItems": "center",
                                     "borderRadius": 8,
-                                    "height": 28,
+                                    "height": 32,
                                     "justifyContent": "center",
                                     "opacity": 1,
-                                    "width": 28,
+                                    "width": 32,
                                   }
                                 }
                               >
                                 <SvgMock
                                   color="#121314"
                                   fill="currentColor"
-                                  height={20}
+                                  height={24}
                                   name="ArrowLeft"
                                   style={
                                     {
-                                      "height": 20,
-                                      "width": 20,
+                                      "height": 24,
+                                      "width": 24,
                                     }
                                   }
-                                  width={20}
+                                  width={24}
                                 />
                               </TouchableOpacity>
                             </View>
@@ -1698,25 +1698,25 @@ exports[`SnapUIForm will render with fields 1`] = `
                                   {
                                     "alignItems": "center",
                                     "borderRadius": 8,
-                                    "height": 28,
+                                    "height": 32,
                                     "justifyContent": "center",
                                     "opacity": 1,
-                                    "width": 28,
+                                    "width": 32,
                                   }
                                 }
                               >
                                 <SvgMock
                                   color="#121314"
                                   fill="currentColor"
-                                  height={20}
+                                  height={24}
                                   name="ArrowLeft"
                                   style={
                                     {
-                                      "height": 20,
-                                      "width": 20,
+                                      "height": 24,
+                                      "width": 24,
                                     }
                                   }
-                                  width={20}
+                                  width={24}
                                 />
                               </TouchableOpacity>
                             </View>

--- a/app/components/UI/Bridge/components/BridgeNetworkSelectorBase.tsx
+++ b/app/components/UI/Bridge/components/BridgeNetworkSelectorBase.tsx
@@ -6,7 +6,7 @@ import Text, {
 import BottomSheetHeader from '../../../../component-library/components/BottomSheets/BottomSheetHeader';
 import BottomSheet from '../../../../component-library/components/BottomSheets/BottomSheet';
 import { strings } from '../../../../../locales/i18n';
-import { ButtonIconSizes } from '../../../../component-library/components/Buttons/ButtonIcon';
+
 import { useNavigation } from '@react-navigation/native';
 
 const styles = StyleSheet.create({
@@ -31,7 +31,6 @@ export const BridgeNetworkSelectorBase: React.FC<
         onClose={() => navigation.goBack()}
         closeButtonProps={{
           testID: 'bridge-network-selector-close-button',
-          size: ButtonIconSizes.Lg,
         }}
       >
         <Text variant={TextVariant.HeadingMD} style={styles.headerTitle}>

--- a/app/components/UI/Bridge/components/BridgeTokenSelectorBase.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelectorBase.tsx
@@ -20,7 +20,6 @@ import { FlatList } from 'react-native-gesture-handler';
 import BottomSheet, {
   BottomSheetRef,
 } from '../../../../component-library/components/BottomSheets/BottomSheet';
-import { ButtonIconSizes } from '../../../../component-library/components/Buttons/ButtonIcon';
 
 // FlashList on iOS had some issues so we use FlatList for both platforms now
 const ListComponent = FlatList;
@@ -224,7 +223,6 @@ export const BridgeTokenSelectorBase: React.FC<
         onClose={dismissModal}
         closeButtonProps={{
           testID: 'bridge-token-selector-close-button',
-          size: ButtonIconSizes.Lg,
         }}
       >
         <Text variant={TextVariant.HeadingMD}>

--- a/app/components/UI/Bridge/components/QuoteExpiredModal/__snapshots__/QuoteExpiredModal.test.tsx.snap
+++ b/app/components/UI/Bridge/components/QuoteExpiredModal/__snapshots__/QuoteExpiredModal.test.tsx.snap
@@ -198,25 +198,25 @@ exports[`QuoteExpiredModal renders correctly 1`] = `
                   {
                     "alignItems": "center",
                     "borderRadius": 8,
-                    "height": 28,
+                    "height": 32,
                     "justifyContent": "center",
                     "opacity": 1,
-                    "width": 28,
+                    "width": 32,
                   }
                 }
               >
                 <SvgMock
                   color="#121314"
                   fill="currentColor"
-                  height={20}
+                  height={24}
                   name="Close"
                   style={
                     {
-                      "height": 20,
-                      "width": 20,
+                      "height": 24,
+                      "width": 24,
                     }
                   }
-                  width={20}
+                  width={24}
                 />
               </TouchableOpacity>
             </View>

--- a/app/components/UI/Bridge/components/SlippageModal/__snapshots__/SlippageModal.test.tsx.snap
+++ b/app/components/UI/Bridge/components/SlippageModal/__snapshots__/SlippageModal.test.tsx.snap
@@ -198,25 +198,25 @@ exports[`SlippageModal renders all UI elements with the proper slippage options 
                   {
                     "alignItems": "center",
                     "borderRadius": 8,
-                    "height": 28,
+                    "height": 32,
                     "justifyContent": "center",
                     "opacity": 1,
-                    "width": 28,
+                    "width": 32,
                   }
                 }
               >
                 <SvgMock
                   color="#121314"
                   fill="currentColor"
-                  height={20}
+                  height={24}
                   name="Close"
                   style={
                     {
-                      "height": 20,
-                      "width": 20,
+                      "height": 24,
+                      "width": 24,
                     }
                   }
-                  width={20}
+                  width={24}
                 />
               </TouchableOpacity>
             </View>

--- a/app/components/UI/Card/components/AddFundsBottomSheet/__snapshots__/AddFundsBottomSheet.test.tsx.snap
+++ b/app/components/UI/Card/components/AddFundsBottomSheet/__snapshots__/AddFundsBottomSheet.test.tsx.snap
@@ -499,25 +499,25 @@ exports[`AddFundsBottomSheet renders with both options enabled and matches snaps
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -1310,25 +1310,25 @@ exports[`AddFundsBottomSheet renders with no options when both are disabled and 
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -1905,25 +1905,25 @@ exports[`AddFundsBottomSheet renders with only deposit option when swaps are not
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -2608,25 +2608,25 @@ exports[`AddFundsBottomSheet renders with only swap option when deposit is disab
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Earn/LendingLearnMoreModal/__snapshots__/LendingLearnMoreModal.test.tsx.snap
+++ b/app/components/UI/Earn/LendingLearnMoreModal/__snapshots__/LendingLearnMoreModal.test.tsx.snap
@@ -178,25 +178,25 @@ exports[`LendingLearnMoreModal render lending history apy chart 1`] = `
                   {
                     "alignItems": "center",
                     "borderRadius": 8,
-                    "height": 28,
+                    "height": 32,
                     "justifyContent": "center",
                     "opacity": 1,
-                    "width": 28,
+                    "width": 32,
                   }
                 }
               >
                 <SvgMock
                   color="#121314"
                   fill="currentColor"
-                  height={20}
+                  height={24}
                   name="Close"
                   style={
                     {
-                      "height": 20,
-                      "width": 20,
+                      "height": 24,
+                      "width": 24,
                     }
                   }
-                  width={20}
+                  width={24}
                 />
               </TouchableOpacity>
             </View>

--- a/app/components/UI/Earn/components/MaxInputModal/__snapshots__/MaxInputModal.test.tsx.snap
+++ b/app/components/UI/Earn/components/MaxInputModal/__snapshots__/MaxInputModal.test.tsx.snap
@@ -505,25 +505,25 @@ exports[`MaxInputModal render matches snapshot 1`] = `
                                       {
                                         "alignItems": "center",
                                         "borderRadius": 8,
-                                        "height": 28,
+                                        "height": 32,
                                         "justifyContent": "center",
                                         "opacity": 1,
-                                        "width": 28,
+                                        "width": 32,
                                       }
                                     }
                                   >
                                     <SvgMock
                                       color="#121314"
                                       fill="currentColor"
-                                      height={20}
+                                      height={24}
                                       name="Close"
                                       style={
                                         {
-                                          "height": 20,
-                                          "width": 20,
+                                          "height": 24,
+                                          "width": 24,
                                         }
                                       }
-                                      width={20}
+                                      width={24}
                                     />
                                   </TouchableOpacity>
                                 </View>

--- a/app/components/UI/Earn/modals/LendingMaxWithdrawalModal/__snapshots__/LendingMaxWithdrawalModal.test.tsx.snap
+++ b/app/components/UI/Earn/modals/LendingMaxWithdrawalModal/__snapshots__/LendingMaxWithdrawalModal.test.tsx.snap
@@ -71,25 +71,25 @@ exports[`LendingMaxWithdrawalModal should render correctly 1`] = `
             {
               "alignItems": "center",
               "borderRadius": 8,
-              "height": 28,
+              "height": 32,
               "justifyContent": "center",
               "opacity": 1,
-              "width": 28,
+              "width": 32,
             }
           }
         >
           <SvgMock
             color="#121314"
             fill="currentColor"
-            height={20}
+            height={24}
             name="Close"
             style={
               {
-                "height": 20,
-                "width": 20,
+                "height": 24,
+                "width": 24,
               }
             }
-            width={20}
+            width={24}
           />
         </TouchableOpacity>
       </View>

--- a/app/components/UI/Ramp/Aggregator/Views/Modals/Settings/__snapshots__/SettingsModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/Modals/Settings/__snapshots__/SettingsModal.test.tsx.snap
@@ -500,25 +500,25 @@ exports[`SettingsModal renders snapshot correctly 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Aggregator/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/Views/Quotes/__snapshots__/Quotes.test.tsx.snap
@@ -1229,25 +1229,25 @@ exports[`Quotes custom action renders correctly after animation with the recomme
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -3524,25 +3524,25 @@ exports[`Quotes renders correctly after animation with expanded quotes 2`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -5449,25 +5449,25 @@ exports[`Quotes renders correctly after animation with the recommended quote 1`]
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Aggregator/components/FiatSelectorModal/__snapshots__/FiatSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/FiatSelectorModal/__snapshots__/FiatSelectorModal.test.tsx.snap
@@ -498,25 +498,25 @@ exports[`FiatSelectorModal renders the modal with currency list 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -1436,25 +1436,25 @@ exports[`FiatSelectorModal search displays filtered currencies when search strin
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -2374,25 +2374,25 @@ exports[`FiatSelectorModal search displays filtered currencies when search strin
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -3312,25 +3312,25 @@ exports[`FiatSelectorModal search displays max 20 results 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Aggregator/components/IncompatibleAccountTokenModal/__snapshots__/IncompatibleAccountTokenModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/IncompatibleAccountTokenModal/__snapshots__/IncompatibleAccountTokenModal.test.tsx.snap
@@ -499,25 +499,25 @@ exports[`IncompatibleAccountTokenModal renders the modal with the correct title 
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Aggregator/components/PaymentMethodSelectorModal/__snapshots__/PaymentMethodSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/PaymentMethodSelectorModal/__snapshots__/PaymentMethodSelectorModal.test.tsx.snap
@@ -498,25 +498,25 @@ exports[`PaymentMethodSelectorModal renders correctly 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -1644,25 +1644,25 @@ exports[`PaymentMethodSelectorModal renders for sell flow 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -2790,25 +2790,25 @@ exports[`PaymentMethodSelectorModal renders without disclaimer when selected pay
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Aggregator/components/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
@@ -498,25 +498,25 @@ exports[`RegionSelectorModal clears search when clear button is pressed 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -1360,25 +1360,25 @@ exports[`RegionSelectorModal clears search when clear button is pressed 2`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -2560,25 +2560,25 @@ exports[`RegionSelectorModal filters regions based on search input 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -3422,25 +3422,25 @@ exports[`RegionSelectorModal handles empty regions list gracefully 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -4152,25 +4152,25 @@ exports[`RegionSelectorModal handles undefined regions gracefully 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -4848,10 +4848,10 @@ exports[`RegionSelectorModal navigates back to country view when back button is 
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                   testID="back-button"
@@ -4859,15 +4859,15 @@ exports[`RegionSelectorModal navigates back to country view when back button is 
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="ArrowLeft"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -4916,25 +4916,25 @@ exports[`RegionSelectorModal navigates back to country view when back button is 
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -5734,25 +5734,25 @@ exports[`RegionSelectorModal navigates back to country view when back button is 
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -6934,25 +6934,25 @@ exports[`RegionSelectorModal renders the modal with region list 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -8134,25 +8134,25 @@ exports[`RegionSelectorModal renders the modal with selected region in list 1`] 
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -9362,25 +9362,25 @@ exports[`RegionSelectorModal renders the modal with selected state in list 1`] =
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -10590,25 +10590,25 @@ exports[`RegionSelectorModal shows empty state when search returns no results 1`
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Aggregator/components/TokenSelectModal/__snapshots__/TokenSelectModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Aggregator/components/TokenSelectModal/__snapshots__/TokenSelectModal.test.tsx.snap
@@ -498,25 +498,25 @@ exports[`TokenSelectModal renders the modal with token list 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Deposit/Views/Modals/ConfigurationModal/__snapshots__/ConfigurationModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/ConfigurationModal/__snapshots__/ConfigurationModal.test.tsx.snap
@@ -500,25 +500,25 @@ exports[`ConfigurationModal render matches snapshot 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Deposit/Views/Modals/ErrorDetailsModal/__snapshots__/ErrorDetailsModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/ErrorDetailsModal/__snapshots__/ErrorDetailsModal.test.tsx.snap
@@ -521,25 +521,25 @@ exports[`ErrorDetailsModal renders correctly and matches snapshot 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Deposit/Views/Modals/IncompatibleAccountTokenModal/__snapshots__/IncompatibleAccountTokenModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/IncompatibleAccountTokenModal/__snapshots__/IncompatibleAccountTokenModal.test.tsx.snap
@@ -499,25 +499,25 @@ exports[`IncompatibleAccountTokenModal renders the modal with the correct title 
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Deposit/Views/Modals/PaymentMethodSelectorModal/__snapshots__/PaymentMethodSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/PaymentMethodSelectorModal/__snapshots__/PaymentMethodSelectorModal.test.tsx.snap
@@ -498,25 +498,25 @@ exports[`PaymentMethodSelectorModal Component renders correctly and matches snap
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Deposit/Views/Modals/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/RegionSelectorModal/__snapshots__/RegionSelectorModal.test.tsx.snap
@@ -498,25 +498,25 @@ exports[`RegionSelectorModal Component handles empty regions array from navigati
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -1205,25 +1205,25 @@ exports[`RegionSelectorModal Component receives and uses regions from navigation
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -2108,25 +2108,25 @@ exports[`RegionSelectorModal Component render matches snapshot 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -3255,25 +3255,25 @@ exports[`RegionSelectorModal Component render matches snapshot when search has n
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -4003,25 +4003,25 @@ exports[`RegionSelectorModal Component render matches snapshot when searching fo
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -4839,25 +4839,25 @@ exports[`RegionSelectorModal Component render matches snapshot with allRegionsSe
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -5986,25 +5986,25 @@ exports[`RegionSelectorModal Component render matches snapshot with custom selec
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -7133,25 +7133,25 @@ exports[`RegionSelectorModal Component sorts recommended regions to the top when
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Deposit/Views/Modals/SsnInfoModal/__snapshots__/SsnInfoModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/SsnInfoModal/__snapshots__/SsnInfoModal.test.tsx.snap
@@ -499,25 +499,25 @@ exports[`SsnInfoModal Component renders correctly and matches snapshot 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Deposit/Views/Modals/StateSelectorModal/__snapshots__/StateSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/StateSelectorModal/__snapshots__/StateSelectorModal.test.tsx.snap
@@ -498,25 +498,25 @@ exports[`StateSelectorModal Component Snapshot Tests renders cleared search stat
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -1301,25 +1301,25 @@ exports[`StateSelectorModal Component Snapshot Tests renders empty state when no
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -2048,25 +2048,25 @@ exports[`StateSelectorModal Component Snapshot Tests renders filtered state when
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -2851,25 +2851,25 @@ exports[`StateSelectorModal Component Snapshot Tests renders filtered state when
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -3654,25 +3654,25 @@ exports[`StateSelectorModal Component Snapshot Tests renders initial state corre
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -4720,25 +4720,25 @@ exports[`StateSelectorModal Component Snapshot Tests renders partial search resu
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/TokenSelectorModal/__snapshots__/TokenSelectorModal.test.tsx.snap
@@ -498,25 +498,25 @@ exports[`TokenSelectorModal Component displays empty state when no tokens match 
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -1454,25 +1454,25 @@ exports[`TokenSelectorModal Component displays network filter selector when pres
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -2611,25 +2611,25 @@ exports[`TokenSelectorModal Component renders correctly and matches snapshot 1`]
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedRegionModal/__snapshots__/UnsupportedRegionModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedRegionModal/__snapshots__/UnsupportedRegionModal.test.tsx.snap
@@ -478,25 +478,25 @@ exports[`UnsupportedRegionModal handles missing region gracefully 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>
@@ -1151,25 +1151,25 @@ exports[`UnsupportedRegionModal render match snapshot 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedStateModal/__snapshots__/UnsupportedStateModal.test.tsx.snap
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/UnsupportedStateModal/__snapshots__/UnsupportedStateModal.test.tsx.snap
@@ -478,25 +478,25 @@ exports[`UnsupportedStateModal render match snapshot 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>

--- a/app/components/UI/Stake/components/GasImpactModal/__snapshots__/GasImpactModal.test.tsx.snap
+++ b/app/components/UI/Stake/components/GasImpactModal/__snapshots__/GasImpactModal.test.tsx.snap
@@ -205,25 +205,25 @@ exports[`GasImpactModal render matches snapshot 1`] = `
                     {
                       "alignItems": "center",
                       "borderRadius": 8,
-                      "height": 28,
+                      "height": 32,
                       "justifyContent": "center",
                       "opacity": 1,
-                      "width": 28,
+                      "width": 32,
                     }
                   }
                 >
                   <SvgMock
                     color="#121314"
                     fill="currentColor"
-                    height={20}
+                    height={24}
                     name="Close"
                     style={
                       {
-                        "height": 20,
-                        "width": 20,
+                        "height": 24,
+                        "width": 24,
                       }
                     }
-                    width={20}
+                    width={24}
                   />
                 </TouchableOpacity>
               </View>

--- a/app/components/UI/Stake/components/PoolStakingLearnMoreModal/__snapshots__/PoolStakingLearnMoreModal.test.tsx.snap
+++ b/app/components/UI/Stake/components/PoolStakingLearnMoreModal/__snapshots__/PoolStakingLearnMoreModal.test.tsx.snap
@@ -182,25 +182,25 @@ exports[`PoolStakingLearnMoreModal render matches snapshot 1`] = `
                       {
                         "alignItems": "center",
                         "borderRadius": 8,
-                        "height": 28,
+                        "height": 32,
                         "justifyContent": "center",
                         "opacity": 1,
-                        "width": 28,
+                        "width": 32,
                       }
                     }
                   >
                     <SvgMock
                       color="#121314"
                       fill="currentColor"
-                      height={20}
+                      height={24}
                       name="Close"
                       style={
                         {
-                          "height": 20,
-                          "width": 20,
+                          "height": 24,
+                          "width": 24,
                         }
                       }
-                      width={20}
+                      width={24}
                     />
                   </TouchableOpacity>
                 </View>

--- a/app/components/Views/AddressSelector/__snapshots__/AddressSelector.test.tsx.snap
+++ b/app/components/Views/AddressSelector/__snapshots__/AddressSelector.test.tsx.snap
@@ -501,25 +501,25 @@ exports[`AccountSelector renders correctly and matches snapshot 1`] = `
                                     {
                                       "alignItems": "center",
                                       "borderRadius": 8,
-                                      "height": 28,
+                                      "height": 32,
                                       "justifyContent": "center",
                                       "opacity": 1,
-                                      "width": 28,
+                                      "width": 32,
                                     }
                                   }
                                 >
                                   <SvgMock
                                     color="#121314"
                                     fill="currentColor"
-                                    height={20}
+                                    height={24}
                                     name="Close"
                                     style={
                                       {
-                                        "height": 20,
-                                        "width": 20,
+                                        "height": 24,
+                                        "width": 24,
                                       }
                                     }
-                                    width={20}
+                                    width={24}
                                   />
                                 </TouchableOpacity>
                               </View>


### PR DESCRIPTION
## **Description**

Updates the default button size for BottomSheetHeader close (X) and back (<) buttons from Medium (MD) to Large (LG) to align with the BottomSheet standardization specifications.

This change makes all BottomSheets consistent by default without requiring individual components to explicitly set the button size.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of: https://consensyssoftware.atlassian.net/browse/MDP-343

<img width="450" height="397" alt="Screenshot 2025-11-04 at 4 44 57 PM" src="https://github.com/user-attachments/assets/08fb3eee-7d14-4e91-af13-694ab8d93802" />

## **Manual testing steps**

```gherkin
Feature: BottomSheetHeader button size update

  Scenario: View updated button sizes in Storybook
    Given Storybook is running
    When I navigate to BottomSheetHeader component
    Then I should see the close button (X) is size LG (32x32px)
    And I should see the back button (<) is size LG (32x32px)
```

## **Screenshots/Recordings**

### **Before**

Close and back buttons were size MD (28x28px with 20x20px icons)

<img width="422" height="174" alt="Screenshot 2025-11-04 at 3 45 52 PM" src="https://github.com/user-attachments/assets/91a44051-2ef6-4b20-94b9-86b395ec92a2" />

### **After**

Close and back buttons are now size LG (32x32px with 24x24px icons)

<img width="420" height="168" alt="Screenshot 2025-11-04 at 3 40 07 PM" src="https://github.com/user-attachments/assets/c8dd306e-fadb-45ff-8d9c-58f57cdf5e24" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets `BottomSheetHeader` back/close `ButtonIcon` size to LG by default and updates affected consumers and snapshots.
> 
> - **Component Library**:
>   - `BottomSheets/BottomSheetHeader`: Back and close `ButtonIcon` now default to `size=LG`.
> - **App UI**:
>   - Remove redundant `size` overrides for `BottomSheetHeader` close/back buttons in Bridge selectors and related screens to rely on new default.
> - **Tests/Snapshots**:
>   - Update snapshots across BottomSheet-based modals/views to reflect `32x32` buttons with `24x24` icons (was `28x28` with `20x20`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 737d5bb26c9d8fa6cccbf2c4891a762532c3858c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->