### PR TITLE
chore(INFRA-3041): Stable Sync workflow update github-tools

### DIFF
--- a/.github/workflows/stable-branch-sync.yml
+++ b/.github/workflows/stable-branch-sync.yml
@@ -37,11 +37,11 @@ jobs:
   run-stable-sync:
     name: Run Stable branch sync
     needs: get-next-version
-    uses: metamask/github-tools/.github/workflows/stable-sync.yml@486f5d113c5524eaab9a058abe76097f83a4c33e
+    uses: metamask/github-tools/.github/workflows/stable-sync.yml@79ce6e3ab56c7f3d0ee0c2cf5900a2522d20be0b
     secrets:
       github-token: ${{ secrets.STABLE_SYNC_TOKEN }}
     with:
       semver-version: ${{ needs.get-next-version.outputs.next-version }}
       repo-type: 'mobile' # Accepts 'mobile' or 'extension'
-      github-tools-version: '486f5d113c5524eaab9a058abe76097f83a4c33e'
+      github-tools-version: '79ce6e3ab56c7f3d0ee0c2cf5900a2522d20be0b'
       stable-branch-name: 'stable'

--- a/.github/workflows/stable-branch-sync.yml
+++ b/.github/workflows/stable-branch-sync.yml
@@ -37,11 +37,11 @@ jobs:
   run-stable-sync:
     name: Run Stable branch sync
     needs: get-next-version
-    uses: metamask/github-tools/.github/workflows/stable-sync.yml@79ce6e3ab56c7f3d0ee0c2cf5900a2522d20be0b
+    uses: metamask/github-tools/.github/workflows/stable-sync.yml@701a894f38883ab48560f948e98b76cc6b4d623f
     secrets:
       github-token: ${{ secrets.STABLE_SYNC_TOKEN }}
     with:
       semver-version: ${{ needs.get-next-version.outputs.next-version }}
       repo-type: 'mobile' # Accepts 'mobile' or 'extension'
-      github-tools-version: '79ce6e3ab56c7f3d0ee0c2cf5900a2522d20be0b'
+      github-tools-version: '701a894f38883ab48560f948e98b76cc6b4d623f'
       stable-branch-name: 'stable'


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Ticket: https://consensyssoftware.atlassian.net/browse/INFRA-3041
Github-tools PR: https://github.com/MetaMask/github-tools/pull/154, https://github.com/MetaMask/github-tools/pull/160

Changelog PR before updates: https://github.com/consensys-test/metamask-mobile-test-workflow/pull/31
Changelog PR after updates: https://github.com/consensys-test/metamask-mobile-test-workflow/pull/37

Summary of Changes

Prevented github-tools from appearing in PRs
File: github-tools/.github/workflows/stable-sync.yml
What: Added explicit cleanup commands to unstage and remove github-tools directory before pushing
Impact: The sync PR will no longer include a github-tools/ submodule or directory
Disabled package.json version bump for Extension
File: github-tools/.github/scripts/stable-sync.js
What: Removed the yarn version logic that bumped package.json version
Before: Extension ran yarn version to update the version
After: Extension now preserves package.json from stable branch (same as mobile)
Impact: No version bump will occur in the sync PR for either mobile or extension
Verified PR title format
File: github-tools/.github/workflows/stable-sync.yml (line 147)
What: Confirmed it already uses release: prefix (no change needed)
Format: "release: sync stable to main for version X.Y.Z"
Testing in Extension: https://github.com/consensys-test/metamask-extension-test-workflow2/pull/209, https://github.com/consensys-test/metamask-extension-test-workflow2/actions/runs/18951817173
Testing in Mobile: https://github.com/consensys-test/metamask-mobile-test-workflow/pull/30, https://github.com/consensys-test/metamask-mobile-test-workflow/actions/runs/18951842114

Testing Post CR comments: https://github.com/consensys-test/metamask-extension-test-workflow2/pull/212


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: None

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the stable branch sync workflow to use metamask/github-tools commit 701a894 for both the reusable workflow and the input version.
> 
> - **CI/Workflows**:
>   - Update `uses` in `.github/workflows/stable-branch-sync.yml` to `metamask/github-tools/.github/workflows/stable-sync.yml@701a894f38883ab48560f948e98b76cc6b4d623f`.
>   - Set `github-tools-version` input to `701a894f38883ab48560f948e98b76cc6b4d623f`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77f51188b1cc71603d3cd233faf0d9708ec80bf3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->