### PR TITLE
feat: predict deposit account created metric

### DIFF
--- a/app/core/Engine/controllers/transaction-controller/event_properties/metamask-pay.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/event_properties/metamask-pay.test.ts
@@ -46,19 +46,6 @@ describe('Metamask Pay Metrics', () => {
     });
   });
 
-  it('returns nothing if predict_deposit', () => {
-    request.transactionMeta.nestedTransactions = [
-      { type: TransactionType.predictDeposit },
-    ];
-
-    const result = getMetaMaskPayProperties(request);
-
-    expect(result).toStrictEqual({
-      properties: {},
-      sensitiveProperties: {},
-    });
-  });
-
   it('copies properties from parent transaction if bridge', () => {
     getUIMetricsMock.mockReturnValue({
       properties: {
@@ -358,5 +345,37 @@ describe('Metamask Pay Metrics', () => {
     const result = getMetaMaskPayProperties(request);
 
     expect(result.properties.mm_pay_dust_usd).toBeUndefined();
+  });
+
+  it('sets polymarket_account_created as true if predict deposit and matching nested transaction', () => {
+    request.transactionMeta.nestedTransactions = [
+      { type: TransactionType.predictDeposit },
+      { data: '0xa1884d2c1234' },
+    ];
+
+    const result = getMetaMaskPayProperties(request);
+
+    expect(result).toStrictEqual({
+      properties: {
+        polymarket_account_created: true,
+      },
+      sensitiveProperties: {},
+    });
+  });
+
+  it('sets polymarket_account_created as false if predict deposit with no matching nested transaction', () => {
+    request.transactionMeta.nestedTransactions = [
+      { type: TransactionType.predictDeposit },
+      { data: '0xa1884d2d' },
+    ];
+
+    const result = getMetaMaskPayProperties(request);
+
+    expect(result).toStrictEqual({
+      properties: {
+        polymarket_account_created: false,
+      },
+      sensitiveProperties: {},
+    });
   });
 });

--- a/app/core/Engine/controllers/transaction-controller/event_properties/metamask-pay.ts
+++ b/app/core/Engine/controllers/transaction-controller/event_properties/metamask-pay.ts
@@ -5,6 +5,8 @@ import { orderBy } from 'lodash';
 import { NATIVE_TOKEN_ADDRESS } from '../../../../../components/Views/confirmations/constants/tokens';
 import { hasTransactionType } from '../../../../../components/Views/confirmations/utils/transaction';
 
+const FOUR_BYTE_SAFE_PROXY_CREATE = '0xa1884d2c';
+
 const COPY_METRICS = [
   'mm_pay',
   'mm_pay_use_case',
@@ -31,6 +33,12 @@ export const getMetaMaskPayProperties: TransactionMetricsBuilder = ({
       tx.requiredTransactionIds?.includes(transactionId) ||
       (batchId && hasTransactionType(tx, PAY_TYPES) && tx.batchId === batchId),
   );
+
+  if (hasTransactionType(transactionMeta, [TransactionType.predictDeposit])) {
+    properties.polymarket_account_created = (
+      transactionMeta?.nestedTransactions ?? []
+    ).some((t) => t.data?.startsWith(FOUR_BYTE_SAFE_PROXY_CREATE));
+  }
 
   if (hasTransactionType(transactionMeta, PAY_TYPES) || !parentTransaction) {
     return {


### PR DESCRIPTION
## **Description**

Add `polymarket_account_created` property to transaction events if Predict deposit creates Safe proxy.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#5944](https://github.com/MetaMask/MetaMask-planning/issues/5944)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `polymarket_account_created` metric to Predict deposit transactions by detecting Safe proxy creation via 4-byte prefix, with accompanying tests.
> 
> - **Metrics**:
>   - Add `polymarket_account_created` to `getMetaMaskPayProperties` for `predictDeposit` based on nested tx data starting with `0xa1884d2c`.
>   - Introduce `FOUR_BYTE_SAFE_PROXY_CREATE` constant for detection.
> - **Tests**:
>   - Add tests asserting `polymarket_account_created` is set to `true`/`false` depending on presence of matching nested transaction.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00929144196761db987bb0b0359bb6cd72bfbe85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->