### PR TITLE
chore(runway): cherry-pick fix: cp-7.58.2 update close position calculation with funding fees and live data

### DIFF
--- a/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
@@ -48,7 +48,11 @@ import {
   usePerpsRewards,
   usePerpsToasts,
 } from '../../hooks';
-import { usePerpsLivePrices, usePerpsTopOfBook } from '../../hooks/stream';
+import {
+  usePerpsLivePositions,
+  usePerpsLivePrices,
+  usePerpsTopOfBook,
+} from '../../hooks/stream';
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
 import { usePerpsMeasurement } from '../../hooks/usePerpsMeasurement';
 import {
@@ -127,9 +131,19 @@ const PerpsClosePositionView: React.FC = () => {
     symbol: position.coin,
   });
 
-  // Determine position direction
-  const isLong = parseFloat(position.size) > 0;
-  const absSize = Math.abs(parseFloat(position.size));
+  // Subscribe to live position updates for this coin
+  // This ensures margin and PnL values include real-time funding fees
+  const { positions: livePositions } = usePerpsLivePositions({
+    throttleMs: 1000,
+  });
+  const livePosition = useMemo(
+    () => livePositions.find((p) => p.coin === position.coin) || position,
+    [livePositions, position],
+  );
+
+  // Determine position direction using live position data
+  const isLong = parseFloat(livePosition.size) > 0;
+  const absSize = Math.abs(parseFloat(livePosition.size));
   // Calculate effective price for calculations
   // For limit orders, use limit price when available; otherwise use current market price
   const effectivePrice = useMemo(() => {
@@ -162,12 +176,25 @@ const PerpsClosePositionView: React.FC = () => {
       ? closeAmountUSDString
       : calculatedUSDString;
 
+  // Use live position data which includes real-time funding fees
+  // HyperLiquid's marginUsed already includes accumulated PnL
+  const marginUsed = parseFloat(livePosition.marginUsed);
+
+  // Use unrealizedPnl from live position (includes funding fees)
+  const unrealizedPnl = parseFloat(livePosition.unrealizedPnl);
+
+  // Keep pnl reference for backwards compatibility with event tracking
+  const pnl = unrealizedPnl;
+
   // Calculate position value and effective margin
   // For limit orders, use limit price for display calculations
-  const positionValue = useMemo(
-    () => absSize * effectivePrice,
-    [absSize, effectivePrice], // Round to 2 decimal places
-  );
+  const positionValue = useMemo(() => {
+    const priceToUse =
+      orderType === 'limit' && limitPrice
+        ? parseFloat(limitPrice)
+        : currentPrice;
+    return absSize * priceToUse;
+  }, [absSize, orderType, limitPrice, currentPrice]);
 
   // Calculate P&L based on effective price (limit price for limit orders)
   const entryPrice = parseFloat(position.entryPrice);
@@ -175,21 +202,19 @@ const PerpsClosePositionView: React.FC = () => {
     // Calculate P&L based on the effective price (limit price for limit orders)
     // For long positions: (effectivePrice - entryPrice) * absSize
     // For short positions: (entryPrice - effectivePrice) * absSize
+    if (orderType === 'market') {
+      return pnl;
+    }
+    const priceToUse = limitPrice ? parseFloat(limitPrice) : currentPrice;
     const priceDiff = isLong
-      ? effectivePrice - entryPrice
-      : entryPrice - effectivePrice;
+      ? priceToUse - entryPrice
+      : entryPrice - priceToUse;
     return priceDiff * absSize;
-  }, [effectivePrice, entryPrice, absSize, isLong]);
-
-  // Use the actual initial margin from the position
-  const initialMargin = parseFloat(position.marginUsed);
-
-  // Use unrealized PnL from position for current market price (for reference/tracking)
-  const pnl = parseFloat(position.unrealizedPnl);
+  }, [entryPrice, absSize, isLong, orderType, limitPrice, currentPrice, pnl]); // Exclude effectivePrice from deps
 
   // Calculate fees using the unified fee hook
   const closingValue = useMemo(
-    () => positionValue * (closePercentage / 100), // Round to 2 decimal places
+    () => positionValue * (closePercentage / 100),
     [positionValue, closePercentage],
   );
   const closingValueString = useMemo(
@@ -226,13 +251,17 @@ const PerpsClosePositionView: React.FC = () => {
     orderAmount: closingValueString,
   });
 
-  // Calculate what user will receive (initial margin + P&L - fees)
-  // P&L is already shown separately in the margin section as "includes P&L"
+  // Calculate what user will receive (margin - fees)
+  // Round each component separately to match what user sees in UI
+  // This ensures: displayed margin - displayed fees = displayed receive amount
   const receiveAmount = useMemo(() => {
-    const marginPortion = (closePercentage / 100) * initialMargin;
-    const pnlPortion = effectivePnL * (closePercentage / 100);
-    return marginPortion + pnlPortion - feeResults.totalFee;
-  }, [closePercentage, initialMargin, effectivePnL, feeResults.totalFee]);
+    const marginPortion = (closePercentage / 100) * marginUsed;
+    // Round margin and fees to 2 decimals (what user sees)
+    const roundedMargin = Math.round(marginPortion * 100) / 100;
+    const roundedFees = Math.round(feeResults.totalFee * 100) / 100;
+    // Subtract rounded values for transparent calculation
+    return roundedMargin - roundedFees;
+  }, [closePercentage, marginUsed, feeResults.totalFee]);
 
   // Get minimum order amount for this asset
   const { minimumOrderAmount } = useMinimumOrderAmount({
@@ -262,10 +291,10 @@ const PerpsClosePositionView: React.FC = () => {
 
   const { handleClosePosition, isClosing } = usePerpsClosePosition();
 
-  const unrealizedPnlPercent = useMemo(
-    () => (initialMargin > 0 ? (pnl / initialMargin) * 100 : 0),
-    [initialMargin, pnl],
-  );
+  const unrealizedPnlPercent = useMemo(() => {
+    const initialMargin = marginUsed - pnl; // Back-calculate initial margin
+    return initialMargin > 0 ? (pnl / initialMargin) * 100 : 0;
+  }, [marginUsed, pnl]);
 
   usePerpsEventTracking({
     eventName: MetaMetricsEvents.PERPS_SCREEN_VIEWED,
@@ -311,7 +340,7 @@ const PerpsClosePositionView: React.FC = () => {
     navigation.goBack();
 
     await handleClosePosition(
-      position,
+      livePosition,
       sizeToClose || '',
       orderType,
       orderType === 'limit' ? limitPrice : undefined,
@@ -487,13 +516,9 @@ const PerpsClosePositionView: React.FC = () => {
         </View>
         <View style={styles.summaryValue}>
           <Text variant={TextVariant.BodyMD}>
-            {formatPerpsFiat(
-              (closePercentage / 100) * initialMargin +
-                effectivePnL * (closePercentage / 100),
-              {
-                ranges: PRICE_RANGES_MINIMAL_VIEW,
-              },
-            )}
+            {formatPerpsFiat((closePercentage / 100) * marginUsed, {
+              ranges: PRICE_RANGES_MINIMAL_VIEW,
+            })}
           </Text>
           <View style={styles.inclusiveFeeRow}>
             <Text variant={TextVariant.BodySM} color={TextColor.Default}>


### PR DESCRIPTION
fix: cp-7.59.0 hotfix-7.58.2 update close position calculation with funding fees and live data (https://github.com/MetaMask/metamask-mobile/pull/22229)
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been
completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes bug where close position view showed incorrect receive amounts,
sometimes displaying negative values when position value had dropped.

Root causes:
1. Used stale position data from route params instead of live WebSocket
updates
2. HyperLiquid's marginUsed already includes PnL, but code was
double-counting
3. Recalculated PnL from prices, which missed accumulated funding fees
4. Timing mismatch between price updates and position updates

Changes:
- Add usePerpsLivePositions to subscribe to real-time position data
- Use livePosition.marginUsed which already includes accumulated PnL and
funding fees
- Use livePosition.positionValue for fee calculations to keep margin and
fees synchronized
- Remove effectivePnL recalculation that missed funding fees
- Round margin and fees separately before subtraction for transparent
calculation
- Update tests to reflect that marginUsed includes PnL from HyperLiquid

Result:
- Position card and close position view now show matching margin values
- Funding fees correctly included in all calculations
- No more incorrect negative receive amounts
- Calculation transparency: displayed margin - displayed fees =
displayed receive amount

<!--
Write a short description of the changes included in this pull request,
also include relevant motivation and context. Have in mind the following
questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the
CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing
description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and
accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1956    

## **Manual testing steps**

```gherkin
Feature: Close Position Calculation with Funding Fees

  Scenario: Close position with accumulated funding fees shows correct receive amount
    Given I have an open position with the following details:
      | Coin          | ETH    |
      | Margin Used   | $100   |
      | Unrealized PnL| -$5    |
      | Entry Price   | $2000  |
      | Current Price | $2000  |
    When I navigate to the close position view
    And I view the close position summary
    Then the margin displayed should be "$100"
    And the receive amount should match "margin - fees"
    And the receive amount should be positive
    And the receive amount should not be negative or zero

  Scenario: Receive amount calculation matches visual breakdown
    Given I have an open position
    When I view the close position summary
    Then the displayed margin should be rounded to 2 decimals
    And the displayed fees should be rounded to 2 decimals
    And the receive amount should equal "rounded margin minus rounded fees"
    And the calculation should be transparent to the user
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the
before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/29289663-7b77-45f7-8ff6-c48917e1e21a

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor
Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile
Coding
Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format
if applicable
- [x] I’ve applied the right labels on the PR (see [labeling
guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).
Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the
app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described
in the ticket it closes and includes the necessary testing evidence such
as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update close position logic to use live position data (including funding fees) and compute receive amount as rounded margin portion minus rounded fees, with extensive test coverage and price-sync behavior.
> 
> - **PerpsClosePositionView (`PerpsClosePositionView.tsx`)**:
>   - Integrates `usePerpsLivePositions`; derives `livePosition` and uses `marginUsed` and `unrealizedPnl` for calculations and tracking.
>   - Computes `positionValue` from limit price when set, else current price; for market orders `effectivePnL` uses live `pnl`; for limit orders derives PnL from limit/current price vs entry.
>   - Replaces receive calculation with `receiveAmount = round(close% × marginUsed) − round(totalFee)`; updates summary UI to display `(close% × marginUsed)` and “includes PnL”.
>   - Back-calculates `unrealizedPnlPercent` from `marginUsed − pnl`; initializes USD amount once; improves input focus and syncing behavior; passes `livePosition` to `handleClosePosition`.
> - **Tests (`PerpsClosePositionView.test.tsx`)**:
>   - Mocks `usePerpsLivePositions` and updates expectations to reflect `marginUsed` includes PnL and new receive logic.
>   - Adds price update synchronization cases (live price changes, input sync, editing protection) and limit-order calculations.
>   - Removes reliance on market szDecimals; broadens interaction, validation, rewards, and tooltip coverage; updates confirm handler assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51cf3ccbeaba1ec8312c12dd9dcd51ea046171da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



---------

Co-authored-by: abretonc7s <107169956+abretonc7s@users.noreply.github.com>