### PR TITLE
fix(perps): invalid decimals in pnl card

### DIFF
--- a/app/components/UI/Perps/Views/PerpsHeroCardView/PerpsHeroCardView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHeroCardView/PerpsHeroCardView.tsx
@@ -35,7 +35,6 @@ import RewardsReferralCodeTag from '../../../Rewards/components/RewardsReferralC
 import {
   formatPerpsFiat,
   parseCurrencyString,
-  PRICE_RANGES_MINIMAL_VIEW,
   PRICE_RANGES_UNIVERSAL,
 } from '../../utils/formatUtils';
 import MetaMaskLogo from '../../../../../images/branding/metamask-name.png';
@@ -232,7 +231,7 @@ const PerpsHeroCardView: React.FC = () => {
                   variant={TextVariant.BodySMMedium}
                 >
                   {formatPerpsFiat(data.entryPrice, {
-                    ranges: PRICE_RANGES_MINIMAL_VIEW,
+                    ranges: PRICE_RANGES_UNIVERSAL,
                   })}
                 </Text>
               </View>

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsPositionTransactionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsPositionTransactionView.tsx
@@ -32,6 +32,7 @@ import {
 import {
   formatPerpsFiat,
   formatTransactionDate,
+  PRICE_RANGES_UNIVERSAL,
 } from '../../utils/formatUtils';
 import { styleSheet } from './PerpsPositionTransactionView.styles';
 
@@ -103,7 +104,9 @@ const PerpsPositionTransactionView: React.FC = () => {
           transaction.fill?.action === 'Closed'
             ? strings('perps.transactions.position.close_price')
             : strings('perps.transactions.position.entry_price'),
-        value: formatPerpsFiat(transaction.fill.entryPrice),
+        value: formatPerpsFiat(transaction.fill.entryPrice, {
+          ranges: PRICE_RANGES_UNIVERSAL,
+        }),
       },
   ].filter(Boolean);
 


### PR DESCRIPTION
## **Description**

Fixed incorrect decimal precision for Entry price display on the PnL card and transaction details.

**Problem:** Entry prices were using `PRICE_RANGES_MINIMAL_VIEW` (2 decimal places, fiat-style) instead of `PRICE_RANGES_UNIVERSAL` (5 significant digits, up to 6 decimals) that Mark prices use. This caused:
- PUMP: Displayed "<$0.01" instead of actual value
- ETH: Displayed "xxxx.60" instead of "xxxx.6" (trailing zero)
- XRP: Displayed "$2.26" instead of "$2.2626" (insufficient precision)

**Solution:** Changed Entry price formatting to use `PRICE_RANGES_UNIVERSAL` to match Mark price decimal logic, ensuring consistent precision across all price displays.

## **Changelog**

CHANGELOG entry: Fixed Entry price decimal precision on PnL card to match Mark price formatting

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1976

## **Manual testing steps**

```gherkin
Feature: Entry price decimal consistency

  Scenario: user views PnL card for low-value asset (PUMP)
    Given user has an open position in PUMP
    When user navigates to the PnL hero card (Share your trade view)
    Then Entry price should display actual value with appropriate decimals
    And Entry price should match Mark price decimal formatting

  Scenario: user views PnL card for ETH
    Given user has an open position in ETH
    When user navigates to the PnL hero card
    Then Entry price should display "xxxx.6" without trailing zeros
    And Entry price should match Mark price decimal formatting

  Scenario: user views PnL card for XRP
    Given user has an open position in XRP
    When user navigates to the PnL hero card
    Then Entry price should display "$2.2626" with full precision
    And Entry price should match Mark price decimal formatting

  Scenario: user views transaction history
    Given user has closed positions
    When user views position transaction details
    Then Entry/Close price should display with universal decimal precision
```

## **Screenshots/Recordings**

### **Before**

PUMP: Entry shows "<$0.01"
ETH: Entry shows "xxxx.60" (trailing zero)
XRP: Entry shows "$2.26" (insufficient precision)

### **After**

Entry prices now match Mark price formatting:
- PUMP: Shows actual value (e.g., "$0.003889")
- ETH: Shows "xxxx.6" (no trailing zero)
- XRP: Shows "$2.2626" (full precision)

https://github.com/user-attachments/assets/22528486-a079-41a3-abfa-1f344ef5dbb6


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable (existing tests pass)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---

## **Technical Details**

### Files Modified:
1. `app/components/UI/Perps/Views/PerpsHeroCardView/PerpsHeroCardView.tsx:235`
   - Changed Entry price from `PRICE_RANGES_MINIMAL_VIEW` � `PRICE_RANGES_UNIVERSAL`

2. `app/components/UI/Perps/Views/PerpsTransactionsView/PerpsPositionTransactionView.tsx:107-109`
   - Added `PRICE_RANGES_UNIVERSAL` config to Entry/Close price formatting

### Verification:
-  ESLint: No errors
-  Prettier: Formatting correct
-  Unit tests: All tests pass (21 tests for PerpsHeroCardView, 2 tests for PerpsPositionTransactionView)

### Reference Implementation:
- `PerpsPositionCard.tsx` already uses `PRICE_RANGES_UNIVERSAL` (lines 414-417)
- `PerpsTPSLView.tsx` already uses `PRICE_RANGES_UNIVERSAL` (lines 445-447)
- Consistent with `fix/perps/decimal-consistency` branch work

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch Entry/Close price formatting to PRICE_RANGES_UNIVERSAL in PnL hero card and transaction details for consistent precision.
> 
> - **Perps UI**:
>   - **PnL Hero Card (`PerpsHeroCardView.tsx`)**: Format `entryPrice` with `formatPerpsFiat(..., { ranges: `PRICE_RANGES_UNIVERSAL` })`.
>   - **Transaction Details (`PerpsPositionTransactionView.tsx`)**: Format Entry/Close price with `PRICE_RANGES_UNIVERSAL` for consistent decimal precision.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a13254a364dab24096524eb4213383325d8affa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->