### PR TITLE
fix: safe area in full screen confirmations

### DIFF
--- a/app/components/Views/confirmations/components/confirm/confirm-component.styles.ts
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.styles.ts
@@ -16,11 +16,7 @@ const styleSheet = (params: {
       maxHeight: '100%',
     },
     flatContainer: {
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      right: 0,
-      bottom: 0,
+      flex: 1,
       zIndex: 9999,
       backgroundColor: theme.colors.background.alternative,
       justifyContent: 'space-between',

--- a/app/components/Views/confirmations/components/confirm/confirm-component.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.tsx
@@ -156,14 +156,18 @@ function Loader() {
 
   if (loader === ConfirmationLoader.CustomAmount) {
     return (
-      <View style={styles.flatContainer} testID="confirm-loader-custom-amount">
+      <SafeAreaView
+        edges={['right', 'bottom', 'left']}
+        style={styles.flatContainer}
+        testID="confirm-loader-custom-amount"
+      >
         <ScrollView
           style={styles.scrollView}
           contentContainerStyle={styles.scrollViewContent}
         >
           <CustomAmountInfoSkeleton />
         </ScrollView>
-      </View>
+      </SafeAreaView>
     );
   }
 

--- a/app/components/Views/confirmations/components/confirm/confirm-component.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.tsx
@@ -1,10 +1,5 @@
 import React, { useEffect } from 'react';
-import {
-  BackHandler,
-  StyleSheet,
-  TouchableWithoutFeedback,
-  View,
-} from 'react-native';
+import { BackHandler, TouchableWithoutFeedback, View } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import { useNavigation } from '@react-navigation/native';
 
@@ -31,6 +26,7 @@ import { TransactionType } from '@metamask/transaction-controller';
 import { useParams } from '../../../../../util/navigation/navUtils';
 import AnimatedSpinner, { SpinnerSize } from '../../../../UI/AnimatedSpinner';
 import { CustomAmountInfoSkeleton } from '../info/custom-amount-info';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export enum ConfirmationLoader {
   Default = 'default',
@@ -46,7 +42,7 @@ const ConfirmWrapped = ({
   styles,
   route,
 }: {
-  styles: StyleSheet.NamedStyles<Record<string, unknown>>;
+  styles: ReturnType<typeof styleSheet>;
   route?: UnstakeConfirmationViewProps['route'];
 }) => {
   const alerts = useConfirmationAlerts();
@@ -59,11 +55,7 @@ const ConfirmWrapped = ({
             <LedgerContextProvider>
               <Title />
               <ScrollView
-                // @ts-expect-error - React Native style type mismatch due to outdated @types/react-native
-                // See: https://github.com/MetaMask/metamask-mobile/pull/18956#discussion_r2316407382
                 style={styles.scrollView}
-                // @ts-expect-error - React Native style type mismatch due to outdated @types/react-native
-                // See: https://github.com/MetaMask/metamask-mobile/pull/18956#discussion_r2316407382
                 contentContainerStyle={styles.scrollViewContent}
                 nestedScrollEnabled
               >
@@ -133,9 +125,13 @@ export const Confirm = ({ route }: ConfirmProps) => {
   // Show confirmation in a flat container if the confirmation is full screen
   if (isFullScreenConfirmation) {
     return (
-      <View style={styles.flatContainer} testID={ConfirmationUIType.FLAT}>
+      <SafeAreaView
+        edges={['right', 'bottom', 'left']}
+        style={styles.flatContainer}
+        testID={ConfirmationUIType.FLAT}
+      >
         <ConfirmWrapped styles={styles} route={route} />
-      </View>
+      </SafeAreaView>
     );
   }
 


### PR DESCRIPTION
## **Description**

Respect safe area in full screen confirmations to accommodate navigation controls.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#6161](https://github.com/MetaMask/MetaMask-planning/issues/6161)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

<img width="300" alt="Confirmation" src="https://github.com/user-attachments/assets/c3e931ba-0224-4eb9-95b8-7046e6523b90" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wrap full-screen confirmation and custom-amount loader in SafeAreaView and switch layout to flex to respect device safe areas.
> 
> - **UI/Behavior**:
>   - Wrap full-screen confirmation (`ConfirmationUIType.FLAT`) and custom-amount loader with `SafeAreaView` using edges `['right','bottom','left']`.
> - **Styles**:
>   - Replace absolute positioning in `styles.flatContainer` with `flex: 1` for proper layout with safe areas.
> - **Code Cleanup**:
>   - Type improvement for `styles` prop (`ReturnType<typeof styleSheet>`); remove unnecessary `StyleSheet` import and TS expect-error comments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 643c9a47752b21061ba2288f82955586bc937f5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->