### PR TITLE
feat(ramp): add buy/deposit settings modal event

### DIFF
--- a/app/components/UI/Ramp/Aggregator/Views/Modals/Settings/SettingsModal.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/Modals/Settings/SettingsModal.test.tsx
@@ -3,14 +3,19 @@ import { fireEvent } from '@testing-library/react-native';
 
 // Internal dependencies.
 import SettingsModal from './SettingsModal';
-import { renderScreen } from '../../../../../../../util/test/renderWithProvider';
+import {
+  DeepPartial,
+  renderScreen,
+} from '../../../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../../../util/test/initial-root-state';
 import Routes from '../../../../../../../constants/navigation/Routes';
 import { createDepositNavigationDetails } from '../../../../Deposit/routes/utils';
+import { RampSDK } from '../../../sdk';
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
 const mockDangerouslyGetParent = jest.fn();
+const mockTrackEvent = jest.fn();
 
 jest.mock('@react-navigation/native', () => {
   const actualReactNavigation = jest.requireActual('@react-navigation/native');
@@ -24,6 +29,17 @@ jest.mock('@react-navigation/native', () => {
     }),
   };
 });
+
+jest.mock('../../../../hooks/useAnalytics', () => () => mockTrackEvent);
+
+const mockUseRampSDKValues: DeepPartial<RampSDK> = {
+  selectedRegion: { id: 'us' },
+};
+
+jest.mock('../../../sdk', () => ({
+  ...jest.requireActual('../../../sdk'),
+  useRampSDK: () => mockUseRampSDKValues,
+}));
 
 function render() {
   return renderScreen(
@@ -145,6 +161,19 @@ describe('SettingsModal', () => {
 
       expect(mockNavigate).not.toHaveBeenCalled();
       expect(mockDangerouslyGetParent).not.toHaveBeenCalled();
+    });
+
+    it('tracks event when deposit is pressed', () => {
+      const { getByText } = render();
+      const newBuyExperienceButton = getByText('Use new buy experience');
+
+      fireEvent.press(newBuyExperienceButton);
+
+      expect(mockTrackEvent).toHaveBeenCalledWith('RAMPS_BUTTON_CLICKED', {
+        location: 'Settings Modal',
+        ramp_type: 'DEPOSIT',
+        region: 'us',
+      });
     });
   });
 });

--- a/app/components/UI/Ramp/Aggregator/Views/Modals/Settings/SettingsModal.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/Modals/Settings/SettingsModal.test.tsx
@@ -170,7 +170,7 @@ describe('SettingsModal', () => {
       fireEvent.press(newBuyExperienceButton);
 
       expect(mockTrackEvent).toHaveBeenCalledWith('RAMPS_BUTTON_CLICKED', {
-        location: 'Settings Modal',
+        location: 'Buy Settings Modal',
         ramp_type: 'DEPOSIT',
         region: 'us',
       });

--- a/app/components/UI/Ramp/Aggregator/Views/Modals/Settings/SettingsModal.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/Modals/Settings/SettingsModal.tsx
@@ -10,6 +10,8 @@ import Routes from '../../../../../../../constants/navigation/Routes';
 import { createNavigationDetails } from '../../../../../../../util/navigation/navUtils';
 import MenuItem from '../../../../components/MenuItem';
 import { createDepositNavigationDetails } from '../../../../Deposit/routes/utils';
+import useAnalytics from '../../../../hooks/useAnalytics';
+import { useRampSDK } from '../../../sdk';
 
 export const createBuySettingsModalNavigationDetails = createNavigationDetails(
   Routes.RAMP.MODALS.ID,
@@ -19,6 +21,9 @@ export const createBuySettingsModalNavigationDetails = createNavigationDetails(
 function SettingsModal() {
   const sheetRef = useRef<BottomSheetRef>(null);
   const navigation = useNavigation();
+  const { selectedRegion } = useRampSDK();
+
+  const trackEvent = useAnalytics();
 
   const handleNavigateToOrderHistory = useCallback(() => {
     sheetRef.current?.onCloseBottomSheet();
@@ -34,7 +39,13 @@ function SettingsModal() {
     sheetRef.current?.onCloseBottomSheet();
     navigation.dangerouslyGetParent()?.dangerouslyGetParent()?.goBack();
     navigation.navigate(...createDepositNavigationDetails());
-  }, [navigation]);
+
+    trackEvent('RAMPS_BUTTON_CLICKED', {
+      location: 'Settings Modal',
+      ramp_type: 'DEPOSIT',
+      region: selectedRegion?.id as string,
+    });
+  }, [navigation, selectedRegion?.id, trackEvent]);
 
   const handleClosePress = useCallback(() => {
     sheetRef.current?.onCloseBottomSheet();

--- a/app/components/UI/Ramp/Aggregator/Views/Modals/Settings/SettingsModal.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/Modals/Settings/SettingsModal.tsx
@@ -41,7 +41,7 @@ function SettingsModal() {
     navigation.navigate(...createDepositNavigationDetails());
 
     trackEvent('RAMPS_BUTTON_CLICKED', {
-      location: 'Settings Modal',
+      location: 'Buy Settings Modal',
       ramp_type: 'DEPOSIT',
       region: selectedRegion?.id as string,
     });

--- a/app/components/UI/Ramp/Aggregator/Views/Modals/Settings/SettingsModal.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/Modals/Settings/SettingsModal.tsx
@@ -36,15 +36,14 @@ function SettingsModal() {
   }, [navigation]);
 
   const handleDepositPress = useCallback(() => {
-    sheetRef.current?.onCloseBottomSheet();
-    navigation.dangerouslyGetParent()?.dangerouslyGetParent()?.goBack();
-    navigation.navigate(...createDepositNavigationDetails());
-
     trackEvent('RAMPS_BUTTON_CLICKED', {
       location: 'Buy Settings Modal',
       ramp_type: 'DEPOSIT',
       region: selectedRegion?.id as string,
     });
+    sheetRef.current?.onCloseBottomSheet();
+    navigation.dangerouslyGetParent()?.dangerouslyGetParent()?.goBack();
+    navigation.navigate(...createDepositNavigationDetails());
   }, [navigation, selectedRegion?.id, trackEvent]);
 
   const handleClosePress = useCallback(() => {

--- a/app/components/UI/Ramp/Deposit/Views/Modals/ConfigurationModal/ConfigurationModal.test.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/ConfigurationModal/ConfigurationModal.test.tsx
@@ -46,6 +46,9 @@ const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
 const mockSetNavigationOptions = jest.fn();
 const mockClearAuthToken = jest.fn();
+const mockTrackEvent = jest.fn();
+
+jest.mock('../../../../hooks/useAnalytics', () => () => mockTrackEvent);
 
 jest.mock('@react-navigation/native', () => {
   const actualReactNavigation = jest.requireActual('@react-navigation/native');
@@ -96,6 +99,7 @@ describe('ConfigurationModal', () => {
     mockUseDepositSDK.mockReturnValue({
       logoutFromProvider: mockClearAuthToken,
       isAuthenticated: false,
+      selectedRegion: { isoCode: 'us' },
     });
   });
 
@@ -126,6 +130,17 @@ describe('ConfigurationModal', () => {
     const contactSupportButton = getByText('Contact support');
     fireEvent.press(contactSupportButton);
     expect(Linking.openURL).toHaveBeenCalledWith(TRANSAK_SUPPORT_URL);
+  });
+
+  it('tracks event when more ways to buy is pressed', () => {
+    const { getByText } = renderWithProvider(ConfigurationModal);
+    const moreWaysToBuyButton = getByText('More ways to buy');
+    fireEvent.press(moreWaysToBuyButton);
+    expect(mockTrackEvent).toHaveBeenCalledWith('RAMPS_BUTTON_CLICKED', {
+      location: 'Configuration Modal',
+      ramp_type: 'BUY',
+      region: 'us',
+    });
   });
 
   describe('when user is authenticated', () => {

--- a/app/components/UI/Ramp/Deposit/Views/Modals/ConfigurationModal/ConfigurationModal.test.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/ConfigurationModal/ConfigurationModal.test.tsx
@@ -137,7 +137,7 @@ describe('ConfigurationModal', () => {
     const moreWaysToBuyButton = getByText('More ways to buy');
     fireEvent.press(moreWaysToBuyButton);
     expect(mockTrackEvent).toHaveBeenCalledWith('RAMPS_BUTTON_CLICKED', {
-      location: 'Configuration Modal',
+      location: 'Deposit Settings Modal',
       ramp_type: 'BUY',
       region: 'us',
     });

--- a/app/components/UI/Ramp/Deposit/Views/Modals/ConfigurationModal/ConfigurationModal.test.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/ConfigurationModal/ConfigurationModal.test.tsx
@@ -148,6 +148,7 @@ describe('ConfigurationModal', () => {
       mockUseDepositSDK.mockReturnValue({
         logoutFromProvider: mockClearAuthToken,
         isAuthenticated: true,
+        selectedRegion: { isoCode: 'us' },
       });
     });
 

--- a/app/components/UI/Ramp/Deposit/Views/Modals/ConfigurationModal/ConfigurationModal.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/ConfigurationModal/ConfigurationModal.tsx
@@ -22,6 +22,7 @@ import {
 import Logger from '../../../../../../../util/Logger';
 import BottomSheetHeader from '../../../../../../../component-library/components/BottomSheets/BottomSheetHeader';
 import MenuItem from '../../../../components/MenuItem';
+import useAnalytics from '../../../../hooks/useAnalytics';
 
 export const createConfigurationModalNavigationDetails =
   createNavigationDetails(
@@ -33,8 +34,10 @@ function ConfigurationModal() {
   const sheetRef = useRef<BottomSheetRef>(null);
   const navigation = useNavigation();
   const { toastRef } = useContext(ToastContext);
+  const trackEvent = useAnalytics();
 
-  const { logoutFromProvider, isAuthenticated } = useDepositSDK();
+  const { logoutFromProvider, isAuthenticated, selectedRegion } =
+    useDepositSDK();
 
   const navigateToOrderHistory = useCallback(() => {
     sheetRef.current?.onCloseBottomSheet();
@@ -52,9 +55,14 @@ function ConfigurationModal() {
   }, []);
 
   const handleNavigateToAggregator = useCallback(() => {
+    trackEvent('RAMPS_BUTTON_CLICKED', {
+      location: 'Configuration Modal',
+      ramp_type: 'BUY',
+      region: selectedRegion?.isoCode as string,
+    });
     navigation.dangerouslyGetParent()?.dangerouslyGetParent()?.goBack();
     navigation.navigate(...createBuyNavigationDetails());
-  }, [navigation]);
+  }, [navigation, selectedRegion?.isoCode, trackEvent]);
 
   const handleLogOut = useCallback(async () => {
     try {

--- a/app/components/UI/Ramp/Deposit/Views/Modals/ConfigurationModal/ConfigurationModal.tsx
+++ b/app/components/UI/Ramp/Deposit/Views/Modals/ConfigurationModal/ConfigurationModal.tsx
@@ -56,7 +56,7 @@ function ConfigurationModal() {
 
   const handleNavigateToAggregator = useCallback(() => {
     trackEvent('RAMPS_BUTTON_CLICKED', {
-      location: 'Configuration Modal',
+      location: 'Deposit Settings Modal',
       ramp_type: 'BUY',
       region: selectedRegion?.isoCode as string,
     });

--- a/app/components/UI/Ramp/Deposit/types/analytics.ts
+++ b/app/components/UI/Ramp/Deposit/types/analytics.ts
@@ -1,6 +1,6 @@
 interface RampsButtonClicked {
   quote_session_id?: string;
-  ramp_type: 'DEPOSIT';
+  ramp_type: 'DEPOSIT' | 'BUY';
   user_id?: string;
   region: string;
   location: string;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This pull request adds analytics tracking for button presses in the buy and deposit settings modals, ensuring that user interactions are logged with relevant context such as modal location, ramp type, and region. It also updates tests to cover the new analytics behavior and adjusts the analytics event type to support both deposit and buy actions.

**Analytics tracking enhancements:**

* Added calls to `useAnalytics` in both `SettingsModal` and `ConfigurationModal` to track when users press key buttons, logging the event `RAMPS_BUTTON_CLICKED` with details including location, ramp type, and region. [[1]](diffhunk://#diff-e763577f4d665c8606263239492930e87bf3d4e279cbbac587936cf66d7bd4d8R24-R26) [[2]](diffhunk://#diff-e763577f4d665c8606263239492930e87bf3d4e279cbbac587936cf66d7bd4d8L37-R48) [[3]](diffhunk://#diff-14b45fbd996660ab55073b32a73ea45aa0488624ceb4efbd267c8a967cda1f4cR37-R40) [[4]](diffhunk://#diff-14b45fbd996660ab55073b32a73ea45aa0488624ceb4efbd267c8a967cda1f4cR58-R65)
* Updated the analytics event type definition in `analytics.ts` to allow `ramp_type` to be either `'DEPOSIT'` or `'BUY'`.

**Testing improvements:**

* Added and updated mocks for the analytics hook (`useAnalytics`) and region selection in test files to verify that analytics events are triggered with the correct parameters. [[1]](diffhunk://#diff-c97ef93052f382820dc15a75c6550cfb58cb2e02701b00954bf6627ee973dae5L6-R18) [[2]](diffhunk://#diff-c97ef93052f382820dc15a75c6550cfb58cb2e02701b00954bf6627ee973dae5R33-R43) [[3]](diffhunk://#diff-2b29b56f399f76e64d8c1f0562554c20f367f832fcef7a8bbd87d7a31363dcd4R49-R51) [[4]](diffhunk://#diff-2b29b56f399f76e64d8c1f0562554c20f367f832fcef7a8bbd87d7a31363dcd4R102)
* Added new test cases to ensure that pressing the relevant buttons in both modals triggers the analytics event as expected. [[1]](diffhunk://#diff-c97ef93052f382820dc15a75c6550cfb58cb2e02701b00954bf6627ee973dae5R165-R177) [[2]](diffhunk://#diff-2b29b56f399f76e64d8c1f0562554c20f367f832fcef7a8bbd87d7a31363dcd4R135-R145)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-2840

## **Manual testing steps**

```gherkin
Feature: Deposit and Buy switcher

  Scenario: user switches between buy and deposit
    Given user is in Deposit or Buy

    When user opens the settings modal
    And navigates to the other experience
    Then analytic event is tracked
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add analytics tracking for settings modal button presses in buy/deposit flows (with region) and update event types; tests updated to cover tracking.
> 
> - **Analytics tracking**:
>   - Add `useAnalytics` calls in `Aggregator/Views/Modals/Settings/SettingsModal.tsx` and `Deposit/Views/Modals/ConfigurationModal/ConfigurationModal.tsx` to emit `RAMPS_BUTTON_CLICKED` with `location`, `ramp_type`, and `region` from SDK-selected region.
> - **Types**:
>   - Expand `RampsButtonClicked.ramp_type` in `Deposit/types/analytics.ts` to support `'DEPOSIT' | 'BUY'`.
> - **Tests**:
>   - Mock `useAnalytics` and region in `SettingsModal.test.tsx` and `ConfigurationModal.test.tsx`.
>   - Add assertions that pressing "Use new buy experience" / "More ways to buy" triggers `RAMPS_BUTTON_CLICKED` with correct params.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcf0b8bcc50a218b80684209d782fcf8b59d7931. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->