### PR TITLE
fix: Close all orders/positions bottom sheet dismissal

### DIFF
--- a/app/components/UI/Perps/Views/PerpsCancelAllOrdersView/PerpsCancelAllOrdersView.tsx
+++ b/app/components/UI/Perps/Views/PerpsCancelAllOrdersView/PerpsCancelAllOrdersView.tsx
@@ -177,11 +177,22 @@ const PerpsCancelAllOrdersView: React.FC<PerpsCancelAllOrdersViewProps> = ({
     }
   }, [navigation, externalSheetRef, sheetRef, onExternalClose]);
 
+  // Wrapper for "Keep Orders" button that properly handles overlay dismissal
+  const handleKeepButtonPress = useCallback(() => {
+    if (externalSheetRef) {
+      // When used as overlay, close the sheet properly to remove overlay
+      handleClose();
+    } else {
+      // When used as standalone screen, use hook's navigation
+      handleKeepOrders();
+    }
+  }, [externalSheetRef, handleClose, handleKeepOrders]);
+
   const footerButtons = useMemo(
     () => [
       {
         label: strings('perps.cancel_all_modal.keep_orders'),
-        onPress: handleKeepOrders,
+        onPress: handleKeepButtonPress,
         variant: ButtonVariants.Secondary,
         size: ButtonSize.Lg,
         disabled: isCanceling,
@@ -197,13 +208,17 @@ const PerpsCancelAllOrdersView: React.FC<PerpsCancelAllOrdersViewProps> = ({
         danger: true,
       },
     ],
-    [handleKeepOrders, handleCancelAll, isCanceling],
+    [handleKeepButtonPress, handleCancelAll, isCanceling],
   );
 
   // Show empty state if no orders (WebSocket data loads instantly, no loading state needed)
   if (!orders || orders.length === 0) {
     return (
-      <BottomSheet ref={sheetRef} shouldNavigateBack={!externalSheetRef}>
+      <BottomSheet
+        ref={sheetRef}
+        shouldNavigateBack={!externalSheetRef}
+        onClose={externalSheetRef ? onExternalClose : undefined}
+      >
         <BottomSheetHeader onClose={handleClose}>
           <Text variant={TextVariant.HeadingMD}>
             {strings('perps.cancel_all_modal.title')}
@@ -219,7 +234,11 @@ const PerpsCancelAllOrdersView: React.FC<PerpsCancelAllOrdersViewProps> = ({
   }
 
   return (
-    <BottomSheet ref={sheetRef} shouldNavigateBack={!externalSheetRef}>
+    <BottomSheet
+      ref={sheetRef}
+      shouldNavigateBack={!externalSheetRef}
+      onClose={externalSheetRef ? onExternalClose : undefined}
+    >
       <BottomSheetHeader onClose={handleClose}>
         <Text variant={TextVariant.HeadingMD}>
           {strings('perps.cancel_all_modal.title')}

--- a/app/components/UI/Perps/Views/PerpsCloseAllPositionsView/PerpsCloseAllPositionsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsCloseAllPositionsView/PerpsCloseAllPositionsView.tsx
@@ -204,11 +204,22 @@ const PerpsCloseAllPositionsView: React.FC<PerpsCloseAllPositionsViewProps> = ({
     }
   }, [navigation, externalSheetRef, sheetRef, onExternalClose]);
 
+  // Wrapper for "Keep Positions" button that properly handles overlay dismissal
+  const handleKeepButtonPress = useCallback(() => {
+    if (externalSheetRef) {
+      // When used as overlay, close the sheet properly to remove overlay
+      handleClose();
+    } else {
+      // When used as standalone screen, use hook's navigation
+      handleKeepPositions();
+    }
+  }, [externalSheetRef, handleClose, handleKeepPositions]);
+
   const footerButtons = useMemo(
     () => [
       {
         label: strings('perps.close_all_modal.keep_positions'),
-        onPress: handleKeepPositions,
+        onPress: handleKeepButtonPress,
         variant: ButtonVariants.Secondary,
         size: ButtonSize.Lg,
         disabled: isClosing,
@@ -224,13 +235,17 @@ const PerpsCloseAllPositionsView: React.FC<PerpsCloseAllPositionsViewProps> = ({
         danger: true,
       },
     ],
-    [handleKeepPositions, handleCloseAll, isClosing],
+    [handleKeepButtonPress, handleCloseAll, isClosing],
   );
 
   // Show loading state while fetching positions
   if (isInitialLoading) {
     return (
-      <BottomSheet ref={sheetRef} shouldNavigateBack={!externalSheetRef}>
+      <BottomSheet
+        ref={sheetRef}
+        shouldNavigateBack={!externalSheetRef}
+        onClose={externalSheetRef ? onExternalClose : undefined}
+      >
         <BottomSheetHeader onClose={handleClose}>
           <Text variant={TextVariant.HeadingMD}>
             {strings('perps.close_all_modal.title')}
@@ -249,7 +264,11 @@ const PerpsCloseAllPositionsView: React.FC<PerpsCloseAllPositionsViewProps> = ({
   // Show empty state if no positions
   if (!positions || positions.length === 0) {
     return (
-      <BottomSheet ref={sheetRef} shouldNavigateBack={!externalSheetRef}>
+      <BottomSheet
+        ref={sheetRef}
+        shouldNavigateBack={!externalSheetRef}
+        onClose={externalSheetRef ? onExternalClose : undefined}
+      >
         <BottomSheetHeader onClose={handleClose}>
           <Text variant={TextVariant.HeadingMD}>
             {strings('perps.close_all_modal.title')}
@@ -265,7 +284,11 @@ const PerpsCloseAllPositionsView: React.FC<PerpsCloseAllPositionsViewProps> = ({
   }
 
   return (
-    <BottomSheet ref={sheetRef} shouldNavigateBack={!externalSheetRef}>
+    <BottomSheet
+      ref={sheetRef}
+      shouldNavigateBack={!externalSheetRef}
+      onClose={externalSheetRef ? onExternalClose : undefined}
+    >
       <BottomSheetHeader onClose={handleClose}>
         <Text variant={TextVariant.HeadingMD}>
           {strings('perps.close_all_modal.title')}


### PR DESCRIPTION
## **Description**

Bug was reported where dismissing the close all positions/orders bottom sheet was dismissing the bottom sheet, but the overlay would persist. This made the PerpsHomeScreenView non-interactive and blocked users.

This PR introduces a fix where we properly dismiss the bottom sheet both via close icon press, as well as externally by pressing the overlay outside of the sheet.

## **Changelog**

CHANGELOG entry: Fix to close all positions/orders bottom sheet

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2021

## **Manual testing steps**

```gherkin
Feature: Close All and Cancel All bottom sheet overlay dismissal

  Scenario: user dismisses Close All bottom sheet by pressing overlay
    Given user is on PerpsHomeScreen with open positions
    And Close All bottom sheet is displayed with overlay

    When user presses outside the bottom sheet on the overlay
    Then the bottom sheet dismisses with animation
    And the overlay is removed
    And PerpsHomeScreen becomes interactive

  Scenario: user dismisses Close All bottom sheet by pressing Keep Positions
    Given user is on PerpsHomeScreen with open positions
    And Close All bottom sheet is displayed with overlay

    When user presses "Keep Positions" button
    Then the bottom sheet dismisses with animation
    And the overlay is removed
    And PerpsHomeScreen becomes interactive

  Scenario: user dismisses Cancel All bottom sheet by pressing overlay
    Given user is on PerpsHomeScreen with open orders
    And Cancel All bottom sheet is displayed with overlay

    When user presses outside the bottom sheet on the overlay
    Then the bottom sheet dismisses with animation
    And the overlay is removed
    And PerpsHomeScreen becomes interactive

  Scenario: user dismisses Cancel All bottom sheet by pressing Keep Orders
    Given user is on PerpsHomeScreen with open orders
    And Cancel All bottom sheet is displayed with overlay

    When user presses "Keep Orders" button
    Then the bottom sheet dismisses with animation
    And the overlay is removed
    And PerpsHomeScreen becomes interactive
```

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/381fcd6c-acd7-4f71-aa29-a4fb2f27450d

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Properly closes the bottom sheet and removes the overlay when dismissed via overlay tap, close icon, or "Keep" buttons for Close All Positions and Cancel All Orders.
> 
> - **Perps**:
>   - **`PerpsCancelAllOrdersView`**:
>     - Add `handleKeepButtonPress` to correctly close when used as overlay; wire to footer `keep_orders` button.
>     - Pass `onClose` to `BottomSheet` when `externalSheetRef` is provided; update all instances (empty/content states).
>   - **`PerpsCloseAllPositionsView`**:
>     - Add `handleKeepButtonPress` to correctly close when used as overlay; wire to footer `keep_positions` button.
>     - Pass `onClose` to `BottomSheet` when `externalSheetRef` is provided; update all instances (loading/empty/content states).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 232ec9430832aa2ca98401c4426386f874f994f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->