### PR TITLE
Analyze and resolve metamask issue

### DIFF
--- a/app/components/Views/confirmations/hooks/useTokenAsset.ts
+++ b/app/components/Views/confirmations/hooks/useTokenAsset.ts
@@ -8,6 +8,8 @@ import { safeToChecksumAddress } from '../../../../util/address';
 import { TokenI } from '../../../UI/Tokens/types';
 import { getNativeTokenAddress } from '../utils/asset';
 import { useTransactionMetadataRequest } from './transactions/useTransactionMetadataRequest';
+import { useGetTokenStandardAndDetails } from './useGetTokenStandardAndDetails';
+import Engine from '../../../../core/Engine';
 
 const TypesForNativeToken = [
   TransactionType.simpleSend,
@@ -38,6 +40,32 @@ export const useTokenAsset = () => {
   const asset = tokens[chainId]?.find(
     ({ address }) => address.toLowerCase() === tokenAddress,
   ) as TokenI;
+
+  // If asset is not in state, try to fetch token details on-demand
+  const networkClientId =
+    Engine.context.NetworkController.findNetworkClientIdByChainId(
+      chainId as Hex,
+    );
+
+  const { details: tokenDetails } = useGetTokenStandardAndDetails(
+    !asset && tokenAddress ? (tokenAddress as Hex) : undefined,
+    networkClientId,
+  );
+
+  // If token is not in state but we have fetched details, use those
+  if (!asset && tokenDetails?.symbol) {
+    const displayName =
+      tokenDetails.symbol ?? tokenDetails.name ?? strings('token.unknown');
+
+    return {
+      asset: {
+        symbol: tokenDetails.symbol,
+        name: tokenDetails.name,
+        address: tokenAddress,
+      } as Partial<TokenI>,
+      displayName,
+    };
+  }
 
   if (!asset) {
     return { asset: {}, displayName: strings('token.unknown') };


### PR DESCRIPTION
Fetch token metadata on-demand in `useTokenAsset` to display correct token names/symbols for dapp-initiated ERC-20 transfers not yet in the wallet.

---
<a href="https://cursor.com/background-agent?bcId=bc-74ba448e-2f4e-49f0-866e-074b25865bee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-74ba448e-2f4e-49f0-866e-074b25865bee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

