### PR TITLE
feat: metamask pay buy button

### DIFF
--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -54,6 +54,7 @@ import { useAccountTokens } from '../../../hooks/send/useAccountTokens';
 import { getNativeTokenAddress } from '../../../utils/asset';
 import { toCaipAssetType } from '@metamask/utils';
 import { AlignItems } from '../../../../../UI/Box/box.types';
+import { strings } from '../../../../../../../locales/i18n';
 
 export interface CustomAmountInfoProps {
   children?: ReactNode;
@@ -218,7 +219,7 @@ function BuySection() {
         Add funds to your wallet to use Predictions.
       </Text>
       <Button
-        label="Buy crypto"
+        label={strings('confirm.custom_amount.buy_button')}
         variant={ButtonVariants.Primary}
         onPress={handleBuyPress}
         width={ButtonWidthTypes.Full}

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -32,9 +32,28 @@ import {
 import {
   useIsTransactionPayLoading,
   useTransactionPayQuotes,
+  useTransactionPayRequiredTokens,
   useTransactionPaySourceAmounts,
 } from '../../../hooks/pay/useTransactionPayData';
 import { useTransactionPayMetrics } from '../../../hooks/pay/useTransactionPayMetrics';
+import { useTransactionPayAvailableTokens } from '../../../hooks/pay/useTransactionPayAvailableTokens';
+import Button, {
+  ButtonVariants,
+  ButtonWidthTypes,
+} from '../../../../../../component-library/components/Buttons/Button';
+import Text, {
+  TextColor,
+  TextVariant,
+} from '../../../../../../component-library/components/Texts/Text';
+import {
+  RampMode,
+  useRampNavigation,
+} from '../../../../../UI/Ramp/hooks/useRampNavigation';
+import { RampType } from '../../../../../../reducers/fiatOrders/types';
+import { useAccountTokens } from '../../../hooks/send/useAccountTokens';
+import { getNativeTokenAddress } from '../../../utils/asset';
+import { toCaipAssetType } from '@metamask/utils';
+import { AlignItems } from '../../../../../UI/Box/box.types';
 
 export interface CustomAmountInfoProps {
   children?: ReactNode;
@@ -51,6 +70,8 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     const { styles } = useStyles(styleSheet, {});
     const [isKeyboardVisible, setKeyboardVisible] = useState(true);
     const { setIsFooterVisible } = useConfirmationContext();
+    const availableTokens = useTransactionPayAvailableTokens();
+    const hasTokens = availableTokens.length > 0;
 
     const isResultReady = useIsResultReady({
       isKeyboardVisible,
@@ -94,8 +115,11 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
             currency={currency}
             hasAlert={Boolean(keyboardAlertMessage)}
             onPress={handleAmountPress}
+            disabled={!hasTokens}
           />
-          {disablePay !== true && <PayTokenAmount amountHuman={amountHuman} />}
+          {disablePay !== true && (
+            <PayTokenAmount amountHuman={amountHuman} disabled={!hasTokens} />
+          )}
           {children}
           {!isKeyboardVisible && (
             <AlertBanner
@@ -105,7 +129,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
               inline
             />
           )}
-          {disablePay !== true && (
+          {disablePay !== true && hasTokens && (
             <InfoSection>
               <PayWithRow />
             </InfoSection>
@@ -121,7 +145,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
             </>
           )}
         </Box>
-        {isKeyboardVisible && (
+        {isKeyboardVisible && hasTokens && (
           <DepositKeyboard
             alertMessage={keyboardAlertMessage}
             value={amountFiat}
@@ -131,6 +155,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
             hasInput={hasInput}
           />
         )}
+        {!hasTokens && <BuySection />}
       </Box>
     );
   },
@@ -149,6 +174,55 @@ export function CustomAmountInfoSkeleton() {
         </InfoSection>
       </Box>
       <DepositKeyboardSkeleton />
+    </Box>
+  );
+}
+
+function BuySection() {
+  const tokens = useAccountTokens({ includeNoBalance: true });
+  const requiredTokens = useTransactionPayRequiredTokens();
+
+  const primaryRequiredToken = requiredTokens.find(
+    (token) => token.address !== getNativeTokenAddress(token.chainId),
+  );
+
+  const asset = tokens.find(
+    (token) =>
+      token.address?.toLowerCase() ===
+        primaryRequiredToken?.address.toLowerCase() &&
+      token.chainId === primaryRequiredToken?.chainId,
+  );
+
+  const assetId = toCaipAssetType(
+    'eip155',
+    Number(primaryRequiredToken?.chainId ?? '0x0').toString(),
+    'erc20',
+    asset?.assetId ?? '0x0',
+  );
+
+  const { goToRamps } = useRampNavigation();
+
+  const handleBuyPress = useCallback(() => {
+    goToRamps({
+      mode: RampMode.AGGREGATOR,
+      params: {
+        rampType: RampType.BUY,
+        intent: { assetId },
+      },
+    });
+  }, [assetId, goToRamps]);
+
+  return (
+    <Box alignItems={AlignItems.center} gap={20}>
+      <Text variant={TextVariant.BodySM} color={TextColor.Error}>
+        Add funds to your wallet to use Predictions.
+      </Text>
+      <Button
+        label="Buy crypto"
+        variant={ButtonVariants.Primary}
+        onPress={handleBuyPress}
+        width={ButtonWidthTypes.Full}
+      />
     </Box>
   );
 }

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -55,6 +55,9 @@ import { getNativeTokenAddress } from '../../../utils/asset';
 import { toCaipAssetType } from '@metamask/utils';
 import { AlignItems } from '../../../../../UI/Box/box.types';
 import { strings } from '../../../../../../../locales/i18n';
+import { hasTransactionType } from '../../../utils/transaction';
+import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
+import { TransactionType } from '@metamask/transaction-controller';
 
 export interface CustomAmountInfoProps {
   children?: ReactNode;
@@ -180,6 +183,7 @@ export function CustomAmountInfoSkeleton() {
 }
 
 function BuySection() {
+  const transactionMeta = useTransactionMetadataRequest();
   const tokens = useAccountTokens({ includeNoBalance: true });
   const requiredTokens = useTransactionPayRequiredTokens();
 
@@ -213,11 +217,23 @@ function BuySection() {
     });
   }, [assetId, goToRamps]);
 
+  let message: string | undefined;
+
+  if (hasTransactionType(transactionMeta, [TransactionType.perpsDeposit])) {
+    message = strings('confirm.custom_amount.buy_perps');
+  }
+
+  if (hasTransactionType(transactionMeta, [TransactionType.predictDeposit])) {
+    message = strings('confirm.custom_amount.buy_predict');
+  }
+
   return (
     <Box alignItems={AlignItems.center} gap={20}>
-      <Text variant={TextVariant.BodySM} color={TextColor.Error}>
-        Add funds to your wallet to use Predictions.
-      </Text>
+      {message && (
+        <Text variant={TextVariant.BodySM} color={TextColor.Error}>
+          {message}
+        </Text>
+      )}
       <Button
         label={strings('confirm.custom_amount.buy_button')}
         variant={ButtonVariants.Primary}

--- a/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
@@ -16,7 +16,6 @@ import { TransactionPayRequiredToken } from '@metamask/transaction-pay-controlle
 import { useTransactionPayRequiredTokens } from '../../../hooks/pay/useTransactionPayData';
 import { EthAccountType, SolAccountType } from '@metamask/keyring-api';
 import { Hex } from '@metamask/utils';
-import { strings } from '../../../../../../../locales/i18n';
 
 jest.mock('../../../hooks/pay/useTransactionPayToken');
 jest.mock('../../../hooks/send/useAccountTokens');
@@ -147,72 +146,6 @@ describe('PayWithModal', () => {
     expect(getByText('Test Token 1')).toBeDefined();
     expect(getByText('2.34 TST1')).toBeDefined();
     expect(getByText('$2.34')).toBeDefined();
-  });
-
-  it('renders token with zero balance if required token', async () => {
-    useTransactionPayRequiredTokensMock.mockReturnValue([
-      {
-        address: '0x234' as Hex,
-        chainId: CHAIN_ID_1_MOCK,
-      },
-    ] as TransactionPayRequiredToken[]);
-
-    const { getByText } = render();
-
-    expect(getByText('Test Token 2')).toBeDefined();
-    expect(getByText('0 TST2')).toBeDefined();
-    expect(getByText('$0.00')).toBeDefined();
-  });
-
-  it('renders token with zero balance if payment token', async () => {
-    useTransactionPayTokenMock.mockReturnValue({
-      payToken: { address: '0x234' as Hex, chainId: CHAIN_ID_1_MOCK },
-      setPayToken: setPayTokenMock,
-    } as unknown as ReturnType<typeof useTransactionPayToken>);
-
-    const { getByText } = render();
-
-    expect(getByText('Test Token 2')).toBeDefined();
-    expect(getByText('0 TST2')).toBeDefined();
-    expect(getByText('$0.00')).toBeDefined();
-  });
-
-  it('renders disabled token with message if no native gas', async () => {
-    const { getByText } = render();
-
-    expect(getByText('Test Token 5')).toBeDefined();
-    expect(getByText('5.67 TST5')).toBeDefined();
-    expect(getByText('$5.67')).toBeDefined();
-    expect(getByText(strings('pay_with_modal.no_gas'))).toBeDefined();
-  });
-
-  it('does not render token if no balance', async () => {
-    const { queryByText } = render();
-    expect(queryByText('Test Token 2')).toBeNull();
-  });
-
-  it('does not render token if not ERC-20', async () => {
-    const { queryByText } = render();
-    expect(queryByText('Test Token 3')).toBeNull();
-  });
-
-  it('does not render token if account type is not EVM', async () => {
-    const { queryByText } = render();
-    expect(queryByText('Test Token 4')).toBeNull();
-  });
-
-  it('does not render token with zero balance if required token and skipIfBalance is true', async () => {
-    useTransactionPayRequiredTokensMock.mockReturnValue([
-      {
-        address: '0x234' as Hex,
-        chainId: CHAIN_ID_1_MOCK,
-        skipIfBalance: true,
-      },
-    ] as TransactionPayRequiredToken[]);
-
-    const { queryByText } = render();
-
-    expect(queryByText('Test Token 2')).toBeNull();
   });
 
   describe('on token select', () => {

--- a/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
@@ -7,10 +7,9 @@ import BottomSheet, {
   BottomSheetRef,
 } from '../../../../../../component-library/components/BottomSheets/BottomSheet';
 import BottomSheetHeader from '../../../../../../component-library/components/BottomSheets/BottomSheetHeader';
-import { AssetType, TokenStandard } from '../../../types/token';
+import { AssetType } from '../../../types/token';
 import { useTransactionPayRequiredTokens } from '../../../hooks/pay/useTransactionPayData';
-import { BigNumber } from 'bignumber.js';
-import { getNativeTokenAddress } from '../../../utils/asset';
+import { getAvailableTokens } from '../../../utils/transaction-pay';
 
 export function PayWithModal() {
   const { payToken, setPayToken } = useTransactionPayToken();
@@ -33,65 +32,13 @@ export function PayWithModal() {
     [handleClose, setPayToken],
   );
 
-  const getAvailableTokens = useCallback(
+  const tokenFilter = useCallback(
     (tokens: AssetType[]) =>
-      tokens
-        .filter((token) => {
-          if (
-            token.standard !== TokenStandard.ERC20 ||
-            !token.accountType?.includes('eip155')
-          ) {
-            return false;
-          }
-
-          const isSelected =
-            payToken?.address.toLowerCase() === token.address.toLowerCase() &&
-            payToken?.chainId === token.chainId;
-
-          if (isSelected) {
-            return true;
-          }
-
-          const isRequiredToken = requiredTokens.some(
-            (t) =>
-              t.address.toLowerCase() === token.address.toLowerCase() &&
-              t.chainId === token.chainId &&
-              !t.skipIfBalance,
-          );
-
-          if (isRequiredToken) {
-            return true;
-          }
-
-          return new BigNumber(token.balance).gt(0);
-        })
-        .map((token) => {
-          const isSelected =
-            payToken?.address.toLowerCase() === token.address.toLowerCase() &&
-            payToken?.chainId === token.chainId;
-
-          const nativeTokenAddress = getNativeTokenAddress(
-            token.chainId as Hex,
-          );
-
-          const nativeToken = tokens.find(
-            (t) =>
-              t.address === nativeTokenAddress && t.chainId === token.chainId,
-          );
-
-          const disabled = new BigNumber(nativeToken?.balance ?? 0).isZero();
-
-          const disabledMessage = disabled
-            ? strings('pay_with_modal.no_gas')
-            : undefined;
-
-          return {
-            ...token,
-            disabled,
-            disabledMessage,
-            isSelected,
-          };
-        }),
+      getAvailableTokens({
+        payToken,
+        requiredTokens,
+        tokens,
+      }),
     [payToken, requiredTokens],
   );
 
@@ -103,7 +50,7 @@ export function PayWithModal() {
       <Asset
         includeNoBalance
         hideNfts
-        tokenFilter={getAvailableTokens}
+        tokenFilter={tokenFilter}
         onTokenSelect={handleTokenSelect}
       />
     </BottomSheet>

--- a/app/components/Views/confirmations/components/pay-token-amount/pay-token-amount.test.tsx
+++ b/app/components/Views/confirmations/components/pay-token-amount/pay-token-amount.test.tsx
@@ -20,9 +20,9 @@ const PAY_TOKEN_SYMBOL_MOCK = 'TST';
 const CHAIN_ID_2_MOCK = '0x456';
 const ADDRESS_2_MOCK = '0xdef';
 
-function render() {
+function render({ disabled = false } = {}) {
   return renderWithProvider(
-    <PayTokenAmount amountHuman={ASSET_AMOUNT_MOCK} />,
+    <PayTokenAmount amountHuman={ASSET_AMOUNT_MOCK} disabled={disabled} />,
     {
       state: merge(
         simpleSendTransactionControllerMock,
@@ -70,5 +70,10 @@ describe('PayTokenAmount', () => {
     const { getByTestId } = render();
 
     expect(getByTestId('pay-token-amount-skeleton')).toBeDefined();
+  });
+
+  it('returns fixed value if disabled', () => {
+    const { getByText } = render({ disabled: true });
+    expect(getByText('0 ETH')).toBeDefined();
   });
 });

--- a/app/components/Views/confirmations/components/pay-token-amount/pay-token-amount.tsx
+++ b/app/components/Views/confirmations/components/pay-token-amount/pay-token-amount.tsx
@@ -1,6 +1,8 @@
 import React, { useMemo } from 'react';
 import { View } from 'react-native';
-import Text from '../../../../../component-library/components/Texts/Text';
+import Text, {
+  TextColor,
+} from '../../../../../component-library/components/Texts/Text';
 import { useStyles } from '../../../../hooks/useStyles';
 import styleSheet from './pay-token-amount.styles';
 import { useTransactionPayToken } from '../../hooks/pay/useTransactionPayToken';
@@ -15,9 +17,10 @@ import { getTokenAddress } from '../../utils/transaction-pay';
 
 export interface PayTokenAmountProps {
   amountHuman: string;
+  disabled?: boolean;
 }
 
-export function PayTokenAmount({ amountHuman }: PayTokenAmountProps) {
+export function PayTokenAmount({ amountHuman, disabled }: PayTokenAmountProps) {
   const { styles } = useStyles(styleSheet, {});
   const transaction = useTransactionMetadataRequest();
   const { chainId } = transaction ?? { chainId: '0x0' };
@@ -45,6 +48,14 @@ export function PayTokenAmount({ amountHuman }: PayTokenAmountProps) {
 
   const payTokenFiatRate = fiatRates[0];
   const assetFiatRate = fiatRates[1];
+
+  if (disabled) {
+    return (
+      <View testID="pay-token-amount" style={styles.container}>
+        <Text color={TextColor.Muted}>0 ETH</Text>
+      </View>
+    );
+  }
 
   if (!payToken || !payTokenFiatRate || !assetFiatRate)
     return <PayTokenAmountSkeleton />;

--- a/app/components/Views/confirmations/components/transactions/custom-amount/custom-amount.styles.ts
+++ b/app/components/Views/confirmations/components/transactions/custom-amount/custom-amount.styles.ts
@@ -10,7 +10,7 @@ function getFontSize(length: number) {
 
 const styleSheet = (params: {
   theme: Theme;
-  vars: { amountLength: number; hasAlert: boolean };
+  vars: { amountLength: number; hasAlert: boolean; disabled: boolean };
 }) =>
   StyleSheet.create({
     container: {
@@ -30,7 +30,9 @@ const styleSheet = (params: {
       fontWeight: '500',
       color: params.vars.hasAlert
         ? params.theme.colors.error.default
-        : params.theme.colors.text.default,
+        : params.vars.disabled
+          ? params.theme.colors.text.muted
+          : params.theme.colors.text.default,
     },
     alertMessage: {
       textAlign: 'center',

--- a/app/components/Views/confirmations/components/transactions/custom-amount/custom-amount.tsx
+++ b/app/components/Views/confirmations/components/transactions/custom-amount/custom-amount.tsx
@@ -11,6 +11,7 @@ import Text from '../../../../../../component-library/components/Texts/Text';
 export interface CustomAmountProps {
   amountFiat: string;
   currency?: string;
+  disabled?: boolean;
   hasAlert?: boolean;
   isLoading?: boolean;
   onPress?: () => void;
@@ -20,6 +21,7 @@ export const CustomAmount: React.FC<CustomAmountProps> = React.memo((props) => {
   const {
     amountFiat,
     currency: currencyProp,
+    disabled = false,
     hasAlert = false,
     isLoading,
     onPress,
@@ -33,6 +35,7 @@ export const CustomAmount: React.FC<CustomAmountProps> = React.memo((props) => {
   const { styles } = useStyles(styleSheet, {
     amountLength,
     hasAlert,
+    disabled,
   });
 
   if (isLoading) {
@@ -44,7 +47,11 @@ export const CustomAmount: React.FC<CustomAmountProps> = React.memo((props) => {
       <Text testID="custom-amount-symbol" style={styles.input}>
         {fiatSymbol}
       </Text>
-      <Text testID="custom-amount-input" style={styles.input} onPress={onPress}>
+      <Text
+        testID="custom-amount-input"
+        style={styles.input}
+        onPress={disabled ? undefined : onPress}
+      >
         {amountFiat}
       </Text>
     </View>
@@ -55,6 +62,7 @@ export function CustomAmountSkeleton() {
   const { styles } = useStyles(styleSheet, {
     amountLength: 1,
     hasAlert: false,
+    disabled: false,
   });
 
   return (

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.test.ts
@@ -1,0 +1,32 @@
+import { EthAccountType } from '@metamask/keyring-api';
+import { useAccountTokens } from '../send/useAccountTokens';
+import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
+import { NATIVE_TOKEN_ADDRESS } from '../../constants/tokens';
+import { AssetType, TokenStandard } from '../../types/token';
+
+const TOKEN_MOCK = {
+  accountType: EthAccountType.Eoa,
+  address: NATIVE_TOKEN_ADDRESS,
+  balance: '1.23',
+  balanceInSelectedCurrency: '$1.23',
+  chainId: '0x123',
+  decimals: 18,
+  name: 'Native Token 1',
+  standard: TokenStandard.ERC20,
+  symbol: 'NTV1',
+} as AssetType;
+
+describe('useTransactionPayAvailableTokens', () => {
+  const useAccountTokensMock = jest.mocked(useAccountTokens);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    useAccountTokensMock.mockReturnValue([TOKEN_MOCK]);
+  });
+
+  it('returns available tokens', () => {
+    const result = useTransactionPayAvailableTokens();
+    expect(result).toStrictEqual([TOKEN_MOCK]);
+  });
+});

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.test.ts
@@ -3,6 +3,9 @@ import { useAccountTokens } from '../send/useAccountTokens';
 import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
 import { NATIVE_TOKEN_ADDRESS } from '../../constants/tokens';
 import { AssetType, TokenStandard } from '../../types/token';
+import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
+
+jest.mock('../send/useAccountTokens');
 
 const TOKEN_MOCK = {
   accountType: EthAccountType.Eoa,
@@ -26,7 +29,7 @@ describe('useTransactionPayAvailableTokens', () => {
   });
 
   it('returns available tokens', () => {
-    const result = useTransactionPayAvailableTokens();
-    expect(result).toStrictEqual([TOKEN_MOCK]);
+    const { result } = renderHookWithProvider(useTransactionPayAvailableTokens);
+    expect(result.current).toMatchObject([TOKEN_MOCK]);
   });
 });

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayAvailableTokens.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react';
+import { useAccountTokens } from '../send/useAccountTokens';
+import { getAvailableTokens } from '../../utils/transaction-pay';
+
+export function useTransactionPayAvailableTokens() {
+  const tokens = useAccountTokens({ includeNoBalance: true });
+
+  const availableTokens = useMemo(
+    () =>
+      getAvailableTokens({
+        tokens,
+      }),
+    [tokens],
+  );
+
+  return availableTokens;
+}

--- a/app/components/Views/confirmations/utils/transaction-pay.test.ts
+++ b/app/components/Views/confirmations/utils/transaction-pay.test.ts
@@ -3,16 +3,40 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 import {
+  getAvailableTokens,
   getRequiredBalance,
   getTokenAddress,
   getTokenTransferData,
 } from './transaction-pay';
 import { PERPS_MINIMUM_DEPOSIT } from '../constants/perps';
 import { PREDICT_MINIMUM_DEPOSIT } from '../constants/predict';
+import { NATIVE_TOKEN_ADDRESS } from '../constants/tokens';
+import { EthAccountType, SolAccountType } from '@metamask/keyring-api';
+import { AssetType, TokenStandard } from '../types/token';
+import {
+  TransactionPayRequiredToken,
+  TransactionPaymentToken,
+} from '@metamask/transaction-pay-controller';
+import { Hex } from '@metamask/utils';
+import { strings } from '../../../../../locales/i18n';
 
+const CHAIN_ID_MOCK = '0x1';
 const TO_MOCK = '0x0987654321098765432109876543210987654321';
+
 const TOKEN_TRANSFER_DATA_MOCK =
   '0xa9059cbb0000000000000000000000007e5f4552091a69125d5dfcb7b8c2659029395bdf000000000000000000000000000000000000000000000000000000000000012c;';
+
+const TOKEN_MOCK = {
+  accountType: EthAccountType.Eoa,
+  address: NATIVE_TOKEN_ADDRESS,
+  balance: '1.23',
+  balanceInSelectedCurrency: '$1.23',
+  chainId: CHAIN_ID_MOCK,
+  decimals: 18,
+  name: 'Native Token 1',
+  standard: TokenStandard.ERC20,
+  symbol: 'NTV1',
+} as AssetType;
 
 describe('Transaction Pay Utils', () => {
   describe('getRequiredBalance', () => {
@@ -125,6 +149,113 @@ describe('Transaction Pay Utils', () => {
       } as TransactionMeta;
 
       expect(getTokenAddress(transactionMeta)).toBe(TO_MOCK);
+    });
+  });
+
+  describe('getAvailableTokens', () => {
+    it('returns tokens if balance', () => {
+      const result = getAvailableTokens({
+        tokens: [TOKEN_MOCK] as AssetType[],
+      });
+
+      expect(result).toMatchObject([TOKEN_MOCK]);
+    });
+
+    it('returns token with zero balance if required token', async () => {
+      const tokenWithZeroBalance = {
+        ...TOKEN_MOCK,
+        balance: '0',
+        balanceInSelectedCurrency: '$0.00',
+      } as AssetType;
+
+      const result = getAvailableTokens({
+        tokens: [tokenWithZeroBalance] as AssetType[],
+        requiredTokens: [
+          {
+            address: TOKEN_MOCK.address as Hex,
+            chainId: TOKEN_MOCK.chainId as Hex,
+          } as TransactionPayRequiredToken,
+        ],
+      });
+
+      expect(result).toMatchObject([tokenWithZeroBalance]);
+    });
+
+    it('returns token with zero balance if payment token', async () => {
+      const tokenWithZeroBalance = {
+        ...TOKEN_MOCK,
+        balance: '0',
+        balanceInSelectedCurrency: '$0.00',
+      } as AssetType;
+
+      const result = getAvailableTokens({
+        tokens: [tokenWithZeroBalance] as AssetType[],
+        payToken: {
+          address: TOKEN_MOCK.address as Hex,
+          chainId: TOKEN_MOCK.chainId as Hex,
+        } as TransactionPaymentToken,
+      });
+
+      expect(result).toMatchObject([tokenWithZeroBalance]);
+    });
+
+    it('returns disabled token with message if no native gas', async () => {
+      const nonNativeToken = {
+        ...TOKEN_MOCK,
+        address: '0x234',
+      } as AssetType;
+
+      const result = getAvailableTokens({
+        tokens: [nonNativeToken] as AssetType[],
+      });
+
+      expect(result).toMatchObject([
+        {
+          ...nonNativeToken,
+          disabled: true,
+          disabledMessage: strings('pay_with_modal.no_gas'),
+        },
+      ]);
+    });
+
+    it('does not return token if no balance', async () => {
+      const tokenWithZeroBalance = {
+        ...TOKEN_MOCK,
+        balance: '0',
+        balanceInSelectedCurrency: '$0.00',
+      } as AssetType;
+
+      const result = getAvailableTokens({
+        tokens: [tokenWithZeroBalance] as AssetType[],
+      });
+
+      expect(result).toStrictEqual([]);
+    });
+
+    it('does not return token if not ERC-20', async () => {
+      const tokenWithWrongStandard = {
+        ...TOKEN_MOCK,
+        standard: TokenStandard.ERC721,
+      } as AssetType;
+
+      const result = getAvailableTokens({
+        tokens: [tokenWithWrongStandard] as AssetType[],
+      });
+
+      expect(result).toStrictEqual([]);
+    });
+
+    it('does not return token if account type is not EVM', async () => {
+      const tokenWithWrongAccountType = {
+        ...TOKEN_MOCK,
+        accountType: SolAccountType.DataAccount,
+      } as AssetType;
+
+      const result = getAvailableTokens({
+        tokens: [tokenWithWrongAccountType] as AssetType[],
+      });
+
+      expect(result).toStrictEqual([]);
     });
   });
 });

--- a/app/components/Views/confirmations/utils/transaction-pay.ts
+++ b/app/components/Views/confirmations/utils/transaction-pay.ts
@@ -6,6 +6,14 @@ import { PREDICT_MINIMUM_DEPOSIT } from '../constants/predict';
 import { hasTransactionType } from './transaction';
 import { Hex } from '@metamask/utils';
 import { PERPS_MINIMUM_DEPOSIT } from '../constants/perps';
+import { AssetType, TokenStandard } from '../types/token';
+import {
+  TransactionPayRequiredToken,
+  TransactionPaymentToken,
+} from '@metamask/transaction-pay-controller';
+import { getNativeTokenAddress } from './asset';
+import { strings } from '../../../../../locales/i18n';
+import { BigNumber } from 'bignumber.js';
 
 const FOUR_BYTE_TOKEN_TRANSFER = '0xa9059cbb';
 
@@ -70,4 +78,69 @@ export function getTokenAddress(
   }
 
   return transactionMeta?.txParams?.to as Hex;
+}
+
+export function getAvailableTokens({
+  payToken,
+  requiredTokens,
+  tokens,
+}: {
+  payToken?: TransactionPaymentToken;
+  requiredTokens?: TransactionPayRequiredToken[];
+  tokens: AssetType[];
+}): AssetType[] {
+  return tokens
+    .filter((token) => {
+      if (
+        token.standard !== TokenStandard.ERC20 ||
+        !token.accountType?.includes('eip155')
+      ) {
+        return false;
+      }
+
+      const isSelected =
+        payToken?.address.toLowerCase() === token.address.toLowerCase() &&
+        payToken?.chainId === token.chainId;
+
+      if (isSelected) {
+        return true;
+      }
+
+      const isRequiredToken = (requiredTokens ?? []).some(
+        (t) =>
+          t.address.toLowerCase() === token.address.toLowerCase() &&
+          t.chainId === token.chainId &&
+          !t.skipIfBalance,
+      );
+
+      if (isRequiredToken) {
+        return true;
+      }
+
+      return new BigNumber(token.balance).gt(0);
+    })
+    .map((token) => {
+      const isSelected =
+        payToken?.address.toLowerCase() === token.address.toLowerCase() &&
+        payToken?.chainId === token.chainId;
+
+      const nativeTokenAddress = getNativeTokenAddress(token.chainId as Hex);
+
+      const nativeToken = tokens.find(
+        (t) => t.address === nativeTokenAddress && t.chainId === token.chainId,
+      );
+
+      const disabled = new BigNumber(nativeToken?.balance ?? 0).isZero();
+
+      const disabledMessage = disabled
+        ? strings('pay_with_modal.no_gas')
+        : undefined;
+
+      return {
+        ...token,
+        disabled,
+        disabledMessage,
+        isSelected,
+      };
+    });
 }

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5791,6 +5791,9 @@
       "footer_bottom": "Funds will be added to your available balance",
       "footer_top": "Winnings from {{count}} markets"
     },
+    "custom_amount": {
+      "buy_button": "Buy crypto"
+    },
     "unlimited": "Unlimited",
     "all": "All",
     "none": "None",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5792,7 +5792,9 @@
       "footer_top": "Winnings from {{count}} markets"
     },
     "custom_amount": {
-      "buy_button": "Buy crypto"
+      "buy_button": "Buy crypto",
+      "buy_predict": "Add funds to your wallet to use Predictions.",
+      "buy_perps": "Add funds to your wallet to use Perps."
     },
     "unlimited": "Unlimited",
     "all": "All",


### PR DESCRIPTION
## **Description**

Add button to Predict and Perps deposit confirmations to redirect to ramps if account has no token balances.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:[ #6006](https://github.com/MetaMask/MetaMask-planning/issues/6006)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

<img width="300" alt="Buy Perps" src="https://github.com/user-attachments/assets/19db49ac-b65a-4d33-8bb6-394b6b16691d" />

<img width="300" alt="Buy Predictions" src="https://github.com/user-attachments/assets/58885d80-0fbb-4d19-add4-4d08297de893" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shows a Buy Crypto button on Perps/Predictions deposit confirmations when no eligible pay tokens are available, disables amount/pay UI, and centralizes token availability logic used by the Pay With modal.
> 
> - **Confirmations UI**:
>   - Add `BuySection` with "Buy crypto" CTA in `CustomAmountInfo` when `useTransactionPayAvailableTokens()` returns none; navigates to Ramp Aggregator with inferred `assetId`.
>   - Disable `CustomAmount`, `PayTokenAmount`, and `DepositKeyboard` when no tokens; greyed styling and fixed "0 ETH" display.
>   - Gate "Pay with" row and keyboard behind token availability.
> - **Token availability refactor**:
>   - Introduce `getAvailableTokens` in `utils/transaction-pay` to filter/select tokens (handles required/pay token inclusion, ERC-20/EVM checks, gas availability, disabled messaging).
>   - New hook `useTransactionPayAvailableTokens` to expose filtered tokens; used in `CustomAmountInfo`.
>   - Update `PayWithModal` to consume `getAvailableTokens` via `tokenFilter`.
> - **Tests**:
>   - Add unit tests for `useTransactionPayAvailableTokens` and `getAvailableTokens` scenarios.
>   - Update `custom-amount-info` and `pay-token-amount` tests for new disabled and Buy CTA behaviors; simplify `pay-with-modal` tests.
> - **i18n**:
>   - Add `confirm.custom_amount.buy_button`, `buy_predict`, and `buy_perps` strings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa99fa2e3dab662b7a2d237f9a41253ec6a8eaad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->