### PR TITLE
feat(STX-250): Gasless Xswaps with eth_sendBundle

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
@@ -24,6 +24,8 @@ import { MOCK_ENTROPY_SOURCE as mockEntropySource } from '../../../../../util/te
 import { RootState } from '../../../../../reducers';
 import { mockQuoteWithMetadata } from '../../_mocks_/bridgeQuoteWithMetadata';
 import { BridgeViewMode } from '../../types';
+import { useGasIncluded } from '../../hooks/useGasIncluded';
+import { useIsSendBundleSupported } from '../../hooks/useIsSendBundleSupported';
 
 // Mock the account-tree-controller file that imports the problematic module
 jest.mock(
@@ -255,6 +257,16 @@ jest.mock('../../hooks/useBridgeQuoteData', () => ({
     .mockImplementation(() => mockUseBridgeQuoteData),
 }));
 
+// Mock useGasIncluded hook
+jest.mock('../../hooks/useGasIncluded', () => ({
+  useGasIncluded: jest.fn(),
+}));
+
+// Mock useIsSendBundleSupported hook (dependency of useGasIncluded)
+jest.mock('../../hooks/useIsSendBundleSupported', () => ({
+  useIsSendBundleSupported: jest.fn().mockReturnValue(false),
+}));
+
 jest.mock('../../../../../util/address', () => ({
   ...jest.requireActual('../../../../../util/address'),
   isHardwareAccount: jest.fn(),
@@ -266,6 +278,8 @@ describe('BridgeView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     // Set default mock values
+    (useGasIncluded as jest.Mock).mockReturnValue(undefined);
+    (useIsSendBundleSupported as jest.Mock).mockReturnValue(false);
   });
 
   it('renders', async () => {
@@ -1576,6 +1590,103 @@ describe('BridgeView', () => {
 
       // Should display default ETH token from Redux state
       expect(getByText('ETH')).toBeTruthy();
+    });
+  });
+
+  describe('gasIncluded functionality', () => {
+    it('calls useGasIncluded hook with source chain ID', () => {
+      const testState = createBridgeTestState({
+        bridgeReducerOverrides: {
+          sourceToken: {
+            address: '0x0000000000000000000000000000000000000000',
+            chainId: '0x1',
+            decimals: 18,
+            symbol: 'ETH',
+          },
+        },
+      });
+
+      renderScreen(
+        BridgeView,
+        { name: Routes.BRIDGE.ROOT },
+        { state: testState },
+      );
+
+      expect(useGasIncluded).toHaveBeenCalledWith('0x1');
+    });
+
+    it('calls useGasIncluded with undefined when source token not set', () => {
+      const testState = createBridgeTestState({
+        bridgeReducerOverrides: {
+          sourceToken: undefined,
+        },
+      });
+
+      renderScreen(
+        BridgeView,
+        { name: Routes.BRIDGE.ROOT },
+        { state: testState },
+      );
+
+      expect(useGasIncluded).toHaveBeenCalledWith(undefined);
+    });
+
+    it('updates gasIncluded when source chain changes', () => {
+      const testState = createBridgeTestState({
+        bridgeReducerOverrides: {
+          sourceToken: {
+            address: '0x0000000000000000000000000000000000000000',
+            chainId: '0x1',
+            decimals: 18,
+            symbol: 'ETH',
+          },
+        },
+      });
+
+      const { store } = renderScreen(
+        BridgeView,
+        { name: Routes.BRIDGE.ROOT },
+        { state: testState },
+      );
+
+      // Change source token to different chain
+      act(() => {
+        store.dispatch(
+          setSourceToken({
+            address: '0x0000000000000000000000000000000000000000',
+            chainId: '0xa', // Optimism
+            decimals: 18,
+            symbol: 'ETH',
+          }),
+        );
+      });
+
+      // useGasIncluded should be called with the new chain ID
+      expect(useGasIncluded).toHaveBeenCalledWith('0xa');
+    });
+
+    it('calls useGasIncluded with non-EVM chainId directly', () => {
+      const testState = createBridgeTestState({
+        bridgeReducerOverrides: {
+          sourceToken: {
+            address: 'SomeNonEvmAddress',
+            chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+            decimals: 9,
+            symbol: 'SOL',
+          },
+        },
+      });
+
+      renderScreen(
+        BridgeView,
+        { name: Routes.BRIDGE.ROOT },
+        { state: testState },
+      );
+
+      // Hook receives the raw chainId and handles filtering internally
+      expect(useGasIncluded).toHaveBeenCalledWith(
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+      );
     });
   });
 });

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -85,6 +85,7 @@ import { RootState } from '../../../../../reducers/index.ts';
 import { BRIDGE_MM_FEE_RATE } from '@metamask/bridge-controller';
 import { isNullOrUndefined } from '@metamask/utils';
 import { useBridgeQuoteEvents } from '../../hooks/useBridgeQuoteEvents/index.ts';
+import { useGasIncluded } from '../../hooks/useGasIncluded';
 
 export interface BridgeRouteParams {
   sourcePage: string;
@@ -140,6 +141,9 @@ const BridgeView = () => {
   const inputRef = useRef<{ blur: () => void }>(null);
 
   const updateQuoteParams = useBridgeQuoteRequest();
+
+  // Update gasIncluded state based on source chain capabilities
+  useGasIncluded(sourceToken?.chainId);
 
   const initialSourceToken = route.params?.sourceToken;
   const initialSourceAmount = route.params?.sourceAmount;

--- a/app/components/UI/Bridge/_mocks_/bridgeReducerState.ts
+++ b/app/components/UI/Bridge/_mocks_/bridgeReducerState.ts
@@ -29,6 +29,7 @@ export const mockBridgeReducerState: BridgeState = {
   selectedDestChainId: '0xa',
   slippage: '0.5',
   isSubmittingTx: false,
+  gasIncluded: false,
   bridgeViewMode: BridgeViewMode.Bridge,
   isSelectingRecipient: false,
 };

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
@@ -9,12 +9,12 @@ import {
   selectSelectedDestChainId,
   selectSlippage,
   selectDestAddress,
+  selectGasIncluded,
 } from '../../../../../core/redux/slices/bridge';
 import { getDecimalChainId } from '../../../../../util/networks';
 import { calcTokenValue } from '../../../../../util/transactions';
 import { debounce } from 'lodash';
 import { useUnifiedSwapBridgeContext } from '../useUnifiedSwapBridgeContext';
-import { selectShouldUseSmartTransaction } from '../../../../../selectors/smartTransactionsController';
 import { selectSourceWalletAddress } from '../../../../../selectors/bridge';
 import useIsInsufficientBalance from '../useInsufficientBalance';
 import { useLatestBalance } from '../useLatestBalance';
@@ -34,9 +34,6 @@ export const useBridgeQuoteRequest = () => {
   const walletAddress = useSelector(selectSourceWalletAddress);
   const destAddress = useSelector(selectDestAddress);
   const context = useUnifiedSwapBridgeContext();
-  const shouldUseSmartTransaction = useSelector(
-    selectShouldUseSmartTransaction,
-  );
 
   const latestSourceBalance = useLatestBalance({
     address: sourceToken?.address,
@@ -54,6 +51,8 @@ export const useBridgeQuoteRequest = () => {
   useEffect(() => {
     insufficientBalRef.current = insufficientBal;
   }, [insufficientBal]);
+
+  const gasIncluded = useSelector(selectGasIncluded);
 
   /**
    * Updates quote parameters in the bridge controller
@@ -86,8 +85,8 @@ export const useBridgeQuoteRequest = () => {
       slippage: slippage ? Number(slippage) : undefined,
       walletAddress,
       destWalletAddress: destAddress ?? walletAddress,
-      gasIncluded: shouldUseSmartTransaction,
-      gasIncluded7702: false, // TODO research how to handle this
+      gasIncluded,
+      gasIncluded7702: false, // TODO: https://consensyssoftware.atlassian.net/browse/STX-263
       insufficientBal: insufficientBalRef.current,
     };
 
@@ -104,7 +103,7 @@ export const useBridgeQuoteRequest = () => {
     walletAddress,
     destAddress,
     context,
-    shouldUseSmartTransaction,
+    gasIncluded,
   ]);
 
   // Create a stable debounced function that persists across renders

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/useBridgeQuoteRequest.test.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/useBridgeQuoteRequest.test.ts
@@ -345,4 +345,74 @@ describe('useBridgeQuoteRequest', () => {
     // Reset mock
     (isSolanaChainId as jest.Mock).mockReset();
   });
+
+  describe('gasIncluded parameter', () => {
+    it('includes gasIncluded true in quote request when enabled', async () => {
+      const testState = createBridgeTestState({
+        bridgeReducerOverrides: {
+          gasIncluded: true,
+        },
+      });
+
+      const { result } = renderHookWithProvider(() => useBridgeQuoteRequest(), {
+        state: testState,
+      });
+
+      await act(async () => {
+        await result.current();
+        jest.advanceTimersByTime(DEBOUNCE_WAIT);
+      });
+
+      expect(spyUpdateBridgeQuoteRequestParams).toHaveBeenCalledWith(
+        expect.objectContaining({
+          gasIncluded: true,
+        }),
+        undefined,
+      );
+    });
+
+    it('includes gasIncluded false in quote request when disabled', async () => {
+      const testState = createBridgeTestState({
+        bridgeReducerOverrides: {
+          gasIncluded: false,
+        },
+      });
+
+      const { result } = renderHookWithProvider(() => useBridgeQuoteRequest(), {
+        state: testState,
+      });
+
+      await act(async () => {
+        await result.current();
+        jest.advanceTimersByTime(DEBOUNCE_WAIT);
+      });
+
+      expect(spyUpdateBridgeQuoteRequestParams).toHaveBeenCalledWith(
+        expect.objectContaining({
+          gasIncluded: false,
+        }),
+        undefined,
+      );
+    });
+
+    it('includes gasIncluded7702 false in quote request', async () => {
+      const testState = createBridgeTestState();
+
+      const { result } = renderHookWithProvider(() => useBridgeQuoteRequest(), {
+        state: testState,
+      });
+
+      await act(async () => {
+        await result.current();
+        jest.advanceTimersByTime(DEBOUNCE_WAIT);
+      });
+
+      expect(spyUpdateBridgeQuoteRequestParams).toHaveBeenCalledWith(
+        expect.objectContaining({
+          gasIncluded7702: false,
+        }),
+        undefined,
+      );
+    });
+  });
 });

--- a/app/components/UI/Bridge/hooks/useGasIncluded/index.ts
+++ b/app/components/UI/Bridge/hooks/useGasIncluded/index.ts
@@ -1,0 +1,46 @@
+import { useEffect, useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { setGasIncluded } from '../../../../../core/redux/slices/bridge';
+import { selectShouldUseSmartTransaction } from '../../../../../selectors/smartTransactionsController';
+import { useIsSendBundleSupported } from '../useIsSendBundleSupported';
+import { RootState } from '../../../../../reducers';
+import { CaipChainId, Hex } from '@metamask/utils';
+import {
+  formatChainIdToHex,
+  isNonEvmChainId,
+} from '@metamask/bridge-controller';
+
+/**
+ * Hook that calculates and updates gasIncluded state for bridge and swap transactions.
+ * Should be used at the page level (e.g., BridgeView) to avoid repeated calculations.
+ *
+ * Returns true only when BOTH smart transactions are enabled AND sendBundle is supported.
+ * Only applies to EVM chains - non-EVM chains will always have gasIncluded set to false.
+ *
+ * @param chainId - The chain ID to check gasIncluded support for (can be Hex, CAIP, or other format)
+ */
+export const useGasIncluded = (chainId?: Hex | CaipChainId | string) => {
+  const dispatch = useDispatch();
+
+  // Only check gasIncluded for EVM chains
+  const evmChainId = useMemo(() => {
+    if (!chainId || isNonEvmChainId(chainId)) {
+      return undefined;
+    }
+    return formatChainIdToHex(chainId);
+  }, [chainId]);
+
+  const isSendBundleSupportedForChain = useIsSendBundleSupported(evmChainId);
+
+  const shouldUseSmartTransaction = useSelector((state: RootState) =>
+    selectShouldUseSmartTransaction(state, evmChainId),
+  );
+
+  // gasIncluded is true only when BOTH smart transactions are enabled AND sendBundle is supported
+  const gasIncluded =
+    shouldUseSmartTransaction && Boolean(isSendBundleSupportedForChain);
+
+  useEffect(() => {
+    dispatch(setGasIncluded(gasIncluded));
+  }, [gasIncluded, dispatch]);
+};

--- a/app/components/UI/Bridge/hooks/useGasIncluded/useGasIncluded.test.ts
+++ b/app/components/UI/Bridge/hooks/useGasIncluded/useGasIncluded.test.ts
@@ -1,0 +1,195 @@
+import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
+import { useGasIncluded } from './index';
+import { useIsSendBundleSupported } from '../useIsSendBundleSupported';
+import { selectShouldUseSmartTransaction } from '../../../../../selectors/smartTransactionsController';
+import { Hex } from '@metamask/utils';
+import { act } from '@testing-library/react-native';
+
+// Mock dependencies
+jest.mock('../useIsSendBundleSupported');
+jest.mock('../../../../../selectors/smartTransactionsController');
+
+const mockUseIsSendBundleSupported =
+  useIsSendBundleSupported as jest.MockedFunction<
+    typeof useIsSendBundleSupported
+  >;
+const mockSelectShouldUseSmartTransaction =
+  selectShouldUseSmartTransaction as jest.MockedFunction<
+    typeof selectShouldUseSmartTransaction
+  >;
+
+describe('useGasIncluded', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when both smart transactions and sendBundle are supported', () => {
+    it('updates state with gasIncluded true for Ethereum mainnet', () => {
+      mockSelectShouldUseSmartTransaction.mockReturnValue(true);
+      mockUseIsSendBundleSupported.mockReturnValue(true);
+
+      const { store } = renderHookWithProvider(
+        () => useGasIncluded('0x1' as Hex),
+        { state: {} },
+      );
+
+      const state = store.getState();
+      expect(state.bridge.gasIncluded).toBe(true);
+    });
+
+    it('updates state with gasIncluded true for Optimism chain', () => {
+      mockSelectShouldUseSmartTransaction.mockReturnValue(true);
+      mockUseIsSendBundleSupported.mockReturnValue(true);
+
+      const { store } = renderHookWithProvider(
+        () => useGasIncluded('0xa' as Hex),
+        { state: {} },
+      );
+
+      const state = store.getState();
+      expect(state.bridge.gasIncluded).toBe(true);
+    });
+  });
+
+  describe('when smart transactions are not supported', () => {
+    it('updates state with gasIncluded false when smart transactions disabled', () => {
+      mockSelectShouldUseSmartTransaction.mockReturnValue(false);
+      mockUseIsSendBundleSupported.mockReturnValue(true);
+
+      const { store } = renderHookWithProvider(
+        () => useGasIncluded('0x1' as Hex),
+        { state: {} },
+      );
+
+      const state = store.getState();
+      expect(state.bridge.gasIncluded).toBe(false);
+    });
+  });
+
+  describe('when sendBundle is not supported', () => {
+    it('updates state with gasIncluded false when sendBundle not supported', () => {
+      mockSelectShouldUseSmartTransaction.mockReturnValue(true);
+      mockUseIsSendBundleSupported.mockReturnValue(false);
+
+      const { store } = renderHookWithProvider(
+        () => useGasIncluded('0x1' as Hex),
+        { state: {} },
+      );
+
+      const state = store.getState();
+      expect(state.bridge.gasIncluded).toBe(false);
+    });
+
+    it('updates state with gasIncluded false when sendBundle returns undefined', () => {
+      mockSelectShouldUseSmartTransaction.mockReturnValue(true);
+      mockUseIsSendBundleSupported.mockReturnValue(undefined);
+
+      const { store } = renderHookWithProvider(
+        () => useGasIncluded('0x1' as Hex),
+        { state: {} },
+      );
+
+      const state = store.getState();
+      expect(state.bridge.gasIncluded).toBe(false);
+    });
+
+    it('updates state with gasIncluded false when sendBundle returns null', () => {
+      mockSelectShouldUseSmartTransaction.mockReturnValue(true);
+      mockUseIsSendBundleSupported.mockReturnValue(null as unknown as boolean);
+
+      const { store } = renderHookWithProvider(
+        () => useGasIncluded('0x1' as Hex),
+        { state: {} },
+      );
+
+      const state = store.getState();
+      expect(state.bridge.gasIncluded).toBe(false);
+    });
+  });
+
+  describe('when both smart transactions and sendBundle are not supported', () => {
+    it('updates state with gasIncluded false', () => {
+      mockSelectShouldUseSmartTransaction.mockReturnValue(false);
+      mockUseIsSendBundleSupported.mockReturnValue(false);
+
+      const { store } = renderHookWithProvider(
+        () => useGasIncluded('0x1' as Hex),
+        { state: {} },
+      );
+
+      const state = store.getState();
+      expect(state.bridge.gasIncluded).toBe(false);
+    });
+  });
+
+  describe('when chainId is undefined', () => {
+    it('updates state with gasIncluded false when chainId is undefined', () => {
+      mockSelectShouldUseSmartTransaction.mockReturnValue(false);
+      mockUseIsSendBundleSupported.mockReturnValue(false);
+
+      const { store } = renderHookWithProvider(
+        () => useGasIncluded(undefined),
+        { state: {} },
+      );
+
+      const state = store.getState();
+      expect(state.bridge.gasIncluded).toBe(false);
+    });
+  });
+
+  describe('when chainId is non-EVM', () => {
+    it('updates state with gasIncluded false for Solana mainnet', () => {
+      // When evmChainId is undefined, mocks should return false
+      mockSelectShouldUseSmartTransaction.mockReturnValue(false);
+      mockUseIsSendBundleSupported.mockReturnValue(false);
+
+      const { store } = renderHookWithProvider(
+        () => useGasIncluded('solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'),
+        { state: {} },
+      );
+
+      const state = store.getState();
+      expect(state.bridge.gasIncluded).toBe(false);
+    });
+
+    it('calls useIsSendBundleSupported with undefined for non-EVM chains', () => {
+      mockSelectShouldUseSmartTransaction.mockReturnValue(false);
+      mockUseIsSendBundleSupported.mockReturnValue(false);
+
+      renderHookWithProvider(
+        () => useGasIncluded('solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'),
+        { state: {} },
+      );
+
+      expect(mockUseIsSendBundleSupported).toHaveBeenCalledWith(undefined);
+    });
+  });
+
+  describe('when chainId changes', () => {
+    it('updates state when chainId changes', () => {
+      mockSelectShouldUseSmartTransaction.mockReturnValue(true);
+      mockUseIsSendBundleSupported.mockReturnValue(true);
+
+      const { store, rerender } = renderHookWithProvider(
+        () => useGasIncluded('0x1' as Hex),
+        { state: {} },
+      );
+
+      // Initial state
+      let state = store.getState();
+      expect(state.bridge.gasIncluded).toBe(true);
+
+      // Change conditions - smart transactions not supported on new chain
+      mockSelectShouldUseSmartTransaction.mockReturnValue(false);
+      mockUseIsSendBundleSupported.mockReturnValue(false);
+
+      act(() => {
+        rerender(() => useGasIncluded('0x1' as Hex));
+      });
+
+      // State should be updated to false
+      state = store.getState();
+      expect(state.bridge.gasIncluded).toBe(false);
+    });
+  });
+});

--- a/app/components/UI/Bridge/hooks/useIsSendBundleSupported/index.ts
+++ b/app/components/UI/Bridge/hooks/useIsSendBundleSupported/index.ts
@@ -1,0 +1,19 @@
+import { useAsyncResult } from '../../../../hooks/useAsyncResult';
+import { isSendBundleSupported } from '../../../../../util/transactions/sentinel-api';
+import { Hex } from '@metamask/utils';
+
+/**
+ * Hook that checks if sendBundle is supported for the given chain
+ * @param chainId - The chain ID to check sendBundle support for
+ * @returns Whether sendBundle is supported for the chain, or undefined while loading
+ */
+export const useIsSendBundleSupported = (
+  chainId?: Hex,
+): boolean | undefined => {
+  const { value: isSendBundleSupportedForChain } = useAsyncResult(
+    async () => (chainId ? isSendBundleSupported(chainId) : false),
+    [chainId],
+  );
+
+  return isSendBundleSupportedForChain;
+};

--- a/app/components/UI/Bridge/hooks/useIsSendBundleSupported/useIsSendBundleSupported.test.ts
+++ b/app/components/UI/Bridge/hooks/useIsSendBundleSupported/useIsSendBundleSupported.test.ts
@@ -1,0 +1,118 @@
+import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
+import { useIsSendBundleSupported } from './index';
+import { useAsyncResult } from '../../../../hooks/useAsyncResult';
+import { Hex } from '@metamask/utils';
+
+// Mock dependencies
+jest.mock('../../../../hooks/useAsyncResult');
+jest.mock('../../../../../util/transactions/sentinel-api');
+
+const mockUseAsyncResult = useAsyncResult as jest.MockedFunction<
+  typeof useAsyncResult
+>;
+
+describe('useIsSendBundleSupported', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when chainId is provided', () => {
+    it('returns true when sendBundle is supported for Ethereum mainnet', () => {
+      mockUseAsyncResult.mockReturnValue({ pending: false, value: true });
+
+      const { result } = renderHookWithProvider(
+        () => useIsSendBundleSupported('0x1' as Hex),
+        { state: {} },
+      );
+
+      expect(result.current).toBe(true);
+    });
+
+    it('returns false when sendBundle is not supported for the chain', () => {
+      mockUseAsyncResult.mockReturnValue({ pending: false, value: false });
+
+      const { result } = renderHookWithProvider(
+        () => useIsSendBundleSupported('0x89' as Hex),
+        { state: {} },
+      );
+
+      expect(result.current).toBe(false);
+    });
+
+    it('returns undefined while async operation is pending', () => {
+      mockUseAsyncResult.mockReturnValue({ pending: true, value: undefined });
+
+      const { result } = renderHookWithProvider(
+        () => useIsSendBundleSupported('0x1' as Hex),
+        { state: {} },
+      );
+
+      expect(result.current).toBe(undefined);
+    });
+  });
+
+  describe('when chainId is undefined', () => {
+    it('returns false when chainId is undefined', () => {
+      mockUseAsyncResult.mockReturnValue({ pending: false, value: false });
+
+      const { result } = renderHookWithProvider(
+        () => useIsSendBundleSupported(undefined),
+        { state: {} },
+      );
+
+      expect(result.current).toBe(false);
+    });
+  });
+
+  describe('when chainId changes', () => {
+    it('returns new value when chainId changes', () => {
+      // Initially supported
+      mockUseAsyncResult.mockReturnValue({ pending: false, value: true });
+
+      const { result, rerender } = renderHookWithProvider(
+        () => useIsSendBundleSupported('0x1' as Hex),
+        { state: {} },
+      );
+
+      expect(result.current).toBe(true);
+
+      // Change to unsupported chain
+      mockUseAsyncResult.mockReturnValue({ pending: false, value: false });
+
+      rerender(() => useIsSendBundleSupported('0x89' as Hex));
+
+      expect(result.current).toBe(false);
+    });
+
+    it('returns undefined while loading after chainId change', () => {
+      mockUseAsyncResult.mockReturnValue({ pending: false, value: true });
+
+      const { result, rerender } = renderHookWithProvider(
+        () => useIsSendBundleSupported('0x1' as Hex),
+        { state: {} },
+      );
+
+      expect(result.current).toBe(true);
+
+      // Simulate loading state
+      mockUseAsyncResult.mockReturnValue({ pending: true, value: undefined });
+
+      rerender(() => useIsSendBundleSupported('0xa' as Hex));
+
+      expect(result.current).toBe(undefined);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns null when async result is null', () => {
+      mockUseAsyncResult.mockReturnValue({ pending: false, value: null });
+
+      const { result } = renderHookWithProvider(
+        () => useIsSendBundleSupported('0x1' as Hex),
+        { state: {} },
+      );
+
+      expect(result.current).toBe(null);
+    });
+  });
+});

--- a/app/core/redux/slices/bridge/index.test.ts
+++ b/app/core/redux/slices/bridge/index.test.ts
@@ -50,6 +50,7 @@ describe('bridge slice', () => {
         destAmount: undefined,
         sourceToken: undefined,
         destToken: undefined,
+        gasIncluded: false,
         destAddress: undefined,
         selectedSourceChainIds: undefined,
         selectedDestChainId: undefined,

--- a/app/core/redux/slices/bridge/index.ts
+++ b/app/core/redux/slices/bridge/index.ts
@@ -57,6 +57,7 @@ export interface BridgeState {
   bridgeViewMode: BridgeViewMode | undefined;
   isMaxSourceAmount?: boolean;
   isSelectingRecipient: boolean;
+  gasIncluded: boolean;
 }
 
 export const initialState: BridgeState = {
@@ -72,6 +73,7 @@ export const initialState: BridgeState = {
   bridgeViewMode: undefined,
   isMaxSourceAmount: false,
   isSelectingRecipient: false,
+  gasIncluded: false,
 };
 
 const name = 'bridge';
@@ -140,6 +142,9 @@ const slice = createSlice({
     },
     setIsSelectingRecipient: (state, action: PayloadAction<boolean>) => {
       state.isSelectingRecipient = action.payload;
+    },
+    setGasIncluded: (state, action: PayloadAction<boolean>) => {
+      state.gasIncluded = action.payload;
     },
   },
   extraReducers: (builder) => {
@@ -399,6 +404,8 @@ export const selectDestAddress = createSelector(
   (bridgeState) => bridgeState.destAddress,
 );
 
+export const selectGasIncluded = (state: RootState) => state.bridge.gasIncluded;
+
 const selectControllerFields = (state: RootState) => ({
   ...state.engine.backgroundState.BridgeController,
   gasFeeEstimates: selectGasFeeControllerEstimates(state) as GasFeeEstimates,
@@ -583,4 +590,5 @@ export const {
   setIsSubmittingTx,
   setBridgeViewMode,
   setIsSelectingRecipient,
+  setGasIncluded,
 } = actions;

--- a/app/util/smart-transactions/smart-publish-hook.test.ts
+++ b/app/util/smart-transactions/smart-publish-hook.test.ts
@@ -291,22 +291,6 @@ describe('submitSmartTransactionHook', () => {
     });
   });
 
-  it('falls back to regular transaction submit if it is a bridge transaction', async () => {
-    withRequest(async ({ request }) => {
-      request.transactionMeta.type = TransactionType.bridge;
-      const result = await submitSmartTransactionHook(request);
-      expect(result).toEqual({ transactionHash: undefined });
-    });
-  });
-
-  it('falls back to regular transaction submit if it is a bridgeApproval transaction', async () => {
-    withRequest(async ({ request }) => {
-      request.transactionMeta.type = TransactionType.bridgeApproval;
-      const result = await submitSmartTransactionHook(request);
-      expect(result).toEqual({ transactionHash: undefined });
-    });
-  });
-
   it('returns a txHash asap if the feature flag requires it', async () => {
     withRequest(async ({ request }) => {
       request.featureFlags.smartTransactions.mobileReturnTxHashAsap = true;

--- a/app/util/smart-transactions/smart-publish-hook.ts
+++ b/app/util/smart-transactions/smart-publish-hook.ts
@@ -2,7 +2,6 @@ import {
   TransactionParams,
   TransactionController,
   TransactionMeta,
-  TransactionType,
   type PublishBatchHookTransaction,
 } from '@metamask/transaction-controller';
 import {
@@ -183,9 +182,7 @@ class SmartTransactionHook {
     if (
       !this.#shouldUseSmartTransaction ||
       this.#transactionMeta.origin === RAMPS_SEND ||
-      isLegacyTransaction(this.#transactionMeta) ||
-      this.#transactionMeta.type === TransactionType.bridge ||
-      this.#transactionMeta.type === TransactionType.bridgeApproval
+      isLegacyTransaction(this.#transactionMeta)
     ) {
       return useRegularTransactionSubmit;
     }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Enable Gasless crosschain swaps (bridge) using eth_sendBundle

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added Gasless bridging for users with STX ON on networks supporting eth_sendBundle

Relates to https://consensyssoftware.atlassian.net/browse/STX-250
 
## **Manual testing steps**

```gherkin
Feature: Gasless crosschain swaps (bridge) using eth_sendBundle

  Scenario: user perform a gasless cross chain swap from MUSD (Ethereum-mainnet) to ETH (Base-mainnet)
    Given the user enabled Smart transactions
    AND the use does not have ETH on Ethereum-mainnet

    When user swap MUSD (Ethereum-mainnet) to ETH (Base-mainnet)
    Then the swap has gas included
```

## **Screenshots/Recordings**

TO DO

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces gasIncluded flow for Bridge/Swap by detecting eth_sendBundle support and STX enablement, wiring it into Redux and quote requests, and refining STX publish fallback behavior, with comprehensive tests.
> 
> - **Bridge UI/Hooks**:
>   - Add `useGasIncluded` to compute and dispatch `gasIncluded` based on `selectShouldUseSmartTransaction` and `useIsSendBundleSupported` (EVM-only).
>   - Add `useIsSendBundleSupported` (async sentinel check).
>   - Call `useGasIncluded(sourceToken?.chainId)` in `BridgeView` to update state on source chain changes.
> - **Redux (bridge slice)**:
>   - Add `bridge.gasIncluded` to state, selectors, and `setGasIncluded` action; update initial state and tests.
> - **Quote Request**:
>   - Include `gasIncluded` and `gasIncluded7702: false` in `GenericQuoteRequest` via `useBridgeQuoteRequest`; remove reliance on smart-transaction selector here.
> - **Smart Transactions publish hook**:
>   - Simplify fallback: drop special cases for bridge/bridgeApproval types; keep legacy and non-STX fallbacks.
> - **Tests**:
>   - New tests for `useGasIncluded` and `useIsSendBundleSupported`.
>   - Update `BridgeView` and `useBridgeQuoteRequest` tests to cover `gasIncluded` propagation and chain changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 590356d275450a6d2ceb7e01204775c6b120c13a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->