### PR TITLE
fix: Updated main navigator to conditionally show rewards or settings tab

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -695,20 +695,21 @@ const HomeTabs = () => {
         component={TransactionsHome}
         layout={({ children }) => <UnmountOnBlur>{children}</UnmountOnBlur>}
       />
-      {isRewardsEnabled && (
+      {isRewardsEnabled ? (
         <Tab.Screen
           name={Routes.REWARDS_VIEW}
           options={options.rewards}
           component={RewardsHome}
           layout={({ children }) => UnmountOnBlurComponent(children)}
         />
+      ) : (
+        <Tab.Screen
+          name={Routes.SETTINGS_VIEW}
+          options={options.settings}
+          component={SettingsFlow}
+          layout={({ children }) => UnmountOnBlurComponent(children)}
+        />
       )}
-      <Tab.Screen
-        name={Routes.SETTINGS_VIEW}
-        options={options.settings}
-        component={SettingsFlow}
-        layout={({ children }) => UnmountOnBlurComponent(children)}
-      />
     </Tab.Navigator>
   );
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR updated main navigator to conditionally show rewards or settings tab
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="333" height="720" alt="image" src="https://github.com/user-attachments/assets/d901acf6-4da6-46bb-b771-d7ebf5a12343" />

<!-- [screenshots/recordings] -->

### **After**
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2025-11-05 at 08 55 21" src="https://github.com/user-attachments/assets/e131190b-cdbb-4d73-b90a-ac6049141f11" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Home tab bar now displays Rewards when enabled; otherwise Settings, removing the always-present Settings tab.
> 
> - **Navigation**:
>   - **HomeTabs (`app/components/Nav/Main/MainNavigator.js`)**:
>     - Conditionally render either `Routes.REWARDS_VIEW` or `Routes.SETTINGS_VIEW` based on `isRewardsEnabled`.
>     - Remove the unconditional `Routes.SETTINGS_VIEW` tab to prevent both tabs appearing simultaneously.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86e7f212556c394d3c797de162a4c73111810f0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->