### PR TITLE
fix: cp-7.59.0 market list open interest sort

### DIFF
--- a/app/components/UI/Perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/components/UI/Perps/services/HyperLiquidSubscriptionService.ts
@@ -37,6 +37,7 @@ import type { CaipAccountId } from '@metamask/utils';
 import { TP_SL_CONFIG, PERPS_CONSTANTS } from '../constants/perpsConfig';
 import { ensureError } from '../utils/perpsErrorHandler';
 import { processL2BookData } from '../utils/hyperLiquidOrderBookProcessor';
+import { calculateOpenInterestUSD } from '../utils/marketDataTransform';
 
 /**
  * Service for managing HyperLiquid WebSocket subscriptions
@@ -1511,6 +1512,10 @@ export class HyperLiquidSubscriptionService {
 
             // Cache market data for consolidation with price updates
             const ctxPrice = ctx.midPx || ctx.markPx;
+            const openInterestUSD =
+              isPerpsContext(data) && ctxPrice
+                ? calculateOpenInterestUSD(data.ctx.openInterest, ctxPrice)
+                : NaN;
             const marketData = {
               prevDayPx: ctx.prevDayPx
                 ? parseFloat(ctx.prevDayPx.toString())
@@ -1520,13 +1525,9 @@ export class HyperLiquidSubscriptionService {
               funding: isPerpsContext(data)
                 ? parseFloat(data.ctx.funding.toString())
                 : undefined,
-              // Convert openInterest from token units to USD by multiplying by current price
-              // Note: openInterest from API is in token units (e.g., BTC), while volume is already in USD
-              openInterest:
-                isPerpsContext(data) && ctxPrice
-                  ? parseFloat(data.ctx.openInterest.toString()) *
-                    parseFloat(ctxPrice.toString())
-                  : undefined,
+              openInterest: !isNaN(openInterestUSD)
+                ? openInterestUSD
+                : undefined,
               volume24h: ctx.dayNtlVlm
                 ? parseFloat(ctx.dayNtlVlm.toString())
                 : undefined,
@@ -1675,14 +1676,17 @@ export class HyperLiquidSubscriptionService {
             if (ctx && 'funding' in ctx) {
               // This is a perps context
               const ctxPrice = ctx.midPx || ctx.markPx;
+              const openInterestUSD = calculateOpenInterestUSD(
+                ctx.openInterest,
+                ctxPrice,
+              );
               const marketData = {
                 prevDayPx: ctx.prevDayPx
                   ? parseFloat(ctx.prevDayPx.toString())
                   : undefined,
                 funding: parseFloat(ctx.funding.toString()),
-                openInterest: ctxPrice
-                  ? parseFloat(ctx.openInterest.toString()) *
-                    parseFloat(ctxPrice.toString())
+                openInterest: !isNaN(openInterestUSD)
+                  ? openInterestUSD
                   : undefined,
                 volume24h: ctx.dayNtlVlm
                   ? parseFloat(ctx.dayNtlVlm.toString())

--- a/app/components/UI/Perps/utils/marketDataTransform.test.ts
+++ b/app/components/UI/Perps/utils/marketDataTransform.test.ts
@@ -479,7 +479,7 @@ describe('marketDataTransform', () => {
       expect(result).toBeNaN();
     });
 
-    it('returns NaN when price is zero', () => {
+    it('returns 0 when price is zero', () => {
       // Arrange
       const openInterest = '1000000';
       const price = '0';
@@ -489,6 +489,18 @@ describe('marketDataTransform', () => {
 
       // Assert
       expect(result).toBe(0); // 1M * 0 = 0
+    });
+
+    it('returns 0 when open interest is zero', () => {
+      // Arrange
+      const openInterest = '0';
+      const price = '50000';
+
+      // Act
+      const result = calculateOpenInterestUSD(openInterest, price);
+
+      // Assert
+      expect(result).toBe(0); // 0 * $50K = 0
     });
 
     it('returns NaN when open interest contains invalid characters', () => {

--- a/app/components/UI/Perps/utils/marketDataTransform.test.ts
+++ b/app/components/UI/Perps/utils/marketDataTransform.test.ts
@@ -4,6 +4,7 @@
 
 import {
   transformMarketData,
+  calculateOpenInterestUSD,
   formatChange,
   formatPercentage,
   HyperLiquidMarketData,
@@ -78,7 +79,7 @@ describe('marketDataTransform', () => {
         fundingRate: 0.01,
         marketSource: undefined, // Main DEX has no source
         marketType: undefined, // Main DEX has no type
-        openInterest: '$1.00M',
+        openInterest: '$52.00B', // 1M contracts * $52K price
       });
     });
 
@@ -390,6 +391,164 @@ describe('marketDataTransform', () => {
       expect(result[0].symbol).toBe('BTC');
       expect(result[0].marketSource).toBeUndefined();
       expect(result[0].marketType).toBeUndefined();
+    });
+  });
+
+  describe('calculateOpenInterestUSD', () => {
+    it('calculates open interest correctly with string inputs', () => {
+      // Arrange
+      const openInterest = '1000000'; // 1M contracts
+      const price = '50000'; // $50K per contract
+
+      // Act
+      const result = calculateOpenInterestUSD(openInterest, price);
+
+      // Assert
+      expect(result).toBe(50000000000); // $50B
+    });
+
+    it('calculates open interest correctly with number inputs', () => {
+      // Arrange
+      const openInterest = 1000000;
+      const price = 50000;
+
+      // Act
+      const result = calculateOpenInterestUSD(openInterest, price);
+
+      // Assert
+      expect(result).toBe(50000000000);
+    });
+
+    it('calculates open interest correctly with mixed inputs', () => {
+      // Arrange
+      const openInterest = '500000'; // string
+      const price = 100000; // number
+
+      // Act
+      const result = calculateOpenInterestUSD(openInterest, price);
+
+      // Assert
+      expect(result).toBe(50000000000);
+    });
+
+    it('returns NaN when open interest is undefined', () => {
+      // Arrange
+      const openInterest = undefined;
+      const price = '50000';
+
+      // Act
+      const result = calculateOpenInterestUSD(openInterest, price);
+
+      // Assert
+      expect(result).toBeNaN();
+    });
+
+    it('returns NaN when price is undefined', () => {
+      // Arrange
+      const openInterest = '1000000';
+      const price = undefined;
+
+      // Act
+      const result = calculateOpenInterestUSD(openInterest, price);
+
+      // Assert
+      expect(result).toBeNaN();
+    });
+
+    it('returns NaN when both inputs are undefined', () => {
+      // Arrange
+      const openInterest = undefined;
+      const price = undefined;
+
+      // Act
+      const result = calculateOpenInterestUSD(openInterest, price);
+
+      // Assert
+      expect(result).toBeNaN();
+    });
+
+    it('returns NaN when open interest is empty string', () => {
+      // Arrange
+      const openInterest = '';
+      const price = '50000';
+
+      // Act
+      const result = calculateOpenInterestUSD(openInterest, price);
+
+      // Assert
+      expect(result).toBeNaN();
+    });
+
+    it('returns NaN when price is zero', () => {
+      // Arrange
+      const openInterest = '1000000';
+      const price = '0';
+
+      // Act
+      const result = calculateOpenInterestUSD(openInterest, price);
+
+      // Assert
+      expect(result).toBe(0); // 1M * 0 = 0
+    });
+
+    it('returns NaN when open interest contains invalid characters', () => {
+      // Arrange
+      const openInterest = 'invalid';
+      const price = '50000';
+
+      // Act
+      const result = calculateOpenInterestUSD(openInterest, price);
+
+      // Assert
+      expect(result).toBeNaN();
+    });
+
+    it('returns NaN when price contains invalid characters', () => {
+      // Arrange
+      const openInterest = '1000000';
+      const price = 'invalid';
+
+      // Act
+      const result = calculateOpenInterestUSD(openInterest, price);
+
+      // Assert
+      expect(result).toBeNaN();
+    });
+
+    it('handles decimal values correctly', () => {
+      // Arrange
+      const openInterest = '1234.5678';
+      const price = '98765.4321';
+
+      // Act
+      const result = calculateOpenInterestUSD(openInterest, price);
+
+      // Assert
+      expect(result).toBeCloseTo(121932622.22, 2);
+    });
+
+    it('handles very large numbers without precision loss', () => {
+      // Arrange
+      const openInterest = '10000000'; // 10M contracts
+      const price = '100000'; // $100K per contract
+
+      // Act
+      const result = calculateOpenInterestUSD(openInterest, price);
+
+      // Assert
+      expect(result).toBe(1000000000000); // $1T
+    });
+
+    it('handles very small decimal numbers', () => {
+      // Arrange
+      const openInterest = '0.001';
+      const price = '50000';
+
+      // Act
+      const result = calculateOpenInterestUSD(openInterest, price);
+
+      // Assert
+      expect(result).toBe(50);
     });
   });
 

--- a/app/components/UI/Perps/utils/marketDataTransform.ts
+++ b/app/components/UI/Perps/utils/marketDataTransform.ts
@@ -28,7 +28,7 @@ export function calculateOpenInterestUSD(
   openInterest: string | number | undefined,
   currentPrice: string | number | undefined,
 ): number {
-  if (!openInterest || !currentPrice) {
+  if (openInterest == null || currentPrice == null) {
     return NaN;
   }
 

--- a/app/components/UI/Perps/utils/marketDataTransform.ts
+++ b/app/components/UI/Perps/utils/marketDataTransform.ts
@@ -16,6 +16,35 @@ import { getIntlNumberFormatter } from '../../../../util/intl';
 import { parseAssetName } from './hyperLiquidAdapter';
 
 /**
+ * Calculate open interest in USD
+ * Open interest from HyperLiquid is in contracts/units, not USD
+ * To get USD value, multiply by current price
+ *
+ * @param openInterest - Raw open interest value in contracts/units
+ * @param currentPrice - Current price of the asset
+ * @returns Open interest in USD, or NaN if invalid
+ */
+export function calculateOpenInterestUSD(
+  openInterest: string | number | undefined,
+  currentPrice: string | number | undefined,
+): number {
+  if (!openInterest || !currentPrice) {
+    return NaN;
+  }
+
+  const openInterestNum =
+    typeof openInterest === 'string' ? parseFloat(openInterest) : openInterest;
+  const priceNum =
+    typeof currentPrice === 'string' ? parseFloat(currentPrice) : currentPrice;
+
+  if (isNaN(openInterestNum) || isNaN(priceNum)) {
+    return NaN;
+  }
+
+  return openInterestNum * priceNum;
+}
+
+/**
  * HyperLiquid-specific market data structure
  */
 export interface HyperLiquidMarketData {
@@ -170,11 +199,11 @@ export function transformMarketData(
     // If assetCtx is missing or dayNtlVlm is not available, use NaN to indicate missing data
     const volume = assetCtx?.dayNtlVlm ? parseFloat(assetCtx.dayNtlVlm) : NaN;
 
-    // Format open interest
-    // If assetCtx is missing or openInterest is not available, use NaN to indicate missing data
-    const openInterest = assetCtx?.openInterest
-      ? parseFloat(assetCtx.openInterest)
-      : NaN;
+    // Calculate open interest in USD
+    const openInterest = calculateOpenInterestUSD(
+      assetCtx?.openInterest,
+      effectiveCurrentPrice,
+    );
 
     // Get current funding rate from assetCtx - this is the actual current funding rate
     let fundingRate: number | undefined;

--- a/app/components/UI/Perps/utils/marketDataTransform.ts
+++ b/app/components/UI/Perps/utils/marketDataTransform.ts
@@ -202,7 +202,7 @@ export function transformMarketData(
     // Calculate open interest in USD
     const openInterest = calculateOpenInterestUSD(
       assetCtx?.openInterest,
-      effectiveCurrentPrice,
+      currentPrice,
     );
 
     // Get current funding rate from assetCtx - this is the actual current funding rate


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

### Summary

Fixes incorrect open interest calculation in the market list. Open interest was showing values in thousands instead of billions because the calculation wasn't converting raw contract units to USD by multiplying by the current price.

### Root Cause

The transformMarketData() function used by the market list was parsing raw open interest values directly:
// BEFORE (incorrect)const openInterest = assetCtx?.openInterest  ? parseFloat(assetCtx.openInterest)  : NaN;
This treated open interest as USD when it's actually in contract units. For example, BTC with 1M open interest contracts at $50K should be $50B, but was showing as $1M.

### Solution

Created a centralized calculateOpenInterestUSD() utility function that properly converts contract units to USD by multiplying by the current price:
// AFTER (correct)const openInterest = calculateOpenInterestUSD(  assetCtx?.openInterest,  effectiveCurrentPrice,);
This utility is now used consistently in:
transformMarketData() - Initial REST API data transformation (market list)
HyperLiquidSubscriptionService - WebSocket real-time updates (2 locations)

### Known Discrepancy (Not Addressed in This PR)

There are two separate data sources for market data:

Market List: Uses REST API snapshot via getMarketDataWithPrices()
Data source: allMids prices from REST API
Update frequency: Cached, refreshes periodically or on pull-to-refresh
Use case: Browsing markets

Market Statistics Card: Uses real-time WebSocket via subscribeToPrices()
Data source: midPx || markPx from WebSocket
Update frequency: Real-time, updates every ~1-2 seconds
Use case: Viewing specific market details

Impact: While both now use the same calculation logic (calculateOpenInterestUSD), the market list shows a snapshot while the statistics card shows live real-time values. This is by design to prevent scroll jumping and excessive re-renders in the list view. Users can pull-to-refresh to update the market list.

### Changes Made

Created utility function: calculateOpenInterestUSD() in marketDataTransform.ts
Updated market list: Uses utility in transformMarketData()
Updated WebSocket service: Uses utility in HyperLiquidSubscriptionService (2 locations)
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1972

## **Manual testing steps**

```gherkin
Scenario: Sorting preserves correct open interest calculation
    Given BTC has 1,000,000 contracts at $52,000 per contract
    And ETH has 5,000,000 contracts at $3,100 per contract
    When I sort markets by open interest
    Then BTC displays "$52.00B" and appears before ETH
    And ETH displays "$15.50B" and appears after BTC
    And the sorting uses the calculated USD values (contracts × price)
    And not the raw contract numbers

  Scenario: Switching from volume sort to open interest sort
    Given markets are currently sorted by "Volume"
    And the order is: SOL ($500M), BTC ($450M), ETH ($300M)
    When I change the sort to "Open Interest"
    Then markets reorder immediately
    And the new order is: BTC ($52.00B), ETH ($15.50B), SOL ($1.50B)
    And the sort dropdown shows "Open Interest" as selected
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="400"  alt="image" src="https://github.com/user-attachments/assets/240a07c0-3a32-4e05-ae7e-6ec2ff026d92" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes open interest USD calculation and uses it in REST transform and WebSocket subscriptions, updating displays and adding unit tests.
> 
> - **Utils**:
>   - Add `calculateOpenInterestUSD` in `app/components/UI/Perps/utils/marketDataTransform.ts` and use it in `transformMarketData()` to convert contract units × price to USD.
> - **Services**:
>   - Update `app/components/UI/Perps/services/HyperLiquidSubscriptionService.ts` to compute `openInterest` via `calculateOpenInterestUSD` in both `activeAssetCtx` and `assetCtxs` handlers.
> - **Tests**:
>   - Expand `app/components/UI/Perps/utils/marketDataTransform.test.ts` with comprehensive tests for `calculateOpenInterestUSD` and adjust expectations (e.g., BTC `openInterest` to `$52.00B`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f48648e9ad47d218800082f60aefa20481571b94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->