### PR TITLE
chore(predict): implement sequential refresh pattern for order preview

### DIFF
--- a/app/components/UI/Predict/hooks/usePredictOrderPreview.ts
+++ b/app/components/UI/Predict/hooks/usePredictOrderPreview.ts
@@ -160,7 +160,15 @@ export function usePredictOrderPreview(
     }, 100);
 
     return () => clearTimeout(debounceTimer);
-  }, [providerId, marketId, outcomeId, outcomeTokenId, side, size]);
+  }, [
+    providerId,
+    marketId,
+    outcomeId,
+    outcomeTokenId,
+    side,
+    size,
+    autoRefreshTimeout,
+  ]);
 
   return {
     preview,

--- a/app/components/UI/Predict/hooks/usePredictOrderPreview.ts
+++ b/app/components/UI/Predict/hooks/usePredictOrderPreview.ts
@@ -20,6 +20,7 @@ export function usePredictOrderPreview(
 
   const currentOperationRef = useRef<number>(0);
   const isMountedRef = useRef<boolean>(true);
+  const refreshTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   const { previewOrder } = usePredictTrading();
 
@@ -34,6 +35,26 @@ export function usePredictOrderPreview(
     autoRefreshTimeout,
     positionId,
   } = params;
+
+  // Define ref before using it in scheduleNextRefresh
+  const calculatePreviewRef = useRef<(() => Promise<void>) | null>(null);
+
+  const scheduleNextRefresh = useCallback(() => {
+    if (!autoRefreshTimeout || !isMountedRef.current) return;
+
+    // Clear any existing timer
+    if (refreshTimerRef.current) {
+      clearTimeout(refreshTimerRef.current);
+    }
+
+    // Schedule next refresh after the timeout
+    refreshTimerRef.current = setTimeout(() => {
+      calculatePreviewRef.current?.();
+    }, autoRefreshTimeout);
+  }, [autoRefreshTimeout]);
+
+  const scheduleNextRefreshRef = useRef(scheduleNextRefresh);
+  scheduleNextRefreshRef.current = scheduleNextRefresh;
 
   const calculatePreview = useCallback(async () => {
     const operationId = ++currentOperationRef.current;
@@ -63,6 +84,8 @@ export function usePredictOrderPreview(
       if (operationId === currentOperationRef.current && isMountedRef.current) {
         setPreview(p);
         setError(null);
+        // Schedule next refresh after successful response
+        scheduleNextRefreshRef.current();
       }
     } catch (err) {
       console.error('Failed to preview order:', err);
@@ -93,6 +116,8 @@ export function usePredictOrderPreview(
           defaultCode: PREDICT_ERROR_CODES.PREVIEW_FAILED,
         });
         setError(parsedErrorMessage);
+        // Schedule next refresh after error response
+        scheduleNextRefreshRef.current();
       }
     } finally {
       if (operationId === currentOperationRef.current && isMountedRef.current) {
@@ -110,41 +135,32 @@ export function usePredictOrderPreview(
     positionId,
   ]);
 
-  const calculatePreviewRef = useRef(calculatePreview);
   calculatePreviewRef.current = calculatePreview;
 
   useEffect(
     () => () => {
       isMountedRef.current = false;
+      // Clear refresh timer on unmount
+      if (refreshTimerRef.current) {
+        clearTimeout(refreshTimerRef.current);
+      }
     },
     [],
   );
 
   useEffect(() => {
+    // Clear any pending refresh timer when parameters change
+    if (refreshTimerRef.current) {
+      clearTimeout(refreshTimerRef.current);
+      refreshTimerRef.current = null;
+    }
+
     const debounceTimer = setTimeout(() => {
-      calculatePreviewRef.current();
+      calculatePreviewRef.current?.();
     }, 100);
 
     return () => clearTimeout(debounceTimer);
   }, [providerId, marketId, outcomeId, outcomeTokenId, side, size]);
-
-  useEffect(() => {
-    if (!autoRefreshTimeout) return undefined;
-
-    const refreshTimer = setInterval(() => {
-      calculatePreviewRef.current();
-    }, autoRefreshTimeout);
-
-    return () => clearInterval(refreshTimer);
-  }, [
-    providerId,
-    marketId,
-    outcomeId,
-    outcomeTokenId,
-    side,
-    size,
-    autoRefreshTimeout,
-  ]);
 
   return {
     preview,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Changes the auto-refresh behavior in usePredictOrderPreview from interval-based
to sequential pattern. The timer now waits for the preview response before
starting the timeout countdown, preventing overlapping requests.

Key changes:
- Replace setInterval with recursive setTimeout pattern
- Add scheduleNextRefresh function to trigger after response
- Schedule next refresh after both successful and error responses
- Clear pending timers on unmount and parameter changes
- Update tests to verify sequential refresh behavior

This ensures the autoRefreshTimeout is a delay AFTER each response
completes, rather than a fixed interval that could cause overlapping
requests when API response times exceed the timeout value.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: [PRED-299](https://consensyssoftware.atlassian.net/browse/PRED-299?atlOrigin=eyJpIjoiOTQwNThkMTg4N2UzNDQ1MjljZTEyNGM0MTlhOGZjMjUiLCJwIjoiaiJ9)

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces interval-based auto-refresh with response-triggered sequential timeouts in `usePredictOrderPreview`, adds cleanup on param changes/unmount, and updates tests accordingly.
> 
> - **Hook `usePredictOrderPreview`**:
>   - Replace `setInterval` auto-refresh with sequential `setTimeout` scheduled via `scheduleNextRefresh` after each response (success or error).
>   - Introduce refs for timer and callbacks: `refreshTimerRef`, `calculatePreviewRef`, `scheduleNextRefreshRef`.
>   - Clear pending refresh timers on unmount and when parameters change; debounce initial calculation.
>   - Minor safety: optional chaining on `calculatePreviewRef.current?.()`.
> - **Tests `usePredictOrderPreview.test.ts`**:
>   - Rename and add cases to verify response-triggered scheduling, waiting before countdown, scheduling after errors, and clearing timers on parameter changes and unmount.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c9fb28f60e74565ef1603d5455cee94c41d3a35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[PRED-299]: https://consensyssoftware.atlassian.net/browse/PRED-299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ