### PR TITLE
fix(predict): improve placeOrder error handling

### DIFF
--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -1157,69 +1157,57 @@ export class PredictController extends BaseController<
       // Track Predict Action Completed or Failed
       const completionDuration = performance.now() - startTime;
 
-      if (result.success) {
-        const { spentAmount, receivedAmount } = result.response;
-
-        const cachedBalance =
-          this.state.balances[providerId]?.[signer.address]?.balance ?? 0;
-        let realAmountUsd = amountUsd;
-        let realSharePrice = sharePrice;
-        try {
-          if (preview.side === Side.BUY) {
-            realAmountUsd = parseFloat(spentAmount);
-            realSharePrice =
-              parseFloat(spentAmount) / parseFloat(receivedAmount);
-
-            // Optimistically update balance
-            this.update((state) => {
-              state.balances[providerId] = state.balances[providerId] || {};
-              state.balances[providerId][signer.address] = {
-                balance: cachedBalance - realAmountUsd,
-                // valid for 5 seconds (since it takes some time to reflect balance on-chain)
-                validUntil: Date.now() + 5000,
-              };
-            });
-          } else {
-            realAmountUsd = parseFloat(receivedAmount);
-            realSharePrice =
-              parseFloat(receivedAmount) / parseFloat(spentAmount);
-
-            // Optimistically update balance
-            this.update((state) => {
-              state.balances[providerId] = state.balances[providerId] || {};
-              state.balances[providerId][signer.address] = {
-                balance: cachedBalance + realAmountUsd,
-                // valid for 5 seconds (since it takes some time to reflect balance on-chain)
-                validUntil: Date.now() + 5000,
-              };
-            });
-          }
-        } catch (_e) {
-          // If we can't get real share price, continue without it
-        }
-
-        // Track Predict Action Completed (fire and forget)
-        this.trackPredictOrderEvent({
-          eventType: PredictEventType.COMPLETED,
-          amountUsd: realAmountUsd,
-          analyticsProperties,
-          providerId,
-          completionDuration,
-          sharePrice: realSharePrice,
-        });
-      } else {
-        // Track Predict Action Failed (fire and forget)
-        this.trackPredictOrderEvent({
-          eventType: PredictEventType.FAILED,
-          amountUsd,
-          analyticsProperties,
-          providerId,
-          sharePrice,
-          completionDuration,
-          failureReason: result.error || 'Unknown error',
-        });
+      if (!result.success) {
         throw new Error(result.error);
       }
+
+      const { spentAmount, receivedAmount } = result.response;
+
+      const cachedBalance =
+        this.state.balances[providerId]?.[signer.address]?.balance ?? 0;
+      let realAmountUsd = amountUsd;
+      let realSharePrice = sharePrice;
+      try {
+        if (preview.side === Side.BUY) {
+          realAmountUsd = parseFloat(spentAmount);
+          realSharePrice = parseFloat(spentAmount) / parseFloat(receivedAmount);
+
+          // Optimistically update balance
+          this.update((state) => {
+            state.balances[providerId] = state.balances[providerId] || {};
+            state.balances[providerId][signer.address] = {
+              balance: cachedBalance - realAmountUsd,
+              // valid for 5 seconds (since it takes some time to reflect balance on-chain)
+              validUntil: Date.now() + 5000,
+            };
+          });
+        } else {
+          realAmountUsd = parseFloat(receivedAmount);
+          realSharePrice = parseFloat(receivedAmount) / parseFloat(spentAmount);
+
+          // Optimistically update balance
+          this.update((state) => {
+            state.balances[providerId] = state.balances[providerId] || {};
+            state.balances[providerId][signer.address] = {
+              balance: cachedBalance + realAmountUsd,
+              // valid for 5 seconds (since it takes some time to reflect balance on-chain)
+              validUntil: Date.now() + 5000,
+            };
+          });
+        }
+      } catch (_e) {
+        // If we can't get real share price, continue without it
+      }
+
+      // Track Predict Action Completed (fire and forget)
+      this.trackPredictOrderEvent({
+        eventType: PredictEventType.COMPLETED,
+        amountUsd: realAmountUsd,
+        analyticsProperties,
+        providerId,
+        completionDuration,
+        sharePrice: realSharePrice,
+      });
 
       return result as unknown as Result;
     } catch (error) {
@@ -1229,6 +1217,7 @@ export class PredictController extends BaseController<
           ? error.message
           : PREDICT_ERROR_CODES.PLACE_ORDER_FAILED;
 
+      // Track Predict Action Failed (fire and forget)
       this.trackPredictOrderEvent({
         eventType: PredictEventType.FAILED,
         amountUsd,

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -711,7 +711,10 @@ export class PolymarketProvider implements PredictProvider {
         if (error.includes(`order couldn't be fully filled`)) {
           throw new Error(PREDICT_ERROR_CODES.ORDER_NOT_FULLY_FILLED);
         }
-        if (error.includes(`not available in your region`)) {
+        if (
+          error.includes(`not available in your region`) ||
+          error.includes(`unable to access this provider`)
+        ) {
           throw new Error(PREDICT_ERROR_CODES.NOT_ELIGIBLE);
         }
         throw new Error(error ?? PREDICT_ERROR_CODES.PLACE_ORDER_FAILED);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR improves error handling in the Predict feature's `placeOrder` method by refactoring the control flow to fail fast and ensuring analytics tracking is consistent across both success and error paths.

**Reason for change:** The previous implementation had nested success/failure logic that made the code harder to follow and potentially allowed analytics events to be tracked incorrectly in edge cases.

**Improvement:**

- Refactored to throw immediately on failure, simplifying the control flow
- Moved analytics failure tracking to the catch block where it belongs
- Added support for detecting "unable to access this provider" error messages as eligibility errors in the Polymarket provider

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Predict order placement error handling

  Scenario: user places an order that fails
    Given user is on the Predict screen with a valid market

    When user attempts to place an order that fails (e.g., region restriction)
    Then the appropriate error message is displayed
    And analytics failure event is tracked correctly

  Scenario: user places a successful order
    Given user is on the Predict screen with a valid market

    When user places a valid order
    Then the order completes successfully
    And analytics completion event is tracked with correct amounts
    And user balance is optimistically updated
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors `placeOrder` to fail fast with unified success/failed analytics and optimistic balance updates; adds detection of "unable to access this provider" as an eligibility error in Polymarket.
> 
> - **PredictController (`PredictController.ts`)**:
>   - **placeOrder**: Fail-fast on unsuccessful provider response; centralizes COMPLETED tracking after result parsing and moves FAILED tracking to catch block; keeps optimistic balance updates and real share price/amount derivation.
> - **PolymarketProvider (`PolymarketProvider.ts`)**:
>   - **placeOrder**: Treats errors containing "unable to access this provider" (in addition to region block) as `NOT_ELIGIBLE`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cafad44300487d337950a84fdffd850644ed0a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->