### PR TITLE
chore: rewards optimize usage of get opt in status

### DIFF
--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -4139,7 +4139,7 @@ describe('RewardsController', () => {
       );
     });
 
-    it('should handle SeasonNotFoundError by invalidating cache, clearing seasons, and rethrowing error', async () => {
+    it('should handle SeasonNotFoundError by clearing seasons and rethrowing error', async () => {
       // Arrange
       const seasonNotFoundError = new SeasonNotFoundError('Season not found');
       const localMockMessenger = {
@@ -4185,27 +4185,10 @@ describe('RewardsController', () => {
 
       localMockMessenger.call.mockRejectedValue(seasonNotFoundError);
 
-      const invalidateSubscriptionCacheSpy = jest.spyOn(
-        testableController,
-        'invalidateSubscriptionCache',
-      );
-      const invalidateAccountsAndSubscriptionsSpy = jest.spyOn(
-        testableController,
-        'invalidateAccountsAndSubscriptions',
-      );
-
       // Act & Assert
       await expect(
         testableController.getSeasonStatus(mockSubscriptionId, mockSeasonId),
       ).rejects.toThrow(seasonNotFoundError);
-
-      // Verify invalidateSubscriptionCache was called
-      expect(invalidateSubscriptionCacheSpy).toHaveBeenCalledWith(
-        mockSubscriptionId,
-      );
-
-      // Verify invalidateAccountsAndSubscriptions was called
-      expect(invalidateAccountsAndSubscriptionsSpy).toHaveBeenCalled();
 
       // Verify seasons state was cleared
       expect(testableController.state.seasons).toEqual({});

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -63,6 +63,7 @@ jest.mock('./services/rewards-data-service', () => {
     InvalidTimestampError: actual.InvalidTimestampError,
     AuthorizationFailedError: actual.AuthorizationFailedError,
     AccountAlreadyRegisteredError: actual.AccountAlreadyRegisteredError,
+    SeasonNotFoundError: actual.SeasonNotFoundError,
   };
 });
 // Mock base58 decode from ethers
@@ -93,6 +94,7 @@ import {
   AuthorizationFailedError,
   InvalidTimestampError,
   AccountAlreadyRegisteredError,
+  SeasonNotFoundError,
   RewardsDataService,
 } from './services/rewards-data-service';
 
@@ -2657,14 +2659,34 @@ describe('RewardsController', () => {
       // Clear previous calls
       mockMessenger.call.mockClear();
       mockLogger.log.mockClear();
+      mockStoreSubscriptionToken.mockResolvedValue({ success: true });
 
-      // Mock the calls in order
-      mockMessenger.call
-        .mockReturnValueOnce([mockInternalAccount]) // AccountTreeController:getAccountsFromSelectedAccountGroup
-        .mockReturnValueOnce([mockInternalAccount]) // AccountsController:listMultichainAccounts (for getOptInStatus)
-        .mockResolvedValueOnce(mockOptInStatusResponse) // RewardsDataService:getOptInStatus
-        .mockResolvedValueOnce('0xsignature') // KeyringController:signPersonalMessage
-        .mockResolvedValueOnce(mockLoginResponse); // RewardsDataService:login
+      // Mock the calls in order - need to use mockImplementation to handle all calls
+      // since mockClear() removes the default implementation
+      mockMessenger.call.mockImplementation(
+        (method: string, ..._args: unknown[]) => {
+          if (
+            method ===
+            'AccountTreeController:getAccountsFromSelectedAccountGroup'
+          ) {
+            return [mockInternalAccount];
+          }
+          if (method === 'AccountsController:listMultichainAccounts') {
+            return [mockInternalAccount];
+          }
+          if (method === 'RewardsDataService:getOptInStatus') {
+            return Promise.resolve(mockOptInStatusResponse);
+          }
+          if (method === 'KeyringController:signPersonalMessage') {
+            return Promise.resolve('0xsignature');
+          }
+          if (method === 'RewardsDataService:login') {
+            return Promise.resolve(mockLoginResponse);
+          }
+          // Default: return a resolved promise for any other calls
+          return Promise.resolve(undefined);
+        },
+      );
 
       // Act
       if (subscribeCallback) {
@@ -4116,6 +4138,78 @@ describe('RewardsController', () => {
         'Too Many Requests: 429',
       );
     });
+
+    it('should handle SeasonNotFoundError by invalidating cache, clearing seasons, and rethrowing error', async () => {
+      // Arrange
+      const seasonNotFoundError = new SeasonNotFoundError('Season not found');
+      const localMockMessenger = {
+        subscribe: jest.fn(),
+        call: jest.fn(),
+        registerActionHandler: jest.fn(),
+        unregisterActionHandler: jest.fn(),
+        publish: jest.fn(),
+        clearEventSubscriptions: jest.fn(),
+        registerInitialEventPayload: jest.fn(),
+        unsubscribe: jest.fn(),
+      } as unknown as jest.Mocked<RewardsControllerMessenger>;
+      const testableController = new TestableRewardsController({
+        messenger: localMockMessenger,
+        isDisabled: () => false,
+      });
+      testableController.testUpdate((state) => {
+        state.activeAccount = {
+          subscriptionId: mockSubscriptionId,
+          account: 'eip155:1:0x123',
+          hasOptedIn: true,
+          perpsFeeDiscount: null,
+          lastPerpsDiscountRateFetched: null,
+        };
+        state.accounts = {};
+        state.subscriptions = {};
+        state.seasons = {
+          [mockSeasonId]: {
+            id: mockSeasonId,
+            name: 'Mock Season',
+            startDate: new Date('2024-01-01T00:00:00Z').getTime(),
+            endDate: new Date('2024-12-31T23:59:59Z').getTime(),
+            tiers: createTestTiers(),
+            lastFetched: Date.now(),
+          },
+        };
+        state.subscriptionReferralDetails = {};
+        state.seasonStatuses = {};
+        state.activeBoosts = {};
+        state.unlockedRewards = {};
+        state.pointsEvents = {};
+      });
+
+      localMockMessenger.call.mockRejectedValue(seasonNotFoundError);
+
+      const invalidateSubscriptionCacheSpy = jest.spyOn(
+        testableController,
+        'invalidateSubscriptionCache',
+      );
+      const invalidateAccountsAndSubscriptionsSpy = jest.spyOn(
+        testableController,
+        'invalidateAccountsAndSubscriptions',
+      );
+
+      // Act & Assert
+      await expect(
+        testableController.getSeasonStatus(mockSubscriptionId, mockSeasonId),
+      ).rejects.toThrow(seasonNotFoundError);
+
+      // Verify invalidateSubscriptionCache was called
+      expect(invalidateSubscriptionCacheSpy).toHaveBeenCalledWith(
+        mockSubscriptionId,
+      );
+
+      // Verify invalidateAccountsAndSubscriptions was called
+      expect(invalidateAccountsAndSubscriptionsSpy).toHaveBeenCalled();
+
+      // Verify seasons state was cleared
+      expect(testableController.state.seasons).toEqual({});
+    });
   });
 
   describe('getSeasonMetadata', () => {
@@ -5385,7 +5479,7 @@ describe('RewardsController', () => {
       mockIsSolanaAddress.mockReturnValue(false);
     });
 
-    it('should return false when account has no state (never checked before)', () => {
+    it('should return false when account has no state (never checked before)', async () => {
       // Arrange
       const mockInternalAccount = {
         address: '0x123',
@@ -5419,7 +5513,7 @@ describe('RewardsController', () => {
       const caipAccount = 'eip155:1:0x123' as CaipAccountId;
 
       // Act
-      const result = controller.shouldSkipSilentAuth(
+      const result = await controller.shouldSkipSilentAuth(
         caipAccount,
         mockInternalAccount,
       );
@@ -5428,7 +5522,7 @@ describe('RewardsController', () => {
       expect(result).toBe(false);
     });
 
-    it('should return true when account has opted in', () => {
+    it('should return true when account has opted in', async () => {
       // Arrange
       const mockInternalAccount = {
         address: '0x123',
@@ -5445,13 +5539,20 @@ describe('RewardsController', () => {
       };
 
       const caipAccount = 'eip155:1:0x123' as CaipAccountId;
+      const subscriptionId = 'sub123';
       const accountState: RewardsAccountState = {
         account: caipAccount,
         hasOptedIn: true,
-        subscriptionId: 'sub123',
+        subscriptionId,
         perpsFeeDiscount: 0,
         lastPerpsDiscountRateFetched: Date.now(),
       };
+
+      // Mock getSubscriptionToken to return a valid token
+      mockGetSubscriptionToken.mockResolvedValueOnce({
+        success: true,
+        token: 'valid-session-token',
+      });
 
       controller = new RewardsController({
         messenger: mockMessenger,
@@ -5469,16 +5570,18 @@ describe('RewardsController', () => {
       });
 
       // Act
-      const result = controller.shouldSkipSilentAuth(
+      const result = await controller.shouldSkipSilentAuth(
         caipAccount,
         mockInternalAccount,
       );
 
       // Assert
       expect(result).toBe(true);
+      expect(accountState.subscriptionId).toBe(subscriptionId);
+      expect(mockGetSubscriptionToken).toHaveBeenCalledWith(subscriptionId);
     });
 
-    it('should return false when account has not opted in and lastFreshOptInStatusCheck is missing', () => {
+    it('should return false when account has not opted in and lastFreshOptInStatusCheck is missing', async () => {
       // Arrange
       const mockInternalAccount = {
         address: '0x123',
@@ -5520,7 +5623,7 @@ describe('RewardsController', () => {
       });
 
       // Act
-      const result = controller.shouldSkipSilentAuth(
+      const result = await controller.shouldSkipSilentAuth(
         caipAccount,
         mockInternalAccount,
       );
@@ -5529,7 +5632,7 @@ describe('RewardsController', () => {
       expect(result).toBe(false);
     });
 
-    it('should return true when account has not opted in but cache is fresh (within 1 hour)', () => {
+    it('should return true when account has not opted in but cache is fresh (within 1 hour)', async () => {
       // Arrange
       const mockInternalAccount = {
         address: '0x123',
@@ -5573,7 +5676,7 @@ describe('RewardsController', () => {
       });
 
       // Act
-      const result = controller.shouldSkipSilentAuth(
+      const result = await controller.shouldSkipSilentAuth(
         caipAccount,
         mockInternalAccount,
       );
@@ -5582,7 +5685,7 @@ describe('RewardsController', () => {
       expect(result).toBe(true);
     });
 
-    it('should return false when account has not opted in and cache is stale (beyond 1 hour)', () => {
+    it('should return false when account has not opted in and cache is stale (beyond 1 hour)', async () => {
       // Arrange
       const mockInternalAccount = {
         address: '0x123',
@@ -5626,7 +5729,7 @@ describe('RewardsController', () => {
       });
 
       // Act
-      const result = controller.shouldSkipSilentAuth(
+      const result = await controller.shouldSkipSilentAuth(
         caipAccount,
         mockInternalAccount,
       );
@@ -5635,7 +5738,7 @@ describe('RewardsController', () => {
       expect(result).toBe(false);
     });
 
-    it('should handle CAIP ID normalization correctly (eip155:0 format)', () => {
+    it('should handle CAIP ID normalization correctly (eip155:0 format)', async () => {
       // Arrange
       const mockInternalAccount = {
         address: '0xABC',
@@ -5653,13 +5756,20 @@ describe('RewardsController', () => {
 
       // Store with normalized format (eip155:0)
       const normalizedCaipAccount = 'eip155:0:0xabc' as CaipAccountId;
+      const subscriptionId = 'sub123';
       const accountState: RewardsAccountState = {
         account: normalizedCaipAccount,
         hasOptedIn: true,
-        subscriptionId: 'sub123',
+        subscriptionId,
         perpsFeeDiscount: 0,
         lastPerpsDiscountRateFetched: Date.now(),
       };
+
+      // Mock getSubscriptionToken to return a valid token
+      mockGetSubscriptionToken.mockResolvedValueOnce({
+        success: true,
+        token: 'valid-session-token',
+      });
 
       controller = new RewardsController({
         messenger: mockMessenger,
@@ -5679,63 +5789,15 @@ describe('RewardsController', () => {
       const lookupCaipAccount = 'eip155:1:0xABC' as CaipAccountId;
 
       // Act - Should find account even with different chain ID format
-      const result = controller.shouldSkipSilentAuth(
+      const result = await controller.shouldSkipSilentAuth(
         lookupCaipAccount,
         mockInternalAccount,
       );
 
       // Assert
       expect(result).toBe(true);
-    });
-
-    it('should return false when account state exists but hasOptedIn is undefined', () => {
-      // Arrange
-      const mockInternalAccount = {
-        address: '0x123',
-        type: 'eip155:eoa' as const,
-        id: 'test-id',
-        scopes: ['eip155:1' as const],
-        options: {},
-        methods: ['personal_sign'],
-        metadata: {
-          name: 'Test Account',
-          keyring: { type: 'HD Key Tree' },
-          importTime: Date.now(),
-        },
-      };
-
-      const caipAccount = 'eip155:1:0x123' as CaipAccountId;
-      const accountState = {
-        account: caipAccount,
-        subscriptionId: null,
-        perpsFeeDiscount: 0,
-        lastPerpsDiscountRateFetched: Date.now(),
-        // hasOptedIn is undefined
-      } as unknown as RewardsAccountState;
-
-      controller = new RewardsController({
-        messenger: mockMessenger,
-        state: {
-          activeAccount: accountState,
-          accounts: { [caipAccount]: accountState },
-          subscriptions: {},
-          seasons: {},
-          subscriptionReferralDetails: {},
-          seasonStatuses: {},
-          activeBoosts: {},
-          unlockedRewards: {},
-          pointsEvents: {},
-        },
-      });
-
-      // Act
-      const result = controller.shouldSkipSilentAuth(
-        caipAccount,
-        mockInternalAccount,
-      );
-
-      // Assert
-      expect(result).toBe(true);
+      expect(accountState.subscriptionId).toBe(subscriptionId);
+      expect(mockGetSubscriptionToken).toHaveBeenCalledWith(subscriptionId);
     });
   });
 

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -54,6 +54,7 @@ import {
   AuthorizationFailedError,
   InvalidTimestampError,
   AccountAlreadyRegisteredError,
+  SeasonNotFoundError,
 } from './services/rewards-data-service';
 import { sortAccounts } from './utils/sortAccounts';
 
@@ -668,6 +669,15 @@ export class RewardsController extends BaseController<
       } else {
         const sortedAccounts = sortAccounts(accounts);
 
+        try {
+          // Prefer to get opt in status in bulk for sorted accounts.
+          await this.getOptInStatus({
+            addresses: sortedAccounts.map((account) => account.address),
+          });
+        } catch {
+          // Failed to get opt in status in bulk for sorted accounts, let silent auth do it individually
+        }
+
         // Try silent auth on each account until one succeeds
         let successAccount: InternalAccount | null = null;
         for (const account of sortedAccounts) {
@@ -717,10 +727,10 @@ export class RewardsController extends BaseController<
   /**
    * Check if silent authentication should be skipped
    */
-  shouldSkipSilentAuth(
+  async shouldSkipSilentAuth(
     account: CaipAccountId,
     internalAccount: InternalAccount,
-  ): boolean {
+  ): Promise<boolean> {
     // Skip if opt-in is not supported (e.g., hardware wallets, unsupported account types)
     if (!this.isOptInSupported(internalAccount)) return true;
 
@@ -736,7 +746,13 @@ export class RewardsController extends BaseController<
           NOT_OPTED_IN_OIS_STALE_CACHE_THRESHOLD_MS
         );
       }
-      return true;
+      return (
+        Boolean(accountState.subscriptionId) &&
+        Boolean(
+          (await getSubscriptionToken(accountState.subscriptionId as string))
+            ?.token,
+        )
+      );
     }
 
     return false;
@@ -816,7 +832,7 @@ export class RewardsController extends BaseController<
       this.convertInternalAccountToCaipAccountId(internalAccount);
 
     const shouldSkip = account
-      ? this.shouldSkipSilentAuth(account, internalAccount)
+      ? await this.shouldSkipSilentAuth(account, internalAccount)
       : false;
 
     if (shouldSkip && respectSkipSilentAuth) {
@@ -1804,6 +1820,13 @@ export class RewardsController extends BaseController<
               await this.invalidateAccountsAndSubscriptions();
               throw error;
             }
+          } else if (error instanceof SeasonNotFoundError) {
+            this.invalidateSubscriptionCache(subscriptionId);
+            this.invalidateAccountsAndSubscriptions();
+            this.update((state: RewardsControllerState) => {
+              state.seasons = {};
+            });
+            throw error;
           }
           Logger.log(
             'RewardsController: Failed to get season status:',

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -1821,8 +1821,6 @@ export class RewardsController extends BaseController<
               throw error;
             }
           } else if (error instanceof SeasonNotFoundError) {
-            this.invalidateSubscriptionCache(subscriptionId);
-            this.invalidateAccountsAndSubscriptions();
             this.update((state: RewardsControllerState) => {
               state.seasons = {};
             });

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
@@ -2,6 +2,7 @@ import {
   InvalidTimestampError,
   AuthorizationFailedError,
   AccountAlreadyRegisteredError,
+  SeasonNotFoundError,
   RewardsDataService,
   type RewardsDataServiceMessenger,
 } from './rewards-data-service';
@@ -1069,6 +1070,46 @@ describe('RewardsDataService', () => {
       await expect(
         service.getSeasonStatus(mockSeasonId, mockSubscriptionId),
       ).rejects.toBeInstanceOf(AuthorizationFailedError);
+    });
+
+    it('throws SeasonNotFoundError when season is not found', async () => {
+      const mockResponse = {
+        ok: false,
+        status: 404,
+        json: jest.fn().mockResolvedValue({
+          message: 'Season not found',
+        }),
+      } as unknown as Response;
+      mockFetch.mockResolvedValue(mockResponse);
+
+      let caughtError: unknown;
+      try {
+        await service.getSeasonStatus(mockSeasonId, mockSubscriptionId);
+      } catch (error) {
+        caughtError = error;
+      }
+
+      expect(caughtError).toBeInstanceOf(SeasonNotFoundError);
+      const seasonNotFoundError = caughtError as SeasonNotFoundError;
+      expect(seasonNotFoundError.name).toBe('SeasonNotFoundError');
+      expect(seasonNotFoundError.message).toBe(
+        'Season not found. Please try again with a different season.',
+      );
+    });
+
+    it('detects season not found when message contains the phrase', async () => {
+      const mockResponse = {
+        ok: false,
+        status: 404,
+        json: jest.fn().mockResolvedValue({
+          message: 'The requested Season not found in the system',
+        }),
+      } as unknown as Response;
+      mockFetch.mockResolvedValue(mockResponse);
+
+      await expect(
+        service.getSeasonStatus(mockSeasonId, mockSubscriptionId),
+      ).rejects.toBeInstanceOf(SeasonNotFoundError);
     });
 
     it('throws error when fetch fails', async () => {

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.ts
@@ -52,6 +52,16 @@ export class AuthorizationFailedError extends Error {
 }
 
 /**
+ * Custom error for season not found
+ */
+export class SeasonNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SeasonNotFoundError';
+  }
+}
+
+/**
  * Custom error for account already registered (409 conflict)
  */
 export class AccountAlreadyRegisteredError extends Error {
@@ -642,6 +652,12 @@ export class RewardsDataService {
       if (errorData?.message?.includes('Rewards authorization failed')) {
         throw new AuthorizationFailedError(
           'Rewards authorization failed. Please login and try again.',
+        );
+      }
+
+      if (errorData?.message?.includes('Season not found')) {
+        throw new SeasonNotFoundError(
+          'Season not found. Please try again with a different season.',
         );
       }
 


### PR DESCRIPTION
## **Description**

Before this PR, the silent auth function was calling the get opt in status endpoint (under some circumstances) for an individual address. This is fine if it's called in some places, but not so efficient when it's called for an entire account group via an auth trigger (i.e. account group changed). In this new implementation, we now do this in bulk before attempting to start calling silent auth for any account of the account group.

We're also adding a new defined exception for when the season state returns a 404. In this case we also clear some of the state in the app. 

## **Changelog**

CHANGELOG entry: null

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prefetches bulk opt-in status for account groups, makes silent-auth skip token-aware, and throws/handles SeasonNotFound by clearing season cache.
> 
> - **RewardsController**:
>   - Prefetch `getOptInStatus` for sorted accounts before running per-account silent auth.
>   - Make `shouldSkipSilentAuth` async and require valid session token when `hasOptedIn` is true.
>   - Await async skip check in `performSilentAuth`.
>   - On `SeasonNotFoundError` in `getSeasonStatus`, clear `state.seasons` and rethrow.
> - **RewardsDataService**:
>   - Add `SeasonNotFoundError`; throw when 404 message indicates season not found in `getSeasonStatus`.
> - **Tests**:
>   - Update tests to await async `shouldSkipSilentAuth`, validate token checks, and add coverage for `SeasonNotFoundError` handling.
>   - Adjust mocks to support new call flow (bulk opt-in status, token retrieval).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdd6b1a59d693b13cf80653b9384a837ec757ca9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->