### PR TITLE
fix: max predict withdraw

### DIFF
--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPredictBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPredictBalanceAlert.ts
@@ -22,7 +22,7 @@ export function useInsufficientPredictBalanceAlert({
   const { amountPrecise } = useTokenAmount();
   const amountHuman = pendingAmount ?? amountPrecise ?? '0';
 
-  const { balance: predictBalanceUsd } = usePredictBalance({
+  const { balance: predictBalanceHuman } = usePredictBalance({
     loadOnMount: true,
   });
 
@@ -33,8 +33,8 @@ export function useInsufficientPredictBalanceAlert({
   const isInsufficient = useMemo(
     () =>
       isPredictWithdraw &&
-      new BigNumber(predictBalanceUsd ?? '0').isLessThan(amountHuman),
-    [amountHuman, isPredictWithdraw, predictBalanceUsd],
+      new BigNumber(predictBalanceHuman ?? '0').isLessThan(amountHuman),
+    [amountHuman, isPredictWithdraw, predictBalanceHuman],
   );
 
   return useMemo(() => {

--- a/app/components/Views/confirmations/hooks/tokens/useTokenFiatRates.test.ts
+++ b/app/components/Views/confirmations/hooks/tokens/useTokenFiatRates.test.ts
@@ -3,6 +3,7 @@ import { backgroundState } from '../../../../../util/test/initial-root-state';
 import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
 import { TokenFiatRateRequest, useTokenFiatRates } from './useTokenFiatRates';
 import { ARBITRUM_USDC } from '../../constants/perps';
+import { POLYGON_USDCE } from '../../constants/predict';
 
 jest.mock('../../../../../util/address', () => ({
   toChecksumAddress: jest.fn((address) => address),
@@ -112,6 +113,20 @@ describe('useTokenFiatRates', () => {
         {
           address: ARBITRUM_USDC.address,
           chainId: CHAIN_IDS.ARBITRUM,
+          currency: 'usd',
+        },
+      ],
+    });
+
+    expect(result).toEqual([1]);
+  });
+
+  it('returns fixed exchange rate if Polygon USDCE and selected currency is USD', () => {
+    const result = runHook({
+      requests: [
+        {
+          address: POLYGON_USDCE.address,
+          chainId: CHAIN_IDS.POLYGON,
           currency: 'usd',
         },
       ],

--- a/app/components/Views/confirmations/hooks/tokens/useTokenFiatRates.ts
+++ b/app/components/Views/confirmations/hooks/tokens/useTokenFiatRates.ts
@@ -11,6 +11,7 @@ import { useDeepMemo } from '../useDeepMemo';
 import { toChecksumAddress } from '../../../../../util/address';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { ARBITRUM_USDC } from '../../constants/perps';
+import { POLYGON_USDCE } from '../../constants/predict';
 
 export interface TokenFiatRateRequest {
   address: Hex;
@@ -29,12 +30,17 @@ export function useTokenFiatRates(requests: TokenFiatRateRequest[]) {
     () =>
       safeRequests.map(({ address, chainId, currency: currencyOverride }) => {
         const currency = currencyOverride ?? selectedCurrency;
+        const isUsd = currency.toLowerCase() === 'usd';
 
-        if (
-          currency.toLowerCase() === 'usd' &&
+        const isArbitrumUSDC =
           address.toLowerCase() === ARBITRUM_USDC.address.toLowerCase() &&
-          chainId === CHAIN_IDS.ARBITRUM
-        ) {
+          chainId === CHAIN_IDS.ARBITRUM;
+
+        const isPolygonUSDCE =
+          address.toLowerCase() === POLYGON_USDCE.address.toLowerCase() &&
+          chainId === CHAIN_IDS.POLYGON;
+
+        if (isUsd && (isArbitrumUSDC || isPolygonUSDCE)) {
           return 1;
         }
 

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
@@ -342,8 +342,6 @@ describe('useTransactionCustomAmount', () => {
         {},
       ] as TransactionPayRequiredToken[]);
 
-      useParamsMock.mockReturnValue({ amount: '43.21' });
-
       const { result } = runHook();
 
       await act(async () => {
@@ -368,7 +366,7 @@ describe('useTransactionCustomAmount', () => {
       expect(result.current.amountFiat).toBe('1234.56');
     });
 
-    it('to percentage of predict balance', async () => {
+    it('to percentage of predict balance converted to USD', async () => {
       usePredictBalanceMock.mockReturnValue({ balance: 4321.23 } as never);
 
       const { result } = runHook({
@@ -381,7 +379,23 @@ describe('useTransactionCustomAmount', () => {
         result.current.updatePendingAmountPercentage(43);
       });
 
-      expect(result.current.amountFiat).toBe('1858.12');
+      expect(result.current.amountFiat).toBe('3716.25');
+    });
+
+    it('to total predict balance with no buffers if 100', async () => {
+      usePredictBalanceMock.mockReturnValue({ balance: 4321.23 } as never);
+
+      const { result } = runHook({
+        transactionMeta: {
+          type: TransactionType.predictWithdraw,
+        },
+      });
+
+      await act(async () => {
+        result.current.updatePendingAmountPercentage(100);
+      });
+
+      expect(result.current.amountFiat).toBe('8642.46');
     });
   });
 });


### PR DESCRIPTION
## **Description**

Ensure the Predict withdraw confirmation uses the entire balance if the `Max` button is used.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#6156](https://github.com/MetaMask/MetaMask-planning/issues/6156) #22190 

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure Predict withdraw Max uses the full balance converted to USD and add a fixed 1:1 USD rate for Polygon USDCE.
> 
> - **Confirmations / Amounts**:
>   - Convert Predict balance to USD via `tokenFiatRate` for withdraw calculations and `Max` behavior; default rate falls back to `1`.
>   - Refine max-percentage logic when pay token is missing or matches the first required token.
> - **Token Fiat Rates**:
>   - Return fixed `1` rate for `POLYGON_USDCE` on `POLYGON` when currency is USD (alongside `ARBITRUM_USDC`).
>   - Minor refactor for USD checks and token matches.
> - **Alerts**:
>   - Use human Predict balance in `useInsufficientPredictBalanceAlert` comparison.
> - **Tests**:
>   - Update and add tests for USDCE fixed rate and Predict withdraw USD conversion/max behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f179f68117eb8f4e87a46448fa94bc75b4fa2aa7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->