### PR TITLE
fix: btc account selection during btc network change cp-7.59.0

### DIFF
--- a/app/components/hooks/useNetworkSelection/useNetworkSelection.test.ts
+++ b/app/components/hooks/useNetworkSelection/useNetworkSelection.test.ts
@@ -1308,21 +1308,6 @@ describe('useNetworkSelection', () => {
       );
       expect(mockEnableNetwork).toHaveBeenCalledWith(bitcoinMainnet);
     });
-
-    it('selectPopularNetwork sets selected address for Bitcoin networks', async () => {
-      const setSelectedAddressSpy = jest.spyOn(Engine, 'setSelectedAddress');
-
-      const { result } = renderHook(() =>
-        useNetworkSelection({ networks: mockNetworks }),
-      );
-
-      await result.current.selectPopularNetwork(bitcoinMainnet);
-
-      expect(setSelectedAddressSpy).toHaveBeenCalledWith(
-        mockBitcoinAccount.address,
-      );
-      expect(mockEnableNetwork).toHaveBeenCalledWith(bitcoinMainnet);
-    });
   });
 
   describe('error handling and edge cases', () => {

--- a/app/components/hooks/useNetworkSelection/useNetworkSelection.ts
+++ b/app/components/hooks/useNetworkSelection/useNetworkSelection.ts
@@ -205,18 +205,6 @@ export const useNetworkSelection = ({
   /** Toggles a popular network and resets all custom networks */
   const selectPopularNetwork = useCallback(
     async (chainId: CaipChainId, onComplete?: () => void) => {
-      ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
-      if (chainId.includes(KnownCaipNamespace.Bip122)) {
-        const bitcoAccountInScope = bitcoinInternalAccounts.find((account) =>
-          account.scopes.includes(chainId),
-        );
-
-        if (bitcoAccountInScope) {
-          Engine.setSelectedAddress(bitcoAccountInScope.address);
-        }
-      }
-      ///: END:ONLY_INCLUDE_IF
-
       // Enable the network in NetworkEnablementController
       await enableNetwork(chainId);
 
@@ -225,13 +213,7 @@ export const useNetworkSelection = ({
 
       onComplete?.();
     },
-    [
-      enableNetwork,
-      switchActiveNetwork,
-      ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
-      bitcoinInternalAccounts,
-      ///: END:ONLY_INCLUDE_IF(bitcoin)
-    ],
+    [enableNetwork, switchActiveNetwork],
   );
 
   /** Selects a network, automatically handling popular vs custom logic */


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes the issue when the user selects a BTC network, it would switch the user to the first multichain account. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Changing networks to btc does not switch the selected account.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/22236#event-20790225755

## **Manual testing steps**

```gherkin
Feature: network switching

  Scenario: user wants to change the network filter
    Given the user is using a multichain account

    When user selected the btc network
    Then the account does not change.
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/ee43b688-8f64-4d16-bde9-b7efecef6cfe



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stops auto-switching to a BTC account when toggling a popular BTC network; BTC address selection now only occurs during custom BTC network selection.
> 
> - **Hooks (`useNetworkSelection.ts`)**:
>   - Remove Bitcoin-specific `Engine.setSelectedAddress` logic from `selectPopularNetwork`; keep BTC address handling only in `selectCustomNetwork`.
>   - Simplify `selectPopularNetwork` dependencies to exclude Bitcoin internals.
> - **Tests (`useNetworkSelection.test.ts`)**:
>   - Delete test asserting BTC address is set on `selectPopularNetwork` for Bitcoin networks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4746e4f5f39cc537bd66f8dd8a6e853b63a0cbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->