### PR TITLE
chore: remove unsupported alert in accountgroup opt in modal

### DIFF
--- a/app/components/UI/Rewards/components/Settings/RewardOptInAccountGroupModal.test.tsx
+++ b/app/components/UI/Rewards/components/Settings/RewardOptInAccountGroupModal.test.tsx
@@ -162,6 +162,7 @@ jest.mock(
           {
             testID: 'bottom-sheet',
             ref,
+            onClose,
             ...props,
           },
           children,
@@ -227,41 +228,16 @@ jest.mock(
         ReactActual.createElement(
           View,
           { testID, ...props },
-          ReactActual.createElement(View, { testID: `address-${address}` }),
           ReactActual.createElement(View, {
-            testID: `network-${networkName}`,
+            testID: `multichain-address-row-address`,
+          }),
+          ReactActual.createElement(View, {
+            testID: `multichain-address-row-network-name`,
           }),
         ),
     };
   },
 );
-
-// Mock RewardsInfoBanner
-jest.mock('../RewardsInfoBanner', () => {
-  const ReactActual = jest.requireActual('react');
-  const { View, Text } = jest.requireActual('react-native');
-
-  return {
-    __esModule: true,
-    default: ({
-      title,
-      description,
-      testID,
-      ...props
-    }: {
-      title: string;
-      description: string;
-      testID?: string;
-      [key: string]: unknown;
-    }) =>
-      ReactActual.createElement(
-        View,
-        { testID, ...props },
-        ReactActual.createElement(Text, {}, title),
-        ReactActual.createElement(Text, {}, description),
-      ),
-  };
-});
 
 const mockUseNavigation = useNavigation as jest.MockedFunction<
   typeof useNavigation
@@ -390,80 +366,76 @@ describe('RewardOptInAccountGroupModal', () => {
   });
 
   describe('Basic Rendering', () => {
-    it('should render bottom sheet container', () => {
+    it('renders bottom sheet container', () => {
       const { getByTestId } = render(<RewardOptInAccountGroupModal />);
 
       expect(getByTestId('bottom-sheet')).toBeOnTheScreen();
     });
 
-    it('should render header with account group name', () => {
+    it('renders header with account group name', () => {
       const { getByTestId } = render(<RewardOptInAccountGroupModal />);
 
       expect(getByTestId('bottom-sheet-header')).toBeOnTheScreen();
     });
 
-    it('should render address list', () => {
+    it('renders address list', () => {
       const { getByTestId } = render(<RewardOptInAccountGroupModal />);
 
       expect(getByTestId('reward-opt-in-address-list')).toBeOnTheScreen();
     });
 
-    it('should render address items for each address', () => {
+    it('renders address items for each address', () => {
       const { getByTestId } = render(<RewardOptInAccountGroupModal />);
 
-      // Check that the MultichainAddressRow components are rendered
       expect(
-        getByTestId('address-0x1234567890123456789012345678901234567890'),
+        getByTestId(
+          'flat-list-item-0x1234567890123456789012345678901234567890-eip155:1',
+        ),
       ).toBeOnTheScreen();
       expect(
-        getByTestId('address-0x0987654321098765432109876543210987654321'),
+        getByTestId(
+          'flat-list-item-0x0987654321098765432109876543210987654321-eip155:1',
+        ),
       ).toBeOnTheScreen();
     });
-  });
 
-  describe('Unsupported Accounts Banner', () => {
-    it('should show banner when there are unsupported accounts', () => {
-      // Arrange
+    it('does not render address list when addressData is empty', () => {
       mockUseRoute.mockReturnValue({
         params: {
           ...defaultRouteParams,
-          addressData: [
-            ...defaultRouteParams.addressData,
-            {
-              address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-              hasOptedIn: false,
-              scopes: ['eip155:1' as CaipChainId],
-              isSupported: false,
-            },
-          ],
+          addressData: [],
         },
         key: 'test-route',
         name: 'RewardOptInAccountGroupModal',
       } as never);
 
-      // Act
-      const { getByTestId } = render(<RewardOptInAccountGroupModal />);
-
-      // Assert
-      expect(getByTestId('unsupported-accounts-banner')).toBeOnTheScreen();
-    });
-
-    it('should not show banner when all accounts are supported', () => {
       const { queryByTestId } = render(<RewardOptInAccountGroupModal />);
 
-      expect(queryByTestId('unsupported-accounts-banner')).toBeNull();
+      expect(queryByTestId('reward-opt-in-address-list')).toBeNull();
+    });
+
+    it('calls navigation.goBack when BottomSheet onClose is triggered', () => {
+      const { getByTestId } = render(<RewardOptInAccountGroupModal />);
+
+      const bottomSheet = getByTestId('bottom-sheet');
+      const onClose = bottomSheet.props.onClose;
+
+      if (onClose) {
+        onClose();
+      }
+
+      expect(mockGoBack).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('Link Account Group Button', () => {
-    it('should render link button when there are accounts that can opt in', () => {
+    it('renders link button when there are accounts that can opt in', () => {
       const { getByTestId } = render(<RewardOptInAccountGroupModal />);
 
       expect(getByTestId('link-account-group-button')).toBeOnTheScreen();
     });
 
-    it('should not render link button when all accounts are opted in', () => {
-      // Arrange
+    it('does not render link button when all accounts are opted in', () => {
       mockUseRoute.mockReturnValue({
         params: {
           ...defaultRouteParams,
@@ -480,15 +452,40 @@ describe('RewardOptInAccountGroupModal', () => {
         name: 'RewardOptInAccountGroupModal',
       } as never);
 
-      // Act
       const { queryByTestId } = render(<RewardOptInAccountGroupModal />);
 
-      // Assert
       expect(queryByTestId('link-account-group-button')).toBeNull();
     });
 
-    it('should call linkAccountGroup when button is pressed', async () => {
-      // Arrange
+    it('does not render link button when all supported addresses are opted in but unsupported addresses exist', () => {
+      mockUseRoute.mockReturnValue({
+        params: {
+          ...defaultRouteParams,
+          addressData: [
+            {
+              address: '0x1234567890123456789012345678901234567890',
+              hasOptedIn: true,
+              scopes: ['eip155:1' as CaipChainId],
+              isSupported: true,
+            },
+            {
+              address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              hasOptedIn: false,
+              scopes: ['eip155:1' as CaipChainId],
+              isSupported: false,
+            },
+          ],
+        },
+        key: 'test-route',
+        name: 'RewardOptInAccountGroupModal',
+      } as never);
+
+      const { queryByTestId } = render(<RewardOptInAccountGroupModal />);
+
+      expect(queryByTestId('link-account-group-button')).toBeNull();
+    });
+
+    it('calls linkAccountGroup when button is pressed', async () => {
       mockLinkAccountGroup.mockResolvedValue({
         success: true,
         byAddress: {
@@ -498,11 +495,9 @@ describe('RewardOptInAccountGroupModal', () => {
 
       const { getByTestId } = render(<RewardOptInAccountGroupModal />);
 
-      // Act
       const linkButton = getByTestId('link-account-group-button');
       fireEvent.press(linkButton);
 
-      // Assert
       await waitFor(() => {
         expect(mockLinkAccountGroup).toHaveBeenCalledWith(
           'keyring:wallet-1/ethereum',
@@ -510,24 +505,20 @@ describe('RewardOptInAccountGroupModal', () => {
       });
     });
 
-    it('should show loading state when linking', () => {
-      // Arrange
+    it('shows loading state when linking', () => {
       mockUseLinkAccountGroup.mockReturnValue({
         linkAccountGroup: mockLinkAccountGroup,
         isLoading: true,
         isError: false,
       });
 
-      // Act
       const { getByTestId } = render(<RewardOptInAccountGroupModal />);
 
-      // Assert
       const linkButton = getByTestId('link-account-group-button');
       expect(linkButton).toHaveProp('disabled', true);
     });
 
-    it('should update local state after successful link', async () => {
-      // Arrange
+    it('updates local state after successful link', async () => {
       mockLinkAccountGroup.mockResolvedValue({
         success: true,
         byAddress: {
@@ -537,18 +528,24 @@ describe('RewardOptInAccountGroupModal', () => {
 
       const { getByTestId } = render(<RewardOptInAccountGroupModal />);
 
-      // Act
       const linkButton = getByTestId('link-account-group-button');
       fireEvent.press(linkButton);
 
-      // Assert
       await waitFor(() => {
         expect(mockLinkAccountGroup).toHaveBeenCalled();
       });
+
+      // Wait for the async state update to complete
+      await waitFor(() => {
+        expect(
+          getByTestId(
+            'flat-list-item-0x0987654321098765432109876543210987654321-eip155:1',
+          ),
+        ).toBeOnTheScreen();
+      });
     });
 
-    it('should handle link failure gracefully', async () => {
-      // Arrange
+    it('handles link failure gracefully', async () => {
       const consoleErrorSpy = jest
         .spyOn(console, 'error')
         .mockImplementation(() => {
@@ -558,11 +555,9 @@ describe('RewardOptInAccountGroupModal', () => {
 
       const { getByTestId } = render(<RewardOptInAccountGroupModal />);
 
-      // Act
       const linkButton = getByTestId('link-account-group-button');
       fireEvent.press(linkButton);
 
-      // Assert
       await waitFor(() => {
         expect(consoleErrorSpy).toHaveBeenCalledWith(
           'Failed to link account group:',
@@ -575,8 +570,7 @@ describe('RewardOptInAccountGroupModal', () => {
   });
 
   describe('Network Resolution', () => {
-    it('should resolve non-EVM network names correctly', () => {
-      // Arrange
+    it('resolves non-EVM network names correctly', () => {
       mockUseRoute.mockReturnValue({
         params: {
           ...defaultRouteParams,
@@ -595,15 +589,16 @@ describe('RewardOptInAccountGroupModal', () => {
         name: 'RewardOptInAccountGroupModal',
       } as never);
 
-      // Act
       const { getByTestId } = render(<RewardOptInAccountGroupModal />);
 
-      // Assert
-      expect(getByTestId('network-Bitcoin')).toBeOnTheScreen();
+      expect(
+        getByTestId(
+          'flat-list-item-bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh-bip122:000000000019d6689c085ae165831e93',
+        ),
+      ).toBeOnTheScreen();
     });
 
-    it('should handle unknown network scopes', () => {
-      // Arrange
+    it('handles unknown network scopes', () => {
       const consoleWarnSpy = jest
         .spyOn(console, 'warn')
         .mockImplementation(() => {
@@ -626,10 +621,8 @@ describe('RewardOptInAccountGroupModal', () => {
         name: 'RewardOptInAccountGroupModal',
       } as never);
 
-      // Act
       render(<RewardOptInAccountGroupModal />);
 
-      // Assert
       expect(consoleWarnSpy).toHaveBeenCalledWith(
         'Unknown network for scope:',
         'unknown:network',
@@ -637,11 +630,37 @@ describe('RewardOptInAccountGroupModal', () => {
 
       consoleWarnSpy.mockRestore();
     });
+
+    it('treats addresses with undefined isSupported as supported', () => {
+      mockUseRoute.mockReturnValue({
+        params: {
+          ...defaultRouteParams,
+          addressData: [
+            {
+              address: '0x1234567890123456789012345678901234567890',
+              hasOptedIn: false,
+              scopes: ['eip155:1' as CaipChainId],
+              isSupported: undefined,
+            },
+          ],
+        },
+        key: 'test-route',
+        name: 'RewardOptInAccountGroupModal',
+      } as never);
+
+      const { getByTestId } = render(<RewardOptInAccountGroupModal />);
+
+      expect(
+        getByTestId(
+          'flat-list-item-0x1234567890123456789012345678901234567890-eip155:1',
+        ),
+      ).toBeOnTheScreen();
+      expect(getByTestId('link-account-group-button')).toBeOnTheScreen();
+    });
   });
 
   describe('Wildcard Scope Handling', () => {
-    it('should expand eip155:* wildcard to all EVM networks', () => {
-      // Arrange
+    it('expands eip155:* wildcard to all EVM networks', () => {
       mockUseRoute.mockReturnValue({
         params: {
           ...defaultRouteParams,
@@ -658,15 +677,16 @@ describe('RewardOptInAccountGroupModal', () => {
         name: 'RewardOptInAccountGroupModal',
       } as never);
 
-      // Act
       const { getByTestId } = render(<RewardOptInAccountGroupModal />);
 
-      // Assert - Should render Ethereum Mainnet, but not Goerli testnet
-      expect(getByTestId('network-Ethereum Mainnet')).toBeOnTheScreen();
+      expect(
+        getByTestId(
+          'flat-list-item-0x1234567890123456789012345678901234567890-eip155:1',
+        ),
+      ).toBeOnTheScreen();
     });
 
-    it('should expand bip122:0 wildcard to all Bitcoin networks', () => {
-      // Arrange
+    it('expands bip122:0 wildcard to all Bitcoin networks', () => {
       mockUseRoute.mockReturnValue({
         params: {
           ...defaultRouteParams,
@@ -683,15 +703,16 @@ describe('RewardOptInAccountGroupModal', () => {
         name: 'RewardOptInAccountGroupModal',
       } as never);
 
-      // Act
       const { getByTestId } = render(<RewardOptInAccountGroupModal />);
 
-      // Assert
-      expect(getByTestId('network-Bitcoin')).toBeOnTheScreen();
+      expect(
+        getByTestId(
+          'flat-list-item-bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh-bip122:000000000019d6689c085ae165831e93',
+        ),
+      ).toBeOnTheScreen();
     });
 
-    it('should filter out testnets when expanding EVM wildcards', () => {
-      // Arrange
+    it('filters out testnets when expanding EVM wildcards', () => {
       mockUseRoute.mockReturnValue({
         params: {
           ...defaultRouteParams,
@@ -708,15 +729,17 @@ describe('RewardOptInAccountGroupModal', () => {
         name: 'RewardOptInAccountGroupModal',
       } as never);
 
-      // Act
       const { queryByTestId } = render(<RewardOptInAccountGroupModal />);
 
-      // Assert - Goerli testnet should not be rendered
-      expect(queryByTestId('network-Goerli Testnet')).toBeNull();
+      // Goerli testnet should be filtered out, so no items with that network should exist
+      expect(
+        queryByTestId(
+          'flat-list-item-0x1234567890123456789012345678901234567890-eip155:5',
+        ),
+      ).toBeNull();
     });
 
-    it('should handle invalid CAIP scope format', () => {
-      // Arrange
+    it('handles invalid CAIP scope format', () => {
       const consoleWarnSpy = jest
         .spyOn(console, 'warn')
         .mockImplementation(() => {
@@ -739,10 +762,8 @@ describe('RewardOptInAccountGroupModal', () => {
         name: 'RewardOptInAccountGroupModal',
       } as never);
 
-      // Act
       render(<RewardOptInAccountGroupModal />);
 
-      // Assert
       expect(consoleWarnSpy).toHaveBeenCalledWith(
         'Unknown network for scope:',
         'invalid',
@@ -750,22 +771,64 @@ describe('RewardOptInAccountGroupModal', () => {
 
       consoleWarnSpy.mockRestore();
     });
+
+    it('handles wildcard scope with missing namespace', () => {
+      const consoleWarnSpy = jest
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {
+          // Suppress warning output in test
+        });
+
+      mockUseRoute.mockReturnValue({
+        params: {
+          ...defaultRouteParams,
+          addressData: [
+            {
+              address: '0x1234567890123456789012345678901234567890',
+              hasOptedIn: false,
+              scopes: [':*' as CaipChainId],
+              isSupported: true,
+            },
+          ],
+        },
+        key: 'test-route',
+        name: 'RewardOptInAccountGroupModal',
+      } as never);
+
+      render(<RewardOptInAccountGroupModal />);
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'Invalid CAIP scope format:',
+        ':*',
+      );
+
+      consoleWarnSpy.mockRestore();
+    });
   });
 
   describe('Edge Cases', () => {
-    it('should handle missing account group context', () => {
-      // Arrange
+    it('handles missing account group context', () => {
       mockSelectAccountGroupById.mockReturnValue(undefined);
 
-      // Act
       const { queryByTestId } = render(<RewardOptInAccountGroupModal />);
 
-      // Assert - Header should not render without account group name
       expect(queryByTestId('bottom-sheet-header')).toBeNull();
     });
 
-    it('should handle EVM chain ID conversion errors', () => {
-      // Arrange
+    it('handles account group context without metadata name', () => {
+      mockSelectAccountGroupById.mockReturnValue({
+        id: 'keyring:wallet-1/ethereum',
+        scopes: [],
+        keyringType: 'HD Key Tree',
+        metadata: {},
+      } as never);
+
+      const { queryByTestId } = render(<RewardOptInAccountGroupModal />);
+
+      expect(queryByTestId('bottom-sheet-header')).toBeNull();
+    });
+
+    it('handles EVM chain ID conversion errors', () => {
       const consoleWarnSpy = jest
         .spyOn(console, 'warn')
         .mockImplementation(() => {
@@ -786,10 +849,8 @@ describe('RewardOptInAccountGroupModal', () => {
         throw new Error('Invalid chain ID');
       });
 
-      // Act
       render(<RewardOptInAccountGroupModal />);
 
-      // Assert
       expect(consoleWarnSpy).toHaveBeenCalledWith(
         'Invalid EVM chain ID:',
         'invalid-chain-id',
@@ -799,8 +860,7 @@ describe('RewardOptInAccountGroupModal', () => {
       consoleWarnSpy.mockRestore();
     });
 
-    it('should handle address items with valid scope', () => {
-      // Arrange
+    it('handles address items with valid scope', () => {
       mockUseRoute.mockReturnValue({
         params: {
           ...defaultRouteParams,
@@ -817,46 +877,247 @@ describe('RewardOptInAccountGroupModal', () => {
         name: 'RewardOptInAccountGroupModal',
       } as never);
 
-      // Act
       const { getByTestId } = render(<RewardOptInAccountGroupModal />);
 
-      // Assert - Should render the address
       expect(
-        getByTestId('address-0x1234567890123456789012345678901234567890'),
+        getByTestId(
+          'flat-list-item-0x1234567890123456789012345678901234567890-eip155:1',
+        ),
+      ).toBeOnTheScreen();
+    });
+
+    it('skips address items with missing address', () => {
+      mockUseRoute.mockReturnValue({
+        params: {
+          ...defaultRouteParams,
+          addressData: [
+            {
+              address: '',
+              hasOptedIn: false,
+              scopes: ['eip155:1' as CaipChainId],
+              isSupported: true,
+            },
+          ],
+        },
+        key: 'test-route',
+        name: 'RewardOptInAccountGroupModal',
+      } as never);
+
+      const { queryByTestId } = render(<RewardOptInAccountGroupModal />);
+
+      expect(queryByTestId('reward-opt-in-address-list')).toBeNull();
+    });
+
+    it('skips address items with null address', () => {
+      mockUseRoute.mockReturnValue({
+        params: {
+          ...defaultRouteParams,
+          addressData: [
+            {
+              address: null as unknown as string,
+              hasOptedIn: false,
+              scopes: ['eip155:1' as CaipChainId],
+              isSupported: true,
+            },
+          ],
+        },
+        key: 'test-route',
+        name: 'RewardOptInAccountGroupModal',
+      } as never);
+
+      const { queryByTestId } = render(<RewardOptInAccountGroupModal />);
+
+      expect(queryByTestId('reward-opt-in-address-list')).toBeNull();
+    });
+
+    it('skips address items with empty scopes array', () => {
+      mockUseRoute.mockReturnValue({
+        params: {
+          ...defaultRouteParams,
+          addressData: [
+            {
+              address: '0x1234567890123456789012345678901234567890',
+              hasOptedIn: false,
+              scopes: [],
+              isSupported: true,
+            },
+          ],
+        },
+        key: 'test-route',
+        name: 'RewardOptInAccountGroupModal',
+      } as never);
+
+      const { queryByTestId } = render(<RewardOptInAccountGroupModal />);
+
+      expect(queryByTestId('reward-opt-in-address-list')).toBeNull();
+    });
+
+    it('skips address items with null scopes', () => {
+      mockUseRoute.mockReturnValue({
+        params: {
+          ...defaultRouteParams,
+          addressData: [
+            {
+              address: '0x1234567890123456789012345678901234567890',
+              hasOptedIn: false,
+              scopes: null as unknown as string[],
+              isSupported: true,
+            },
+          ],
+        },
+        key: 'test-route',
+        name: 'RewardOptInAccountGroupModal',
+      } as never);
+
+      const { queryByTestId } = render(<RewardOptInAccountGroupModal />);
+
+      expect(queryByTestId('reward-opt-in-address-list')).toBeNull();
+    });
+
+    it('skips empty scope strings', () => {
+      mockUseRoute.mockReturnValue({
+        params: {
+          ...defaultRouteParams,
+          addressData: [
+            {
+              address: '0x1234567890123456789012345678901234567890',
+              hasOptedIn: false,
+              scopes: ['', 'eip155:1' as CaipChainId],
+              isSupported: true,
+            },
+          ],
+        },
+        key: 'test-route',
+        name: 'RewardOptInAccountGroupModal',
+      } as never);
+
+      const { getByTestId } = render(<RewardOptInAccountGroupModal />);
+
+      expect(
+        getByTestId(
+          'flat-list-item-0x1234567890123456789012345678901234567890-eip155:1',
+        ),
+      ).toBeOnTheScreen();
+    });
+
+    it('skips whitespace-only scope strings', () => {
+      mockUseRoute.mockReturnValue({
+        params: {
+          ...defaultRouteParams,
+          addressData: [
+            {
+              address: '0x1234567890123456789012345678901234567890',
+              hasOptedIn: false,
+              scopes: ['   ', 'eip155:1' as CaipChainId],
+              isSupported: true,
+            },
+          ],
+        },
+        key: 'test-route',
+        name: 'RewardOptInAccountGroupModal',
+      } as never);
+
+      const { getByTestId } = render(<RewardOptInAccountGroupModal />);
+
+      expect(
+        getByTestId(
+          'flat-list-item-0x1234567890123456789012345678901234567890-eip155:1',
+        ),
+      ).toBeOnTheScreen();
+    });
+
+    it('handles address items with multiple scopes', () => {
+      mockUseRoute.mockReturnValue({
+        params: {
+          ...defaultRouteParams,
+          addressData: [
+            {
+              address: '0x1234567890123456789012345678901234567890',
+              hasOptedIn: false,
+              scopes: [
+                'eip155:1' as CaipChainId,
+                'bip122:000000000019d6689c085ae165831e93' as CaipChainId,
+              ],
+              isSupported: true,
+            },
+          ],
+        },
+        key: 'test-route',
+        name: 'RewardOptInAccountGroupModal',
+      } as never);
+
+      const { getByTestId } = render(<RewardOptInAccountGroupModal />);
+
+      expect(
+        getByTestId(
+          'flat-list-item-0x1234567890123456789012345678901234567890-eip155:1',
+        ),
+      ).toBeOnTheScreen();
+      expect(
+        getByTestId(
+          'flat-list-item-0x1234567890123456789012345678901234567890-bip122:000000000019d6689c085ae165831e93',
+        ),
       ).toBeOnTheScreen();
     });
   });
 
   describe('FlatList Configuration', () => {
-    it('should render FlatList with correct testID', () => {
+    it('renders FlatList with correct testID', () => {
       const { getByTestId } = render(<RewardOptInAccountGroupModal />);
 
-      // Verify the FlatList is rendered
       expect(getByTestId('reward-opt-in-address-list')).toBeOnTheScreen();
     });
 
-    it('should have correct FlatList props for scrolling', () => {
+    it('has correct FlatList props for scrolling', () => {
       const { getByTestId } = render(<RewardOptInAccountGroupModal />);
 
       const flatList = getByTestId('reward-opt-in-address-list');
       expect(flatList).toHaveProp('showsVerticalScrollIndicator', true);
     });
+
+    it('generates correct keys for header items', () => {
+      const { getByTestId } = render(<RewardOptInAccountGroupModal />);
+
+      const flatList = getByTestId('reward-opt-in-address-list');
+      const keyExtractor = flatList.props.keyExtractor;
+
+      const headerItem = { type: 'header' as const, title: 'Test Header' };
+      const key = keyExtractor(headerItem, 0);
+
+      expect(key).toBe('header-Test Header-0');
+    });
+
+    it('generates correct keys for address items', () => {
+      const { getByTestId } = render(<RewardOptInAccountGroupModal />);
+
+      const flatList = getByTestId('reward-opt-in-address-list');
+      const keyExtractor = flatList.props.keyExtractor;
+
+      const addressItem = {
+        type: 'item' as const,
+        address: '0x123',
+        scope: 'eip155:1' as CaipChainId,
+        hasOptedIn: false,
+        networkName: 'Ethereum',
+        isSupported: true,
+      };
+      const key = keyExtractor(addressItem, 1);
+
+      expect(key).toBe('0x123-eip155:1-1');
+    });
   });
 
   describe('Section Headers (Tracked/Untracked)', () => {
-    it('should show section headers when there are both tracked and untracked addresses', () => {
-      // Arrange - default route params has both tracked and untracked addresses
+    it('shows section headers when there are both tracked and untracked addresses', () => {
       const { getByText } = render(<RewardOptInAccountGroupModal />);
 
-      // Assert
       expect(getByText('rewards.link_account_group.tracked')).toBeOnTheScreen();
       expect(
         getByText('rewards.link_account_group.untracked'),
       ).toBeOnTheScreen();
     });
 
-    it('should not show section headers when all addresses are tracked', () => {
-      // Arrange
+    it('does not show section headers when all addresses are tracked', () => {
       mockUseRoute.mockReturnValue({
         params: {
           ...defaultRouteParams,
@@ -873,16 +1134,13 @@ describe('RewardOptInAccountGroupModal', () => {
         name: 'RewardOptInAccountGroupModal',
       } as never);
 
-      // Act
       const { queryByText } = render(<RewardOptInAccountGroupModal />);
 
-      // Assert - Headers should not be rendered when there's only one type
       expect(queryByText('rewards.link_account_group.tracked')).toBeNull();
       expect(queryByText('rewards.link_account_group.untracked')).toBeNull();
     });
 
-    it('should not show section headers when all addresses are untracked', () => {
-      // Arrange
+    it('does not show section headers when all addresses are untracked', () => {
       mockUseRoute.mockReturnValue({
         params: {
           ...defaultRouteParams,
@@ -899,16 +1157,13 @@ describe('RewardOptInAccountGroupModal', () => {
         name: 'RewardOptInAccountGroupModal',
       } as never);
 
-      // Act
       const { queryByText } = render(<RewardOptInAccountGroupModal />);
 
-      // Assert - Headers should not be rendered when there's only one type
       expect(queryByText('rewards.link_account_group.tracked')).toBeNull();
       expect(queryByText('rewards.link_account_group.untracked')).toBeNull();
     });
 
-    it('should not show section headers for unsupported addresses', () => {
-      // Arrange
+    it('shows unsupported section header for unsupported addresses', () => {
       mockUseRoute.mockReturnValue({
         params: {
           ...defaultRouteParams,
@@ -925,22 +1180,109 @@ describe('RewardOptInAccountGroupModal', () => {
         name: 'RewardOptInAccountGroupModal',
       } as never);
 
-      // Act
-      const { queryByText } = render(<RewardOptInAccountGroupModal />);
+      const { getByText } = render(<RewardOptInAccountGroupModal />);
 
-      // Assert - Unsupported addresses should not be shown in the list
-      expect(queryByText('rewards.link_account_group.tracked')).toBeNull();
-      expect(queryByText('rewards.link_account_group.untracked')).toBeNull();
+      expect(
+        getByText('rewards.link_account_group.unsupported'),
+      ).toBeOnTheScreen();
+    });
+
+    it('shows unsupported section header when unsupported addresses exist alongside supported ones', () => {
+      mockUseRoute.mockReturnValue({
+        params: {
+          ...defaultRouteParams,
+          addressData: [
+            {
+              address: '0x1234567890123456789012345678901234567890',
+              hasOptedIn: true,
+              scopes: ['eip155:1' as CaipChainId],
+              isSupported: true,
+            },
+            {
+              address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              hasOptedIn: false,
+              scopes: ['eip155:1' as CaipChainId],
+              isSupported: false,
+            },
+          ],
+        },
+        key: 'test-route',
+        name: 'RewardOptInAccountGroupModal',
+      } as never);
+
+      const { getByText } = render(<RewardOptInAccountGroupModal />);
+
+      expect(
+        getByText('rewards.link_account_group.unsupported'),
+      ).toBeOnTheScreen();
     });
   });
 
   describe('Accessibility', () => {
-    it('should have proper testIDs for all interactive elements', () => {
+    it('has proper testIDs for all interactive elements', () => {
       const { getByTestId } = render(<RewardOptInAccountGroupModal />);
 
       expect(getByTestId('bottom-sheet')).toBeOnTheScreen();
       expect(getByTestId('reward-opt-in-address-list')).toBeOnTheScreen();
       expect(getByTestId('link-account-group-button')).toBeOnTheScreen();
+    });
+  });
+
+  describe('RenderItem Function', () => {
+    it('renders header items correctly', () => {
+      const { getByTestId } = render(<RewardOptInAccountGroupModal />);
+
+      const flatList = getByTestId('reward-opt-in-address-list');
+      const renderItem = flatList.props.renderItem;
+
+      const headerItem = {
+        item: { type: 'header' as const, title: 'Test Header' },
+      };
+      const headerComponent = renderItem(headerItem);
+
+      expect(headerComponent).toBeTruthy();
+    });
+
+    it('returns null for items without address', () => {
+      const { getByTestId } = render(<RewardOptInAccountGroupModal />);
+
+      const flatList = getByTestId('reward-opt-in-address-list');
+      const renderItem = flatList.props.renderItem;
+
+      const invalidItem = {
+        item: {
+          type: 'item' as const,
+          address: '',
+          scope: 'eip155:1' as CaipChainId,
+          hasOptedIn: false,
+          networkName: 'Ethereum',
+          isSupported: true,
+        },
+      };
+      const result = renderItem(invalidItem);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for items without scope', () => {
+      const { getByTestId } = render(<RewardOptInAccountGroupModal />);
+
+      const flatList = getByTestId('reward-opt-in-address-list');
+      const renderItem = flatList.props.renderItem;
+
+      const invalidItem = {
+        item: {
+          type: 'item' as const,
+          address: '0x123',
+          scope: '' as CaipChainId,
+          hasOptedIn: false,
+          networkName: 'Ethereum',
+          isSupported: true,
+        },
+      };
+      const result = renderItem(invalidItem);
+
+      expect(result).toBeNull();
     });
   });
 });

--- a/app/components/UI/Rewards/components/Settings/RewardOptInAccountGroupModal.tsx
+++ b/app/components/UI/Rewards/components/Settings/RewardOptInAccountGroupModal.tsx
@@ -21,7 +21,6 @@ import { useSelector } from 'react-redux';
 import { RootState } from '../../../../../reducers';
 import { strings } from '../../../../../../locales/i18n';
 import { useLinkAccountGroup } from '../../hooks/useLinkAccountGroup';
-import RewardsInfoBanner from '../RewardsInfoBanner';
 import { selectEvmNetworkConfigurationsByChainId } from '../../../../../selectors/networkController';
 import { selectNonEvmNetworkConfigurationsByChainId } from '../../../../../selectors/multichainNetworkController';
 import { CaipChainId } from '@metamask/utils';
@@ -116,7 +115,126 @@ const RewardOptInAccountGroupModal: React.FC = () => {
   const flattenedAddressData = useMemo(() => {
     const flattened: FlattenedAddressItem[] = [];
 
-    addressData.forEach((item) => {
+    const addFlattenedItem = (
+      address: string,
+      hasOptedIn: boolean,
+      scope: CaipChainId,
+      networkName: string,
+      isSupported?: boolean,
+    ) => {
+      flattened.push({
+        address,
+        hasOptedIn,
+        scope,
+        networkName,
+        isSupported,
+      });
+    };
+
+    const processMatchingNetwork = (
+      chainId: string,
+      network: { name: string; hexChainId?: string },
+      namespace: string,
+      address: string,
+      hasOptedIn: boolean,
+      isSupported: boolean | undefined,
+    ) => {
+      const chainIdParts = chainId.split(':');
+      if (chainIdParts.length < 2) {
+        return;
+      }
+
+      const chainIdNamespace = chainIdParts[0];
+      if (chainIdNamespace !== namespace) {
+        return;
+      }
+
+      // Skip testnets for EVM networks
+      if (network.hexChainId && isTestNet(network.hexChainId)) {
+        return;
+      }
+
+      addFlattenedItem(
+        address,
+        hasOptedIn,
+        chainId as CaipChainId,
+        network.name,
+        isSupported,
+      );
+    };
+
+    const processWildcardScope = (
+      caipScope: CaipChainId,
+      address: string,
+      hasOptedIn: boolean,
+      isSupported: boolean | undefined,
+    ) => {
+      const scopeParts = caipScope.split(':');
+      if (scopeParts.length < 2) {
+        console.warn('Invalid CAIP scope format:', caipScope);
+        return;
+      }
+
+      const namespace = scopeParts[0];
+      if (!namespace) {
+        console.warn('Invalid CAIP scope format:', caipScope);
+        return;
+      }
+
+      // Add all networks matching this namespace (excluding testnets)
+      Object.entries(allNetworks).forEach(([chainId, network]) => {
+        processMatchingNetwork(
+          chainId,
+          network,
+          namespace,
+          address,
+          hasOptedIn,
+          isSupported,
+        );
+      });
+    };
+
+    const processSpecificScope = (
+      caipScope: CaipChainId,
+      address: string,
+      hasOptedIn: boolean,
+      isSupported: boolean | undefined,
+    ) => {
+      const network = allNetworks[caipScope];
+      if (network) {
+        addFlattenedItem(
+          address,
+          hasOptedIn,
+          caipScope,
+          network.name,
+          isSupported,
+        );
+      } else {
+        console.warn('Unknown network for scope:', caipScope);
+      }
+    };
+
+    const processScope = (
+      scope: string,
+      address: string,
+      hasOptedIn: boolean,
+      isSupported: boolean | undefined,
+    ) => {
+      if (typeof scope !== 'string' || !scope.trim()) {
+        return;
+      }
+
+      const caipScope = scope as CaipChainId;
+
+      // Handle wildcard patterns (e.g., "eip155:*" or "bip122:0")
+      if (caipScope.includes(':*') || caipScope.endsWith(':0')) {
+        processWildcardScope(caipScope, address, hasOptedIn, isSupported);
+      } else {
+        processSpecificScope(caipScope, address, hasOptedIn, isSupported);
+      }
+    };
+
+    const processAddressItem = (item: AddressItem) => {
       if (!item?.address || !Array.isArray(item.scopes)) {
         return;
       }
@@ -125,66 +243,11 @@ const RewardOptInAccountGroupModal: React.FC = () => {
         localAccountStatuses[item.address] ?? item.hasOptedIn;
 
       item.scopes.forEach((scope: string) => {
-        if (typeof scope !== 'string' || !scope.trim()) {
-          return;
-        }
-
-        const caipScope = scope as CaipChainId;
-
-        // Handle wildcard patterns (e.g., "eip155:*" or "bip122:0")
-        if (caipScope.includes(':*') || caipScope.endsWith(':0')) {
-          const scopeParts = caipScope.split(':');
-          if (scopeParts.length < 2) {
-            console.warn('Invalid CAIP scope format:', caipScope);
-            return;
-          }
-
-          const namespace = scopeParts[0];
-          if (!namespace) {
-            return;
-          }
-
-          // Add all networks matching this namespace (excluding testnets)
-          Object.entries(allNetworks).forEach(([chainId, network]) => {
-            const chainIdParts = chainId.split(':');
-            if (chainIdParts.length < 2) {
-              return;
-            }
-
-            const chainIdNamespace = chainIdParts[0];
-
-            if (chainIdNamespace === namespace) {
-              // Skip testnets for EVM networks
-              if (network.hexChainId && isTestNet(network.hexChainId)) {
-                return;
-              }
-
-              flattened.push({
-                address: item.address,
-                hasOptedIn: updatedHasOptedIn,
-                scope: chainId as CaipChainId,
-                networkName: network.name,
-                isSupported: item.isSupported,
-              });
-            }
-          });
-        } else {
-          // Specific network scope
-          const network = allNetworks[caipScope];
-          if (network) {
-            flattened.push({
-              address: item.address,
-              hasOptedIn: updatedHasOptedIn,
-              scope: caipScope,
-              networkName: network.name,
-              isSupported: item.isSupported,
-            });
-          } else {
-            console.warn('Unknown network for scope:', caipScope);
-          }
-        }
+        processScope(scope, item.address, updatedHasOptedIn, item.isSupported);
       });
-    });
+    };
+
+    addressData.forEach(processAddressItem);
 
     return flattened;
   }, [addressData, localAccountStatuses, allNetworks]);
@@ -205,13 +268,13 @@ const RewardOptInAccountGroupModal: React.FC = () => {
 
   const renderItem = useCallback(
     ({
-      item,
+      item: itemCtx,
     }: {
       item:
         | { type: 'header'; title: string }
         | ({ type: 'item' } & FlattenedAddressItem);
     }) => {
-      if (item.type === 'header') {
+      if (itemCtx.type === 'header') {
         return (
           <Box twClassName="px-4 py-2">
             <Text
@@ -219,38 +282,32 @@ const RewardOptInAccountGroupModal: React.FC = () => {
               fontWeight={FontWeight.Medium}
               twClassName="text-alternative"
             >
-              {item.title}
+              {itemCtx.title}
             </Text>
           </Box>
         );
       }
 
-      if (!item.address || !item.scope) {
+      if (!itemCtx.address || !itemCtx.scope) {
         return null;
       }
 
       return (
         <MultichainAddressRow
-          testID={`flat-list-item-${item.address}-${item.scope}`}
-          chainId={item.scope}
-          networkName={item.networkName}
-          address={item.address}
+          testID={`flat-list-item-${itemCtx.address}-${itemCtx.scope}`}
+          chainId={itemCtx.scope}
+          networkName={itemCtx.networkName}
+          address={itemCtx.address}
         />
       );
     },
     [],
   );
 
-  const unsupportedAddresses = useMemo(
-    () =>
-      flattenedAddressData?.filter((item) => item.isSupported === false) ?? [],
-    [flattenedAddressData],
-  );
-
   const canOptInAddresses = useMemo(
     () =>
       flattenedAddressData?.filter(
-        (item) => item.isSupported === true && !item.hasOptedIn,
+        (item) => item.isSupported !== false && !item.hasOptedIn,
       ) ?? [],
     [flattenedAddressData],
   );
@@ -259,6 +316,9 @@ const RewardOptInAccountGroupModal: React.FC = () => {
   const flatListData = useMemo(() => {
     const supportedAddresses = flattenedAddressData.filter(
       (item) => item.isSupported !== false,
+    );
+    const unsupportedAddresses = flattenedAddressData.filter(
+      (item) => item.isSupported === false,
     );
 
     const trackedAddresses = supportedAddresses.filter(
@@ -301,6 +361,16 @@ const RewardOptInAccountGroupModal: React.FC = () => {
       });
     }
 
+    if (unsupportedAddresses.length > 0) {
+      data.push({
+        type: 'header',
+        title: strings('rewards.link_account_group.unsupported'),
+      });
+      unsupportedAddresses.forEach((item) => {
+        data.push({ type: 'item', ...item });
+      });
+    }
+
     return data;
   }, [flattenedAddressData]);
 
@@ -316,20 +386,6 @@ const RewardOptInAccountGroupModal: React.FC = () => {
             {accountGroupContext?.metadata?.name}
           </Text>
         </BottomSheetHeader>
-      )}
-
-      {unsupportedAddresses.length > 0 && (
-        <Box twClassName="px-4 pb-4">
-          <RewardsInfoBanner
-            title={strings(
-              'rewards.onboarding.not_supported_account_type_title',
-            )}
-            description={strings(
-              'rewards.onboarding.not_supported_account_type_description',
-            )}
-            testID="unsupported-accounts-banner"
-          />
-        </Box>
       )}
 
       {flatListData.length > 0 && (

--- a/app/components/UI/Rewards/components/Settings/RewardSettingsAccountGroup.test.tsx
+++ b/app/components/UI/Rewards/components/Settings/RewardSettingsAccountGroup.test.tsx
@@ -172,6 +172,12 @@ jest.mock('@metamask/design-system-react-native', () => {
       Details: 'details',
       Check: 'check',
       Add: 'add',
+      Minus: 'minus',
+    },
+    TextColor: {
+      TextAlternative: 'textAlternative',
+      TextDefault: 'textDefault',
+      TextMuted: 'textMuted',
     },
   };
 });
@@ -325,21 +331,10 @@ jest.mock('../../../../../component-library/components/Texts/Text', () => ({
 }));
 
 // Mock selectors
+const mockSelectIconSeedAddressByAccountGroupId = jest.fn();
 jest.mock('../../../../../selectors/multichainAccounts/accounts', () => ({
-  selectIconSeedAddressByAccountGroupId: jest.fn(),
-}));
-
-jest.mock('../../../../../selectors/assets/balances', () => ({
-  selectBalanceByAccountGroup: jest.fn(),
-}));
-
-jest.mock('../../../../../selectors/preferencesController', () => ({
-  selectPrivacyMode: jest.fn(),
-}));
-
-// Mock utility functions
-jest.mock('../../../../../util/assets', () => ({
-  formatWithThreshold: jest.fn((value: number) => `$${value.toFixed(2)}`),
+  selectIconSeedAddressByAccountGroupId: (groupId: string) =>
+    mockSelectIconSeedAddressByAccountGroupId(groupId),
 }));
 
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
@@ -353,6 +348,7 @@ const mockUseLinkAccountGroup = useLinkAccountGroup as jest.MockedFunction<
 describe('RewardSettingsAccountGroup', () => {
   const mockNavigate = jest.fn();
   const mockLinkAccountGroup = jest.fn();
+  const mockEvmAddress = '0x1234567890123456789012345678901234567890';
 
   const mockAccountGroup: AccountGroupWithOptInStatus = {
     id: 'keyring:wallet-1/ethereum',
@@ -410,6 +406,11 @@ describe('RewardSettingsAccountGroup', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
+    // Mock selectIconSeedAddressByAccountGroupId to return a selector function
+    mockSelectIconSeedAddressByAccountGroupId.mockReturnValue(
+      () => mockEvmAddress,
+    );
+
     // Mock useNavigation
     mockUseNavigation.mockReturnValue({
       navigate: mockNavigate,
@@ -430,28 +431,14 @@ describe('RewardSettingsAccountGroup', () => {
       isError: false,
     });
 
-    // Mock useSelector calls
+    // Mock useSelector to execute the selector function
     mockUseSelector.mockImplementation((selector) => {
-      // Mock selectIconSeedAddressByAccountGroupId
-      if (
-        selector.toString().includes('selectIconSeedAddressByAccountGroupId')
-      ) {
-        return '0x1234567890123456789012345678901234567890';
+      // The selector is a function that takes state and returns a value
+      // In the component, it calls selectIconSeedAddressByAccountGroupId(accountGroup.id)
+      // which returns a selector function, then calls that with state
+      if (typeof selector === 'function') {
+        return selector({} as never);
       }
-
-      // Mock selectBalanceByAccountGroup
-      if (selector.toString().includes('selectBalanceByAccountGroup')) {
-        return {
-          totalBalanceInUserCurrency: 100.5,
-          userCurrency: 'usd',
-        };
-      }
-
-      // Mock selectPrivacyMode
-      if (selector.toString().includes('selectPrivacyMode')) {
-        return false;
-      }
-
       return null;
     });
   });
@@ -496,7 +483,7 @@ describe('RewardSettingsAccountGroup', () => {
       ).toBeOnTheScreen();
     });
 
-    it('should render account group balance when available', () => {
+    it('should render tracked accounts count', () => {
       const { getByTestId } = render(
         <RewardSettingsAccountGroup
           item={mockItem}
@@ -505,7 +492,7 @@ describe('RewardSettingsAccountGroup', () => {
       );
 
       expect(
-        getByTestId(`rewards-account-group-balance-${mockAccountGroup.id}`),
+        getByTestId(`rewards-account-group-tracked-${mockAccountGroup.id}`),
       ).toBeOnTheScreen();
     });
 
@@ -546,7 +533,27 @@ describe('RewardSettingsAccountGroup', () => {
       expect(getByTestId('icon-check')).toBeOnTheScreen();
     });
 
-    it('should show add icon when there are opted out accounts', () => {
+    it('should show add icon when there are only opted out accounts', () => {
+      const itemWithOnlyOptedOut: RewardSettingsAccountGroupListFlatListItem = {
+        type: 'accountGroup',
+        accountGroup: {
+          ...mockAccountGroup,
+          optedInAccounts: [],
+          optedOutAccounts: mockAccountGroup.optedOutAccounts,
+        },
+      };
+
+      const { getByTestId } = render(
+        <RewardSettingsAccountGroup
+          item={itemWithOnlyOptedOut}
+          avatarAccountType={AvatarAccountType.Maskicon}
+        />,
+      );
+
+      expect(getByTestId('icon-add')).toBeOnTheScreen();
+    });
+
+    it('should show add icon when there are both opted in and opted out accounts', () => {
       const { getByTestId } = render(
         <RewardSettingsAccountGroup
           item={mockItem}
@@ -781,82 +788,10 @@ describe('RewardSettingsAccountGroup', () => {
       ).toBeNull();
     });
 
-    it('should not render balance when balance data is unavailable', () => {
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector.toString().includes('selectBalanceByAccountGroup')) {
-          return null;
-        }
-        if (
-          selector.toString().includes('selectIconSeedAddressByAccountGroupId')
-        ) {
-          return '0x1234567890123456789012345678901234567890';
-        }
-        if (selector.toString().includes('selectPrivacyMode')) {
-          return false;
-        }
-        return null;
-      });
-
-      const { queryByTestId } = render(
-        <RewardSettingsAccountGroup
-          item={mockItem}
-          avatarAccountType={AvatarAccountType.Maskicon}
-        />,
-      );
-
-      expect(
-        queryByTestId(`rewards-account-group-balance-${mockAccountGroup.id}`),
-      ).toBeNull();
-    });
-
-    it('should not render balance when totalBalanceInUserCurrency is zero', () => {
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector.toString().includes('selectBalanceByAccountGroup')) {
-          return {
-            totalBalanceInUserCurrency: 0,
-            userCurrency: 'usd',
-          };
-        }
-        if (
-          selector.toString().includes('selectIconSeedAddressByAccountGroupId')
-        ) {
-          return '0x1234567890123456789012345678901234567890';
-        }
-        if (selector.toString().includes('selectPrivacyMode')) {
-          return false;
-        }
-        return null;
-      });
-
-      const { queryByTestId } = render(
-        <RewardSettingsAccountGroup
-          item={mockItem}
-          avatarAccountType={AvatarAccountType.Maskicon}
-        />,
-      );
-
-      expect(
-        queryByTestId(`rewards-account-group-balance-${mockAccountGroup.id}`),
-      ).toBeNull();
-    });
-
     it('should use fallback address when evmAddress is undefined', () => {
-      mockUseSelector.mockImplementation((selector) => {
-        if (
-          selector.toString().includes('selectIconSeedAddressByAccountGroupId')
-        ) {
-          return undefined;
-        }
-        if (selector.toString().includes('selectBalanceByAccountGroup')) {
-          return {
-            totalBalanceInUserCurrency: 100.5,
-            userCurrency: 'usd',
-          };
-        }
-        if (selector.toString().includes('selectPrivacyMode')) {
-          return false;
-        }
-        return null;
+      // Mock selector to throw an error (simulating no accounts found)
+      mockSelectIconSeedAddressByAccountGroupId.mockReturnValue(() => {
+        throw new Error('No accounts found');
       });
 
       const { getByTestId } = render(
@@ -872,24 +807,11 @@ describe('RewardSettingsAccountGroup', () => {
       ).toBeOnTheScreen();
     });
 
-    it('should hide balance when privacy mode is enabled', () => {
-      mockUseSelector.mockImplementation((selector) => {
-        if (selector.toString().includes('selectBalanceByAccountGroup')) {
-          return {
-            totalBalanceInUserCurrency: 100.5,
-            userCurrency: 'usd',
-          };
-        }
-        if (
-          selector.toString().includes('selectIconSeedAddressByAccountGroupId')
-        ) {
-          return '0x1234567890123456789012345678901234567890';
-        }
-        if (selector.toString().includes('selectPrivacyMode')) {
-          return true;
-        }
-        return null;
-      });
+    it('should use fallback address when selector returns undefined', () => {
+      // Mock selector to return undefined
+      mockSelectIconSeedAddressByAccountGroupId.mockReturnValue(
+        () => undefined,
+      );
 
       const { getByTestId } = render(
         <RewardSettingsAccountGroup
@@ -898,11 +820,44 @@ describe('RewardSettingsAccountGroup', () => {
         />,
       );
 
-      // Balance should render but be hidden
-      const balance = getByTestId(
-        `rewards-account-group-balance-${mockAccountGroup.id}`,
+      // Component should still render with fallback address
+      expect(
+        getByTestId(`rewards-account-group-avatar-${mockAccountGroup.id}`),
+      ).toBeOnTheScreen();
+    });
+
+    it('should call selectIconSeedAddressByAccountGroupId with correct account group ID', () => {
+      render(
+        <RewardSettingsAccountGroup
+          item={mockItem}
+          avatarAccountType={AvatarAccountType.Maskicon}
+        />,
       );
-      expect(balance).toBeOnTheScreen();
+
+      // Verify the selector factory was called with the correct account group ID
+      expect(mockSelectIconSeedAddressByAccountGroupId).toHaveBeenCalledWith(
+        mockAccountGroup.id,
+      );
+    });
+
+    it('should not call selector when accountGroup.id is undefined', () => {
+      const itemWithoutId: RewardSettingsAccountGroupListFlatListItem = {
+        type: 'accountGroup',
+        accountGroup: {
+          ...mockAccountGroup,
+          id: undefined as never,
+        },
+      };
+
+      render(
+        <RewardSettingsAccountGroup
+          item={itemWithoutId}
+          avatarAccountType={AvatarAccountType.Maskicon}
+        />,
+      );
+
+      // Verify the selector was not called when accountGroup.id is undefined
+      expect(mockSelectIconSeedAddressByAccountGroupId).not.toHaveBeenCalled();
     });
   });
 
@@ -926,7 +881,7 @@ describe('RewardSettingsAccountGroup', () => {
         getByTestId(`rewards-account-group-name-${mockAccountGroup.id}`),
       ).toBeOnTheScreen();
       expect(
-        getByTestId(`rewards-account-group-balance-${mockAccountGroup.id}`),
+        getByTestId(`rewards-account-group-tracked-${mockAccountGroup.id}`),
       ).toBeOnTheScreen();
       expect(
         getByTestId(`rewards-account-addresses-${mockAccountGroup.id}`),

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6703,6 +6703,8 @@
       "link_account": "Add account",
       "tracked": "Tracked",
       "untracked": "Untracked",
+      "unsupported": "Unsupported",
+      "tracked_count": "{{optedIn}}/{{total}} tracked",
       "link_account_success": "{{accountName}} added successfully",
       "link_account_error": "Failed to add one or more addresses for {{accountName}}"
     },


### PR DESCRIPTION
## **Description**

Instead of showing the balance per account group in reward settings page, we now show the tracked/total tracked addresses per account group. 

Also in the detail modal spawnable on that page (via details button) we no longer show the unsupported account type rewards banner.

## **Changelog**

CHANGELOG entry: show tracked/untracked in reward settings view

## **Screenshots/Recordings**

<img width="1062" height="1920" alt="image" src="https://github.com/user-attachments/assets/b5c1298c-f8e2-4adb-a7e1-0f7c21c22d28" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x]  I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Show tracked/total count per account group, remove unsupported banner in the opt-in modal, add explicit Unsupported section, and refactor list/render logic with updated tests and strings.
> 
> - **Rewards Settings UI**:
>   - `RewardSettingsAccountGroup`:
>     - Replace balance display with `tracked/total` count (`rewards.link_account_group.tracked_count`).
>     - Simplify link button icon/disabled states; add loading indicator; minor layout tweaks.
> - **Opt-in Modal**:
>   - `RewardOptInAccountGroupModal`:
>     - Remove `RewardsInfoBanner` and unsupported alert banner.
>     - Build FlatList with section headers for `Tracked`, `Untracked`, and new `Unsupported` (via `rewards.link_account_group.unsupported`).
>     - Treat `isSupported: undefined` as supported; filter EVM testnets on wildcards; robust CAIP scope handling; improved key extraction and `onClose`→`navigation.goBack`.
> - **Account Group List**:
>   - `RewardSettingsAccountGroupList`:
>     - Add `getItemType` to FlashList; factor address lookup per group; header/skeleton tweaks; stable keys.
> - **i18n**:
>   - Add `rewards.link_account_group.unsupported` and `rewards.link_account_group.tracked_count` strings.
> - **Tests**:
>   - Update/expand tests for new testIDs, section headers, wildcard/scope edge cases, selector factories, loading/disabled states, and FlashList `getItemType`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac79782c7e5fbee89a1687f50458773a33a3c68b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->