### PR TITLE
fix: validate insufficient balance for bridges

### DIFF
--- a/app/components/UI/Bridge/hooks/useInsufficientBalance/index.ts
+++ b/app/components/UI/Bridge/hooks/useInsufficientBalance/index.ts
@@ -5,6 +5,8 @@ import { BridgeToken } from '../../types';
 import { isNativeAddress, isSolanaChainId } from '@metamask/bridge-controller';
 import { selectBridgeQuotes } from '../../../../../core/redux/slices/bridge';
 import { BigNumber } from 'ethers';
+import { BigNumber as BigNumberJS } from 'bignumber.js';
+import { isNumberValue } from '../../../../../util/number';
 
 interface UseIsInsufficientBalanceParams {
   amount: string | undefined;
@@ -68,21 +70,45 @@ const useIsInsufficientBalance = ({
     normalizeAmount(amount, token.decimals),
     token.decimals,
   );
-  const isSOL =
-    token.chainId &&
-    isSolanaChainId(token.chainId) &&
-    isNativeAddress(token.address);
+
+  const isNativeToken = token.chainId && isNativeAddress(token.address);
+  const isSOL = isNativeToken && isSolanaChainId(token.chainId);
+
+  // Calculate gas fees if needed for native token source
+  // For ERC-20 tokens (USDC, DAI, etc.), gas is checked separately in useHasSufficientGas
+  // For native tokens (ETH, MATIC, etc.), gas comes from the SAME balance we're spending,
+  // so we need to ensure: balance >= sourceAmount + gasAmount
+  let atomicGasFee = BigNumber.from(0);
+  if (isNativeToken && !gasIncluded) {
+    const gasAmount = bestQuote?.gasFee?.effective?.amount;
+    const effectiveGasFee = isNumberValue(gasAmount)
+      ? // we guard against null and undefined values of gasAmount when checked isNumberValue
+        new BigNumberJS(gasAmount as string | number).toFixed()
+      : null;
+
+    if (effectiveGasFee) {
+      atomicGasFee = parseUnits(effectiveGasFee, token.decimals);
+    }
+  }
 
   let isInsufficientBalance = false;
 
   if (isSOL) {
-    // For SOL: check if balance - inputAmount >= minSolBalance (rent exemption)
+    // SOL: check if balance - inputAmount >= minSolBalance (rent exemption)
     const minSolBalanceLamports = parseUnits(minSolBalance, token.decimals);
     const remainingBalance = latestAtomicBalance.sub(inputAmount);
     isInsufficientBalance =
       isInsufficientBalance || remainingBalance.lt(minSolBalanceLamports);
+  } else if (isNativeToken && !gasIncluded && atomicGasFee.gt(0)) {
+    // Native tokens (ETH, MATIC, etc.): check balance >= sourceAmount + gasAmount
+    // Example: User has 1 ETH, wants to send 1 ETH, needs 0.01 ETH gas = insufficient
+    const totalRequired = inputAmount.add(atomicGasFee);
+    isInsufficientBalance =
+      isInsufficientBalance || totalRequired.gt(latestAtomicBalance);
   } else {
-    // For non-SOL: just check if inputAmount > balance
+    // ERC-20 tokens or gasless transactions: check balance >= sourceAmount only
+    // Example: User has 100 USDC, wants to send 50 USDC = sufficient
+    // (Gas check happens separately in useHasSufficientGas for ERC-20 tokens)
     isInsufficientBalance =
       isInsufficientBalance || inputAmount.gt(latestAtomicBalance);
   }

--- a/app/components/UI/Bridge/hooks/useInsufficientBalance/useInsufficientBalance.test.tsx
+++ b/app/components/UI/Bridge/hooks/useInsufficientBalance/useInsufficientBalance.test.tsx
@@ -1,0 +1,555 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { Provider } from 'react-redux';
+import { createStore, Store } from 'redux';
+import useIsInsufficientBalance from './index';
+import { BridgeToken } from '../../types';
+import { BigNumber } from 'ethers';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import { SolScope } from '@metamask/keyring-api';
+import { initialState } from '../../_mocks_/initialState';
+
+// Mock the selectBridgeQuotes selector
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let mockQuotes: any = null;
+jest.mock('../../../../../core/redux/slices/bridge', () => ({
+  ...jest.requireActual('../../../../../core/redux/slices/bridge'),
+  selectBridgeQuotes: jest.fn(() => mockQuotes),
+}));
+
+// Mock selectMinSolBalance
+jest.mock('../../../../../selectors/bridgeController', () => ({
+  selectMinSolBalance: jest.fn(() => '0.001'),
+}));
+
+// Helper to create a mock store with proper state structure
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const createMockStore = (quotes: any): Store => {
+  mockQuotes = quotes;
+  const rootReducer = (state = initialState) => state;
+  return createStore(rootReducer, initialState);
+};
+
+// Helper to wrap hook with provider
+const wrapper =
+  (store: Store) =>
+  ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>{children}</Provider>
+  );
+
+describe('useIsInsufficientBalance', () => {
+  afterEach(() => {
+    mockQuotes = null;
+  });
+
+  describe('ERC-20 Tokens', () => {
+    const usdcToken: BridgeToken = {
+      address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC
+      symbol: 'USDC',
+      decimals: 6,
+      chainId: CHAIN_IDS.MAINNET as `0x${string}`,
+    };
+
+    it('should return false when user has sufficient USDC balance for swap (gasless)', () => {
+      const store = createMockStore({
+        recommendedQuote: {
+          quote: {
+            gasIncluded: true,
+          },
+        },
+      });
+
+      const { result } = renderHook(
+        () =>
+          useIsInsufficientBalance({
+            amount: '50', // 50 USDC
+            token: usdcToken,
+            latestAtomicBalance: BigNumber.from('100000000'), // 100 USDC (6 decimals)
+          }),
+        { wrapper: wrapper(store) },
+      );
+
+      expect(result.current).toBe(false);
+    });
+
+    it('should return true when user has insufficient USDC balance', () => {
+      const store = createMockStore({
+        recommendedQuote: {
+          quote: {
+            gasIncluded: false,
+          },
+        },
+      });
+
+      const { result } = renderHook(
+        () =>
+          useIsInsufficientBalance({
+            amount: '150', // 150 USDC
+            token: usdcToken,
+            latestAtomicBalance: BigNumber.from('100000000'), // 100 USDC (6 decimals)
+          }),
+        { wrapper: wrapper(store) },
+      );
+
+      expect(result.current).toBe(true);
+    });
+
+    it('should return false for cross-chain USDC transaction with sufficient token balance (gas checked separately)', () => {
+      // For ERC-20 tokens, gas is checked in useHasSufficientGas, not here
+      const store = createMockStore({
+        recommendedQuote: {
+          quote: {
+            gasIncluded: false,
+          },
+          gasFee: {
+            effective: {
+              amount: '0.001', // 0.001 ETH gas
+            },
+          },
+        },
+      });
+
+      const { result } = renderHook(
+        () =>
+          useIsInsufficientBalance({
+            amount: '50', // 50 USDC
+            token: usdcToken,
+            latestAtomicBalance: BigNumber.from('100000000'), // 100 USDC
+          }),
+        { wrapper: wrapper(store) },
+      );
+
+      // Should return false because USDC balance is sufficient
+      // Gas check happens in useHasSufficientGas
+      expect(result.current).toBe(false);
+    });
+  });
+
+  describe('Native Tokens - Ethereum (ETH)', () => {
+    const ethToken: BridgeToken = {
+      address: '0x0000000000000000000000000000000000000000',
+      symbol: 'ETH',
+      decimals: 18,
+      chainId: CHAIN_IDS.MAINNET as `0x${string}`,
+    };
+
+    it('should return false when user has sufficient ETH for gasless swap', () => {
+      const store = createMockStore({
+        recommendedQuote: {
+          quote: {
+            gasIncluded: true, // Gasless swap
+          },
+        },
+      });
+
+      const { result } = renderHook(
+        () =>
+          useIsInsufficientBalance({
+            amount: '0.5', // 0.5 ETH
+            token: ethToken,
+            latestAtomicBalance: BigNumber.from('1000000000000000000'), // 1 ETH
+          }),
+        { wrapper: wrapper(store) },
+      );
+
+      expect(result.current).toBe(false);
+    });
+
+    it('should return false when user has sufficient ETH including gas for cross-chain', () => {
+      const store = createMockStore({
+        recommendedQuote: {
+          quote: {
+            gasIncluded: false, // Cross-chain, needs gas
+          },
+          gasFee: {
+            effective: {
+              amount: '0.01', // 0.01 ETH gas
+            },
+          },
+        },
+      });
+
+      const { result } = renderHook(
+        () =>
+          useIsInsufficientBalance({
+            amount: '0.5', // 0.5 ETH
+            token: ethToken,
+            latestAtomicBalance: BigNumber.from('1000000000000000000'), // 1 ETH
+            // Total needed: 0.5 + 0.01 = 0.51 ETH < 1 ETH ✓
+          }),
+        { wrapper: wrapper(store) },
+      );
+
+      expect(result.current).toBe(false);
+    });
+
+    it('should return true when ETH amount + gas exceeds balance for cross-chain', () => {
+      const store = createMockStore({
+        recommendedQuote: {
+          quote: {
+            gasIncluded: false,
+          },
+          gasFee: {
+            effective: {
+              amount: '0.02', // 0.02 ETH gas
+            },
+          },
+        },
+      });
+
+      const { result } = renderHook(
+        () =>
+          useIsInsufficientBalance({
+            amount: '0.99', // 0.99 ETH
+            token: ethToken,
+            latestAtomicBalance: BigNumber.from('1000000000000000000'), // 1 ETH
+            // Total needed: 0.99 + 0.02 = 1.01 ETH > 1 ETH ✗
+          }),
+        { wrapper: wrapper(store) },
+      );
+
+      expect(result.current).toBe(true);
+    });
+
+    it('should return true when user tries to send more ETH than balance (even without gas)', () => {
+      const store = createMockStore({
+        recommendedQuote: {
+          quote: {
+            gasIncluded: false,
+          },
+          gasFee: {
+            effective: {
+              amount: '0.001',
+            },
+          },
+        },
+      });
+
+      const { result } = renderHook(
+        () =>
+          useIsInsufficientBalance({
+            amount: '2', // 2 ETH
+            token: ethToken,
+            latestAtomicBalance: BigNumber.from('1000000000000000000'), // 1 ETH
+          }),
+        { wrapper: wrapper(store) },
+      );
+
+      expect(result.current).toBe(true);
+    });
+
+    it('should handle scientific notation in gas amounts', () => {
+      const store = createMockStore({
+        recommendedQuote: {
+          quote: {
+            gasIncluded: false,
+          },
+          gasFee: {
+            effective: {
+              amount: '1.5e-3', // 0.0015 ETH in scientific notation
+            },
+          },
+        },
+      });
+
+      const { result } = renderHook(
+        () =>
+          useIsInsufficientBalance({
+            amount: '0.5', // 0.5 ETH
+            token: ethToken,
+            latestAtomicBalance: BigNumber.from('1000000000000000000'), // 1 ETH
+            // Total needed: 0.5 + 0.0015 = 0.5015 ETH < 1 ETH ✓
+          }),
+        { wrapper: wrapper(store) },
+      );
+
+      // Should handle scientific notation correctly and return false
+      expect(result.current).toBe(false);
+    });
+
+    it('should return true when scientific notation gas causes insufficient balance', () => {
+      const store = createMockStore({
+        recommendedQuote: {
+          quote: {
+            gasIncluded: false,
+          },
+          gasFee: {
+            effective: {
+              amount: '5e-2', // 0.05 ETH in scientific notation
+            },
+          },
+        },
+      });
+
+      const { result } = renderHook(
+        () =>
+          useIsInsufficientBalance({
+            amount: '0.96', // 0.96 ETH
+            token: ethToken,
+            latestAtomicBalance: BigNumber.from('1000000000000000000'), // 1 ETH
+            // Total needed: 0.96 + 0.05 = 1.01 ETH > 1 ETH ✗
+          }),
+        { wrapper: wrapper(store) },
+      );
+
+      expect(result.current).toBe(true);
+    });
+  });
+
+  describe('Native Tokens - Polygon (MATIC)', () => {
+    const maticToken: BridgeToken = {
+      address: '0x0000000000000000000000000000000000000000',
+      symbol: 'MATIC',
+      decimals: 18,
+      chainId: CHAIN_IDS.POLYGON as `0x${string}`,
+    };
+
+    it('should return false when user has sufficient MATIC including gas', () => {
+      const store = createMockStore({
+        recommendedQuote: {
+          quote: {
+            gasIncluded: false,
+          },
+          gasFee: {
+            effective: {
+              amount: '0.1', // 0.1 MATIC gas
+            },
+          },
+        },
+      });
+
+      const { result } = renderHook(
+        () =>
+          useIsInsufficientBalance({
+            amount: '5', // 5 MATIC
+            token: maticToken,
+            latestAtomicBalance: BigNumber.from('10000000000000000000'), // 10 MATIC
+            // Total needed: 5 + 0.1 = 5.1 MATIC < 10 MATIC ✓
+          }),
+        { wrapper: wrapper(store) },
+      );
+
+      expect(result.current).toBe(false);
+    });
+
+    it('should return true when MATIC amount + gas exceeds balance', () => {
+      const store = createMockStore({
+        recommendedQuote: {
+          quote: {
+            gasIncluded: false,
+          },
+          gasFee: {
+            effective: {
+              amount: '1', // 1 MATIC gas
+            },
+          },
+        },
+      });
+
+      const { result } = renderHook(
+        () =>
+          useIsInsufficientBalance({
+            amount: '9.5', // 9.5 MATIC
+            token: maticToken,
+            latestAtomicBalance: BigNumber.from('10000000000000000000'), // 10 MATIC
+            // Total needed: 9.5 + 1 = 10.5 MATIC > 10 MATIC ✗
+          }),
+        { wrapper: wrapper(store) },
+      );
+
+      expect(result.current).toBe(true);
+    });
+  });
+
+  describe('Solana (SOL)', () => {
+    const solToken: BridgeToken = {
+      address: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+      symbol: 'SOL',
+      decimals: 9,
+      chainId: SolScope.Mainnet,
+    };
+
+    it('should return false when user has sufficient SOL above rent exemption', () => {
+      const store = createMockStore({
+        recommendedQuote: {
+          quote: {
+            gasIncluded: false,
+          },
+        },
+      });
+
+      const { result } = renderHook(
+        () =>
+          useIsInsufficientBalance({
+            amount: '1', // 1 SOL
+            token: solToken,
+            latestAtomicBalance: BigNumber.from('3000000000'), // 3 SOL (9 decimals)
+            // Remaining: 3 - 1 = 2 SOL > 0.001 SOL rent exemption ✓
+          }),
+        { wrapper: wrapper(store) },
+      );
+
+      expect(result.current).toBe(false);
+    });
+
+    it('should return true when SOL balance would drop below rent exemption', () => {
+      const store = createMockStore({
+        recommendedQuote: {
+          quote: {
+            gasIncluded: false,
+          },
+        },
+      });
+
+      const { result } = renderHook(
+        () =>
+          useIsInsufficientBalance({
+            amount: '1.9999', // 1.9999 SOL
+            token: solToken,
+            latestAtomicBalance: BigNumber.from('2000000000'), // 2 SOL
+            // Remaining: 2 - 1.9999 = 0.0001 SOL < 0.001 SOL rent exemption ✗
+          }),
+        { wrapper: wrapper(store) },
+      );
+
+      expect(result.current).toBe(true);
+    });
+  });
+
+  describe('Edge Cases', () => {
+    const ethToken: BridgeToken = {
+      address: '0x0000000000000000000000000000000000000000',
+      symbol: 'ETH',
+      decimals: 18,
+      chainId: CHAIN_IDS.MAINNET as `0x${string}`,
+    };
+
+    it('should return false when amount is undefined', () => {
+      const store = createMockStore({
+        recommendedQuote: {
+          quote: {
+            gasIncluded: false,
+          },
+        },
+      });
+
+      const { result } = renderHook(
+        () =>
+          useIsInsufficientBalance({
+            amount: undefined,
+            token: ethToken,
+            latestAtomicBalance: BigNumber.from('1000000000000000000'),
+          }),
+        { wrapper: wrapper(store) },
+      );
+
+      expect(result.current).toBe(false);
+    });
+
+    it('should return false when amount is just a decimal point', () => {
+      const store = createMockStore({
+        recommendedQuote: {
+          quote: {
+            gasIncluded: false,
+          },
+        },
+      });
+
+      const { result } = renderHook(
+        () =>
+          useIsInsufficientBalance({
+            amount: '.',
+            token: ethToken,
+            latestAtomicBalance: BigNumber.from('1000000000000000000'),
+          }),
+        { wrapper: wrapper(store) },
+      );
+
+      expect(result.current).toBe(false);
+    });
+
+    it('should return false when token is undefined', () => {
+      const store = createMockStore({
+        recommendedQuote: {
+          quote: {
+            gasIncluded: false,
+          },
+        },
+      });
+
+      const { result } = renderHook(
+        () =>
+          useIsInsufficientBalance({
+            amount: '1',
+            token: undefined,
+            latestAtomicBalance: BigNumber.from('1000000000000000000'),
+          }),
+        { wrapper: wrapper(store) },
+      );
+
+      expect(result.current).toBe(false);
+    });
+
+    it('should return false when balance is undefined', () => {
+      const store = createMockStore({
+        recommendedQuote: {
+          quote: {
+            gasIncluded: false,
+          },
+        },
+      });
+
+      const { result } = renderHook(
+        () =>
+          useIsInsufficientBalance({
+            amount: '1',
+            token: ethToken,
+            latestAtomicBalance: undefined,
+          }),
+        { wrapper: wrapper(store) },
+      );
+
+      expect(result.current).toBe(false);
+    });
+
+    it('should still check balance when no quote is available', () => {
+      const store = createMockStore(null);
+
+      const { result } = renderHook(
+        () =>
+          useIsInsufficientBalance({
+            amount: '1',
+            token: ethToken,
+            latestAtomicBalance: BigNumber.from('500000000000000000'), // 0.5 ETH
+          }),
+        { wrapper: wrapper(store) },
+      );
+
+      // Should return true because 1 ETH > 0.5 ETH balance
+      // Even without a quote, basic balance check still applies
+      expect(result.current).toBe(true);
+    });
+
+    it('should handle zero balance correctly', () => {
+      const store = createMockStore({
+        recommendedQuote: {
+          quote: {
+            gasIncluded: false,
+          },
+        },
+      });
+
+      const { result } = renderHook(
+        () =>
+          useIsInsufficientBalance({
+            amount: '0.1',
+            token: ethToken,
+            latestAtomicBalance: BigNumber.from('0'),
+          }),
+        { wrapper: wrapper(store) },
+      );
+
+      expect(result.current).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Re validate gas fees after users move from swap to bridge while they have selected max balance on a gasless transaction.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Re validate gas fees after users move from swap to bridge while they have selected max balance on a gasless transaction.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3417

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**



<!-- [screenshots/recordings] -->

### **After**
<img width="455" height="902" alt="Screenshot 2025-11-11 at 2 02 32 PM" src="https://github.com/user-attachments/assets/87e0f398-66d0-48e0-ab3c-ab76f232c9ed" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `useIsInsufficientBalance` to include native-token gas and SOL rent checks, handle scientific notation, and adds thorough unit tests across tokens and edge cases.
> 
> - **Bridge hook `useInsufficientBalance`**:
>   - Handle native-token gas by summing `sourceAmount + gasFee` using `quotes.recommendedQuote.gasFee.effective.amount` when `gasIncluded` is false.
>   - Preserve SOL rent exemption check using `selectMinSolBalance` with lamports comparison.
>   - Normalize numeric inputs (incl. scientific notation) via `BigNumber.js`/`normalizeAmount`; validate decimal precision.
>   - Refactor native token detection (`isNativeAddress`) and branch logic; early-return safeguards for invalid inputs and gasless swaps.
> - **Tests**:
>   - Add comprehensive unit tests covering ERC-20 (gasless/cross-chain), ETH/MATIC native gas scenarios, SOL rent exemption, scientific notation, and edge cases (undefined inputs, no quote, zero balance).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1025b2edc619999ed3b863dd6e938cea6ad01e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->