### PR TITLE
fix: cp-7.59.0 Return empty contacts for nonEVM send flow

### DIFF
--- a/app/components/Views/confirmations/hooks/send/useContacts.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useContacts.test.ts
@@ -201,6 +201,20 @@ describe('useContacts', () => {
     expect(result.current).toEqual([]);
   });
 
+  it('returns empty array when isNonEvmSendType is true', () => {
+    mockUseSendType.mockReturnValue({
+      isEvmSendType: true,
+      isSolanaSendType: false,
+      isEvmNativeSendType: false,
+      isNonEvmSendType: true,
+      isNonEvmNativeSendType: false,
+      isBitcoinSendType: false,
+      isTronSendType: false,
+    });
+    const { result } = renderHook(() => useContacts());
+    expect(result.current).toEqual([]);
+  });
+
   it('handles address book with empty chains', () => {
     mockUseSelector.mockImplementation((selector) => {
       if (selector === selectAddressBook) {

--- a/app/components/Views/confirmations/hooks/send/useContacts.ts
+++ b/app/components/Views/confirmations/hooks/send/useContacts.ts
@@ -8,7 +8,7 @@ import { useSendType } from './useSendType';
 
 export const useContacts = () => {
   const addressBook = useSelector(selectAddressBook);
-  const { isEvmSendType } = useSendType();
+  const { isEvmSendType, isNonEvmSendType } = useSendType();
 
   const contacts = useMemo(() => {
     const flattenedContacts: RecipientType[] = [];
@@ -37,6 +37,10 @@ export const useContacts = () => {
       return true;
     });
   }, [addressBook, isEvmSendType]);
+
+  if (isNonEvmSendType) {
+    return [];
+  }
 
   return contacts;
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR early return empty contacts for nonEVM send flow contact recipients.

BTC feature is getting released in this release hence there is no need for changelog.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/22205

## **Manual testing steps**

Contacts shouldn't appear for nonEVM send flow as it's EVM only.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `useContacts` returns an empty list for non-EVM send types and add a test to cover it.
> 
> - **Hooks**:
>   - `useContacts`: include `isNonEvmSendType` from `useSendType` and early-return `[]` when true; retain EVM-only address filtering logic.
> - **Tests**:
>   - Add test verifying empty contacts when `isNonEvmSendType` is true.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31d42ce46666bdd69ce552e9e8663540333e741f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->