### PR TITLE
fix: Deduplicate y-axis values in TradingView chart

### DIFF
--- a/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.html
+++ b/app/components/UI/Perps/components/TradingViewChart/TradingViewChart.html
@@ -107,6 +107,7 @@ PERFORMANCE OPTIMIZATIONS:
         window.lastDataKey = null; // Track the last dataset to avoid unnecessary autoscaling
         window.visibleCandleCount = 45; // Default visible candle count
         window.allCandleData = []; // Store all loaded data for zoom functionality
+        window.visiblePriceRange = null; // Track visible price range for dynamic decimal precision
         
         // Zoom limits - consistent with chart configuration
         window.ZOOM_LIMITS = {
@@ -184,40 +185,68 @@ PERFORMANCE OPTIMIZATIONS:
                     },
                     localization: {
                         priceFormatter: (price) => {
-                            // Smart decimal precision based on price value and range
-                            const absPrice = Math.abs(price);
+                            // Dynamic Y-axis formatter that adjusts precision based on visible price range
+                            // This prevents duplicate labels (e.g., "160 160 161 161") by using more decimals when zoomed in
                             
-                            if (absPrice >= 1000) {
-                                // For large values (like ETH), show no decimals
+                            if (price === 0) return '0.00';
+
+                            const absPrice = Math.abs(price);
+
+                            // For values >= 1, use dynamic precision based on visible range
+                            if (absPrice >= 1) {
+                                let targetDecimals;
+
+                                // Use visible price range to determine precision (prevents duplicates when zoomed in)
+                                if (window.visiblePriceRange && window.visiblePriceRange.span > 0) {
+                                    const span = window.visiblePriceRange.span;
+                                    
+                                    if (span < 1) {
+                                        // Very tight range (e.g., 160.00-160.50): use 4 decimals
+                                        targetDecimals = 4;
+                                    } else if (span < 10) {
+                                        // Tight range (e.g., 160-165): use 3 decimals
+                                        targetDecimals = 3;
+                                    } else if (span < 100) {
+                                        // Medium range (e.g., 100-200): use 2 decimals
+                                        targetDecimals = 2;
+                                    } else {
+                                        // Wide range (e.g., 0-1000): use 1 decimal
+                                        targetDecimals = 1;
+                                    }
+                                } else {
+                                    // Fallback to price-based rules when range not available
+                                    if (absPrice >= 100) {
+                                        targetDecimals = 2; // Increased from 0 to prevent duplicates
+                                    } else if (absPrice >= 10) {
+                                        targetDecimals = 2;
+                                    } else {
+                                        targetDecimals = 3;
+                                    }
+                                }
+
+                                // Round to prevent floating-point artifacts (e.g., 2.820000000000003 → 2.82)
+                                const roundedPrice = Number(price.toFixed(targetDecimals));
+
                                 return new Intl.NumberFormat('en-US', {
-                                    minimumFractionDigits: 0,
-                                    maximumFractionDigits: 0
-                                }).format(price);
-                            } else if (absPrice >= 100) {
-                                // For medium values, show 1 decimal place
-                                return new Intl.NumberFormat('en-US', {
-                                    minimumFractionDigits: 1,
-                                    maximumFractionDigits: 1
-                                }).format(price);
-                            } else if (absPrice >= 1) {
-                                // For small values, show 2 decimal places
-                                return new Intl.NumberFormat('en-US', {
-                                    minimumFractionDigits: 2,
-                                    maximumFractionDigits: 2
-                                }).format(price);
-                            } else if (absPrice >= 0.01) {
-                                // For very small values, show 4 decimal places
-                                return new Intl.NumberFormat('en-US', {
-                                    minimumFractionDigits: 4,
-                                    maximumFractionDigits: 4
-                                }).format(price);
-                            } else {
-                                // For extremely small values (like PUMP-USD), show 6 decimal places
-                                return new Intl.NumberFormat('en-US', {
-                                    minimumFractionDigits: 6,
-                                    maximumFractionDigits: 6
-                                }).format(price);
+                                    minimumFractionDigits: 0, // Allow trailing zeros to be removed
+                                    maximumFractionDigits: targetDecimals
+                                }).format(roundedPrice);
                             }
+
+                            // For values < 1, use 4 significant figures
+                            // Examples: 0.1234, 0.01234
+                            const precisionStr = absPrice.toPrecision(4);
+                            const precisionNum = parseFloat(precisionStr);
+                            const valueStr = precisionNum.toString();
+                            const [, decPart = ''] = valueStr.split('.');
+                            const actualDecimals = Math.min(decPart.length, 10);
+
+                            const finalValue = price < 0 ? -precisionNum : precisionNum;
+
+                            return new Intl.NumberFormat('en-US', {
+                                minimumFractionDigits: 0,
+                                maximumFractionDigits: actualDecimals
+                            }).format(finalValue);
                         },
                         timeFormatter: (time) => {
                             // Format time in user's local timezone for crosshair labels
@@ -411,6 +440,68 @@ PERFORMANCE OPTIMIZATIONS:
             });
             
             return window.candlestickSeries;
+        };
+        
+        // Function to update visible price range for dynamic formatting
+        window.updateVisiblePriceRange = function() {
+            if (!window.allCandleData || window.allCandleData.length === 0) {
+                return;
+            }
+            
+            try {
+                // Get visible range from time scale
+                const timeScale = window.chart.timeScale();
+                const visibleLogicalRange = timeScale.getVisibleLogicalRange();
+                
+                if (!visibleLogicalRange) {
+                    // Fallback: use all data
+                    let minPrice = Infinity;
+                    let maxPrice = -Infinity;
+                    
+                    window.allCandleData.forEach(candle => {
+                        if (candle && candle.low !== undefined && candle.high !== undefined) {
+                            minPrice = Math.min(minPrice, candle.low);
+                            maxPrice = Math.max(maxPrice, candle.high);
+                        }
+                    });
+                    
+                    if (minPrice !== Infinity && maxPrice !== -Infinity) {
+                        window.visiblePriceRange = {
+                            min: minPrice,
+                            max: maxPrice,
+                            span: maxPrice - minPrice
+                        };
+                    }
+                    return;
+                }
+                
+                // Calculate visible data indices
+                const firstVisibleIndex = Math.max(0, Math.ceil(visibleLogicalRange.from));
+                const lastVisibleIndex = Math.min(window.allCandleData.length - 1, Math.floor(visibleLogicalRange.to));
+                
+                if (firstVisibleIndex <= lastVisibleIndex) {
+                    let minPrice = Infinity;
+                    let maxPrice = -Infinity;
+                    
+                    for (let i = firstVisibleIndex; i <= lastVisibleIndex; i++) {
+                        const candle = window.allCandleData[i];
+                        if (candle && candle.low !== undefined && candle.high !== undefined) {
+                            minPrice = Math.min(minPrice, candle.low);
+                            maxPrice = Math.max(maxPrice, candle.high);
+                        }
+                    }
+                    
+                    if (minPrice !== Infinity && maxPrice !== -Infinity) {
+                        window.visiblePriceRange = {
+                            min: minPrice,
+                            max: maxPrice,
+                            span: maxPrice - minPrice
+                        };
+                    }
+                }
+            } catch (error) {
+                console.error('Error updating visible price range:', error);
+            }
         };
         
         // Function to create/update current price line
@@ -623,6 +714,9 @@ PERFORMANCE OPTIMIZATIONS:
             }
             
             window.visibleCandleCount = actualCandleCount;
+            
+            // Update visible price range for dynamic formatting after zoom
+            window.updateVisiblePriceRange();
         };
 
         // Update TPSL price lines
@@ -909,6 +1003,9 @@ PERFORMANCE OPTIMIZATIONS:
                                     window.applyZoom(window.visibleCandleCount, true);
                                     console.log('📊 TradingView: Applied initial zoom to', window.visibleCandleCount, 'candles');
                                 }
+                                
+                                // Update visible price range for dynamic formatting
+                                window.updateVisiblePriceRange();
                                 
                                 // Mark initial load as complete
                                 window.isInitialDataLoad = false;

--- a/app/components/UI/Perps/components/TradingViewChart/TradingViewChartTemplate.tsx
+++ b/app/components/UI/Perps/components/TradingViewChart/TradingViewChartTemplate.tsx
@@ -50,6 +50,7 @@ export const createTradingViewChartTemplate = (
         window.lastDataKey = null; // Track the last dataset to avoid unnecessary autoscaling
         window.visibleCandleCount = 45; // Default visible candle count
         window.allCandleData = []; // Store all loaded data for zoom functionality
+        window.visiblePriceRange = null; // Track visible price range for dynamic decimal precision
         
         // Smart timestamp formatter using TradingView's native tickMarkType with fallback
         window.formatTimestamp = function(time, tickMarkType, isCrosshair = false) {
@@ -247,42 +248,50 @@ export const createTradingViewChartTemplate = (
                     },
                     localization: {
                         priceFormatter: (price) => {
-                            // Specialized chart Y-axis formatter with space constraints
-                            // Different rules than price displays to keep axis labels compact
-                            // Rules:
-                            // - ≥$100: No decimals (e.g., BTC: 121,613 not 121,612.50 - too long)
-                            // - $10-$100: 2 decimals (e.g., 56.12)
-                            // - $1-$10: 3 decimals for 4 sig figs (e.g., XRP: 2.801)
-                            // - <$1: 4 sig figs (e.g., 0.1234)
-
+                            // Dynamic Y-axis formatter that adjusts precision based on visible price range
+                            // This prevents duplicate labels (e.g., "160 160 161 161") by using more decimals when zoomed in
+                            
                             if (price === 0) return '0.00';
 
                             const absPrice = Math.abs(price);
 
-                            // For values >= 1, calculate decimals based on magnitude with chart space constraints
+                            // For values >= 1, use dynamic precision based on visible range
                             if (absPrice >= 1) {
                                 let targetDecimals;
 
-                                if (absPrice >= 100) {
-                                    // ≥$100: No decimals for compact display on Y-axis
-                                    // BTC example: 121,613 instead of 121,612.50 (saves space)
-                                    targetDecimals = 0;
-                                } else if (absPrice >= 10) {
-                                    // $10-$100: 2 decimals (currency standard)
-                                    // Example: 56.12, 89.45
-                                    targetDecimals = 2;
+                                // Use visible price range to determine precision (prevents duplicates when zoomed in)
+                                if (window.visiblePriceRange && window.visiblePriceRange.span > 0) {
+                                    const span = window.visiblePriceRange.span;
+                                    
+                                    if (span < 1) {
+                                        // Very tight range (e.g., 160.00-160.50): use 4 decimals
+                                        targetDecimals = 4;
+                                    } else if (span < 10) {
+                                        // Tight range (e.g., 160-165): use 3 decimals
+                                        targetDecimals = 3;
+                                    } else if (span < 100) {
+                                        // Medium range (e.g., 100-200): use 2 decimals
+                                        targetDecimals = 2;
+                                    } else {
+                                        // Wide range (e.g., 0-1000): use 1 decimal
+                                        targetDecimals = 1;
+                                    }
                                 } else {
-                                    // $1-$10: 3 decimals for 4 sig figs
-                                    // XRP example: 2.801 (1 integer + 3 decimals = 4 sig figs)
-                                    // SOL example: 5.123 (1 integer + 3 decimals = 4 sig figs)
-                                    targetDecimals = 3;
+                                    // Fallback to price-based rules when range not available
+                                    if (absPrice >= 100) {
+                                        targetDecimals = 2; // Increased from 0 to prevent duplicates
+                                    } else if (absPrice >= 10) {
+                                        targetDecimals = 2;
+                                    } else {
+                                        targetDecimals = 3;
+                                    }
                                 }
 
                                 // Round to prevent floating-point artifacts (e.g., 2.820000000000003 → 2.82)
                                 const roundedPrice = Number(price.toFixed(targetDecimals));
 
                                 return new Intl.NumberFormat('en-US', {
-                                    minimumFractionDigits: targetDecimals,
+                                    minimumFractionDigits: 0, // Allow trailing zeros to be removed
                                     maximumFractionDigits: targetDecimals
                                 }).format(roundedPrice);
                             }
@@ -472,6 +481,68 @@ export const createTradingViewChartTemplate = (
             });
             
             return window.candlestickSeries;
+        };
+        
+        // Function to update visible price range for dynamic formatting
+        window.updateVisiblePriceRange = function() {
+            if (!window.allCandleData || window.allCandleData.length === 0) {
+                return;
+            }
+            
+            try {
+                // Get visible range from time scale
+                const timeScale = window.chart.timeScale();
+                const visibleLogicalRange = timeScale.getVisibleLogicalRange();
+                
+                if (!visibleLogicalRange) {
+                    // Fallback: use all data
+                    let minPrice = Infinity;
+                    let maxPrice = -Infinity;
+                    
+                    window.allCandleData.forEach(candle => {
+                        if (candle && candle.low !== undefined && candle.high !== undefined) {
+                            minPrice = Math.min(minPrice, candle.low);
+                            maxPrice = Math.max(maxPrice, candle.high);
+                        }
+                    });
+                    
+                    if (minPrice !== Infinity && maxPrice !== -Infinity) {
+                        window.visiblePriceRange = {
+                            min: minPrice,
+                            max: maxPrice,
+                            span: maxPrice - minPrice
+                        };
+                    }
+                    return;
+                }
+                
+                // Calculate visible data indices
+                const firstVisibleIndex = Math.max(0, Math.ceil(visibleLogicalRange.from));
+                const lastVisibleIndex = Math.min(window.allCandleData.length - 1, Math.floor(visibleLogicalRange.to));
+                
+                if (firstVisibleIndex <= lastVisibleIndex) {
+                    let minPrice = Infinity;
+                    let maxPrice = -Infinity;
+                    
+                    for (let i = firstVisibleIndex; i <= lastVisibleIndex; i++) {
+                        const candle = window.allCandleData[i];
+                        if (candle && candle.low !== undefined && candle.high !== undefined) {
+                            minPrice = Math.min(minPrice, candle.low);
+                            maxPrice = Math.max(maxPrice, candle.high);
+                        }
+                    }
+                    
+                    if (minPrice !== Infinity && maxPrice !== -Infinity) {
+                        window.visiblePriceRange = {
+                            min: minPrice,
+                            max: maxPrice,
+                            span: maxPrice - minPrice
+                        };
+                    }
+                }
+            } catch (error) {
+                console.error('Error updating visible price range:', error);
+            }
         };
         
         // Function to create/update current price line
@@ -709,6 +780,9 @@ export const createTradingViewChartTemplate = (
             }
             
             window.visibleCandleCount = actualCandleCount;
+            
+            // Update visible price range for dynamic formatting after zoom
+            window.updateVisiblePriceRange();
         };
 
         // Update TPSL price lines
@@ -880,6 +954,9 @@ export const createTradingViewChartTemplate = (
                                     window.applyZoom(window.visibleCandleCount, true);
                                     console.log('📊 TradingView: Applied initial zoom to', window.visibleCandleCount, 'candles');
                                 }
+                                
+                                // Update visible price range for dynamic formatting
+                                window.updateVisiblePriceRange();
                                 
                                 // Mark initial load as complete
                                 window.isInitialDataLoad = false;


### PR DESCRIPTION
## **Description**

We noticed that during certain candle intervals (eg SOL-USD) that there wasn't enough distinction between the y-axis intervals to register as a significant step increment in the chart.

For assets like SOL-USD trading around $160, the chart would display multiple candles with slightly different prices within a small range (e.g., 160.12, 160.34, 160.56, 160.78). When these prices were formatted with only 1 decimal place, they would all round to the same values

The bug was in the `priceFormatter` function, where we weren't being smart enough about calculating the visible range.

Instead of using a fixed number of decimals based solely on the price magnitude, this fix implements dynamic precision that adapts to the visible price range:

- Min price in visible range
- Max price in visible range
- Span (max - min)

Then, based on this span, we can dynamically set the target decimals. It's important to handle this in the webview itself, since the values are dynamic as the user navigates the chart, rather than relying on post messages to pass props from React into the WebView.

## **Changelog**

CHANGELOG entry: Dynamically calculate y-axis precision in Perps chart

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1919

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="400" height="1770" alt="Screenshot 2025-11-05 at 8 32 58 AM" src="https://github.com/user-attachments/assets/edf741ac-b96e-4234-8449-2aa16598eb32" />

### **After**

https://github.com/user-attachments/assets/fa0fcea1-0c66-4982-87e5-28bb7462e8b4

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts Y-axis price label precision dynamically from the visible price range, updating on zoom and initial data load to prevent duplicate labels.
> 
> - **Perps TradingView chart**:
>   - **Dynamic Y-axis precision**: Replaces magnitude-based `priceFormatter` with range-aware formatting using `window.visiblePriceRange`; adds rounding to avoid FP artifacts and 4-sig-fig handling for values < 1.
>   - **State & utilities**: Introduces `window.visiblePriceRange` and new `window.updateVisiblePriceRange()` to compute min/max/span from visible candles.
>   - **Lifecycle hooks**: Calls `updateVisiblePriceRange()` after initial data load and on `applyZoom()` to keep labels consistent during navigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fede60cb3dab7d9c1e0cc76e28e759102628583f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->