### PR TITLE
feat(predict): relay sell orders

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -823,6 +823,7 @@ describe('PolymarketProvider', () => {
     mockSubmitClobOrder.mockResolvedValue({
       success: true,
       response: {
+        success: true,
         makingAmount: '1000000',
         orderID: 'order-123',
         status: 'success',
@@ -1131,7 +1132,7 @@ describe('PolymarketProvider', () => {
       });
       mockSubmitClobOrder.mockResolvedValue({
         success: true,
-        response: { orderId: 'test-order' },
+        response: { success: true, orderId: 'test-order' },
         error: undefined,
       });
       mockCreateApiKey.mockResolvedValue({
@@ -2599,7 +2600,7 @@ describe('PolymarketProvider', () => {
         });
       };
 
-      it('does not set rateLimited for SELL orders', async () => {
+      it('sets rateLimited for SELL orders after BUY order', async () => {
         setupPreviewOrderMock();
         const { provider, mockSigner } = setupPlaceOrderTest();
 
@@ -2610,7 +2611,7 @@ describe('PolymarketProvider', () => {
           preview,
         });
 
-        // Now try to preview a SELL order - should NOT be rate limited
+        // Now try to preview a SELL order - should also be rate limited
         const sellPreview = await provider.previewOrder({
           marketId: 'market-1',
           outcomeId: 'outcome-1',
@@ -2620,7 +2621,7 @@ describe('PolymarketProvider', () => {
           signer: mockSigner,
         });
 
-        expect(sellPreview.rateLimited).toBeUndefined();
+        expect(sellPreview.rateLimited).toBe(true);
       });
 
       it('does not set rateLimited when signer is not provided', async () => {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -44,7 +44,7 @@ import {
 } from '../types';
 import { PREDICT_CONSTANTS } from '../../constants/errors';
 import {
-  BUY_ORDER_RATE_LIMIT_MS,
+  ORDER_RATE_LIMIT_MS,
   FEE_COLLECTOR_ADDRESS,
   MATIC_CONTRACTS,
   POLYGON_MAINNET_CHAIN_ID,
@@ -203,7 +203,7 @@ export class PolymarketProvider implements PredictProvider {
       return false;
     }
     const elapsed = Date.now() - lastTimestamp;
-    return elapsed < BUY_ORDER_RATE_LIMIT_MS;
+    return elapsed < ORDER_RATE_LIMIT_MS;
   }
 
   public async getMarkets(params?: GetMarketsParams): Promise<PredictMarket[]> {
@@ -463,7 +463,7 @@ export class PolymarketProvider implements PredictProvider {
   ): Promise<OrderPreview> {
     const basePreview = await previewOrder(params);
 
-    if (params.side === Side.BUY && params.signer) {
+    if (params.signer) {
       if (this.isRateLimited(params.signer.address)) {
         return {
           ...basePreview,
@@ -603,10 +603,17 @@ export class PolymarketProvider implements PredictProvider {
         feeAuthorization,
       });
 
-      if (!response) {
+      if (!success) {
         return {
           success,
           error,
+        } as OrderResult;
+      }
+
+      if (!response.success) {
+        return {
+          success: false,
+          error: response.errorMsg,
         } as OrderResult;
       }
 

--- a/app/components/UI/Predict/providers/polymarket/constants.ts
+++ b/app/components/UI/Predict/providers/polymarket/constants.ts
@@ -13,7 +13,7 @@ export const FEE_COLLECTOR_ADDRESS =
  */
 export const SLIPPAGE = 0.015; // 1.5%
 
-export const BUY_ORDER_RATE_LIMIT_MS = 5000;
+export const ORDER_RATE_LIMIT_MS = 5000;
 
 export const POLYGON_MAINNET_CHAIN_ID = 137;
 export const POLYGON_MAINNET_CAIP_CHAIN_ID =

--- a/app/components/UI/Predict/providers/polymarket/types.ts
+++ b/app/components/UI/Predict/providers/polymarket/types.ts
@@ -302,13 +302,13 @@ export interface L2HeaderArgs {
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type OrderResponse = {
-  errorMsg: string;
-  makingAmount: string;
-  orderID: string;
-  status: string;
+  errorMsg?: string;
+  makingAmount?: string;
+  orderID?: string;
+  status?: string;
   success: boolean;
-  takingAmount: string;
-  transactionsHashes: string[];
+  takingAmount?: string;
+  transactionsHashes?: string[];
 };
 
 export interface TickSizeResponse {

--- a/app/components/UI/Predict/providers/polymarket/utils.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.test.ts
@@ -712,11 +712,25 @@ describe('polymarket utils', () => {
         response: mockOrderResponse,
       });
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://clob.polymarket.com/order',
+        'https://predict.api.cx.metamask.io/order',
         {
           method: 'POST',
-          headers: mockHeaders,
-          body: JSON.stringify(mockClobOrder),
+          headers: {
+            POLY_ADDRESS: mockAddress,
+            POLY_SIGNATURE: 'test-signature_',
+            POLY_TIMESTAMP: '1704067200',
+            POLY_API_KEY: 'test-api-key',
+            POLY_PASSPHRASE: 'test-passphrase',
+            'POLY-ADDRESS': mockAddress,
+            'POLY-SIGNATURE': 'test-signature_',
+            'POLY-TIMESTAMP': '1704067200',
+            'POLY-API-KEY': 'test-api-key',
+            'POLY-PASSPHRASE': 'test-passphrase',
+          },
+          body: JSON.stringify({
+            ...mockClobOrder,
+            feeAuthorization: undefined,
+          }),
         },
       );
     });
@@ -781,12 +795,24 @@ describe('polymarket utils', () => {
       });
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://clob.polymarket.com/order',
+        'https://predict.api.cx.metamask.io/order',
         {
           method: 'POST',
-          headers: mockHeaders,
+          headers: {
+            POLY_ADDRESS: mockAddress,
+            POLY_SIGNATURE: 'test-signature_',
+            POLY_TIMESTAMP: '1704067200',
+            POLY_API_KEY: 'test-api-key',
+            POLY_PASSPHRASE: 'test-passphrase',
+            'POLY-ADDRESS': mockAddress,
+            'POLY-SIGNATURE': 'test-signature_',
+            'POLY-TIMESTAMP': '1704067200',
+            'POLY-API-KEY': 'test-api-key',
+            'POLY-PASSPHRASE': 'test-passphrase',
+          },
           body: JSON.stringify({
             ...mockClobOrder,
+            feeAuthorization: undefined,
           }),
         },
       );
@@ -820,25 +846,37 @@ describe('polymarket utils', () => {
       expect(parsedBody.feeAuthorization).toEqual(feeAuthorization);
     });
 
-    it('uses CLOB endpoint when feeAuthorization is not provided for BUY orders', async () => {
+    it('uses CLOB_RELAYER endpoint when feeAuthorization is not provided for BUY orders', async () => {
       await submitClobOrder({
         headers: mockHeaders,
         clobOrder: mockClobOrder,
       });
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://clob.polymarket.com/order',
+        'https://predict.api.cx.metamask.io/order',
         {
           method: 'POST',
-          headers: mockHeaders,
+          headers: {
+            POLY_ADDRESS: mockAddress,
+            POLY_SIGNATURE: 'test-signature_',
+            POLY_TIMESTAMP: '1704067200',
+            POLY_API_KEY: 'test-api-key',
+            POLY_PASSPHRASE: 'test-passphrase',
+            'POLY-ADDRESS': mockAddress,
+            'POLY-SIGNATURE': 'test-signature_',
+            'POLY-TIMESTAMP': '1704067200',
+            'POLY-API-KEY': 'test-api-key',
+            'POLY-PASSPHRASE': 'test-passphrase',
+          },
           body: JSON.stringify({
             ...mockClobOrder,
+            feeAuthorization: undefined,
           }),
         },
       );
     });
 
-    it('uses CLOB endpoint for SELL orders even with feeAuthorization', async () => {
+    it('uses CLOB_RELAYER endpoint for SELL orders with feeAuthorization', async () => {
       const sellClobOrder: ClobOrderObject = {
         ...mockClobOrder,
         order: {
@@ -867,12 +905,24 @@ describe('polymarket utils', () => {
       });
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://clob.polymarket.com/order',
+        'https://predict.api.cx.metamask.io/order',
         {
           method: 'POST',
-          headers: mockHeaders,
+          headers: {
+            POLY_ADDRESS: mockAddress,
+            POLY_SIGNATURE: 'test-signature_',
+            POLY_TIMESTAMP: '1704067200',
+            POLY_API_KEY: 'test-api-key',
+            POLY_PASSPHRASE: 'test-passphrase',
+            'POLY-ADDRESS': mockAddress,
+            'POLY-SIGNATURE': 'test-signature_',
+            'POLY-TIMESTAMP': '1704067200',
+            'POLY-API-KEY': 'test-api-key',
+            'POLY-PASSPHRASE': 'test-passphrase',
+          },
           body: JSON.stringify({
             ...sellClobOrder,
+            feeAuthorization,
           }),
         },
       );
@@ -1894,7 +1944,6 @@ describe('polymarket utils', () => {
       expect(result).toEqual({
         success: false,
         error: 'You are unable to access this provider.',
-        errorCode: 403,
       });
     });
 

--- a/app/components/UI/Predict/providers/polymarket/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/utils.ts
@@ -15,6 +15,7 @@ import {
   type PredictMarket,
   type PredictPosition,
   PredictActivity,
+  Result,
 } from '../../types';
 import { getRecurrence } from '../../utils/format';
 import type {
@@ -324,29 +325,24 @@ export const submitClobOrder = async ({
   headers: ClobHeaders;
   clobOrder: ClobOrderObject;
   feeAuthorization?: SafeFeeAuthorization;
-}) => {
-  const { CLOB_ENDPOINT, CLOB_RELAYER } = getPolymarketEndpoints();
-  let url = `${CLOB_ENDPOINT}/order`;
-  let body: ClobOrderObject & { feeAuthorization?: SafeFeeAuthorization } = {
+}): Promise<Result<OrderResponse>> => {
+  const { CLOB_RELAYER } = getPolymarketEndpoints();
+  const url = `${CLOB_RELAYER}/order`;
+  const body: ClobOrderObject & { feeAuthorization?: SafeFeeAuthorization } = {
     ...clobOrder,
+    feeAuthorization,
   };
 
-  // If a feeAuthorization is provided, we need to use our clob
-  // relayer to submit the order and collect the fee.
-  if (clobOrder.order.side === Side.BUY && feeAuthorization) {
-    url = `${CLOB_RELAYER}/order`;
-    body = { ...body, feeAuthorization };
-    // For our relayer, we need to replace the underscores with dashes
-    // since underscores are not standardly allowed in headers
-    headers = {
-      ...headers,
-      ...Object.entries(headers)
-        .map(([key, value]) => ({
-          [key.replace(/_/g, '-')]: value,
-        }))
-        .reduce((acc, curr) => ({ ...acc, ...curr }), {}),
-    };
-  }
+  // For our relayer, we need to replace the underscores with dashes
+  // since underscores are not standardly allowed in headers
+  headers = {
+    ...headers,
+    ...Object.entries(headers)
+      .map(([key, value]) => ({
+        [key.replace(/_/g, '-')]: value,
+      }))
+      .reduce((acc, curr) => ({ ...acc, ...curr }), {}),
+  };
 
   const response = await fetch(url, {
     method: 'POST',
@@ -359,7 +355,6 @@ export const submitClobOrder = async ({
       return {
         success: false,
         error: 'You are unable to access this provider.',
-        errorCode: response.status,
       };
     }
     const responseData = await response.json();


### PR DESCRIPTION
## **Description**

This PR enables relaying of SELL orders through the MetaMask Predict API relay, similar to how BUY orders are already relayed. Previously, only BUY orders were sent through the relay to collect fees, while SELL orders went directly to the Polymarket CLOB endpoint. 

**Reason for change:**
- SELL orders should also be relayed to enable consistent fee collection and monitoring across all order types
- Provides better control and observability for all trading activity

**Improvements:**
- All orders (BUY and SELL) now route through the `CLOB_RELAYER` endpoint
- Rate limiting now applies to both BUY and SELL orders based on the last BUY order timestamp
- Simplified order submission logic by removing conditional endpoint selection
- Updated `OrderResponse` type fields to be optional for better error handling
- Renamed `BUY_ORDER_RATE_LIMIT_MS` to `ORDER_RATE_LIMIT_MS` to reflect that rate limiting applies to all orders

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Polymarket SELL order relaying

  Scenario: user places a SELL order
    Given user has an open position in a Polymarket market
    And user is connected to Polygon mainnet
    And the Predict feature is enabled

    When user navigates to the position details
    And user initiates a SELL order
    And user confirms the transaction
    Then the order should be relayed through the MetaMask API endpoint
    And the order should be successfully submitted to Polymarket
    And fees should be collected appropriately

  Scenario: user is rate limited after placing orders
    Given user has placed a BUY order within the last 5 seconds

    When user attempts to preview a new order (BUY or SELL)
    Then the preview should show rateLimited: true
    And user should be prevented from placing another order too quickly
```

## **Screenshots/Recordings**

N/A - Backend/API changes only, no UI changes

### **Before**

- BUY orders → CLOB_RELAYER endpoint (with fees)
- SELL orders → Direct to Polymarket CLOB endpoint (no fees)
- Rate limiting only applied to BUY order previews

### **After**

- BUY orders → CLOB_RELAYER endpoint (with fees)
- SELL orders → CLOB_RELAYER endpoint (no fees)
- Rate limiting applies to all order previews after a BUY order

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Routes both BUY and SELL orders through the MetaMask Predict relayer, applies unified rate limiting, and updates response handling/types with corresponding tests.
> 
> - **Order routing (utils/submitClobOrder)**:
>   - Always post to `CLOB_RELAYER` (`/order`), removing conditional CLOB endpoint usage.
>   - Send both underscore and dash variants of `POLY_*` headers; include `feeAuthorization` when provided.
> - **Rate limiting**:
>   - Rename `BUY_ORDER_RATE_LIMIT_MS` to `ORDER_RATE_LIMIT_MS` and apply in `PolymarketProvider.isRateLimited`.
>   - `previewOrder` now rate-limits when a `signer` is present (affects SELL after a recent BUY).
> - **Order handling**:
>   - `OrderResponse` fields (`errorMsg`, `makingAmount`, `orderID`, `status`, `takingAmount`, `transactionsHashes`) made optional.
>   - `placeOrder` checks top-level `success` and nested `response.success`; returns `errorMsg` when present.
> - **Tests**:
>   - Update submit order tests to expect relayer URL, dual-format headers, and serialized `feeAuthorization`.
>   - Adjust expectations for `response` shape (includes `success: true`).
>   - Update rate limit test to expect SELL previews to be rate-limited after a BUY.
>   - Remove unused `errorCode` from 403 path expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33a2d3e3937563d55a98293e137570b8f1852f87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->