### PR TITLE
fix(card): add temporary fix for crashing KYC webview on Android

### DIFF
--- a/app/components/UI/Card/components/Onboarding/VerifyIdentity.tsx
+++ b/app/components/UI/Card/components/Onboarding/VerifyIdentity.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
+import { Platform, Linking } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import OnboardingStep from './OnboardingStep';
 import { strings } from '../../../../../../locales/i18n';
@@ -25,11 +26,19 @@ const VerifyIdentity = () => {
 
   const { sessionUrl } = verificationResponse || {};
 
-  const handleContinue = useCallback(() => {
+  const handleContinue = useCallback(async () => {
     if (sessionUrl) {
-      navigation.navigate(Routes.CARD.ONBOARDING.WEBVIEW, {
-        url: sessionUrl,
-      });
+      if (Platform.OS === 'android') {
+        // On Android, open the URL in the native browser
+        await Linking.openURL(sessionUrl);
+        // Navigate to the validating screen while user completes KYC in browser
+        navigation.navigate(Routes.CARD.ONBOARDING.VALIDATING_KYC);
+      } else {
+        // On iOS, use the WebView
+        navigation.navigate(Routes.CARD.ONBOARDING.WEBVIEW, {
+          url: sessionUrl,
+        });
+      }
     }
 
     trackEvent(

--- a/app/components/UI/Card/routes/OnboardingNavigator.tsx
+++ b/app/components/UI/Card/routes/OnboardingNavigator.tsx
@@ -29,8 +29,9 @@ import Text, {
   TextVariant,
 } from '../../../../component-library/components/Texts/Text';
 import { strings } from '../../../../../locales/i18n';
-import { View, ActivityIndicator } from 'react-native';
+import { View, ActivityIndicator, Alert } from 'react-native';
 import { Box } from '@metamask/design-system-react-native';
+import Logger from '../../../../util/Logger';
 
 const Stack = createStackNavigator();
 
@@ -38,27 +39,48 @@ const KYCModalavigationOptions = ({
   navigation,
 }: {
   navigation: NavigationProp<ParamListBase>;
-}): StackNavigationOptions => ({
-  headerLeft: () => <View />,
-  headerTitle: () => (
-    <Text
-      variant={TextVariant.HeadingSM}
-      style={headerStyle.title}
-      testID={'card-view-title'}
-    >
-      {strings('card.card')}
-    </Text>
-  ),
-  headerRight: () => (
-    <ButtonIcon
-      style={headerStyle.icon}
-      size={ButtonIconSizes.Lg}
-      iconName={IconName.Close}
-      testID="close-button"
-      onPress={() => navigation.navigate(Routes.CARD.ONBOARDING.VALIDATING_KYC)}
-    />
-  ),
-});
+}): StackNavigationOptions => {
+  const handleClosePress = () => {
+    Alert.alert(
+      strings('card.card_onboarding.kyc_webview.close_confirmation_title'),
+      strings('card.card_onboarding.kyc_webview.close_confirmation_message'),
+      [
+        {
+          text: strings('card.card_onboarding.kyc_webview.cancel_button'),
+          style: 'cancel',
+        },
+        {
+          text: strings('card.card_onboarding.kyc_webview.close_button'),
+          onPress: () =>
+            navigation.navigate(Routes.CARD.ONBOARDING.VALIDATING_KYC),
+          style: 'destructive',
+        },
+      ],
+    );
+  };
+
+  return {
+    headerLeft: () => <View />,
+    headerTitle: () => (
+      <Text
+        variant={TextVariant.HeadingSM}
+        style={headerStyle.title}
+        testID={'card-view-title'}
+      >
+        {strings('card.card')}
+      </Text>
+    ),
+    headerRight: () => (
+      <ButtonIcon
+        style={headerStyle.icon}
+        size={ButtonIconSizes.Lg}
+        iconName={IconName.Close}
+        testID="close-button"
+        onPress={handleClosePress}
+      />
+    ),
+  };
+};
 
 const ValidatingKYCNavigationOptions = ({
   navigation,
@@ -91,6 +113,8 @@ const ValidatingKYCNavigationOptions = ({
 const OnboardingNavigator: React.FC = () => {
   const onboardingId = useSelector(selectOnboardingId);
   const { user, isLoading } = useCardSDK();
+  Logger.log('onboardingId', onboardingId);
+  Logger.log('user', user);
 
   const getInitialRouteName = useCallback(() => {
     if (!onboardingId || !user?.id) {

--- a/app/components/UI/Card/routes/OnboardingNavigator.tsx
+++ b/app/components/UI/Card/routes/OnboardingNavigator.tsx
@@ -33,7 +33,7 @@ import { View, ActivityIndicator, Alert } from 'react-native';
 import { Box } from '@metamask/design-system-react-native';
 const Stack = createStackNavigator();
 
-const KYCModalavigationOptions = ({
+export const KYCModalNavigationOptions = ({
   navigation,
 }: {
   navigation: NavigationProp<ParamListBase>;
@@ -202,7 +202,7 @@ const OnboardingNavigator: React.FC = () => {
       <Stack.Screen
         name={Routes.CARD.ONBOARDING.WEBVIEW}
         component={KYCWebview}
-        options={KYCModalavigationOptions}
+        options={KYCModalNavigationOptions}
       />
     </Stack.Navigator>
   );

--- a/app/components/UI/Card/routes/OnboardingNavigator.tsx
+++ b/app/components/UI/Card/routes/OnboardingNavigator.tsx
@@ -31,8 +31,6 @@ import Text, {
 import { strings } from '../../../../../locales/i18n';
 import { View, ActivityIndicator, Alert } from 'react-native';
 import { Box } from '@metamask/design-system-react-native';
-import Logger from '../../../../util/Logger';
-
 const Stack = createStackNavigator();
 
 const KYCModalavigationOptions = ({
@@ -113,8 +111,6 @@ const ValidatingKYCNavigationOptions = ({
 const OnboardingNavigator: React.FC = () => {
   const onboardingId = useSelector(selectOnboardingId);
   const { user, isLoading } = useCardSDK();
-  Logger.log('onboardingId', onboardingId);
-  Logger.log('user', user);
 
   const getInitialRouteName = useCallback(() => {
     if (!onboardingId || !user?.id) {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6193,6 +6193,12 @@
         "verify_button": "Start verification",
         "start_verification_error": "Error starting verification. Please try again shortly."
       },
+      "kyc_webview": {
+        "close_confirmation_title": "Exit verification?",
+        "close_confirmation_message": "If you exit now, you'll need to restart the identity verification process. Are you sure you want to exit?",
+        "cancel_button": "Stay",
+        "close_button": "Exit"
+      },
       "validating_kyc": {
         "title": "Validating your KYC...",
         "timeout_button": "Restart verification"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR introduces a temporary workaround for the Android KYC verification flow.
Instead of launching the embedded WebView during the Card onboarding process, it now opens the user’s native browser.

The change addresses a crash caused by MetaMask’s custom WebView library, which fails under this specific KYC scenario.

Additionally, this PR adds a confirmation alert when the user attempts to close the KYC page, improving user experience and preventing accidental exits.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Android crash during KYC verification caused by the custom WebView implementation.
CHANGELOG entry: KYC verification flow now opens in the native browser instead of an embedded view.
CHANGELOG entry: Confirmation alert when closing the KYC verification page.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Route Android KYC to the native browser and add a close-confirmation dialog for the KYC WebView; update navigator wiring, i18n, and tests.
> 
> - **Card Onboarding (KYC flow)**:
>   - **`VerifyIdentity`**: On Android, open `sessionUrl` via `Linking.openURL` then navigate to `Routes.CARD.ONBOARDING.VALIDATING_KYC`; iOS continues to `WEBVIEW`. Make `handleContinue` async and platform-aware.
>   - **Navigation**: Export and use `KYCModalNavigationOptions` that shows an `Alert` confirming exit from the KYC WebView; wire it to `Routes.CARD.ONBOARDING.WEBVIEW`.
> - **Tests**:
>   - Add/expand platform-specific tests for Android/iOS behaviors, `Linking.openURL` call order, multiple button presses, and absence of navigation without `sessionUrl` in `VerifyIdentity.test.tsx`.
>   - Add tests for header buttons, alert actions, and title rendering in `OnboardingNavigator.test.tsx`; update mocks accordingly.
> - **i18n**: Add `card.card_onboarding.kyc_webview.*` strings for the close-confirmation alert.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 861e222d549cb2fe5ae3e609fa79765871470523. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->