### PR TITLE
chore(predict): bug bash changes

### DIFF
--- a/app/components/UI/Predict/components/PredictAmountDisplay/PredictAmountDisplay.test.tsx
+++ b/app/components/UI/Predict/components/PredictAmountDisplay/PredictAmountDisplay.test.tsx
@@ -1,5 +1,5 @@
+import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
 import { PerpsAmountDisplaySelectorsIDs } from '../../../../../../e2e/selectors/Perps/Perps.selectors';
 import PredictAmountDisplay from './PredictAmountDisplay';
 

--- a/app/components/UI/Predict/components/PredictAmountDisplay/PredictAmountDisplay.tsx
+++ b/app/components/UI/Predict/components/PredictAmountDisplay/PredictAmountDisplay.tsx
@@ -101,7 +101,7 @@ const PredictAmountDisplay: React.FC<PredictAmountDisplayProps> = ({
           <Animated.View
             testID="cursor"
             style={[
-              tw.style('w-0.5 h-13.5 ml-1'),
+              tw.style(`w-0.5 h-[${lineHeight - 4}px] ml-0.5`),
               {
                 opacity: fadeAnim,
                 backgroundColor: colors.text.default,

--- a/app/components/UI/Predict/components/PredictFeeSummary/PredictFeeSummary.tsx
+++ b/app/components/UI/Predict/components/PredictFeeSummary/PredictFeeSummary.tsx
@@ -1,18 +1,11 @@
-import React from 'react';
 import { Box } from '@metamask/design-system-react-native';
+import React from 'react';
+import { strings } from '../../../../../../locales/i18n';
 import Text, {
   TextColor,
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
 import { formatPrice } from '../../utils/format';
-import ButtonIcon, {
-  ButtonIconSizes,
-} from '../../../../../component-library/components/Buttons/ButtonIcon';
-import {
-  IconColor,
-  IconName,
-} from '../../../../../component-library/components/Icons/Icon';
-import { strings } from '../../../../../../locales/i18n';
 
 interface PredictFeeSummaryProps {
   disabled: boolean;
@@ -37,11 +30,6 @@ const PredictFeeSummary: React.FC<PredictFeeSummaryProps> = ({
           <Text color={TextColor.Alternative} variant={TextVariant.BodyMD}>
             {strings('predict.fee_summary.provider_fee')}
           </Text>
-          <ButtonIcon
-            iconName={IconName.Info}
-            size={ButtonIconSizes.Sm}
-            iconColor={IconColor.Alternative}
-          />
         </Box>
         <Text color={TextColor.Alternative}>
           {formatPrice(providerFee, {
@@ -54,11 +42,6 @@ const PredictFeeSummary: React.FC<PredictFeeSummaryProps> = ({
           <Text color={TextColor.Alternative} variant={TextVariant.BodyMD}>
             {strings('predict.fee_summary.metamask_fee')}
           </Text>
-          <ButtonIcon
-            iconName={IconName.Info}
-            size={ButtonIconSizes.Sm}
-            iconColor={IconColor.Alternative}
-          />
         </Box>
         <Text color={TextColor.Alternative}>
           {formatPrice(metamaskFee, {
@@ -71,11 +54,6 @@ const PredictFeeSummary: React.FC<PredictFeeSummaryProps> = ({
           <Text color={TextColor.Alternative} variant={TextVariant.BodyMD}>
             {strings('predict.fee_summary.total')}
           </Text>
-          <ButtonIcon
-            iconName={IconName.Info}
-            size={ButtonIconSizes.Sm}
-            iconColor={IconColor.Alternative}
-          />
         </Box>
         <Text color={TextColor.Alternative}>
           {formatPrice(total, {

--- a/app/components/UI/Predict/components/PredictPosition/PredictPosition.styles.ts
+++ b/app/components/UI/Predict/components/PredictPosition/PredictPosition.styles.ts
@@ -23,11 +23,14 @@ const styleSheet = () =>
       width: '100%',
       flex: 5,
     },
+    positionImageContainer: {
+      paddingTop: 4,
+    },
     positionImage: {
       width: 40,
       height: 40,
       borderRadius: 100,
-      alignSelf: 'center',
+      alignSelf: 'flex-start',
     },
     positionPnl: {
       flexDirection: 'column',

--- a/app/components/UI/Predict/components/PredictPosition/PredictPosition.tsx
+++ b/app/components/UI/Predict/components/PredictPosition/PredictPosition.tsx
@@ -36,16 +36,11 @@ const PredictPosition: React.FC<PredictPositionProps> = ({
       style={styles.positionContainer}
       onPress={() => onPress?.(position)}
     >
-      <View style={styles.positionImage}>
+      <View style={styles.positionImageContainer}>
         <Image source={{ uri: icon }} style={styles.positionImage} />
       </View>
       <View style={styles.positionDetails}>
-        <Text
-          variant={TextVariant.BodyMDMedium}
-          color={TextColor.Default}
-          numberOfLines={1}
-          ellipsizeMode="tail"
-        >
+        <Text variant={TextVariant.BodyMDMedium} color={TextColor.Default}>
           {title}
         </Text>
         <Text variant={TextVariant.BodySMMedium} color={TextColor.Alternative}>

--- a/app/components/UI/Predict/components/PredictPositionDetail/PredictPositionDetail.test.tsx
+++ b/app/components/UI/Predict/components/PredictPositionDetail/PredictPositionDetail.test.tsx
@@ -17,12 +17,8 @@ declare global {
 }
 
 jest.mock('../../../../../../locales/i18n', () => ({
-  strings: (key: string, vars?: Record<string, string | number>) => {
+  strings: (key: string, _vars?: Record<string, string | number>) => {
     switch (key) {
-      case 'predict.market_details.amount_on_outcome':
-        return `$${vars?.amount} on ${vars?.outcome}`;
-      case 'predict.market_details.outcome_at_price':
-        return `${vars?.outcome} at ${vars?.price}¢`;
       case 'predict.market_details.won':
         return 'Won';
       case 'predict.market_details.lost':
@@ -189,8 +185,10 @@ describe('PredictPositionDetail', () => {
   it('renders open position with current value, percent change and cash out', () => {
     renderComponent();
 
-    expect(screen.getByText('$123.45 on Yes')).toBeOnTheScreen();
-    expect(screen.getByText('Yes at 34¢')).toBeOnTheScreen();
+    expect(screen.getByText('Group')).toBeOnTheScreen();
+    expect(
+      screen.getByText('$123.45 on Yes • 34¢', { exact: false }),
+    ).toBeOnTheScreen();
 
     expect(screen.getByText('$2,345.67')).toBeOnTheScreen();
     expect(screen.getByText('+5.25%')).toBeOnTheScreen();
@@ -210,8 +208,10 @@ describe('PredictPositionDetail', () => {
   it('renders initial value line and avgPrice cents', () => {
     renderComponent({ initialValue: 50, outcome: 'No', avgPrice: 0.7 });
 
-    expect(screen.getByText('$50.00 on No')).toBeOnTheScreen();
-    expect(screen.getByText('No at 70¢')).toBeOnTheScreen();
+    expect(screen.getByText('Group')).toBeOnTheScreen();
+    expect(
+      screen.getByText('$50.00 on No • 70¢', { exact: false }),
+    ).toBeOnTheScreen();
   });
 
   it('renders won result with current value when market is closed and percent positive', () => {

--- a/app/components/UI/Predict/components/PredictPositionDetail/PredictPositionDetail.tsx
+++ b/app/components/UI/Predict/components/PredictPositionDetail/PredictPositionDetail.tsx
@@ -37,8 +37,16 @@ const PredictPosition: React.FC<PredictPositionProps> = ({
   marketStatus,
 }: PredictPositionProps) => {
   const tw = useTailwind();
-  const { icon, initialValue, percentPnl, outcome, avgPrice, currentValue } =
-    position;
+
+  const {
+    icon,
+    initialValue,
+    percentPnl,
+    outcome,
+    avgPrice,
+    currentValue,
+    title,
+  } = position;
   const navigation =
     useNavigation<NavigationProp<PredictNavigationParamList>>();
   const { navigate } = navigation;
@@ -46,6 +54,10 @@ const PredictPosition: React.FC<PredictPositionProps> = ({
     providerId: position.providerId,
     navigation,
   });
+
+  const groupItemTitle = market?.outcomes.find(
+    (o) => o.id === position.outcomeId && o.groupItemTitle,
+  )?.groupItemTitle;
 
   const onCashOut = () => {
     executeGuardedAction(() => {
@@ -91,38 +103,34 @@ const PredictPosition: React.FC<PredictPositionProps> = ({
   };
 
   return (
-    <Box twClassName="w-full p-4 mb-4 gap-3 bg-background-muted rounded-xl">
+    <Box twClassName="w-full p-4 mb-4 gap-3 bg-background-muted rounded-xl justify-between">
       <Box twClassName="flex-row items-start gap-4">
         {Boolean(icon) && (
-          <Image
-            source={{ uri: icon }}
-            resizeMode="cover"
-            style={tw.style('w-10 h-10 rounded-lg self-center')}
-          />
+          <Box twClassName="w-10 h-10 self-start mt-1">
+            <Image
+              source={{ uri: icon }}
+              resizeMode="cover"
+              style={tw.style('w-full h-full rounded-lg')}
+            />
+          </Box>
         )}
-        <Box>
+        <Box twClassName="flex-1">
           <Text
             variant={TextVariant.BodyMDMedium}
             color={TextColor.Default}
-            numberOfLines={1}
             ellipsizeMode="tail"
           >
-            {strings('predict.market_details.amount_on_outcome', {
-              amount: initialValue.toFixed(2),
-              outcome,
-            })}
+            {groupItemTitle ?? title}
           </Text>
           <Text
             variant={TextVariant.BodySMMedium}
             color={TextColor.Alternative}
           >
-            {strings('predict.market_details.outcome_at_price', {
-              outcome,
-              price: (avgPrice * 100).toFixed(0),
-            })}
+            ${initialValue.toFixed(2)} on {outcome} •{' '}
+            {(avgPrice * 100).toFixed(0)}¢
           </Text>
         </Box>
-        <Box twClassName="items-end justify-end ml-auto">
+        <Box twClassName="items-end justify-end ml-auto shrink-0">
           {renderValueText()}
           {marketStatus === PredictMarketStatus.OPEN && (
             <Text

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -597,7 +597,7 @@ describe('PredictMarketDetails', () => {
       expect(screen.getByText('12/31/2024')).toBeOnTheScreen();
     });
 
-    it('displays provider information', () => {
+    it('displays resolution details information', () => {
       setupPredictMarketDetailsTest();
 
       const aboutTab = screen.getByTestId(
@@ -606,23 +606,9 @@ describe('PredictMarketDetails', () => {
       fireEvent.press(aboutTab);
 
       expect(
-        screen.getByText('predict.market_details.powered_by'),
+        screen.getByText('predict.market_details.resolution_details'),
       ).toBeOnTheScreen();
-      expect(screen.getByText('polymarket')).toBeOnTheScreen();
-    });
-
-    it('displays resolver information', () => {
-      setupPredictMarketDetailsTest();
-
-      const aboutTab = screen.getByTestId(
-        'predict-market-details-tab-bar-tab-1',
-      );
-      fireEvent.press(aboutTab);
-
-      expect(
-        screen.getByText('predict.market_details.resolver'),
-      ).toBeOnTheScreen();
-      expect(screen.getByText('UMA')).toBeOnTheScreen();
+      expect(screen.getByText('Polymarket')).toBeOnTheScreen();
     });
   });
 
@@ -707,7 +693,7 @@ describe('PredictMarketDetails', () => {
         screen.getByText('predict.market_details.end_date'),
       ).toBeOnTheScreen();
       expect(
-        screen.getByText('predict.market_details.resolver'),
+        screen.getByText('predict.market_details.resolution_details'),
       ).toBeOnTheScreen();
     });
 
@@ -1060,6 +1046,7 @@ describe('PredictMarketDetails', () => {
         id: 'position-1',
         outcomeId: 'outcome-1',
         outcome: 'Yes',
+        title: 'Yes',
         size: 100,
         initialValue: 65,
         currentValue: 70,
@@ -1082,10 +1069,7 @@ describe('PredictMarketDetails', () => {
 
       expect(screen.getByText('predict.cash_out')).toBeOnTheScreen();
       expect(
-        screen.getByText('predict.market_details.amount_on_outcome'),
-      ).toBeOnTheScreen();
-      expect(
-        screen.getByText('predict.market_details.outcome_at_price'),
+        screen.getByText('$65.00 on Yes • 65¢', { exact: false }),
       ).toBeOnTheScreen();
       expect(screen.getByText('+7.70%')).toBeOnTheScreen();
     });
@@ -1095,6 +1079,7 @@ describe('PredictMarketDetails', () => {
         id: 'position-1',
         outcomeId: 'outcome-1',
         outcome: 'Yes',
+        title: 'Yes',
         size: 100,
         initialValue: 65,
         currentValue: 60,
@@ -1229,6 +1214,7 @@ describe('PredictMarketDetails', () => {
         id: 'position-1',
         outcomeId: 'outcome-1',
         outcome: 'Yes',
+        title: 'Yes',
         size: 100,
         initialValue: 65,
         currentValue: 70,
@@ -1248,11 +1234,9 @@ describe('PredictMarketDetails', () => {
       );
       fireEvent.press(positionsTab);
 
+      expect(screen.getByText('Yes Option')).toBeOnTheScreen();
       expect(
-        screen.getByText('predict.market_details.amount_on_outcome'),
-      ).toBeOnTheScreen();
-      expect(
-        screen.getByText('predict.market_details.outcome_at_price'),
+        screen.getByText('$65.00 on Yes • 65¢', { exact: false }),
       ).toBeOnTheScreen();
     });
 
@@ -1261,6 +1245,7 @@ describe('PredictMarketDetails', () => {
         id: 'position-1',
         outcomeId: 'outcome-1',
         outcome: 'Yes',
+        title: 'Yes',
         size: 100,
         initialValue: 65,
         currentValue: 70,
@@ -1280,11 +1265,9 @@ describe('PredictMarketDetails', () => {
       );
       fireEvent.press(positionsTab);
 
+      expect(screen.getByText('Yes')).toBeOnTheScreen();
       expect(
-        screen.getByText('predict.market_details.amount_on_outcome'),
-      ).toBeOnTheScreen();
-      expect(
-        screen.getByText('predict.market_details.outcome_at_price'),
+        screen.getByText('$65.00 on Yes • 65¢', { exact: false }),
       ).toBeOnTheScreen();
     });
 
@@ -1293,6 +1276,7 @@ describe('PredictMarketDetails', () => {
         id: 'position-1',
         outcomeId: 'outcome-1',
         outcome: 'Yes',
+        title: 'Yes',
         size: 100,
         initialValue: 65,
         currentValue: 65,

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -5,7 +5,13 @@ import {
   useRoute,
 } from '@react-navigation/native';
 import React, { useMemo, useState, useEffect, useCallback } from 'react';
-import { Image, Pressable, RefreshControl, ScrollView } from 'react-native';
+import {
+  Image,
+  Linking,
+  Pressable,
+  RefreshControl,
+  ScrollView,
+} from 'react-native';
 import {
   SafeAreaView,
   useSafeAreaInsets,
@@ -24,11 +30,7 @@ import Routes from '../../../../../constants/navigation/Routes';
 import { useTheme } from '../../../../../util/theme';
 import { PredictNavigationParamList } from '../../types/navigation';
 import { PredictEventValues } from '../../constants/eventNames';
-import {
-  formatVolume,
-  formatAddress,
-  estimateLineCount,
-} from '../../utils/format';
+import { formatVolume, estimateLineCount } from '../../utils/format';
 import Engine from '../../../../../core/Engine';
 import { PredictMarketDetailsSelectorsIDs } from '../../../../../../e2e/selectors/Predict/Predict.selectors';
 import {
@@ -466,7 +468,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
     <Box
       flexDirection={BoxFlexDirection.Row}
       alignItems={BoxAlignItems.Start}
-      twClassName="gap-3"
+      twClassName="gap-3 pb-4"
       style={{ paddingTop: insets.top + 12 }}
     >
       <Box twClassName="flex-row items-center gap-3 px-1">
@@ -513,7 +515,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
   );
 
   const renderMarketStatus = () => (
-    <Box twClassName="pt-4 gap-2">
+    <Box twClassName="gap-2">
       <Box flexDirection={BoxFlexDirection.Column} twClassName="gap-2">
         {winningOutcomeToken && !multipleOpenOutcomesPartiallyResolved && (
           <Box
@@ -676,10 +678,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
             color={colors.text.muted}
           />
           <Text variant={TextVariant.BodyMDMedium} color={TextColor.Default}>
-            {strings('predict.market_details.resolver')}
-          </Text>
-          <Text variant={TextVariant.BodyMDMedium} color={TextColor.Error}>
-            UMA
+            {strings('predict.market_details.resolution_details')}
           </Text>
         </Box>
         <Box
@@ -687,11 +686,18 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
           alignItems={BoxAlignItems.Center}
           twClassName="gap-2"
         >
-          <Pressable>
-            <Text variant={TextVariant.BodyMD} color={TextColor.Primary}>
-              {isMarketFetching || !market?.outcomes[0]?.resolvedBy
-                ? strings('predict.loading')
-                : formatAddress(market.outcomes[0].resolvedBy)}
+          <Pressable
+            onPress={() => {
+              Linking.openURL(
+                'https://docs.polymarket.com/polymarket-learn/markets/how-are-markets-resolved',
+              );
+            }}
+          >
+            <Text
+              variant={TextVariant.BodyMDMedium}
+              color={colors.primary.default}
+            >
+              Polymarket
             </Text>
           </Pressable>
           <Icon
@@ -699,37 +705,6 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
             size={IconSize.Sm}
             color={colors.primary.default}
           />
-        </Box>
-      </Box>
-
-      <Box
-        flexDirection={BoxFlexDirection.Row}
-        alignItems={BoxAlignItems.Center}
-        justifyContent={BoxJustifyContent.Between}
-        twClassName="gap-3 my-2 pb-2"
-      >
-        <Box
-          flexDirection={BoxFlexDirection.Row}
-          alignItems={BoxAlignItems.Center}
-          twClassName="gap-3"
-        >
-          <Icon
-            name={IconName.Apps}
-            size={IconSize.Md}
-            color={colors.text.muted}
-          />
-          <Text variant={TextVariant.BodyMDMedium} color={TextColor.Default}>
-            {strings('predict.market_details.powered_by')}
-          </Text>
-        </Box>
-        <Box
-          flexDirection={BoxFlexDirection.Row}
-          alignItems={BoxAlignItems.Center}
-          twClassName="gap-2"
-        >
-          <Text variant={TextVariant.BodyMD} color={TextColor.Default}>
-            {market?.providerId}
-          </Text>
         </Box>
       </Box>
       <Box twClassName="w-full border-t border-muted py-2" />
@@ -880,6 +855,13 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
             multipleOutcomes &&
             multipleOpenOutcomesPartiallyResolved ? (
             <Box>
+              {openOutcomes.map((outcome) => (
+                <PredictMarketOutcome
+                  key={outcome.id}
+                  market={market}
+                  outcome={outcome}
+                />
+              ))}
               <Pressable
                 onPress={() => setIsResolvedExpanded((prev) => !prev)}
                 style={({ pressed }) =>
@@ -986,13 +968,6 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
                     </Box>
                   ))}
               </Pressable>
-              {openOutcomes.map((outcome) => (
-                <PredictMarketOutcome
-                  key={outcome.id}
-                  market={market}
-                  outcome={outcome}
-                />
-              ))}
             </Box>
           ) : (
             <Box>

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1746,6 +1746,7 @@
       "end_date": "End date",
       "resolver": "Resolver",
       "powered_by": "Powered by",
+      "resolution_details": "Resolution details",
       "yes": "Yes",
       "no": "No",
       "on": "on",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Changes resolver link
- Position's title on home screen are full now
- Change the positions on market details

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Revamps Predict UI: adds “Resolution details” with Polymarket link, shows full/grouped position titles with new layout, reorders outcomes, removes fee info icons, and makes amount cursor height dynamic.
> 
> - **Predict Market Details**:
>   - Replace resolver/provider sections with **“`resolution_details`”** and link to Polymarket docs; remove powered-by/resolver address.
>   - Minor header/status spacing tweaks.
>   - In partially resolved markets, list open outcomes above the expandable resolved outcomes.
> - **Positions UI**:
>   - `PredictPositionDetail`: show `groupItemTitle` (fallback to `title`); subtitle now `${initial} on {outcome} • {avgPrice}¢`; image/layout refinements.
>   - `PredictPosition`: show full `title` (no truncation); new image container; minor style tweaks.
> - **Amount Display**:
>   - `PredictAmountDisplay`: make active cursor height dynamic based on line height; slight margin tweak.
> - **Fee Summary**:
>   - `PredictFeeSummary`: remove info icons from fee rows.
> - **i18n**:
>   - Add `predict.market_details.resolution_details` string.
> - **Tests**:
>   - Update expectations for new texts, layout, and outcome ordering across affected components.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ce52b7a59a23acf428763324b42125c7cc21b72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->