### PR TITLE
fix: bug 22375

### DIFF
--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -612,6 +612,11 @@ const ImportSRPView = () => (
       component={SeedphraseModal}
       options={{
         cardStyle: { backgroundColor: 'transparent' },
+        cardStyleInterpolator: () => ({
+          overlayStyle: {
+            opacity: 0,
+          },
+        }),
       }}
     />
   </Stack.Navigator>

--- a/app/components/Views/WalletRecovery/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/WalletRecovery/__snapshots__/index.test.tsx.snap
@@ -1,183 +1,198 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`WalletRecovery render matches snapshot 1`] = `
-<RCTScrollView>
-  <View>
-    <View
-      style={
-        {
-          "flex": 1,
-          "flexDirection": "column",
-          "paddingVertical": 8,
-          "rowGap": 24,
-        }
-      }
-    >
+<RNCSafeAreaView
+  edges={
+    {
+      "bottom": "additive",
+      "left": "off",
+      "right": "off",
+      "top": "off",
+    }
+  }
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <RCTScrollView>
+    <View>
       <View
         style={
           {
-            "display": "flex",
             "flexDirection": "column",
-            "paddingHorizontal": 16,
-            "rowGap": 8,
+            "paddingVertical": 8,
+            "rowGap": 24,
           }
         }
       >
-        <Text
-          accessibilityRole="text"
-          style={
-            {
-              "color": "#686e7d",
-              "fontFamily": "Geist Medium",
-              "fontSize": 14,
-              "letterSpacing": 0,
-              "lineHeight": 22,
-            }
-          }
-        >
-          GOOGLE RECOVERY
-        </Text>
         <View
           style={
             {
-              "width": "100%",
+              "display": "flex",
+              "flexDirection": "column",
+              "paddingHorizontal": 16,
+              "rowGap": 8,
             }
           }
         >
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#686e7d",
+                "fontFamily": "Geist Medium",
+                "fontSize": 14,
+                "letterSpacing": 0,
+                "lineHeight": 22,
+              }
+            }
+          >
+            GOOGLE RECOVERY
+          </Text>
           <View
             style={
               {
-                "alignItems": "center",
-                "backgroundColor": "#3c4d9d0f",
-                "borderRadius": 8,
-                "columnGap": 8,
-                "flexDirection": "row",
-                "justifyContent": "flex-start",
-                "padding": 16,
+                "width": "100%",
               }
             }
           >
             <View
               style={
                 {
-                  "marginRight": 8,
+                  "alignItems": "center",
+                  "backgroundColor": "#3c4d9d0f",
+                  "borderRadius": 8,
+                  "columnGap": 8,
+                  "flexDirection": "row",
+                  "justifyContent": "flex-start",
+                  "padding": 16,
                 }
               }
             >
-              <AppleIcon
-                color="#121314"
-                fill="currentColor"
-                height={24}
-                name="google"
-                width={24}
-              />
-            </View>
-            <View
-              style={
-                {
-                  "alignItems": "flex-start",
-                  "display": "flex",
-                  "flexDirection": "column",
-                  "justifyContent": "center",
-                }
-              }
-            >
-              <Text
-                accessibilityRole="text"
+              <View
                 style={
                   {
-                    "color": "#121314",
-                    "fontFamily": "Geist Medium",
-                    "fontSize": 16,
-                    "letterSpacing": 0,
-                    "lineHeight": 24,
+                    "marginRight": 8,
                   }
                 }
               >
-                Enabled
-              </Text>
-              <Text
-                accessibilityRole="text"
+                <AppleIcon
+                  color="#121314"
+                  fill="currentColor"
+                  height={24}
+                  name="google"
+                  width={24}
+                />
+              </View>
+              <View
                 style={
                   {
-                    "color": "#686e7d",
-                    "fontFamily": "Geist Regular",
-                    "fontSize": 14,
-                    "letterSpacing": 0,
-                    "lineHeight": 22,
-                    "width": "100%",
+                    "alignItems": "flex-start",
+                    "display": "flex",
+                    "flexDirection": "column",
+                    "justifyContent": "center",
                   }
                 }
               >
-                t********@example.com
-              </Text>
+                <Text
+                  accessibilityRole="text"
+                  style={
+                    {
+                      "color": "#121314",
+                      "fontFamily": "Geist Medium",
+                      "fontSize": 16,
+                      "letterSpacing": 0,
+                      "lineHeight": 24,
+                    }
+                  }
+                >
+                  Enabled
+                </Text>
+                <Text
+                  accessibilityRole="text"
+                  style={
+                    {
+                      "color": "#686e7d",
+                      "fontFamily": "Geist Regular",
+                      "fontSize": 14,
+                      "letterSpacing": 0,
+                      "lineHeight": 22,
+                      "width": "100%",
+                    }
+                  }
+                >
+                  t********@example.com
+                </Text>
+              </View>
             </View>
           </View>
-        </View>
-        <Text
-          accessibilityRole="text"
-          style={
-            {
-              "color": "#686e7d",
-              "fontFamily": "Geist Regular",
-              "fontSize": 14,
-              "letterSpacing": 0,
-              "lineHeight": 22,
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#686e7d",
+                "fontFamily": "Geist Regular",
+                "fontSize": 14,
+                "letterSpacing": 0,
+                "lineHeight": 22,
+              }
             }
-          }
-        >
-          Use your Google login and MetaMask password to recover your account and secret recovery phrases.
-        </Text>
-      </View>
-      <View
-        style={
-          {
-            "paddingHorizontal": 16,
-          }
-        }
-      >
-        <View
-          style={
-            {
-              "backgroundColor": "#b7bbc866",
-              "height": 1,
-              "paddingHorizontal": 16,
-            }
-          }
-        />
-      </View>
-      <View
-        style={
-          {
-            "flexDirection": "column",
-            "rowGap": 6,
-          }
-        }
-      >
-        <Text
-          accessibilityRole="text"
-          style={
-            {
-              "color": "#686e7d",
-              "fontFamily": "Geist Medium",
-              "fontSize": 14,
-              "letterSpacing": 0,
-              "lineHeight": 22,
-              "paddingHorizontal": 16,
-            }
-          }
-        >
-          SECRET RECOVERY PHRASES
-        </Text>
-        <View
-          testID="select-srp"
-        >
-          <Text>
-            SelectSRP Component
+          >
+            Use your Google login and MetaMask password to recover your account and secret recovery phrases.
           </Text>
+        </View>
+        <View
+          style={
+            {
+              "paddingHorizontal": 16,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "backgroundColor": "#b7bbc866",
+                "height": 1,
+                "paddingHorizontal": 16,
+              }
+            }
+          />
+        </View>
+        <View
+          style={
+            {
+              "flexDirection": "column",
+              "rowGap": 6,
+            }
+          }
+        >
+          <Text
+            accessibilityRole="text"
+            style={
+              {
+                "color": "#686e7d",
+                "fontFamily": "Geist Medium",
+                "fontSize": 14,
+                "letterSpacing": 0,
+                "lineHeight": 22,
+                "paddingHorizontal": 16,
+              }
+            }
+          >
+            SECRET RECOVERY PHRASES
+          </Text>
+          <View
+            testID="select-srp"
+          >
+            <Text>
+              SelectSRP Component
+            </Text>
+          </View>
         </View>
       </View>
     </View>
-  </View>
-</RCTScrollView>
+  </RCTScrollView>
+</RNCSafeAreaView>
 `;

--- a/app/components/Views/WalletRecovery/index.tsx
+++ b/app/components/Views/WalletRecovery/index.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useEffect, useState } from 'react';
 import { View, StyleSheet, ScrollView } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTheme } from '../../../util/theme';
 import Text, {
   TextVariant,
@@ -175,8 +176,10 @@ const WalletRecovery = () => {
   const seedlessOnboardingUserId = useSelector(selectSeedlessOnboardingUserId);
 
   const styles = StyleSheet.create({
-    root: {
+    safeArea: {
       flex: 1,
+    },
+    root: {
       flexDirection: 'column',
       rowGap: 24,
       paddingVertical: 8,
@@ -277,57 +280,59 @@ const WalletRecovery = () => {
   }, [userEmail]);
 
   return (
-    <ScrollView>
-      <View style={styles.root}>
-        {authConnection && (
-          <View style={styles.socialContainer}>
+    <SafeAreaView edges={{ bottom: 'additive' }} style={styles.safeArea}>
+      <ScrollView>
+        <View style={styles.root}>
+          {authConnection && (
+            <View style={styles.socialContainer}>
+              <Text
+                variant={TextVariant.BodySMMedium}
+                color={TextColor.Alternative}
+              >
+                {strings('protect_your_wallet.social_recovery_title', {
+                  authConnection: authConnection
+                    ? authConnection.toUpperCase()
+                    : 'GOOGLE OR APPLE',
+                })}
+              </Text>
+              {authConnection && seedlessOnboardingUserId ? (
+                <SocialLinked
+                  email={finalUserEmail || ''}
+                  authConnection={authConnection}
+                />
+              ) : (
+                <SocialNotLinked />
+              )}
+              <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
+                {strings('protect_your_wallet.social_login_description', {
+                  authConnection: capitalize(authConnection) || 'Google',
+                })}
+              </Text>
+            </View>
+          )}
+
+          {authConnection && (
+            <View style={styles.lineBreakContainer}>
+              <View style={styles.lineBreak} />
+            </View>
+          )}
+
+          <View style={styles.srpContainer}>
             <Text
               variant={TextVariant.BodySMMedium}
               color={TextColor.Alternative}
+              style={styles.srpTitle}
             >
-              {strings('protect_your_wallet.social_recovery_title', {
-                authConnection: authConnection
-                  ? authConnection.toUpperCase()
-                  : 'GOOGLE OR APPLE',
-              })}
+              {strings('protect_your_wallet.srps_title')}
             </Text>
-            {authConnection && seedlessOnboardingUserId ? (
-              <SocialLinked
-                email={finalUserEmail || ''}
-                authConnection={authConnection}
-              />
-            ) : (
-              <SocialNotLinked />
-            )}
-            <Text variant={TextVariant.BodySM} color={TextColor.Alternative}>
-              {strings('protect_your_wallet.social_login_description', {
-                authConnection: capitalize(authConnection) || 'Google',
-              })}
-            </Text>
+            <SelectSRP
+              containerStyle={styles.srpListContainer}
+              showArrowName={strings('protect_your_wallet.reveal')}
+            />
           </View>
-        )}
-
-        {authConnection && (
-          <View style={styles.lineBreakContainer}>
-            <View style={styles.lineBreak} />
-          </View>
-        )}
-
-        <View style={styles.srpContainer}>
-          <Text
-            variant={TextVariant.BodySMMedium}
-            color={TextColor.Alternative}
-            style={styles.srpTitle}
-          >
-            {strings('protect_your_wallet.srps_title')}
-          </Text>
-          <SelectSRP
-            containerStyle={styles.srpListContainer}
-            showArrowName={strings('protect_your_wallet.reveal')}
-          />
         </View>
-      </View>
-    </ScrollView>
+      </ScrollView>
+    </SafeAreaView>
   );
 };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
* BugFix: https://github.com/MetaMask/metamask-mobile/issues/22375
* Jira: https://consensyssoftware.atlassian.net/browse/SL-280
* Shadow overlay issue in import srp via home screen
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: BugFix: https://github.com/MetaMask/metamask-mobile/issues/22375

## **Related issues**

Fixes: 
* https://github.com/MetaMask/metamask-mobile/issues/22375
* Shadow overlay issue in import srp via home screen

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="353" height="798" alt="bug" src="https://github.com/user-attachments/assets/2c4b5b6c-8bbd-4bf7-9e0e-4d898a6c855b" />

<!-- [screenshots/recordings] -->


### **After**
https://github.com/user-attachments/assets/b36c5b81-96ca-4bd9-b422-db4cde062bdb
<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/be424bbd-3175-4cf6-92d0-a5ec18f11c6d


https://github.com/user-attachments/assets/278508ca-f130-4f65-a472-10f49be445f3



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wraps WalletRecovery in SafeAreaView and updates layout/styles, updating the snapshot accordingly.
> 
> - **UI (WalletRecovery)**
>   - Wrap screen with `SafeAreaView` (`edges={{ bottom: 'additive' }}`) and add `safeArea` style.
>   - Adjust layout: reorganize `root` container spacing, `socialContainer` structure, line break placement, and `srp` section paddings (`srpTitle`, `srpListContainer`).
> - **Tests**
>   - Update snapshot `app/components/Views/WalletRecovery/__snapshots__/index.test.tsx.snap` to reflect the new safe area wrapper and layout changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5af8694960ef37ad056a3b157e4ae80c11fa933. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->