### PR TITLE
fix(predict): Ensures both active and claimable positions are visible on market details

### DIFF
--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -452,15 +452,43 @@ function createMockMarket(overrides = {}) {
   };
 }
 
+type HookOverrideShape = Record<string, unknown>;
+
+interface PredictPositionsHookResultMock {
+  positions: Record<string, unknown>[];
+  isLoading: boolean;
+  isRefreshing: boolean;
+  error: unknown;
+  loadPositions: jest.Mock;
+}
+
+interface SplitPositionsOverrides {
+  active?: Partial<PredictPositionsHookResultMock>;
+  claimable?: Partial<PredictPositionsHookResultMock>;
+}
+
+type PositionsOverride =
+  | Partial<PredictPositionsHookResultMock>
+  | SplitPositionsOverrides;
+
+const isSplitPositionsOverride = (
+  override: PositionsOverride,
+): override is SplitPositionsOverrides =>
+  override !== null &&
+  typeof override === 'object' &&
+  ('active' in override || 'claimable' in override);
+
+interface HookOverrides {
+  market?: HookOverrideShape;
+  priceHistory?: HookOverrideShape;
+  positions?: PositionsOverride;
+  eligibility?: HookOverrideShape;
+}
+
 function setupPredictMarketDetailsTest(
-  marketOverrides = {},
-  routeOverrides = {},
-  hookOverrides: {
-    market?: object;
-    priceHistory?: object;
-    positions?: object;
-    eligibility?: object;
-  } = {},
+  marketOverrides: HookOverrideShape = {},
+  routeOverrides: HookOverrideShape = {},
+  hookOverrides: HookOverrides = {},
 ) {
   jest.clearAllMocks();
   runAfterInteractionsCallbacks.length = 0;
@@ -533,14 +561,42 @@ function setupPredictMarketDetailsTest(
     ...hookOverrides.priceHistory,
   });
 
-  usePredictPositions.mockReturnValue({
+  const positionsOverridesValue = (hookOverrides.positions ??
+    {}) as PositionsOverride;
+
+  let activeOverride: Partial<PredictPositionsHookResultMock> = {};
+  let claimableOverride: Partial<PredictPositionsHookResultMock> = {};
+
+  if (isSplitPositionsOverride(positionsOverridesValue)) {
+    activeOverride = positionsOverridesValue.active ?? {};
+    claimableOverride = positionsOverridesValue.claimable ?? {};
+  } else {
+    activeOverride =
+      positionsOverridesValue as Partial<PredictPositionsHookResultMock>;
+  }
+
+  const activePositionsHook: PredictPositionsHookResultMock = {
     positions: [],
     isLoading: false,
     isRefreshing: false,
     error: null,
     loadPositions: jest.fn(),
-    ...hookOverrides.positions,
-  });
+    ...activeOverride,
+  };
+
+  const claimablePositionsHook: PredictPositionsHookResultMock = {
+    positions: [],
+    isLoading: false,
+    isRefreshing: false,
+    error: null,
+    loadPositions: jest.fn(),
+    ...claimableOverride,
+  };
+
+  usePredictPositions.mockImplementation(
+    ({ claimable }: { claimable?: boolean }) =>
+      claimable ? claimablePositionsHook : activePositionsHook,
+  );
 
   const result = renderWithProvider(<PredictMarketDetails />);
 
@@ -1086,10 +1142,10 @@ describe('PredictMarketDetails', () => {
       expect(refreshControlProps.refreshing).toBe(false);
     });
 
-    it('triggers market, price history, and positions refresh', async () => {
+    it('triggers market, price history, and active positions refresh', async () => {
       const mockRefetchMarket = jest.fn(() => Promise.resolve());
       const mockRefetchPriceHistory = jest.fn(() => Promise.resolve());
-      const mockLoadPositions = jest.fn(() => Promise.resolve());
+      const mockLoadActivePositions = jest.fn(() => Promise.resolve());
 
       setupPredictMarketDetailsTest(
         {},
@@ -1097,7 +1153,7 @@ describe('PredictMarketDetails', () => {
         {
           market: { refetch: mockRefetchMarket },
           priceHistory: { refetch: mockRefetchPriceHistory },
-          positions: { loadPositions: mockLoadPositions },
+          positions: { loadPositions: mockLoadActivePositions },
         },
       );
 
@@ -1112,8 +1168,10 @@ describe('PredictMarketDetails', () => {
       await waitFor(() => {
         expect(mockRefetchMarket).toHaveBeenCalledTimes(1);
         expect(mockRefetchPriceHistory).toHaveBeenCalledTimes(1);
-        expect(mockLoadPositions).toHaveBeenCalledTimes(1);
-        expect(mockLoadPositions).toHaveBeenCalledWith({ isRefresh: true });
+        expect(mockLoadActivePositions).toHaveBeenCalled();
+        expect(mockLoadActivePositions).toHaveBeenCalledWith({
+          isRefresh: true,
+        });
       });
     });
   });

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -1548,18 +1548,20 @@ describe('PredictMarketDetails', () => {
         {},
         {
           positions: {
-            positions: [
-              {
-                id: 'position-1',
-                outcomeId: 'outcome-1',
-                outcome: 'Yes',
-                size: 10,
-                initialValue: 10,
-                currentValue: 12,
-                avgPrice: 0.5,
-                percentPnl: 20,
-              },
-            ],
+            claimable: {
+              positions: [
+                {
+                  id: 'position-1',
+                  outcomeId: 'outcome-1',
+                  outcome: 'Yes',
+                  size: 10,
+                  initialValue: 10,
+                  currentValue: 12,
+                  avgPrice: 0.5,
+                  percentPnl: 20,
+                },
+              ],
+            },
           },
         },
       );
@@ -1595,18 +1597,20 @@ describe('PredictMarketDetails', () => {
         {},
         {
           positions: {
-            positions: [
-              {
-                id: 'position-1',
-                outcomeId: 'outcome-1',
-                outcome: 'Yes',
-                size: 10,
-                initialValue: 10,
-                currentValue: 12,
-                avgPrice: 0.5,
-                percentPnl: 20,
-              },
-            ],
+            claimable: {
+              positions: [
+                {
+                  id: 'position-1',
+                  outcomeId: 'outcome-1',
+                  outcome: 'Yes',
+                  size: 10,
+                  initialValue: 10,
+                  currentValue: 12,
+                  avgPrice: 0.5,
+                  percentPnl: 20,
+                },
+              ],
+            },
           },
         },
       );

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -140,7 +140,8 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
     loadPositions: loadActivePositions,
   } = usePredictPositions({
     marketId: resolvedMarketId,
-    claimable: false && !isMarketFetching,
+    claimable: false,
+    loadOnMount: false,
   });
 
   // "claimable" positions
@@ -150,8 +151,22 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
     loadPositions: loadClaimablePositions,
   } = usePredictPositions({
     marketId: resolvedMarketId,
-    claimable: true && !isMarketFetching,
+    claimable: true,
+    loadOnMount: false,
   });
+
+  // Load positions when market is ready
+  useEffect(() => {
+    if (!isMarketFetching && resolvedMarketId) {
+      loadActivePositions();
+      loadClaimablePositions();
+    }
+  }, [
+    isMarketFetching,
+    resolvedMarketId,
+    loadActivePositions,
+    loadClaimablePositions,
+  ]);
 
   useEffect(() => {
     // if market is closed
@@ -837,7 +852,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
   );
 
   // see if there are any positions with positive percentPnl
-  const hasPositivePnl = activePositions.some(
+  const hasPositivePnl = claimablePositions.some(
     (position) => position.percentPnl > 0,
   );
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Ensures both active and claimable positions are visible under the positions tab on the market details view
- Note I've tested with all the possible combinations I can, but a local test would be awesome (view the positions tab for a selection of positions)

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: NA

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="420" alt="image" src="https://github.com/user-attachments/assets/2ce4f958-0a7d-462f-a6aa-63facb6293e8" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Market details now loads, displays, and refreshes both active and claimable positions, updating tabs, claim logic, and tests accordingly.
> 
> - **PredictMarketDetails**
>   - Split positions into `activePositions` and `claimablePositions` via two `usePredictPositions` calls; defer load and trigger both after market ready.
>   - Refresh now refetches market, price history, and both active/claimable positions.
>   - Tabs show Positions if either list has items; readiness includes both positions states.
>   - Positions section renders active positions (market status) then claimable positions (closed status).
>   - Claim button visibility depends on positive PnL in `claimablePositions` when market is closed.
> - **Tests**
>   - Test setup supports split positions overrides (`active`/`claimable`) and mocks hook implementation accordingly.
>   - Updated pull-to-refresh to expect active positions reload; added claimable positions cases for closed markets and claim flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bcf6326762d505d6fc81e5c0f0e9805eebdb3df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->