### PR TITLE
fix(perps): use current price to compute PnL

### DIFF
--- a/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
@@ -115,11 +115,6 @@ const PerpsClosePositionView: React.FC = () => {
     ? parseFloat(priceData[position.coin].price)
     : parseFloat(position.entryPrice);
 
-  // Use ref to access latest price without triggering fee recalculations
-  // This prevents continuous recalculations on every WebSocket price update
-  const currentPriceRef = useRef(currentPrice);
-  currentPriceRef.current = currentPrice;
-
   // Get top of book data for maker/taker fee determination
   const currentTopOfBook = usePerpsTopOfBook({
     symbol: position.coin,
@@ -167,9 +162,9 @@ const PerpsClosePositionView: React.FC = () => {
     const priceToUse =
       orderType === 'limit' && limitPrice
         ? parseFloat(limitPrice)
-        : currentPriceRef.current;
+        : currentPrice;
     return absSize * priceToUse;
-  }, [absSize, orderType, limitPrice]); // Exclude currentPrice from deps to prevent recalculation
+  }, [absSize, orderType, limitPrice, currentPrice]); // Exclude currentPrice from deps to prevent recalculation
 
   // Calculate P&L based on effective price (limit price for limit orders)
   // Use ref for market price to prevent recalculation on every WebSocket update
@@ -181,12 +176,12 @@ const PerpsClosePositionView: React.FC = () => {
     const priceToUse =
       orderType === 'limit' && limitPrice
         ? parseFloat(limitPrice)
-        : currentPriceRef.current;
+        : currentPrice;
     const priceDiff = isLong
       ? priceToUse - entryPrice
       : entryPrice - priceToUse;
     return priceDiff * absSize;
-  }, [entryPrice, absSize, isLong, orderType, limitPrice]); // Exclude effectivePrice from deps
+  }, [entryPrice, absSize, isLong, orderType, limitPrice, currentPrice]); // Exclude effectivePrice from deps
 
   // Use the actual initial margin from the position
   const initialMargin = parseFloat(position.marginUsed);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes PnL calculation when closing positions. Previously the UI used ref which did not trigger a recalculation of the PnL. To solve the issue we refer to the variable without using ref.

## **Changelog**

CHANGELOG entry: Fixed PnL calculation to use current price


## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2035

## **Manual testing steps**

```gherkin
Feature: Close position

  Scenario: User closes a position 
    Given I have an open long position for BTC
    And the current market price is $50,000
    And my entry price was $45,000
    When I click on close position
    Then the P&L shown should be calculated using the current price
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2025-11-07 at 10 46 59" src="https://github.com/user-attachments/assets/92685b3e-e680-4434-8793-1761d694a60d" />

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2025-11-07 at 10 46 40" src="https://github.com/user-attachments/assets/8978c655-5cff-417b-b43a-91f516780b79" />


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use `currentPrice` directly (not a ref) for close-position `positionValue` and PnL, updating memo dependencies to reflect live price.
> 
> - **Perps Close Position View (`PerpsClosePositionView.tsx`)**:
>   - **Calculations**:
>     - Replace ref-based price with direct `currentPrice` for `positionValue` and P&L computations.
>     - Update `useMemo` dependencies to include `currentPrice` for live recalculation.
>   - **Cleanup**:
>     - Remove unused `useRef` for current price and related comments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1e77d14ec2ba106449e3d4b8d574a98b5e1db03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->