### PR TITLE
fix: hide predict deposit incoming transactions

### DIFF
--- a/app/components/Views/TransactionsView/index.js
+++ b/app/components/Views/TransactionsView/index.js
@@ -48,6 +48,7 @@ import { PopularList } from '../../../util/networks/customNetworks';
 import { isRemoveGlobalNetworkSelectorEnabled } from '../../../util/networks';
 import useCurrencyRatePolling from '../../hooks/AssetPolling/useCurrencyRatePolling';
 import useTokenRatesPolling from '../../hooks/AssetPolling/useTokenRatesPolling';
+import { selectBridgeHistoryForAccount } from '../../../selectors/bridgeStatusController';
 
 const styles = StyleSheet.create({
   wrapper: {
@@ -71,6 +72,8 @@ const TransactionsView = ({
   const [confirmedTxs, setConfirmedTxs] = useState([]);
   const [loading, setLoading] = useState();
   const selectedNetworkClientId = useSelector(selectSelectedNetworkClientId);
+  const bridgeHistory = useSelector(selectBridgeHistoryForAccount);
+
   const enabledNetworksByNamespace = useSelector(
     selectEnabledNetworksByNamespace,
   );
@@ -105,6 +108,7 @@ const TransactionsView = ({
           selectedAddress,
           tokenNetworkFilter,
           allTransactionsSorted,
+          bridgeHistory,
         );
 
         if (!filter) return false;
@@ -226,6 +230,7 @@ const TransactionsView = ({
       tokenNetworkFilter,
       isPopularNetwork,
       enabledNetworksByNamespace,
+      bridgeHistory,
     ],
   );
 

--- a/app/components/Views/TransactionsView/index.test.tsx
+++ b/app/components/Views/TransactionsView/index.test.tsx
@@ -186,6 +186,10 @@ jest.mock('../../../core/Engine', () => ({
   rejectPendingApproval: jest.fn(),
 }));
 
+jest.mock('../../../selectors/bridgeStatusController', () => ({
+  selectBridgeHistoryForAccount: () => ({}),
+}));
+
 jest.mock('../../hooks/AssetPolling/useCurrencyRatePolling', () => jest.fn());
 jest.mock('../../hooks/AssetPolling/useTokenRatesPolling', () => jest.fn());
 

--- a/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.test.tsx
+++ b/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.test.tsx
@@ -146,6 +146,10 @@ jest.mock('../../UI/Bridge/hooks/useBridgeHistoryItemBySrcTxHash', () => ({
   }),
 }));
 
+jest.mock('../../../selectors/bridgeStatusController', () => ({
+  selectBridgeHistoryForAccount: () => ({}),
+}));
+
 const mockGetBlockExplorerUrl = jest.fn(() => undefined);
 const mockGetBlockExplorerName = jest.fn(() => 'Explorer');
 jest.mock('../../hooks/useBlockExplorer', () => ({

--- a/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
+++ b/app/components/Views/UnifiedTransactionsView/UnifiedTransactionsView.tsx
@@ -62,6 +62,7 @@ import UpdateEIP1559Tx from '../confirmations/legacy/components/UpdateEIP1559Tx'
 import styleSheet from './UnifiedTransactionsView.styles';
 import { useUnifiedTxActions } from './useUnifiedTxActions';
 import useBlockExplorer from '../../hooks/useBlockExplorer';
+import { selectBridgeHistoryForAccount } from '../../../selectors/bridgeStatusController';
 
 type SmartTransactionWithId = SmartTransaction & { id: string };
 type EvmTransaction = TransactionMeta | SmartTransactionWithId;
@@ -158,6 +159,8 @@ const UnifiedTransactionsView = ({
   // we need to use the selected account group chain ids
   const currentEvmChainId = useSelector(selectChainId);
 
+  const bridgeHistory = useSelector(selectBridgeHistoryForAccount);
+
   const { data, nonEvmTransactionsForSelectedChain } = useMemo<{
     data: UnifiedItem[];
     nonEvmTransactionsForSelectedChain: NonEvmTransaction[];
@@ -199,7 +202,7 @@ const UnifiedTransactionsView = ({
 
       const isReceivedOrSentTransaction =
         selectedAccountGroupInternalAccountsAddresses.some((addr) =>
-          filterByAddress(tx, tokens, addr, transactionMetaPool),
+          filterByAddress(tx, tokens, addr, transactionMetaPool, bridgeHistory),
         );
       if (!isReceivedOrSentTransaction) return false;
 
@@ -356,6 +359,7 @@ const UnifiedTransactionsView = ({
     selectedInternalAccount,
     tokens,
     currentEvmChainId,
+    bridgeHistory,
   ]);
 
   const hasEvmChainsEnabled = enabledEVMChainIds.length > 0;

--- a/app/util/activity/index.ts
+++ b/app/util/activity/index.ts
@@ -7,6 +7,7 @@ import {
 import { uniq } from 'lodash';
 import { Hex } from '@metamask/utils';
 import { hasTransactionType } from '../../components/Views/confirmations/utils/transaction';
+import { BridgeHistoryItem } from '@metamask/bridge-status-controller';
 
 export const PAY_TYPES = [
   TransactionType.perpsDeposit,
@@ -89,7 +90,8 @@ export const filterByAddressAndNetwork = (
   tokens: any[],
   selectedAddress: string,
   tokenNetworkFilter: { [key: string]: boolean },
-  allTransactions?: TransactionMeta[],
+  allTransactions: TransactionMeta[],
+  bridgeHistory: Record<string, BridgeHistoryItem>,
 ): boolean => {
   const {
     isTransfer,
@@ -97,7 +99,7 @@ export const filterByAddressAndNetwork = (
     txParams: { from, to },
   } = tx;
 
-  if (isFilteredByMetaMaskPay(tx, allTransactions ?? [])) {
+  if (isFilteredByMetaMaskPay(tx, allTransactions ?? [], bridgeHistory)) {
     return false;
   }
 
@@ -131,7 +133,8 @@ export const filterByAddress = (
   tx: TransactionMeta,
   tokens: { address: string }[],
   selectedAddress: string,
-  allTransactions?: TransactionMeta[],
+  allTransactions: TransactionMeta[],
+  bridgeHistory: Record<string, BridgeHistoryItem>,
 ): boolean => {
   const {
     isTransfer,
@@ -139,7 +142,7 @@ export const filterByAddress = (
     txParams: { from, to },
   } = tx;
 
-  if (isFilteredByMetaMaskPay(tx, allTransactions ?? [])) {
+  if (isFilteredByMetaMaskPay(tx, allTransactions ?? [], bridgeHistory)) {
     return false;
   }
 
@@ -183,6 +186,7 @@ export function isTransactionOnChains(
 function isFilteredByMetaMaskPay(
   tx: TransactionMeta,
   allTransactions: TransactionMeta[],
+  bridgeHistory: Record<string, BridgeHistoryItem>,
 ): boolean {
   const { batchId, id: transactionId } = tx;
 
@@ -193,6 +197,19 @@ function isFilteredByMetaMaskPay(
   const isRequiredTransaction = requiredTransactionIds?.includes(transactionId);
 
   if (isRequiredTransaction) {
+    return true;
+  }
+
+  const isBridgeReceive =
+    tx.hash &&
+    Object.values(bridgeHistory).some(
+      (item) =>
+        item.status.destChain?.txHash?.toLowerCase() ===
+          tx.hash?.toLowerCase() &&
+        requiredTransactionIds.includes(item.txMetaId),
+    );
+
+  if (isBridgeReceive) {
     return true;
   }
 


### PR DESCRIPTION
## **Description**

Hide incoming transactions resulting from a predict deposit.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#6145](http://github.com/MetaMask/MetaMask-planning/issues/6145)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Integrates bridge history into transaction filtering to hide bridge destination txs, wires selector through transaction views, and adds targeted tests.
> 
> - **Activity filtering (`app/util/activity`)**:
>   - Extend `filterByAddress` and `filterByAddressAndNetwork` to accept `allTransactions` and `bridgeHistory` and exclude:
>     - Transactions required by others.
>     - Bridge destination txs whose source tx is a required dependency (match via `destChain.txHash`).
>   - Update internal `isFilteredByMetaMaskPay` with bridge-based exclusion.
> - **Transaction views**:
>   - `TransactionsView` and `UnifiedTransactionsView` now select `bridgeHistory` (`selectBridgeHistoryForAccount`) and pass it into filtering (`filterByAddress*`).
> - **Tests**:
>   - Add unit tests covering bridge destination exclusion in both `filterByAddress` and `filterByAddressAndNetwork`.
>   - Update view tests to mock `selectBridgeHistoryForAccount`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 112d3e0b6598df83dffdbb4b9b941696a153dcad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->