### PR TITLE
fix: cp-7.59.0 unconfirmed status styling

### DIFF
--- a/app/components/Base/StatusText.js
+++ b/app/components/Base/StatusText.js
@@ -15,41 +15,50 @@ const styles = StyleSheet.create({
   },
 });
 
-export const ConfirmedText = ({ testID, ...props }) => (
-  <Text testID={testID} bold green style={styles.status} {...props} />
+export const ConfirmedText = ({ testID, style: styleProp, ...props }) => (
+  <Text
+    testID={testID}
+    bold
+    green
+    style={[styles.status, styleProp]}
+    {...props}
+  />
 );
 ConfirmedText.propTypes = {
   testID: PropTypes.string,
+  style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
 };
 
-export const PendingText = ({ testID, ...props }) => {
+export const PendingText = ({ testID, style: styleProp, ...props }) => {
   const { colors } = useTheme();
   return (
     <Text
       testID={testID}
       bold
-      style={[styles.status, { color: colors.warning.default }]}
+      style={[styles.status, { color: colors.warning.default }, styleProp]}
       {...props}
     />
   );
 };
 PendingText.propTypes = {
   testID: PropTypes.string,
+  style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
 };
 
-export const FailedText = ({ testID, ...props }) => {
+export const FailedText = ({ testID, style: styleProp, ...props }) => {
   const { colors } = useTheme();
   return (
     <Text
       testID={testID}
       bold
-      style={[styles.status, { color: colors.error.default }]}
+      style={[styles.status, { color: colors.error.default }, styleProp]}
       {...props}
     />
   );
 };
 FailedText.propTypes = {
   testID: PropTypes.string,
+  style: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
 };
 
 function StatusText({ status, context, testID, ...props }) {
@@ -65,6 +74,8 @@ function StatusText({ status, context, testID, ...props }) {
     case 'pending':
     case 'Submitted':
     case 'submitted':
+    case 'Unconfirmed':
+    case 'unconfirmed':
     case TransactionStatus.signed:
       return (
         <PendingText testID={testID} {...props}>

--- a/app/components/UI/TransactionElement/TransactionDetails/__snapshots__/index.test.tsx.snap
+++ b/app/components/UI/TransactionElement/TransactionDetails/__snapshots__/index.test.tsx.snap
@@ -430,11 +430,14 @@ exports[`TransactionDetails should render correctly 1`] = `
                                 undefined,
                                 undefined,
                                 undefined,
-                                {
-                                  "fontSize": 12,
-                                  "letterSpacing": 0.5,
-                                  "marginTop": 4,
-                                },
+                                [
+                                  {
+                                    "fontSize": 12,
+                                    "letterSpacing": 0.5,
+                                    "marginTop": 4,
+                                  },
+                                  undefined,
+                                ],
                               ]
                             }
                           >
@@ -1704,11 +1707,14 @@ exports[`TransactionDetails should render correctly for multi-layer fee network 
                                 undefined,
                                 undefined,
                                 undefined,
-                                {
-                                  "fontSize": 12,
-                                  "letterSpacing": 0.5,
-                                  "marginTop": 4,
-                                },
+                                [
+                                  {
+                                    "fontSize": 12,
+                                    "letterSpacing": 0.5,
+                                    "marginTop": 4,
+                                  },
+                                  undefined,
+                                ],
                               ]
                             }
                           >
@@ -2978,11 +2984,14 @@ exports[`TransactionDetails should render correctly for multi-layer fee network 
                                 undefined,
                                 undefined,
                                 undefined,
-                                {
-                                  "fontSize": 12,
-                                  "letterSpacing": 0.5,
-                                  "marginTop": 4,
-                                },
+                                [
+                                  {
+                                    "fontSize": 12,
+                                    "letterSpacing": 0.5,
+                                    "marginTop": 4,
+                                  },
+                                  undefined,
+                                ],
                               ]
                             }
                           >

--- a/app/selectors/multichain/multichain.ts
+++ b/app/selectors/multichain/multichain.ts
@@ -14,10 +14,8 @@ import {
 import { createDeepEqualSelector } from '../util';
 import {
   Balance,
-  BtcScope,
   SolScope,
   Transaction as NonEvmTransaction,
-  TransactionType,
 } from '@metamask/keyring-api';
 import { isMainNet } from '../../util/networks';
 import { selectAccountBalanceByChainId } from '../accountTrackerController';
@@ -502,65 +500,10 @@ export const selectNonEvmTransactions = createDeepEqualSelector(
     }
 
     // For all other cases, return transactions for the selected chain
-    const chainTransactions =
+    return (
       accountTransactions[selectedNonEvmNetworkChainId] ??
-      DEFAULT_TRANSACTION_STATE_ENTRY;
-
-    // Add hardcoded unconfirmed BTC transaction for testing
-    if (selectedNonEvmNetworkChainId === BtcScope.Mainnet) {
-      const hardcodedBtcTransaction: NonEvmTransaction = {
-        id: 'hardcoded-btc-tx-unconfirmed',
-        chain: BtcScope.Mainnet,
-        account: selectedAccount.address,
-        from: [
-          {
-            address: selectedAccount.address,
-            asset: {
-              amount: '0.005',
-              unit: 'BTC',
-              fungible: true,
-              type: `${BtcScope.Mainnet}/slip44:0`,
-            },
-          },
-        ],
-        to: [
-          {
-            address: 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh',
-            asset: {
-              amount: '0.005',
-              unit: 'BTC',
-              fungible: true,
-              type: `${BtcScope.Mainnet}/slip44:0`,
-            },
-          },
-        ],
-        type: TransactionType.Send,
-        timestamp: Math.floor(Date.now() / 1000) - 300, // 5 minutes ago (in seconds)
-        status: 'unconfirmed',
-        events: [],
-        fees: [
-          {
-            type: 'base',
-            asset: {
-              amount: '0.00001',
-              unit: 'BTC',
-              fungible: true,
-              type: `${BtcScope.Mainnet}/slip44:0`,
-            },
-          },
-        ],
-      };
-
-      return {
-        ...chainTransactions,
-        transactions: [
-          hardcodedBtcTransaction,
-          ...chainTransactions.transactions,
-        ],
-      };
-    }
-
-    return chainTransactions;
+      DEFAULT_TRANSACTION_STATE_ENTRY
+    );
   },
 );
 
@@ -618,62 +561,6 @@ export const selectNonEvmTransactionsForSelectedAccountGroup =
                 : lu;
           }
         }
-      }
-
-      // Add hardcoded unconfirmed BTC transaction for testing
-      const btcAccount = selectedGroupAccounts.find(
-        (account) =>
-          account.type === 'bip122:p2wpkh' ||
-          account.type === 'bip122:p2pkh' ||
-          account.type === 'bip122:p2sh' ||
-          account.type === 'bip122:p2tr',
-      );
-
-      if (btcAccount) {
-        const hardcodedBtcTransaction: NonEvmTransaction = {
-          id: 'hardcoded-btc-tx-unconfirmed',
-          chain: BtcScope.Mainnet,
-          account: btcAccount.address,
-          from: [
-            {
-              address: btcAccount.address,
-              asset: {
-                amount: '0.005',
-                unit: 'BTC',
-                fungible: true,
-                type: `${BtcScope.Mainnet}/slip44:0`,
-              },
-            },
-          ],
-          to: [
-            {
-              address: 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh',
-              asset: {
-                amount: '0.005',
-                unit: 'BTC',
-                fungible: true,
-                type: `${BtcScope.Mainnet}/slip44:0`,
-              },
-            },
-          ],
-          type: TransactionType.Send,
-          timestamp: Math.floor(Date.now() / 1000) - 300, // 5 minutes ago (in seconds)
-          status: 'unconfirmed',
-          events: [],
-          fees: [
-            {
-              type: 'base',
-              asset: {
-                amount: '0.00001',
-                unit: 'BTC',
-                fungible: true,
-                type: `${BtcScope.Mainnet}/slip44:0`,
-              },
-            },
-          ],
-        };
-
-        aggregated.transactions.push(hardcodedBtcTransaction);
       }
 
       // Sort by timestamp (non-EVM tx use seconds)

--- a/app/selectors/multichain/multichain.ts
+++ b/app/selectors/multichain/multichain.ts
@@ -14,8 +14,10 @@ import {
 import { createDeepEqualSelector } from '../util';
 import {
   Balance,
+  BtcScope,
   SolScope,
   Transaction as NonEvmTransaction,
+  TransactionType,
 } from '@metamask/keyring-api';
 import { isMainNet } from '../../util/networks';
 import { selectAccountBalanceByChainId } from '../accountTrackerController';
@@ -500,10 +502,65 @@ export const selectNonEvmTransactions = createDeepEqualSelector(
     }
 
     // For all other cases, return transactions for the selected chain
-    return (
+    const chainTransactions =
       accountTransactions[selectedNonEvmNetworkChainId] ??
-      DEFAULT_TRANSACTION_STATE_ENTRY
-    );
+      DEFAULT_TRANSACTION_STATE_ENTRY;
+
+    // Add hardcoded unconfirmed BTC transaction for testing
+    if (selectedNonEvmNetworkChainId === BtcScope.Mainnet) {
+      const hardcodedBtcTransaction: NonEvmTransaction = {
+        id: 'hardcoded-btc-tx-unconfirmed',
+        chain: BtcScope.Mainnet,
+        account: selectedAccount.address,
+        from: [
+          {
+            address: selectedAccount.address,
+            asset: {
+              amount: '0.005',
+              unit: 'BTC',
+              fungible: true,
+              type: `${BtcScope.Mainnet}/slip44:0`,
+            },
+          },
+        ],
+        to: [
+          {
+            address: 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh',
+            asset: {
+              amount: '0.005',
+              unit: 'BTC',
+              fungible: true,
+              type: `${BtcScope.Mainnet}/slip44:0`,
+            },
+          },
+        ],
+        type: TransactionType.Send,
+        timestamp: Math.floor(Date.now() / 1000) - 300, // 5 minutes ago (in seconds)
+        status: 'unconfirmed',
+        events: [],
+        fees: [
+          {
+            type: 'base',
+            asset: {
+              amount: '0.00001',
+              unit: 'BTC',
+              fungible: true,
+              type: `${BtcScope.Mainnet}/slip44:0`,
+            },
+          },
+        ],
+      };
+
+      return {
+        ...chainTransactions,
+        transactions: [
+          hardcodedBtcTransaction,
+          ...chainTransactions.transactions,
+        ],
+      };
+    }
+
+    return chainTransactions;
   },
 );
 
@@ -561,6 +618,62 @@ export const selectNonEvmTransactionsForSelectedAccountGroup =
                 : lu;
           }
         }
+      }
+
+      // Add hardcoded unconfirmed BTC transaction for testing
+      const btcAccount = selectedGroupAccounts.find(
+        (account) =>
+          account.type === 'bip122:p2wpkh' ||
+          account.type === 'bip122:p2pkh' ||
+          account.type === 'bip122:p2sh' ||
+          account.type === 'bip122:p2tr',
+      );
+
+      if (btcAccount) {
+        const hardcodedBtcTransaction: NonEvmTransaction = {
+          id: 'hardcoded-btc-tx-unconfirmed',
+          chain: BtcScope.Mainnet,
+          account: btcAccount.address,
+          from: [
+            {
+              address: btcAccount.address,
+              asset: {
+                amount: '0.005',
+                unit: 'BTC',
+                fungible: true,
+                type: `${BtcScope.Mainnet}/slip44:0`,
+              },
+            },
+          ],
+          to: [
+            {
+              address: 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh',
+              asset: {
+                amount: '0.005',
+                unit: 'BTC',
+                fungible: true,
+                type: `${BtcScope.Mainnet}/slip44:0`,
+              },
+            },
+          ],
+          type: TransactionType.Send,
+          timestamp: Math.floor(Date.now() / 1000) - 300, // 5 minutes ago (in seconds)
+          status: 'unconfirmed',
+          events: [],
+          fees: [
+            {
+              type: 'base',
+              asset: {
+                amount: '0.00001',
+                unit: 'BTC',
+                fungible: true,
+                type: `${BtcScope.Mainnet}/slip44:0`,
+              },
+            },
+          ],
+        };
+
+        aggregated.transactions.push(hardcodedBtcTransaction);
       }
 
       // Sort by timestamp (non-EVM tx use seconds)

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3235,6 +3235,7 @@
     "failed": "Failed",
     "cancelled": "Cancelled",
     "signed": "Pending",
+    "unconfirmed": "Pending",
     "tokenContractAddressWarning_1": "This address is a ",
     "tokenContractAddressWarning_2": "token contract address",
     "tokenContractAddressWarning_3": ". If you send tokens to this address, you will lose them.",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR fixes styling for "unconfirmed" transaction status
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed styling for "unconfirmed" transaction status

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/21574
https://consensyssoftware.atlassian.net/browse/TMCU-158

## **Manual testing steps**

```gherkin
Feature: Send BTC

  Scenario: user sends BTC
    Given BTC is enabled

    When user initiates BTC transaction and navigates to Activity tab
    Then unconfirmed transaction with yellow/orange "Pending" status should appear
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="395" height="835" alt="Screenshot 2025-11-07 at 13 53 14" src="https://github.com/user-attachments/assets/e74b1b50-be28-4800-a1cc-6be00665d119" />

<!-- [screenshots/recordings] -->

### **After**
<img width="396" height="833" alt="Screenshot 2025-11-07 at 13 52 51" src="https://github.com/user-attachments/assets/431a522f-0338-4b22-b39a-29d51d03dfca" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Maps `Unconfirmed` statuses to pending and enables overriding styles on status text components; updates i18n and snapshots.
> 
> - **UI**:
>   - `app/components/Base/StatusText.js`:
>     - `ConfirmedText`, `PendingText`, `FailedText` now accept optional `style` prop merged with base styles.
>     - Treat `"Unconfirmed"/"unconfirmed"` as pending in `StatusText` switch.
> - **i18n**:
>   - `locales/languages/en.json`: add `"transaction.unconfirmed": "Pending"`.
> - **Tests**:
>   - Update `TransactionDetails` snapshots to reflect array-based `style` merging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa442473831e91e84b7076fd8d94ff442d7b4a91. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->