### PR TITLE
fix(card): cp-7.58.2 delegation issues

### DIFF
--- a/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.test.tsx
+++ b/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.test.tsx
@@ -1022,6 +1022,116 @@ describe('SpendingLimit Component', () => {
         );
       });
     });
+
+    it('does not call updateTokenPriority when delegation amount is zero', async () => {
+      const mockExternalWalletDetails = {
+        walletDetails: [
+          {
+            id: 1,
+            walletAddress: '0xwallet123',
+            currency: 'USDC',
+            balance: '1000',
+            allowance: '1000000',
+            priority: 1,
+            tokenDetails: {
+              address: '0x123',
+              symbol: 'USDC',
+              name: 'USD Coin',
+              decimals: 6,
+            },
+            caipChainId: 'eip155:59144' as `${string}:${string}`,
+            network: 'linea' as const,
+          },
+        ] as unknown as CardExternalWalletDetailsResponse,
+        mappedWalletDetails: [mockPriorityToken],
+        priorityWalletDetail: mockPriorityToken,
+      };
+
+      const routeWithWalletDetails: MockRoute = {
+        params: {
+          ...mockRoute.params,
+          externalWalletDetailsData: mockExternalWalletDetails,
+        },
+      };
+
+      render(routeWithWalletDetails);
+
+      const setLimitButton = screen.getByText('Set a limit');
+      fireEvent.press(setLimitButton);
+
+      const restrictedOption = screen.getByText('Restricted');
+      fireEvent.press(restrictedOption);
+
+      const input = screen.getByPlaceholderText('0');
+      fireEvent.changeText(input, '0');
+
+      const confirmButton = screen.getByText('Confirm');
+      fireEvent.press(confirmButton);
+
+      await waitFor(() => {
+        expect(mockSubmitDelegation).toHaveBeenCalled();
+      });
+
+      expect(mockUpdateTokenPriority).not.toHaveBeenCalled();
+      expect(mockDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: expect.stringContaining('clearCacheData'),
+          payload: 'card-external-wallet-details',
+        }),
+      );
+    });
+
+    it('does not call updateTokenPriority when delegation amount is 0x0', async () => {
+      const mockExternalWalletDetails = {
+        walletDetails: [
+          {
+            id: 1,
+            walletAddress: '0xwallet123',
+            currency: 'USDC',
+            balance: '1000',
+            allowance: '1000000',
+            priority: 1,
+            tokenDetails: {
+              address: '0x123',
+              symbol: 'USDC',
+              name: 'USD Coin',
+              decimals: 6,
+            },
+            caipChainId: 'eip155:59144' as `${string}:${string}`,
+            network: 'linea' as const,
+          },
+        ] as unknown as CardExternalWalletDetailsResponse,
+        mappedWalletDetails: [mockPriorityToken],
+        priorityWalletDetail: mockPriorityToken,
+      };
+
+      const routeWithWalletDetails: MockRoute = {
+        params: {
+          ...mockRoute.params,
+          externalWalletDetailsData: mockExternalWalletDetails,
+        },
+      };
+
+      render(routeWithWalletDetails);
+
+      const setLimitButton = screen.getByText('Set a limit');
+      fireEvent.press(setLimitButton);
+
+      const restrictedOption = screen.getByText('Restricted');
+      fireEvent.press(restrictedOption);
+
+      const input = screen.getByPlaceholderText('0');
+      fireEvent.changeText(input, '0x0');
+
+      const confirmButton = screen.getByText('Confirm');
+      fireEvent.press(confirmButton);
+
+      await waitFor(() => {
+        expect(mockSubmitDelegation).toHaveBeenCalled();
+      });
+
+      expect(mockUpdateTokenPriority).not.toHaveBeenCalled();
+    });
   });
 
   describe('Cancel Behavior', () => {

--- a/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.tsx
+++ b/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.tsx
@@ -54,6 +54,7 @@ import { useDispatch } from 'react-redux';
 import Routes from '../../../../../constants/navigation/Routes';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
+import { isZeroValue } from '../../../../../util/number';
 
 const getNetworkFromCaipChainId = (caipChainId: string): CardNetwork => {
   if (caipChainId === SolScope.Mainnet || caipChainId.startsWith('solana:')) {
@@ -271,10 +272,11 @@ const SpendingLimit = ({
             network,
           });
 
-          // Update token priority if external wallet details are available
+          // Update token priority if external wallet details are available and delegation is more than 0
           if (
             externalWalletDetailsData?.walletDetails &&
-            externalWalletDetailsData.walletDetails.length > 0
+            externalWalletDetailsData.walletDetails.length > 0 &&
+            !isZeroValue(parseFloat(delegationAmount))
           ) {
             const tokenWithWallet = tokenToUse || priorityToken;
             if (tokenWithWallet) {
@@ -284,7 +286,6 @@ const SpendingLimit = ({
               );
             }
           } else {
-            // If no external wallet details, just invalidate cache
             dispatch(clearCacheData('card-external-wallet-details'));
           }
 

--- a/app/components/UI/Card/hooks/useCardDelegation.ts
+++ b/app/components/UI/Card/hooks/useCardDelegation.ts
@@ -18,6 +18,7 @@ import { MetaMetricsEvents, useMetrics } from '../../../hooks/useMetrics';
 import { ARBITRARY_ALLOWANCE } from '../constants';
 import { toTokenMinimalUnit } from '../../../../util/number';
 import AppConstants from '../../../../core/AppConstants';
+import { safeToChecksumAddress } from '../../../../util/address';
 
 /**
  * Custom error class for user-initiated cancellations
@@ -238,7 +239,10 @@ export const useCardDelegation = (token?: CardTokenAllowance | null) => {
         const userAccount = selectAccountByScope(
           params.network === 'solana' ? SolScope.Mainnet : 'eip155:0',
         );
-        const address = userAccount?.address;
+        const address =
+          params.network === 'solana'
+            ? userAccount?.address
+            : safeToChecksumAddress(userAccount?.address);
 
         if (!address) {
           throw new Error('No account found');

--- a/app/components/UI/Card/sdk/CardSDK.ts
+++ b/app/components/UI/Card/sdk/CardSDK.ts
@@ -53,6 +53,7 @@ import { SOLANA_MAINNET } from '../../Ramp/Deposit/constants/networks';
 import { CaipChainId } from '@metamask/utils';
 import { formatChainIdToCaip } from '@metamask/bridge-controller';
 import { SolScope } from '@metamask/keyring-api';
+import { isZeroValue } from '../../../../util/number';
 
 // Default timeout for all API requests (10 seconds)
 const DEFAULT_REQUEST_TIMEOUT_MS = 10000;
@@ -890,7 +891,11 @@ export class CardSDK {
     const combinedDetails = externalWalletDetails
       .map((wallet: CardWalletExternalResponse) => {
         const networkLower = wallet.network?.toLowerCase();
-        if (!SUPPORTED_ASSET_NETWORKS.includes(networkLower)) {
+        if (
+          !SUPPORTED_ASSET_NETWORKS.includes(networkLower) ||
+          isNaN(parseInt(wallet.allowance)) ||
+          isZeroValue(parseInt(wallet.allowance))
+        ) {
           return null;
         }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes an issue where delegation was failing in certain cases due to the wallet address being lowercased. The lowercase format did not comply with the SIWE (Sign-In With Ethereum) standard required by the delegation flow.

Additionally, this update includes a fix for assets that were not enabled, ensuring consistent behavior across all supported assets.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Delegation failing due to lowercased wallet address not complying with SIWE standard
CHANGELOG entry: Handling of not-enabled assets in the delegation flow

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use checksummed EVM addresses for delegation, filter external wallets with zero/invalid allowances, and only update token priority when delegation amount > 0, with corresponding tests.
> 
> - **Hooks**:
>   - `useCardDelegation`: Use `safeToChecksumAddress` for non-Solana networks; keep raw address for Solana.
> - **SDK**:
>   - `CardSDK.getCardExternalWalletDetails`: Filter out wallets with unsupported networks or zero/invalid `allowance` using `isZeroValue`; maintain priority mapping and sorting.
> - **UI**:
>   - `SpendingLimit`: Only call `updateTokenPriority` when external wallet details exist and `delegationAmount` is non-zero; otherwise clear `card-external-wallet-details` cache.
> - **Tests**:
>   - Add/expand tests covering checksummed vs raw addresses, zero/hex-zero allowances filtering, and skipping `updateTokenPriority` when delegation amount is 0/`0x0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b03ccdc1fd1a5908c8428f6ea112bb3a41227052. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->