### PR TITLE
Analyze and resolve metamask issue

### DIFF
--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.test.ts
@@ -132,7 +132,7 @@ describe('useTransactionConfirm', () => {
     expect(onApprovalConfirm).toHaveBeenCalled();
   });
 
-  it('sets waitForResult true when not smart tx, no quotes, no fee token', async () => {
+  it('sets waitForResult false to prevent UI hanging', async () => {
     const { result } = renderHook();
 
     await act(async () => {
@@ -141,7 +141,7 @@ describe('useTransactionConfirm', () => {
 
     expect(onApprovalConfirm).toHaveBeenCalledWith(
       expect.objectContaining({
-        waitForResult: true,
+        waitForResult: false,
       }),
       expect.anything(),
     );

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionConfirm.ts
@@ -46,8 +46,9 @@ export function useTransactionConfirm() {
     selectShouldUseSmartTransaction(state, chainId),
   );
 
-  const waitForResult =
-    !shouldUseSmartTransaction && !quotes?.length && !selectedGasFeeToken;
+  // Don't wait for transaction result to prevent UI from hanging
+  // Users can check transaction status in the activity tab
+  const waitForResult = false;
 
   const handleSmartTransaction = useCallback(
     (updatedMetadata: TransactionMeta) => {


### PR DESCRIPTION
Set `waitForResult` to `false` in transaction confirmation to prevent the UI from hanging indefinitely during ERC20 token transfers.

The app was previously waiting indefinitely for transaction mining to complete for standard ERC20 transfers, leading to a frozen UI. This change aligns the behavior with the MetaMask extension, allowing users to track transaction status in the activity tab.

---
<a href="https://cursor.com/background-agent?bcId=bc-a5ef20dc-6604-4256-9c00-2743bbac4b29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a5ef20dc-6604-4256-9c00-2743bbac4b29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

