### PR TITLE
fix: Consider client active once it is open and unlocked

### DIFF
--- a/app/core/Snaps/SnapsMethodMiddleware.ts
+++ b/app/core/Snaps/SnapsMethodMiddleware.ts
@@ -36,6 +36,7 @@ import { MetricsEventBuilder } from '../Analytics/MetricsEventBuilder';
 import { Json } from '@metamask/utils';
 import { SchedulableBackgroundEvent } from '@metamask/snaps-controllers';
 import { endTrace, trace } from '../../util/trace';
+import { AppState } from 'react-native';
 
 export function getSnapIdFromRequest(
   request: Record<string, unknown>,
@@ -190,7 +191,9 @@ const snapMethodMiddlewareBuilder = (
       engineContext.ApprovalController.addAndShowApprovalRequest.bind(
         engineContext.ApprovalController,
       ),
-    getIsActive: () => true, // For now we consider the app to be always active.
+    getIsActive: () =>
+      AppState.currentState === 'active' &&
+      engineContext.KeyringController.isUnlocked(),
     getIsLocked: () => !engineContext.KeyringController.isUnlocked(),
     getEntropySources: () => {
       const state = controllerMessenger.call('KeyringController:getState');


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Mirror the change made to the extension where the client is only consider active when it is open and unlocked.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `getIsActive` to return true only when the app is active (foreground) and the keyring is unlocked.
> 
> - **Snaps middleware (`app/core/Snaps/SnapsMethodMiddleware.ts`)**:
>   - Refines `getIsActive` to check `AppState.currentState === 'active'` and `KeyringController.isUnlocked()`.
>   - Adds `AppState` import from `react-native`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94f4010a8940c4f51fa85d5da2f42cc6405f94a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->