### PR TITLE
fix: cp-7.59.0 Fix minimum BTC amount validation in send flow

### DIFF
--- a/app/components/Views/confirmations/hooks/send/useAmountValidation.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useAmountValidation.test.ts
@@ -5,6 +5,7 @@ import { evmSendStateMock } from '../../__mocks__/send.mock';
 import { useSendContext } from '../../context/send-context';
 import { useAmountValidation } from './useAmountValidation';
 import { useBalance } from './useBalance';
+import { useSendType } from './useSendType';
 
 jest.mock('../../context/send-context', () => ({
   useSendContext: jest.fn(),
@@ -12,6 +13,10 @@ jest.mock('../../context/send-context', () => ({
 
 jest.mock('./useBalance', () => ({
   useBalance: jest.fn(),
+}));
+
+jest.mock('./useSendType', () => ({
+  useSendType: jest.fn(),
 }));
 
 const mockState = {
@@ -24,7 +29,15 @@ const mockUseSendContext = useSendContext as jest.MockedFunction<
 
 const mockUseBalance = useBalance as jest.MockedFunction<typeof useBalance>;
 
+const mockUseSendType = useSendType as jest.MockedFunction<typeof useSendType>;
+
 describe('useAmountValidation', () => {
+  beforeEach(() => {
+    mockUseSendType.mockReturnValue({
+      isBitcoinSendType: false,
+    } as ReturnType<typeof useSendType>);
+  });
+
   it('return field for amount error', () => {
     mockUseSendContext.mockReturnValue({
       value: '',
@@ -108,6 +121,69 @@ describe('useAmountValidation', () => {
       () => useAmountValidation(),
       mockState,
     );
+    expect(result.current.amountError).toEqual(undefined);
+  });
+
+  it('returns error for Bitcoin amount below minimum threshold', () => {
+    mockUseSendType.mockReturnValue({
+      isBitcoinSendType: true,
+    } as ReturnType<typeof useSendType>);
+    mockUseSendContext.mockReturnValue({
+      value: '0.00005',
+    } as unknown as ReturnType<typeof useSendContext>);
+    mockUseBalance.mockReturnValue({
+      balance: '1',
+      decimals: 8,
+      rawBalanceBN: new BN('100000000'),
+    });
+
+    const { result } = renderHookWithProvider(
+      () => useAmountValidation(),
+      mockState,
+    );
+
+    expect(result.current.amountError).toEqual('Invalid value');
+  });
+
+  it('does not return error for Bitcoin amount at minimum threshold', () => {
+    mockUseSendType.mockReturnValue({
+      isBitcoinSendType: true,
+    } as ReturnType<typeof useSendType>);
+    mockUseSendContext.mockReturnValue({
+      value: '0.0001',
+    } as unknown as ReturnType<typeof useSendContext>);
+    mockUseBalance.mockReturnValue({
+      balance: '1',
+      decimals: 8,
+      rawBalanceBN: new BN('100000000'),
+    });
+
+    const { result } = renderHookWithProvider(
+      () => useAmountValidation(),
+      mockState,
+    );
+
+    expect(result.current.amountError).toEqual(undefined);
+  });
+
+  it('does not return error for Bitcoin amount above minimum threshold', () => {
+    mockUseSendType.mockReturnValue({
+      isBitcoinSendType: true,
+    } as ReturnType<typeof useSendType>);
+    mockUseSendContext.mockReturnValue({
+      value: '0.5',
+    } as unknown as ReturnType<typeof useSendContext>);
+    mockUseBalance.mockReturnValue({
+      balance: '1',
+      decimals: 8,
+      rawBalanceBN: new BN('100000000'),
+    });
+
+    const { result } = renderHookWithProvider(
+      () => useAmountValidation(),
+      mockState,
+    );
+
     expect(result.current.amountError).toEqual(undefined);
   });
 });

--- a/app/components/Views/confirmations/hooks/send/useAmountValidation.ts
+++ b/app/components/Views/confirmations/hooks/send/useAmountValidation.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { BigNumber } from 'bignumber.js';
 
 import { strings } from '../../../../../../locales/i18n';
 import {
@@ -8,10 +9,18 @@ import {
 
 import { useSendContext } from '../../context/send-context';
 import { useBalance } from './useBalance';
+import { useSendType } from './useSendType';
+
+const MINIMUM_BITCOIN_TRANSACTION_AMOUNT = new BigNumber('0.0001');
+const isValidBitcoinAmount = (value: string) => {
+  const valueBN = new BigNumber(value);
+  return valueBN.gte(MINIMUM_BITCOIN_TRANSACTION_AMOUNT);
+};
 
 export const useAmountValidation = () => {
   const { value } = useSendContext();
   const { decimals, rawBalanceBN } = useBalance();
+  const { isBitcoinSendType } = useSendType();
 
   const amountError = useMemo(() => {
     if (value === undefined || value === null || value === '') {
@@ -24,8 +33,14 @@ export const useAmountValidation = () => {
     if (rawBalanceBN.cmp(amountInputBN) === -1) {
       return strings('send.insufficient_funds');
     }
+
+    // This is a temporary fix for the bitcoin send type.
+    // Once onAmountInput validation is implemented, this can be removed.
+    if (isBitcoinSendType && !isValidBitcoinAmount(value)) {
+      return strings('send.invalid_value');
+    }
     return undefined;
-  }, [decimals, rawBalanceBN, value]);
+  }, [decimals, isBitcoinSendType, rawBalanceBN, value]);
 
   return { amountError };
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to fix BTC amount validation in send flow. 

As we will implement `onAmountInput` validations - this is a temporary fix to handle it in the client code. In near future this validation will be handled in snap repository.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/22204

## **Manual testing steps**

1. Go send flow
2. Pick BTC
3. Try sending lower than 0.0001
4. You shouldn't be able to proceed to recipient page

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces a 0.0001 BTC minimum in send amount validation and adds tests for BTC thresholds.
> 
> - **Validation**:
>   - Update `useAmountValidation` to use `useSendType` and `bignumber.js` to enforce a Bitcoin minimum amount of `0.0001`.
>   - Add temporary Bitcoin-specific check returning `strings('send.invalid_value')` when below threshold.
>   - Update memo dependencies to include `isBitcoinSendType`.
> - **Tests**:
>   - Extend `useAmountValidation.test.ts` to mock `useSendType` and cover BTC amounts below, at, and above the minimum threshold.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab9acac568d3b285d59d173214fe4aedabcca2f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->