### PR TITLE
chore: Filter out position tpsl when canceling all orders

### DIFF
--- a/app/components/UI/Perps/controllers/PerpsController.ts
+++ b/app/components/UI/Perps/controllers/PerpsController.ts
@@ -23,6 +23,7 @@ import { v4 as uuidv4 } from 'uuid';
 import Engine from '../../../../core/Engine';
 import { generateDepositId } from '../utils/idUtils';
 import { USDC_SYMBOL } from '../constants/hyperLiquidConfig';
+import { isTPSLOrder } from '../constants/orderTypes';
 import {
   LastTransactionResult,
   TransactionStatus,
@@ -1928,8 +1929,10 @@ export class PerpsController extends BaseController<
         // Filter orders based on params
         let ordersToCancel = orders;
         if (params.cancelAll || (!params.coins && !params.orderIds)) {
-          // Cancel all orders
-          ordersToCancel = orders;
+          // Cancel all orders (excluding TP/SL orders for positions)
+          ordersToCancel = orders.filter(
+            (o) => !isTPSLOrder(o.detailedOrderType),
+          );
         } else if (params.orderIds && params.orderIds.length > 0) {
           // Cancel specific order IDs
           ordersToCancel = orders.filter((o) =>


### PR DESCRIPTION
## **Description**

Bug was reported where "Cancel all" orders flow also closed TP/SL associated with open positions of that asset pair. This shouldn't happen, and "Cancel all" orders should only cancel limit orders.

This PR introduces a filter into the cancel all logic that filters out TP/SL from the orders array when canceling.

## **Changelog**

CHANGELOG entry: Bugfix to cancel all order flow to ensure position TP/SL persists

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Cancel all order flow

  Scenario: user cancels all orders
    Given they have multiple orders, along with a position with TP/SL for the same asset pair

    When user cancels all orders
    Then it should not delete the TP/SL for the open position asset pair
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Cancel-all now skips take-profit/stop-loss orders; targeted cancellations by orderId still allow TP/SL.
> 
> - **PerpsController**:
>   - Update `cancelOrders` to filter out TP/SL orders when `cancelAll` (or no filters) is used via `isTPSLOrder` on `detailedOrderType`.
>   - Import `isTPSLOrder` from `../constants/orderTypes`.
> - **Tests** (`PerpsController.test.ts`):
>   - Add coverage ensuring TP/SL orders are excluded on `cancelAll` and that only regular orders are canceled.
>   - Add tests confirming TP/SL orders can be canceled when explicitly specified by `orderIds`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f49569b54f8bf6010bf2087940f0a7f23a85754. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->