### PR TITLE
fix: cp-7.59.0 metaMetrics not tracking events for social login users

### DIFF
--- a/app/core/Analytics/MetaMetrics.ts
+++ b/app/core/Analytics/MetaMetrics.ts
@@ -695,7 +695,7 @@ class MetaMetrics implements IMetaMetrics {
    * and user traits are updated with the latest ones
    */
   addTraitsToUser = (userTraits: UserTraits): Promise<void> => {
-    if (this.enabled) {
+    if (this.isEnabled()) {
       return this.#identify(userTraits);
     }
     return Promise.resolve();
@@ -708,7 +708,7 @@ class MetaMetrics implements IMetaMetrics {
    * @param groupTraits - group relevant traits or properties (optional)
    */
   group = (groupId: string, groupTraits?: GroupTraits): Promise<void> => {
-    if (this.enabled) {
+    if (this.isEnabled()) {
       this.#group(groupId, groupTraits);
     }
     return Promise.resolve();
@@ -759,7 +759,7 @@ class MetaMetrics implements IMetaMetrics {
     event: ITrackingEvent,
     saveDataRecording: boolean = true,
   ): void => {
-    if (!this.enabled) {
+    if (!this.isEnabled()) {
       return;
     }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Bugfix: metaMetrics not tracking events for social login users
Fix: https://github.com/MetaMask/metamask-mobile/issues/22296
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Bugfix: metaMetrics not tracking events for social login users

## **Related issues**

Fixes: metaMetrics not tracking events for social login users(https://github.com/MetaMask/metamask-mobile/issues/22296)

## **Manual testing steps**

```gherkin
Feature: track events for social login
  Scenario: New Google login wallet setup track "Wallet Setup Started" event
    Given app is a clean install
    And user is on the onboarding screen
    And user presses "Continue with Google/Apple"
    When user complete onboarding
    Then "Wallet Setup Started" event appears in Segment for this user
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**
<img width="1296" height="821" alt="Screenshot 2025-11-07 at 1 18 15 PM" src="https://github.com/user-attachments/assets/1460f986-e010-43b7-aee8-fcc8e0d6fc1d" />
<img width="1204" height="183" alt="Screenshot 2025-11-07 at 1 18 40 PM" src="https://github.com/user-attachments/assets/750ada94-ce19-474b-b8b3-40453f6ecea0" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 8b10f73a0871e91db652fdd2dae9d7022d2ca2c7. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->