### PR TITLE
chore: remove rewards feature flag

### DIFF
--- a/app/component-library/components/Navigation/TabBar/TabBar.test.tsx
+++ b/app/component-library/components/Navigation/TabBar/TabBar.test.tsx
@@ -30,11 +30,6 @@ interface TestDescriptors {
   [key: string]: TestTabDescriptor;
 }
 
-// Force rewards feature flag to be enabled for this test file
-jest.mock('../../../../selectors/featureFlagController/rewards', () => ({
-  selectRewardsEnabledFlag: () => true,
-}));
-
 // Mock trending tokens feature flag selector
 jest.mock('../../../../selectors/featureFlagController/assetsTrendingTokens');
 

--- a/app/component-library/components/Navigation/TabBar/TabBar.tsx
+++ b/app/component-library/components/Navigation/TabBar/TabBar.tsx
@@ -27,14 +27,12 @@ import {
   LABEL_BY_TAB_BAR_ICON_KEY,
 } from './TabBar.constants';
 import { selectChainId } from '../../../../selectors/networkController';
-import { selectRewardsEnabledFlag } from '../../../../selectors/featureFlagController/rewards';
 import { selectAssetsTrendingTokensEnabled } from '../../../../selectors/featureFlagController/assetsTrendingTokens';
 
 const TabBar = ({ state, descriptors, navigation }: TabBarProps) => {
   const { trackEvent, createEventBuilder } = useMetrics();
   const { bottom: bottomInset } = useSafeAreaInsets();
   const chainId = useSelector(selectChainId);
-  const isRewardsEnabled = useSelector(selectRewardsEnabledFlag);
   const isAssetsTrendingTokensEnabled = useSelector(
     selectAssetsTrendingTokensEnabled,
   );
@@ -86,9 +84,7 @@ const TabBar = ({ state, descriptors, navigation }: TabBarProps) => {
             navigation.navigate(Routes.TRANSACTIONS_VIEW);
             break;
           case Routes.REWARDS_VIEW:
-            if (isRewardsEnabled) {
-              navigation.navigate(Routes.REWARDS_VIEW);
-            }
+            navigation.navigate(Routes.REWARDS_VIEW);
             break;
           case Routes.SETTINGS_VIEW:
             navigation.navigate(Routes.SETTINGS_VIEW, {
@@ -127,7 +123,6 @@ const TabBar = ({ state, descriptors, navigation }: TabBarProps) => {
       trackEvent,
       createEventBuilder,
       tw,
-      isRewardsEnabled,
       isAssetsTrendingTokensEnabled,
     ],
   );

--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -107,7 +107,6 @@ import {
   PredictModalStack,
   selectPredictEnabledFlag,
 } from '../../UI/Predict';
-import { selectRewardsEnabledFlag } from '../../../selectors/featureFlagController/rewards';
 import { selectAssetsTrendingTokensEnabled } from '../../../selectors/featureFlagController/assetsTrendingTokens';
 import PerpsPositionTransactionView from '../../UI/Perps/Views/PerpsTransactionsView/PerpsPositionTransactionView';
 import PerpsOrderTransactionView from '../../UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView';
@@ -526,7 +525,6 @@ const HomeTabs = () => {
   const [isKeyboardHidden, setIsKeyboardHidden] = useState(true);
 
   const accountsLength = useSelector(selectAccountsLength);
-  const isRewardsEnabled = useSelector(selectRewardsEnabledFlag);
   const rewardsSubscription = useSelector(selectRewardsSubscriptionId);
   const isAssetsTrendingTokensEnabled = useSelector(
     selectAssetsTrendingTokensEnabled,
@@ -649,11 +647,7 @@ const HomeTabs = () => {
     const currentRoute = state.routes[state.index];
 
     // Hide tab bar for rewards onboarding splash screen
-    if (
-      currentRoute.name?.startsWith('Rewards') &&
-      isRewardsEnabled &&
-      !rewardsSubscription
-    ) {
+    if (currentRoute.name?.startsWith('Rewards') && !rewardsSubscription) {
       return null;
     }
 
@@ -715,21 +709,12 @@ const HomeTabs = () => {
         component={TransactionsHome}
         layout={({ children }) => <UnmountOnBlur>{children}</UnmountOnBlur>}
       />
-      {isRewardsEnabled ? (
-        <Tab.Screen
-          name={Routes.REWARDS_VIEW}
-          options={options.rewards}
-          component={RewardsHome}
-          layout={({ children }) => UnmountOnBlurComponent(children)}
-        />
-      ) : (
-        <Tab.Screen
-          name={Routes.SETTINGS_VIEW}
-          options={options.settings}
-          component={SettingsFlow}
-          layout={({ children }) => UnmountOnBlurComponent(children)}
-        />
-      )}
+      <Tab.Screen
+        name={Routes.REWARDS_VIEW}
+        options={options.rewards}
+        component={RewardsHome}
+        layout={({ children }) => UnmountOnBlurComponent(children)}
+      />
     </Tab.Navigator>
   );
 };
@@ -948,7 +933,6 @@ const MainNavigator = () => {
   const { enabled: isSendRedesignEnabled } = useSelector(
     selectSendRedesignFlags,
   );
-  const isRewardsEnabled = useSelector(selectRewardsEnabledFlag);
 
   return (
     <Stack.Navigator
@@ -1008,28 +992,26 @@ const MainNavigator = () => {
         component={ConfirmAddAsset}
         options={{ headerShown: true }}
       />
-      {isRewardsEnabled && (
-        <Stack.Screen
-          name={Routes.SETTINGS_VIEW}
-          component={SettingsFlow}
-          options={{
-            headerShown: false,
-            animationEnabled: true,
-            cardStyleInterpolator: ({ current, layouts }) => ({
-              cardStyle: {
-                transform: [
-                  {
-                    translateX: current.progress.interpolate({
-                      inputRange: [0, 1],
-                      outputRange: [layouts.screen.width, 0],
-                    }),
-                  },
-                ],
-              },
-            }),
-          }}
-        />
-      )}
+      <Stack.Screen
+        name={Routes.SETTINGS_VIEW}
+        component={SettingsFlow}
+        options={{
+          headerShown: false,
+          animationEnabled: true,
+          cardStyleInterpolator: ({ current, layouts }) => ({
+            cardStyle: {
+              transform: [
+                {
+                  translateX: current.progress.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [layouts.screen.width, 0],
+                  }),
+                },
+              ],
+            },
+          }),
+        }}
+      />
       <Stack.Screen name="Asset" component={AssetModalFlow} />
       <Stack.Screen name="Webview" component={Webview} />
       <Stack.Screen name="SendView" component={SendView} />

--- a/app/components/Nav/Main/MainNavigator.test.js
+++ b/app/components/Nav/Main/MainNavigator.test.js
@@ -66,14 +66,6 @@ jest.mock('./MainNavigator', () => {
       }),
     );
 
-    // Add Settings tab (always shown at the end)
-    tabs.push(
-      React.createElement(View, {
-        key: 'settings',
-        testID: `tab-bar-item-${TabBarIconKey.Setting}`,
-      }),
-    );
-
     return React.createElement(View, { testID: 'main-navigator' }, tabs);
   };
 });

--- a/app/components/Nav/Main/MainNavigator.test.js
+++ b/app/components/Nav/Main/MainNavigator.test.js
@@ -13,17 +13,13 @@ jest.mock('./MainNavigator', () => {
     TabBarIconKey,
   } = require('../../../component-library/components/Navigation/TabBar/TabBar.types');
   const {
-    selectRewardsEnabledFlag,
-  } = require('../../../selectors/featureFlagController/rewards');
-  const {
     selectAssetsTrendingTokensEnabled,
   } = require('../../../selectors/featureFlagController/assetsTrendingTokens');
   const { selectBrowserFullscreen } = require('../../../selectors/browser');
   const Routes = require('../../../constants/navigation/Routes').default;
 
-  // Mock implementation that tests tab visibility based on rewards flag and browser fullscreen state
+  // Mock implementation that tests tab visibility based on browser fullscreen state
   return function MockMainNavigator({ route }) {
-    const isRewardsEnabled = selectRewardsEnabledFlag();
     const isTrendingEnabled = selectAssetsTrendingTokensEnabled();
     const isBrowserFullscreen = selectBrowserFullscreen();
 
@@ -62,15 +58,13 @@ jest.mock('./MainNavigator', () => {
       }),
     );
 
-    // Add Rewards tab if enabled
-    if (isRewardsEnabled) {
-      tabs.push(
-        React.createElement(View, {
-          key: 'rewards',
-          testID: `tab-bar-item-${TabBarIconKey.Rewards}`,
-        }),
-      );
-    }
+    // Add Rewards tab
+    tabs.push(
+      React.createElement(View, {
+        key: 'rewards',
+        testID: `tab-bar-item-${TabBarIconKey.Rewards}`,
+      }),
+    );
 
     // Add Settings tab (always shown at the end)
     tabs.push(
@@ -86,7 +80,6 @@ jest.mock('./MainNavigator', () => {
 
 // Mock the rewards selector
 jest.mock('../../../selectors/featureFlagController/rewards', () => ({
-  selectRewardsEnabledFlag: jest.fn(),
   selectRewardsSubscriptionId: jest.fn().mockReturnValue(null),
 }));
 
@@ -103,7 +96,6 @@ jest.mock('../../../selectors/browser', () => ({
   selectBrowserFullscreen: jest.fn(),
 }));
 
-import { selectRewardsEnabledFlag } from '../../../selectors/featureFlagController/rewards';
 import { selectAssetsTrendingTokensEnabled } from '../../../selectors/featureFlagController/assetsTrendingTokens';
 import { selectBrowserFullscreen } from '../../../selectors/browser';
 import MainNavigator from './MainNavigator';
@@ -111,13 +103,11 @@ import MainNavigator from './MainNavigator';
 describe('MainNavigator', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    selectRewardsEnabledFlag.mockReturnValue(false);
     selectAssetsTrendingTokensEnabled.mockReturnValue(false);
     selectBrowserFullscreen.mockReturnValue(false);
   });
 
   it('shows Browser tab when trending feature flag is off', () => {
-    selectRewardsEnabledFlag.mockReturnValue(false);
     selectAssetsTrendingTokensEnabled.mockReturnValue(false);
 
     const { getByTestId, queryByTestId } = render(<MainNavigator />);
@@ -126,11 +116,10 @@ describe('MainNavigator', () => {
     expect(queryByTestId('tab-bar-item-Trending')).toBeNull();
     expect(getByTestId('tab-bar-item-Wallet')).toBeDefined();
     expect(getByTestId('tab-bar-item-Trade')).toBeDefined();
-    expect(getByTestId('tab-bar-item-Setting')).toBeDefined();
+    expect(getByTestId('tab-bar-item-Rewards')).toBeDefined();
   });
 
   it('shows Trending tab and hides Browser tab when trending feature flag is on', () => {
-    selectRewardsEnabledFlag.mockReturnValue(false);
     selectAssetsTrendingTokensEnabled.mockReturnValue(true);
 
     const { getByTestId, queryByTestId } = render(<MainNavigator />);
@@ -139,37 +128,20 @@ describe('MainNavigator', () => {
     expect(queryByTestId('tab-bar-item-Browser')).toBeNull();
     expect(getByTestId('tab-bar-item-Wallet')).toBeDefined();
     expect(getByTestId('tab-bar-item-Trade')).toBeDefined();
-    expect(getByTestId('tab-bar-item-Setting')).toBeDefined();
+    expect(getByTestId('tab-bar-item-Rewards')).toBeDefined();
   });
 
-  it('shows Settings tab when rewards feature flag is off', () => {
-    selectRewardsEnabledFlag.mockReturnValue(false);
-    selectAssetsTrendingTokensEnabled.mockReturnValue(false);
-
-    const { getByTestId, queryByTestId } = render(<MainNavigator />);
-
-    expect(getByTestId('tab-bar-item-Setting')).toBeDefined();
-    expect(queryByTestId('tab-bar-item-Rewards')).toBeNull();
-    expect(getByTestId('tab-bar-item-Wallet')).toBeDefined();
-    expect(getByTestId('tab-bar-item-Browser')).toBeDefined();
-    expect(getByTestId('tab-bar-item-Trade')).toBeDefined();
-  });
-
-  it('shows Rewards tab when rewards feature flag is on', () => {
-    selectRewardsEnabledFlag.mockReturnValue(true);
-    selectAssetsTrendingTokensEnabled.mockReturnValue(false);
-
+  it('should show Rewards tab', () => {
     const { getByTestId } = render(<MainNavigator />);
 
     expect(getByTestId('tab-bar-item-Rewards')).toBeDefined();
-    expect(getByTestId('tab-bar-item-Setting')).toBeDefined();
+    // Verify other core tabs are present
     expect(getByTestId('tab-bar-item-Wallet')).toBeDefined();
     expect(getByTestId('tab-bar-item-Browser')).toBeDefined();
     expect(getByTestId('tab-bar-item-Trade')).toBeDefined();
   });
 
   it('shows Trending and Rewards tabs and hides Browser tab when both feature flags are on', () => {
-    selectRewardsEnabledFlag.mockReturnValue(true);
     selectAssetsTrendingTokensEnabled.mockReturnValue(true);
 
     const { getByTestId, queryByTestId } = render(<MainNavigator />);
@@ -179,7 +151,6 @@ describe('MainNavigator', () => {
     expect(queryByTestId('tab-bar-item-Browser')).toBeNull();
     expect(getByTestId('tab-bar-item-Wallet')).toBeDefined();
     expect(getByTestId('tab-bar-item-Trade')).toBeDefined();
-    expect(getByTestId('tab-bar-item-Setting')).toBeDefined();
   });
 
   it('should show navbar tabs when browser is not in fullscreen mode', () => {
@@ -193,7 +164,7 @@ describe('MainNavigator', () => {
     expect(getByTestId('tab-bar-item-Wallet')).toBeDefined();
     expect(getByTestId('tab-bar-item-Browser')).toBeDefined();
     expect(getByTestId('tab-bar-item-Trade')).toBeDefined();
-    expect(getByTestId('tab-bar-item-Setting')).toBeDefined();
+    expect(getByTestId('tab-bar-item-Rewards')).toBeDefined();
   });
 
   it('should not show navbar when browser is in fullscreen mode', () => {
@@ -209,7 +180,7 @@ describe('MainNavigator', () => {
     expect(queryByTestId('tab-bar-item-Wallet')).toBeNull();
     expect(queryByTestId('tab-bar-item-Browser')).toBeNull();
     expect(queryByTestId('tab-bar-item-Trade')).toBeNull();
-    expect(queryByTestId('tab-bar-item-Setting')).toBeNull();
+    expect(queryByTestId('tab-bar-item-Rewards')).toBeNull();
   });
 
   it('should show navbar tabs when browser is in fullscreen mode but on non-browser route', () => {
@@ -225,7 +196,7 @@ describe('MainNavigator', () => {
     expect(getByTestId('tab-bar-item-Wallet')).toBeDefined();
     expect(getByTestId('tab-bar-item-Browser')).toBeDefined();
     expect(getByTestId('tab-bar-item-Trade')).toBeDefined();
-    expect(getByTestId('tab-bar-item-Setting')).toBeDefined();
+    expect(getByTestId('tab-bar-item-Rewards')).toBeDefined();
   });
 
   it('should return null when isBrowserFullscreen is true AND route starts with BrowserTabHome', () => {

--- a/app/components/Nav/Main/__snapshots__/MainNavigator.test.js.snap
+++ b/app/components/Nav/Main/__snapshots__/MainNavigator.test.js.snap
@@ -19,8 +19,5 @@ exports[`MainNavigator should match snapshot when browser is not infullscreen mo
   <View
     testID="tab-bar-item-Rewards"
   />
-  <View
-    testID="tab-bar-item-Setting"
-  />
 </View>
 `;

--- a/app/components/Nav/Main/__snapshots__/MainNavigator.test.js.snap
+++ b/app/components/Nav/Main/__snapshots__/MainNavigator.test.js.snap
@@ -17,6 +17,9 @@ exports[`MainNavigator should match snapshot when browser is not infullscreen mo
     testID="tab-bar-item-Activity"
   />
   <View
+    testID="tab-bar-item-Rewards"
+  />
+  <View
     testID="tab-bar-item-Setting"
   />
 </View>

--- a/app/components/Nav/Main/__snapshots__/MainNavigator.test.tsx.snap
+++ b/app/components/Nav/Main/__snapshots__/MainNavigator.test.tsx.snap
@@ -63,6 +63,17 @@ exports[`MainNavigator matches rendered snapshot 1`] = `
   />
   <Screen
     component={[Function]}
+    name="SettingsView"
+    options={
+      {
+        "animationEnabled": true,
+        "cardStyleInterpolator": [Function],
+        "headerShown": false,
+      }
+    }
+  />
+  <Screen
+    component={[Function]}
     name="Asset"
   />
   <Screen

--- a/app/components/UI/Navbar/index.js
+++ b/app/components/UI/Navbar/index.js
@@ -918,7 +918,6 @@ export function getOfflineModalNavbar() {
  * @param {number} unreadNotificationCount - The number of unread notifications
  * @param {number} readNotificationCount - The number of read notifications
  * @param {boolean} shouldDisplayCardButton - Whether to display the card button
- * @param {boolean} isRewardsEnabled - Whether rewards are enabled
  * @returns {Object} An object containing the navbar options for the wallet screen
  */
 export function getWalletNavbarOptions(
@@ -935,7 +934,6 @@ export function getWalletNavbarOptions(
   unreadNotificationCount,
   readNotificationCount,
   shouldDisplayCardButton,
-  isRewardsEnabled = false,
 ) {
   const innerStyles = StyleSheet.create({
     headerContainer: {
@@ -1152,16 +1150,14 @@ export function getWalletNavbarOptions(
                     />
                   </BadgeWrapper>
                 )}
-                {isRewardsEnabled && (
-                  <ButtonIcon
-                    iconProps={{ color: MMDSIconColor.Default }}
-                    onPress={handleHamburgerPress}
-                    iconName={IconName.Menu}
-                    size={ButtonIconSize.Lg}
-                    testID="navbar-hamburger-menu-button"
-                    hitSlop={innerStyles.touchAreaSlop}
-                  />
-                )}
+                <ButtonIcon
+                  iconProps={{ color: MMDSIconColor.Default }}
+                  onPress={handleHamburgerPress}
+                  iconName={IconName.Menu}
+                  size={ButtonIconSize.Lg}
+                  testID="navbar-hamburger-menu-button"
+                  hitSlop={innerStyles.touchAreaSlop}
+                />
               </View>
             }
           </View>
@@ -2025,7 +2021,6 @@ export const getSettingsNavigationOptions = (
   title,
   themeColors,
   navigation,
-  isRewardsEnabled = false,
 ) => {
   const innerStyles = StyleSheet.create({
     headerStyle: {
@@ -2047,16 +2042,15 @@ export const getSettingsNavigationOptions = (
         {title}
       </MorphText>
     ),
-    headerRight: () =>
-      isRewardsEnabled ? (
-        <ButtonIcon
-          size={ButtonIconSize.Lg}
-          iconName={IconName.Close}
-          onPress={() => navigation?.goBack()}
-          style={innerStyles.accessories}
-          testID={NetworksViewSelectorsIDs.CLOSE_ICON}
-        />
-      ) : null,
+    headerRight: () => (
+      <ButtonIcon
+        size={ButtonIconSize.Lg}
+        iconName={IconName.Close}
+        onPress={() => navigation?.goBack()}
+        style={innerStyles.accessories}
+        testID={NetworksViewSelectorsIDs.CLOSE_ICON}
+      />
+    ),
     ...innerStyles,
   };
 };

--- a/app/components/UI/Navbar/index.test.jsx
+++ b/app/components/UI/Navbar/index.test.jsx
@@ -633,28 +633,44 @@ describe('getSettingsNavigationOptions', () => {
   };
 
   describe('Basic Functionality', () => {
-    it('should return navigation options object', () => {
-      const options = getSettingsNavigationOptions(mockTitle, mockThemeColors);
+    it('returns navigation options object', () => {
+      const options = getSettingsNavigationOptions(
+        mockTitle,
+        mockThemeColors,
+        mockNavigation,
+      );
 
       expect(options).toBeDefined();
       expect(typeof options).toBe('object');
     });
 
-    it('should set headerLeft to null', () => {
-      const options = getSettingsNavigationOptions(mockTitle, mockThemeColors);
+    it('sets headerLeft to null', () => {
+      const options = getSettingsNavigationOptions(
+        mockTitle,
+        mockThemeColors,
+        mockNavigation,
+      );
 
       expect(options.headerLeft).toBeNull();
     });
 
-    it('should return headerTitle as a function', () => {
-      const options = getSettingsNavigationOptions(mockTitle, mockThemeColors);
+    it('returns headerTitle as a function', () => {
+      const options = getSettingsNavigationOptions(
+        mockTitle,
+        mockThemeColors,
+        mockNavigation,
+      );
 
       expect(options.headerTitle).toBeDefined();
       expect(typeof options.headerTitle).toBe('function');
     });
 
-    it('should include headerStyle with correct background color', () => {
-      const options = getSettingsNavigationOptions(mockTitle, mockThemeColors);
+    it('includes headerStyle with correct background color', () => {
+      const options = getSettingsNavigationOptions(
+        mockTitle,
+        mockThemeColors,
+        mockNavigation,
+      );
 
       expect(options.headerStyle).toBeDefined();
       expect(options.headerStyle.backgroundColor).toBe(
@@ -662,44 +678,35 @@ describe('getSettingsNavigationOptions', () => {
       );
     });
 
-    it('should set transparent shadow and elevation', () => {
-      const options = getSettingsNavigationOptions(mockTitle, mockThemeColors);
+    it('sets transparent shadow and elevation', () => {
+      const options = getSettingsNavigationOptions(
+        mockTitle,
+        mockThemeColors,
+        mockNavigation,
+      );
 
       expect(options.headerStyle.shadowColor).toBe('transparent');
       expect(options.headerStyle.elevation).toBe(0);
     });
   });
 
-  describe('Rewards Enabled Functionality', () => {
-    it('should show close button when rewards are enabled', () => {
+  describe('Close Button Functionality', () => {
+    it('shows close button in headerRight', () => {
       const options = getSettingsNavigationOptions(
         mockTitle,
         mockThemeColors,
         mockNavigation,
-        true,
       );
 
       expect(options.headerRight).toBeDefined();
       expect(typeof options.headerRight).toBe('function');
     });
 
-    it('should not show close button when rewards are disabled', () => {
+    it('calls navigation.goBack when close button is pressed', () => {
       const options = getSettingsNavigationOptions(
         mockTitle,
         mockThemeColors,
         mockNavigation,
-        false,
-      );
-
-      expect(options.headerRight()).toBeNull();
-    });
-
-    it('should call navigation.goBack when close button is pressed', () => {
-      const options = getSettingsNavigationOptions(
-        mockTitle,
-        mockThemeColors,
-        mockNavigation,
-        true,
       );
 
       const HeaderRightComponent = options.headerRight;
@@ -713,24 +720,22 @@ describe('getSettingsNavigationOptions', () => {
       expect(mockNavigation.goBack).toHaveBeenCalledTimes(1);
     });
 
-    it('should handle missing navigation object gracefully', () => {
+    it('handles missing navigation object gracefully', () => {
       const options = getSettingsNavigationOptions(
         mockTitle,
         mockThemeColors,
         null,
-        true,
       );
 
       expect(options.headerRight).toBeDefined();
       expect(typeof options.headerRight).toBe('function');
     });
 
-    it('should handle undefined navigation object when rewards enabled', () => {
+    it('handles undefined navigation object gracefully', () => {
       const options = getSettingsNavigationOptions(
         mockTitle,
         mockThemeColors,
         undefined,
-        true,
       );
 
       expect(options.headerRight).toBeDefined();
@@ -739,8 +744,12 @@ describe('getSettingsNavigationOptions', () => {
   });
 
   describe('HeaderTitle Component', () => {
-    it('should render MorphText component with correct props', () => {
-      const options = getSettingsNavigationOptions(mockTitle, mockThemeColors);
+    it('renders MorphText component with correct props', () => {
+      const options = getSettingsNavigationOptions(
+        mockTitle,
+        mockThemeColors,
+        mockNavigation,
+      );
       const HeaderTitleComponent = options.headerTitle;
 
       const { getByText, getByTestId } = renderWithProvider(
@@ -751,11 +760,12 @@ describe('getSettingsNavigationOptions', () => {
       expect(getByText(mockTitle)).toBeDefined();
     });
 
-    it('should display the provided title text', () => {
+    it('displays the provided title text', () => {
       const customTitle = 'Custom Settings Title';
       const options = getSettingsNavigationOptions(
         customTitle,
         mockThemeColors,
+        mockNavigation,
       );
       const HeaderTitleComponent = options.headerTitle;
 
@@ -768,19 +778,23 @@ describe('getSettingsNavigationOptions', () => {
   });
 
   describe('Parameter Validation', () => {
-    it('should handle different title types', () => {
+    it('handles different title types', () => {
       const titles = ['Settings', 'Privacy & Security', 'Networks', ''];
 
       titles.forEach((title) => {
         expect(() => {
-          const options = getSettingsNavigationOptions(title, mockThemeColors);
+          const options = getSettingsNavigationOptions(
+            title,
+            mockThemeColors,
+            mockNavigation,
+          );
           expect(options).toBeDefined();
           expect(options.headerTitle).toBeDefined();
         }).not.toThrow();
       });
     });
 
-    it('should handle different theme colors', () => {
+    it('handles different theme colors', () => {
       const themeVariations = [
         { background: { default: '#000000' } },
         { background: { default: '#FFFFFF' } },
@@ -789,7 +803,11 @@ describe('getSettingsNavigationOptions', () => {
 
       themeVariations.forEach((theme) => {
         expect(() => {
-          const options = getSettingsNavigationOptions(mockTitle, theme);
+          const options = getSettingsNavigationOptions(
+            mockTitle,
+            theme,
+            mockNavigation,
+          );
           expect(options).toBeDefined();
           expect(options.headerStyle.backgroundColor).toBe(
             theme.background.default,
@@ -798,55 +816,53 @@ describe('getSettingsNavigationOptions', () => {
       });
     });
 
-    it('should handle undefined or null parameters gracefully', () => {
+    it('handles undefined or null parameters gracefully', () => {
       // Test with undefined title
       expect(() => {
         const options = getSettingsNavigationOptions(
           undefined,
           mockThemeColors,
+          mockNavigation,
         );
         expect(options).toBeDefined();
       }).not.toThrow();
 
       // Test with null title
       expect(() => {
-        const options = getSettingsNavigationOptions(null, mockThemeColors);
+        const options = getSettingsNavigationOptions(
+          null,
+          mockThemeColors,
+          mockNavigation,
+        );
         expect(options).toBeDefined();
       }).not.toThrow();
     });
 
-    it('should handle new navigation and isRewardsEnabled parameters', () => {
+    it('handles navigation parameter', () => {
       expect(() => {
         const options = getSettingsNavigationOptions(
           mockTitle,
           mockThemeColors,
           mockNavigation,
-          true,
         );
         expect(options).toBeDefined();
         expect(options.headerRight).toBeDefined();
-      }).not.toThrow();
-
-      expect(() => {
-        const options = getSettingsNavigationOptions(
-          mockTitle,
-          mockThemeColors,
-          mockNavigation,
-          false,
-        );
-        expect(options).toBeDefined();
-        expect(options.headerRight()).toBeNull();
       }).not.toThrow();
     });
   });
 
   describe('Return Value Structure', () => {
-    it('should return object with expected properties', () => {
-      const options = getSettingsNavigationOptions(mockTitle, mockThemeColors);
+    it('returns object with expected properties', () => {
+      const options = getSettingsNavigationOptions(
+        mockTitle,
+        mockThemeColors,
+        mockNavigation,
+      );
 
       expect(options).toMatchObject({
         headerLeft: null,
         headerTitle: expect.any(Function),
+        headerRight: expect.any(Function),
         headerStyle: expect.objectContaining({
           backgroundColor: expect.any(String),
           shadowColor: 'transparent',
@@ -855,11 +871,19 @@ describe('getSettingsNavigationOptions', () => {
       });
     });
 
-    it('should maintain consistent structure across different inputs', () => {
-      const options1 = getSettingsNavigationOptions('Title 1', mockThemeColors);
-      const options2 = getSettingsNavigationOptions('Title 2', {
-        background: { default: '#000000' },
-      });
+    it('maintains consistent structure across different inputs', () => {
+      const options1 = getSettingsNavigationOptions(
+        'Title 1',
+        mockThemeColors,
+        mockNavigation,
+      );
+      const options2 = getSettingsNavigationOptions(
+        'Title 2',
+        {
+          background: { default: '#000000' },
+        },
+        mockNavigation,
+      );
 
       expect(Object.keys(options1)).toEqual(Object.keys(options2));
       expect(typeof options1.headerTitle).toBe(typeof options2.headerTitle);
@@ -868,9 +892,13 @@ describe('getSettingsNavigationOptions', () => {
   });
 
   describe('Integration', () => {
-    it('should work with React Navigation stack', () => {
+    it('works with React Navigation stack', () => {
       const Stack = createStackNavigator();
-      const options = getSettingsNavigationOptions(mockTitle, mockThemeColors);
+      const options = getSettingsNavigationOptions(
+        mockTitle,
+        mockThemeColors,
+        mockNavigation,
+      );
 
       expect(() => {
         renderWithProvider(

--- a/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.test.tsx
@@ -53,10 +53,6 @@ jest.mock('../../hooks/usePerpsOrderFees', () => ({
   formatFeeRate: jest.fn((rate) => `${((rate || 0) * 100).toFixed(3)}%`),
 }));
 
-jest.mock('../../../../../selectors/featureFlagController/rewards', () => ({
-  selectRewardsEnabledFlag: jest.fn(() => true),
-}));
-
 // Mock PerpsMarketBalanceActions dependencies
 jest.mock('../../hooks/stream', () => ({
   usePerpsLiveAccount: jest.fn(() => ({
@@ -122,7 +118,7 @@ jest.mock('../../hooks', () => ({
     navigateToBrowser: jest.fn(),
     navigateToActions: jest.fn(),
     navigateToActivity: jest.fn(),
-    navigateToRewardsOrSettings: jest.fn(),
+    navigateToRewards: jest.fn(),
     navigateToMarketDetails: jest.fn(),
     navigateToHome: jest.fn(),
     navigateToMarketList: jest.fn(),

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
@@ -7,7 +7,6 @@ import {
   waitFor,
 } from '@testing-library/react-native';
 import React, { useCallback } from 'react';
-import { useSelector } from 'react-redux';
 import { TouchableOpacity } from 'react-native';
 import { Text } from '@metamask/design-system-react-native';
 import { SafeAreaProvider, Metrics } from 'react-native-safe-area-context';
@@ -67,7 +66,6 @@ import {
 } from '../../providers/PerpsStreamManager';
 import { usePerpsOrderContext } from '../../contexts/PerpsOrderContext';
 import PerpsOrderView from './PerpsOrderView';
-import { selectRewardsEnabledFlag } from '../../../../../selectors/featureFlagController/rewards';
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(),
@@ -281,10 +279,7 @@ jest.mock('react-redux', () => ({
   }),
 }));
 
-// Mock rewards selector
-jest.mock('../../../../../selectors/featureFlagController/rewards', () => ({
-  selectRewardsEnabledFlag: jest.fn(() => false),
-}));
+// Rewards feature flag removed - rewards are always enabled
 
 // Mock DevLogger (module appears to use default export with .log())
 jest.mock('../../../../../core/SDKConnect/utils/DevLogger', () => {
@@ -1903,15 +1898,8 @@ describe('PerpsOrderView', () => {
   });
 
   describe('Rewards Points Row', () => {
-    it('should display points row when rewards are enabled and should show', async () => {
-      // Arrange - Enable rewards
-      (useSelector as jest.Mock).mockImplementation((selector) => {
-        if (selector === selectRewardsEnabledFlag) {
-          return true;
-        }
-        return undefined;
-      });
-
+    it('displays points row when rewards should show', async () => {
+      // Arrange - Rewards are always enabled
       (usePerpsRewards as jest.Mock).mockReturnValue({
         shouldShowRewardsRow: true,
         estimatedPoints: 100,
@@ -1931,43 +1919,8 @@ describe('PerpsOrderView', () => {
       });
     });
 
-    it('should not display points row when rewards are disabled', async () => {
-      // Arrange - Disable rewards
-      (useSelector as jest.Mock).mockImplementation((selector) => {
-        if (selector === selectRewardsEnabledFlag) {
-          return false;
-        }
-        return undefined;
-      });
-
-      (usePerpsRewards as jest.Mock).mockReturnValue({
-        shouldShowRewardsRow: false,
-        estimatedPoints: undefined,
-        isLoading: false,
-        hasError: false,
-        bonusBips: undefined,
-        feeDiscountPercentage: undefined,
-        isRefresh: false,
-      });
-
-      // Act
-      render(<PerpsOrderView />, { wrapper: TestWrapper });
-
-      // Assert
-      await waitFor(() => {
-        expect(screen.queryByText('perps.estimated_points')).toBeFalsy();
-      });
-    });
-
-    it('should handle points tooltip interaction', async () => {
-      // Arrange
-      (useSelector as jest.Mock).mockImplementation((selector) => {
-        if (selector === selectRewardsEnabledFlag) {
-          return true;
-        }
-        return undefined;
-      });
-
+    it('handles points tooltip interaction', async () => {
+      // Arrange - Rewards are always enabled
       (usePerpsRewards as jest.Mock).mockReturnValue({
         shouldShowRewardsRow: true,
         estimatedPoints: 150,
@@ -1989,15 +1942,8 @@ describe('PerpsOrderView', () => {
       expect(screen.getByText('perps.estimated_points')).toBeTruthy();
     });
 
-    it('should render RewardsAnimations component with correct props when rewards shown', async () => {
-      // Arrange - Enable rewards with specific values
-      (useSelector as jest.Mock).mockImplementation((selector) => {
-        if (selector === selectRewardsEnabledFlag) {
-          return true;
-        }
-        return undefined;
-      });
-
+    it('renders RewardsAnimations component with correct props when rewards shown', async () => {
+      // Arrange - Rewards are always enabled
       (usePerpsRewards as jest.Mock).mockReturnValue({
         shouldShowRewardsRow: true,
         estimatedPoints: 1000,
@@ -2019,15 +1965,8 @@ describe('PerpsOrderView', () => {
       });
     });
 
-    it('should render RewardsAnimations in loading state', async () => {
-      // Arrange - Enable rewards in loading state
-      (useSelector as jest.Mock).mockImplementation((selector) => {
-        if (selector === selectRewardsEnabledFlag) {
-          return true;
-        }
-        return undefined;
-      });
-
+    it('renders RewardsAnimations in loading state', async () => {
+      // Arrange - Rewards are always enabled, in loading state
       (usePerpsRewards as jest.Mock).mockReturnValue({
         shouldShowRewardsRow: true,
         estimatedPoints: 0,
@@ -2047,15 +1986,8 @@ describe('PerpsOrderView', () => {
       });
     });
 
-    it('should render RewardsAnimations in error state', async () => {
-      // Arrange - Enable rewards in error state
-      (useSelector as jest.Mock).mockImplementation((selector) => {
-        if (selector === selectRewardsEnabledFlag) {
-          return true;
-        }
-        return undefined;
-      });
-
+    it('renders RewardsAnimations in error state', async () => {
+      // Arrange - Rewards are always enabled, in error state
       (usePerpsRewards as jest.Mock).mockReturnValue({
         shouldShowRewardsRow: true,
         estimatedPoints: 0,
@@ -2076,15 +2008,8 @@ describe('PerpsOrderView', () => {
       });
     });
 
-    it('should render RewardsAnimations with bonus bips when provided', async () => {
-      // Arrange - Enable rewards with bonus
-      (useSelector as jest.Mock).mockImplementation((selector) => {
-        if (selector === selectRewardsEnabledFlag) {
-          return true;
-        }
-        return undefined;
-      });
-
+    it('renders RewardsAnimations with bonus bips when provided', async () => {
+      // Arrange - Rewards are always enabled, with bonus
       (usePerpsRewards as jest.Mock).mockReturnValue({
         shouldShowRewardsRow: true,
         estimatedPoints: 2500,
@@ -2281,16 +2206,8 @@ describe('PerpsOrderView', () => {
   });
 
   describe('Points section with rewards', () => {
-    it('should display points row and handle tooltip when rewards enabled', async () => {
-      // Enable rewards flag
-      (useSelector as jest.Mock).mockImplementation((selector) => {
-        if (selector === selectRewardsEnabledFlag) {
-          return true;
-        }
-        return undefined;
-      });
-
-      // Mock rewards with points
+    it('displays points row and handles tooltip when rewards should show', async () => {
+      // Arrange - Rewards are always enabled
       (usePerpsRewards as jest.Mock).mockReturnValue({
         shouldShowRewardsRow: true,
         isLoading: false,
@@ -2301,9 +2218,10 @@ describe('PerpsOrderView', () => {
         isRefresh: false,
       });
 
+      // Act
       render(<PerpsOrderView />, { wrapper: TestWrapper });
 
-      // Verify points section is displayed
+      // Assert - Verify points section is displayed
       await waitFor(() => {
         expect(screen.getByText('perps.estimated_points')).toBeDefined();
       });
@@ -2474,16 +2392,8 @@ describe('PerpsOrderView', () => {
       });
     });
 
-    it('should show rewards state integration with fee discount', async () => {
-      // Enable rewards and mock state
-      (useSelector as jest.Mock).mockImplementation((selector) => {
-        if (selector === selectRewardsEnabledFlag) {
-          return true;
-        }
-        return undefined;
-      });
-
-      // Mock rewards state with all properties
+    it('shows rewards state integration with fee discount', async () => {
+      // Arrange - Rewards are always enabled
       (usePerpsRewards as jest.Mock).mockReturnValue({
         shouldShowRewardsRow: true,
         isLoading: false,

--- a/app/components/UI/Perps/hooks/usePerpsNavigation.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsNavigation.test.ts
@@ -1,15 +1,10 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { useNavigation } from '@react-navigation/native';
-import { useSelector } from 'react-redux';
 import { usePerpsNavigation } from './usePerpsNavigation';
 import Routes from '../../../../constants/navigation/Routes';
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(),
-}));
-
-jest.mock('react-redux', () => ({
-  useSelector: jest.fn(),
 }));
 
 describe('usePerpsNavigation', () => {
@@ -18,9 +13,6 @@ describe('usePerpsNavigation', () => {
   const mockGoBack = jest.fn();
   const mockUseNavigation = useNavigation as jest.MockedFunction<
     typeof useNavigation
-  >;
-  const mockUseSelector = useSelector as jest.MockedFunction<
-    typeof useSelector
   >;
 
   beforeEach(() => {
@@ -33,7 +25,6 @@ describe('usePerpsNavigation', () => {
     } as Partial<ReturnType<typeof useNavigation>> as ReturnType<
       typeof useNavigation
     >);
-    mockUseSelector.mockReturnValue(false); // isRewardsEnabled = false
   });
 
   describe('Main App Navigation', () => {
@@ -81,22 +72,10 @@ describe('usePerpsNavigation', () => {
       });
     });
 
-    it('navigates to settings when rewards disabled', () => {
-      mockUseSelector.mockReturnValue(false);
+    it('navigates to rewards', () => {
       const { result } = renderHook(() => usePerpsNavigation());
 
-      result.current.navigateToRewardsOrSettings();
-
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.SETTINGS_VIEW, {
-        screen: 'Settings',
-      });
-    });
-
-    it('navigates to rewards when rewards enabled', () => {
-      mockUseSelector.mockReturnValue(true);
-      const { result } = renderHook(() => usePerpsNavigation());
-
-      result.current.navigateToRewardsOrSettings();
+      result.current.navigateToRewards();
 
       expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_VIEW);
     });

--- a/app/components/UI/Perps/hooks/usePerpsNavigation.ts
+++ b/app/components/UI/Perps/hooks/usePerpsNavigation.ts
@@ -1,8 +1,6 @@
 import { useCallback } from 'react';
 import { useNavigation, NavigationProp } from '@react-navigation/native';
-import { useSelector } from 'react-redux';
 import Routes from '../../../../constants/navigation/Routes';
-import { selectRewardsEnabledFlag } from '../../../../selectors/featureFlagController/rewards';
 import type { PerpsNavigationParamList } from '../types/navigation';
 import type { PerpsMarketData } from '../controllers/types';
 
@@ -15,7 +13,7 @@ export interface PerpsNavigationHandlers {
   navigateToBrowser: () => void;
   navigateToActions: () => void;
   navigateToActivity: () => void;
-  navigateToRewardsOrSettings: () => void;
+  navigateToRewards: () => void;
 
   // Perps-specific navigation
   navigateToMarketDetails: (market: PerpsMarketData, source?: string) => void;
@@ -62,7 +60,6 @@ export interface PerpsNavigationHandlers {
  */
 export const usePerpsNavigation = (): PerpsNavigationHandlers => {
   const navigation = useNavigation<NavigationProp<PerpsNavigationParamList>>();
-  const isRewardsEnabled = useSelector(selectRewardsEnabledFlag);
 
   // Main app navigation handlers
   const navigateToWallet = useCallback(() => {
@@ -93,15 +90,9 @@ export const usePerpsNavigation = (): PerpsNavigationHandlers => {
     });
   }, [navigation]);
 
-  const navigateToRewardsOrSettings = useCallback(() => {
-    if (isRewardsEnabled) {
-      navigation.navigate(Routes.REWARDS_VIEW);
-    } else {
-      navigation.navigate(Routes.SETTINGS_VIEW, {
-        screen: 'Settings',
-      });
-    }
-  }, [navigation, isRewardsEnabled]);
+  const navigateToRewards = useCallback(() => {
+    navigation.navigate(Routes.REWARDS_VIEW);
+  }, [navigation]);
 
   // Perps-specific navigation handlers
   const navigateToMarketDetails = useCallback(
@@ -159,7 +150,7 @@ export const usePerpsNavigation = (): PerpsNavigationHandlers => {
     navigateToBrowser,
     navigateToActions,
     navigateToActivity,
-    navigateToRewardsOrSettings,
+    navigateToRewards,
 
     // Perps-specific navigation
     navigateToMarketDetails,

--- a/app/components/UI/Perps/hooks/usePerpsOrderFees.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderFees.test.ts
@@ -28,11 +28,6 @@ jest.mock('../../../../core/Engine', () => ({
   context: mockEngineContext,
 }));
 
-// Mock specific selectors directly
-jest.mock('../../../../selectors/featureFlagController/rewards', () => ({
-  selectRewardsEnabledFlag: jest.fn().mockReturnValue(true),
-}));
-
 jest.mock('../../../../selectors/accountsController', () => ({
   selectSelectedInternalAccountFormattedAddress: jest
     .fn()
@@ -424,12 +419,7 @@ describe('usePerpsOrderFees', () => {
       expect(result.current.estimatedPoints).toBeUndefined();
     });
 
-    it('should handle rewards disabled', async () => {
-      const { selectRewardsEnabledFlag } = jest.requireMock(
-        '../../../../selectors/featureFlagController/rewards',
-      );
-      selectRewardsEnabledFlag.mockReturnValue(false);
-
+    it('should handle rewards enabled', async () => {
       const mockFeeResult: FeeCalculationResult = {
         feeRate: 0.00045,
         feeAmount: 45,

--- a/app/components/UI/Perps/hooks/usePerpsOrderFees.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderFees.ts
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux';
 import Engine from '../../../../core/Engine';
 import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../../selectors/accountsController';
-import { selectRewardsEnabledFlag } from '../../../../selectors/featureFlagController/rewards';
 import { selectChainId } from '../../../../selectors/networkController';
 
 import { setMeasurement } from '@sentry/react-native';
@@ -113,7 +112,6 @@ export function usePerpsOrderFees({
   currentBidPrice,
 }: UsePerpsOrderFeesParams): OrderFeesResult {
   const { calculateFees } = usePerpsTrading();
-  const rewardsEnabled = useSelector(selectRewardsEnabledFlag);
   const selectedAddress = useSelector(
     selectSelectedInternalAccountFormattedAddress,
   );
@@ -153,11 +151,6 @@ export function usePerpsOrderFees({
     async (
       address: string,
     ): Promise<{ discountBips?: number; tier?: string }> => {
-      // Early return if feature flag is disabled - never make API call
-      if (!rewardsEnabled) {
-        return {};
-      }
-
       // Check cache first
       const now = Date.now();
       if (
@@ -225,7 +218,7 @@ export function usePerpsOrderFees({
         return {};
       }
     },
-    [rewardsEnabled, currentChainId],
+    [currentChainId],
   );
 
   /**
@@ -239,11 +232,6 @@ export function usePerpsOrderFees({
       isClose: boolean,
       actualFeeUSD?: number,
     ): Promise<EstimatedPointsDto | null> => {
-      // Early return if feature flag is disabled - never make API call
-      if (!rewardsEnabled) {
-        return null;
-      }
-
       try {
         const amountNum = Number.parseFloat(tradeAmount || '0');
         if (amountNum <= 0) {
@@ -314,7 +302,7 @@ export function usePerpsOrderFees({
         return null;
       }
     },
-    [rewardsEnabled, currentChainId],
+    [currentChainId],
   );
 
   // State for fees from provider
@@ -345,7 +333,7 @@ export function usePerpsOrderFees({
    */
   const applyFeeDiscount = useCallback(
     async (originalRate: number) => {
-      if (!rewardsEnabled || !selectedAddress) {
+      if (!selectedAddress) {
         return { adjustedRate: originalRate, discountPercentage: undefined };
       }
 
@@ -390,7 +378,7 @@ export function usePerpsOrderFees({
         return { adjustedRate: originalRate, discountPercentage: undefined };
       }
     },
-    [rewardsEnabled, fetchFeeDiscount, amount, selectedAddress],
+    [fetchFeeDiscount, amount, selectedAddress],
   );
 
   /**
@@ -401,7 +389,7 @@ export function usePerpsOrderFees({
       userAddress: string,
       actualFeeUSD: number,
     ): Promise<{ points?: number; bonusBips?: number }> => {
-      if (!rewardsEnabled || Number.parseFloat(amount) <= 0) {
+      if (Number.parseFloat(amount) <= 0) {
         return {};
       }
 
@@ -491,7 +479,7 @@ export function usePerpsOrderFees({
         return {};
       }
     },
-    [rewardsEnabled, amount, coin, isClosing, estimatePoints],
+    [amount, coin, isClosing, estimatePoints],
   );
 
   /**

--- a/app/components/UI/Perps/hooks/usePerpsRewards.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsRewards.test.ts
@@ -2,11 +2,6 @@ import { renderHook, act } from '@testing-library/react-native';
 import { usePerpsRewards } from './usePerpsRewards';
 import type { OrderFeesResult } from './usePerpsOrderFees';
 
-// Mock the Redux selector
-jest.mock('react-redux', () => ({
-  useSelector: jest.fn(),
-}));
-
 // Mock the development config
 jest.mock('../constants/perpsConfig', () => ({
   DEVELOPMENT_CONFIG: {
@@ -14,9 +9,6 @@ jest.mock('../constants/perpsConfig', () => ({
     SIMULATE_REWARDS_LOADING_AMOUNT: 43,
   },
 }));
-
-import { useSelector } from 'react-redux';
-const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 
 describe('usePerpsRewards', () => {
   // Mock fee results for testing
@@ -39,35 +31,11 @@ describe('usePerpsRewards', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    // Default: rewards enabled
-    mockUseSelector.mockReturnValue(true);
   });
 
-  describe('Feature flag scenarios', () => {
-    it('should not show rewards row when feature flag is disabled', () => {
+  describe('Rewards row visibility', () => {
+    it('should show rewards row when has valid amount', () => {
       // Arrange
-      mockUseSelector.mockReturnValue(false);
-      const feeResults = createMockFeeResults({ estimatedPoints: 100 });
-
-      // Act
-      const { result } = renderHook(() =>
-        usePerpsRewards({
-          feeResults,
-          hasValidAmount: true,
-          isFeesLoading: false,
-          orderAmount: '1000',
-        }),
-      );
-
-      // Assert
-      expect(result.current.shouldShowRewardsRow).toBe(false);
-      expect(result.current.isLoading).toBe(false);
-      expect(result.current.hasError).toBe(false);
-    });
-
-    it('should show rewards row when feature flag is enabled and has valid amount', () => {
-      // Arrange
-      mockUseSelector.mockReturnValue(true);
       const feeResults = createMockFeeResults({ estimatedPoints: 100 });
 
       // Act
@@ -87,7 +55,6 @@ describe('usePerpsRewards', () => {
 
     it('should not show rewards row when hasValidAmount is false', () => {
       // Arrange
-      mockUseSelector.mockReturnValue(true);
       const feeResults = createMockFeeResults({ estimatedPoints: 100 });
 
       // Act

--- a/app/components/UI/Perps/hooks/usePerpsRewards.ts
+++ b/app/components/UI/Perps/hooks/usePerpsRewards.ts
@@ -1,6 +1,4 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useSelector } from 'react-redux';
-import { selectRewardsEnabledFlag } from '../../../../selectors/featureFlagController/rewards';
 import { DEVELOPMENT_CONFIG } from '../constants/perpsConfig';
 import { OrderFeesResult } from './usePerpsOrderFees';
 
@@ -42,9 +40,6 @@ export const usePerpsRewards = ({
   isFeesLoading = false,
   orderAmount = '',
 }: UsePerpsRewardsParams): UsePerpsRewardsResult => {
-  // Get rewards feature flag
-  const rewardsEnabled = useSelector(selectRewardsEnabledFlag);
-
   // Track previous points to detect refresh state
   const [previousPoints, setPreviousPoints] = useState<number | undefined>();
 
@@ -69,8 +64,8 @@ export const usePerpsRewards = ({
 
   // Determine if we should show rewards row
   const shouldShowRewardsRow = useMemo(
-    () => rewardsEnabled && hasValidAmount, // Show row if we have valid amount (even if there's an error or points are undefined)
-    [rewardsEnabled, hasValidAmount],
+    () => hasValidAmount, // Show row if we have valid amount (even if there's an error or points are undefined)
+    [hasValidAmount],
   );
 
   // Determine loading state

--- a/app/components/UI/Rewards/hooks/useRewardsIntroModal.test.ts
+++ b/app/components/UI/Rewards/hooks/useRewardsIntroModal.test.ts
@@ -3,10 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 import Routes from '../../../../constants/navigation/Routes';
 import { useRewardsIntroModal } from './useRewardsIntroModal';
-import {
-  selectRewardsEnabledFlag,
-  selectRewardsAnnouncementModalEnabledFlag,
-} from '../../../../selectors/featureFlagController/rewards';
+import { selectRewardsAnnouncementModalEnabledFlag } from '../../../../selectors/featureFlagController/rewards';
 import { selectMultichainAccountsIntroModalSeen } from '../../../../reducers/user';
 import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
 import { setOnboardingActiveStep } from '../../../../reducers/rewards';
@@ -65,7 +62,6 @@ describe('useRewardsIntroModal', () => {
 
     // Default selector values: all conditions satisfied
     mockUseSelector.mockImplementation((selector: unknown) => {
-      if (selector === selectRewardsEnabledFlag) return true;
       if (selector === selectRewardsAnnouncementModalEnabledFlag) return true;
       if (selector === selectMultichainAccountsIntroModalSeen) return true;
       if (selector === selectMultichainAccountsState2Enabled) return true;
@@ -109,27 +105,8 @@ describe('useRewardsIntroModal', () => {
     });
   });
 
-  it('does not navigate when rewards feature is disabled', async () => {
-    mockUseSelector.mockImplementation((selector: unknown) => {
-      if (selector === selectRewardsEnabledFlag) return false;
-      if (selector === selectRewardsAnnouncementModalEnabledFlag) return true;
-      if (selector === selectMultichainAccountsIntroModalSeen) return true;
-      if (selector === selectMultichainAccountsState2Enabled) return true;
-      return undefined;
-    });
-    (StorageWrapper.getItem as jest.Mock).mockResolvedValueOnce('false');
-
-    renderHook(() => useRewardsIntroModal());
-
-    // Give effects a tick
-    await waitFor(() => {
-      expect(navigate).not.toHaveBeenCalled();
-    });
-  });
-
   it('does not navigate when announcement flag is disabled', async () => {
     mockUseSelector.mockImplementation((selector: unknown) => {
-      if (selector === selectRewardsEnabledFlag) return true;
       if (selector === selectRewardsAnnouncementModalEnabledFlag) return false;
       if (selector === selectMultichainAccountsIntroModalSeen) return true;
       if (selector === selectMultichainAccountsState2Enabled) return true;
@@ -146,7 +123,6 @@ describe('useRewardsIntroModal', () => {
 
   it('does not navigate when BIP44 intro modal has not been seen', async () => {
     mockUseSelector.mockImplementation((selector: unknown) => {
-      if (selector === selectRewardsEnabledFlag) return true;
       if (selector === selectRewardsAnnouncementModalEnabledFlag) return true;
       if (selector === selectMultichainAccountsIntroModalSeen) return false;
       if (selector === selectMultichainAccountsState2Enabled) return true;
@@ -163,7 +139,6 @@ describe('useRewardsIntroModal', () => {
 
   it('does not navigate when subscriptionId is present', async () => {
     mockUseSelector.mockImplementation((selector: unknown) => {
-      if (selector === selectRewardsEnabledFlag) return true;
       if (selector === selectRewardsAnnouncementModalEnabledFlag) return true;
       if (selector === selectMultichainAccountsIntroModalSeen) return true;
       if (selector === selectMultichainAccountsState2Enabled) return true;
@@ -184,7 +159,6 @@ describe('useRewardsIntroModal', () => {
   it('sets storage flag when subscriptionId is present', async () => {
     // Arrange
     mockUseSelector.mockImplementation((selector: unknown) => {
-      if (selector === selectRewardsEnabledFlag) return true;
       if (selector === selectRewardsAnnouncementModalEnabledFlag) return true;
       if (selector === selectMultichainAccountsIntroModalSeen) return true;
       if (selector === selectMultichainAccountsState2Enabled) return true;
@@ -217,7 +191,6 @@ describe('useRewardsIntroModal', () => {
 
     // Mock BIP-44 modal as already seen (from previous session)
     mockUseSelector.mockImplementation((selector: unknown) => {
-      if (selector === selectRewardsEnabledFlag) return true;
       if (selector === selectRewardsAnnouncementModalEnabledFlag) return true;
       if (selector === selectMultichainAccountsIntroModalSeen) return true; // Seen in previous session
       if (selector === selectMultichainAccountsState2Enabled) return true;
@@ -247,7 +220,6 @@ describe('useRewardsIntroModal', () => {
 
     // Start with BIP-44 modal already seen (from previous session)
     mockUseSelector.mockImplementation((selector: unknown) => {
-      if (selector === selectRewardsEnabledFlag) return true;
       if (selector === selectRewardsAnnouncementModalEnabledFlag) return true;
       if (selector === selectMultichainAccountsIntroModalSeen) return true; // Already seen
       if (selector === selectMultichainAccountsState2Enabled) return true;
@@ -278,7 +250,6 @@ describe('useRewardsIntroModal', () => {
 
     // Start with BIP-44 modal NOT seen initially
     mockUseSelector.mockImplementation((selector: unknown) => {
-      if (selector === selectRewardsEnabledFlag) return true;
       if (selector === selectRewardsAnnouncementModalEnabledFlag) return true;
       if (selector === selectMultichainAccountsIntroModalSeen) return false; // Initially not seen
       if (selector === selectMultichainAccountsState2Enabled) return true;
@@ -303,7 +274,6 @@ describe('useRewardsIntroModal', () => {
 
     // Now simulate BIP-44 modal being seen (state changes from false to true)
     mockUseSelector.mockImplementation((selector: unknown) => {
-      if (selector === selectRewardsEnabledFlag) return true;
       if (selector === selectRewardsAnnouncementModalEnabledFlag) return true;
       if (selector === selectMultichainAccountsIntroModalSeen) return true; // Now seen
       if (selector === selectMultichainAccountsState2Enabled) return true;

--- a/app/components/UI/Rewards/hooks/useRewardsIntroModal.ts
+++ b/app/components/UI/Rewards/hooks/useRewardsIntroModal.ts
@@ -1,10 +1,7 @@
 import { useNavigation } from '@react-navigation/native';
 import { useCallback, useEffect, useState, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import {
-  selectRewardsAnnouncementModalEnabledFlag,
-  selectRewardsEnabledFlag,
-} from '../../../../selectors/featureFlagController/rewards';
+import { selectRewardsAnnouncementModalEnabledFlag } from '../../../../selectors/featureFlagController/rewards';
 import { selectMultichainAccountsIntroModalSeen } from '../../../../reducers/user';
 import StorageWrapper from '../../../../store/storage-wrapper';
 import {
@@ -24,17 +21,15 @@ const isE2ETest =
 /**
  * Hook to handle showing the rewards GTM intro modal
  * Shows the modal only when:
- * 1. Rewards feature flag is enabled
- * 2. Rewards announcement feature flag is enabled
- * 3. The modal hasn't been seen before
- * 4. The MultichainAccountsIntroModal has been seen in a PREVIOUS session (not current)
- * 5. User does not have an active subscription
+ * 1. Rewards announcement feature flag is enabled
+ * 2. The modal hasn't been seen before
+ * 3. The MultichainAccountsIntroModal has been seen in a PREVIOUS session (not current)
+ * 4. User does not have an active subscription
  */
 export const useRewardsIntroModal = () => {
   const navigation = useNavigation();
   const dispatch = useDispatch();
 
-  const isRewardsFeatureEnabled = useSelector(selectRewardsEnabledFlag);
   const isRewardsAnnouncementEnabled = useSelector(
     selectRewardsAnnouncementModalEnabledFlag,
   );
@@ -76,7 +71,6 @@ export const useRewardsIntroModal = () => {
     const isUpdate = !!lastAppVersion && currentAppVersion !== lastAppVersion;
 
     const shouldShow =
-      isRewardsFeatureEnabled &&
       isRewardsAnnouncementEnabled &&
       // BIP44 intro modal has been seen in a PREVIOUS session (not current)
       // OR it's a fresh install (which doesn't trigger bip44 modal)
@@ -95,7 +89,6 @@ export const useRewardsIntroModal = () => {
       });
     }
   }, [
-    isRewardsFeatureEnabled,
     isMultichainAccountsState2Enabled,
     isRewardsAnnouncementEnabled,
     hasSeenBIP44IntroModal,
@@ -121,7 +114,6 @@ export const useRewardsIntroModal = () => {
   }, [checkAndShowRewardsIntroModal]);
 
   return {
-    isRewardsFeatureEnabled,
     hasSeenRewardsIntroModal,
   };
 };

--- a/app/components/Views/Settings/index.tsx
+++ b/app/components/Views/Settings/index.tsx
@@ -22,7 +22,6 @@ import { isTest } from '../../../util/test/utils';
 import { isPermissionsSettingsV1Enabled } from '../../../util/networks';
 import { selectIsEvmNetworkSelected } from '../../../selectors/multichainNetworkController';
 import { selectSeedlessOnboardingLoginFlow } from '../../../selectors/seedlessOnboardingController';
-import { selectRewardsEnabledFlag } from '../../../selectors/featureFlagController/rewards';
 
 const createStyles = (colors: Colors) =>
   StyleSheet.create({
@@ -37,7 +36,6 @@ const Settings = () => {
   const { colors } = useTheme();
   const { trackEvent, createEventBuilder } = useMetrics();
   const styles = createStyles(colors);
-  const isRewardsEnabled = useSelector(selectRewardsEnabledFlag);
   // TODO: Replace "any" with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const navigation = useNavigation<any>();
@@ -56,10 +54,9 @@ const Settings = () => {
         strings('app_settings.title'),
         colors,
         navigation,
-        isRewardsEnabled,
       ),
     );
-  }, [navigation, colors, isRewardsEnabled]);
+  }, [navigation, colors]);
 
   useEffect(() => {
     updateNavBar();

--- a/app/components/Views/Wallet/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/Wallet/__snapshots__/index.test.tsx.snap
@@ -448,6 +448,93 @@ exports[`Wallet Conditional Rendering should render banner when basic functional
                       }
                     />
                   </View>
+                  <View
+                    style={
+                      [
+                        {
+                          "transform": [
+                            {
+                              "scale": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "alignItems": "center",
+                          "justifyContent": "center",
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": false,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      hitSlop={
+                        {
+                          "bottom": 12,
+                          "left": 12,
+                          "right": 12,
+                          "top": 12,
+                        }
+                      }
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                      style={
+                        [
+                          {
+                            "alignItems": "center",
+                            "backgroundColor": "transparent",
+                            "borderRadius": 2,
+                            "height": 40,
+                            "justifyContent": "center",
+                            "opacity": 1,
+                            "width": 40,
+                          },
+                          undefined,
+                        ]
+                      }
+                      testID="navbar-hamburger-menu-button"
+                    >
+                      <SvgMock
+                        fill="currentColor"
+                        name="Menu"
+                        style={
+                          [
+                            {
+                              "color": "#121314",
+                              "height": 24,
+                              "width": 24,
+                            },
+                            undefined,
+                          ]
+                        }
+                      />
+                    </View>
+                  </View>
                 </View>
               </View>
             </View>
@@ -1536,6 +1623,93 @@ exports[`Wallet Conditional Rendering should render loader when no selected acco
                         ]
                       }
                     />
+                  </View>
+                  <View
+                    style={
+                      [
+                        {
+                          "transform": [
+                            {
+                              "scale": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "alignItems": "center",
+                          "justifyContent": "center",
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": false,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      hitSlop={
+                        {
+                          "bottom": 12,
+                          "left": 12,
+                          "right": 12,
+                          "top": 12,
+                        }
+                      }
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                      style={
+                        [
+                          {
+                            "alignItems": "center",
+                            "backgroundColor": "transparent",
+                            "borderRadius": 2,
+                            "height": 40,
+                            "justifyContent": "center",
+                            "opacity": 1,
+                            "width": 40,
+                          },
+                          undefined,
+                        ]
+                      }
+                      testID="navbar-hamburger-menu-button"
+                    >
+                      <SvgMock
+                        fill="currentColor"
+                        name="Menu"
+                        style={
+                          [
+                            {
+                              "color": "#121314",
+                              "height": 24,
+                              "width": 24,
+                            },
+                            undefined,
+                          ]
+                        }
+                      />
+                    </View>
                   </View>
                 </View>
               </View>
@@ -2626,6 +2800,93 @@ exports[`Wallet should render correctly 1`] = `
                       }
                     />
                   </View>
+                  <View
+                    style={
+                      [
+                        {
+                          "transform": [
+                            {
+                              "scale": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "alignItems": "center",
+                          "justifyContent": "center",
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": false,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      hitSlop={
+                        {
+                          "bottom": 12,
+                          "left": 12,
+                          "right": 12,
+                          "top": 12,
+                        }
+                      }
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                      style={
+                        [
+                          {
+                            "alignItems": "center",
+                            "backgroundColor": "transparent",
+                            "borderRadius": 2,
+                            "height": 40,
+                            "justifyContent": "center",
+                            "opacity": 1,
+                            "width": 40,
+                          },
+                          undefined,
+                        ]
+                      }
+                      testID="navbar-hamburger-menu-button"
+                    >
+                      <SvgMock
+                        fill="currentColor"
+                        name="Menu"
+                        style={
+                          [
+                            {
+                              "color": "#121314",
+                              "height": 24,
+                              "width": 24,
+                            },
+                            undefined,
+                          ]
+                        }
+                      />
+                    </View>
+                  </View>
                 </View>
               </View>
             </View>
@@ -3715,6 +3976,93 @@ exports[`Wallet should render correctly when Solana support is enabled 1`] = `
                       }
                     />
                   </View>
+                  <View
+                    style={
+                      [
+                        {
+                          "transform": [
+                            {
+                              "scale": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "alignItems": "center",
+                          "justifyContent": "center",
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": false,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      hitSlop={
+                        {
+                          "bottom": 12,
+                          "left": 12,
+                          "right": 12,
+                          "top": 12,
+                        }
+                      }
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                      style={
+                        [
+                          {
+                            "alignItems": "center",
+                            "backgroundColor": "transparent",
+                            "borderRadius": 2,
+                            "height": 40,
+                            "justifyContent": "center",
+                            "opacity": 1,
+                            "width": 40,
+                          },
+                          undefined,
+                        ]
+                      }
+                      testID="navbar-hamburger-menu-button"
+                    >
+                      <SvgMock
+                        fill="currentColor"
+                        name="Menu"
+                        style={
+                          [
+                            {
+                              "color": "#121314",
+                              "height": 24,
+                              "width": 24,
+                            },
+                            undefined,
+                          ]
+                        }
+                      />
+                    </View>
+                  </View>
                 </View>
               </View>
             </View>
@@ -4803,6 +5151,93 @@ exports[`Wallet should render correctly when there are no detected tokens 1`] = 
                         ]
                       }
                     />
+                  </View>
+                  <View
+                    style={
+                      [
+                        {
+                          "transform": [
+                            {
+                              "scale": 1,
+                            },
+                          ],
+                        },
+                        {
+                          "alignItems": "center",
+                          "justifyContent": "center",
+                        },
+                      ]
+                    }
+                  >
+                    <View
+                      accessibilityState={
+                        {
+                          "busy": undefined,
+                          "checked": undefined,
+                          "disabled": false,
+                          "expanded": undefined,
+                          "selected": undefined,
+                        }
+                      }
+                      accessibilityValue={
+                        {
+                          "max": undefined,
+                          "min": undefined,
+                          "now": undefined,
+                          "text": undefined,
+                        }
+                      }
+                      accessible={true}
+                      collapsable={false}
+                      focusable={true}
+                      hitSlop={
+                        {
+                          "bottom": 12,
+                          "left": 12,
+                          "right": 12,
+                          "top": 12,
+                        }
+                      }
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onResponderGrant={[Function]}
+                      onResponderMove={[Function]}
+                      onResponderRelease={[Function]}
+                      onResponderTerminate={[Function]}
+                      onResponderTerminationRequest={[Function]}
+                      onStartShouldSetResponder={[Function]}
+                      style={
+                        [
+                          {
+                            "alignItems": "center",
+                            "backgroundColor": "transparent",
+                            "borderRadius": 2,
+                            "height": 40,
+                            "justifyContent": "center",
+                            "opacity": 1,
+                            "width": 40,
+                          },
+                          undefined,
+                        ]
+                      }
+                      testID="navbar-hamburger-menu-button"
+                    >
+                      <SvgMock
+                        fill="currentColor"
+                        name="Menu"
+                        style={
+                          [
+                            {
+                              "color": "#121314",
+                              "height": 24,
+                              "width": 24,
+                            },
+                            undefined,
+                          ]
+                        }
+                      />
+                    </View>
                   </View>
                 </View>
               </View>

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -183,7 +183,6 @@ import PredictTabView from '../../UI/Predict/views/PredictTabView';
 import { InitSendLocation } from '../confirmations/constants/send';
 import { useSendNavigation } from '../confirmations/hooks/useSendNavigation';
 import { selectCarouselBannersFlag } from '../../UI/Carousel/selectors/featureFlags';
-import { selectRewardsEnabledFlag } from '../../../selectors/featureFlagController/rewards';
 import { SolScope } from '@metamask/keyring-api';
 import { selectSelectedInternalAccountByScope } from '../../../selectors/multichainAccounts/accounts';
 import { EVM_SCOPE } from '../../UI/Earn/constants/networks';
@@ -1091,7 +1090,6 @@ const Wallet = ({
   );
 
   const shouldDisplayCardButton = useSelector(selectDisplayCardButton);
-  const isRewardsEnabled = useSelector(selectRewardsEnabledFlag);
   const isHomepageRedesignV1Enabled = useSelector(
     selectHomepageRedesignV1Enabled,
   );
@@ -1113,7 +1111,6 @@ const Wallet = ({
         unreadNotificationCount,
         readNotificationCount,
         shouldDisplayCardButton,
-        isRewardsEnabled,
       ),
     );
   }, [
@@ -1129,7 +1126,6 @@ const Wallet = ({
     unreadNotificationCount,
     readNotificationCount,
     shouldDisplayCardButton,
-    isRewardsEnabled,
   ]);
 
   const getTokenAddedAnalyticsParams = useCallback(

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -38,8 +38,6 @@ jest.mock('../../../../util/Logger', () => ({
     debug: jest.fn(),
   },
 }));
-jest.mock('../../../../selectors/featureFlagController/rewards');
-jest.mock('../../../../store');
 jest.mock('../../../../util/address', () => ({
   isHardwareAccount: jest.fn(),
 }));
@@ -75,8 +73,6 @@ jest.mock('ethers/lib/utils', () => ({
 }));
 
 // Import mocked modules
-import { selectRewardsEnabledFlag } from '../../../../selectors/featureFlagController/rewards';
-import { store } from '../../../../store';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { isHardwareAccount } from '../../../../util/address';
 import { isNonEvmAddress } from '../../../Multichain/utils';
@@ -99,11 +95,7 @@ import {
 } from './services/rewards-data-service';
 
 // Type the mocked modules
-const mockSelectRewardsEnabledFlag =
-  selectRewardsEnabledFlag as jest.MockedFunction<
-    typeof selectRewardsEnabledFlag
-  >;
-const mockStore = store as jest.Mocked<typeof store>;
+// Note: mockStore is kept for potential future use but currently unused after feature flag removal
 const mockIsHardwareAccount = isHardwareAccount as jest.MockedFunction<
   typeof isHardwareAccount
 >;
@@ -364,9 +356,6 @@ describe('RewardsController', () => {
     // Mock Date.now to return a consistent timestamp
     jest.spyOn(Date, 'now').mockReturnValue(123);
 
-    // Mock feature flag to be enabled by default for all tests
-    mockSelectRewardsEnabledFlag.mockReturnValue(true);
-
     // Reset import mocks
     // @ts-expect-error TODO: Resolve type mismatch
     mockStoreSubscriptionToken.mockResolvedValue(undefined);
@@ -405,9 +394,6 @@ describe('RewardsController', () => {
       registerInitialEventPayload: jest.fn(),
       unsubscribe: jest.fn(),
     } as unknown as jest.Mocked<RewardsControllerMessenger>;
-
-    // Reset feature flag to enabled by default
-    mockSelectRewardsEnabledFlag.mockReturnValue(true);
 
     controller = new RewardsController({
       messenger: mockMessenger,
@@ -522,10 +508,16 @@ describe('RewardsController', () => {
   });
 
   describe('getHasAccountOptedIn', () => {
-    it('should return false when feature flag is disabled', async () => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(false);
+    it('should return false when disabled via isDisabled callback', async () => {
+      const isDisabled = () => true;
+      const disabledController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+        isDisabled,
+      });
 
-      const result = await controller.getHasAccountOptedIn(CAIP_ACCOUNT_1);
+      const result =
+        await disabledController.getHasAccountOptedIn(CAIP_ACCOUNT_1);
 
       expect(result).toBe(false);
       expect(mockMessenger.call).not.toHaveBeenCalledWith(
@@ -765,8 +757,13 @@ describe('RewardsController', () => {
   });
 
   describe('estimatePoints', () => {
-    it('should return default response when feature flag is disabled', async () => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(false);
+    it('should return default response when disabled via isDisabled callback', async () => {
+      const isDisabled = () => true;
+      const disabledController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+        isDisabled,
+      });
 
       const mockRequest = {
         activityType: 'SWAP' as const,
@@ -774,7 +771,7 @@ describe('RewardsController', () => {
         activityContext: {},
       };
 
-      const result = await controller.estimatePoints(mockRequest);
+      const result = await disabledController.estimatePoints(mockRequest);
 
       expect(result).toEqual({ pointsEstimate: 0, bonusBips: 0 });
       expect(mockMessenger.call).not.toHaveBeenCalledWith(
@@ -854,8 +851,13 @@ describe('RewardsController', () => {
   });
 
   describe('getPointsEvents', () => {
-    it('should return empty response when feature flag is disabled', async () => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(false);
+    it('should return empty response when disabled via isDisabled callback', async () => {
+      const isDisabled = () => true;
+      const disabledController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+        isDisabled,
+      });
 
       const mockRequest = {
         seasonId: 'current',
@@ -863,7 +865,7 @@ describe('RewardsController', () => {
         cursor: null,
       };
 
-      const result = await controller.getPointsEvents(mockRequest);
+      const result = await disabledController.getPointsEvents(mockRequest);
 
       expect(result).toEqual({
         has_more: false,
@@ -1853,11 +1855,16 @@ describe('RewardsController', () => {
   });
 
   describe('getPerpsDiscountForAccount', () => {
-    it('should return 0 when feature flag is disabled', async () => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(false);
+    it('should return 0 when disabled via isDisabled callback', async () => {
+      const isDisabled = () => true;
+      const disabledController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+        isDisabled,
+      });
 
       const result =
-        await controller.getPerpsDiscountForAccount(CAIP_ACCOUNT_1);
+        await disabledController.getPerpsDiscountForAccount(CAIP_ACCOUNT_1);
 
       expect(result).toBe(0);
     });
@@ -2253,33 +2260,23 @@ describe('RewardsController', () => {
   });
 
   describe('isRewardsFeatureEnabled', () => {
-    it('should return true when feature flag is enabled', () => {
-      // Mock the feature flag selector to return true
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
-
+    it('should return true when not disabled', () => {
       const result = controller.isRewardsFeatureEnabled();
 
       expect(result).toBe(true);
-      expect(mockSelectRewardsEnabledFlag).toHaveBeenCalled();
     });
 
-    it('should return false when feature flag is disabled', () => {
-      // Mock the feature flag selector to return false
-      mockSelectRewardsEnabledFlag.mockReturnValue(false);
+    it('should return false when disabled via isDisabled callback', () => {
+      const isDisabled = () => true;
+      const disabledController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+        isDisabled,
+      });
 
-      const result = controller.isRewardsFeatureEnabled();
+      const result = disabledController.isRewardsFeatureEnabled();
 
       expect(result).toBe(false);
-      expect(mockSelectRewardsEnabledFlag).toHaveBeenCalled();
-    });
-
-    it('should call selectRewardsEnabledFlag with store state', () => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
-
-      controller.isRewardsFeatureEnabled();
-
-      expect(mockStore.getState).toHaveBeenCalled();
-      expect(mockSelectRewardsEnabledFlag).toHaveBeenCalled();
     });
   });
 
@@ -2302,7 +2299,6 @@ describe('RewardsController', () => {
     };
 
     beforeEach(() => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
       mockIsHardwareAccount.mockReturnValue(false);
       mockIsSolanaAddress.mockReturnValue(false);
 
@@ -2715,14 +2711,14 @@ describe('RewardsController', () => {
     const mockSeasonId = 'season123';
     const mockSubscriptionId = 'sub123';
 
-    beforeEach(() => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
-    });
-
     it('should return null when feature flag is disabled', async () => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(false);
+      const disabledController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+        isDisabled: () => true,
+      });
 
-      const result = await controller.getSeasonStatus(
+      const result = await disabledController.getSeasonStatus(
         mockSubscriptionId,
         mockSeasonId,
       );
@@ -4198,10 +4194,8 @@ describe('RewardsController', () => {
   describe('getSeasonMetadata', () => {
     const mockSeasonId = 'season123';
 
-    it('returns null when rewards feature is not enabled', async () => {
-      // Mock the feature flag to be disabled
-      mockSelectRewardsEnabledFlag.mockReturnValue(false);
-
+    it('returns null when disabled via isDisabled callback', async () => {
+      const isDisabled = () => true;
       controller = new RewardsController({
         messenger: mockMessenger,
         state: {
@@ -4213,12 +4207,12 @@ describe('RewardsController', () => {
           seasonStatuses: {},
           pointsEvents: {},
         },
+        isDisabled,
       });
 
       const result = await controller.getSeasonMetadata('current');
 
       expect(result).toBeNull();
-      expect(mockSelectRewardsEnabledFlag).toHaveBeenCalled();
       expect(mockMessenger.call).not.toHaveBeenCalled();
     });
 
@@ -4668,14 +4662,8 @@ describe('RewardsController', () => {
     const mockSubscriptionId = 'sub123';
     const mockSeasonId = 'season456';
 
-    beforeEach(() => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
-    });
-
     it('returns null when feature flag is disabled', async () => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(false);
-
-      controller = new RewardsController({
+      const disabledController = new RewardsController({
         messenger: mockMessenger,
         state: {
           activeAccount: null,
@@ -4688,9 +4676,10 @@ describe('RewardsController', () => {
           unlockedRewards: {},
           pointsEvents: {},
         },
+        isDisabled: () => true,
       });
 
-      const result = await controller.getReferralDetails(
+      const result = await disabledController.getReferralDetails(
         mockSubscriptionId,
         mockSeasonId,
       );
@@ -4933,7 +4922,6 @@ describe('RewardsController', () => {
 
   describe('handleAuthenticationTrigger', () => {
     beforeEach(() => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
       mockIsHardwareAccount.mockReturnValue(false);
       mockIsSolanaAddress.mockReturnValue(false);
     });
@@ -5457,7 +5445,6 @@ describe('RewardsController', () => {
 
   describe('shouldSkipSilentAuth', () => {
     beforeEach(() => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
       mockIsHardwareAccount.mockReturnValue(false);
       mockIsSolanaAddress.mockReturnValue(false);
     });
@@ -5787,16 +5774,17 @@ describe('RewardsController', () => {
   // Removed outdated 'reset' tests; behavior covered by 'resetAll' and 'logout' tests
 
   describe('logout', () => {
-    beforeEach(() => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
-    });
-
-    it('should skip logout when feature flag is disabled', async () => {
+    it('should skip logout when disabled via isDisabled callback', async () => {
       // Arrange
-      mockSelectRewardsEnabledFlag.mockReturnValue(false);
+      const isDisabled = () => true;
+      const disabledController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+        isDisabled,
+      });
 
       // Act
-      await controller.logout();
+      await disabledController.logout();
 
       // Assert - Should not call logout service
       expect(mockMessenger.call).not.toHaveBeenCalledWith(
@@ -6010,13 +5998,8 @@ describe('RewardsController', () => {
   });
 
   describe('resetAll', () => {
-    beforeEach(() => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
-    });
-
     it('should skip reset when feature flag is disabled', async () => {
       // Arrange
-      mockSelectRewardsEnabledFlag.mockReturnValue(false);
       const mockSubscriptionId = 'sub-abc';
       const activeAccountState = {
         account: CAIP_ACCOUNT_1,
@@ -6044,7 +6027,7 @@ describe('RewardsController', () => {
           seasonStatuses: {},
           pointsEvents: {},
         },
-        isDisabled: () => false,
+        isDisabled: () => true,
       });
 
       // Act
@@ -6161,16 +6144,16 @@ describe('RewardsController', () => {
   });
 
   describe('validateReferralCode', () => {
-    beforeEach(() => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
-    });
-
     it('should return false when feature flag is disabled', async () => {
       // Arrange
-      mockSelectRewardsEnabledFlag.mockReturnValue(false);
+      const disabledController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+        isDisabled: () => true,
+      });
 
       // Act
-      const result = await controller.validateReferralCode('ABC123');
+      const result = await disabledController.validateReferralCode('ABC123');
 
       // Assert
       expect(result).toBe(false);
@@ -6269,10 +6252,6 @@ describe('RewardsController', () => {
   });
 
   describe('calculateTierStatus', () => {
-    beforeEach(() => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
-    });
-
     it('should throw error when current tier ID is not found in season tiers', () => {
       // Arrange
       const tiers = createTestTiers();
@@ -6416,10 +6395,6 @@ describe('RewardsController', () => {
   });
 
   describe('convertToSeasonStatusDto', () => {
-    beforeEach(() => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
-    });
-
     it('should convert SeasonDtoState and SeasonStateDto to SeasonStatusDto with all required fields', () => {
       // Arrange
       const tiers = createTestTiers();
@@ -6627,10 +6602,6 @@ describe('RewardsController', () => {
   });
 
   describe('convertInternalAccountToCaipAccountId', () => {
-    beforeEach(() => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
-    });
-
     it('should log error when conversion fails due to invalid internal account', () => {
       // Arrange
       const invalidInternalAccount = {
@@ -7153,16 +7124,16 @@ describe('RewardsController', () => {
   });
 
   describe('getGeoRewardsMetadata', () => {
-    beforeEach(() => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
-    });
-
     it('should return default metadata when rewards feature is disabled', async () => {
       // Arrange
-      mockSelectRewardsEnabledFlag.mockReturnValue(false);
+      const disabledController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+        isDisabled: () => true,
+      });
 
       // Act
-      const result = await controller.getGeoRewardsMetadata();
+      const result = await disabledController.getGeoRewardsMetadata();
 
       // Assert
       expect(result).toEqual({
@@ -7339,7 +7310,6 @@ describe('RewardsController', () => {
     };
 
     beforeEach(() => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
       // Clear calls resulting from top-level `beforeEach`
       jest.clearAllMocks();
     });
@@ -7421,11 +7391,14 @@ describe('RewardsController', () => {
 
     it('should return null when rewards feature is disabled', async () => {
       // Arrange
-      mockSelectRewardsEnabledFlag.mockReturnValue(false);
-      const mockAccounts = [mockEvmInternalAccount];
+      const disabledController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+        isDisabled: () => true,
+      });
 
       // Act
-      const result = await controller.optIn(mockAccounts);
+      const result = await disabledController.optIn([]);
 
       // Assert
       expect(result).toBeNull();
@@ -7835,10 +7808,16 @@ describe('RewardsController', () => {
       const mockAccounts = [mockEvmInternalAccount];
 
       // Mock rewards disabled check inside #optIn
-      mockSelectRewardsEnabledFlag.mockImplementation(() => {
-        // First call (in main optIn) returns true, second call (in #optIn) returns false
-        const callCount = mockSelectRewardsEnabledFlag.mock.calls.length;
-        return callCount === 1;
+      // Test with isDisabled callback that returns false initially, then true
+      let callCount = 0;
+      const isDisabled = () => {
+        callCount++;
+        return callCount === 2; // Second call returns true (disabled)
+      };
+      const testController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+        isDisabled,
       });
 
       mockMessenger.call.mockImplementation((_, ..._args): any =>
@@ -7851,7 +7830,7 @@ describe('RewardsController', () => {
       }));
 
       // Act & Assert
-      await expect(controller.optIn(mockAccounts)).rejects.toThrow(
+      await expect(testController.optIn(mockAccounts)).rejects.toThrow(
         'Failed to opt in any account from the account group',
       );
     });
@@ -8058,10 +8037,6 @@ describe('RewardsController', () => {
       },
     } as unknown as InternalAccount;
 
-    beforeEach(() => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
-    });
-
     it('should return empty array when accounts array is empty', async () => {
       // Act
       const result = await controller.linkAccountsToSubscriptionCandidate([]);
@@ -8072,7 +8047,6 @@ describe('RewardsController', () => {
 
     it('should return all accounts as failed when rewards feature is disabled', async () => {
       // Arrange
-      mockSelectRewardsEnabledFlag.mockReturnValue(false);
       const accounts = [mockEvmInternalAccount, mockEvmInternalAccount2];
 
       // Act
@@ -8308,10 +8282,6 @@ describe('RewardsController', () => {
   });
 
   describe('optOut', () => {
-    beforeEach(() => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
-    });
-
     it('should return false when subscription ID is not found', async () => {
       // Arrange
       const testController = new TestableRewardsController({
@@ -8551,10 +8521,6 @@ describe('RewardsController', () => {
   });
 
   describe('optIn and optOut edge cases', () => {
-    beforeEach(() => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
-    });
-
     describe('optIn edge cases', () => {
       it('should handle empty account group gracefully', async () => {
         // Arrange
@@ -8882,13 +8848,8 @@ describe('RewardsController', () => {
   });
 
   describe('getCandidateSubscriptionId', () => {
-    beforeEach(() => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
-    });
-
     it('should return null when feature flag is disabled', async () => {
       // Arrange
-      mockSelectRewardsEnabledFlag.mockReturnValue(false);
 
       // Act
       const result = await controller.getCandidateSubscriptionId();
@@ -9094,9 +9055,8 @@ describe('RewardsController', () => {
       // Create a test controller with a custom implementation
       class TestRewardsController extends RewardsController {
         async getCandidateSubscriptionId(): Promise<string | null> {
-          // Mock the first part of the method to return null for active account and subscriptions
-          const rewardsEnabled = selectRewardsEnabledFlag(store.getState());
-          if (!rewardsEnabled) {
+          // Mock the first part of the method to return null when disabled
+          if (this.isRewardsFeatureEnabled() === false) {
             return null;
           }
 
@@ -9948,17 +9908,20 @@ describe('RewardsController', () => {
     } as InternalAccount;
 
     beforeEach(() => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
       mockIsSolanaAddress.mockReturnValue(false); // Default to non-Solana
     });
 
     it('should return false when feature flag is disabled', async () => {
       // Arrange
-      mockSelectRewardsEnabledFlag.mockReturnValue(false);
+      const disabledController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+        isDisabled: () => true,
+      });
 
       // Act
       const result =
-        await controller.linkAccountToSubscriptionCandidate(
+        await disabledController.linkAccountToSubscriptionCandidate(
           mockInternalAccount,
         );
 
@@ -10910,18 +10873,21 @@ describe('RewardsController', () => {
     } as InternalAccount;
 
     beforeEach(() => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
       mockIsSolanaAddress.mockReturnValue(false);
     });
 
     it('should return all accounts as failed when feature flag is disabled', async () => {
       // Arrange
-      mockSelectRewardsEnabledFlag.mockReturnValue(false);
+      const disabledController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+        isDisabled: () => true,
+      });
       const accounts = [mockInternalAccount1, mockInternalAccount2];
 
       // Act
       const result =
-        await controller.linkAccountsToSubscriptionCandidate(accounts);
+        await disabledController.linkAccountsToSubscriptionCandidate(accounts);
 
       // Assert
       expect(result).toEqual([
@@ -10994,16 +10960,16 @@ describe('RewardsController', () => {
     const mockParams = { addresses: ['0x123', '0x456'] };
     const mockResponse = { ois: [true, false], sids: ['sub_123', null] };
 
-    beforeEach(() => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
-    });
-
     it('should return false array when feature flag is disabled', async () => {
       // Arrange
-      mockSelectRewardsEnabledFlag.mockReturnValue(false);
+      const disabledController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+        isDisabled: () => true,
+      });
 
       // Act
-      const result = await controller.getOptInStatus(mockParams);
+      const result = await disabledController.getOptInStatus(mockParams);
 
       // Assert
       expect(result).toEqual({ ois: [false, false], sids: [null, null] });
@@ -11626,7 +11592,6 @@ describe('RewardsController', () => {
 
       const mockResponse = { boosts: mockBoosts };
       mockMessenger.call.mockResolvedValue(mockResponse);
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
 
       // Act
       const result = await controller.getActivePointsBoosts(
@@ -11654,7 +11619,6 @@ describe('RewardsController', () => {
       const mockResponse = { boosts: mockEmptyBoosts };
 
       mockMessenger.call.mockResolvedValue(mockResponse);
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
 
       // Act
       const result = await controller.getActivePointsBoosts(
@@ -11674,7 +11638,6 @@ describe('RewardsController', () => {
       const mockError = new Error('Data service error');
 
       mockMessenger.call.mockRejectedValue(mockError);
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
 
       // Act & Assert
       await expect(
@@ -11695,7 +11658,6 @@ describe('RewardsController', () => {
       const timeoutError = new Error('Request timeout after 10000ms');
 
       mockMessenger.call.mockRejectedValue(timeoutError);
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
 
       // Act & Assert
       await expect(
@@ -11710,7 +11672,6 @@ describe('RewardsController', () => {
       const authError = new Error('Authentication failed');
 
       mockMessenger.call.mockRejectedValue(authError);
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
 
       // Act & Assert
       await expect(
@@ -11738,7 +11699,6 @@ describe('RewardsController', () => {
 
       const mockResponse = { boosts: mockBoosts };
       mockMessenger.call.mockResolvedValue(mockResponse);
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
 
       // Act
       const result = await controller.getActivePointsBoosts(
@@ -11758,12 +11718,16 @@ describe('RewardsController', () => {
 
     it('should return empty array when rewards feature is disabled', async () => {
       // Arrange
+      const disabledController = new RewardsController({
+        messenger: mockMessenger,
+        state: getRewardsControllerDefaultState(),
+        isDisabled: () => true,
+      });
       const seasonId = 'season-123';
       const subscriptionId = 'sub-456';
-      mockSelectRewardsEnabledFlag.mockReturnValue(false);
 
       // Act
-      const result = await controller.getActivePointsBoosts(
+      const result = await disabledController.getActivePointsBoosts(
         seasonId,
         subscriptionId,
       );
@@ -11829,8 +11793,6 @@ describe('RewardsController', () => {
           },
         },
       });
-
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
 
       // Act
       const result = await controller.getActivePointsBoosts(
@@ -11925,7 +11887,6 @@ describe('RewardsController', () => {
 
       const mockResponse = { boosts: mockFreshBoosts };
       mockMessenger.call.mockResolvedValue(mockResponse);
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
 
       // Act
       const result = await controller.getActivePointsBoosts(
@@ -11994,7 +11955,6 @@ describe('RewardsController', () => {
 
       const mockResponse = { boosts: mockFreshBoosts };
       mockMessenger.call.mockResolvedValue(mockResponse);
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
 
       // Act
       const result = await controller.getActivePointsBoosts(
@@ -12057,7 +12017,6 @@ describe('RewardsController', () => {
 
       const mockResponse = { boosts: mockBoosts };
       mockMessenger.call.mockResolvedValue(mockResponse);
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
 
       // Act
       const result = await controller.getActivePointsBoosts(
@@ -12154,7 +12113,6 @@ describe('RewardsController', () => {
       // Clear any calls made during controller initialization
       mockMessenger.call.mockClear();
 
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
       const mockResponse2 = { boosts: mockBoosts2 };
       mockMessenger.call.mockResolvedValue(mockResponse2);
 
@@ -12213,19 +12171,16 @@ describe('RewardsController', () => {
         registerInitialEventPayload: jest.fn(),
         unsubscribe: jest.fn(),
       } as unknown as jest.Mocked<RewardsControllerMessenger>;
-
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
     });
 
     it('should return empty array when feature flag is disabled', async () => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(false);
-
-      controller = new RewardsController({
+      const disabledController = new RewardsController({
         messenger: mockMessenger,
         state: getRewardsControllerDefaultState(),
+        isDisabled: () => true,
       });
 
-      const result = await controller.getUnlockedRewards(
+      const result = await disabledController.getUnlockedRewards(
         mockSeasonId,
         mockSubscriptionId,
       );
@@ -12603,7 +12558,6 @@ describe('RewardsController', () => {
     const mockSubscriptionId = 'test-subscription-id';
 
     beforeEach(() => {
-      mockSelectRewardsEnabledFlag.mockReturnValue(true);
       mockMessenger.call.mockClear();
       mockMessenger.publish.mockClear();
       mockLogger.log.mockClear();
@@ -12764,15 +12718,15 @@ describe('RewardsController', () => {
 
     it('should throw error when rewards are not enabled', async () => {
       // Arrange
-      mockSelectRewardsEnabledFlag.mockReturnValue(false);
-      controller = new RewardsController({
+      const disabledController = new RewardsController({
         messenger: mockMessenger,
         state: getRewardsControllerDefaultState(),
+        isDisabled: () => true,
       });
 
       // Act & Assert
       await expect(
-        controller.claimReward(mockRewardId, mockSubscriptionId),
+        disabledController.claimReward(mockRewardId, mockSubscriptionId),
       ).rejects.toThrow('Rewards are not enabled');
 
       expect(mockMessenger.call).not.toHaveBeenCalled();

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -40,8 +40,6 @@ import Logger from '../../../../util/Logger';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import { isAddress as isSolanaAddress } from '@solana/addresses';
 import { isHardwareAccount } from '../../../../util/address';
-import { selectRewardsEnabledFlag } from '../../../../selectors/featureFlagController/rewards';
-import { store } from '../../../../store';
 import {
   CaipAccountId,
   parseCaipChainId,
@@ -1602,13 +1600,13 @@ export class RewardsController extends BaseController<
   }
 
   /**
-   * Check if the rewards feature is enabled via feature flag
+   * Check if the rewards feature is enabled
    * @returns boolean - True if rewards feature is enabled, false otherwise
    */
   isRewardsFeatureEnabled(): boolean {
     const isDisabled = this.#isDisabled();
     if (isDisabled) return false;
-    return selectRewardsEnabledFlag(store.getState());
+    return true;
   }
 
   /**

--- a/app/selectors/featureFlagController/rewards/index.test.ts
+++ b/app/selectors/featureFlagController/rewards/index.test.ts
@@ -1,5 +1,4 @@
 import {
-  selectRewardsEnabledFlag,
   selectRewardsAnnouncementModalEnabledFlag,
   selectRewardsCardSpendFeatureFlags,
   selectRewardsMusdDepositEnabledFlag,
@@ -29,92 +28,6 @@ describe('Rewards Feature Flag Selectors', () => {
 
   afterEach(() => {
     mockHasMinimumRequiredVersion?.mockRestore();
-  });
-
-  describe('selectRewardsEnabledFlag', () => {
-    it('returns false when basic functionality is disabled', () => {
-      const result = selectRewardsEnabledFlag.resultFunc(
-        {
-          rewardsEnabled: {
-            enabled: true,
-            minimumVersion: '1.0.0',
-          },
-        },
-        false,
-      );
-
-      expect(result).toBe(false);
-    });
-
-    it('returns true when remote flag is valid and enabled and basic functionality is enabled', () => {
-      const result = selectRewardsEnabledFlag.resultFunc(
-        {
-          rewardsEnabled: {
-            enabled: true,
-            minimumVersion: '1.0.0',
-          },
-        },
-        true,
-      );
-
-      expect(result).toBe(true);
-    });
-
-    it('returns false when remote flag is valid but disabled and basic functionality is enabled', () => {
-      const result = selectRewardsEnabledFlag.resultFunc(
-        {
-          rewardsEnabled: {
-            enabled: false,
-            minimumVersion: '1.0.0',
-          },
-        },
-        true,
-      );
-
-      expect(result).toBe(false);
-    });
-
-    it('returns false when version check fails and basic functionality is enabled', () => {
-      mockHasMinimumRequiredVersion.mockReturnValue(false);
-
-      const result = selectRewardsEnabledFlag.resultFunc(
-        {
-          rewardsEnabled: {
-            enabled: true,
-            minimumVersion: '99.0.0',
-          },
-        },
-        true,
-      );
-
-      expect(result).toBe(false);
-    });
-
-    it('returns false when remote flag is invalid and basic functionality is enabled', () => {
-      const result = selectRewardsEnabledFlag.resultFunc(
-        {
-          rewardsEnabled: {
-            enabled: 'invalid',
-            minimumVersion: 123,
-          },
-        },
-        true,
-      );
-
-      expect(result).toBe(false);
-    });
-
-    it('returns false when remote feature flags are empty and basic functionality is enabled', () => {
-      const result = selectRewardsEnabledFlag.resultFunc({}, true);
-
-      expect(result).toBe(false);
-    });
-
-    it('returns false when remote feature flags are empty and basic functionality is disabled', () => {
-      const result = selectRewardsEnabledFlag.resultFunc({}, false);
-
-      expect(result).toBe(false);
-    });
   });
 
   describe('selectRewardsAnnouncementModalEnabledFlag', () => {

--- a/app/selectors/featureFlagController/rewards/index.ts
+++ b/app/selectors/featureFlagController/rewards/index.ts
@@ -5,50 +5,27 @@ import {
   validatedVersionGatedFeatureFlag,
   VersionGatedFeatureFlag,
 } from '../../../util/remoteFeatureFlag';
-import { selectBasicFunctionalityEnabled } from '../../settings';
 
-const DEFAULT_REWARDS_ENABLED = false;
+const DEFAULT_REWARDS_ANNOUNCEMENT_MODAL_ENABLED = false;
 const DEFAULT_CARD_SPEND_ENABLED = false;
 const DEFAULT_MUSD_DEPOSIT_ENABLED = false;
-export const FEATURE_FLAG_NAME = 'rewardsEnabled';
 export const ANNOUNCEMENT_MODAL_FLAG_NAME = 'rewardsAnnouncementModalEnabled';
 export const CARD_SPEND_FLAG_NAME = 'rewardsEnableCardSpend';
 export const MUSD_DEPOSIT_FLAG_NAME = 'rewardsEnableMusdDeposit';
-
-export const selectRewardsEnabledFlag = createSelector(
-  selectRemoteFeatureFlags,
-  selectBasicFunctionalityEnabled,
-  (remoteFeatureFlags, isBasicFunctionalityEnabled) => {
-    // If basic functionality is disabled, rewards should be disabled
-    if (!isBasicFunctionalityEnabled) {
-      return false;
-    }
-
-    if (!hasProperty(remoteFeatureFlags, FEATURE_FLAG_NAME)) {
-      return DEFAULT_REWARDS_ENABLED;
-    }
-    const remoteFlag = remoteFeatureFlags[
-      FEATURE_FLAG_NAME
-    ] as unknown as VersionGatedFeatureFlag;
-
-    return (
-      validatedVersionGatedFeatureFlag(remoteFlag) ?? DEFAULT_REWARDS_ENABLED
-    );
-  },
-);
 
 export const selectRewardsAnnouncementModalEnabledFlag = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags) => {
     if (!hasProperty(remoteFeatureFlags, ANNOUNCEMENT_MODAL_FLAG_NAME)) {
-      return DEFAULT_REWARDS_ENABLED;
+      return DEFAULT_REWARDS_ANNOUNCEMENT_MODAL_ENABLED;
     }
     const remoteFlag = remoteFeatureFlags[
       ANNOUNCEMENT_MODAL_FLAG_NAME
     ] as unknown as VersionGatedFeatureFlag;
 
     return (
-      validatedVersionGatedFeatureFlag(remoteFlag) ?? DEFAULT_REWARDS_ENABLED
+      validatedVersionGatedFeatureFlag(remoteFlag) ??
+      DEFAULT_REWARDS_ANNOUNCEMENT_MODAL_ENABLED
     );
   },
 );

--- a/e2e/pages/Settings/SettingsView.ts
+++ b/e2e/pages/Settings/SettingsView.ts
@@ -5,6 +5,7 @@ import {
   SettingsViewSelectorsText,
 } from '../../selectors/Settings/SettingsView.selectors';
 import { CommonSelectorsText } from '../../selectors/Common.selectors';
+import { NetworksViewSelectorsIDs } from '../../selectors/Settings/NetworksView.selectors';
 
 class SettingsView {
   get title(): DetoxElement {
@@ -191,6 +192,16 @@ class SettingsView {
 
     await Gestures.tap(this.snapsSectionButton, {
       elemDescription: 'Settings - Snaps Button',
+    });
+  }
+
+  get closeButton(): DetoxElement {
+    return Matchers.getElementByID(NetworksViewSelectorsIDs.CLOSE_ICON);
+  }
+
+  async tapCloseButton(): Promise<void> {
+    await Gestures.tap(this.closeButton, {
+      elemDescription: 'Settings - Close Button',
     });
   }
 }

--- a/e2e/pages/wallet/TabBarComponent.ts
+++ b/e2e/pages/wallet/TabBarComponent.ts
@@ -81,9 +81,9 @@ class TabBarComponent {
   async tapSettings(): Promise<void> {
     await Utilities.executeWithRetry(
       async () => {
-        await Gestures.waitAndTap(this.tabBarSettingButton, {
-          elemDescription: 'Tab Bar - Settings Button',
-        });
+        // Ensure we're on WalletView where the hamburger menu is located
+        await this.tapWallet();
+        await WalletView.tapHamburgerMenu();
         await Assertions.expectElementToBeVisible(SettingsView.title);
       },
       {

--- a/e2e/pages/wallet/WalletView.ts
+++ b/e2e/pages/wallet/WalletView.ts
@@ -51,6 +51,12 @@ class WalletView {
     );
   }
 
+  get hamburgerMenuButton(): DetoxElement {
+    return Matchers.getElementByID(
+      WalletViewSelectorsIDs.WALLET_HAMBURGER_MENU_BUTTON,
+    );
+  }
+
   get navbarNetworkText(): DetoxElement {
     return Matchers.getElementByID(WalletViewSelectorsIDs.NAVBAR_NETWORK_TEXT);
   }
@@ -217,6 +223,12 @@ class WalletView {
   async tapBellIcon(): Promise<void> {
     await Gestures.waitAndTap(this.notificationBellIcon, {
       elemDescription: 'Notification Bell Icon',
+    });
+  }
+
+  async tapHamburgerMenu(): Promise<void> {
+    await Gestures.waitAndTap(this.hamburgerMenuButton, {
+      elemDescription: 'Hamburger Menu Button',
     });
   }
 

--- a/e2e/selectors/wallet/WalletView.selectors.ts
+++ b/e2e/selectors/wallet/WalletView.selectors.ts
@@ -6,6 +6,7 @@ export const WalletViewSelectorsIDs = {
   NFT_CONTAINER: 'collectible-name',
   WALLET_SCAN_BUTTON: 'wallet-scan-button',
   WALLET_NOTIFICATIONS_BUTTON: 'wallet-notifications-button',
+  WALLET_HAMBURGER_MENU_BUTTON: 'navbar-hamburger-menu-button',
   WALLET_TOKEN_DETECTION_LINK_BUTTON: 'wallet-token-detection-link-button',
   TOTAL_BALANCE_TEXT: 'total-balance-text',
   CARD_BUTTON: 'card-button',

--- a/e2e/specs/identity/account-syncing/account-syncing-settings-toggle.spec.ts
+++ b/e2e/specs/identity/account-syncing/account-syncing-settings-toggle.spec.ts
@@ -132,7 +132,7 @@ describe(SmokeIdentity('Account syncing - Setting'), () => {
           SettingsView.backupAndSyncSectionButton,
         );
         // Close settings drawer (opened from hamburger menu) to return to wallet view
-        await CommonView.tapBackButton();
+        await SettingsView.tapCloseButton();
         await Assertions.expectElementToBeVisible(WalletView.container);
         // Wait for settings drawer to fully close and tab bar to be visible
         await Assertions.expectElementToBeVisible(

--- a/e2e/specs/identity/account-syncing/account-syncing-settings-toggle.spec.ts
+++ b/e2e/specs/identity/account-syncing/account-syncing-settings-toggle.spec.ts
@@ -131,8 +131,13 @@ describe(SmokeIdentity('Account syncing - Setting'), () => {
         await Assertions.expectElementToBeVisible(
           SettingsView.backupAndSyncSectionButton,
         );
-        await TabBarComponent.tapWallet();
+        // Close settings drawer (opened from hamburger menu) to return to wallet view
+        await CommonView.tapBackButton();
         await Assertions.expectElementToBeVisible(WalletView.container);
+        // Wait for settings drawer to fully close and tab bar to be visible
+        await Assertions.expectElementToBeVisible(
+          TabBarComponent.tabBarWalletButton,
+        );
 
         // Create third account with sync disabled - this should NOT sync to user storage
         await WalletView.tapIdenticon();

--- a/e2e/specs/identity/contact-syncing/contact-sync-toggle.spec.ts
+++ b/e2e/specs/identity/contact-syncing/contact-sync-toggle.spec.ts
@@ -12,6 +12,7 @@ import BackupAndSyncView from '../../../pages/Settings/BackupAndSyncView';
 import { createUserStorageController } from '../utils/mocks.ts';
 import ContactsView from '../../../pages/Settings/Contacts/ContactsView.ts';
 import AddContactView from '../../../pages/Settings/Contacts/AddContactView.ts';
+import CommonView from '../../../pages/CommonView.ts';
 
 describe(SmokeIdentity('Contacts syncing - Settings'), () => {
   let sharedUserStorageController: UserStorageMockttpController;
@@ -87,6 +88,8 @@ describe(SmokeIdentity('Contacts syncing - Settings'), () => {
         await SettingsView.tapContacts();
         await Assertions.expectElementToBeVisible(ContactsView.container);
         await ContactsView.expectContactIsVisible(TEST_CONTACT_NAME);
+        await CommonView.tapBackButton();
+        await SettingsView.tapCloseButton();
 
         // Disable contact syncing
         await TabBarComponent.tapSettings();
@@ -105,6 +108,9 @@ describe(SmokeIdentity('Contacts syncing - Settings'), () => {
         await Assertions.expectToggleToBeOff(
           BackupAndSyncView.contactSyncToggle,
         );
+
+        await CommonView.tapBackButton();
+        await SettingsView.tapCloseButton();
 
         // Add second contact while sync is disabled
         await TabBarComponent.tapSettings();


### PR DESCRIPTION
## **Description**

Remove rewards feature flag, this is now always enabled.

## **Changelog**

CHANGELOG entry: null

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the rewards feature flag across app, always enables Rewards UI/flows, updates navigation, hooks, controller logic, selectors, and tests/e2e accordingly.
> 
> - **Navigation/UI**:
>   - Always render and navigate to `Routes.REWARDS_VIEW`; remove `selectRewardsEnabledFlag` checks in `TabBar`, `MainNavigator`, and tests/snapshots.
>   - Navbar: always show hamburger menu button; `getSettingsNavigationOptions` always renders a close button and no longer accepts rewards flag; update Wallet/Settings to stop passing it.
> - **Perps**:
>   - Replace `navigateToRewardsOrSettings` with `navigateToRewards`; remove rewards flag usage in `usePerpsNavigation`, `usePerpsOrderFees`, and `usePerpsRewards`, enabling rewards-related calls unconditionally; update related tests.
> - **Rewards onboarding**:
>   - `useRewardsIntroModal` no longer depends on rewards-enabled flag; continues to use announcement flag and subscription checks.
> - **Controller**:
>   - `RewardsController` no longer reads Redux feature flag; `isRewardsFeatureEnabled` now only respects `isDisabled` callback; update tests to reflect new gating.
> - **Selectors**:
>   - Remove `selectRewardsEnabledFlag` and related tests; keep other rewards selectors (e.g., announcement modal) with defaults.
> - **E2E**:
>   - Settings access updated to use wallet hamburger menu and new close button; adjust tests to close drawer before proceeding.
> - **Tests/Snapshots**:
>   - Widespread updates to unit tests and snapshots to remove rewards flag conditions and assert Rewards tab/button presence.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43da35a63727ce16571dcb91b5d154f6716de44b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->