### PR TITLE
Analyze and resolve metamask issue

### DIFF
--- a/app/components/Views/confirmations/components/send/amount/amount.tsx
+++ b/app/components/Views/confirmations/components/send/amount/amount.tsx
@@ -144,7 +144,7 @@ export const Amount = () => {
             <AnimatedCursor />
             <Text
               style={styles.inputText}
-              color={amountError ? TextColor.Error : TextColor.Muted}
+              color={textColor}
               numberOfLines={1}
               variant={TextVariant.DisplayLG}
             >


### PR DESCRIPTION
Align currency label color logic with amount value to fix visual inconsistency after clearing invalid input.

The currency label's color previously only checked for `amountError`, while the amount value's color also checked if the input was empty. This led to a bug where the label remained red even after an invalid amount was cleared, because `amountError` could briefly stay truthy while the input itself was empty. Using a single `textColor` variable ensures both elements update consistently.

---
<a href="https://cursor.com/background-agent?bcId=bc-259fa7fb-ae73-4cb0-9234-3f1610165d85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-259fa7fb-ae73-4cb0-9234-3f1610165d85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

