### PR TITLE
feat(predict): refresh eligibility on app focus

### DIFF
--- a/app/components/UI/Predict/hooks/usePredictEligibility.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictEligibility.test.ts
@@ -1,6 +1,8 @@
 import { act, renderHook } from '@testing-library/react-native';
+import { AppState, AppStateStatus } from 'react-native';
 import { useSelector } from 'react-redux';
 import Engine from '../../../../core/Engine';
+import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
 import { usePredictEligibility } from './usePredictEligibility';
 
 jest.mock('react-redux', () => ({
@@ -15,16 +17,49 @@ jest.mock('../../../../core/Engine', () => ({
   },
 }));
 
+jest.mock('react-native', () => ({
+  AppState: {
+    currentState: 'active' as 'active' | 'background' | 'inactive',
+    addEventListener: jest.fn(),
+  },
+}));
+
+jest.mock('../../../../core/SDKConnect/utils/DevLogger');
+
 describe('usePredictEligibility', () => {
   const mockUseSelector = useSelector as jest.Mock;
   const mockRefreshEligibility = Engine.context.PredictController
     .refreshEligibility as jest.Mock;
+  const mockAppStateAddEventListener = AppState.addEventListener as jest.Mock;
+  const mockDevLogger = DevLogger.log as jest.Mock;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let mockState: any;
+  let mockState: {
+    engine: {
+      backgroundState: {
+        PredictController: {
+          eligibility: Record<
+            string,
+            { eligible: boolean; country?: string } | undefined
+          >;
+        };
+      };
+    };
+  };
+  let mockSubscriptionRemove: jest.Mock;
 
   beforeEach(() => {
+    jest.useFakeTimers();
     jest.clearAllMocks();
+
+    // Reset AppState mock
+    (AppState as jest.Mocked<typeof AppState>).currentState = 'active';
+
+    mockSubscriptionRemove = jest.fn();
+    mockAppStateAddEventListener.mockReturnValue({
+      remove: mockSubscriptionRemove,
+    });
+
+    mockRefreshEligibility.mockResolvedValue(undefined);
 
     mockState = {
       engine: {
@@ -40,55 +75,392 @@ describe('usePredictEligibility', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
+    jest.useRealTimers();
   });
 
-  it('returns isEligible for the specified provider', () => {
-    mockState.engine.backgroundState.PredictController.eligibility = {
-      polymarket: { eligible: true, country: 'US' },
-      example: { eligible: false, country: 'UK' },
-    };
+  describe('eligibility state', () => {
+    it('returns isEligible true for eligible provider', () => {
+      mockState.engine.backgroundState.PredictController.eligibility = {
+        polymarket: { eligible: true, country: 'US' },
+        example: { eligible: false, country: 'UK' },
+      };
 
-    const { result } = renderHook(() =>
-      usePredictEligibility({ providerId: 'polymarket' }),
-    );
+      const { result } = renderHook(() =>
+        usePredictEligibility({ providerId: 'polymarket' }),
+      );
 
-    expect(result.current.isEligible).toBe(true);
-    expect(result.current.country).toBe('US');
-  });
-
-  it('returns false when provider is not eligible', () => {
-    mockState.engine.backgroundState.PredictController.eligibility = {
-      polymarket: { eligible: true, country: 'US' },
-      example: { eligible: false, country: 'UK' },
-    };
-
-    const { result } = renderHook(() =>
-      usePredictEligibility({ providerId: 'example' }),
-    );
-
-    expect(result.current.isEligible).toBe(false);
-    expect(result.current.country).toBe('UK');
-  });
-
-  it('returns false when provider eligibility is not set', () => {
-    const { result } = renderHook(() =>
-      usePredictEligibility({ providerId: 'unknown' }),
-    );
-
-    expect(result.current.isEligible).toBe(false);
-    expect(result.current.country).toBeUndefined();
-  });
-
-  it('calls refreshEligibility on the controller', async () => {
-    const { result } = renderHook(() =>
-      usePredictEligibility({ providerId: 'polymarket' }),
-    );
-
-    await act(async () => {
-      await result.current.refreshEligibility();
+      expect(result.current.isEligible).toBe(true);
+      expect(result.current.country).toBe('US');
     });
 
-    expect(mockRefreshEligibility).toHaveBeenCalledTimes(1);
+    it('returns isEligible false for ineligible provider', () => {
+      mockState.engine.backgroundState.PredictController.eligibility = {
+        polymarket: { eligible: true, country: 'US' },
+        example: { eligible: false, country: 'UK' },
+      };
+
+      const { result } = renderHook(() =>
+        usePredictEligibility({ providerId: 'example' }),
+      );
+
+      expect(result.current.isEligible).toBe(false);
+      expect(result.current.country).toBe('UK');
+    });
+
+    it('returns false when provider eligibility is not set', () => {
+      const { result } = renderHook(() =>
+        usePredictEligibility({ providerId: 'unknown' }),
+      );
+
+      expect(result.current.isEligible).toBe(false);
+      expect(result.current.country).toBeUndefined();
+    });
+  });
+
+  describe('AppState listener setup', () => {
+    it('sets up AppState listener on mount', () => {
+      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+
+      expect(mockAppStateAddEventListener).toHaveBeenCalledTimes(1);
+      expect(mockAppStateAddEventListener).toHaveBeenCalledWith(
+        'change',
+        expect.any(Function),
+      );
+    });
+
+    it('removes AppState listener on unmount', () => {
+      const { unmount } = renderHook(() =>
+        usePredictEligibility({ providerId: 'polymarket' }),
+      );
+
+      unmount();
+
+      expect(mockSubscriptionRemove).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('auto-refresh on app focus', () => {
+    it('refreshes eligibility when app transitions from background to active', async () => {
+      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+
+      const handleAppStateChange = mockAppStateAddEventListener.mock
+        .calls[0][1] as (nextState: AppStateStatus) => void;
+
+      await act(async () => {
+        handleAppStateChange('background');
+        handleAppStateChange('active');
+      });
+
+      expect(mockRefreshEligibility).toHaveBeenCalledTimes(1);
+      expect(mockDevLogger).toHaveBeenCalledWith(
+        'PredictController: App became active, refreshing eligibility',
+        expect.objectContaining({
+          providerId: 'polymarket',
+        }),
+      );
+    });
+
+    it('refreshes eligibility when app transitions from inactive to active', async () => {
+      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+
+      const handleAppStateChange = mockAppStateAddEventListener.mock
+        .calls[0][1] as (nextState: AppStateStatus) => void;
+
+      await act(async () => {
+        handleAppStateChange('inactive');
+        handleAppStateChange('active');
+      });
+
+      expect(mockRefreshEligibility).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores transition from active to background', async () => {
+      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+
+      const handleAppStateChange = mockAppStateAddEventListener.mock
+        .calls[0][1] as (nextState: AppStateStatus) => void;
+
+      await act(async () => {
+        handleAppStateChange('active');
+        handleAppStateChange('background');
+      });
+
+      expect(mockRefreshEligibility).not.toHaveBeenCalled();
+    });
+
+    it('ignores transition from active to inactive', async () => {
+      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+
+      const handleAppStateChange = mockAppStateAddEventListener.mock
+        .calls[0][1] as (nextState: AppStateStatus) => void;
+
+      await act(async () => {
+        handleAppStateChange('active');
+        handleAppStateChange('inactive');
+      });
+
+      expect(mockRefreshEligibility).not.toHaveBeenCalled();
+    });
+
+    it('ignores transition from background to inactive', async () => {
+      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+
+      const handleAppStateChange = mockAppStateAddEventListener.mock
+        .calls[0][1] as (nextState: AppStateStatus) => void;
+
+      await act(async () => {
+        handleAppStateChange('background');
+        handleAppStateChange('inactive');
+      });
+
+      expect(mockRefreshEligibility).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('debouncing', () => {
+    it('skips refresh when less than 1 minute has passed', async () => {
+      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+
+      const handleAppStateChange = mockAppStateAddEventListener.mock
+        .calls[0][1] as (nextState: AppStateStatus) => void;
+
+      await act(async () => {
+        handleAppStateChange('background');
+        handleAppStateChange('active');
+      });
+
+      expect(mockRefreshEligibility).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(30000);
+
+      await act(async () => {
+        handleAppStateChange('background');
+        handleAppStateChange('active');
+      });
+
+      expect(mockRefreshEligibility).toHaveBeenCalledTimes(1);
+      expect(mockDevLogger).toHaveBeenCalledWith(
+        'PredictController: Skipping refresh due to debounce',
+        expect.objectContaining({
+          providerId: 'polymarket',
+          timeSinceLastRefresh: expect.any(Number),
+          minimumInterval: 60000,
+        }),
+      );
+    });
+
+    it('allows refresh when 1 minute has elapsed', async () => {
+      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+
+      const handleAppStateChange = mockAppStateAddEventListener.mock
+        .calls[0][1] as (nextState: AppStateStatus) => void;
+
+      await act(async () => {
+        handleAppStateChange('background');
+        handleAppStateChange('active');
+      });
+
+      expect(mockRefreshEligibility).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(60000);
+
+      await act(async () => {
+        handleAppStateChange('background');
+        handleAppStateChange('active');
+      });
+
+      expect(mockRefreshEligibility).toHaveBeenCalledTimes(2);
+    });
+
+    it('allows refresh when more than 1 minute has elapsed', async () => {
+      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+
+      const handleAppStateChange = mockAppStateAddEventListener.mock
+        .calls[0][1] as (nextState: AppStateStatus) => void;
+
+      await act(async () => {
+        handleAppStateChange('background');
+        handleAppStateChange('active');
+      });
+
+      expect(mockRefreshEligibility).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(120000);
+
+      await act(async () => {
+        handleAppStateChange('background');
+        handleAppStateChange('active');
+      });
+
+      expect(mockRefreshEligibility).toHaveBeenCalledTimes(2);
+    });
+
+    it('resets debounce timer after successful refresh', async () => {
+      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+
+      const handleAppStateChange = mockAppStateAddEventListener.mock
+        .calls[0][1] as (nextState: AppStateStatus) => void;
+
+      await act(async () => {
+        handleAppStateChange('background');
+        handleAppStateChange('active');
+      });
+
+      expect(mockRefreshEligibility).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(60000);
+
+      await act(async () => {
+        handleAppStateChange('background');
+        handleAppStateChange('active');
+      });
+
+      expect(mockRefreshEligibility).toHaveBeenCalledTimes(2);
+
+      jest.advanceTimersByTime(30000);
+
+      await act(async () => {
+        handleAppStateChange('background');
+        handleAppStateChange('active');
+      });
+
+      expect(mockRefreshEligibility).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('manual refresh', () => {
+    it('calls controller refreshEligibility method', async () => {
+      const { result } = renderHook(() =>
+        usePredictEligibility({ providerId: 'polymarket' }),
+      );
+
+      await act(async () => {
+        await result.current.refreshEligibility();
+      });
+
+      expect(mockRefreshEligibility).toHaveBeenCalledTimes(1);
+    });
+
+    it('bypasses debounce for manual refresh', async () => {
+      const { result } = renderHook(() =>
+        usePredictEligibility({ providerId: 'polymarket' }),
+      );
+
+      await act(async () => {
+        await result.current.refreshEligibility();
+      });
+
+      expect(mockRefreshEligibility).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(1000);
+
+      await act(async () => {
+        await result.current.refreshEligibility();
+      });
+
+      expect(mockRefreshEligibility).toHaveBeenCalledTimes(2);
+    });
+
+    it('updates debounce timer after manual refresh', async () => {
+      const { result } = renderHook(() =>
+        usePredictEligibility({ providerId: 'polymarket' }),
+      );
+
+      const handleAppStateChange = mockAppStateAddEventListener.mock
+        .calls[0][1] as (nextState: AppStateStatus) => void;
+
+      await act(async () => {
+        await result.current.refreshEligibility();
+      });
+
+      expect(mockRefreshEligibility).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(30000);
+
+      await act(async () => {
+        handleAppStateChange('background');
+        handleAppStateChange('active');
+      });
+
+      expect(mockRefreshEligibility).toHaveBeenCalledTimes(1);
+      expect(mockDevLogger).toHaveBeenCalledWith(
+        'PredictController: Skipping refresh due to debounce',
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe('error handling', () => {
+    it('logs error when auto-refresh fails', async () => {
+      const testError = new Error('Network error');
+      mockRefreshEligibility.mockRejectedValueOnce(testError);
+
+      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+
+      const handleAppStateChange = mockAppStateAddEventListener.mock
+        .calls[0][1] as (nextState: AppStateStatus) => void;
+
+      await act(async () => {
+        handleAppStateChange('background');
+        handleAppStateChange('active');
+      });
+
+      expect(mockDevLogger).toHaveBeenCalledWith(
+        'PredictController: Auto-refresh failed',
+        expect.objectContaining({
+          providerId: 'polymarket',
+          error: 'Network error',
+        }),
+      );
+    });
+
+    it('logs unknown error when auto-refresh fails with non-Error', async () => {
+      mockRefreshEligibility.mockRejectedValueOnce('string error');
+
+      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+
+      const handleAppStateChange = mockAppStateAddEventListener.mock
+        .calls[0][1] as (nextState: AppStateStatus) => void;
+
+      await act(async () => {
+        handleAppStateChange('background');
+        handleAppStateChange('active');
+      });
+
+      expect(mockDevLogger).toHaveBeenCalledWith(
+        'PredictController: Auto-refresh failed',
+        expect.objectContaining({
+          providerId: 'polymarket',
+          error: 'Unknown',
+        }),
+      );
+    });
+
+    it('continues operation after failed refresh', async () => {
+      mockRefreshEligibility.mockRejectedValueOnce(new Error('Network error'));
+
+      renderHook(() => usePredictEligibility({ providerId: 'polymarket' }));
+
+      const handleAppStateChange = mockAppStateAddEventListener.mock
+        .calls[0][1] as (nextState: AppStateStatus) => void;
+
+      await act(async () => {
+        handleAppStateChange('background');
+        handleAppStateChange('active');
+      });
+
+      expect(mockRefreshEligibility).toHaveBeenCalledTimes(1);
+
+      mockRefreshEligibility.mockResolvedValueOnce(undefined);
+      jest.advanceTimersByTime(60000);
+
+      await act(async () => {
+        handleAppStateChange('background');
+        handleAppStateChange('active');
+      });
+
+      expect(mockRefreshEligibility).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/app/components/UI/Predict/hooks/usePredictEligibility.ts
+++ b/app/components/UI/Predict/hooks/usePredictEligibility.ts
@@ -1,8 +1,10 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
+import { AppState, AppStateStatus } from 'react-native';
 import { createSelector } from 'reselect';
 import { useSelector } from 'react-redux';
 import Engine from '../../../../core/Engine';
 import { RootState } from '../../../../reducers';
+import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
 
 const selectPredictEligibility = createSelector(
   (state: RootState) => state.engine.backgroundState.PredictController,
@@ -13,8 +15,12 @@ export type PredictEligibilityState = ReturnType<
   typeof selectPredictEligibility
 >;
 
+// Minimum time between automatic eligibility refreshes (1 minute)
+const DEBOUNCE_INTERVAL_MS = 60000;
+
 /**
  * Hook to access Predict eligibility state and trigger refreshes via the controller.
+ * Automatically refreshes eligibility when the app comes to foreground.
  */
 export const usePredictEligibility = ({
   providerId,
@@ -22,11 +28,74 @@ export const usePredictEligibility = ({
   providerId: string;
 }) => {
   const eligibility = useSelector(selectPredictEligibility);
+  const lastRefreshTimeRef = useRef<number>(0);
 
+  // Manual refresh - bypasses debounce and updates timestamp
   const refreshEligibility = useCallback(async () => {
     const controller = Engine.context.PredictController;
     await controller.refreshEligibility();
+    lastRefreshTimeRef.current = Date.now();
   }, []);
+
+  // Auto-refresh with debouncing - used by AppState listener
+  const autoRefreshEligibility = useCallback(async () => {
+    const now = Date.now();
+    const timeSinceLastRefresh = now - lastRefreshTimeRef.current;
+
+    // Skip if within debounce interval
+    if (timeSinceLastRefresh < DEBOUNCE_INTERVAL_MS) {
+      DevLogger.log('PredictController: Skipping refresh due to debounce', {
+        providerId,
+        timeSinceLastRefresh,
+        minimumInterval: DEBOUNCE_INTERVAL_MS,
+      });
+      return;
+    }
+
+    try {
+      DevLogger.log('PredictController: Auto-refreshing eligibility', {
+        providerId,
+      });
+      await refreshEligibility();
+    } catch (error) {
+      DevLogger.log('PredictController: Auto-refresh failed', {
+        providerId,
+        error: error instanceof Error ? error.message : 'Unknown',
+      });
+    }
+  }, [providerId, refreshEligibility]);
+
+  // Set up AppState listener to refresh eligibility when app comes to foreground
+  useEffect(() => {
+    let previousAppState = AppState.currentState;
+
+    const handleAppStateChange = (nextAppState: AppStateStatus) => {
+      // Only refresh when transitioning from background/inactive to active
+      if (
+        previousAppState.match(/inactive|background/) &&
+        nextAppState === 'active'
+      ) {
+        DevLogger.log(
+          'PredictController: App became active, refreshing eligibility',
+          {
+            providerId,
+            previousState: previousAppState,
+          },
+        );
+        autoRefreshEligibility();
+      }
+      previousAppState = nextAppState;
+    };
+
+    const subscription = AppState.addEventListener(
+      'change',
+      handleAppStateChange,
+    );
+
+    return () => {
+      subscription.remove();
+    };
+  }, [providerId, autoRefreshEligibility]);
 
   return {
     isEligible: eligibility[providerId]?.eligible ?? false,


### PR DESCRIPTION
## **Description**

This PR implements automatic eligibility refresh for the Predict feature when the app comes to foreground. Previously, eligibility was only checked on initial load or manual refresh. Now, when a user backgrounds the app and then returns to it, the eligibility status is automatically refreshed.

**What is the reason for the change?**
Users may change their network configuration (e.g., switching between different network connections) while the app is backgrounded. When they return to the app, the Predict feature should automatically check eligibility again to reflect any potential changes in their connection status.

**What is the improvement/solution?**

- Added an `AppState` listener to the `usePredictEligibility` hook that detects when the app transitions from `background`/`inactive` to `active` state
- Implemented 1-minute debouncing to prevent excessive API calls if the user switches in and out of the app multiple times
- Manual refresh functionality remains unchanged and bypasses the debounce
- Added comprehensive error handling and logging

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Auto-refresh Predict eligibility on app focus

  Scenario: user returns to app and eligibility is refreshed
    Given user has opened the Predict feature
    And user is eligible to use Predict

    When user backgrounds the app (switches to another app)
    And user returns to the app
    Then eligibility is automatically refreshed
    And user sees updated eligibility status if it changed

  Scenario: user rapidly switches in and out of app
    Given user has opened the Predict feature
    And eligibility was just refreshed

    When user backgrounds the app
    And user returns to the app within 1 minute
    Then eligibility refresh is skipped due to debouncing
    And user still has access to Predict feature

  Scenario: user returns after debounce period
    Given user has opened the Predict feature
    And eligibility was refreshed more than 1 minute ago

    When user backgrounds the app
    And user returns to the app
    Then eligibility is automatically refreshed
```

## **Screenshots/Recordings**

N/A - This is an internal behavior change with no visual UI impact.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a singleton-managed AppState listener to auto-refresh Predict eligibility on app foreground with 1-minute debounce, logging, and race-condition prevention, plus comprehensive tests.
> 
> - **Predict Hook (`usePredictEligibility.ts`)**:
>   - **Singleton manager (`EligibilityRefreshManager`)**:
>     - Manages a single `AppState` `change` listener across hook instances.
>     - Refreshes `Engine.context.PredictController.refreshEligibility()` on transition to `active`.
>     - Debounces auto-refreshes by 60s; manual `refreshEligibility` bypasses debounce.
>     - Prevents concurrent calls by reusing in-flight promise; tracks last refresh time.
>     - Registers/unregisters per hook mount/unmount; adds detailed `DevLogger` logs and error handling.
> - **Tests (`usePredictEligibility.test.ts`)**:
>   - Cover eligibility state selection, singleton registration/unregistration, app focus auto-refresh, debounce behavior, manual refresh bypass, error logging/continuation, and concurrency/race-condition scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c94340e0a7ac7b9a415ef00871ed1e4e40642a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->