### PR TITLE
feat: predict claim loader

### DIFF
--- a/app/components/UI/Predict/hooks/usePredictClaim.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictClaim.test.ts
@@ -11,6 +11,7 @@ import { useConfirmNavigation } from '../../../Views/confirmations/hooks/useConf
 import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
 import { usePredictClaim } from './usePredictClaim';
 import { usePredictTrading } from './usePredictTrading';
+import { ConfirmationLoader } from '../../../Views/confirmations/components/confirm/confirm-component';
 
 // Create mock functions
 const mockNavigate = jest.fn();
@@ -143,6 +144,7 @@ describe('usePredictClaim', () => {
       expect(mockNavigateToConfirmation).toHaveBeenCalledWith({
         headerShown: false,
         stack: Routes.PREDICT.ROOT,
+        loader: ConfirmationLoader.PredictClaim,
       });
       expect(mockClaimWinnings).toHaveBeenCalledWith({
         providerId: POLYMARKET_PROVIDER_ID,
@@ -273,6 +275,7 @@ describe('usePredictClaim', () => {
       expect(mockNavigateToConfirmation).toHaveBeenCalledWith({
         headerShown: false,
         stack: Routes.PREDICT.ROOT,
+        loader: ConfirmationLoader.PredictClaim,
       });
       expect(mockClaimWinnings).toHaveBeenCalledWith({
         providerId: POLYMARKET_PROVIDER_ID,

--- a/app/components/UI/Predict/hooks/usePredictClaim.ts
+++ b/app/components/UI/Predict/hooks/usePredictClaim.ts
@@ -12,6 +12,7 @@ import { PREDICT_CONSTANTS } from '../constants/errors';
 import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
 import { ensureError } from '../utils/predictErrorHandler';
 import { usePredictTrading } from './usePredictTrading';
+import { ConfirmationLoader } from '../../../Views/confirmations/components/confirm/confirm-component';
 
 interface UsePredictClaimParams {
   providerId?: string;
@@ -31,6 +32,7 @@ export const usePredictClaim = ({
       navigateToConfirmation({
         headerShown: false,
         stack: Routes.PREDICT.ROOT,
+        loader: ConfirmationLoader.PredictClaim,
       });
       await claimWinnings({ providerId });
     } catch (err) {

--- a/app/components/Views/confirmations/components/UI/navbar/navbar.tsx
+++ b/app/components/Views/confirmations/components/UI/navbar/navbar.tsx
@@ -11,7 +11,6 @@ import {
 } from '../../../../../../component-library/components/Texts/Text';
 import Device from '../../../../../../util/device';
 import { Theme } from '../../../../../../util/theme/models';
-import { NetworksViewSelectorsIDs } from '../../../../../../../e2e/selectors/Settings/NetworksView.selectors';
 
 export function getNavbar({
   title,
@@ -78,25 +77,11 @@ export function getEmptyNavHeader({ theme }: { theme: Theme }) {
   };
 }
 
-export function getModalNavigationOptions({ onBack }: { onBack: () => void }) {
-  const innerStyles = StyleSheet.create({
-    accessories: {
-      marginHorizontal: 16,
-    },
-  });
-
+export function getModalNavigationOptions() {
   return {
     title: '',
     headerLeft: () => null,
     headerTransparent: true,
-    headerRight: () => (
-      <ButtonIcon
-        size={ButtonIconSizes.Lg}
-        iconName={IconName.Close}
-        onPress={onBack}
-        style={innerStyles.accessories}
-        testID={NetworksViewSelectorsIDs.CLOSE_ICON}
-      />
-    ),
+    headerRight: () => null,
   };
 }

--- a/app/components/Views/confirmations/components/confirm/confirm-component.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.tsx
@@ -27,6 +27,8 @@ import { useParams } from '../../../../../util/navigation/navUtils';
 import AnimatedSpinner, { SpinnerSize } from '../../../../UI/AnimatedSpinner';
 import { CustomAmountInfoSkeleton } from '../info/custom-amount-info';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { useTransactionMetadataRequest } from '../../hooks/transactions/useTransactionMetadataRequest';
+import { hasTransactionType } from '../../utils/transaction';
 
 export enum ConfirmationLoader {
   Default = 'default',
@@ -46,6 +48,7 @@ const ConfirmWrapped = ({
   route?: UnstakeConfirmationViewProps['route'];
 }) => {
   const alerts = useConfirmationAlerts();
+  const isScrollDisabled = useDisableScroll();
 
   return (
     <ConfirmationContextProvider>
@@ -58,6 +61,7 @@ const ConfirmWrapped = ({
                 style={styles.scrollView}
                 contentContainerStyle={styles.scrollViewContent}
                 nestedScrollEnabled
+                scrollEnabled={!isScrollDisabled}
               >
                 <TouchableWithoutFeedback>
                   <>
@@ -176,4 +180,9 @@ function Loader() {
       <AnimatedSpinner size={SpinnerSize.MD} />
     </View>
   );
+}
+
+function useDisableScroll() {
+  const transaction = useTransactionMetadataRequest();
+  return hasTransactionType(transaction, [TransactionType.predictClaim]);
 }

--- a/app/components/Views/confirmations/components/confirm/confirm-component.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.tsx
@@ -29,10 +29,12 @@ import { CustomAmountInfoSkeleton } from '../info/custom-amount-info';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTransactionMetadataRequest } from '../../hooks/transactions/useTransactionMetadataRequest';
 import { hasTransactionType } from '../../utils/transaction';
+import { PredictClaimInfoSkeleton } from '../info/predict-claim-info';
 
 export enum ConfirmationLoader {
   Default = 'default',
   CustomAmount = 'customAmount',
+  PredictClaim = 'predictClaim',
 }
 
 export interface ConfirmationParams {
@@ -172,6 +174,19 @@ function Loader() {
           <CustomAmountInfoSkeleton />
         </ScrollView>
       </SafeAreaView>
+    );
+  }
+
+  if (loader === ConfirmationLoader.PredictClaim) {
+    return (
+      <View style={styles.flatContainer} testID="confirm-loader-custom-amount">
+        <ScrollView
+          style={styles.scrollView}
+          contentContainerStyle={styles.scrollViewContent}
+        >
+          <PredictClaimInfoSkeleton />
+        </ScrollView>
+      </View>
     );
   }
 

--- a/app/components/Views/confirmations/components/confirm/confirm-component.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { ReactNode, useEffect } from 'react';
 import { BackHandler, TouchableWithoutFeedback, View } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import { useNavigation } from '@react-navigation/native';
@@ -162,31 +162,17 @@ function Loader() {
 
   if (loader === ConfirmationLoader.CustomAmount) {
     return (
-      <SafeAreaView
-        edges={['right', 'bottom', 'left']}
-        style={styles.flatContainer}
-        testID="confirm-loader-custom-amount"
-      >
-        <ScrollView
-          style={styles.scrollView}
-          contentContainerStyle={styles.scrollViewContent}
-        >
-          <CustomAmountInfoSkeleton />
-        </ScrollView>
-      </SafeAreaView>
+      <InfoLoader testId="confirm-loader-custom-amount">
+        <CustomAmountInfoSkeleton />
+      </InfoLoader>
     );
   }
 
   if (loader === ConfirmationLoader.PredictClaim) {
     return (
-      <View style={styles.flatContainer} testID="confirm-loader-custom-amount">
-        <ScrollView
-          style={styles.scrollView}
-          contentContainerStyle={styles.scrollViewContent}
-        >
-          <PredictClaimInfoSkeleton />
-        </ScrollView>
-      </View>
+      <InfoLoader testId="confirm-loader-predict-claim">
+        <PredictClaimInfoSkeleton />
+      </InfoLoader>
     );
   }
 
@@ -194,6 +180,31 @@ function Loader() {
     <View style={styles.spinnerContainer} testID="confirm-loader-default">
       <AnimatedSpinner size={SpinnerSize.MD} />
     </View>
+  );
+}
+
+function InfoLoader({
+  children,
+  testId,
+}: {
+  children: ReactNode;
+  testId?: string;
+}) {
+  const { styles } = useStyles(styleSheet, { isFullScreenConfirmation: true });
+
+  return (
+    <SafeAreaView
+      edges={['right', 'bottom', 'left']}
+      style={styles.flatContainer}
+      testID={testId}
+    >
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollViewContent}
+      >
+        {children}
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 

--- a/app/components/Views/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.tsx
+++ b/app/components/Views/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.tsx
@@ -67,6 +67,7 @@ function PredictClaim() {
     addTransactionBatchAndNavigate({
       headerShown: false,
       transactionType: TransactionType.predictClaim,
+      loader: ConfirmationLoader.PredictClaim,
     });
   }, [addTransactionBatchAndNavigate]);
 

--- a/app/components/Views/confirmations/components/info/predict-claim-info/predict-claim-info.styles.ts
+++ b/app/components/Views/confirmations/components/info/predict-claim-info/predict-claim-info.styles.ts
@@ -1,0 +1,14 @@
+import { StyleSheet } from 'react-native';
+import { Theme } from '../../../../../../util/theme/models';
+
+const styleSheet = (_params: { theme: Theme }) =>
+  StyleSheet.create({
+    backButton: {
+      position: 'absolute',
+      top: 60,
+      right: 0,
+      zIndex: 10,
+    },
+  });
+
+export default styleSheet;

--- a/app/components/Views/confirmations/components/info/predict-claim-info/predict-claim-info.tsx
+++ b/app/components/Views/confirmations/components/info/predict-claim-info/predict-claim-info.tsx
@@ -3,6 +3,13 @@ import { PredictClaimAmount } from '../../predict-confirmations/predict-claim-am
 import { PredictClaimBackground } from '../../predict-confirmations/predict-claim-background';
 import { useModalNavbar } from '../../../hooks/ui/useNavbar';
 import { usePredictClaimConfirmationMetrics } from '../../../hooks/metrics/usePredictClaimConfirmationMetrics';
+import ButtonIcon, {
+  ButtonIconSizes,
+} from '../../../../../../component-library/components/Buttons/ButtonIcon';
+import { IconName } from '../../../../../../component-library/components/Icons/Icon';
+import { useConfirmActions } from '../../../hooks/useConfirmActions';
+import { useStyles } from '../../../../../../component-library/hooks';
+import styleSheet from './predict-claim-info.styles';
 
 export function PredictClaimInfo() {
   useModalNavbar();
@@ -10,8 +17,26 @@ export function PredictClaimInfo() {
 
   return (
     <>
+      <BackButton />
       <PredictClaimBackground />
       <PredictClaimAmount />
     </>
+  );
+}
+
+/**
+ * Intentionally not using navigation header as `headerTransparent` not rendering buttons on Android.
+ */
+function BackButton() {
+  const { styles } = useStyles(styleSheet, {});
+  const { onReject } = useConfirmActions();
+
+  return (
+    <ButtonIcon
+      size={ButtonIconSizes.Lg}
+      iconName={IconName.Close}
+      onPress={() => onReject()}
+      style={styles.backButton}
+    />
   );
 }

--- a/app/components/Views/confirmations/components/info/predict-claim-info/predict-claim-info.tsx
+++ b/app/components/Views/confirmations/components/info/predict-claim-info/predict-claim-info.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import { PredictClaimAmount } from '../../predict-confirmations/predict-claim-amount';
+import {
+  PredictClaimAmount,
+  PredictClaimAmountSkeleton,
+} from '../../predict-confirmations/predict-claim-amount';
 import { PredictClaimBackground } from '../../predict-confirmations/predict-claim-background';
 import { useModalNavbar } from '../../../hooks/ui/useNavbar';
 import { usePredictClaimConfirmationMetrics } from '../../../hooks/metrics/usePredictClaimConfirmationMetrics';
@@ -20,6 +23,15 @@ export function PredictClaimInfo() {
       <BackButton />
       <PredictClaimBackground />
       <PredictClaimAmount />
+    </>
+  );
+}
+
+export function PredictClaimInfoSkeleton() {
+  return (
+    <>
+      <PredictClaimBackground />
+      <PredictClaimAmountSkeleton />
     </>
   );
 }

--- a/app/components/Views/confirmations/components/predict-confirmations/predict-claim-amount/predict-claim-amount.styles.ts
+++ b/app/components/Views/confirmations/components/predict-confirmations/predict-claim-amount/predict-claim-amount.styles.ts
@@ -17,7 +17,7 @@ const styleSheet = (_params: { theme: Theme }) =>
 
     change: {
       fontSize: 20,
-      lineHeight: 20,
+      lineHeight: 25,
     },
   });
 

--- a/app/components/Views/confirmations/components/predict-confirmations/predict-claim-amount/predict-claim-amount.tsx
+++ b/app/components/Views/confirmations/components/predict-confirmations/predict-claim-amount/predict-claim-amount.tsx
@@ -18,6 +18,7 @@ import {
 import { PredictClaimConfirmationSelectorsIDs } from '../../../../../../../e2e/selectors/Predict/Predict.selectors';
 import styleSheet from './predict-claim-amount.styles';
 import { selectSelectedInternalAccountAddress } from '../../../../../../selectors/accountsController';
+import { Skeleton } from '../../../../../../component-library/components/Skeleton';
 
 export function PredictClaimAmount() {
   const { styles } = useStyles(styleSheet, {});
@@ -62,6 +63,20 @@ export function PredictClaimAmount() {
       >
         {formattedWinningsPnl}
       </Text>
+    </Box>
+  );
+}
+
+export function PredictClaimAmountSkeleton() {
+  const { styles } = useStyles(styleSheet, {});
+
+  return (
+    <Box style={styles.container}>
+      <Text variant={TextVariant.HeadingLG} color={TextColor.Alternative}>
+        {strings('confirm.predict_claim.summary')}
+      </Text>
+      <Skeleton width={300} height={70} />
+      <Skeleton width={200} height={30} />
     </Box>
   );
 }

--- a/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.styles.ts
+++ b/app/components/Views/confirmations/components/predict-confirmations/predict-claim-footer/predict-claim-footer.styles.ts
@@ -11,7 +11,6 @@ const styleSheet = (params: { theme: Theme }) =>
       flexDirection: 'column',
       alignItems: 'stretch',
       gap: 12,
-      marginBottom: 42,
       padding: 12,
     },
 

--- a/app/components/Views/confirmations/hooks/ui/useNavbar.ts
+++ b/app/components/Views/confirmations/hooks/ui/useNavbar.ts
@@ -45,11 +45,7 @@ export function useModalNavbar() {
   const { onReject } = useConfirmActions();
 
   useEffect(() => {
-    navigation.setOptions(
-      getModalNavigationOptions({
-        onBack: () => onReject(),
-      }),
-    );
+    navigation.setOptions(getModalNavigationOptions());
   }, [navigation, onReject]);
 }
 


### PR DESCRIPTION
## **Description**

Show skeleton loader while loading predict claim confirmation.

Also disable scrolling, and fix back button on Android.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#6606](https://github.com/MetaMask/MetaMask-planning/issues/6066) [#6260](https://github.com/MetaMask/MetaMask-planning/issues/6260) [#6251](https://github.com/MetaMask/MetaMask-planning/issues/6251)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

<img width="300" alt="Claim Loader" src="https://github.com/user-attachments/assets/95b47027-fb11-4ce9-bb97-6f974df4e723" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Predict Claim-specific loader with skeleton UI, disables scrolling during claim confirmations, and moves close handling to an in-view button.
> 
> - **Confirmations**
>   - Introduces `ConfirmationLoader.PredictClaim` and integrates loader selection in `confirm-component` with new `InfoLoader` wrapper.
>   - Disables scroll for `TransactionType.predictClaim` confirmations.
> - **Predict Claim UI**
>   - Adds `PredictClaimInfoSkeleton` and `PredictClaimAmountSkeleton` for loading state.
>   - Adds in-view close `BackButton` (Android-safe) and adjusts styles (e.g., `lineHeight`, layout tweaks).
> - **Navigation/UI**
>   - `getModalNavigationOptions` no longer renders a right-close button; `useModalNavbar` updated accordingly.
> - **Developer Tools**
>   - `ConfirmationsDeveloperOptions` now navigates with `loader: ConfirmationLoader.PredictClaim` for claim flow.
> - **Tests**
>   - Updates `usePredictClaim` tests to expect `loader: ConfirmationLoader.PredictClaim` when navigating to confirmation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5eaac0c601d53447a6f02176a42bc45b92faff96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->