### PR TITLE
Analyze and resolve metamask issue

### DIFF
--- a/app/lib/ppom/ppom-util.test.ts
+++ b/app/lib/ppom/ppom-util.test.ts
@@ -502,6 +502,33 @@ describe('PPOM Utils', () => {
         );
       },
     );
+
+    it('should validate wallet_sendCalls requests', async () => {
+      const walletSendCallsRequest = {
+        ...mockRequest,
+        method: 'wallet_sendCalls',
+        params: [
+          {
+            from: '0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb',
+            to: '0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb',
+            value: '0x0',
+            data: '0x',
+          },
+        ],
+      };
+
+      await PPOMUtil.validateRequest(walletSendCallsRequest, {
+        transactionMeta: mockTransactionMeta,
+      });
+
+      expect(validateWithSecurityAlertsAPIMock).toHaveBeenCalledTimes(1);
+      expect(validateWithSecurityAlertsAPIMock).toHaveBeenCalledWith(
+        CHAIN_ID_TRANSACTION_MOCK,
+        expect.objectContaining({
+          method: 'wallet_sendCalls',
+        }),
+      );
+    });
   });
 
   describe('clearSignatureSecurityAlertResponse', () => {


### PR DESCRIPTION
Add `wallet_sendCalls` to PPOM validation and normalize its parameters to ensure EIP 5792 transactions are scanned by Blockaid.

This fixes a security vulnerability where `wallet_sendCalls` transactions were not being validated by Blockaid/PPOM on mobile, allowing malicious transactions to bypass security checks and display inconsistent UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-fa797ccc-71ce-4bfd-b90f-776174da2326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fa797ccc-71ce-4bfd-b90f-776174da2326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

