### PR TITLE
fix(card): cp-7.58.2 CardHome and SpendingLimit UI issues

### DIFF
--- a/app/components/UI/Card/Views/CardHome/CardHome.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.tsx
@@ -483,13 +483,18 @@ const CardHome = () => {
         testID={CardHomeSelectors.ADD_FUNDS_BUTTON}
       />
     );
-    // eslint-disable-next-line react-compiler/react-compiler
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     addFundsAction,
-    priorityTokenWarning,
+    changeAssetAction,
+    enableCardAction,
+    isBaanxLoginEnabled,
     isLoading,
+    isLoadingPollCardStatusUntilProvisioned,
+    isLoadingProvisionCard,
     isSwapEnabledForPriorityToken,
+    needToEnableAssets,
+    needToEnableCard,
+    styles,
   ]);
 
   // Handle authentication errors (expired token, invalid credentials, etc.)
@@ -528,13 +533,16 @@ const CardHome = () => {
    * Some tokens (e.g., aUSDC) have different allowance behavior and are unsupported.
    */
   const isSpendingLimitSupported = useMemo(() => {
-    if (!priorityToken?.symbol) {
+    if (
+      !priorityToken?.symbol ||
+      isSolanaChainId(priorityToken.caipChainId ?? '')
+    ) {
       return false;
     }
     return !SPENDING_LIMIT_UNSUPPORTED_TOKENS.includes(
       priorityToken.symbol.toUpperCase(),
     );
-  }, [priorityToken?.symbol]);
+  }, [priorityToken?.symbol, priorityToken?.caipChainId]);
 
   /**
    * This warning is shown when the user is close to their spending limit.

--- a/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.styles.ts
+++ b/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.styles.ts
@@ -3,15 +3,18 @@ import { Theme } from '../../../../../util/theme/models';
 
 const createStyles = (theme: Theme) =>
   StyleSheet.create({
-    wrapper: {
+    safeAreaView: {
       flex: 1,
       backgroundColor: theme.colors.background.default,
     },
-    contentContainer: {
+    wrapper: {
       flexGrow: 1,
       paddingHorizontal: 16,
+    },
+    contentContainer: {
+      flexGrow: 1,
       paddingTop: 16,
-      paddingBottom: 32,
+      paddingBottom: 16,
     },
     assetContainer: {
       marginBottom: 24,

--- a/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.tsx
+++ b/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.tsx
@@ -5,7 +5,7 @@ import React, {
   useContext,
   useMemo,
 } from 'react';
-import { ScrollView, TouchableOpacity, View, TextInput } from 'react-native';
+import { TouchableOpacity, View, TextInput } from 'react-native';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { useTheme } from '../../../../../util/theme';
 import {
@@ -52,6 +52,8 @@ import { mapCaipChainIdToChainName } from '../../util/mapCaipChainIdToChainName'
 import { clearCacheData } from '../../../../../core/redux/slices/card';
 import { useDispatch } from 'react-redux';
 import Routes from '../../../../../constants/navigation/Routes';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 
 const getNetworkFromCaipChainId = (caipChainId: string): CardNetwork => {
   if (caipChainId === SolScope.Mainnet || caipChainId.startsWith('solana:')) {
@@ -472,174 +474,184 @@ const SpendingLimit = ({
   }, [tempSelectedOption, isSolanaSelected, customLimit]);
 
   return (
-    <ScrollView
-      style={styles.wrapper}
-      showsVerticalScrollIndicator={false}
-      alwaysBounceVertical={false}
-      contentContainerStyle={styles.contentContainer}
-    >
-      <View style={styles.assetContainer}>
-        <TouchableOpacity
-          style={styles.dropdownButton}
-          onPress={handleOpenAssetSelection}
-        >
-          {renderSelectedToken()}
-        </TouchableOpacity>
-      </View>
+    <SafeAreaView style={styles.safeAreaView} edges={['bottom']}>
+      <KeyboardAwareScrollView
+        style={styles.wrapper}
+        showsVerticalScrollIndicator={false}
+        alwaysBounceVertical={false}
+        enableOnAndroid
+        enableAutomaticScroll
+        contentContainerStyle={styles.contentContainer}
+      >
+        <View style={styles.assetContainer}>
+          <TouchableOpacity
+            style={styles.dropdownButton}
+            onPress={handleOpenAssetSelection}
+          >
+            {renderSelectedToken()}
+          </TouchableOpacity>
+        </View>
 
-      <View style={styles.optionsContainer}>
-        {!showOptions ? (
-          // Initial view - only show full access option without radio button
-          <View style={styles.optionCard}>
-            <Text variant={TextVariant.BodyMDMedium} style={styles.optionTitle}>
-              {strings('card.card_spending_limit.full_access_title')}
-            </Text>
-            <Text variant={TextVariant.BodySM} style={styles.optionDescription}>
-              {strings('card.card_spending_limit.full_access_description')}
-            </Text>
-            <TouchableOpacity
-              style={styles.editLimitButton}
-              onPress={handleEditLimit}
-            >
-              <Text variant={TextVariant.BodySM} style={styles.editLimitText}>
-                {strings('card.card_spending_limit.set_new_limit')}
+        <View style={styles.optionsContainer}>
+          {!showOptions ? (
+            // Initial view - only show full access option without radio button
+            <View style={styles.optionCard}>
+              <Text
+                variant={TextVariant.BodyMDMedium}
+                style={styles.optionTitle}
+              >
+                {strings('card.card_spending_limit.full_access_title')}
               </Text>
-            </TouchableOpacity>
-          </View>
-        ) : (
-          // Options view - show both options with radio buttons in a single container
-          <View style={styles.optionCard}>
-            <TouchableOpacity
-              style={styles.optionItem}
-              onPress={() => {
-                handleOptionSelect('full');
-                trackEvent(
-                  createEventBuilder(MetaMetricsEvents.CARD_BUTTON_CLICKED)
-                    .addProperties({
-                      action: CardActions.ENABLE_TOKEN_FULL_ACCESS_BUTTON,
-                    })
-                    .build(),
-                );
-              }}
-            >
-              <View style={styles.optionHeader}>
-                <View style={styles.radioButton}>
-                  {tempSelectedOption === 'full' && (
-                    <View style={styles.radioButtonSelected} />
-                  )}
-                </View>
-                <Text
-                  variant={TextVariant.BodyMDMedium}
-                  style={styles.optionTitle}
-                >
-                  {strings('card.card_spending_limit.full_access_title')}
-                </Text>
-              </View>
               <Text
                 variant={TextVariant.BodySM}
                 style={styles.optionDescription}
               >
                 {strings('card.card_spending_limit.full_access_description')}
               </Text>
-            </TouchableOpacity>
-
-            <TouchableOpacity
-              style={styles.optionItem}
-              onPress={() => handleOptionSelect('restricted')}
-            >
-              <View style={styles.optionHeader}>
-                <View style={styles.radioButton}>
-                  {tempSelectedOption === 'restricted' && (
-                    <View style={styles.radioButtonSelected} />
-                  )}
+              <TouchableOpacity
+                style={styles.editLimitButton}
+                onPress={handleEditLimit}
+              >
+                <Text variant={TextVariant.BodySM} style={styles.editLimitText}>
+                  {strings('card.card_spending_limit.set_new_limit')}
+                </Text>
+              </TouchableOpacity>
+            </View>
+          ) : (
+            // Options view - show both options with radio buttons in a single container
+            <View style={styles.optionCard}>
+              <TouchableOpacity
+                style={styles.optionItem}
+                onPress={() => {
+                  handleOptionSelect('full');
+                  trackEvent(
+                    createEventBuilder(MetaMetricsEvents.CARD_BUTTON_CLICKED)
+                      .addProperties({
+                        action: CardActions.ENABLE_TOKEN_FULL_ACCESS_BUTTON,
+                      })
+                      .build(),
+                  );
+                }}
+              >
+                <View style={styles.optionHeader}>
+                  <View style={styles.radioButton}>
+                    {tempSelectedOption === 'full' && (
+                      <View style={styles.radioButtonSelected} />
+                    )}
+                  </View>
+                  <Text
+                    variant={TextVariant.BodyMDMedium}
+                    style={styles.optionTitle}
+                  >
+                    {strings('card.card_spending_limit.full_access_title')}
+                  </Text>
                 </View>
                 <Text
-                  variant={TextVariant.BodyMDMedium}
-                  style={styles.optionTitle}
+                  variant={TextVariant.BodySM}
+                  style={styles.optionDescription}
                 >
-                  {strings('card.card_spending_limit.restricted_limit_title')}
+                  {strings('card.card_spending_limit.full_access_description')}
                 </Text>
-              </View>
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                style={styles.optionItem}
+                onPress={() => handleOptionSelect('restricted')}
+              >
+                <View style={styles.optionHeader}>
+                  <View style={styles.radioButton}>
+                    {tempSelectedOption === 'restricted' && (
+                      <View style={styles.radioButtonSelected} />
+                    )}
+                  </View>
+                  <Text
+                    variant={TextVariant.BodyMDMedium}
+                    style={styles.optionTitle}
+                  >
+                    {strings('card.card_spending_limit.restricted_limit_title')}
+                  </Text>
+                </View>
+                <Text
+                  variant={TextVariant.BodySM}
+                  style={styles.optionDescription}
+                >
+                  {strings(
+                    'card.card_spending_limit.restricted_limit_description',
+                  )}
+                </Text>
+                {tempSelectedOption === 'restricted' && (
+                  <View style={styles.limitInputContainer}>
+                    <TextInput
+                      style={styles.limitInput}
+                      value={customLimit}
+                      onChangeText={(text) => {
+                        // Allow only numbers and decimal point
+                        const sanitized = text.replace(/[^0-9.]/g, '');
+                        // Prevent multiple decimal points
+                        const parts = sanitized.split('.');
+                        const formatted =
+                          parts.length > 2
+                            ? parts[0] + '.' + parts.slice(1).join('')
+                            : sanitized;
+                        setCustomLimit(formatted);
+                      }}
+                      placeholder="0"
+                      placeholderTextColor={theme.colors.text.muted}
+                      keyboardType="decimal-pad"
+                      returnKeyType="done"
+                    />
+                  </View>
+                )}
+              </TouchableOpacity>
+            </View>
+          )}
+        </View>
+
+        <View style={styles.buttonsContainer}>
+          {isSolanaSelected && (
+            <View style={styles.warningContainer}>
+              <Icon
+                name={IconName.Info}
+                size={IconSize.Sm}
+                color={theme.colors.warning.default}
+                style={styles.warningIcon}
+              />
               <Text
                 variant={TextVariant.BodySM}
-                style={styles.optionDescription}
+                style={[
+                  styles.warningText,
+                  { color: theme.colors.warning.default },
+                ]}
               >
-                {strings(
-                  'card.card_spending_limit.restricted_limit_description',
-                )}
+                {strings('card.card_spending_limit.solana_not_supported')}
               </Text>
-              {tempSelectedOption === 'restricted' && (
-                <View style={styles.limitInputContainer}>
-                  <TextInput
-                    style={styles.limitInput}
-                    value={customLimit}
-                    onChangeText={(text) => {
-                      // Allow only numbers and decimal point
-                      const sanitized = text.replace(/[^0-9.]/g, '');
-                      // Prevent multiple decimal points
-                      const parts = sanitized.split('.');
-                      const formatted =
-                        parts.length > 2
-                          ? parts[0] + '.' + parts.slice(1).join('')
-                          : sanitized;
-                      setCustomLimit(formatted);
-                    }}
-                    placeholder="0"
-                    placeholderTextColor={theme.colors.text.muted}
-                    keyboardType="decimal-pad"
-                    returnKeyType="done"
-                  />
-                </View>
-              )}
-            </TouchableOpacity>
-          </View>
-        )}
-      </View>
-
-      <View style={styles.buttonsContainer}>
-        {isSolanaSelected && (
-          <View style={styles.warningContainer}>
-            <Icon
-              name={IconName.Info}
-              size={IconSize.Sm}
-              color={theme.colors.warning.default}
-              style={styles.warningIcon}
-            />
-            <Text
-              variant={TextVariant.BodySM}
-              style={[
-                styles.warningText,
-                { color: theme.colors.warning.default },
-              ]}
-            >
-              {strings('card.card_spending_limit.solana_not_supported')}
-            </Text>
-          </View>
-        )}
-        <Button
-          variant={ButtonVariants.Primary}
-          label={strings('card.card_spending_limit.confirm_new_limit')}
-          size={ButtonSize.Lg}
-          onPress={handleConfirm}
-          width={ButtonWidthTypes.Full}
-          disabled={isConfirmDisabled || isDelegationLoading}
-          style={
-            isConfirmDisabled || isDelegationLoading
-              ? styles.disabledButton
-              : undefined
-          }
-          loading={isDelegationLoading}
-        />
-        <Button
-          variant={ButtonVariants.Secondary}
-          label={strings('card.card_spending_limit.cancel')}
-          size={ButtonSize.Lg}
-          onPress={handleCancel}
-          width={ButtonWidthTypes.Full}
-          disabled={isDelegationLoading}
-        />
-      </View>
-    </ScrollView>
+            </View>
+          )}
+          <Button
+            variant={ButtonVariants.Primary}
+            label={strings('card.card_spending_limit.confirm_new_limit')}
+            size={ButtonSize.Lg}
+            onPress={handleConfirm}
+            width={ButtonWidthTypes.Full}
+            disabled={isConfirmDisabled || isDelegationLoading}
+            style={
+              isConfirmDisabled || isDelegationLoading
+                ? styles.disabledButton
+                : undefined
+            }
+            loading={isDelegationLoading}
+          />
+          <Button
+            variant={ButtonVariants.Secondary}
+            label={strings('card.card_spending_limit.cancel')}
+            size={ButtonSize.Lg}
+            onPress={handleCancel}
+            width={ButtonWidthTypes.Full}
+            disabled={isDelegationLoading}
+          />
+        </View>
+      </KeyboardAwareScrollView>
+    </SafeAreaView>
   );
 };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes several minor UI issues on the CardHome and SpendingLimit screens, such as buttons being partially cut off on Android devices. The fix involves wrapping the affected components with a proper SafeAreaView to ensure consistent spacing and layout across platforms.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Buttons being cut off on Android in CardHome and SpendingLimit screens
CHANGELOG entry: Improved layout consistency by adding SafeAreaView wrapping

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Exclude Solana from spending limit features in CardHome and refactor SpendingLimit layout to SafeAreaView + KeyboardAwareScrollView with minor style tweaks and tests.
> 
> - **CardHome**:
>   - Update `isSpendingLimitSupported` to exclude Solana via `isSolanaChainId`; hide progress bar, close-to-limit warning, and `MANAGE_SPENDING_LIMIT_ITEM` for Solana (`caipChainId`).
>   - Minor `ButtonsSection` dependency cleanup to include related actions/flags.
> - **SpendingLimit**:
>   - Replace `ScrollView` with `SafeAreaView` + `KeyboardAwareScrollView` and adjust styles (`safeAreaView`, `wrapper`, `contentContainer` padding).
> - **Tests**:
>   - Mock `@metamask/bridge-controller.isSolanaChainId` and add cases validating Solana exclusions for progress bar, manage button, and warning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4504a0d82bb11a22a8ac63f911b1fa5f4dfe3120. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->