### PR TITLE
chore(predict): change polymarket links to use webview

### DIFF
--- a/app/components/UI/Predict/components/PredictConsentSheet/PredictConsentSheet.tsx
+++ b/app/components/UI/Predict/components/PredictConsentSheet/PredictConsentSheet.tsx
@@ -4,8 +4,8 @@ import Text, {
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import React, { forwardRef, useImperativeHandle } from 'react';
-import { Linking } from 'react-native';
+import React, { forwardRef, useCallback, useImperativeHandle } from 'react';
+import { InteractionManager, TouchableOpacity } from 'react-native';
 import { strings } from '../../../../../../locales/i18n';
 
 // Internal dependencies.
@@ -19,6 +19,7 @@ import {
   usePredictBottomSheet,
   type PredictBottomSheetRef,
 } from '../../hooks/usePredictBottomSheet';
+import { useNavigation } from '@react-navigation/native';
 
 interface PredictConsentSheetProps {
   providerId: string;
@@ -33,6 +34,7 @@ const PredictConsentSheet = forwardRef<
   PredictConsentSheetProps
 >(({ providerId, onDismiss, onAgree }, ref) => {
   const tw = useTailwind();
+  const navigation = useNavigation();
   const { acceptAgreement } = usePredictAgreement({ providerId });
   const { sheetRef, isVisible, closeSheet, handleSheetClosed, getRefHandlers } =
     usePredictBottomSheet({ onDismiss });
@@ -48,6 +50,18 @@ const PredictConsentSheet = forwardRef<
   };
 
   useImperativeHandle(ref, getRefHandlers, [getRefHandlers]);
+
+  const handlePolymarketTerms = useCallback(() => {
+    InteractionManager.runAfterInteractions(() => {
+      navigation.navigate('Webview', {
+        screen: 'SimpleWebview',
+        params: {
+          url: 'https://polymarket.com/tos',
+          title: strings('predict.consent_sheet.title'),
+        },
+      });
+    });
+  }, [navigation]);
 
   if (!isVisible) {
     return null;
@@ -66,19 +80,18 @@ const PredictConsentSheet = forwardRef<
         </Text>
       </BottomSheetHeader>
       <Box twClassName="px-6 pb-6">
-        <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
-          {strings('predict.consent_sheet.description')}{' '}
-        </Text>
-        <Text
-          variant={TextVariant.BodyMD}
-          style={tw.style('text-info-default')}
-          onPress={() => {
-            Linking.openURL('https://polymarket.com/tos');
-          }}
-          suppressHighlighting
-        >
-          {strings('predict.consent_sheet.learn_more')}
-        </Text>
+        <TouchableOpacity onPress={handlePolymarketTerms}>
+          <Text variant={TextVariant.BodyMD} color={TextColor.Alternative}>
+            {strings('predict.consent_sheet.description')}{' '}
+            <Text
+              variant={TextVariant.BodyMD}
+              style={tw.style('text-info-default')}
+              suppressHighlighting
+            >
+              {strings('predict.consent_sheet.learn_more')}
+            </Text>
+          </Text>
+        </TouchableOpacity>
       </Box>
       <BottomSheetFooter
         buttonPropsArray={[

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { screen, fireEvent, waitFor, act } from '@testing-library/react-native';
+import { InteractionManager } from 'react-native';
 import {
   NavigationProp,
   ParamListBase,
@@ -11,6 +12,24 @@ import { strings } from '../../../../../../locales/i18n';
 import Routes from '../../../../../constants/navigation/Routes';
 import { PredictEventValues } from '../../constants/eventNames';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
+
+const runAfterInteractionsCallbacks: (() => void)[] = [];
+const mockRunAfterInteractions = jest.spyOn(
+  InteractionManager,
+  'runAfterInteractions',
+);
+const runAfterInteractionsMockImpl: typeof InteractionManager.runAfterInteractions =
+  (task) => {
+    if (typeof task === 'function') {
+      runAfterInteractionsCallbacks.push(task as () => void);
+    }
+
+    return {
+      then: jest.fn(),
+      done: jest.fn(),
+      cancel: jest.fn(),
+    } as ReturnType<typeof InteractionManager.runAfterInteractions>;
+  };
 
 jest.mock('../../../../../core/Engine', () => ({
   context: {
@@ -434,6 +453,8 @@ function setupPredictMarketDetailsTest(
   } = {},
 ) {
   jest.clearAllMocks();
+  runAfterInteractionsCallbacks.length = 0;
+  mockRunAfterInteractions.mockImplementation(runAfterInteractionsMockImpl);
 
   const mockNavigate = jest.fn();
   const mockSetOptions = jest.fn();
@@ -526,6 +547,15 @@ function setupPredictMarketDetailsTest(
 }
 
 describe('PredictMarketDetails', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    mockRunAfterInteractions.mockReset();
+  });
+
+  afterAll(() => {
+    mockRunAfterInteractions.mockRestore();
+  });
+
   describe('Component Rendering', () => {
     it('renders the main screen container', () => {
       setupPredictMarketDetailsTest();
@@ -609,6 +639,37 @@ describe('PredictMarketDetails', () => {
         screen.getByText('predict.market_details.resolution_details'),
       ).toBeOnTheScreen();
       expect(screen.getByText('Polymarket')).toBeOnTheScreen();
+    });
+
+    it('navigates to polymarket resolution details when pressed', () => {
+      const { mockNavigate } = setupPredictMarketDetailsTest();
+
+      const aboutTab = screen.getByTestId(
+        'predict-market-details-tab-bar-tab-1',
+      );
+      fireEvent.press(aboutTab);
+
+      const resolutionText = screen.getByText('Polymarket');
+
+      act(() => {
+        fireEvent.press(resolutionText);
+      });
+
+      expect(mockRunAfterInteractions).toHaveBeenCalledTimes(1);
+      const callback = runAfterInteractionsCallbacks[0];
+      expect(callback).toBeDefined();
+
+      act(() => {
+        callback?.();
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith('Webview', {
+        screen: 'SimpleWebview',
+        params: {
+          url: 'https://docs.polymarket.com/polymarket-learn/markets/how-are-markets-resolved',
+          title: 'predict.market_details.resolution_details',
+        },
+      });
     });
   });
 

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -7,7 +7,7 @@ import {
 import React, { useMemo, useState, useEffect, useCallback } from 'react';
 import {
   Image,
-  Linking,
+  InteractionManager,
   Pressable,
   RefreshControl,
   ScrollView,
@@ -354,6 +354,18 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
     setIsRefreshing(false);
   }, [loadPositions, refetchMarket, refetchPriceHistory]);
 
+  const handlePolymarketResolution = useCallback(() => {
+    InteractionManager.runAfterInteractions(() => {
+      navigation.navigate('Webview', {
+        screen: 'SimpleWebview',
+        params: {
+          url: 'https://docs.polymarket.com/polymarket-learn/markets/how-are-markets-resolved',
+          title: strings('predict.market_details.resolution_details'),
+        },
+      });
+    });
+  }, [navigation]);
+
   type TabKey = 'positions' | 'outcomes' | 'about';
 
   const trackMarketDetailsOpened = useCallback(
@@ -686,13 +698,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
           alignItems={BoxAlignItems.Center}
           twClassName="gap-2"
         >
-          <Pressable
-            onPress={() => {
-              Linking.openURL(
-                'https://docs.polymarket.com/polymarket-learn/markets/how-are-markets-resolved',
-              );
-            }}
-          >
+          <Pressable onPress={handlePolymarketResolution}>
             <Text
               variant={TextVariant.BodyMDMedium}
               color={colors.primary.default}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- change polymarket links to use webview

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Routes Polymarket Terms and Resolution links to the in-app Webview using navigation (with InteractionManager), replacing direct Linking usage, and adds tests.
> 
> - **Predict UI**:
>   - `PredictConsentSheet.tsx`: Replace `Linking.openURL` with in-app Webview navigation via `useNavigation` and `InteractionManager.runAfterInteractions`; wrap description/`Learn more` in a `TouchableOpacity`.
>   - `PredictMarketDetails.tsx`: Add handler to navigate to Webview for Polymarket resolution details via `InteractionManager.runAfterInteractions`.
> - **Tests**:
>   - `PredictConsentSheet.test.tsx`: Mock `InteractionManager.runAfterInteractions`; assert navigation to `Webview/SimpleWebview` with Polymarket TOS URL and title.
>   - `PredictMarketDetails.test.tsx`: Mock `InteractionManager.runAfterInteractions`; verify About tab "Polymarket" press navigates to `Webview/SimpleWebview` with resolution docs URL and title.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f4e219566a70aff91ef186092eab10b35950754. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->