### PR TITLE
feat: Enable automatic updates of preinstalled Snaps

### DIFF
--- a/app/core/Authentication/Authentication.ts
+++ b/app/core/Authentication/Authentication.ts
@@ -96,19 +96,10 @@ class AuthenticationService {
       AccountTreeInitService.clearState();
     }
     await AccountTreeInitService.initializeAccountTree();
-    const {
-      MultichainAccountService,
-      ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
-      SnapController,
-      ///: END:ONLY_INCLUDE_IF
-    } = Engine.context;
+    const { MultichainAccountService } = Engine.context;
     await MultichainAccountService.init();
 
     ReduxService.store.dispatch(logIn());
-
-    ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
-    SnapController.updateRegistry();
-    ///: END:ONLY_INCLUDE_IF
   }
 
   private dispatchPasswordSet(): void {

--- a/app/core/Authentication/Authentication.ts
+++ b/app/core/Authentication/Authentication.ts
@@ -96,10 +96,19 @@ class AuthenticationService {
       AccountTreeInitService.clearState();
     }
     await AccountTreeInitService.initializeAccountTree();
-    const { MultichainAccountService } = Engine.context;
+    const {
+      MultichainAccountService,
+      ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+      SnapController,
+      ///: END:ONLY_INCLUDE_IF
+    } = Engine.context;
     await MultichainAccountService.init();
 
     ReduxService.store.dispatch(logIn());
+
+    ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+    SnapController.updateRegistry();
+    ///: END:ONLY_INCLUDE_IF
   }
 
   private dispatchPasswordSet(): void {

--- a/app/core/Engine/controllers/snaps/snap-controller-init.test.ts
+++ b/app/core/Engine/controllers/snaps/snap-controller-init.test.ts
@@ -71,6 +71,7 @@ describe('SnapControllerInit', () => {
         disableSnapInstallation: true,
         requireAllowlist: true,
         forcePreinstalledSnaps: false,
+        autoUpdatePreinstalledSnaps: true,
       },
       getFeatureFlags: expect.any(Function),
       getMnemonicSeed: expect.any(Function),

--- a/app/core/Engine/controllers/snaps/snap-controller-init.ts
+++ b/app/core/Engine/controllers/snaps/snap-controller-init.ts
@@ -42,6 +42,7 @@ export const snapControllerInit: ControllerInitFunction<
   const requireAllowlist = process.env.METAMASK_BUILD_TYPE !== 'flask';
   const disableSnapInstallation = process.env.METAMASK_BUILD_TYPE !== 'flask';
   const allowLocalSnaps = process.env.METAMASK_BUILD_TYPE === 'flask';
+  const autoUpdatePreinstalledSnaps = true;
 
   ///: BEGIN:ONLY_INCLUDE_IF(flask)
   const forcePreinstalledSnaps =
@@ -106,6 +107,7 @@ export const snapControllerInit: ControllerInitFunction<
       allowLocalSnaps,
       disableSnapInstallation,
       requireAllowlist,
+      autoUpdatePreinstalledSnaps,
       ///: BEGIN:ONLY_INCLUDE_IF(flask)
       forcePreinstalledSnaps,
       ///: END:ONLY_INCLUDE_IF

--- a/app/store/sagas/index.ts
+++ b/app/store/sagas/index.ts
@@ -235,11 +235,12 @@ export function* handleSnapsRegistry() {
         ? result.completedOnboarding
         : state;
 
-    if (completedOnboarding) {
-      const { SnapController } = Engine.context;
-      yield call([SnapController, SnapController.updateRegistry]);
-      break;
+    if (!completedOnboarding) {
+      continue;
     }
+
+    const { SnapController } = Engine.context;
+    yield call([SnapController, SnapController.updateRegistry]);
   }
 }
 ///: END:ONLY_INCLUDE_IF

--- a/app/store/sagas/index.ts
+++ b/app/store/sagas/index.ts
@@ -218,6 +218,32 @@ export function* handleDeeplinkSaga() {
   }
 }
 
+///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+/**
+ * Handles updating the Snaps registry when the user has booted the app and is onboarded
+ */
+export function* handleSnapsRegistry() {
+  while (true) {
+    const result = (yield take([
+      UserActionType.LOGIN,
+      SET_COMPLETED_ONBOARDING,
+    ])) as LoginAction | SetCompletedOnboardingAction;
+
+    const state: boolean = yield select(selectCompletedOnboarding);
+    const completedOnboarding =
+      result.type === 'SET_COMPLETED_ONBOARDING'
+        ? result.completedOnboarding
+        : state;
+
+    if (completedOnboarding) {
+      const { SnapController } = Engine.context;
+      yield call([SnapController, SnapController.updateRegistry]);
+      break;
+    }
+  }
+}
+///: END:ONLY_INCLUDE_IF
+
 /**
  * Handles initializing app services on start up
  */
@@ -248,4 +274,7 @@ export function* rootSaga() {
   yield fork(authStateMachine);
   yield fork(basicFunctionalityToggle);
   yield fork(handleDeeplinkSaga);
+  ///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
+  yield fork(handleSnapsRegistry);
+  ///: END:ONLY_INCLUDE_IF
 }

--- a/app/store/sagas/index.ts
+++ b/app/store/sagas/index.ts
@@ -239,8 +239,12 @@ export function* handleSnapsRegistry() {
       continue;
     }
 
-    const { SnapController } = Engine.context;
-    yield call([SnapController, SnapController.updateRegistry]);
+    try {
+      const { SnapController } = Engine.context;
+      yield call([SnapController, SnapController.updateRegistry]);
+    } catch {
+      // Ignore
+    }
   }
 }
 ///: END:ONLY_INCLUDE_IF

--- a/package.json
+++ b/package.json
@@ -275,7 +275,7 @@
     "@metamask/signature-controller": "^35.0.0",
     "@metamask/slip44": "^4.2.0",
     "@metamask/smart-transactions-controller": "^20.1.0",
-    "@metamask/snaps-controllers": "^16.1.0",
+    "@metamask/snaps-controllers": "^16.1.1",
     "@metamask/snaps-execution-environments": "^10.2.3",
     "@metamask/snaps-rpc-methods": "^14.1.0",
     "@metamask/snaps-sdk": "^10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8572,9 +8572,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-controllers@npm:^16.1.0":
-  version: 16.1.0
-  resolution: "@metamask/snaps-controllers@npm:16.1.0"
+"@metamask/snaps-controllers@npm:^16.1.1":
+  version: 16.1.1
+  resolution: "@metamask/snaps-controllers@npm:16.1.1"
   dependencies:
     "@metamask/approval-controller": "npm:^8.0.0"
     "@metamask/base-controller": "npm:^9.0.0"
@@ -8610,7 +8610,7 @@ __metadata:
   peerDependenciesMeta:
     "@metamask/snaps-execution-environments":
       optional: true
-  checksum: 10/9af230904002608d73de7d9b87e9e63dda304da2f68fc1cf813b0d43a222edb1d359ba82921f7f88b1e066b39c72a7a73fab90c824907e0b3bcfe84de6b1bc46
+  checksum: 10/c7a01e952ae8d5ac98532c76fd7a02053885d55e0c3800fc621e728844e855c08cca4634a5c6e679ce3ada7ec5176452b2e18d0edd81d065bf4a4ea8e183ea07
   languageName: node
   linkType: hard
 
@@ -34318,7 +34318,7 @@ __metadata:
     "@metamask/signature-controller": "npm:^35.0.0"
     "@metamask/slip44": "npm:^4.2.0"
     "@metamask/smart-transactions-controller": "npm:^20.1.0"
-    "@metamask/snaps-controllers": "npm:^16.1.0"
+    "@metamask/snaps-controllers": "npm:^16.1.1"
     "@metamask/snaps-execution-environments": "npm:^10.2.3"
     "@metamask/snaps-rpc-methods": "npm:^14.1.0"
     "@metamask/snaps-sdk": "npm:^10.1.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR adds a feature flag for automatically updating preinstalled Snaps and enables it. Following onboarding and as long as the user doesn't opt-out, the Snaps registry will be queried and used to serve updates for preinstalled Snaps.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Enable automatic updates of preinstalled Snaps

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables auto-updating preinstalled Snaps and adds a saga to update the Snaps registry after login/onboarding, with tests and a snaps-controllers bump.
> 
> - **Engine / Snaps Controller**:
>   - Add `featureFlags.autoUpdatePreinstalledSnaps: true` in `snap-controller-init.ts`; update expectations in `snap-controller-init.test.ts`.
> - **Sagas**:
>   - Introduce `handleSnapsRegistry` to call `SnapController.updateRegistry` on `LOGIN` or when `SET_COMPLETED_ONBOARDING` indicates completion; register in `rootSaga`.
> - **Tests**:
>   - Add tests for `handleSnapsRegistry` covering login, onboarding completion, and negative cases.
> - **Dependencies**:
>   - Bump `@metamask/snaps-controllers` from `^16.1.0` to `^16.1.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afc3c7fca783bdc9c3fa5b4fa5c72ab4d279a05c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->