### PR TITLE
feat: migrate rewards to new feature flag architecture

### DIFF
--- a/app/component-library/components/Navigation/TabBar/TabBar.test.tsx
+++ b/app/component-library/components/Navigation/TabBar/TabBar.test.tsx
@@ -33,6 +33,9 @@ interface TestDescriptors {
 // Force rewards feature flag to be enabled for this test file
 jest.mock('../../../../components/hooks/FeatureFlags/useFeatureFlag', () => ({
   useFeatureFlag: () => true,
+  FeatureFlagNames: {
+    rewardsEnabled: 'rewardsEnabled',
+  },
 }));
 
 // Mock trending tokens feature flag selector

--- a/app/component-library/components/Navigation/TabBar/TabBar.test.tsx
+++ b/app/component-library/components/Navigation/TabBar/TabBar.test.tsx
@@ -31,8 +31,8 @@ interface TestDescriptors {
 }
 
 // Force rewards feature flag to be enabled for this test file
-jest.mock('../../../../selectors/featureFlagController/rewards', () => ({
-  selectRewardsEnabledFlag: () => true,
+jest.mock('../../../../components/hooks/FeatureFlags/useFeatureFlag', () => ({
+  useFeatureFlag: () => true,
 }));
 
 // Mock trending tokens feature flag selector

--- a/app/component-library/components/Navigation/TabBar/TabBar.test.tsx
+++ b/app/component-library/components/Navigation/TabBar/TabBar.test.tsx
@@ -38,6 +38,15 @@ jest.mock('../../../../selectors/featureFlagController/rewards', () => ({
 // Mock trending tokens feature flag selector
 jest.mock('../../../../selectors/featureFlagController/assetsTrendingTokens');
 
+// Mock isMinimumRequiredVersionSupported to return true for feature flag validation
+jest.mock('../../../../util/feature-flags', () => {
+  const original = jest.requireActual('../../../../util/feature-flags');
+  return {
+    ...original,
+    isMinimumRequiredVersionSupported: jest.fn(() => true),
+  };
+});
+
 // Mock the navigation object with proper typing
 const navigation: NavigationHelpers<ParamListBase> = {
   navigate: jest.fn(),

--- a/app/component-library/components/Navigation/TabBar/TabBar.tsx
+++ b/app/component-library/components/Navigation/TabBar/TabBar.tsx
@@ -28,13 +28,19 @@ import {
 } from './TabBar.constants';
 import { selectChainId } from '../../../../selectors/networkController';
 import { selectAssetsTrendingTokensEnabled } from '../../../../selectors/featureFlagController/assetsTrendingTokens';
-import { useRewardsEnabled } from '../../../../components/hooks/FeatureFlags/useRewardsEnabled';
+import {
+  useFeatureFlag,
+  FeatureFlagNames,
+} from '../../../../components/hooks/FeatureFlags/useFeatureFlag';
 
 const TabBar = ({ state, descriptors, navigation }: TabBarProps) => {
   const { trackEvent, createEventBuilder } = useMetrics();
   const { bottom: bottomInset } = useSafeAreaInsets();
   const chainId = useSelector(selectChainId);
-  const isRewardsEnabled = useRewardsEnabled();
+  const isRewardsEnabled = useFeatureFlag(
+    FeatureFlagNames.rewardsEnabled,
+  ) as boolean;
+
   const isAssetsTrendingTokensEnabled = useSelector(
     selectAssetsTrendingTokensEnabled,
   );

--- a/app/component-library/components/Navigation/TabBar/TabBar.tsx
+++ b/app/component-library/components/Navigation/TabBar/TabBar.tsx
@@ -27,14 +27,14 @@ import {
   LABEL_BY_TAB_BAR_ICON_KEY,
 } from './TabBar.constants';
 import { selectChainId } from '../../../../selectors/networkController';
-import { selectRewardsEnabledFlag } from '../../../../selectors/featureFlagController/rewards';
 import { selectAssetsTrendingTokensEnabled } from '../../../../selectors/featureFlagController/assetsTrendingTokens';
+import { useRewardsEnabled } from '../../../../components/hooks/FeatureFlags/useRewardsEnabled';
 
 const TabBar = ({ state, descriptors, navigation }: TabBarProps) => {
   const { trackEvent, createEventBuilder } = useMetrics();
   const { bottom: bottomInset } = useSafeAreaInsets();
   const chainId = useSelector(selectChainId);
-  const isRewardsEnabled = useSelector(selectRewardsEnabledFlag);
+  const isRewardsEnabled = useRewardsEnabled();
   const isAssetsTrendingTokensEnabled = useSelector(
     selectAssetsTrendingTokensEnabled,
   );

--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -108,7 +108,10 @@ import {
   selectPredictEnabledFlag,
 } from '../../UI/Predict';
 import { selectAssetsTrendingTokensEnabled } from '../../../selectors/featureFlagController/assetsTrendingTokens';
-import { useRewardsEnabled } from '../../../components/hooks/FeatureFlags/useRewardsEnabled';
+import {
+  useFeatureFlag,
+  FeatureFlagNames,
+} from '../../hooks/FeatureFlags/useFeatureFlag';
 import PerpsPositionTransactionView from '../../UI/Perps/Views/PerpsTransactionsView/PerpsPositionTransactionView';
 import PerpsOrderTransactionView from '../../UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView';
 import PerpsFundingTransactionView from '../../UI/Perps/Views/PerpsTransactionsView/PerpsFundingTransactionView';
@@ -526,7 +529,7 @@ const HomeTabs = () => {
   const [isKeyboardHidden, setIsKeyboardHidden] = useState(true);
 
   const accountsLength = useSelector(selectAccountsLength);
-  const isRewardsEnabled = useRewardsEnabled();
+  const isRewardsEnabled = useFeatureFlag(FeatureFlagNames.rewardsEnabled);
   const rewardsSubscription = useSelector(selectRewardsSubscriptionId);
   const isAssetsTrendingTokensEnabled = useSelector(
     selectAssetsTrendingTokensEnabled,
@@ -951,7 +954,7 @@ const MainNavigator = () => {
   const { enabled: isSendRedesignEnabled } = useSelector(
     selectSendRedesignFlags,
   );
-  const isRewardsEnabled = useRewardsEnabled();
+  const isRewardsEnabled = useFeatureFlag(FeatureFlagNames.rewardsEnabled);
 
   return (
     <Stack.Navigator

--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -107,8 +107,8 @@ import {
   PredictModalStack,
   selectPredictEnabledFlag,
 } from '../../UI/Predict';
-import { selectRewardsEnabledFlag } from '../../../selectors/featureFlagController/rewards';
 import { selectAssetsTrendingTokensEnabled } from '../../../selectors/featureFlagController/assetsTrendingTokens';
+import { useRewardsEnabled } from '../../../components/hooks/FeatureFlags/useRewardsEnabled';
 import PerpsPositionTransactionView from '../../UI/Perps/Views/PerpsTransactionsView/PerpsPositionTransactionView';
 import PerpsOrderTransactionView from '../../UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView';
 import PerpsFundingTransactionView from '../../UI/Perps/Views/PerpsTransactionsView/PerpsFundingTransactionView';
@@ -526,7 +526,7 @@ const HomeTabs = () => {
   const [isKeyboardHidden, setIsKeyboardHidden] = useState(true);
 
   const accountsLength = useSelector(selectAccountsLength);
-  const isRewardsEnabled = useSelector(selectRewardsEnabledFlag);
+  const isRewardsEnabled = useRewardsEnabled();
   const rewardsSubscription = useSelector(selectRewardsSubscriptionId);
   const isAssetsTrendingTokensEnabled = useSelector(
     selectAssetsTrendingTokensEnabled,
@@ -951,7 +951,7 @@ const MainNavigator = () => {
   const { enabled: isSendRedesignEnabled } = useSelector(
     selectSendRedesignFlags,
   );
-  const isRewardsEnabled = useSelector(selectRewardsEnabledFlag);
+  const isRewardsEnabled = useRewardsEnabled();
 
   return (
     <Stack.Navigator

--- a/app/components/Nav/Main/MainNavigator.test.js
+++ b/app/components/Nav/Main/MainNavigator.test.js
@@ -13,6 +13,8 @@ jest.mock('../../../components/hooks/FeatureFlags/useFeatureFlag', () => ({
   },
 }));
 
+const getRewardsEnabledFlag = () => false;
+
 // Mock the MainNavigator component directly
 jest.mock('./MainNavigator', () => {
   const React = require('react');
@@ -23,16 +25,13 @@ jest.mock('./MainNavigator', () => {
   const {
     selectAssetsTrendingTokensEnabled,
   } = require('../../../selectors/featureFlagController/assetsTrendingTokens');
-  const {
-    selectRewardsEnabledFlag,
-  } = require('../../../selectors/featureFlagController/rewards');
-
   const { selectBrowserFullscreen } = require('../../../selectors/browser');
   const Routes = require('../../../constants/navigation/Routes').default;
 
   // Mock implementation that tests tab visibility based on rewards flag and browser fullscreen state
   return function MockMainNavigator({ route }) {
-    const isRewardsEnabled = selectRewardsEnabledFlag();
+    const getRewardsEnabledFlag = () => false;
+    const isRewardsEnabled = getRewardsEnabledFlag();
     const isTrendingEnabled = selectAssetsTrendingTokensEnabled();
     const isBrowserFullscreen = selectBrowserFullscreen();
 
@@ -120,7 +119,8 @@ import MainNavigator from './MainNavigator';
 describe('MainNavigator', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    selectRewardsEnabledFlag.mockReturnValue(false);
+    const getRewardsEnabledFlag = () => false;
+    getRewardsEnabledFlag.mockReturnValue(false);
     selectAssetsTrendingTokensEnabled.mockReturnValue(false);
     selectBrowserFullscreen.mockReturnValue(false);
   });

--- a/app/components/Nav/Main/MainNavigator.test.js
+++ b/app/components/Nav/Main/MainNavigator.test.js
@@ -5,6 +5,14 @@ import { render } from '@testing-library/react-native';
 import { TabBarIconKey } from '../../../component-library/components/Navigation/TabBar/TabBar.types';
 import Routes from '../../../constants/navigation/Routes';
 
+// Mock useFeatureFlag before mocking MainNavigator
+jest.mock('../../../components/hooks/FeatureFlags/useFeatureFlag', () => ({
+  useFeatureFlag: jest.fn().mockReturnValue(true),
+  FeatureFlagNames: {
+    rewardsEnabled: 'rewardsEnabled',
+  },
+}));
+
 // Mock the MainNavigator component directly
 jest.mock('./MainNavigator', () => {
   const React = require('react');
@@ -13,11 +21,12 @@ jest.mock('./MainNavigator', () => {
     TabBarIconKey,
   } = require('../../../component-library/components/Navigation/TabBar/TabBar.types');
   const {
-    selectRewardsEnabledFlag,
-  } = require('../../../selectors/featureFlagController/rewards');
-  const {
     selectAssetsTrendingTokensEnabled,
   } = require('../../../selectors/featureFlagController/assetsTrendingTokens');
+  const {
+    selectRewardsEnabledFlag,
+  } = require('../../../selectors/featureFlagController/rewards');
+
   const { selectBrowserFullscreen } = require('../../../selectors/browser');
   const Routes = require('../../../constants/navigation/Routes').default;
 

--- a/app/components/Nav/Main/MainNavigator.test.js
+++ b/app/components/Nav/Main/MainNavigator.test.js
@@ -13,8 +13,6 @@ jest.mock('../../../components/hooks/FeatureFlags/useFeatureFlag', () => ({
   },
 }));
 
-const getRewardsEnabledFlag = () => false;
-
 // Mock the MainNavigator component directly
 jest.mock('./MainNavigator', () => {
   const React = require('react');
@@ -25,13 +23,17 @@ jest.mock('./MainNavigator', () => {
   const {
     selectAssetsTrendingTokensEnabled,
   } = require('../../../selectors/featureFlagController/assetsTrendingTokens');
+  const {
+    useFeatureFlag,
+    FeatureFlagNames,
+  } = require('../../../components/hooks/FeatureFlags/useFeatureFlag');
+
   const { selectBrowserFullscreen } = require('../../../selectors/browser');
   const Routes = require('../../../constants/navigation/Routes').default;
 
   // Mock implementation that tests tab visibility based on rewards flag and browser fullscreen state
   return function MockMainNavigator({ route }) {
-    const getRewardsEnabledFlag = () => false;
-    const isRewardsEnabled = getRewardsEnabledFlag();
+    const isRewardsEnabled = useFeatureFlag(FeatureFlagNames.rewardsEnabled);
     const isTrendingEnabled = selectAssetsTrendingTokensEnabled();
     const isBrowserFullscreen = selectBrowserFullscreen();
 
@@ -92,12 +94,6 @@ jest.mock('./MainNavigator', () => {
   };
 });
 
-// Mock the rewards selector
-jest.mock('../../../selectors/featureFlagController/rewards', () => ({
-  selectRewardsEnabledFlag: jest.fn(),
-  selectRewardsSubscriptionId: jest.fn().mockReturnValue(null),
-}));
-
 // Mock the trending tokens selector
 jest.mock(
   '../../../selectors/featureFlagController/assetsTrendingTokens',
@@ -111,7 +107,10 @@ jest.mock('../../../selectors/browser', () => ({
   selectBrowserFullscreen: jest.fn(),
 }));
 
-import { selectRewardsEnabledFlag } from '../../../selectors/featureFlagController/rewards';
+import {
+  useFeatureFlag,
+  FeatureFlagNames,
+} from '../../../components/hooks/FeatureFlags/useFeatureFlag';
 import { selectAssetsTrendingTokensEnabled } from '../../../selectors/featureFlagController/assetsTrendingTokens';
 import { selectBrowserFullscreen } from '../../../selectors/browser';
 import MainNavigator from './MainNavigator';
@@ -119,14 +118,13 @@ import MainNavigator from './MainNavigator';
 describe('MainNavigator', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    const getRewardsEnabledFlag = () => false;
-    getRewardsEnabledFlag.mockReturnValue(false);
+    useFeatureFlag.mockReturnValue(false);
     selectAssetsTrendingTokensEnabled.mockReturnValue(false);
     selectBrowserFullscreen.mockReturnValue(false);
   });
 
   it('shows Browser tab when trending feature flag is off', () => {
-    selectRewardsEnabledFlag.mockReturnValue(false);
+    useFeatureFlag.mockReturnValue(false);
     selectAssetsTrendingTokensEnabled.mockReturnValue(false);
 
     const { getByTestId, queryByTestId } = render(<MainNavigator />);
@@ -139,7 +137,7 @@ describe('MainNavigator', () => {
   });
 
   it('shows Trending tab and hides Browser tab when trending feature flag is on', () => {
-    selectRewardsEnabledFlag.mockReturnValue(false);
+    useFeatureFlag.mockReturnValue(false);
     selectAssetsTrendingTokensEnabled.mockReturnValue(true);
 
     const { getByTestId, queryByTestId } = render(<MainNavigator />);
@@ -152,7 +150,7 @@ describe('MainNavigator', () => {
   });
 
   it('shows Settings tab when rewards feature flag is off', () => {
-    selectRewardsEnabledFlag.mockReturnValue(false);
+    useFeatureFlag.mockReturnValue(false);
     selectAssetsTrendingTokensEnabled.mockReturnValue(false);
 
     const { getByTestId, queryByTestId } = render(<MainNavigator />);
@@ -165,7 +163,7 @@ describe('MainNavigator', () => {
   });
 
   it('shows Rewards tab when rewards feature flag is on', () => {
-    selectRewardsEnabledFlag.mockReturnValue(true);
+    useFeatureFlag.mockReturnValue(true);
     selectAssetsTrendingTokensEnabled.mockReturnValue(false);
 
     const { getByTestId } = render(<MainNavigator />);
@@ -178,7 +176,7 @@ describe('MainNavigator', () => {
   });
 
   it('shows Trending and Rewards tabs and hides Browser tab when both feature flags are on', () => {
-    selectRewardsEnabledFlag.mockReturnValue(true);
+    useFeatureFlag.mockReturnValue(true);
     selectAssetsTrendingTokensEnabled.mockReturnValue(true);
 
     const { getByTestId, queryByTestId } = render(<MainNavigator />);

--- a/app/components/UI/BackupAlert/BackupAlert.test.tsx
+++ b/app/components/UI/BackupAlert/BackupAlert.test.tsx
@@ -5,6 +5,7 @@ import renderWithProvider from '../../../util/test/renderWithProvider';
 import { fireEvent } from '@testing-library/react-native';
 import Routes from '../../../constants/navigation/Routes';
 import { PROTECT_WALLET_BUTTON } from './BackupAlert.constants';
+import { backgroundState } from '../../../util/test/initial-root-state';
 
 const initialState = {
   user: {
@@ -12,18 +13,14 @@ const initialState = {
     passwordSet: false,
     backUpSeedphraseVisible: true,
   },
+  engine: {
+    backgroundState,
+  },
 };
 const mockNavigation = {
   navigate: jest.fn(),
   dangerouslyGetState: jest.fn(() => ({ routes: [{ name: 'WalletView' }] })),
 };
-
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: jest
-    .fn()
-    .mockImplementation((callback) => callback(initialState)),
-}));
 
 describe('BackupAlert', () => {
   beforeEach(() => {

--- a/app/components/UI/BackupAlert/BackupAlert.test.tsx
+++ b/app/components/UI/BackupAlert/BackupAlert.test.tsx
@@ -5,7 +5,6 @@ import renderWithProvider from '../../../util/test/renderWithProvider';
 import { fireEvent } from '@testing-library/react-native';
 import Routes from '../../../constants/navigation/Routes';
 import { PROTECT_WALLET_BUTTON } from './BackupAlert.constants';
-import { backgroundState } from '../../../util/test/initial-root-state';
 
 const initialState = {
   user: {
@@ -13,14 +12,18 @@ const initialState = {
     passwordSet: false,
     backUpSeedphraseVisible: true,
   },
-  engine: {
-    backgroundState,
-  },
 };
 const mockNavigation = {
   navigate: jest.fn(),
   dangerouslyGetState: jest.fn(() => ({ routes: [{ name: 'WalletView' }] })),
 };
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest
+    .fn()
+    .mockImplementation((callback) => callback(initialState)),
+}));
 
 describe('BackupAlert', () => {
   beforeEach(() => {
@@ -33,6 +36,8 @@ describe('BackupAlert', () => {
       {
         state: initialState,
       },
+      true,
+      false,
     );
     expect(toJSON()).toMatchSnapshot();
   });
@@ -43,6 +48,8 @@ describe('BackupAlert', () => {
       {
         state: initialState,
       },
+      true,
+      false,
     );
     const rightButton = getByTestId(PROTECT_WALLET_BUTTON);
     fireEvent.press(rightButton);

--- a/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.test.tsx
@@ -256,6 +256,10 @@ jest.mock('../../../../../component-library/components/Skeleton', () => {
   };
 });
 
+jest.mock('../../../../../contexts/FeatureFlagOverrideContext', () => ({
+  FeatureFlagOverrideProvider: jest.fn(({ children }) => children),
+}));
+
 jest.mock('react-native', () => {
   const RN = jest.requireActual('react-native');
   return {

--- a/app/components/UI/Perps/hooks/usePerpsNavigation.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsNavigation.test.ts
@@ -3,6 +3,14 @@ import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 import { usePerpsNavigation } from './usePerpsNavigation';
 import Routes from '../../../../constants/navigation/Routes';
+import { useFeatureFlag } from '../../../../components/hooks/FeatureFlags/useFeatureFlag';
+
+jest.mock('../../../../components/hooks/FeatureFlags/useFeatureFlag', () => ({
+  useFeatureFlag: jest.fn().mockReturnValue(true),
+  FeatureFlagNames: {
+    rewardsEnabled: 'rewardsEnabled',
+  },
+}));
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(),
@@ -22,6 +30,9 @@ describe('usePerpsNavigation', () => {
   const mockUseSelector = useSelector as jest.MockedFunction<
     typeof useSelector
   >;
+  const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<
+    typeof useFeatureFlag
+  >;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -34,6 +45,7 @@ describe('usePerpsNavigation', () => {
       typeof useNavigation
     >);
     mockUseSelector.mockReturnValue(false); // isRewardsEnabled = false
+    mockUseFeatureFlag.mockReturnValue(true); // Reset to default true
   });
 
   describe('Main App Navigation', () => {
@@ -82,7 +94,7 @@ describe('usePerpsNavigation', () => {
     });
 
     it('navigates to settings when rewards disabled', () => {
-      mockUseSelector.mockReturnValue(false);
+      mockUseFeatureFlag.mockReturnValue(false);
       const { result } = renderHook(() => usePerpsNavigation());
 
       result.current.navigateToRewardsOrSettings();

--- a/app/components/UI/Perps/hooks/usePerpsNavigation.ts
+++ b/app/components/UI/Perps/hooks/usePerpsNavigation.ts
@@ -1,8 +1,7 @@
 import { useCallback } from 'react';
 import { useNavigation, NavigationProp } from '@react-navigation/native';
-import { useSelector } from 'react-redux';
 import Routes from '../../../../constants/navigation/Routes';
-import { selectRewardsEnabledFlag } from '../../../../selectors/featureFlagController/rewards';
+import { useRewardsEnabled } from '../../../../components/hooks/FeatureFlags/useRewardsEnabled';
 import type { PerpsNavigationParamList } from '../types/navigation';
 import type { PerpsMarketData } from '../controllers/types';
 
@@ -62,7 +61,7 @@ export interface PerpsNavigationHandlers {
  */
 export const usePerpsNavigation = (): PerpsNavigationHandlers => {
   const navigation = useNavigation<NavigationProp<PerpsNavigationParamList>>();
-  const isRewardsEnabled = useSelector(selectRewardsEnabledFlag);
+  const isRewardsEnabled = useRewardsEnabled();
 
   // Main app navigation handlers
   const navigateToWallet = useCallback(() => {

--- a/app/components/UI/Perps/hooks/usePerpsNavigation.ts
+++ b/app/components/UI/Perps/hooks/usePerpsNavigation.ts
@@ -1,7 +1,10 @@
 import { useCallback } from 'react';
 import { useNavigation, NavigationProp } from '@react-navigation/native';
 import Routes from '../../../../constants/navigation/Routes';
-import { useRewardsEnabled } from '../../../../components/hooks/FeatureFlags/useRewardsEnabled';
+import {
+  useFeatureFlag,
+  FeatureFlagNames,
+} from '../../../hooks/FeatureFlags/useFeatureFlag';
 import type { PerpsNavigationParamList } from '../types/navigation';
 import type { PerpsMarketData } from '../controllers/types';
 
@@ -61,7 +64,9 @@ export interface PerpsNavigationHandlers {
  */
 export const usePerpsNavigation = (): PerpsNavigationHandlers => {
   const navigation = useNavigation<NavigationProp<PerpsNavigationParamList>>();
-  const isRewardsEnabled = useRewardsEnabled();
+  const isRewardsEnabled = useFeatureFlag(
+    FeatureFlagNames.rewardsEnabled,
+  ) as boolean;
 
   // Main app navigation handlers
   const navigateToWallet = useCallback(() => {

--- a/app/components/UI/Perps/hooks/usePerpsOrderFees.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderFees.test.ts
@@ -11,6 +11,13 @@ import {
 } from './usePerpsOrderFees';
 import type { FeeCalculationResult } from '../controllers/types';
 
+import { useFeatureFlag } from '../../../hooks/FeatureFlags/useFeatureFlag';
+
+const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<
+  typeof useFeatureFlag
+>;
+mockUseFeatureFlag.mockReturnValue(true);
+
 jest.mock('./usePerpsTrading');
 
 // Import existing mocks
@@ -28,9 +35,11 @@ jest.mock('../../../../core/Engine', () => ({
   context: mockEngineContext,
 }));
 
-// Mock specific selectors directly
-jest.mock('../../../../selectors/featureFlagController/rewards', () => ({
-  selectRewardsEnabledFlag: jest.fn().mockReturnValue(true),
+jest.mock('../../../../components/hooks/FeatureFlags/useFeatureFlag', () => ({
+  useFeatureFlag: jest.fn().mockReturnValue(true),
+  FeatureFlagNames: {
+    rewardsEnabled: 'rewardsEnabled',
+  },
 }));
 
 jest.mock('../../../../selectors/accountsController', () => ({
@@ -425,10 +434,7 @@ describe('usePerpsOrderFees', () => {
     });
 
     it('should handle rewards disabled', async () => {
-      const { selectRewardsEnabledFlag } = jest.requireMock(
-        '../../../../selectors/featureFlagController/rewards',
-      );
-      selectRewardsEnabledFlag.mockReturnValue(false);
+      mockUseFeatureFlag.mockReturnValue(false);
 
       const mockFeeResult: FeeCalculationResult = {
         feeRate: 0.00045,

--- a/app/components/UI/Perps/hooks/usePerpsOrderFees.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderFees.ts
@@ -3,7 +3,10 @@ import { useSelector } from 'react-redux';
 import Engine from '../../../../core/Engine';
 import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../../selectors/accountsController';
-import { useRewardsEnabled } from '../../../../components/hooks/FeatureFlags/useRewardsEnabled';
+import {
+  useFeatureFlag,
+  FeatureFlagNames,
+} from '../../../hooks/FeatureFlags/useFeatureFlag';
 import { selectChainId } from '../../../../selectors/networkController';
 
 import { setMeasurement } from '@sentry/react-native';
@@ -113,7 +116,9 @@ export function usePerpsOrderFees({
   currentBidPrice,
 }: UsePerpsOrderFeesParams): OrderFeesResult {
   const { calculateFees } = usePerpsTrading();
-  const rewardsEnabled = useRewardsEnabled();
+  const rewardsEnabled = useFeatureFlag(
+    FeatureFlagNames.rewardsEnabled,
+  ) as boolean;
   const selectedAddress = useSelector(
     selectSelectedInternalAccountFormattedAddress,
   );

--- a/app/components/UI/Perps/hooks/usePerpsOrderFees.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderFees.ts
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import Engine from '../../../../core/Engine';
 import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../../selectors/accountsController';
-import { selectRewardsEnabledFlag } from '../../../../selectors/featureFlagController/rewards';
+import { useRewardsEnabled } from '../../../../components/hooks/FeatureFlags/useRewardsEnabled';
 import { selectChainId } from '../../../../selectors/networkController';
 
 import { setMeasurement } from '@sentry/react-native';
@@ -113,7 +113,7 @@ export function usePerpsOrderFees({
   currentBidPrice,
 }: UsePerpsOrderFeesParams): OrderFeesResult {
   const { calculateFees } = usePerpsTrading();
-  const rewardsEnabled = useSelector(selectRewardsEnabledFlag);
+  const rewardsEnabled = useRewardsEnabled();
   const selectedAddress = useSelector(
     selectSelectedInternalAccountFormattedAddress,
   );

--- a/app/components/UI/Perps/hooks/usePerpsRewards.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsRewards.test.ts
@@ -15,8 +15,18 @@ jest.mock('../constants/perpsConfig', () => ({
   },
 }));
 
-import { useSelector } from 'react-redux';
-const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+import { useFeatureFlag } from '../../../hooks/FeatureFlags/useFeatureFlag';
+jest.mock('../../../../components/hooks/FeatureFlags/useFeatureFlag', () => ({
+  useFeatureFlag: jest.fn().mockReturnValue(true),
+  FeatureFlagNames: {
+    rewardsEnabled: 'rewardsEnabled',
+  },
+}));
+
+const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<
+  typeof useFeatureFlag
+>;
+mockUseFeatureFlag.mockReturnValue(true);
 
 describe('usePerpsRewards', () => {
   // Mock fee results for testing
@@ -40,13 +50,13 @@ describe('usePerpsRewards', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     // Default: rewards enabled
-    mockUseSelector.mockReturnValue(true);
+    mockUseFeatureFlag.mockReturnValue(true);
   });
 
   describe('Feature flag scenarios', () => {
     it('should not show rewards row when feature flag is disabled', () => {
       // Arrange
-      mockUseSelector.mockReturnValue(false);
+      mockUseFeatureFlag.mockReturnValue(false);
       const feeResults = createMockFeeResults({ estimatedPoints: 100 });
 
       // Act
@@ -67,7 +77,7 @@ describe('usePerpsRewards', () => {
 
     it('should show rewards row when feature flag is enabled and has valid amount', () => {
       // Arrange
-      mockUseSelector.mockReturnValue(true);
+      mockUseFeatureFlag.mockReturnValue(true);
       const feeResults = createMockFeeResults({ estimatedPoints: 100 });
 
       // Act
@@ -87,7 +97,7 @@ describe('usePerpsRewards', () => {
 
     it('should not show rewards row when hasValidAmount is false', () => {
       // Arrange
-      mockUseSelector.mockReturnValue(true);
+      mockUseFeatureFlag.mockReturnValue(true);
       const feeResults = createMockFeeResults({ estimatedPoints: 100 });
 
       // Act

--- a/app/components/UI/Perps/hooks/usePerpsRewards.ts
+++ b/app/components/UI/Perps/hooks/usePerpsRewards.ts
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useSelector } from 'react-redux';
-import { selectRewardsEnabledFlag } from '../../../../selectors/featureFlagController/rewards';
+import { useRewardsEnabled } from '../../../../components/hooks/FeatureFlags/useRewardsEnabled';
 import { DEVELOPMENT_CONFIG } from '../constants/perpsConfig';
 import { OrderFeesResult } from './usePerpsOrderFees';
 
@@ -43,7 +42,7 @@ export const usePerpsRewards = ({
   orderAmount = '',
 }: UsePerpsRewardsParams): UsePerpsRewardsResult => {
   // Get rewards feature flag
-  const rewardsEnabled = useSelector(selectRewardsEnabledFlag);
+  const rewardsEnabled = useRewardsEnabled();
 
   // Track previous points to detect refresh state
   const [previousPoints, setPreviousPoints] = useState<number | undefined>();

--- a/app/components/UI/Perps/hooks/usePerpsRewards.ts
+++ b/app/components/UI/Perps/hooks/usePerpsRewards.ts
@@ -1,5 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useRewardsEnabled } from '../../../../components/hooks/FeatureFlags/useRewardsEnabled';
+import {
+  useFeatureFlag,
+  FeatureFlagNames,
+} from '../../../hooks/FeatureFlags/useFeatureFlag';
 import { DEVELOPMENT_CONFIG } from '../constants/perpsConfig';
 import { OrderFeesResult } from './usePerpsOrderFees';
 
@@ -42,7 +45,9 @@ export const usePerpsRewards = ({
   orderAmount = '',
 }: UsePerpsRewardsParams): UsePerpsRewardsResult => {
   // Get rewards feature flag
-  const rewardsEnabled = useRewardsEnabled();
+  const rewardsEnabled = useFeatureFlag(
+    FeatureFlagNames.rewardsEnabled,
+  ) as boolean;
 
   // Track previous points to detect refresh state
   const [previousPoints, setPreviousPoints] = useState<number | undefined>();

--- a/app/components/UI/Rewards/hooks/useRewardsIntroModal.test.ts
+++ b/app/components/UI/Rewards/hooks/useRewardsIntroModal.test.ts
@@ -34,6 +34,17 @@ jest.mock('../../../../store/storage-wrapper', () => ({
 }));
 
 import StorageWrapper from '../../../../store/storage-wrapper';
+import { useFeatureFlag } from '../../../hooks/FeatureFlags/useFeatureFlag';
+jest.mock('../../../../components/hooks/FeatureFlags/useFeatureFlag', () => ({
+  useFeatureFlag: jest.fn().mockReturnValue(true),
+  FeatureFlagNames: {
+    rewardsEnabled: 'rewardsEnabled',
+  },
+}));
+const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<
+  typeof useFeatureFlag
+>;
+mockUseFeatureFlag.mockReturnValue(true);
 
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 const mockUseDispatch = useDispatch as jest.MockedFunction<typeof useDispatch>;

--- a/app/components/UI/Rewards/hooks/useRewardsIntroModal.ts
+++ b/app/components/UI/Rewards/hooks/useRewardsIntroModal.ts
@@ -2,7 +2,10 @@ import { useNavigation } from '@react-navigation/native';
 import { useCallback, useEffect, useState, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { selectRewardsAnnouncementModalEnabledFlag } from '../../../../selectors/featureFlagController/rewards';
-import { useRewardsEnabled } from '../../../../components/hooks/FeatureFlags/useRewardsEnabled';
+import {
+  useFeatureFlag,
+  FeatureFlagNames,
+} from '../../../hooks/FeatureFlags/useFeatureFlag';
 import { selectMultichainAccountsIntroModalSeen } from '../../../../reducers/user';
 import StorageWrapper from '../../../../store/storage-wrapper';
 import {
@@ -32,7 +35,9 @@ export const useRewardsIntroModal = () => {
   const navigation = useNavigation();
   const dispatch = useDispatch();
 
-  const isRewardsFeatureEnabled = useRewardsEnabled();
+  const isRewardsFeatureEnabled = useFeatureFlag(
+    FeatureFlagNames.rewardsEnabled,
+  ) as boolean;
   const isRewardsAnnouncementEnabled = useSelector(
     selectRewardsAnnouncementModalEnabledFlag,
   );

--- a/app/components/UI/Rewards/hooks/useRewardsIntroModal.ts
+++ b/app/components/UI/Rewards/hooks/useRewardsIntroModal.ts
@@ -1,10 +1,8 @@
 import { useNavigation } from '@react-navigation/native';
 import { useCallback, useEffect, useState, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import {
-  selectRewardsAnnouncementModalEnabledFlag,
-  selectRewardsEnabledFlag,
-} from '../../../../selectors/featureFlagController/rewards';
+import { selectRewardsAnnouncementModalEnabledFlag } from '../../../../selectors/featureFlagController/rewards';
+import { useRewardsEnabled } from '../../../../components/hooks/FeatureFlags/useRewardsEnabled';
 import { selectMultichainAccountsIntroModalSeen } from '../../../../reducers/user';
 import StorageWrapper from '../../../../store/storage-wrapper';
 import {
@@ -34,7 +32,7 @@ export const useRewardsIntroModal = () => {
   const navigation = useNavigation();
   const dispatch = useDispatch();
 
-  const isRewardsFeatureEnabled = useSelector(selectRewardsEnabledFlag);
+  const isRewardsFeatureEnabled = useRewardsEnabled();
   const isRewardsAnnouncementEnabled = useSelector(
     selectRewardsAnnouncementModalEnabledFlag,
   );

--- a/app/components/UI/Stake/components/GasImpactModal/GasImpactModal.test.tsx
+++ b/app/components/UI/Stake/components/GasImpactModal/GasImpactModal.test.tsx
@@ -94,6 +94,9 @@ const renderGasImpactModal = () =>
     <SafeAreaProvider initialMetrics={initialMetrics}>
       <GasImpactModal {...props} />,
     </SafeAreaProvider>,
+    undefined,
+    true,
+    false,
   );
 
 describe('GasImpactModal', () => {

--- a/app/components/UI/TransactionHeader/index.test.tsx
+++ b/app/components/UI/TransactionHeader/index.test.tsx
@@ -66,6 +66,8 @@ describe('TransactionHeader', () => {
     const wrapper = renderWithProvider(
       <TransactionHeader {...defaultProps} />,
       { state: mockInitialState },
+      true,
+      false,
     );
     expect(wrapper).toMatchSnapshot();
   });
@@ -84,6 +86,8 @@ describe('TransactionHeader', () => {
         }}
       />,
       { state: mockInitialState },
+      true,
+      false,
     );
 
     expect(

--- a/app/components/Views/FeatureFlagOverride/FeatureFlagOverride.tsx
+++ b/app/components/Views/FeatureFlagOverride/FeatureFlagOverride.tsx
@@ -56,13 +56,14 @@ const FeatureFlagRow: React.FC<FeatureFlagRowProps> = ({ flag, onToggle }) => {
           <Box twClassName="items-end">
             <Switch
               value={(localValue as MinimumVersionFlagValue).enabled}
-              disabled //={!isVersionSupported} TODO: Uncomment this when we support overrides for minimum version
+              disabled={!isVersionSupported}
               onValueChange={(newValue: boolean) => {
-                setLocalValue({
+                const updatedValue = {
                   ...(localValue as MinimumVersionFlagValue),
                   enabled: newValue,
-                });
-                onToggle(flag.key, newValue);
+                };
+                setLocalValue(updatedValue);
+                onToggle(flag.key, updatedValue);
               }}
               trackColor={{
                 true: theme.colors.primary.default,

--- a/app/components/Views/MultichainAccounts/IntroModal/LearnMoreBottomSheet.test.tsx
+++ b/app/components/Views/MultichainAccounts/IntroModal/LearnMoreBottomSheet.test.tsx
@@ -77,6 +77,9 @@ describe('LearnMoreBottomSheet', () => {
   it('renders correctly with all elements', () => {
     const { getByTestId } = renderWithProvider(
       <LearnMoreBottomSheet onClose={mockOnClose} />,
+      undefined,
+      true,
+      false,
     );
 
     expect(
@@ -105,6 +108,9 @@ describe('LearnMoreBottomSheet', () => {
   it('displays correct title', () => {
     const { getByTestId } = renderWithProvider(
       <LearnMoreBottomSheet onClose={mockOnClose} />,
+      undefined,
+      true,
+      false,
     );
 
     expect(
@@ -115,6 +121,9 @@ describe('LearnMoreBottomSheet', () => {
   it('displays correct description', () => {
     const { getByTestId } = renderWithProvider(
       <LearnMoreBottomSheet onClose={mockOnClose} />,
+      undefined,
+      true,
+      false,
     );
 
     expect(
@@ -125,6 +134,9 @@ describe('LearnMoreBottomSheet', () => {
   it('displays correct checkbox label', () => {
     const { getByTestId } = renderWithProvider(
       <LearnMoreBottomSheet onClose={mockOnClose} />,
+      undefined,
+      true,
+      false,
     );
 
     expect(
@@ -137,6 +149,9 @@ describe('LearnMoreBottomSheet', () => {
   it('displays correct confirm button label', () => {
     const { getByTestId } = renderWithProvider(
       <LearnMoreBottomSheet onClose={mockOnClose} />,
+      undefined,
+      true,
+      false,
     );
 
     expect(
@@ -149,6 +164,9 @@ describe('LearnMoreBottomSheet', () => {
   it('renders confirm button', () => {
     const { getByTestId } = renderWithProvider(
       <LearnMoreBottomSheet onClose={mockOnClose} />,
+      undefined,
+      true,
+      false,
     );
 
     const confirmButton = getByTestId(
@@ -160,6 +178,9 @@ describe('LearnMoreBottomSheet', () => {
   it('handles back button press', () => {
     const { getByTestId } = renderWithProvider(
       <LearnMoreBottomSheet onClose={mockOnClose} />,
+      undefined,
+      true,
+      false,
     );
 
     const backButton = getByTestId(
@@ -173,6 +194,9 @@ describe('LearnMoreBottomSheet', () => {
   it('handles close button press', () => {
     const { getByTestId } = renderWithProvider(
       <LearnMoreBottomSheet onClose={mockOnClose} />,
+      undefined,
+      true,
+      false,
     );
 
     const closeButton = getByTestId(
@@ -186,6 +210,9 @@ describe('LearnMoreBottomSheet', () => {
   it('handles checkbox press and toggles state', () => {
     const { getByTestId } = renderWithProvider(
       <LearnMoreBottomSheet onClose={mockOnClose} />,
+      undefined,
+      true,
+      false,
     );
 
     const checkbox = getByTestId(LEARN_MORE_BOTTOM_SHEET_TEST_IDS.CHECKBOX);
@@ -206,6 +233,9 @@ describe('LearnMoreBottomSheet', () => {
   it('handles confirm button press when checkbox is checked', () => {
     const { getByTestId } = renderWithProvider(
       <LearnMoreBottomSheet onClose={mockOnClose} />,
+      undefined,
+      true,
+      false,
     );
 
     const checkbox = getByTestId(LEARN_MORE_BOTTOM_SHEET_TEST_IDS.CHECKBOX);
@@ -226,6 +256,9 @@ describe('LearnMoreBottomSheet', () => {
   it('does not navigate when confirm button pressed without checkbox checked', () => {
     const { getByTestId } = renderWithProvider(
       <LearnMoreBottomSheet onClose={mockOnClose} />,
+      undefined,
+      true,
+      false,
     );
 
     const confirmButton = getByTestId(
@@ -253,6 +286,9 @@ describe('LearnMoreBottomSheet', () => {
 
     const { getByTestId } = renderWithProvider(
       <LearnMoreBottomSheet onClose={mockOnClose} />,
+      undefined,
+      true,
+      false,
     );
 
     const checkbox = getByTestId(LEARN_MORE_BOTTOM_SHEET_TEST_IDS.CHECKBOX);

--- a/app/components/Views/Settings/index.tsx
+++ b/app/components/Views/Settings/index.tsx
@@ -22,7 +22,7 @@ import { isTest } from '../../../util/test/utils';
 import { isPermissionsSettingsV1Enabled } from '../../../util/networks';
 import { selectIsEvmNetworkSelected } from '../../../selectors/multichainNetworkController';
 import { selectSeedlessOnboardingLoginFlow } from '../../../selectors/seedlessOnboardingController';
-import { selectRewardsEnabledFlag } from '../../../selectors/featureFlagController/rewards';
+import { useRewardsEnabled } from '../../../components/hooks/FeatureFlags/useRewardsEnabled';
 
 const createStyles = (colors: Colors) =>
   StyleSheet.create({
@@ -37,7 +37,7 @@ const Settings = () => {
   const { colors } = useTheme();
   const { trackEvent, createEventBuilder } = useMetrics();
   const styles = createStyles(colors);
-  const isRewardsEnabled = useSelector(selectRewardsEnabledFlag);
+  const isRewardsEnabled = useRewardsEnabled();
   // TODO: Replace "any" with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const navigation = useNavigation<any>();

--- a/app/components/Views/Settings/index.tsx
+++ b/app/components/Views/Settings/index.tsx
@@ -22,7 +22,10 @@ import { isTest } from '../../../util/test/utils';
 import { isPermissionsSettingsV1Enabled } from '../../../util/networks';
 import { selectIsEvmNetworkSelected } from '../../../selectors/multichainNetworkController';
 import { selectSeedlessOnboardingLoginFlow } from '../../../selectors/seedlessOnboardingController';
-import { useRewardsEnabled } from '../../../components/hooks/FeatureFlags/useRewardsEnabled';
+import {
+  useFeatureFlag,
+  FeatureFlagNames,
+} from '../../hooks/FeatureFlags/useFeatureFlag';
 
 const createStyles = (colors: Colors) =>
   StyleSheet.create({
@@ -37,7 +40,9 @@ const Settings = () => {
   const { colors } = useTheme();
   const { trackEvent, createEventBuilder } = useMetrics();
   const styles = createStyles(colors);
-  const isRewardsEnabled = useRewardsEnabled();
+  const isRewardsEnabled = useFeatureFlag(
+    FeatureFlagNames.rewardsEnabled,
+  ) as boolean;
   // TODO: Replace "any" with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const navigation = useNavigation<any>();

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -177,7 +177,10 @@ import PredictTabView from '../../UI/Predict/views/PredictTabView';
 import { InitSendLocation } from '../confirmations/constants/send';
 import { useSendNavigation } from '../confirmations/hooks/useSendNavigation';
 import { selectCarouselBannersFlag } from '../../UI/Carousel/selectors/featureFlags';
-import { useRewardsEnabled } from '../../../components/hooks/FeatureFlags/useRewardsEnabled';
+import {
+  useFeatureFlag,
+  FeatureFlagNames,
+} from '../../hooks/FeatureFlags/useFeatureFlag';
 import { SolScope } from '@metamask/keyring-api';
 import { selectSelectedInternalAccountByScope } from '../../../selectors/multichainAccounts/accounts';
 import { EVM_SCOPE } from '../../UI/Earn/constants/networks';
@@ -1060,7 +1063,9 @@ const Wallet = ({
   );
 
   const shouldDisplayCardButton = useSelector(selectDisplayCardButton);
-  const isRewardsEnabled = useRewardsEnabled();
+  const isRewardsEnabled = useFeatureFlag(
+    FeatureFlagNames.rewardsEnabled,
+  ) as boolean;
   const isHomepageRedesignV1Enabled = useSelector(
     selectHomepageRedesignV1Enabled,
   );

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -177,7 +177,7 @@ import PredictTabView from '../../UI/Predict/views/PredictTabView';
 import { InitSendLocation } from '../confirmations/constants/send';
 import { useSendNavigation } from '../confirmations/hooks/useSendNavigation';
 import { selectCarouselBannersFlag } from '../../UI/Carousel/selectors/featureFlags';
-import { selectRewardsEnabledFlag } from '../../../selectors/featureFlagController/rewards';
+import { useRewardsEnabled } from '../../../components/hooks/FeatureFlags/useRewardsEnabled';
 import { SolScope } from '@metamask/keyring-api';
 import { selectSelectedInternalAccountByScope } from '../../../selectors/multichainAccounts/accounts';
 import { EVM_SCOPE } from '../../UI/Earn/constants/networks';
@@ -1060,7 +1060,7 @@ const Wallet = ({
   );
 
   const shouldDisplayCardButton = useSelector(selectDisplayCardButton);
-  const isRewardsEnabled = useSelector(selectRewardsEnabledFlag);
+  const isRewardsEnabled = useRewardsEnabled();
   const isHomepageRedesignV1Enabled = useSelector(
     selectHomepageRedesignV1Enabled,
   );

--- a/app/components/hooks/FeatureFlags/useFeatureFlag.ts
+++ b/app/components/hooks/FeatureFlags/useFeatureFlag.ts
@@ -1,0 +1,12 @@
+import { useFeatureFlagOverride } from '../../../contexts/FeatureFlagOverrideContext';
+
+export enum FeatureFlagNames {
+  rewardsEnabled = 'rewardsEnabled',
+  rewardsEnableCardSpend = 'rewardsEnableCardSpend',
+  rewardsAnnouncementModalEnabled = 'rewardsAnnouncementModalEnabled',
+}
+
+export const useFeatureFlag = (key: FeatureFlagNames) => {
+  const { getFeatureFlag } = useFeatureFlagOverride();
+  return getFeatureFlag(key);
+};

--- a/app/components/hooks/FeatureFlags/useFeatureFlag.ts
+++ b/app/components/hooks/FeatureFlags/useFeatureFlag.ts
@@ -1,4 +1,6 @@
+import { useSelector } from 'react-redux';
 import { useFeatureFlagOverride } from '../../../contexts/FeatureFlagOverrideContext';
+import { selectBasicFunctionalityEnabled } from '../../../selectors/settings';
 
 export enum FeatureFlagNames {
   rewardsEnabled = 'rewardsEnabled',
@@ -8,5 +10,11 @@ export enum FeatureFlagNames {
 
 export const useFeatureFlag = (key: FeatureFlagNames) => {
   const { getFeatureFlag } = useFeatureFlagOverride();
+  const isBasicFunctionalityEnabled = useSelector(
+    selectBasicFunctionalityEnabled,
+  );
+  if (!isBasicFunctionalityEnabled) {
+    return false;
+  }
   return getFeatureFlag(key);
 };

--- a/app/components/hooks/FeatureFlags/useRewardsEnabled.ts
+++ b/app/components/hooks/FeatureFlags/useRewardsEnabled.ts
@@ -1,7 +1,0 @@
-import { FeatureFlagNames } from '../../../selectors/featureFlagController';
-import { useFeatureFlagOverride } from '../../../contexts/FeatureFlagOverrideContext';
-
-export const useRewardsEnabled = () => {
-  const { getFeatureFlag } = useFeatureFlagOverride();
-  return getFeatureFlag(FeatureFlagNames.rewardsEnabled);
-};

--- a/app/components/hooks/FeatureFlags/useRewardsEnabled.ts
+++ b/app/components/hooks/FeatureFlags/useRewardsEnabled.ts
@@ -1,0 +1,7 @@
+import { FeatureFlagNames } from '../../../selectors/featureFlagController';
+import { useFeatureFlagOverride } from '../../../contexts/FeatureFlagOverrideContext';
+
+export const useRewardsEnabled = () => {
+  const { getFeatureFlag } = useFeatureFlagOverride();
+  return getFeatureFlag(FeatureFlagNames.rewardsEnabled);
+};

--- a/app/contexts/FeatureFlagOverrideContext.test.tsx
+++ b/app/contexts/FeatureFlagOverrideContext.test.tsx
@@ -145,16 +145,6 @@ describe('FeatureFlagOverrideContext', () => {
       expect(result.current.featureFlags).toEqual({});
       expect(result.current.featureFlagsList).toEqual([]);
     });
-
-    it('throws error when Redux selector returns null due to implementation bug', () => {
-      mockUseSelector.mockReturnValue(null);
-
-      expect(() => {
-        renderHook(() => useFeatureFlagOverride(), {
-          wrapper: createWrapper,
-        });
-      }).toThrow('Cannot convert undefined or null to object');
-    });
   });
 
   describe('Override Management', () => {

--- a/app/contexts/FeatureFlagOverrideContext.tsx
+++ b/app/contexts/FeatureFlagOverrideContext.tsx
@@ -19,6 +19,7 @@ import {
   ToastVariants,
 } from '../component-library/components/Toast';
 import { MinimumVersionFlagValue } from '../components/Views/FeatureFlagOverride/FeatureFlagOverride';
+import { selectBasicFunctionalityEnabled } from '../selectors/settings';
 
 interface FeatureFlagOverrides {
   [key: string]: unknown;
@@ -174,12 +175,14 @@ export const FeatureFlagOverrideProvider: React.FC<
   /**
    * get a specific feature flag value with overrides applied
    */
-  const getFeatureFlag = useCallback(
-    (key: string) => {
-      const flag = featureFlags[key];
-      if (!flag) {
-        return undefined;
-      }
+  const getFeatureFlag = useCallback((key: string) => {
+    if (!selectBasicFunctionalityEnabled) {
+      return false;
+    }
+    const flag = featureFlags[key];
+    if (!flag) {
+      return undefined;
+    }
 
       if (flag.type === 'boolean with minimumVersion') {
         return validateMinimumVersion(

--- a/app/contexts/FeatureFlagOverrideContext.tsx
+++ b/app/contexts/FeatureFlagOverrideContext.tsx
@@ -179,14 +179,15 @@ export const FeatureFlagOverrideProvider: React.FC<
   /**
    * get a specific feature flag value with overrides applied
    */
-  const getFeatureFlag = useCallback((key: string) => {
-    if (!selectBasicFunctionalityEnabled) {
-      return false;
-    }
-    const flag = featureFlags[key];
-    if (!flag) {
-      return undefined;
-    }
+  const getFeatureFlag = useCallback(
+    (key: string) => {
+      if (!selectBasicFunctionalityEnabled) {
+        return false;
+      }
+      const flag = featureFlags[key];
+      if (!flag) {
+        return undefined;
+      }
 
       if (flag.type === 'boolean with minimumVersion') {
         return validateMinimumVersion(

--- a/app/contexts/FeatureFlagOverrideContext.tsx
+++ b/app/contexts/FeatureFlagOverrideContext.tsx
@@ -19,7 +19,6 @@ import {
   ToastVariants,
 } from '../component-library/components/Toast';
 import { MinimumVersionFlagValue } from '../components/Views/FeatureFlagOverride/FeatureFlagOverride';
-import { selectBasicFunctionalityEnabled } from '../selectors/settings';
 
 interface FeatureFlagOverrides {
   [key: string]: unknown;
@@ -54,9 +53,6 @@ export const FeatureFlagOverrideProvider: React.FC<
 > = ({ children }) => {
   // Get the initial feature flags from Redux
   const rawFeatureFlagsSelected = useSelector(selectRemoteFeatureFlags);
-  const isBasicFunctionalityEnabled = useSelector(
-    selectBasicFunctionalityEnabled,
-  );
   const rawFeatureFlags = useMemo(
     () => rawFeatureFlagsSelected || {},
     [rawFeatureFlagsSelected],
@@ -184,9 +180,6 @@ export const FeatureFlagOverrideProvider: React.FC<
    */
   const getFeatureFlag = useCallback(
     (key: string) => {
-      if (!isBasicFunctionalityEnabled) {
-        return false;
-      }
       const flag = featureFlags[key];
       if (!flag) {
         return undefined;
@@ -201,7 +194,7 @@ export const FeatureFlagOverrideProvider: React.FC<
 
       return flag.value;
     },
-    [featureFlags, validateMinimumVersion, isBasicFunctionalityEnabled],
+    [featureFlags, validateMinimumVersion],
   );
 
   const getOverrideCount = useCallback(

--- a/app/contexts/FeatureFlagOverrideContext.tsx
+++ b/app/contexts/FeatureFlagOverrideContext.tsx
@@ -53,7 +53,11 @@ export const FeatureFlagOverrideProvider: React.FC<
   FeatureFlagOverrideProviderProps
 > = ({ children }) => {
   // Get the initial feature flags from Redux
-  const rawFeatureFlags = useSelector(selectRemoteFeatureFlags);
+  const rawFeatureFlagsSelected = useSelector(selectRemoteFeatureFlags);
+  const rawFeatureFlags = useMemo(
+    () => rawFeatureFlagsSelected || {},
+    [rawFeatureFlagsSelected],
+  );
   const toastContext = useContext(ToastContext);
   const toastRef = toastContext?.toastRef;
 

--- a/app/contexts/FeatureFlagOverrideContext.tsx
+++ b/app/contexts/FeatureFlagOverrideContext.tsx
@@ -54,6 +54,9 @@ export const FeatureFlagOverrideProvider: React.FC<
 > = ({ children }) => {
   // Get the initial feature flags from Redux
   const rawFeatureFlagsSelected = useSelector(selectRemoteFeatureFlags);
+  const isBasicFunctionalityEnabled = useSelector(
+    selectBasicFunctionalityEnabled,
+  );
   const rawFeatureFlags = useMemo(
     () => rawFeatureFlagsSelected || {},
     [rawFeatureFlagsSelected],
@@ -181,7 +184,7 @@ export const FeatureFlagOverrideProvider: React.FC<
    */
   const getFeatureFlag = useCallback(
     (key: string) => {
-      if (!selectBasicFunctionalityEnabled) {
+      if (!isBasicFunctionalityEnabled) {
         return false;
       }
       const flag = featureFlags[key];
@@ -198,7 +201,7 @@ export const FeatureFlagOverrideProvider: React.FC<
 
       return flag.value;
     },
-    [featureFlags, validateMinimumVersion],
+    [featureFlags, validateMinimumVersion, isBasicFunctionalityEnabled],
   );
 
   const getOverrideCount = useCallback(

--- a/app/selectors/featureFlagController/index.ts
+++ b/app/selectors/featureFlagController/index.ts
@@ -15,9 +15,3 @@ export const selectRemoteFeatureFlags = createSelector(
     return remoteFeatureFlagControllerState?.remoteFeatureFlags ?? {};
   },
 );
-
-export enum FeatureFlagNames {
-  rewardsEnabled = 'rewardsEnabled',
-  rewardsEnableCardSpend = 'rewardsEnableCardSpend',
-  rewardsAnnouncementModalEnabled = 'rewardsAnnouncementModalEnabled',
-}

--- a/app/selectors/featureFlagController/index.ts
+++ b/app/selectors/featureFlagController/index.ts
@@ -15,3 +15,9 @@ export const selectRemoteFeatureFlags = createSelector(
     return remoteFeatureFlagControllerState?.remoteFeatureFlags ?? {};
   },
 );
+
+export enum FeatureFlagNames {
+  rewardsEnabled = 'rewardsEnabled',
+  rewardsEnableCardSpend = 'rewardsEnableCardSpend',
+  rewardsAnnouncementModalEnabled = 'rewardsAnnouncementModalEnabled',
+}

--- a/app/util/test/renderWithProvider.tsx
+++ b/app/util/test/renderWithProvider.tsx
@@ -16,7 +16,6 @@ import { mockTheme, ThemeContext } from '../theme';
 import { Theme } from '../theme/models';
 import configureStore from './configureStore';
 import { RootState } from '../../reducers';
-import { FeatureFlagOverrideProvider } from '../../contexts/FeatureFlagOverrideContext';
 
 // DeepPartial is a generic type that recursively makes all properties of a given type T optional
 export type DeepPartial<T> = T extends (...args: unknown[]) => unknown
@@ -47,9 +46,7 @@ export default function renderWithProvider(
 
   const InnerProvider = ({ children }: { children: React.ReactElement }) => (
     <Provider store={store}>
-      <ThemeContext.Provider value={theme}>
-        <FeatureFlagOverrideProvider>{children}</FeatureFlagOverrideProvider>
-      </ThemeContext.Provider>
+      <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>
     </Provider>
   );
 

--- a/app/util/test/renderWithProvider.tsx
+++ b/app/util/test/renderWithProvider.tsx
@@ -46,14 +46,8 @@ export default function renderWithProvider(
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
   require('../../store')._updateMockState(state);
 
-  const InnerProvider = ({ children }: { children: React.ReactElement }) => (
-    <Provider store={store}>
-      <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>
-    </Provider>
-  );
-
-  const AllProviders = ({ children }: { children: React.ReactElement }) => {
-    let wrappedChildren = <InnerProvider>{children}</InnerProvider>;
+  const InnerProvider = ({ children }: { children: React.ReactElement }) => {
+    let wrappedChildren = children;
     if (includeFeatureFlagOverrideProvider) {
       wrappedChildren = (
         <FeatureFlagOverrideProvider>
@@ -61,6 +55,17 @@ export default function renderWithProvider(
         </FeatureFlagOverrideProvider>
       );
     }
+    return (
+      <Provider store={store}>
+        <ThemeContext.Provider value={theme}>
+          {wrappedChildren}
+        </ThemeContext.Provider>
+      </Provider>
+    );
+  };
+
+  const AllProviders = ({ children }: { children: React.ReactElement }) => {
+    let wrappedChildren = <InnerProvider>{children}</InnerProvider>;
     if (includeNavigationContainer) {
       wrappedChildren = (
         <NavigationContainer>{wrappedChildren}</NavigationContainer>

--- a/app/util/test/renderWithProvider.tsx
+++ b/app/util/test/renderWithProvider.tsx
@@ -16,6 +16,7 @@ import { mockTheme, ThemeContext } from '../theme';
 import { Theme } from '../theme/models';
 import configureStore from './configureStore';
 import { RootState } from '../../reducers';
+import { FeatureFlagOverrideProvider } from '../../contexts/FeatureFlagOverrideContext';
 
 // DeepPartial is a generic type that recursively makes all properties of a given type T optional
 export type DeepPartial<T> = T extends (...args: unknown[]) => unknown
@@ -38,6 +39,7 @@ export default function renderWithProvider(
   component: React.ReactElement,
   providerValues?: ProviderValues,
   includeNavigationContainer = true,
+  includeFeatureFlagOverrideProvider = true,
 ) {
   const { state = {}, theme = mockTheme } = providerValues ?? {};
   const store = configureStore(state);
@@ -51,14 +53,20 @@ export default function renderWithProvider(
   );
 
   const AllProviders = ({ children }: { children: React.ReactElement }) => {
-    if (includeNavigationContainer) {
-      return (
-        <NavigationContainer>
-          <InnerProvider>{children}</InnerProvider>
-        </NavigationContainer>
+    let wrappedChildren = <InnerProvider>{children}</InnerProvider>;
+    if (includeFeatureFlagOverrideProvider) {
+      wrappedChildren = (
+        <FeatureFlagOverrideProvider>
+          {wrappedChildren}
+        </FeatureFlagOverrideProvider>
       );
     }
-    return <InnerProvider>{children}</InnerProvider>;
+    if (includeNavigationContainer) {
+      wrappedChildren = (
+        <NavigationContainer>{wrappedChildren}</NavigationContainer>
+      );
+    }
+    return wrappedChildren;
   };
 
   return { ...render(component, { wrapper: AllProviders }), store };

--- a/app/util/test/renderWithProvider.tsx
+++ b/app/util/test/renderWithProvider.tsx
@@ -16,6 +16,7 @@ import { mockTheme, ThemeContext } from '../theme';
 import { Theme } from '../theme/models';
 import configureStore from './configureStore';
 import { RootState } from '../../reducers';
+import { FeatureFlagOverrideProvider } from '../../contexts/FeatureFlagOverrideContext';
 
 // DeepPartial is a generic type that recursively makes all properties of a given type T optional
 export type DeepPartial<T> = T extends (...args: unknown[]) => unknown
@@ -46,7 +47,9 @@ export default function renderWithProvider(
 
   const InnerProvider = ({ children }: { children: React.ReactElement }) => (
     <Provider store={store}>
-      <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>
+      <ThemeContext.Provider value={theme}>
+        <FeatureFlagOverrideProvider>{children}</FeatureFlagOverrideProvider>
+      </ThemeContext.Provider>
     </Provider>
   );
 


### PR DESCRIPTION
<!--

Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.

-->



## **Description**



<!--

Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:

1. What is the reason for the change?

2. What is the improvement/solution?

-->

This PR migrates the rewards feature flag from the Redux selector-based approach (`selectRewardsEnabledFlag`) to the new feature flag architecture using the `useFeatureFlag` hook. This migration provides better consistency with the feature flag system and enables feature flag override capabilities for testing and development.

**Reason for change:**
- Standardize feature flag access across the codebase using a unified hook-based approach
- Enable feature flag override functionality through `FeatureFlagOverrideContext` for improved testing and development workflows
- Reduce direct dependency on Redux selectors for feature flags in favor of a more flexible abstraction layer

**Improvement/Solution:**
- Created a new `useFeatureFlag` hook that integrates with `FeatureFlagOverrideContext` to provide feature flag values with override support
- Migrated all rewards feature flag usages from `useSelector(selectRewardsEnabledFlag)` to `useFeatureFlag(FeatureFlagNames.rewardsEnabled)` across multiple components:
  - `TabBar`, `MainNavigator`, `Settings`, `Wallet` views
  - `useRewardsIntroModal`, `usePerpsRewards`, `usePerpsNavigation`, `usePerpsOrderFees` hooks
- Added `FeatureFlagOverrideProvider` to the test render helper (`renderWithProvider`) to ensure feature flag context is available in tests
- Added safeguards for `rawFeatureFlags` in `FeatureFlagOverrideContext` to handle edge cases



## **Changelog**



<!--

If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:

1. Write `CHANGELOG entry: null`

2. Label with `no-changelog`



If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:

`CHANGELOG entry: Added a new tab for users to see their NFTs`

`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`



(This helps the Release Engineer do their job more quickly and accurately)

-->



CHANGELOG entry: null



## **Related issues**



Fixes:



## **Manual testing steps**



```gherkin

Feature: Rewards feature flag migration



  Scenario: user sees rewards features when flag is enabled

    Given the app is running with rewards feature flag enabled

    When user navigates to the Wallet or Settings screen

    Then rewards-related UI elements (tabs, buttons, navigation items) should be visible and functional



  Scenario: user does not see rewards features when flag is disabled

    Given the app is running with rewards feature flag disabled

    When user navigates to the Wallet or Settings screen

    Then rewards-related UI elements should not be visible



  Scenario: developer can override rewards feature flag for testing

    Given the app is running in development mode

    When developer navigates to Settings > Feature Flag Override

    Then developer can toggle the rewards feature flag override

    And the rewards feature visibility should reflect the override value immediately

```



## **Screenshots/Recordings**



<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->



### **Before**

disabled switch for feature flag override

<!-- [screenshots/recordings] -->



### **After**


https://github.com/user-attachments/assets/12b4bdc6-d602-47dc-a951-fbf7a8caf211



<!-- [screenshots/recordings] -->



## **Pre-merge author checklist**



- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).

- [X] I've completed the PR template to the best of my ability

- [X] I've included tests if applicable

- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable

- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.



## **Pre-merge reviewer checklist**



- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).

- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces rewards Redux selector usage with a new useFeatureFlag hook across UI and hooks, and enhances the feature flag override system and tests.
> 
> - **Feature flags**:
>   - Add `useFeatureFlag` hook and `FeatureFlagNames`; gates flags by basic functionality and override context.
>   - Improve `FeatureFlagOverrideProvider` (null-safe Redux state, version validation) and enable version-gated toggle behavior in `FeatureFlagOverride` UI.
> - **UI/Navigation**:
>   - Replace `selectRewardsEnabledFlag` with `useFeatureFlag(FeatureFlagNames.rewardsEnabled)` in `component-library/TabBar`, `MainNavigator` (tabs and stack), `Settings`, `Wallet`.
>   - Update Perps/Rewards logic: `usePerpsNavigation`, `usePerpsOrderFees`, `usePerpsRewards`, `useRewardsIntroModal` now use the new hook.
> - **Tests/Utilities**:
>   - Update tests to mock `useFeatureFlag`; add `FeatureFlagOverrideProvider` to `renderWithProvider` (configurable); adjust snapshots and mocks (e.g., `isMinimumRequiredVersionSupported`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f35098c712209c6a48fe7e1474ecf5f0a3d6365e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->