### PR TITLE
fix: cp-7.59.0 ensure that txs show on asset details page

### DIFF
--- a/app/components/Views/Asset/index.js
+++ b/app/components/Views/Asset/index.js
@@ -76,7 +76,7 @@ import { selectSupportedSwapTokenAddressesForChainId } from '../../../selectors/
 import { isNonEvmChainId } from '../../../core/Multichain/utils';
 import { isBridgeAllowed } from '../../UI/Bridge/utils';
 ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-import { selectNonEvmTransactions } from '../../../selectors/multichain';
+import { selectNonEvmTransactionsForSelectedAccountGroup } from '../../../selectors/multichain';
 ///: END:ONLY_INCLUDE_IF
 import { getIsSwapsAssetAllowed } from './utils';
 import MultichainTransactionsView from '../MultichainTransactionsView/MultichainTransactionsView';
@@ -668,8 +668,12 @@ const mapStateToProps = (state, { route }) => {
 
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   if (asset?.chainId && isNonEvmChainId(asset.chainId)) {
-    const nonEvmTransactions = selectNonEvmTransactions(state);
-    const txs = nonEvmTransactions?.transactions || [];
+    const nonEvmTransactions =
+      selectNonEvmTransactionsForSelectedAccountGroup(state);
+    const txs =
+      nonEvmTransactions?.transactions?.filter(
+        (tx) => tx.chain === asset.chainId,
+      ) || [];
 
     const assetAddress = route.params?.address?.toLowerCase();
     const assetSymbol = route.params?.symbol?.toLowerCase();

--- a/app/selectors/multichain/multichain.ts
+++ b/app/selectors/multichain/multichain.ts
@@ -467,6 +467,10 @@ interface NonEvmTransactionStateEntry {
   lastUpdated: number | undefined;
 }
 
+/**
+ * @deprecated
+ * This selector is deprecated and broken. It should not be used in new code.
+ */
 export const selectNonEvmTransactions = createDeepEqualSelector(
   selectMultichainTransactions,
   selectSelectedInternalAccount,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Fixes an issue in which txs sometimes do not show on the details page for non-evm assets.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an issue in which txs sometimes do not show on the details page for non-evm assets.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/22251

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/d9a517d4-130b-42bc-9d5a-d216dff1d491


### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/d726164c-f231-402f-af58-f7ad67e810f6


## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use a new selector to aggregate/filter non-EVM transactions by chain and asset so the Asset details page shows the correct txs.
> 
> - **Asset view (`app/components/Views/Asset/index.js`)**:
>   - Replace `selectNonEvmTransactions` with `selectNonEvmTransactionsForSelectedAccountGroup`.
>   - For non-EVM assets, filter txs by `chainId` and asset (native vs token via `address`/`symbol`), add lightweight caching, and sort by time.
> - **Selectors (`app/selectors/multichain/multichain.ts`)**:
>   - Mark `selectNonEvmTransactions` as deprecated.
>   - Add `selectNonEvmTransactionsForSelectedAccountGroup` to aggregate and flatten non-EVM txs across the selected account group, sorting by timestamp.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 037033ae8e7d883e58751fb5e37a750791ff3569. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->