### PR TITLE
feat(ds): accept listItemProps in ListItemSelect

### DIFF
--- a/app/component-library/components/List/ListItemSelect/ListItemSelect.test.tsx
+++ b/app/component-library/components/List/ListItemSelect/ListItemSelect.test.tsx
@@ -174,4 +174,21 @@ describe('ListItemSelect', () => {
     const component = getByTestId('list-item-select');
     expect(component).toBeOnTheScreen();
   });
+
+  it('passes through custom listItemProps', () => {
+    const { getByTestId } = render(
+      <ListItemSelect
+        onPress={() => null}
+        listItemProps={{
+          accessibilityHint: 'Custom Hint',
+          testID: 'nested-list-item',
+        }}
+      >
+        <View testID="test-content">Test Content</View>
+      </ListItemSelect>,
+    );
+
+    const component = getByTestId('nested-list-item');
+    expect(component.props.accessibilityHint).toBe('Custom Hint');
+  });
 });

--- a/app/component-library/components/List/ListItemSelect/ListItemSelect.tsx
+++ b/app/component-library/components/List/ListItemSelect/ListItemSelect.tsx
@@ -22,6 +22,7 @@ const ListItemSelect: React.FC<ListItemSelectProps> = ({
   onLongPress,
   gap = DEFAULT_SELECTITEM_GAP,
   verticalAlignment,
+  listItemProps,
   ...props
 }) => {
   const { styles } = useStyles(styleSheet, { style, isDisabled });
@@ -34,7 +35,7 @@ const ListItemSelect: React.FC<ListItemSelectProps> = ({
       onLongPress={onLongPress}
       {...props}
     >
-      <ListItem gap={gap} style={styles.listItem}>
+      <ListItem gap={gap} style={styles.listItem} {...listItemProps}>
         {children}
       </ListItem>
       {isSelected && (

--- a/app/component-library/components/List/ListItemSelect/ListItemSelect.types.ts
+++ b/app/component-library/components/List/ListItemSelect/ListItemSelect.types.ts
@@ -18,6 +18,10 @@ export interface ListItemSelectProps
    * Optional prop to determine if the item is disabled.
    */
   isDisabled?: boolean;
+  /**
+   * Optional prop to configure the prop of nested ListItem
+   */
+  listItemProps?: Partial<ListItemProps>;
 }
 
 /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This pull request enhances the flexibility of the `ListItemSelect` component by allowing custom props to be passed directly to its nested `ListItem` component. This makes it easier to customize accessibility and other properties when using `ListItemSelect`.

**Component extensibility improvements:**

* Added a new optional `listItemProps` prop to the `ListItemSelectProps` interface, allowing consumers to pass custom props to the nested `ListItem` component.
* Updated the `ListItemSelect` component implementation to spread `listItemProps` onto the nested `ListItem` element. [[1]](diffhunk://#diff-b1ce9235b1fa82fff3758d3a8cefedb7decb33dd7445bf3411fb53925c9b06baR25) [[2]](diffhunk://#diff-b1ce9235b1fa82fff3758d3a8cefedb7decb33dd7445bf3411fb53925c9b06baL37-R38)

**Testing enhancements:**

* Added a test to verify that custom `listItemProps` are correctly passed through to the nested `ListItem`, ensuring that properties like `accessibilityHint` are set as expected.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `listItemProps` to `ListItemSelect` to forward props to its nested `ListItem`, with a test verifying passthrough (e.g., accessibility hints).
> 
> - **Component Library**
>   - **`ListItemSelect`**:
>     - Adds optional `listItemProps` to `ListItemSelectProps` and spreads onto nested `ListItem` in `ListItemSelect.tsx`.
>   - **Tests**:
>     - Adds test ensuring `listItemProps` (e.g., `accessibilityHint`, `testID`) are passed through to the nested `ListItem`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e7b8bf73dd4996df6b7ebe0512ef8493b0f6f63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->