### PR TITLE
feat: updated transaction details for predict claim and withdraw

### DIFF
--- a/app/components/UI/TransactionElement/index.js
+++ b/app/components/UI/TransactionElement/index.js
@@ -155,7 +155,9 @@ const transactionIconSwapFailed = require('../../../images/transaction-icons/swa
 
 const NEW_TRANSACTION_DETAILS_TYPES = [
   TransactionType.perpsDeposit,
+  TransactionType.predictClaim,
   TransactionType.predictDeposit,
+  TransactionType.predictWithdraw,
 ];
 
 /**

--- a/app/components/Views/confirmations/components/activity/transaction-details-account-row/index.ts
+++ b/app/components/Views/confirmations/components/activity/transaction-details-account-row/index.ts
@@ -1,0 +1,1 @@
+export * from './transaction-details-account-row';

--- a/app/components/Views/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import renderWithProvider from '../../../../../../util/test/renderWithProvider';
+import { TransactionDetailsAccountRow } from './transaction-details-account-row';
+import { useAccountNames } from '../../../../../hooks/DisplayName/useAccountNames';
+import { Hex } from '@metamask/utils';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
+
+jest.mock('../../../../../hooks/DisplayName/useAccountNames');
+jest.mock('../../../hooks/activity/useTransactionDetails');
+
+const ACCOUNT_NAME_MOCK = 'Test Account 1';
+const ADDRESS_MOCK = '0x123' as Hex;
+
+const TRANSACTION_META_MOCK = {
+  chainId: '0x123' as Hex,
+  txParams: {
+    from: ADDRESS_MOCK,
+  },
+  type: TransactionType.predictWithdraw,
+} as TransactionMeta;
+
+function render() {
+  return renderWithProvider(<TransactionDetailsAccountRow />, {});
+}
+
+describe('TransactionDetailsAccountRow', () => {
+  const useTransactionDetailsMock = jest.mocked(useTransactionDetails);
+  const useAccountNamesMock = jest.mocked(useAccountNames);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    useTransactionDetailsMock.mockReturnValue({
+      transactionMeta: TRANSACTION_META_MOCK,
+    });
+
+    useAccountNamesMock.mockReturnValue([ACCOUNT_NAME_MOCK]);
+  });
+
+  it('renders account name', () => {
+    const { getByText } = render();
+    expect(getByText(ACCOUNT_NAME_MOCK)).toBeDefined();
+  });
+
+  it('renders address if no account name', () => {
+    useAccountNamesMock.mockReturnValue([undefined]);
+
+    const { getByText } = render();
+    expect(getByText(ADDRESS_MOCK)).toBeDefined();
+  });
+
+  it('renders nothing if transaction type is not in the list', () => {
+    useTransactionDetailsMock.mockReturnValue({
+      transactionMeta: {
+        ...TRANSACTION_META_MOCK,
+        type: TransactionType.simpleSend,
+      },
+    });
+
+    const { toJSON } = render();
+    expect(toJSON()).toBeNull();
+  });
+});

--- a/app/components/Views/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
+import { TransactionDetailsRow } from '../transaction-details-row/transaction-details-row';
+import { strings } from '../../../../../../../locales/i18n';
+import { NameType } from '../../../../../UI/Name/Name.types';
+import { useAccountNames } from '../../../../../hooks/DisplayName/useAccountNames';
+import Text, {
+  TextColor,
+} from '../../../../../../component-library/components/Texts/Text';
+import { TransactionType } from '@metamask/transaction-controller';
+import { hasTransactionType } from '../../../utils/transaction';
+
+const TRANSACTION_TYPES = [
+  TransactionType.predictClaim,
+  TransactionType.predictWithdraw,
+];
+
+export function TransactionDetailsAccountRow() {
+  const { transactionMeta } = useTransactionDetails();
+
+  const {
+    chainId,
+    txParams: { from },
+  } = transactionMeta;
+
+  const accountName = useAccountNames([
+    {
+      value: from,
+      variation: chainId,
+      type: NameType.EthereumAddress,
+    },
+  ])?.[0];
+
+  if (!hasTransactionType(transactionMeta, TRANSACTION_TYPES)) {
+    return null;
+  }
+
+  return (
+    <TransactionDetailsRow label={strings('transaction_details.label.account')}>
+      <Text color={TextColor.Alternative}>{accountName ?? from}</Text>
+    </TransactionDetailsRow>
+  );
+}

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
@@ -6,12 +6,12 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 import { TransactionDetailsHero } from './transaction-details-hero';
-import { useTokensWithBalance } from '../../../../../UI/Bridge/hooks/useTokensWithBalance';
 import { merge } from 'lodash';
 import { otherControllersMock } from '../../../__mocks__/controllers/other-controllers-mock';
+import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 
 jest.mock('../../../hooks/activity/useTransactionDetails');
-jest.mock('../../../../../UI/Bridge/hooks/useTokensWithBalance');
+jest.mock('../../../hooks/tokens/useTokenWithBalance');
 
 const TOKEN_ADDRESS_MOCK = '0x1234567890abcdef1234567890abcdef12345678';
 const CHAIN_ID_MOCK = '0x123';
@@ -36,7 +36,7 @@ function render() {
 
 describe('TransactionDetailsHero', () => {
   const useTransactionDetailsMock = jest.mocked(useTransactionDetails);
-  const useTokensWithBalanceMock = jest.mocked(useTokensWithBalance);
+  const useTokenWithBalanceMock = jest.mocked(useTokenWithBalance);
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -45,14 +45,12 @@ describe('TransactionDetailsHero', () => {
       transactionMeta: TRANSACTION_META_MOCK,
     });
 
-    useTokensWithBalanceMock.mockReturnValue([
-      {
-        address: TOKEN_ADDRESS_MOCK,
-        chainId: CHAIN_ID_MOCK,
-        decimals: DECIMALS_MOCK,
-        symbol: 'TST',
-      },
-    ]);
+    useTokenWithBalanceMock.mockReturnValue({
+      address: TOKEN_ADDRESS_MOCK,
+      chainId: CHAIN_ID_MOCK,
+      decimals: DECIMALS_MOCK,
+      symbol: 'TST',
+    } as unknown as ReturnType<typeof useTokenWithBalance>);
   });
 
   it('renders human amount', () => {
@@ -114,7 +112,9 @@ describe('TransactionDetailsHero', () => {
   });
 
   it('renders nothing if no decimals', () => {
-    useTokensWithBalanceMock.mockReturnValue([]);
+    useTokenWithBalanceMock.mockReturnValue(
+      undefined as unknown as ReturnType<typeof useTokenWithBalance>,
+    );
 
     const { queryByTestId } = render();
     expect(queryByTestId('transaction-details-hero')).toBeNull();

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
@@ -18,7 +18,6 @@ import { getTokenTransferData } from '../../../utils/transaction-pay';
 import useFiatFormatter from '../../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 import { PERPS_CURRENCY } from '../../../constants/perps';
 import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
-import { Hex } from '@metamask/utils';
 
 const SUPPORTED_TYPES = [
   TransactionType.perpsDeposit,
@@ -32,7 +31,7 @@ export function TransactionDetailsHero() {
   const { transactionMeta } = useTransactionDetails();
   const { chainId } = transactionMeta;
   const { data, to } = getTokenTransferData(transactionMeta) ?? {};
-  const token = useTokenWithBalance(to as Hex, chainId);
+  const token = useTokenWithBalance(to ?? '0x0', chainId);
 
   if (!hasTransactionType(transactionMeta, SUPPORTED_TYPES)) {
     return null;

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { Box } from '../../../../../UI/Box/Box';
 import Text, {
   TextVariant,
@@ -10,7 +10,6 @@ import {
   hasTransactionType,
   parseStandardTokenTransactionData,
 } from '../../../utils/transaction';
-import { useTokensWithBalance } from '../../../../../UI/Bridge/hooks/useTokensWithBalance';
 import { Result } from '@ethersproject/abi';
 import { calcTokenAmount } from '../../../../../../util/transactions';
 import { useStyles } from '../../../../../../component-library/hooks';
@@ -18,10 +17,14 @@ import styleSheet from './transaction-details-hero.styles';
 import { getTokenTransferData } from '../../../utils/transaction-pay';
 import useFiatFormatter from '../../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 import { PERPS_CURRENCY } from '../../../constants/perps';
+import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
+import { Hex } from '@metamask/utils';
 
 const SUPPORTED_TYPES = [
   TransactionType.perpsDeposit,
+  TransactionType.predictClaim,
   TransactionType.predictDeposit,
+  TransactionType.predictWithdraw,
 ];
 
 export function TransactionDetailsHero() {
@@ -29,24 +32,18 @@ export function TransactionDetailsHero() {
   const { styles } = useStyles(styleSheet, {});
   const { transactionMeta } = useTransactionDetails();
   const { chainId } = transactionMeta;
-  const chainIds = useMemo(() => (chainId ? [chainId] : []), [chainId]);
-  const tokens = useTokensWithBalance({ chainIds });
+  const { data, to } = getTokenTransferData(transactionMeta) ?? {};
+  const token = useTokenWithBalance(to as Hex, chainId);
 
   if (!hasTransactionType(transactionMeta, SUPPORTED_TYPES)) {
     return null;
   }
-
-  const { data, to } = getTokenTransferData(transactionMeta) ?? {};
 
   if (!to || !data) {
     return null;
   }
 
   const decodedData = parseStandardTokenTransactionData(data);
-
-  const token = tokens.find(
-    (t) => t.address.toLowerCase() === to.toLowerCase(),
-  );
 
   const { decimals } = token ?? {};
   const { _value: amount } = decodedData?.args ?? ({} as Result);

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
@@ -22,7 +22,6 @@ import { Hex } from '@metamask/utils';
 
 const SUPPORTED_TYPES = [
   TransactionType.perpsDeposit,
-  TransactionType.predictClaim,
   TransactionType.predictDeposit,
   TransactionType.predictWithdraw,
 ];

--- a/app/components/Views/confirmations/components/activity/transaction-details-network-fee-row/transaction-details-network-fee-row.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-network-fee-row/transaction-details-network-fee-row.test.tsx
@@ -1,12 +1,18 @@
 import React from 'react';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
-import { TransactionMeta } from '@metamask/transaction-controller';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import { TransactionDetailsNetworkFeeRow } from './transaction-details-network-fee-row';
+import { useFeeCalculations } from '../../../hooks/gas/useFeeCalculations';
 
 jest.mock('../../../hooks/activity/useTransactionDetails');
+jest.mock('../../../hooks/gas/useFeeCalculations');
 
-const NETWORK_FEE_FIAT_MOCK = '123.45';
+const PAY_FEE_MOCK = '123.45';
+const CALCULATED_FEE_MOCK = '234.56';
 
 function render() {
   return renderWithProvider(<TransactionDetailsNetworkFeeRow />, {});
@@ -14,6 +20,7 @@ function render() {
 
 describe('TransactionDetailsNetworkFeeRow', () => {
   const useTransactionDetailsMock = jest.mocked(useTransactionDetails);
+  const useFeeCalculationsMock = jest.mocked(useFeeCalculations);
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -21,26 +28,41 @@ describe('TransactionDetailsNetworkFeeRow', () => {
     useTransactionDetailsMock.mockReturnValue({
       transactionMeta: {
         metamaskPay: {
-          networkFeeFiat: NETWORK_FEE_FIAT_MOCK,
+          networkFeeFiat: PAY_FEE_MOCK,
         },
       } as unknown as TransactionMeta,
     });
+
+    useFeeCalculationsMock.mockReturnValue({
+      estimatedFeeFiatPrecise: CALCULATED_FEE_MOCK,
+    } as unknown as ReturnType<typeof useFeeCalculations>);
   });
 
-  it('renders network fee fiat', () => {
+  it('renders network fee from pay metadata', () => {
     const { getByText } = render();
-    expect(getByText(`$${NETWORK_FEE_FIAT_MOCK}`)).toBeDefined();
+    expect(getByText(`$${PAY_FEE_MOCK}`)).toBeDefined();
   });
 
-  it('renders nothing if no network fee fiat', () => {
+  it('renders network fee from calculation', () => {
+    useTransactionDetailsMock.mockReturnValue({
+      transactionMeta: {
+        type: TransactionType.predictWithdraw,
+      } as unknown as TransactionMeta,
+    });
+
+    const { getByText } = render();
+    expect(getByText(`$${CALCULATED_FEE_MOCK}`)).toBeDefined();
+  });
+
+  it('renders nothing if no pay metadata and type not supported', () => {
     useTransactionDetailsMock.mockReturnValue({
       transactionMeta: {
         metamaskPay: {},
       } as unknown as TransactionMeta,
     });
 
-    const { queryByText } = render();
+    const { toJSON } = render();
 
-    expect(queryByText(`$${NETWORK_FEE_FIAT_MOCK}`)).toBeNull();
+    expect(toJSON()).toBeNull();
   });
 });

--- a/app/components/Views/confirmations/components/activity/transaction-details-network-fee-row/transaction-details-network-fee-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-network-fee-row/transaction-details-network-fee-row.tsx
@@ -3,21 +3,36 @@ import { TransactionDetailsRow } from '../transaction-details-row/transaction-de
 import Text from '../../../../../../component-library/components/Texts/Text';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
 import { strings } from '../../../../../../../locales/i18n';
+import { TransactionType } from '@metamask/transaction-controller';
+import { hasTransactionType } from '../../../utils/transaction';
+import { useFeeCalculations } from '../../../hooks/gas/useFeeCalculations';
 import useFiatFormatter from '../../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 import { BigNumber } from 'bignumber.js';
+
+const FALLBACK_TYPES = [
+  TransactionType.predictClaim,
+  TransactionType.predictWithdraw,
+];
 
 export function TransactionDetailsNetworkFeeRow() {
   const formatFiat = useFiatFormatter({ currency: 'usd' });
   const { transactionMeta } = useTransactionDetails();
-  const { metamaskPay } = transactionMeta;
-  const { networkFeeFiat } = metamaskPay || {};
+  const { estimatedFeeFiatPrecise } = useFeeCalculations(transactionMeta);
 
-  const networkFeeFiatFormatted = useMemo(
-    () => formatFiat(new BigNumber(networkFeeFiat ?? 0)),
-    [formatFiat, networkFeeFiat],
+  const { metamaskPay } = transactionMeta;
+  const { networkFeeFiat: payNetworkFeeFiat } = metamaskPay || {};
+
+  const networkFee = estimatedFeeFiatPrecise ?? payNetworkFeeFiat;
+
+  const networkFeeFormatted = useMemo(
+    () => formatFiat(new BigNumber(networkFee ?? 0)),
+    [formatFiat, networkFee],
   );
 
-  if (!networkFeeFiat) {
+  if (
+    !payNetworkFeeFiat &&
+    !hasTransactionType(transactionMeta, FALLBACK_TYPES)
+  ) {
     return null;
   }
 
@@ -25,7 +40,7 @@ export function TransactionDetailsNetworkFeeRow() {
     <TransactionDetailsRow
       label={strings('transaction_details.label.network_fee')}
     >
-      <Text>{networkFeeFiatFormatted}</Text>
+      <Text>{networkFeeFormatted}</Text>
     </TransactionDetailsRow>
   );
 }

--- a/app/components/Views/confirmations/components/activity/transaction-details-network-fee-row/transaction-details-network-fee-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-network-fee-row/transaction-details-network-fee-row.tsx
@@ -22,7 +22,7 @@ export function TransactionDetailsNetworkFeeRow() {
   const { metamaskPay } = transactionMeta;
   const { networkFeeFiat: payNetworkFeeFiat } = metamaskPay || {};
 
-  const networkFee = estimatedFeeFiatPrecise ?? payNetworkFeeFiat;
+  const networkFee = payNetworkFeeFiat ?? estimatedFeeFiatPrecise;
 
   const networkFeeFormatted = useMemo(
     () => formatFiat(new BigNumber(networkFee ?? 0)),

--- a/app/components/Views/confirmations/components/activity/transaction-details-paid-with-row/transaction-details-paid-with-row.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-paid-with-row/transaction-details-paid-with-row.test.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import { TransactionDetailsPaidWithRow } from './transaction-details-paid-with-row';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
-import { useTokensWithBalance } from '../../../../../UI/Bridge/hooks/useTokensWithBalance';
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { merge } from 'lodash';
 import { otherControllersMock } from '../../../__mocks__/controllers/other-controllers-mock';
+import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 
 jest.mock('../../../hooks/activity/useTransactionDetails');
-jest.mock('../../../../../UI/Bridge/hooks/useTokensWithBalance');
+jest.mock('../../../hooks/tokens/useTokenWithBalance');
 
 const TOKEN_ADDRESS_MOCK = '0x1234567890abcdef1234567890abcdef12345678';
 const CHAIN_ID_MOCK = '0x1';
@@ -22,7 +22,7 @@ function render() {
 
 describe('TransactionDetailsPaidWithRow', () => {
   const useTransactionDetailsMock = jest.mocked(useTransactionDetails);
-  const useTokensWithBalanceMock = jest.mocked(useTokensWithBalance);
+  const useTokenWithBalanceMock = jest.mocked(useTokenWithBalance);
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -36,14 +36,12 @@ describe('TransactionDetailsPaidWithRow', () => {
       } as unknown as TransactionMeta,
     });
 
-    useTokensWithBalanceMock.mockReturnValue([
-      {
-        address: TOKEN_ADDRESS_MOCK,
-        chainId: CHAIN_ID_MOCK,
-        decimals: 6,
-        symbol: TOKEN_SYMBOL_MOCK,
-      },
-    ]);
+    useTokenWithBalanceMock.mockReturnValue({
+      address: TOKEN_ADDRESS_MOCK,
+      chainId: CHAIN_ID_MOCK,
+      decimals: 6,
+      symbol: TOKEN_SYMBOL_MOCK,
+    } as unknown as ReturnType<typeof useTokenWithBalance>);
   });
 
   it('renders token symbol', () => {
@@ -69,7 +67,7 @@ describe('TransactionDetailsPaidWithRow', () => {
   });
 
   it('renders nothing if token not found', () => {
-    useTokensWithBalanceMock.mockReturnValue([]);
+    useTokenWithBalanceMock.mockReturnValue(undefined);
 
     const { queryByText } = render();
 

--- a/app/components/Views/confirmations/components/activity/transaction-details-paid-with-row/transaction-details-paid-with-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-paid-with-row/transaction-details-paid-with-row.tsx
@@ -1,23 +1,18 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { TransactionDetailsRow } from '../transaction-details-row/transaction-details-row';
 import Text from '../../../../../../component-library/components/Texts/Text';
 import { Box } from '../../../../../UI/Box/Box';
 import { AlignItems, FlexDirection } from '../../../../../UI/Box/box.types';
 import { TokenIcon, TokenIconVariant } from '../../token-icon';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
-import { useTokensWithBalance } from '../../../../../UI/Bridge/hooks/useTokensWithBalance';
 import { strings } from '../../../../../../../locales/i18n';
+import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 
 export function TransactionDetailsPaidWithRow() {
   const { transactionMeta } = useTransactionDetails();
   const { metamaskPay } = transactionMeta;
   const { chainId, tokenAddress } = metamaskPay || {};
-  const chainIds = useMemo(() => (chainId ? [chainId] : []), [chainId]);
-  const tokens = useTokensWithBalance({ chainIds });
-
-  const token = tokens.find(
-    (t) => t.address.toLowerCase() === tokenAddress?.toLowerCase(),
-  );
+  const token = useTokenWithBalance(tokenAddress ?? '0x0', chainId ?? '0x0');
 
   if (!chainId || !tokenAddress || !token) {
     return null;

--- a/app/components/Views/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.test.tsx
@@ -47,7 +47,7 @@ describe('TransactionDetailsTotalRow', () => {
     useTransactionDetailsMock.mockReturnValue({
       transactionMeta: {
         metamaskPay: {},
-        type: TransactionType.predictClaim,
+        type: TransactionType.predictWithdraw,
       } as unknown as TransactionMeta,
     });
 

--- a/app/components/Views/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.test.tsx
@@ -1,12 +1,18 @@
 import React from 'react';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
-import { TransactionMeta } from '@metamask/transaction-controller';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import { TransactionDetailsTotalRow } from './transaction-details-total-row';
+import { useTokenAmount } from '../../../hooks/useTokenAmount';
 
 jest.mock('../../../hooks/activity/useTransactionDetails');
+jest.mock('../../../hooks/useTokenAmount');
 
-const TOTAL_FIAT_MOCK = '123.45';
+const PAY_TOTAL = '123.45';
+const TOKEN_TOTAL = '234.56';
 
 function render() {
   return renderWithProvider(<TransactionDetailsTotalRow />, {});
@@ -14,6 +20,7 @@ function render() {
 
 describe('TransactionDetailsTotalRow', () => {
   const useTransactionDetailsMock = jest.mocked(useTransactionDetails);
+  const useTokenAmountMock = jest.mocked(useTokenAmount);
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -21,26 +28,43 @@ describe('TransactionDetailsTotalRow', () => {
     useTransactionDetailsMock.mockReturnValue({
       transactionMeta: {
         metamaskPay: {
-          totalFiat: TOTAL_FIAT_MOCK,
+          totalFiat: PAY_TOTAL,
         },
       } as unknown as TransactionMeta,
     });
+
+    useTokenAmountMock.mockReturnValue({
+      amount: TOKEN_TOTAL,
+    } as ReturnType<typeof useTokenAmount>);
   });
 
-  it('renders total fiat', () => {
+  it('renders total from pay metadata', () => {
     const { getByText } = render();
-    expect(getByText(`$${TOTAL_FIAT_MOCK}`)).toBeDefined();
+    expect(getByText(`$${PAY_TOTAL}`)).toBeDefined();
   });
 
-  it('renders nothing if no total fiat', () => {
+  it('renders total from token amount', () => {
+    useTransactionDetailsMock.mockReturnValue({
+      transactionMeta: {
+        metamaskPay: {},
+        type: TransactionType.predictClaim,
+      } as unknown as TransactionMeta,
+    });
+
+    const { getByText } = render();
+
+    expect(getByText(`$${TOKEN_TOTAL}`)).toBeDefined();
+  });
+
+  it('renders nothing if no total fiat and type not supported', () => {
     useTransactionDetailsMock.mockReturnValue({
       transactionMeta: {
         metamaskPay: {},
       } as unknown as TransactionMeta,
     });
 
-    const { queryByText } = render();
+    const { toJSON } = render();
 
-    expect(queryByText(`$${TOTAL_FIAT_MOCK}`)).toBeNull();
+    expect(toJSON()).toBeNull();
   });
 });

--- a/app/components/Views/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.tsx
@@ -9,10 +9,7 @@ import { hasTransactionType } from '../../../utils/transaction';
 import useFiatFormatter from '../../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 import { BigNumber } from 'bignumber.js';
 
-const FALLBACK_TYPES = [
-  TransactionType.predictClaim,
-  TransactionType.predictWithdraw,
-];
+const FALLBACK_TYPES = [TransactionType.predictWithdraw];
 
 export function TransactionDetailsTotalRow() {
   const formatFiat = useFiatFormatter({ currency: 'usd' });

--- a/app/components/Views/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.tsx
@@ -3,27 +3,46 @@ import { TransactionDetailsRow } from '../transaction-details-row/transaction-de
 import Text from '../../../../../../component-library/components/Texts/Text';
 import { useTransactionDetails } from '../../../hooks/activity/useTransactionDetails';
 import { strings } from '../../../../../../../locales/i18n';
+import { useTokenAmount } from '../../../hooks/useTokenAmount';
+import { TransactionType } from '@metamask/transaction-controller';
+import { hasTransactionType } from '../../../utils/transaction';
 import useFiatFormatter from '../../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 import { BigNumber } from 'bignumber.js';
+
+const FALLBACK_TYPES = [
+  TransactionType.predictClaim,
+  TransactionType.predictWithdraw,
+];
 
 export function TransactionDetailsTotalRow() {
   const formatFiat = useFiatFormatter({ currency: 'usd' });
   const { transactionMeta } = useTransactionDetails();
-  const { metamaskPay } = transactionMeta;
-  const { totalFiat } = metamaskPay || {};
+  const { amount } = useTokenAmount({ transactionMeta }) ?? {};
 
-  const totalFiatFormatted = useMemo(
-    () => formatFiat(new BigNumber(totalFiat ?? '0')),
-    [formatFiat, totalFiat],
+  const { metamaskPay } = transactionMeta;
+  const { totalFiat: payTotal } = metamaskPay || {};
+
+  const total = payTotal ?? amount;
+
+  const totalFormatted = useMemo(
+    () => formatFiat(new BigNumber(total ?? '0')),
+    [formatFiat, total],
   );
 
-  if (!totalFiat) {
+  if (!payTotal && !hasTransactionType(transactionMeta, FALLBACK_TYPES)) {
     return null;
   }
 
+  const label = hasTransactionType(transactionMeta, [
+    TransactionType.predictClaim,
+    TransactionType.predictWithdraw,
+  ])
+    ? strings('transaction_details.label.received_total')
+    : strings('transaction_details.label.total');
+
   return (
-    <TransactionDetailsRow label={strings('transaction_details.label.total')}>
-      <Text>{totalFiatFormatted}</Text>
+    <TransactionDetailsRow label={label}>
+      <Text>{totalFormatted}</Text>
     </TransactionDetailsRow>
   );
 }

--- a/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details/transaction-details.tsx
@@ -23,6 +23,12 @@ import { TransactionDetailsBridgeFeeRow } from '../transaction-details-bridge-fe
 import { hasTransactionType } from '../../../utils/transaction';
 import { ScrollView } from 'react-native';
 import { TransactionDetailsRetry } from '../transaction-details-retry';
+import { TransactionDetailsAccountRow } from '../transaction-details-account-row';
+
+export const SUMMARY_SECTION_TYPES = [
+  TransactionType.perpsDeposit,
+  TransactionType.predictDeposit,
+];
 
 export function TransactionDetails() {
   const { styles } = useStyles(styleSheet, {});
@@ -39,28 +45,46 @@ export function TransactionDetails() {
     );
   }, [colors, navigation, theme, title]);
 
+  const showSummarySection = hasTransactionType(
+    transactionMeta,
+    SUMMARY_SECTION_TYPES,
+  );
+
   return (
     <ScrollView>
       <Box style={styles.container} gap={12}>
         <TransactionDetailsHero />
         <TransactionDetailsStatusRow />
         <TransactionDetailsDateRow />
+        <TransactionDetailsAccountRow />
         <TransactionDetailDivider />
         <TransactionDetailsPaidWithRow />
         <TransactionDetailsNetworkFeeRow />
         <TransactionDetailsBridgeFeeRow />
         <TransactionDetailsTotalRow />
-        <TransactionDetailDivider />
-        <TransactionDetailsSummary />
-        <TransactionDetailsRetry />
+        {showSummarySection && (
+          <>
+            <TransactionDetailDivider />
+            <TransactionDetailsSummary />
+            <TransactionDetailsRetry />
+          </>
+        )}
       </Box>
     </ScrollView>
   );
 }
 
 function getTitle(transactionMeta: TransactionMeta) {
+  if (hasTransactionType(transactionMeta, [TransactionType.predictClaim])) {
+    return strings('transaction_details.title.predict_claim');
+  }
+
   if (hasTransactionType(transactionMeta, [TransactionType.predictDeposit])) {
     return strings('transaction_details.title.predict_deposit');
+  }
+
+  if (hasTransactionType(transactionMeta, [TransactionType.predictWithdraw])) {
+    return strings('transaction_details.title.predict_withdraw');
   }
 
   switch (transactionMeta.type) {

--- a/app/components/Views/confirmations/hooks/gas/useFeeCalculations.test.ts
+++ b/app/components/Views/confirmations/hooks/gas/useFeeCalculations.test.ts
@@ -75,6 +75,7 @@ describe('useFeeCalculations', () => {
       gas: '0x5572e9c22d00',
       shouldUseEIP1559FeeLogic: true,
       gasPrice: '0x5572e9c22d00',
+      receiptGasPrice: undefined,
     });
 
     expect(currentCurrencyFee).toBe(null);
@@ -159,6 +160,30 @@ describe('useFeeCalculations', () => {
     expect(result.current.estimatedFeeFiatPrecise).toBe('0.337875011');
     expect(result.current.preciseNativeFeeInHex).toBe('0x5572e9c23d00');
     expect(result.current.calculateGasEstimate).toBeDefined();
+  });
+
+  it('returs fee calculations using receipt values if present', () => {
+    const state = cloneDeep(stakingDepositConfirmationState);
+
+    state.engine.backgroundState.TransactionController.transactions[0].txReceipt =
+      {
+        gasUsed: toHex(50000),
+        effectiveGasPrice: toHex(300000000000000),
+      };
+
+    const transactionWithReceipt =
+      state.engine.backgroundState.TransactionController.transactions[0];
+
+    const { result } = renderHookWithProvider(
+      () => useFeeCalculations(transactionWithReceipt),
+      {
+        state,
+      },
+    );
+
+    expect(result.current).toMatchObject({
+      estimatedFeeNative: '15',
+    });
   });
 
   it('returns fee calculations when gasUsed is present', () => {

--- a/app/components/Views/confirmations/hooks/gas/useFeeCalculations.ts
+++ b/app/components/Views/confirmations/hooks/gas/useFeeCalculations.ts
@@ -41,7 +41,7 @@ export const useFeeCalculations = (
     gas: string;
     shouldUseEIP1559FeeLogic: boolean;
     priorityFeePerGas: string;
-    receiptGasPrice: string | undefined;
+    receiptGasPrice?: string;
   }) => {
     currentCurrencyFee: string | null;
     nativeCurrencyFee: string | null;
@@ -124,7 +124,7 @@ export const useFeeCalculations = (
       gasPrice: string;
       gas: string;
       shouldUseEIP1559FeeLogic: boolean;
-      receiptGasPrice: string | undefined;
+      receiptGasPrice?: string;
     }) =>
       calculateGasEstimate({
         feePerGas,

--- a/app/components/Views/confirmations/hooks/gas/useFeeCalculations.ts
+++ b/app/components/Views/confirmations/hooks/gas/useFeeCalculations.ts
@@ -34,12 +34,14 @@ export const useFeeCalculations = (
     gas,
     shouldUseEIP1559FeeLogic,
     priorityFeePerGas,
+    receiptGasPrice,
   }: {
     feePerGas: string;
     gasPrice: string;
     gas: string;
     shouldUseEIP1559FeeLogic: boolean;
     priorityFeePerGas: string;
+    receiptGasPrice: string | undefined;
   }) => {
     currentCurrencyFee: string | null;
     nativeCurrencyFee: string | null;
@@ -52,8 +54,14 @@ export const useFeeCalculations = (
   maxFeeNativePrecise: string | null;
   maxFeeNativeHex: string | null;
 } => {
-  const { chainId, gasLimitNoBuffer, gasUsed, layer1GasFee, networkClientId } =
-    transactionMeta;
+  const {
+    chainId,
+    gasLimitNoBuffer,
+    gasUsed,
+    layer1GasFee,
+    networkClientId,
+    txReceipt,
+  } = transactionMeta;
 
   const { nativeCurrency } =
     useSelector((state: RootState) =>
@@ -74,6 +82,7 @@ export const useFeeCalculations = (
   // `gasUsed` is the gas limit actually used by the transaction in the
   // simulation environment.
   const optimizedGasLimit =
+    txReceipt?.gasUsed ||
     gasUsed ||
     // While estimating gas for the transaction we add 50% gas limit buffer.
     // With `gasLimitNoBuffer` that buffer is removed. see PR
@@ -85,7 +94,9 @@ export const useFeeCalculations = (
 
   const estimatedBaseFee = (gasFeeEstimates as GasFeeEstimates)
     ?.estimatedBaseFee;
+
   const txParamsGasPrice = transactionMeta.txParams?.gasPrice ?? HEX_ZERO;
+  const receiptGasPriceHex = txReceipt?.effectiveGasPrice;
 
   const getFeesFromHexCallback = useCallback(
     (hexFee: string) =>
@@ -106,12 +117,14 @@ export const useFeeCalculations = (
       gas,
       shouldUseEIP1559FeeLogic,
       priorityFeePerGas,
+      receiptGasPrice,
     }: {
       feePerGas: string;
       priorityFeePerGas: string;
       gasPrice: string;
       gas: string;
       shouldUseEIP1559FeeLogic: boolean;
+      receiptGasPrice: string | undefined;
     }) =>
       calculateGasEstimate({
         feePerGas,
@@ -122,6 +135,7 @@ export const useFeeCalculations = (
         estimatedBaseFee,
         layer1GasFee,
         getFeesFromHexFn: getFeesFromHexCallback,
+        receiptGasPrice,
       }),
     [estimatedBaseFee, layer1GasFee, getFeesFromHexCallback],
   );
@@ -135,6 +149,7 @@ export const useFeeCalculations = (
         gas: optimizedGasLimit,
         shouldUseEIP1559FeeLogic: supportsEIP1559,
         gasPrice: txParamsGasPrice,
+        receiptGasPrice: receiptGasPriceHex,
       }),
     [
       calculateGasEstimateCallback,
@@ -143,6 +158,7 @@ export const useFeeCalculations = (
       optimizedGasLimit,
       supportsEIP1559,
       txParamsGasPrice,
+      receiptGasPriceHex,
     ],
   );
 

--- a/app/components/Views/confirmations/utils/gas.ts
+++ b/app/components/Views/confirmations/utils/gas.ts
@@ -129,6 +129,7 @@ export function calculateGasEstimate({
   estimatedBaseFee,
   layer1GasFee,
   getFeesFromHexFn,
+  receiptGasPrice,
 }: {
   feePerGas: string;
   priorityFeePerGas: string;
@@ -137,6 +138,7 @@ export function calculateGasEstimate({
   shouldUseEIP1559FeeLogic: boolean;
   estimatedBaseFee: string | undefined;
   layer1GasFee?: string;
+  receiptGasPrice?: string;
   getFeesFromHexFn: (hexFee: string) => {
     currentCurrencyFee: string | null;
     nativeCurrencyFee: string | null;
@@ -145,6 +147,10 @@ export function calculateGasEstimate({
     preciseNativeFeeInHex: string | null;
   };
 }) {
+  if (receiptGasPrice) {
+    return getFeesFromHexFn(multiplyHexes(receiptGasPrice as Hex, gas as Hex));
+  }
+
   let minimumFeePerGas = addHexes(
     decGWEIToHexWEI(estimatedBaseFee) ?? HEX_ZERO,
     decimalToHex(priorityFeePerGas),

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6841,7 +6841,9 @@
   "transaction_details": {
     "title": {
       "perps_deposit": "Funded Perps account",
+      "predict_claim": "Claimed winnings",
       "predict_deposit": "Funded Predict account",
+      "predict_withdraw": "Withdrawal",
       "default": "Transaction details"
     },
     "label": {
@@ -6849,7 +6851,9 @@
       "network_fee": "Network fee",
       "paid_with": "Paid with",
       "retry_button": "Try again",
-      "total": "Total"
+      "total": "Total",
+      "account": "Account",
+      "received_total": "Received total"
     },
     "summary_title": {
       "bridge_approval": "Approve {{approveSymbol}}",


### PR DESCRIPTION
## **Description**

Display the updated transaction details for Predict claim and withdraw transactions.

Include new `Account` and `Received total` rows.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#6182](https://github.com/MetaMask/MetaMask-planning/issues/6182)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

<img width="300" alt="Withdraw" src="https://github.com/user-attachments/assets/7ec6ac1b-cafb-4a45-a070-c219ff982d45" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Predict claim/withdraw support to transaction details, introduces Account and Received total rows, refactors fee/amount sourcing, and enhances gas fee calculations using receipt data.
> 
> - **Transaction details UI**
>   - Add `TransactionDetailsAccountRow` (Account) for `predictClaim`/`predictWithdraw`.
>   - Update `TransactionDetails` to show Account row and conditionally render Summary section; set titles for `predictClaim`/`predictWithdraw`.
>   - Extend `TransactionDetailsHero` to support `predictWithdraw` and switch to `useTokenWithBalance` for token metadata.
>   - Update `TransactionDetailsPaidWithRow` to use `useTokenWithBalance`.
>   - Update `TransactionDetailsNetworkFeeRow` to prefer Pay metadata, fallback to calculated fees for `predictClaim`/`predictWithdraw`.
>   - Update `TransactionDetailsTotalRow` to prefer Pay total, fallback to token amount for `predictWithdraw`, and use `received_total` label for claim/withdraw.
>   - Route new detail view from list by adding `predictClaim`/`predictWithdraw` in `TransactionElement`.
> - **Gas/fee logic**
>   - Enhance `useFeeCalculations`/`calculateGasEstimate` to use `txReceipt.gasUsed` and `txReceipt.effectiveGasPrice` when available; plumb `receiptGasPrice` through API.
> - **i18n**
>   - Add strings for Predict titles and new labels (`account`, `received_total`).
> - **Tests**
>   - Add/adjust unit tests for new rows, hero, network fee, total, and fee calculations (including receipt-based paths).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18d53a66d600bcd540e0d5e3ab5134e9faa77b9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->