### PR TITLE
feat: add deeplink support for Predict markets

### DIFF
--- a/app/constants/deeplinks.ts
+++ b/app/constants/deeplinks.ts
@@ -38,6 +38,7 @@ export enum ACTIONS {
   PERPS_MARKETS = 'perps-markets',
   PERPS_ASSET = 'perps-asset',
   REWARDS = 'rewards',
+  PREDICT = 'predict',
   ONBOARDING = 'onboarding',
 }
 
@@ -63,6 +64,7 @@ export const PREFIXES = {
   [ACTIONS.PERPS_MARKETS]: '',
   [ACTIONS.PERPS_ASSET]: '',
   [ACTIONS.REWARDS]: '',
+  [ACTIONS.PREDICT]: '',
   [ACTIONS.ONBOARDING]: '',
   [ACTIONS.ENABLE_CARD_BUTTON]: '',
   METAMASK: 'metamask://',

--- a/app/core/DeeplinkManager/DeeplinkManager.ts
+++ b/app/core/DeeplinkManager/DeeplinkManager.ts
@@ -24,6 +24,7 @@ import { handleDeeplink } from './Handlers/handleDeeplink';
 import SharedDeeplinkManager from './SharedDeeplinkManager';
 import FCMService from '../../util/notifications/services/FCMService';
 import { handleRewardsUrl } from './Handlers/handleRewardsUrl';
+import { handlePredictUrl } from './Handlers/handlePredictUrl';
 import handleFastOnboarding from './Handlers/handleFastOnboarding';
 import { handleEnableCardButton } from './Handlers/handleEnableCardButton';
 
@@ -135,6 +136,12 @@ class DeeplinkManager {
   _handlePerps(perpsPath: string) {
     handlePerpsUrl({
       perpsPath,
+    });
+  }
+
+  _handlePredict(predictPath: string) {
+    handlePredictUrl({
+      predictPath,
     });
   }
 

--- a/app/core/DeeplinkManager/Handlers/handlePredictUrl.test.ts
+++ b/app/core/DeeplinkManager/Handlers/handlePredictUrl.test.ts
@@ -1,0 +1,303 @@
+import { handlePredictUrl } from './handlePredictUrl';
+import NavigationService from '../../NavigationService';
+import Routes from '../../../constants/navigation/Routes';
+import DevLogger from '../../SDKConnect/utils/DevLogger';
+
+// Mock dependencies
+jest.mock('../../NavigationService');
+jest.mock('../../SDKConnect/utils/DevLogger');
+
+describe('handlePredictUrl', () => {
+  let mockNavigate: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Setup navigation mocks
+    mockNavigate = jest.fn();
+    NavigationService.navigation = {
+      navigate: mockNavigate,
+    } as unknown as typeof NavigationService.navigation;
+
+    // Mock DevLogger
+    (DevLogger.log as jest.Mock) = jest.fn();
+  });
+
+  describe('with market parameter', () => {
+    it('navigates to market details when market parameter is provided', async () => {
+      await handlePredictUrl({ predictPath: '?market=23246' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
+        screen: Routes.PREDICT.MARKET_DETAILS,
+        params: {
+          marketId: '23246',
+          entryPoint: 'deeplink',
+        },
+      });
+    });
+
+    it('navigates to market details when marketId parameter is provided', async () => {
+      await handlePredictUrl({ predictPath: '?marketId=12345' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
+        screen: Routes.PREDICT.MARKET_DETAILS,
+        params: {
+          marketId: '12345',
+          entryPoint: 'deeplink',
+        },
+      });
+    });
+
+    it('prioritizes market parameter over marketId when both are provided', async () => {
+      await handlePredictUrl({
+        predictPath: '?market=23246&marketId=99999',
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
+        screen: Routes.PREDICT.MARKET_DETAILS,
+        params: {
+          marketId: '23246',
+          entryPoint: 'deeplink',
+        },
+      });
+    });
+
+    it('extracts market ID from full URL path', async () => {
+      await handlePredictUrl({ predictPath: 'predict?market=abc789' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
+        screen: Routes.PREDICT.MARKET_DETAILS,
+        params: {
+          marketId: 'abc789',
+          entryPoint: 'deeplink',
+        },
+      });
+    });
+
+    it('handles multiple URL parameters', async () => {
+      await handlePredictUrl({
+        predictPath: '?market=xyz123&utm_source=campaign&debug=true',
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
+        screen: Routes.PREDICT.MARKET_DETAILS,
+        params: {
+          marketId: 'xyz123',
+          entryPoint: 'deeplink',
+        },
+      });
+    });
+
+    it('handles numeric market IDs', async () => {
+      await handlePredictUrl({ predictPath: '?market=9876543210' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
+        screen: Routes.PREDICT.MARKET_DETAILS,
+        params: {
+          marketId: '9876543210',
+          entryPoint: 'deeplink',
+        },
+      });
+    });
+
+    it('handles alphanumeric market IDs', async () => {
+      await handlePredictUrl({ predictPath: '?market=abc-123-xyz' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
+        screen: Routes.PREDICT.MARKET_DETAILS,
+        params: {
+          marketId: 'abc-123-xyz',
+          entryPoint: 'deeplink',
+        },
+      });
+    });
+  });
+
+  describe('without market parameter', () => {
+    it('navigates to market list when no parameters provided', async () => {
+      await handlePredictUrl({ predictPath: '' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_LIST,
+      });
+    });
+
+    it('navigates to market list when URL has no query parameters', async () => {
+      await handlePredictUrl({ predictPath: 'predict' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_LIST,
+      });
+    });
+
+    it('navigates to market list when market parameter is empty', async () => {
+      await handlePredictUrl({ predictPath: '?market=' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_LIST,
+      });
+    });
+
+    it('navigates to market list when marketId parameter is empty', async () => {
+      await handlePredictUrl({ predictPath: '?marketId=' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_LIST,
+      });
+    });
+
+    it('navigates to market list when only other parameters provided', async () => {
+      await handlePredictUrl({ predictPath: '?utm_source=campaign' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_LIST,
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    it('falls back to market list when navigation fails', async () => {
+      mockNavigate.mockImplementationOnce(() => {
+        throw new Error('Navigation error');
+      });
+
+      await handlePredictUrl({ predictPath: '?market=23246' });
+
+      expect(mockNavigate).toHaveBeenCalledTimes(2);
+      expect(mockNavigate).toHaveBeenLastCalledWith(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_LIST,
+      });
+    });
+
+    it('falls back to market list when market details navigation throws', async () => {
+      mockNavigate.mockImplementationOnce(() => {
+        throw new Error('Market details navigation error');
+      });
+
+      await handlePredictUrl({ predictPath: '?marketId=invalid' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_LIST,
+      });
+    });
+
+    it('handles malformed URL parameters gracefully', async () => {
+      await handlePredictUrl({
+        predictPath: 'predict?invalid&params&here',
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_LIST,
+      });
+    });
+
+    it('logs error details when handling fails', async () => {
+      const testError = new Error('Test error');
+      mockNavigate.mockImplementationOnce(() => {
+        throw testError;
+      });
+
+      await handlePredictUrl({ predictPath: '?market=23246' });
+
+      expect(DevLogger.log).toHaveBeenCalledWith(
+        'Failed to handle predict deeplink:',
+        testError,
+      );
+    });
+  });
+
+  describe('logging', () => {
+    it('logs start of deeplink handling with path', async () => {
+      await handlePredictUrl({ predictPath: '?market=23246' });
+
+      expect(DevLogger.log).toHaveBeenCalledWith(
+        '[handlePredictUrl] Starting predict deeplink handling with path:',
+        '?market=23246',
+      );
+    });
+
+    it('logs parsed navigation parameters', async () => {
+      await handlePredictUrl({ predictPath: '?market=23246' });
+
+      expect(DevLogger.log).toHaveBeenCalledWith(
+        '[handlePredictUrl] Parsed navigation parameters:',
+        { market: '23246' },
+      );
+    });
+
+    it('logs navigation to market details', async () => {
+      await handlePredictUrl({ predictPath: '?market=23246' });
+
+      expect(DevLogger.log).toHaveBeenCalledWith(
+        '[handlePredictUrl] Navigating to market details for market:',
+        '23246',
+      );
+    });
+
+    it('logs navigation to market list when no market provided', async () => {
+      await handlePredictUrl({ predictPath: '' });
+
+      expect(DevLogger.log).toHaveBeenCalledWith(
+        '[handlePredictUrl] No market parameter, showing list',
+      );
+    });
+
+    it('logs fallback when market ID is empty', async () => {
+      await handlePredictUrl({ predictPath: '?market=' });
+
+      expect(DevLogger.log).toHaveBeenCalledWith(
+        '[handlePredictUrl] No market parameter, showing list',
+      );
+    });
+  });
+
+  describe('URL parsing edge cases', () => {
+    it('handles URL with question mark but no parameters', async () => {
+      await handlePredictUrl({ predictPath: 'predict?' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_LIST,
+      });
+    });
+
+    it('handles URL with multiple question marks', async () => {
+      await handlePredictUrl({ predictPath: 'predict?market=123?extra=param' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
+        screen: Routes.PREDICT.MARKET_DETAILS,
+        params: {
+          marketId: '123',
+          entryPoint: 'deeplink',
+        },
+      });
+    });
+
+    it('handles URL with special characters in market ID', async () => {
+      await handlePredictUrl({
+        predictPath: '?market=test_market-123',
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
+        screen: Routes.PREDICT.MARKET_DETAILS,
+        params: {
+          marketId: 'test_market-123',
+          entryPoint: 'deeplink',
+        },
+      });
+    });
+
+    it('handles URL with encoded parameters', async () => {
+      await handlePredictUrl({
+        predictPath: '?market=test%20market',
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
+        screen: Routes.PREDICT.MARKET_DETAILS,
+        params: {
+          marketId: 'test market',
+          entryPoint: 'deeplink',
+        },
+      });
+    });
+  });
+});

--- a/app/core/DeeplinkManager/Handlers/handlePredictUrl.ts
+++ b/app/core/DeeplinkManager/Handlers/handlePredictUrl.ts
@@ -1,0 +1,116 @@
+import NavigationService from '../../NavigationService';
+import Routes from '../../../constants/navigation/Routes';
+import DevLogger from '../../SDKConnect/utils/DevLogger';
+
+interface HandlePredictUrlParams {
+  predictPath: string;
+}
+
+/**
+ * Interface for parsed predict navigation parameters
+ */
+interface PredictNavigationParams {
+  market?: string; // Market ID
+}
+
+/**
+ * Parse URL parameters into typed navigation parameters
+ * @param predictPath The predict URL path with query parameters
+ * @returns Typed navigation parameters
+ */
+const parsePredictNavigationParams = (
+  predictPath: string,
+): PredictNavigationParams => {
+  const urlParams = new URLSearchParams(
+    predictPath.includes('?') ? predictPath.split('?')[1] : '',
+  );
+
+  // Support both 'market' and 'marketId' parameter names
+  const marketId = urlParams.get('market') || urlParams.get('marketId');
+
+  return {
+    market: marketId || undefined,
+  };
+};
+
+/**
+ * Handle market-specific navigation
+ * @param marketId The market ID to navigate to
+ */
+const handleMarketNavigation = (marketId: string) => {
+  DevLogger.log(
+    '[handlePredictUrl] Navigating to market details for market:',
+    marketId,
+  );
+
+  if (!marketId) {
+    DevLogger.log(
+      '[handlePredictUrl] No market ID provided, fallback to market list',
+    );
+    NavigationService.navigation.navigate(Routes.PREDICT.ROOT, {
+      screen: Routes.PREDICT.MARKET_LIST,
+    });
+    return;
+  }
+
+  // Navigate to market details with the market ID
+  // Note: Market details is under MODALS.ROOT, not the main ROOT
+  NavigationService.navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
+    screen: Routes.PREDICT.MARKET_DETAILS,
+    params: {
+      marketId,
+      entryPoint: 'deeplink',
+    },
+  });
+};
+
+/**
+ * Predict deeplink handler
+ *
+ * @param params Object containing the predict path
+ *
+ * Supported URL formats:
+ * - https://metamask.app.link/predict
+ * - https://metamask.app.link/predict?market=23246
+ * - https://metamask.app.link/predict?marketId=23246
+ * - https://link.metamask.io/predict?market=23246
+ * - https://link.metamask.io/predict?marketId=23246
+ *
+ * Navigation behavior:
+ * - No market param: Navigate to market list
+ * - market=X or marketId=X: Navigate directly to market details for market X
+ */
+export const handlePredictUrl = async ({
+  predictPath,
+}: HandlePredictUrlParams) => {
+  DevLogger.log(
+    '[handlePredictUrl] Starting predict deeplink handling with path:',
+    predictPath,
+  );
+
+  try {
+    // Parse navigation parameters from URL
+    const navParams = parsePredictNavigationParams(predictPath);
+    DevLogger.log(
+      '[handlePredictUrl] Parsed navigation parameters:',
+      navParams,
+    );
+
+    // If market ID is provided, navigate to market details
+    if (navParams.market) {
+      handleMarketNavigation(navParams.market);
+    } else {
+      // Default to market list
+      DevLogger.log('[handlePredictUrl] No market parameter, showing list');
+      NavigationService.navigation.navigate(Routes.PREDICT.ROOT, {
+        screen: Routes.PREDICT.MARKET_LIST,
+      });
+    }
+  } catch (error) {
+    DevLogger.log('Failed to handle predict deeplink:', error);
+    // Fallback to market list on error
+    NavigationService.navigation.navigate(Routes.PREDICT.ROOT, {
+      screen: Routes.PREDICT.MARKET_LIST,
+    });
+  }
+};

--- a/app/core/DeeplinkManager/ParseManager/handleUniversalLink.test.ts
+++ b/app/core/DeeplinkManager/ParseManager/handleUniversalLink.test.ts
@@ -49,6 +49,7 @@ describe('handleUniversalLinks', () => {
   const mockHandleCreateAccount = jest.fn();
   const mockHandlePerps = jest.fn();
   const mockHandleRewards = jest.fn();
+  const mockHandlePredict = jest.fn();
   const mockHandleFastOnboarding = jest.fn();
   const mockHandleEnableCardButton = jest.fn();
   const mockConnectToChannel = jest.fn();
@@ -77,6 +78,7 @@ describe('handleUniversalLinks', () => {
     _handleCreateAccount: mockHandleCreateAccount,
     _handlePerps: mockHandlePerps,
     _handleRewards: mockHandleRewards,
+    _handlePredict: mockHandlePredict,
     _handleFastOnboarding: mockHandleFastOnboarding,
     _handleEnableCardButton: mockHandleEnableCardButton,
   } as unknown as DeeplinkManager;
@@ -578,6 +580,101 @@ describe('handleUniversalLinks', () => {
 
       expect(handled).toHaveBeenCalled();
       expect(mockHandleRewards).toHaveBeenCalledWith('?referral=code123');
+    });
+  });
+
+  describe('ACTIONS.PREDICT', () => {
+    it('calls _handlePredict when action is PREDICT without market parameter', async () => {
+      const predictUrl = `${PROTOCOLS.HTTPS}://${AppConstants.MM_UNIVERSAL_LINK_HOST}/${ACTIONS.PREDICT}`;
+      const predictUrlObj = {
+        ...urlObj,
+        hostname: AppConstants.MM_UNIVERSAL_LINK_HOST,
+        href: predictUrl,
+        pathname: `/${ACTIONS.PREDICT}`,
+      };
+
+      await handleUniversalLink({
+        instance,
+        handled,
+        urlObj: predictUrlObj,
+        browserCallBack: mockBrowserCallBack,
+        url: predictUrl,
+        source: 'test-source',
+      });
+
+      expect(handled).toHaveBeenCalled();
+      expect(mockHandlePredict).toHaveBeenCalledWith('');
+    });
+
+    it('calls _handlePredict when action is PREDICT with market parameter', async () => {
+      const predictUrl = `${PROTOCOLS.HTTPS}://${AppConstants.MM_UNIVERSAL_LINK_HOST}/${ACTIONS.PREDICT}?market=23246`;
+      const predictUrlObj = {
+        ...urlObj,
+        hostname: AppConstants.MM_UNIVERSAL_LINK_HOST,
+        href: predictUrl,
+        pathname: `/${ACTIONS.PREDICT}`,
+        search: '?market=23246',
+      };
+
+      await handleUniversalLink({
+        instance,
+        handled,
+        urlObj: predictUrlObj,
+        browserCallBack: mockBrowserCallBack,
+        url: predictUrl,
+        source: 'test-source',
+      });
+
+      expect(handled).toHaveBeenCalled();
+      expect(mockHandlePredict).toHaveBeenCalledWith('?market=23246');
+    });
+
+    it('calls _handlePredict when action is PREDICT with marketId parameter', async () => {
+      const predictUrl = `${PROTOCOLS.HTTPS}://${AppConstants.MM_UNIVERSAL_LINK_HOST}/${ACTIONS.PREDICT}?marketId=12345`;
+      const predictUrlObj = {
+        ...urlObj,
+        hostname: AppConstants.MM_UNIVERSAL_LINK_HOST,
+        href: predictUrl,
+        pathname: `/${ACTIONS.PREDICT}`,
+        search: '?marketId=12345',
+      };
+
+      await handleUniversalLink({
+        instance,
+        handled,
+        urlObj: predictUrlObj,
+        browserCallBack: mockBrowserCallBack,
+        url: predictUrl,
+        source: 'test-source',
+      });
+
+      expect(handled).toHaveBeenCalled();
+      expect(mockHandlePredict).toHaveBeenCalledWith('?marketId=12345');
+    });
+
+    it('calls _handlePredict with full query string when multiple parameters present', async () => {
+      const predictUrl = `${PROTOCOLS.HTTPS}://${AppConstants.MM_UNIVERSAL_LINK_HOST}/${ACTIONS.PREDICT}?market=23246&utm_source=campaign`;
+      const predictUrlObj = {
+        ...urlObj,
+        hostname: AppConstants.MM_UNIVERSAL_LINK_HOST,
+        href: predictUrl,
+        pathname: `/${ACTIONS.PREDICT}`,
+        search: '?market=23246&utm_source=campaign',
+      };
+
+      await handleUniversalLink({
+        instance,
+        handled,
+        urlObj: predictUrlObj,
+        browserCallBack: mockBrowserCallBack,
+        url: predictUrl,
+        source: 'test-source',
+      });
+
+      expect(handled).toHaveBeenCalled();
+      expect(mockHandlePredict).toHaveBeenCalledWith(
+        '?market=23246&utm_source=campaign',
+      );
     });
   });
 

--- a/app/core/DeeplinkManager/ParseManager/handleUniversalLink.ts
+++ b/app/core/DeeplinkManager/ParseManager/handleUniversalLink.ts
@@ -36,6 +36,7 @@ enum SUPPORTED_ACTIONS {
   PERPS_MARKETS = ACTIONS.PERPS_MARKETS,
   PERPS_ASSET = ACTIONS.PERPS_ASSET,
   REWARDS = ACTIONS.REWARDS,
+  PREDICT = ACTIONS.PREDICT,
   WC = ACTIONS.WC,
   ONBOARDING = ACTIONS.ONBOARDING,
   ENABLE_CARD_BUTTON = ACTIONS.ENABLE_CARD_BUTTON,
@@ -257,6 +258,9 @@ async function handleUniversalLink({
   } else if (action === SUPPORTED_ACTIONS.REWARDS) {
     const rewardsPath = urlObj.href.replace(BASE_URL_ACTION, '');
     instance._handleRewards(rewardsPath);
+  } else if (action === SUPPORTED_ACTIONS.PREDICT) {
+    const predictPath = urlObj.href.replace(BASE_URL_ACTION, '');
+    instance._handlePredict(predictPath);
   } else if (action === SUPPORTED_ACTIONS.WC) {
     const { params } = extractURLParams(urlObj.href);
     const wcURL = params?.uri;


### PR DESCRIPTION
# Add Deeplink Support for Predict Markets

## 📋 Summary

This PR adds deeplink support for Predict markets, allowing users to navigate directly to specific prediction markets or the market list via external links.

CHANGELOG entry: null

https://github.com/user-attachments/assets/a547cdcb-8ca7-4dc3-ac07-b546429f5d1b

## 🎯 Objective

Enable deep linking to Predict markets from external sources (marketing campaigns, push notifications, web links, etc.) to improve user engagement and provide a seamless entry point to specific markets.

## 🔗 Supported URL Formats

### Production Domains
```
https://metamask.app.link/predict
https://metamask.app.link/predict?market=23246
https://metamask.app.link/predict?marketId=23246

metamask://predict
metamask://predict?market=23246
```

## 🔧 Changes

### 1. Core Implementation

#### Added Files
- `app/core/DeeplinkManager/Handlers/handlePredictUrl.ts` - Handler for Predict deeplink navigation
- `app/core/DeeplinkManager/Handlers/handlePredictUrl.test.ts` - Comprehensive test suite (25 tests)

#### Modified Files
- `app/constants/deeplinks.ts` - Added `PREDICT` action constant
- `app/core/DeeplinkManager/DeeplinkManager.ts` - Added `_handlePredict` method
- `app/core/DeeplinkManager/ParseManager/handleUniversalLink.ts` - Wired up PREDICT action routing
- `app/core/DeeplinkManager/ParseManager/handleUniversalLink.test.ts` - Added integration tests

### 2. Implementation Details

**Handler Architecture:**
- Follows the same pattern as existing handlers (`handlePerpsUrl`, `handleRewardsUrl`)
- Parses URL parameters to extract market information
- Provides fallback navigation to market list on errors
- Includes comprehensive logging for debugging

**Navigation Logic:**
- **With market ID**: Navigates to `Routes.PREDICT.MODALS.ROOT` → `MARKET_DETAILS` with marketId
- **Without market ID**: Navigates to `Routes.PREDICT.ROOT` → `MARKET_LIST`

**Parameter Support:**
- Supports both `market` and `marketId` query parameters for flexibility
- `market` parameter takes priority when both are present
- Handles additional query parameters gracefully (e.g., UTM tracking)

### Test Domain
```
https://link-test.metamask.io/predict?market=23246
```

### URL Behavior

| URL Pattern | Navigation Target | Entry Point |
|------------|-------------------|-------------|
| `/predict` | Market list | `deeplink` |
| `/predict?market=X` | Market details (ID: X) | `deeplink` |
| `/predict?marketId=X` | Market details (ID: X) | `deeplink` |

## 🧪 Testing

### Unit Tests

**handlePredictUrl Tests (25 tests)**
- ✅ Navigation with `market` parameter
- ✅ Navigation with `marketId` parameter
- ✅ Parameter priority when both present
- ✅ Navigation to market list (no parameters)
- ✅ Error handling and fallbacks
- ✅ Logging behavior
- ✅ URL parsing edge cases (encoded params, special characters, malformed URLs)

**handleUniversalLink Integration Tests (4 tests)**
- ✅ PREDICT action routing without parameters
- ✅ PREDICT action routing with `market` parameter
- ✅ PREDICT action routing with `marketId` parameter
- ✅ Query string preservation with multiple parameters

**Test Results:**
```bash
PASS app/core/DeeplinkManager/Handlers/handlePredictUrl.test.ts
  ✓ 25 tests passed

PASS app/core/DeeplinkManager/ParseManager/handleUniversalLink.test.ts (PREDICT tests)
  ✓ 4 tests passed
```

### Manual Testing

#### iOS Simulator
```bash
xcrun simctl openurl booted "https://link.metamask.io/predict?market=23246"
```

#### Android Emulator
```bash
adb shell am start -W -a android.intent.action.VIEW \
  -d "https://link.metamask.io/predict?market=23246" \
  com.metamask.debug
```

#### Test Scenarios
1. **Market List Navigation**
   - URL: `https://link.metamask.io/predict`
   - Expected: Opens Predict market list

2. **Specific Market Navigation**
   - URL: `https://link.metamask.io/predict?market=23246`
   - Expected: Opens market details for market ID 23246

3. **Alternative Parameter**
   - URL: `https://link.metamask.io/predict?marketId=12345`
   - Expected: Opens market details for market ID 12345

4. **With Tracking Parameters**
   - URL: `https://link.metamask.io/predict?market=23246&utm_source=campaign`
   - Expected: Opens market details, preserves tracking params

5. **Invalid/Missing Market**
   - URL: `https://link.metamask.io/predict?market=`
   - Expected: Falls back to market list

## 📊 Code Quality

- ✅ No linter errors
- ✅ Follows MetaMask testing guidelines
- ✅ 100% test coverage of new handler
- ✅ TypeScript strict mode compliant
- ✅ Follows existing deeplink handler patterns
- ✅ Comprehensive error handling
- ✅ DevLogger integration for debugging

## 🔍 Code Review Checklist

- [ ] Unit tests cover all code paths
- [ ] Tests follow MetaMask guidelines (no "should", AAA pattern)
- [ ] Error handling provides graceful fallbacks
- [ ] Logging is appropriate for debugging
- [ ] URL parameter parsing handles edge cases
- [ ] Navigation routes are correct
- [ ] Code follows existing patterns
- [ ] TypeScript types are properly defined

## 📝 Additional Notes

### Design Decisions

1. **Dual Parameter Support**: Supporting both `market` and `marketId` provides flexibility for different link sources while maintaining backward compatibility if parameter names change.

2. **Modal Stack Navigation**: Market details are under `MODALS.ROOT` rather than the main `ROOT` stack, which matches the existing navigation structure used by the Predict feature.

3. **Fallback Strategy**: All error conditions fall back to the market list rather than showing error screens, providing a better user experience.

4. **Entry Point Tracking**: The `entryPoint: 'deeplink'` parameter allows analytics to track that users arrived via deeplink.

### Future Enhancements

Potential additions for future PRs:
- Support for additional parameters (outcome selection, buy amount pre-fill)
- Deep linking to specific positions or activity
- Support for market slugs in addition to IDs
- Analytics tracking for deeplink conversions

## 🔗 Related Documentation

- [Deeplink Implementation Guide](docs/readme/deeplinking.md)
- [Predict Feature Documentation](app/components/UI/Predict/README.md)
- [Navigation Routes](app/constants/navigation/Routes.ts)

## 📸 Screenshots

<!-- Add screenshots of the deeplink flow if needed -->

---

**Commits:**
1. `a618f8d2ae` - feat: add deeplink support for Predict markets
2. `8594437f0b` - test: add comprehensive tests for Predict deeplink handling

