### PR TITLE
fix(perps): display live funding rate data in the asset list

### DIFF
--- a/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.test.tsx
@@ -552,6 +552,11 @@ describe('PerpsMarketRowItem', () => {
   });
 
   describe('Funding Rate Display', () => {
+    beforeEach(() => {
+      // Reset mock to return no live prices for these tests
+      mockUsePerpsLivePrices.mockReturnValue({});
+    });
+
     it('displays funding rate when displayMetric is fundingRate', () => {
       const marketWithFundingRate: PerpsMarketData = {
         ...mockMarketData,
@@ -717,6 +722,7 @@ describe('PerpsMarketRowItem', () => {
     });
 
     it('handles very small funding rates correctly', () => {
+      mockUsePerpsLivePrices.mockReturnValue({});
       const marketWithSmallFundingRate: PerpsMarketData = {
         ...mockMarketData,
         fundingRate: 0.000001, // 0.0001% when formatted
@@ -734,6 +740,7 @@ describe('PerpsMarketRowItem', () => {
     });
 
     it('handles large funding rates correctly', () => {
+      mockUsePerpsLivePrices.mockReturnValue({});
       const marketWithLargeFundingRate: PerpsMarketData = {
         ...mockMarketData,
         fundingRate: 0.1575, // 15.75% when formatted
@@ -751,6 +758,7 @@ describe('PerpsMarketRowItem', () => {
     });
 
     it('uses formatFundingRate utility for consistent formatting', () => {
+      mockUsePerpsLivePrices.mockReturnValue({});
       const marketWithFundingRate: PerpsMarketData = {
         ...mockMarketData,
         fundingRate: 0.0125, // 1.25% when formatted

--- a/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.test.tsx
@@ -550,4 +550,278 @@ describe('PerpsMarketRowItem', () => {
       expect(screen.getByText(zeroChangeMarket.symbol)).toBeOnTheScreen();
     });
   });
+
+  describe('Funding Rate Display', () => {
+    it('displays funding rate when displayMetric is fundingRate', () => {
+      const marketWithFundingRate: PerpsMarketData = {
+        ...mockMarketData,
+        fundingRate: 0.0005, // 0.05% when formatted
+      };
+
+      render(
+        <PerpsMarketRowItem
+          market={marketWithFundingRate}
+          displayMetric="fundingRate"
+        />,
+      );
+
+      // Should display formatted funding rate using formatFundingRate utility
+      expect(screen.getByText('0.0500%')).toBeOnTheScreen();
+    });
+
+    it('displays negative funding rate correctly', () => {
+      const marketWithNegativeFundingRate: PerpsMarketData = {
+        ...mockMarketData,
+        fundingRate: -0.0023, // -0.23% when formatted
+      };
+
+      render(
+        <PerpsMarketRowItem
+          market={marketWithNegativeFundingRate}
+          displayMetric="fundingRate"
+        />,
+      );
+
+      // Should display negative funding rate
+      expect(screen.getByText('-0.2300%')).toBeOnTheScreen();
+    });
+
+    it('displays zero funding rate when fundingRate is undefined', () => {
+      const marketWithoutFundingRate: PerpsMarketData = {
+        ...mockMarketData,
+        fundingRate: undefined,
+      };
+
+      render(
+        <PerpsMarketRowItem
+          market={marketWithoutFundingRate}
+          displayMetric="fundingRate"
+        />,
+      );
+
+      // Should display zero funding rate using formatFundingRate utility
+      expect(screen.getByText('0.0000%')).toBeOnTheScreen();
+    });
+
+    it('displays zero funding rate when fundingRate is null', () => {
+      const marketWithNullFundingRate: PerpsMarketData = {
+        ...mockMarketData,
+        fundingRate: null as unknown as number,
+      };
+
+      render(
+        <PerpsMarketRowItem
+          market={marketWithNullFundingRate}
+          displayMetric="fundingRate"
+        />,
+      );
+
+      // Should display zero funding rate
+      expect(screen.getByText('0.0000%')).toBeOnTheScreen();
+    });
+
+    it('displays zero funding rate when fundingRate is 0', () => {
+      const marketWithZeroFundingRate: PerpsMarketData = {
+        ...mockMarketData,
+        fundingRate: 0,
+      };
+
+      render(
+        <PerpsMarketRowItem
+          market={marketWithZeroFundingRate}
+          displayMetric="fundingRate"
+        />,
+      );
+
+      // Should display zero funding rate
+      expect(screen.getByText('0.0000%')).toBeOnTheScreen();
+    });
+
+    it('updates funding rate from live WebSocket data', () => {
+      const marketWithInitialFundingRate: PerpsMarketData = {
+        ...mockMarketData,
+        fundingRate: 0.0001, // Initial: 0.01%
+      };
+
+      // Mock live funding rate update
+      mockUsePerpsLivePrices.mockReturnValue({
+        BTC: {
+          price: '52000.00', // Same price to test funding rate update without price change
+          funding: 0.0005, // Updated: 0.05%
+        },
+      });
+
+      render(
+        <PerpsMarketRowItem
+          market={marketWithInitialFundingRate}
+          displayMetric="fundingRate"
+        />,
+      );
+
+      // Should display the updated live funding rate
+      expect(screen.getByText('0.0500%')).toBeOnTheScreen();
+    });
+
+    it('updates funding rate even when price has not changed', () => {
+      const marketWithInitialFundingRate: PerpsMarketData = {
+        ...mockMarketData,
+        price: '$52,000',
+        fundingRate: 0.0001, // Initial: 0.01%
+      };
+
+      // Mock live data with same price but different funding rate
+      mockUsePerpsLivePrices.mockReturnValue({
+        BTC: {
+          price: '52000.00', // Same as market.price when formatted
+          funding: 0.0012, // Updated: 0.12%
+        },
+      });
+
+      render(
+        <PerpsMarketRowItem
+          market={marketWithInitialFundingRate}
+          displayMetric="fundingRate"
+        />,
+      );
+
+      // Should display the updated funding rate even though price didn't change
+      expect(screen.getByText('0.1200%')).toBeOnTheScreen();
+      // Price should remain the same
+      expect(screen.getByText('$52,000')).toBeOnTheScreen();
+    });
+
+    it('does not update when funding rate has not changed', () => {
+      const marketWithFundingRate: PerpsMarketData = {
+        ...mockMarketData,
+        price: '$52,000',
+        fundingRate: 0.0005, // 0.05%
+      };
+
+      // Mock live data with same price and same funding rate
+      mockUsePerpsLivePrices.mockReturnValue({
+        BTC: {
+          price: '52000.00', // Same price
+          funding: 0.0005, // Same funding rate
+        },
+      });
+
+      render(
+        <PerpsMarketRowItem
+          market={marketWithFundingRate}
+          displayMetric="fundingRate"
+        />,
+      );
+
+      // Should display the original funding rate
+      expect(screen.getByText('0.0500%')).toBeOnTheScreen();
+    });
+
+    it('handles very small funding rates correctly', () => {
+      const marketWithSmallFundingRate: PerpsMarketData = {
+        ...mockMarketData,
+        fundingRate: 0.000001, // 0.0001% when formatted
+      };
+
+      render(
+        <PerpsMarketRowItem
+          market={marketWithSmallFundingRate}
+          displayMetric="fundingRate"
+        />,
+      );
+
+      // Should display with 4 decimal places
+      expect(screen.getByText('0.0001%')).toBeOnTheScreen();
+    });
+
+    it('handles large funding rates correctly', () => {
+      const marketWithLargeFundingRate: PerpsMarketData = {
+        ...mockMarketData,
+        fundingRate: 0.1575, // 15.75% when formatted
+      };
+
+      render(
+        <PerpsMarketRowItem
+          market={marketWithLargeFundingRate}
+          displayMetric="fundingRate"
+        />,
+      );
+
+      // Should display with 4 decimal places
+      expect(screen.getByText('15.7500%')).toBeOnTheScreen();
+    });
+
+    it('uses formatFundingRate utility for consistent formatting', () => {
+      const marketWithFundingRate: PerpsMarketData = {
+        ...mockMarketData,
+        fundingRate: 0.0125, // 1.25% when formatted
+      };
+
+      render(
+        <PerpsMarketRowItem
+          market={marketWithFundingRate}
+          displayMetric="fundingRate"
+        />,
+      );
+
+      // Should use formatFundingRate which formats to 4 decimal places
+      // This ensures consistency with PerpsMarketStatisticsCard
+      expect(screen.getByText('1.2500%')).toBeOnTheScreen();
+    });
+
+    it('passes updated funding rate to onPress callback', () => {
+      const mockOnPress = jest.fn();
+      const marketWithInitialFundingRate: PerpsMarketData = {
+        ...mockMarketData,
+        fundingRate: 0.0001,
+      };
+
+      // Mock live funding rate update
+      mockUsePerpsLivePrices.mockReturnValue({
+        BTC: {
+          price: '52000.00',
+          funding: 0.0005, // Updated funding rate
+        },
+      });
+
+      render(
+        <PerpsMarketRowItem
+          market={marketWithInitialFundingRate}
+          displayMetric="fundingRate"
+          onPress={mockOnPress}
+        />,
+      );
+
+      const touchableOpacity = screen.root.findByType(TouchableOpacity);
+      fireEvent.press(touchableOpacity);
+
+      // Should pass the updated market data with live funding rate
+      expect(mockOnPress).toHaveBeenCalledTimes(1);
+      expect(mockOnPress.mock.calls[0][0].fundingRate).toBe(0.0005);
+    });
+
+    it('handles funding rate update when live data funding is undefined', () => {
+      const marketWithFundingRate: PerpsMarketData = {
+        ...mockMarketData,
+        fundingRate: 0.0005, // Initial: 0.05%
+      };
+
+      // Mock live data without funding rate
+      mockUsePerpsLivePrices.mockReturnValue({
+        BTC: {
+          price: '52000.00',
+          // funding is undefined
+        },
+      });
+
+      render(
+        <PerpsMarketRowItem
+          market={marketWithFundingRate}
+          displayMetric="fundingRate"
+        />,
+      );
+
+      // Should keep the original funding rate when live data doesn't have funding
+      expect(screen.getByText('0.0500%')).toBeOnTheScreen();
+    });
+  });
 });

--- a/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.tsx
@@ -17,6 +17,7 @@ import {
   getMarketBadgeType,
 } from '../../utils/marketUtils';
 import {
+  formatFundingRate,
   formatPercentage,
   formatPerpsFiat,
   formatPnl,
@@ -63,8 +64,13 @@ const PerpsMarketRowItem = ({
       maximumDecimals: 2,
     });
 
-    // Only update if price actually changed
-    if (comparisonPrice === market.price) {
+    // Check if funding rate needs updating (even if price hasn't changed)
+    const fundingRateChanged =
+      livePrice.funding !== undefined &&
+      livePrice.funding !== market.fundingRate;
+
+    // Only update if price actually changed or funding rate needs updating
+    if (comparisonPrice === market.price && !fundingRateChanged) {
       return market;
     }
 
@@ -108,6 +114,11 @@ const PerpsMarketRowItem = ({
       updatedMarket.volume = PERPS_CONSTANTS.FALLBACK_PRICE_DISPLAY;
     }
 
+    // Update funding rate from live data if available
+    if (livePrice.funding !== undefined) {
+      updatedMarket.fundingRate = livePrice.funding;
+    }
+
     return updatedMarket;
   }, [market, livePrices]);
 
@@ -125,14 +136,8 @@ const PerpsMarketRowItem = ({
           displayMarket.openInterest || PERPS_CONSTANTS.FALLBACK_PRICE_DISPLAY
         );
       case 'fundingRate':
-        // Format funding rate as percentage (e.g., 0.0001 → 0.0100%)
-        if (
-          displayMarket.fundingRate !== undefined &&
-          displayMarket.fundingRate !== null
-        ) {
-          return `${(displayMarket.fundingRate * 100).toFixed(4)}%`;
-        }
-        return '0.0000%';
+        // Use formatFundingRate utility for consistent formatting with asset detail screen
+        return formatFundingRate(displayMarket.fundingRate);
       case 'volume':
       default:
         return displayMarket.volume;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes a discrepancy where the funding rate shown in the Perps markets list differed from the asset detail screen. The detail screen used live WebSocket data and `formatFundingRate()`, while the list used static data and manual formatting.

## **Changelog**

CHANGELOG entry: Fixed funding rate display inconsistency between Perps markets list and asset detail screen

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1975

## **Manual testing steps**

```gherkin
Feature: Perps funding rate display consistency

  Scenario: funding rate matches between markets list and detail screen
    Given user is on the Perps markets list view
    And user has selected "Funding Rate" as the display metric
    When user views the funding rate for any market in the list
    Then the funding rate displayed matches the funding rate shown on the asset detail screen
    And the funding rate updates in real-time from WebSocket data
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/11a1cf39-8077-4707-8498-db74f2391e68




### **After**

https://github.com/user-attachments/assets/d5e10cf2-7bb8-404f-bf3c-286b1fccac47


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Displays funding rate from live WebSocket data (even when price is unchanged) and formats it via formatFundingRate; adds comprehensive tests.
> 
> - **PerpsMarketRowItem** (`PerpsMarketRowItem.tsx`):
>   - **Live data merge**: Update `market.fundingRate` from `livePrice.funding` and trigger updates even if `price` is unchanged.
>   - **Formatting**: Use `formatFundingRate` for `displayMetric="fundingRate"` for consistent 4-decimal percentage output.
> - **Tests** (`PerpsMarketRowItem.test.tsx`):
>   - Add funding rate test suite covering positive/negative/zero, undefined/null, very small/large values, live updates, unchanged values, and `onPress` propagation of updated data.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6329c69233903bc48849f78ff37afe89b6caa1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->