### PR TITLE
feat(ramps): add region unsupported modal

### DIFF
--- a/app/components/UI/Ramp/Aggregator/routes/index.tsx
+++ b/app/components/UI/Ramp/Aggregator/routes/index.tsx
@@ -15,6 +15,7 @@ import { colors } from '../../../../../styles/common';
 import IncompatibleAccountTokenModal from '../components/IncompatibleAccountTokenModal';
 import RegionSelectorModal from '../components/RegionSelectorModal';
 import UnsupportedRegionModal from '../components/UnsupportedRegionModal';
+import RampsBottomSheetModal from '../../components/RampsBottomSheetModal';
 
 const Stack = createStackNavigator();
 const ModalsStack = createStackNavigator();
@@ -81,6 +82,10 @@ const RampModalsRoutes = () => (
     <ModalsStack.Screen
       name={Routes.RAMP.MODALS.UNSUPPORTED_REGION}
       component={UnsupportedRegionModal}
+    />
+    <ModalsStack.Screen
+      name={Routes.RAMP.BOTTOM_SHEET_MODAL}
+      component={RampsBottomSheetModal}
     />
   </ModalsStack.Navigator>
 );

--- a/app/components/UI/Ramp/components/ErrorModal/ErrorModal.styles.ts
+++ b/app/components/UI/Ramp/components/ErrorModal/ErrorModal.styles.ts
@@ -1,0 +1,15 @@
+import { StyleSheet } from 'react-native';
+import { Theme } from '../../../../../util/theme/models';
+
+const createStyles = (_params: { theme: Theme }) =>
+  StyleSheet.create({
+    contentContainer: {
+      paddingHorizontal: 16,
+    },
+    footerContainer: {
+      paddingHorizontal: 16,
+      paddingVertical: 24,
+    },
+  });
+
+export default createStyles;

--- a/app/components/UI/Ramp/components/ErrorModal/ErrorModal.test.tsx
+++ b/app/components/UI/Ramp/components/ErrorModal/ErrorModal.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { Metrics, SafeAreaProvider } from 'react-native-safe-area-context';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import ErrorModal from './ErrorModal';
+
+jest.mock('@react-navigation/native', () => {
+  const actualNav = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualNav,
+    useNavigation: () => ({
+      navigate: jest.fn(),
+    }),
+  };
+});
+
+const mockOnClose = jest.fn();
+
+describe('ErrorModal', () => {
+  const initialMetrics: Metrics = {
+    frame: { x: 0, y: 0, width: 320, height: 640 },
+    insets: { top: 0, left: 0, right: 0, bottom: 0 },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders correctly when visible with default text', () => {
+    const { toJSON, getByText } = renderWithProvider(
+      <SafeAreaProvider initialMetrics={initialMetrics}>
+        <ErrorModal isVisible onClose={mockOnClose} />
+      </SafeAreaProvider>,
+    );
+
+    expect(getByText('Error')).toBeTruthy();
+    expect(getByText('Placeholder error message')).toBeTruthy();
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('renders correctly with custom title and description', () => {
+    const { getByText } = renderWithProvider(
+      <SafeAreaProvider initialMetrics={initialMetrics}>
+        <ErrorModal
+          isVisible
+          onClose={mockOnClose}
+          title="Custom Error Title"
+          description="Custom error description text"
+        />
+      </SafeAreaProvider>,
+    );
+
+    expect(getByText('Custom Error Title')).toBeTruthy();
+    expect(getByText('Custom error description text')).toBeTruthy();
+  });
+
+  it('does not render when not visible', () => {
+    const { queryByTestId } = renderWithProvider(
+      <SafeAreaProvider initialMetrics={initialMetrics}>
+        <ErrorModal isVisible={false} onClose={mockOnClose} />
+      </SafeAreaProvider>,
+    );
+
+    expect(queryByTestId('ramps-error-modal')).toBeNull();
+  });
+
+  it('renders with custom testID', () => {
+    const { getByTestId } = renderWithProvider(
+      <SafeAreaProvider initialMetrics={initialMetrics}>
+        <ErrorModal
+          isVisible
+          onClose={mockOnClose}
+          testID="custom-error-test-id"
+        />
+      </SafeAreaProvider>,
+    );
+
+    expect(getByTestId('custom-error-test-id')).toBeTruthy();
+    expect(getByTestId('custom-error-test-id-title')).toBeTruthy();
+    expect(getByTestId('custom-error-test-id-description')).toBeTruthy();
+  });
+});

--- a/app/components/UI/Ramp/components/ErrorModal/ErrorModal.tsx
+++ b/app/components/UI/Ramp/components/ErrorModal/ErrorModal.tsx
@@ -1,0 +1,102 @@
+import React, { useRef, useCallback, useMemo } from 'react';
+import { View } from 'react-native';
+import BottomSheet, {
+  BottomSheetRef,
+} from '../../../../../component-library/components/BottomSheets/BottomSheet';
+import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
+import BottomSheetFooter, {
+  ButtonsAlignment,
+} from '../../../../../component-library/components/BottomSheets/BottomSheetFooter';
+import Text, {
+  TextColor,
+  TextVariant,
+} from '../../../../../component-library/components/Texts/Text';
+import {
+  ButtonSize,
+  ButtonVariants,
+} from '../../../../../component-library/components/Buttons/Button';
+import { useStyles } from '../../../../hooks/useStyles';
+import { strings } from '../../../../../../locales/i18n';
+import { ErrorModalProps } from './ErrorModal.types';
+import createStyles from './ErrorModal.styles';
+import { createNavigationDetails } from '../../../../../util/navigation/navUtils';
+import Routes from '../../../../../constants/navigation/Routes';
+
+export const createErrorModalNavigationDetails = createNavigationDetails(
+  Routes.RAMP.COMPONENTS.ERROR,
+);
+
+const ErrorModal = React.memo<ErrorModalProps>(
+  ({
+    isVisible,
+    onClose,
+    title,
+    description,
+    testID = 'ramps-error-modal',
+  }) => {
+    const { styles } = useStyles(createStyles, {});
+    const bottomSheetRef = useRef<BottomSheetRef>(null);
+
+    const handleGotItPress = useCallback(() => {
+      bottomSheetRef.current?.onCloseBottomSheet();
+    }, []);
+
+    const modalTitle = useMemo(
+      () => title || strings('ramps.error.title'),
+      [title],
+    );
+
+    const modalDescription = useMemo(
+      () => description || strings('ramps.error.description'),
+      [description],
+    );
+
+    const buttonLabel = useMemo(() => strings('ramps.error.got_it_button'), []);
+
+    const footerButtons = useMemo(
+      () => [
+        {
+          label: buttonLabel,
+          onPress: handleGotItPress,
+          variant: ButtonVariants.Primary,
+          size: ButtonSize.Lg,
+          testID: `${testID}-got-it-button`,
+        },
+      ],
+      [buttonLabel, handleGotItPress, testID],
+    );
+
+    if (!isVisible || !modalTitle) return null;
+
+    return (
+      <BottomSheet
+        ref={bottomSheetRef}
+        shouldNavigateBack={false}
+        onClose={onClose}
+        testID={testID}
+      >
+        <BottomSheetHeader>
+          <Text variant={TextVariant.HeadingMD} testID={`${testID}-title`}>
+            {modalTitle}
+          </Text>
+        </BottomSheetHeader>
+        <View style={styles.contentContainer}>
+          <Text
+            variant={TextVariant.BodyMD}
+            color={TextColor.Alternative}
+            testID={`${testID}-description`}
+          >
+            {modalDescription}
+          </Text>
+        </View>
+        <BottomSheetFooter
+          buttonsAlignment={ButtonsAlignment.Horizontal}
+          buttonPropsArray={footerButtons}
+          style={styles.footerContainer}
+        />
+      </BottomSheet>
+    );
+  },
+);
+
+export default ErrorModal;

--- a/app/components/UI/Ramp/components/ErrorModal/ErrorModal.types.ts
+++ b/app/components/UI/Ramp/components/ErrorModal/ErrorModal.types.ts
@@ -1,0 +1,26 @@
+export interface ErrorModalProps {
+  /**
+   * Visibility state of the modal
+   */
+  isVisible: boolean;
+
+  /**
+   * Function called when modal should close
+   */
+  onClose: () => void;
+
+  /**
+   * Optional custom title for the error modal
+   */
+  title?: string;
+
+  /**
+   * Optional custom description for the error modal
+   */
+  description?: string;
+
+  /**
+   * Optional test ID for testing
+   */
+  testID?: string;
+}

--- a/app/components/UI/Ramp/components/ErrorModal/__snapshots__/ErrorModal.test.tsx.snap
+++ b/app/components/UI/Ramp/components/ErrorModal/__snapshots__/ErrorModal.test.tsx.snap
@@ -1,0 +1,249 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ErrorModal renders correctly when visible with default text 1`] = `
+<RNCSafeAreaProvider
+  onInsetsChange={[Function]}
+  style={
+    [
+      {
+        "flex": 1,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    onLayout={[Function]}
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "flex-end",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "paddingBottom": 0,
+        },
+      ]
+    }
+    testID="ramps-error-modal"
+  >
+    <View
+      style={
+        [
+          {
+            "backgroundColor": "#3f434a66",
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          {
+            "opacity": 0,
+          },
+        ]
+      }
+    >
+      <TouchableOpacity
+        onPress={[Function]}
+        style={
+          {
+            "flex": 1,
+          }
+        }
+      />
+    </View>
+    <View
+      onLayout={[Function]}
+      style={
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+          },
+          {
+            "paddingBottom": 0,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        enabled={true}
+        handlerTag={-1}
+        handlerType="PanGestureHandler"
+        onGestureHandlerEvent={[Function]}
+        onGestureHandlerStateChange={[Function]}
+        onLayout={[Function]}
+        style={
+          [
+            {
+              "backgroundColor": "#ffffff",
+              "borderColor": "#b7bbc866",
+              "borderTopLeftRadius": 24,
+              "borderTopRightRadius": 24,
+              "borderWidth": 1,
+              "maxHeight": 640,
+              "overflow": "hidden",
+              "paddingBottom": 0,
+              "shadowColor": "#0000001a",
+              "shadowOffset": {
+                "height": 2,
+                "width": 0,
+              },
+              "shadowOpacity": 1,
+              "shadowRadius": 40,
+            },
+            {
+              "transform": [
+                {
+                  "translateY": 640,
+                },
+              ],
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "alignSelf": "stretch",
+              "padding": 4,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "backgroundColor": "#b7bbc866",
+                "borderRadius": 2,
+                "height": 4,
+                "width": 40,
+              }
+            }
+          />
+        </View>
+        <View
+          style={
+            [
+              {
+                "backgroundColor": "#ffffff",
+                "flexDirection": "row",
+                "gap": 16,
+                "padding": 16,
+              },
+              false,
+            ]
+          }
+          testID="header"
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flex": 1,
+              }
+            }
+          >
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#121314",
+                  "fontFamily": "Geist Bold",
+                  "fontSize": 18,
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                }
+              }
+              testID="ramps-error-modal-title"
+            >
+              Error
+            </Text>
+          </View>
+        </View>
+        <View
+          style={
+            {
+              "paddingHorizontal": 16,
+            }
+          }
+        >
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#686e7d",
+                "fontFamily": "Geist Regular",
+                "fontSize": 16,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              }
+            }
+            testID="ramps-error-modal-description"
+          >
+            Placeholder error message
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "backgroundColor": "#ffffff",
+              "flexDirection": "row",
+              "paddingHorizontal": 16,
+              "paddingVertical": 24,
+            }
+          }
+          testID="bottomsheetfooter"
+        >
+          <TouchableOpacity
+            accessibilityRole="button"
+            accessible={true}
+            activeOpacity={1}
+            onPress={[Function]}
+            onPressIn={[Function]}
+            onPressOut={[Function]}
+            style={
+              {
+                "alignItems": "center",
+                "alignSelf": "flex-start",
+                "backgroundColor": "#121314",
+                "borderRadius": 12,
+                "flex": 1,
+                "flexDirection": "row",
+                "height": 48,
+                "justifyContent": "center",
+                "overflow": "hidden",
+                "paddingHorizontal": 16,
+              }
+            }
+            testID="ramps-error-modal-got-it-button"
+          >
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#ffffff",
+                  "fontFamily": "Geist Medium",
+                  "fontSize": 16,
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                }
+              }
+            >
+              Got it
+            </Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </View>
+  </View>
+</RNCSafeAreaProvider>
+`;

--- a/app/components/UI/Ramp/components/ErrorModal/index.ts
+++ b/app/components/UI/Ramp/components/ErrorModal/index.ts
@@ -1,0 +1,3 @@
+export { default } from './ErrorModal';
+export { createErrorModalNavigationDetails } from './ErrorModal';
+export type { ErrorModalProps } from './ErrorModal.types';

--- a/app/components/UI/Ramp/components/RampsBottomSheetModal/RampsBottomSheetModal.styles.ts
+++ b/app/components/UI/Ramp/components/RampsBottomSheetModal/RampsBottomSheetModal.styles.ts
@@ -1,0 +1,14 @@
+import { StyleSheet } from 'react-native';
+
+const createStyles = () =>
+  StyleSheet.create({
+    container: {
+      paddingHorizontal: 16,
+      paddingVertical: 24,
+    },
+    description: {
+      marginBottom: 24,
+    },
+  });
+
+export default createStyles;

--- a/app/components/UI/Ramp/components/RampsBottomSheetModal/RampsBottomSheetModal.test.tsx
+++ b/app/components/UI/Ramp/components/RampsBottomSheetModal/RampsBottomSheetModal.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { Metrics, SafeAreaProvider } from 'react-native-safe-area-context';
+import { fireEvent } from '@testing-library/react-native';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import RampsBottomSheetModal from './RampsBottomSheetModal';
+import { RampsBottomSheetModalParams } from './RampsBottomSheetModal.types';
+
+jest.mock('@react-navigation/native', () => {
+  const actualNav = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualNav,
+    useNavigation: () => ({
+      goBack: jest.fn(),
+    }),
+  };
+});
+
+describe('RampsBottomSheetModal', () => {
+  const initialMetrics: Metrics = {
+    frame: { x: 0, y: 0, width: 320, height: 640 },
+    insets: { top: 0, left: 0, right: 0, bottom: 0 },
+  };
+
+  const defaultParams: RampsBottomSheetModalParams = {
+    title: 'Test Title',
+    description: 'Test Description',
+    buttonLabel: 'Test Button',
+  };
+
+  const renderModal = (params: RampsBottomSheetModalParams) =>
+    renderWithProvider(
+      <SafeAreaProvider initialMetrics={initialMetrics}>
+        <RampsBottomSheetModal route={{ params }} />
+      </SafeAreaProvider>,
+    );
+
+  it('renders correctly with string title and description', () => {
+    const { getByText, toJSON } = renderModal(defaultParams);
+
+    expect(getByText('Test Title')).toBeTruthy();
+    expect(getByText('Test Description')).toBeTruthy();
+    expect(getByText('Test Button')).toBeTruthy();
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('renders correctly with custom button label', () => {
+    const { getByText } = renderModal({
+      ...defaultParams,
+      buttonLabel: 'Custom Button',
+    });
+
+    expect(getByText('Custom Button')).toBeTruthy();
+  });
+
+  it('renders without close icon when showCloseIcon is false', () => {
+    const { queryByTestId } = renderModal({
+      ...defaultParams,
+      showCloseIcon: false,
+    });
+
+    expect(queryByTestId('header')).toBeNull();
+  });
+
+  it('calls onButtonPress when button is pressed', () => {
+    const mockOnButtonPress = jest.fn();
+    const { getByText } = renderModal({
+      ...defaultParams,
+      onButtonPress: mockOnButtonPress,
+    });
+
+    fireEvent.press(getByText('Test Button'));
+
+    expect(mockOnButtonPress).toHaveBeenCalled();
+  });
+
+  it('renders with unsupported region content', () => {
+    const { getByText } = renderModal({
+      title: 'Unavailable in your region',
+      description:
+        "Buying crypto isn't available in your location due to limitations with local payment providers or regulatory restrictions.",
+      buttonLabel: 'Got it',
+    });
+
+    expect(getByText('Unavailable in your region')).toBeTruthy();
+    expect(
+      getByText(
+        "Buying crypto isn't available in your location due to limitations with local payment providers or regulatory restrictions.",
+      ),
+    ).toBeTruthy();
+    expect(getByText('Got it')).toBeTruthy();
+  });
+
+  it('renders with eligibility check failed content', () => {
+    const { getByText } = renderModal({
+      title: 'Eligibility check failed',
+      description:
+        "We couldn't confirm access based on your region. Please try again. If the issue continues, contact support.",
+      buttonLabel: 'Got it',
+    });
+
+    expect(getByText('Eligibility check failed')).toBeTruthy();
+    expect(
+      getByText(
+        "We couldn't confirm access based on your region. Please try again. If the issue continues, contact support.",
+      ),
+    ).toBeTruthy();
+  });
+});

--- a/app/components/UI/Ramp/components/RampsBottomSheetModal/RampsBottomSheetModal.tsx
+++ b/app/components/UI/Ramp/components/RampsBottomSheetModal/RampsBottomSheetModal.tsx
@@ -1,0 +1,98 @@
+import React, { useCallback, useRef } from 'react';
+import { View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+
+import Text, {
+  TextVariant,
+  TextColor,
+} from '../../../../../component-library/components/Texts/Text';
+import BottomSheet, {
+  BottomSheetRef,
+} from '../../../../../component-library/components/BottomSheets/BottomSheet';
+import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
+import Button, {
+  ButtonSize,
+  ButtonVariants,
+  ButtonWidthTypes,
+} from '../../../../../component-library/components/Buttons/Button';
+
+import { useStyles } from '../../../../hooks/useStyles';
+import { strings } from '../../../../../../locales/i18n';
+import { RampsBottomSheetModalProps } from './RampsBottomSheetModal.types';
+import createStyles from './RampsBottomSheetModal.styles';
+
+const RampsBottomSheetModal = ({ route }: RampsBottomSheetModalProps) => {
+  const sheetRef = useRef<BottomSheetRef>(null);
+  const navigation = useNavigation();
+
+  const {
+    title,
+    description,
+    buttonLabel = strings('fiat_on_ramp.modal.default_button'),
+    onButtonPress,
+    showCloseIcon = true,
+  } = route.params;
+
+  const { styles } = useStyles(createStyles, {});
+
+  const handleClose = useCallback(() => {
+    sheetRef.current?.onCloseBottomSheet(() => {
+      navigation.goBack();
+    });
+  }, [navigation]);
+
+  const handleButtonPress = useCallback(() => {
+    if (onButtonPress) {
+      sheetRef.current?.onCloseBottomSheet(() => {
+        onButtonPress();
+      });
+    } else {
+      handleClose();
+    }
+  }, [onButtonPress, handleClose]);
+
+  const renderTitle = () => {
+    if (typeof title === 'string') {
+      return <Text variant={TextVariant.HeadingMD}>{title}</Text>;
+    }
+    return title;
+  };
+
+  const renderDescription = () => {
+    if (typeof description === 'string') {
+      return (
+        <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+          {description}
+        </Text>
+      );
+    }
+    return description;
+  };
+
+  return (
+    <BottomSheet ref={sheetRef} shouldNavigateBack isInteractable={false}>
+      {showCloseIcon && (
+        <BottomSheetHeader onClose={handleClose}>
+          {renderTitle()}
+        </BottomSheetHeader>
+      )}
+      {!showCloseIcon && <View style={styles.container}>{renderTitle()}</View>}
+
+      <View style={[styles.container, styles.description]}>
+        {renderDescription()}
+      </View>
+
+      <View style={styles.container}>
+        <Button
+          size={ButtonSize.Lg}
+          onPress={handleButtonPress}
+          label={buttonLabel}
+          variant={ButtonVariants.Primary}
+          width={ButtonWidthTypes.Full}
+        />
+      </View>
+    </BottomSheet>
+  );
+};
+
+export default RampsBottomSheetModal;

--- a/app/components/UI/Ramp/components/RampsBottomSheetModal/RampsBottomSheetModal.types.ts
+++ b/app/components/UI/Ramp/components/RampsBottomSheetModal/RampsBottomSheetModal.types.ts
@@ -1,0 +1,32 @@
+export interface RampsBottomSheetModalParams {
+  /**
+   * Title of the modal - can be a string or React node
+   */
+  title: string | React.ReactNode;
+
+  /**
+   * Description/content of the modal - can be a string or React node
+   */
+  description: string | React.ReactNode;
+
+  /**
+   * Label for the primary button (default: "Got it")
+   */
+  buttonLabel?: string;
+
+  /**
+   * Callback when button is pressed
+   */
+  onButtonPress?: () => void;
+
+  /**
+   * Whether to show the close icon in header (default: true)
+   */
+  showCloseIcon?: boolean;
+}
+
+export interface RampsBottomSheetModalProps {
+  route: {
+    params: RampsBottomSheetModalParams;
+  };
+}

--- a/app/components/UI/Ramp/components/RampsBottomSheetModal/__snapshots__/RampsBottomSheetModal.test.tsx.snap
+++ b/app/components/UI/Ramp/components/RampsBottomSheetModal/__snapshots__/RampsBottomSheetModal.test.tsx.snap
@@ -1,0 +1,282 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RampsBottomSheetModal renders correctly with string title and description 1`] = `
+<RNCSafeAreaProvider
+  onInsetsChange={[Function]}
+  style={
+    [
+      {
+        "flex": 1,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    onLayout={[Function]}
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "flex-end",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "paddingBottom": 0,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "backgroundColor": "#3f434a66",
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          {
+            "opacity": 0,
+          },
+        ]
+      }
+    >
+      <TouchableOpacity
+        onPress={[Function]}
+        style={
+          {
+            "flex": 1,
+          }
+        }
+      />
+    </View>
+    <View
+      onLayout={[Function]}
+      style={
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+          },
+          {
+            "paddingBottom": 0,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        enabled={false}
+        handlerTag={-1}
+        handlerType="PanGestureHandler"
+        onGestureHandlerEvent={[Function]}
+        onGestureHandlerStateChange={[Function]}
+        onLayout={[Function]}
+        style={
+          [
+            {
+              "backgroundColor": "#ffffff",
+              "borderColor": "#b7bbc866",
+              "borderTopLeftRadius": 24,
+              "borderTopRightRadius": 24,
+              "borderWidth": 1,
+              "maxHeight": 640,
+              "overflow": "hidden",
+              "paddingBottom": 0,
+              "shadowColor": "#0000001a",
+              "shadowOffset": {
+                "height": 2,
+                "width": 0,
+              },
+              "shadowOpacity": 1,
+              "shadowRadius": 40,
+            },
+            {
+              "transform": [
+                {
+                  "translateY": 640,
+                },
+              ],
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            [
+              {
+                "backgroundColor": "#ffffff",
+                "flexDirection": "row",
+                "gap": 16,
+                "padding": 16,
+              },
+              false,
+            ]
+          }
+          testID="header"
+        >
+          <View
+            style={
+              {
+                "width": undefined,
+              }
+            }
+          >
+            <View
+              onLayout={[Function]}
+            />
+          </View>
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flex": 1,
+              }
+            }
+          >
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#121314",
+                  "fontFamily": "Geist Bold",
+                  "fontSize": 18,
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                }
+              }
+            >
+              Test Title
+            </Text>
+          </View>
+          <View
+            style={
+              {
+                "width": undefined,
+              }
+            }
+          >
+            <View
+              onLayout={[Function]}
+            >
+              <TouchableOpacity
+                accessible={true}
+                activeOpacity={1}
+                disabled={false}
+                onPress={[Function]}
+                onPressIn={[Function]}
+                onPressOut={[Function]}
+                style={
+                  {
+                    "alignItems": "center",
+                    "borderRadius": 8,
+                    "height": 28,
+                    "justifyContent": "center",
+                    "opacity": 1,
+                    "width": 28,
+                  }
+                }
+              >
+                <SvgMock
+                  color="#121314"
+                  fill="currentColor"
+                  height={20}
+                  name="Close"
+                  style={
+                    {
+                      "height": 20,
+                      "width": 20,
+                    }
+                  }
+                  width={20}
+                />
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+        <View
+          style={
+            [
+              {
+                "paddingHorizontal": 16,
+                "paddingVertical": 24,
+              },
+              {
+                "marginBottom": 24,
+              },
+            ]
+          }
+        >
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#686e7d",
+                "fontFamily": "Geist Regular",
+                "fontSize": 16,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              }
+            }
+          >
+            Test Description
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "paddingHorizontal": 16,
+              "paddingVertical": 24,
+            }
+          }
+        >
+          <TouchableOpacity
+            accessibilityRole="button"
+            accessible={true}
+            activeOpacity={1}
+            onPress={[Function]}
+            onPressIn={[Function]}
+            onPressOut={[Function]}
+            style={
+              {
+                "alignItems": "center",
+                "alignSelf": "stretch",
+                "backgroundColor": "#121314",
+                "borderRadius": 12,
+                "flexDirection": "row",
+                "height": 48,
+                "justifyContent": "center",
+                "overflow": "hidden",
+                "paddingHorizontal": 16,
+              }
+            }
+          >
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#ffffff",
+                  "fontFamily": "Geist Medium",
+                  "fontSize": 16,
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                }
+              }
+            >
+              Test Button
+            </Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </View>
+  </View>
+</RNCSafeAreaProvider>
+`;

--- a/app/components/UI/Ramp/components/RampsBottomSheetModal/index.ts
+++ b/app/components/UI/Ramp/components/RampsBottomSheetModal/index.ts
@@ -1,0 +1,5 @@
+export { default } from './RampsBottomSheetModal';
+export type {
+  RampsBottomSheetModalParams,
+  RampsBottomSheetModalProps,
+} from './RampsBottomSheetModal.types';

--- a/app/components/UI/Ramp/components/UnsupportedRegionModal/UnsupportedRegionModal.styles.ts
+++ b/app/components/UI/Ramp/components/UnsupportedRegionModal/UnsupportedRegionModal.styles.ts
@@ -1,0 +1,15 @@
+import { StyleSheet } from 'react-native';
+import { Theme } from '../../../../../util/theme/models';
+
+const createStyles = (_params: { theme: Theme }) =>
+  StyleSheet.create({
+    contentContainer: {
+      paddingHorizontal: 16,
+    },
+    footerContainer: {
+      paddingHorizontal: 16,
+      paddingVertical: 24,
+    },
+  });
+
+export default createStyles;

--- a/app/components/UI/Ramp/components/UnsupportedRegionModal/UnsupportedRegionModal.test.tsx
+++ b/app/components/UI/Ramp/components/UnsupportedRegionModal/UnsupportedRegionModal.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Metrics, SafeAreaProvider } from 'react-native-safe-area-context';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import UnsupportedRegionModal from './UnsupportedRegionModal';
+
+jest.mock('@react-navigation/native', () => {
+  const actualNav = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualNav,
+    useNavigation: () => ({
+      navigate: jest.fn(),
+    }),
+  };
+});
+
+const mockOnClose = jest.fn();
+
+describe('UnsupportedRegionModal', () => {
+  const initialMetrics: Metrics = {
+    frame: { x: 0, y: 0, width: 320, height: 640 },
+    insets: { top: 0, left: 0, right: 0, bottom: 0 },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders correctly when visible', () => {
+    const { toJSON, getByText } = renderWithProvider(
+      <SafeAreaProvider initialMetrics={initialMetrics}>
+        <UnsupportedRegionModal isVisible onClose={mockOnClose} />
+      </SafeAreaProvider>,
+    );
+
+    expect(getByText('Buy unavailable in your region')).toBeTruthy();
+    expect(
+      getByText(
+        "Buying crypto isn't available in your location due to limitations with local payment providers or regulatory restrictions.",
+      ),
+    ).toBeTruthy();
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('does not render when not visible', () => {
+    const { queryByTestId } = renderWithProvider(
+      <SafeAreaProvider initialMetrics={initialMetrics}>
+        <UnsupportedRegionModal isVisible={false} onClose={mockOnClose} />
+      </SafeAreaProvider>,
+    );
+
+    expect(queryByTestId('ramps-unsupported-region-modal')).toBeNull();
+  });
+
+  it('renders with custom testID', () => {
+    const { getByTestId } = renderWithProvider(
+      <SafeAreaProvider initialMetrics={initialMetrics}>
+        <UnsupportedRegionModal
+          isVisible
+          onClose={mockOnClose}
+          testID="custom-test-id"
+        />
+      </SafeAreaProvider>,
+    );
+
+    expect(getByTestId('custom-test-id')).toBeTruthy();
+    expect(getByTestId('custom-test-id-title')).toBeTruthy();
+    expect(getByTestId('custom-test-id-description')).toBeTruthy();
+  });
+});

--- a/app/components/UI/Ramp/components/UnsupportedRegionModal/UnsupportedRegionModal.tsx
+++ b/app/components/UI/Ramp/components/UnsupportedRegionModal/UnsupportedRegionModal.tsx
@@ -1,0 +1,95 @@
+import React, { useRef, useCallback, useMemo } from 'react';
+import { View } from 'react-native';
+import BottomSheet, {
+  BottomSheetRef,
+} from '../../../../../component-library/components/BottomSheets/BottomSheet';
+import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
+import BottomSheetFooter, {
+  ButtonsAlignment,
+} from '../../../../../component-library/components/BottomSheets/BottomSheetFooter';
+import Text, {
+  TextColor,
+  TextVariant,
+} from '../../../../../component-library/components/Texts/Text';
+import {
+  ButtonSize,
+  ButtonVariants,
+} from '../../../../../component-library/components/Buttons/Button';
+import { useStyles } from '../../../../hooks/useStyles';
+import { strings } from '../../../../../../locales/i18n';
+import { UnsupportedRegionModalProps } from './UnsupportedRegionModal.types';
+import createStyles from './UnsupportedRegionModal.styles';
+import { createNavigationDetails } from '../../../../../util/navigation/navUtils';
+import Routes from '../../../../../constants/navigation/Routes';
+
+export const createUnsupportedRegionModalNavigationDetails =
+  createNavigationDetails(Routes.RAMP.COMPONENTS.UNSUPPORTED_REGION);
+
+const UnsupportedRegionModal = React.memo<UnsupportedRegionModalProps>(
+  ({ isVisible, onClose, testID = 'ramps-unsupported-region-modal' }) => {
+    const { styles } = useStyles(createStyles, {});
+    const bottomSheetRef = useRef<BottomSheetRef>(null);
+
+    const handleGotItPress = useCallback(() => {
+      bottomSheetRef.current?.onCloseBottomSheet();
+    }, []);
+
+    const title = useMemo(() => strings('ramps.unsupported_region.title'), []);
+
+    const description = useMemo(
+      () => strings('ramps.unsupported_region.description'),
+      [],
+    );
+
+    const buttonLabel = useMemo(
+      () => strings('ramps.unsupported_region.got_it_button'),
+      [],
+    );
+
+    const footerButtons = useMemo(
+      () => [
+        {
+          label: buttonLabel,
+          onPress: handleGotItPress,
+          variant: ButtonVariants.Primary,
+          size: ButtonSize.Lg,
+          testID: `${testID}-got-it-button`,
+        },
+      ],
+      [buttonLabel, handleGotItPress, testID],
+    );
+
+    if (!isVisible || !title) return null;
+
+    return (
+      <BottomSheet
+        ref={bottomSheetRef}
+        shouldNavigateBack={false}
+        onClose={onClose}
+        testID={testID}
+      >
+        <BottomSheetHeader>
+          <Text variant={TextVariant.HeadingMD} testID={`${testID}-title`}>
+            {title}
+          </Text>
+        </BottomSheetHeader>
+        <View style={styles.contentContainer}>
+          <Text
+            variant={TextVariant.BodyMD}
+            color={TextColor.Alternative}
+            testID={`${testID}-description`}
+          >
+            {description}
+          </Text>
+        </View>
+        <BottomSheetFooter
+          buttonsAlignment={ButtonsAlignment.Horizontal}
+          buttonPropsArray={footerButtons}
+          style={styles.footerContainer}
+        />
+      </BottomSheet>
+    );
+  },
+);
+
+export default UnsupportedRegionModal;

--- a/app/components/UI/Ramp/components/UnsupportedRegionModal/UnsupportedRegionModal.types.ts
+++ b/app/components/UI/Ramp/components/UnsupportedRegionModal/UnsupportedRegionModal.types.ts
@@ -1,0 +1,16 @@
+export interface UnsupportedRegionModalProps {
+  /**
+   * Visibility state of the modal
+   */
+  isVisible: boolean;
+
+  /**
+   * Function called when modal should close
+   */
+  onClose: () => void;
+
+  /**
+   * Optional test ID for testing
+   */
+  testID?: string;
+}

--- a/app/components/UI/Ramp/components/UnsupportedRegionModal/__snapshots__/UnsupportedRegionModal.test.tsx.snap
+++ b/app/components/UI/Ramp/components/UnsupportedRegionModal/__snapshots__/UnsupportedRegionModal.test.tsx.snap
@@ -1,0 +1,249 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UnsupportedRegionModal renders correctly when visible 1`] = `
+<RNCSafeAreaProvider
+  onInsetsChange={[Function]}
+  style={
+    [
+      {
+        "flex": 1,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    onLayout={[Function]}
+    style={
+      [
+        {
+          "bottom": 0,
+          "justifyContent": "flex-end",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "paddingBottom": 0,
+        },
+      ]
+    }
+    testID="ramps-unsupported-region-modal"
+  >
+    <View
+      style={
+        [
+          {
+            "backgroundColor": "#3f434a66",
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          },
+          {
+            "opacity": 0,
+          },
+        ]
+      }
+    >
+      <TouchableOpacity
+        onPress={[Function]}
+        style={
+          {
+            "flex": 1,
+          }
+        }
+      />
+    </View>
+    <View
+      onLayout={[Function]}
+      style={
+        [
+          {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+          },
+          {
+            "paddingBottom": 0,
+          },
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        enabled={true}
+        handlerTag={-1}
+        handlerType="PanGestureHandler"
+        onGestureHandlerEvent={[Function]}
+        onGestureHandlerStateChange={[Function]}
+        onLayout={[Function]}
+        style={
+          [
+            {
+              "backgroundColor": "#ffffff",
+              "borderColor": "#b7bbc866",
+              "borderTopLeftRadius": 24,
+              "borderTopRightRadius": 24,
+              "borderWidth": 1,
+              "maxHeight": 640,
+              "overflow": "hidden",
+              "paddingBottom": 0,
+              "shadowColor": "#0000001a",
+              "shadowOffset": {
+                "height": 2,
+                "width": 0,
+              },
+              "shadowOpacity": 1,
+              "shadowRadius": 40,
+            },
+            {
+              "transform": [
+                {
+                  "translateY": 640,
+                },
+              ],
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            {
+              "alignItems": "center",
+              "alignSelf": "stretch",
+              "padding": 4,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "backgroundColor": "#b7bbc866",
+                "borderRadius": 2,
+                "height": 4,
+                "width": 40,
+              }
+            }
+          />
+        </View>
+        <View
+          style={
+            [
+              {
+                "backgroundColor": "#ffffff",
+                "flexDirection": "row",
+                "gap": 16,
+                "padding": 16,
+              },
+              false,
+            ]
+          }
+          testID="header"
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flex": 1,
+              }
+            }
+          >
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#121314",
+                  "fontFamily": "Geist Bold",
+                  "fontSize": 18,
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                }
+              }
+              testID="ramps-unsupported-region-modal-title"
+            >
+              Buy unavailable in your region
+            </Text>
+          </View>
+        </View>
+        <View
+          style={
+            {
+              "paddingHorizontal": 16,
+            }
+          }
+        >
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#686e7d",
+                "fontFamily": "Geist Regular",
+                "fontSize": 16,
+                "letterSpacing": 0,
+                "lineHeight": 24,
+              }
+            }
+            testID="ramps-unsupported-region-modal-description"
+          >
+            Buying crypto isn't available in your location due to limitations with local payment providers or regulatory restrictions.
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "backgroundColor": "#ffffff",
+              "flexDirection": "row",
+              "paddingHorizontal": 16,
+              "paddingVertical": 24,
+            }
+          }
+          testID="bottomsheetfooter"
+        >
+          <TouchableOpacity
+            accessibilityRole="button"
+            accessible={true}
+            activeOpacity={1}
+            onPress={[Function]}
+            onPressIn={[Function]}
+            onPressOut={[Function]}
+            style={
+              {
+                "alignItems": "center",
+                "alignSelf": "flex-start",
+                "backgroundColor": "#121314",
+                "borderRadius": 12,
+                "flex": 1,
+                "flexDirection": "row",
+                "height": 48,
+                "justifyContent": "center",
+                "overflow": "hidden",
+                "paddingHorizontal": 16,
+              }
+            }
+            testID="ramps-unsupported-region-modal-got-it-button"
+          >
+            <Text
+              accessibilityRole="text"
+              style={
+                {
+                  "color": "#ffffff",
+                  "fontFamily": "Geist Medium",
+                  "fontSize": 16,
+                  "letterSpacing": 0,
+                  "lineHeight": 24,
+                }
+              }
+            >
+              Got it
+            </Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </View>
+  </View>
+</RNCSafeAreaProvider>
+`;

--- a/app/components/UI/Ramp/components/UnsupportedRegionModal/index.ts
+++ b/app/components/UI/Ramp/components/UnsupportedRegionModal/index.ts
@@ -1,0 +1,3 @@
+export { default } from './UnsupportedRegionModal';
+export { createUnsupportedRegionModalNavigationDetails } from './UnsupportedRegionModal';
+export type { UnsupportedRegionModalProps } from './UnsupportedRegionModal.types';

--- a/app/components/UI/Ramp/components/index.ts
+++ b/app/components/UI/Ramp/components/index.ts
@@ -1,0 +1,4 @@
+export { default as UnsupportedRegionModal } from './UnsupportedRegionModal';
+export { default as ErrorModal } from './ErrorModal';
+export { createUnsupportedRegionModalNavigationDetails } from './UnsupportedRegionModal';
+export { createErrorModalNavigationDetails } from './ErrorModal';

--- a/app/components/UI/Ramp/utils/navigation.test.ts
+++ b/app/components/UI/Ramp/utils/navigation.test.ts
@@ -1,0 +1,49 @@
+import { NavigationProp, ParamListBase } from '@react-navigation/native';
+import { goToRamps } from './navigation';
+import {
+  createUnsupportedRegionModalNavigationDetails,
+  createErrorModalNavigationDetails,
+} from '../components';
+
+jest.mock('../components', () => ({
+  createUnsupportedRegionModalNavigationDetails: jest.fn(() => [
+    'RampComponentsUnsupportedRegionModal',
+    {},
+  ]),
+  createErrorModalNavigationDetails: jest.fn(() => [
+    'RampComponentsErrorModal',
+    {},
+  ]),
+}));
+
+describe('navigation utils', () => {
+  describe('goToRamps', () => {
+    let mockNavigation: NavigationProp<ParamListBase>;
+
+    beforeEach(() => {
+      mockNavigation = {
+        navigate: jest.fn(),
+      } as unknown as NavigationProp<ParamListBase>;
+    });
+
+    it('navigates to unsupported region modal', () => {
+      goToRamps(mockNavigation, 'unsupportedRegion');
+
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
+        'RampComponentsUnsupportedRegionModal',
+        {},
+      );
+      expect(createUnsupportedRegionModalNavigationDetails).toHaveBeenCalled();
+    });
+
+    it('navigates to error modal', () => {
+      goToRamps(mockNavigation, 'error');
+
+      expect(mockNavigation.navigate).toHaveBeenCalledWith(
+        'RampComponentsErrorModal',
+        {},
+      );
+      expect(createErrorModalNavigationDetails).toHaveBeenCalled();
+    });
+  });
+});

--- a/app/components/UI/Ramp/utils/navigation.ts
+++ b/app/components/UI/Ramp/utils/navigation.ts
@@ -1,0 +1,23 @@
+import { NavigationProp, ParamListBase } from '@react-navigation/native';
+import {
+  createUnsupportedRegionModalNavigationDetails,
+  createErrorModalNavigationDetails,
+} from '../components';
+
+export type RampModalType = 'unsupportedRegion' | 'error';
+
+/**
+ * Navigate to a ramps modal
+ * @param navigation - Navigation prop from React Navigation
+ * @param modalType - Type of modal to navigate to ('unsupportedRegion' or 'error')
+ */
+export const goToRamps = (
+  navigation: NavigationProp<ParamListBase>,
+  modalType: RampModalType,
+): void => {
+  if (modalType === 'unsupportedRegion') {
+    navigation.navigate(...createUnsupportedRegionModalNavigationDetails());
+  } else if (modalType === 'error') {
+    navigation.navigate(...createErrorModalNavigationDetails());
+  }
+};

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -26,6 +26,10 @@ const Routes = {
       UNSUPPORTED_REGION: 'RampUnsupportedRegionModal',
       PAYMENT_METHOD_SELECTOR: 'RampPaymentMethodSelectorModal',
     },
+    COMPONENTS: {
+      UNSUPPORTED_REGION: 'RampComponentsUnsupportedRegionModal',
+      ERROR: 'RampComponentsErrorModal',
+    },
   },
   DEPOSIT: {
     ID: 'Deposit',


### PR DESCRIPTION
## **Description**

This PR introduces a **generic `RampsBottomSheetModal`** component to display region-related restrictions when users attempt to buy crypto from unsupported regions.

**What is the reason for the change?**
As a user in an unsupported region, when I click the bottomsheet buy button, I need clear feedback explaining why I cannot proceed with the purchase.

**What is the improvement/solution?**
Created a reusable modal component that displays region-related feedback based on smart routing decisions:
1. **"Unavailable in your region"** - When the region is confirmed as unsupported

The implementation follows the Rewards modal pattern (generic reusable component) and integrates with the existing ramps smart routing infrastructure.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-2796

## **Manual testing steps**

```gherkin
Feature: Region unsupported modals for ramps

  Scenario: user sees unsupported region modal
    Given the user is in an unsupported region
    And smart routing decision is UNSUPPORTED

    When user calls goToRamps from useRampNavigation hook
    Then user sees "Unavailable in your region" modal
    And modal displays "Buying crypto isn't available in your location due to limitations with local payment providers or regulatory restrictions."
    And user can dismiss by tapping "Got it"

  Scenario: user sees eligibility check failed modal
    Given the smart routing decision is ERROR or undefined

    When user calls goToRamps from useRampNavigation hook  
    Then user sees "Eligibility check failed" modal
    And modal displays "We couldn't confirm access based on your region. Please try again. If the issue continues, contact support."
    And user can dismiss by tapping "Got it"
```

### Developer Testing

To test the modals directly:

```typescript
// Test unsupported region modal
navigation.navigate(Routes.RAMP.BOTTOM_SHEET_MODAL, {
  title: strings('fiat_on_ramp.modal.unsupported_region_title'),
  description: strings('fiat_on_ramp.modal.unsupported_region_description'),
  buttonLabel: strings('fiat_on_ramp.modal.default_button'),
});

```

Run unit tests:
```bash
yarn jest app/components/UI/Ramp/components/RampsBottomSheetModal/RampsBottomSheetModal.test.tsx
```

## **Screenshots/Recordings**

### **Before**

No region unsupported modal existed for the unified ramps flow.

### **After**

**Modal 1: Unavailable in your region**
![Unsupported Region Modal](https://github.com/user-attachments/assets/...)
- Title: "Unavailable in your region"
- Description: "Buying crypto isn't available in your location due to limitations with local payment providers or regulatory restrictions."
- Button: "Got it"

**Modal 2: Eligibility check failed**
![Eligibility Check Failed Modal](https://github.com/user-attachments/assets/...)
- Title: "Eligibility check failed"
- Description: "We couldn't confirm access based on your region. Please try again. If the issue continues, contact support."
- Button: "Got it"

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---

## Technical Implementation Details

### Component

**RampsBottomSheetModal** (`app/components/UI/Ramp/components/RampsBottomSheetModal/`)
- Generic BottomSheet-based modal for region restrictions
- Accepts title, description, and button label via navigation params
- Supports both string and React node content
- Optional close icon configuration
- 6 unit tests with full coverage ✓

### Files Changed

**New**:
- `app/components/UI/Ramp/components/RampsBottomSheetModal/` (component, styles, types, tests, snapshots)

**Modified**:
- `app/constants/navigation/Routes.ts` - Added `RAMP.BOTTOM_SHEET_MODAL` route constant
- `app/components/UI/Ramp/Aggregator/routes/index.tsx` - Registered modal in ModalsStack
- `locales/languages/en.json` - Added `fiat_on_ramp.modal` section with strings

### Localization Strings

```json
"fiat_on_ramp": {
  "modal": {
    "unsupported_region_title": "Unavailable in your region",
    "unsupported_region_description": "Buying crypto isn't available...",
    "eligibility_check_failed_title": "Eligibility check failed",
    "eligibility_check_failed_description": "We couldn't confirm access...",
    "default_button": "Got it",
    "contact_support": "Contact support"
  }
}
```

### Integration Ready

The modal is designed to integrate with `useRampNavigation` hook's `goToRamps` function based on smart routing decisions:
- `UnifiedRampRoutingType.UNSUPPORTED` → Shows "Unavailable in your region"

