### PR TITLE
feat(predict): new feature flag with minimumVersion

### DIFF
--- a/.js.env.example
+++ b/.js.env.example
@@ -164,5 +164,8 @@ export MM_PERPS_HIP3_ENABLED="true"
 export MM_PERPS_HIP3_ALLOWLIST_MARKETS=""  # Allowlist: Empty = enable all markets. Examples: "xyz:XYZ100,xyz:TSLA" or "xyz:*,abc:TSLA"
 export MM_PERPS_HIP3_BLOCKLIST_MARKETS=""  # Blocklist: Empty = no blocking. Examples: "BTC,ETH" or "xyz:*"
 
+## Predict
+export MM_PREDICT_ENABLED="true"
+
 ## Card
 export MM_CARD_BAANX_API_CLIENT_KEY_DEV=""

--- a/app/components/UI/Predict/mocks/remoteFeatureFlagMocks.ts
+++ b/app/components/UI/Predict/mocks/remoteFeatureFlagMocks.ts
@@ -1,8 +1,13 @@
-import { FEATURE_FLAG_NAME } from '../selectors/featureFlags';
+import { VersionGatedFeatureFlag } from '../../../../util/remoteFeatureFlag';
 
 const mockEnabledPredictLDFlag = {
-  [FEATURE_FLAG_NAME]: true,
+  enabled: true,
+  minimumVersion: '0.0.0',
 };
 
-export const mockedPredictFeatureFlagsEnabledState: Record<string, boolean> =
-  mockEnabledPredictLDFlag;
+export const mockedPredictFeatureFlagsEnabledState: Record<
+  string,
+  VersionGatedFeatureFlag
+> = {
+  predictTradingEnabled: mockEnabledPredictLDFlag,
+};

--- a/app/components/UI/Predict/selectors/featureFlags/index.test.ts
+++ b/app/components/UI/Predict/selectors/featureFlags/index.test.ts
@@ -1,52 +1,315 @@
-import { FeatureFlags } from '@metamask/remote-feature-flag-controller';
+import { selectPredictEnabledFlag } from '.';
+import mockedEngine from '../../../../../core/__mocks__/MockedEngine';
 import {
-  selectPredictEnabledFlag,
-  FEATURE_FLAG_NAME,
-  OVERRIDE_PREDICT_ENABLED_VALUE,
-} from './';
+  mockedState,
+  mockedEmptyFlagsState,
+} from '../../../../../selectors/featureFlagController/mocks';
+import {
+  VersionGatedFeatureFlag,
+  validatedVersionGatedFeatureFlag,
+} from '../../../../../util/remoteFeatureFlag';
+// eslint-disable-next-line import/no-namespace
+import * as remoteFeatureFlagModule from '../../../../../util/remoteFeatureFlag';
 
-describe('selectPredictEnabledFlag', () => {
-  const createMockState = (remoteFlags: FeatureFlags = {}) => ({
-    engine: {
-      backgroundState: {
-        RemoteFeatureFlagController: {
-          remoteFeatureFlags: remoteFlags,
-          cacheTimestamp: 0,
-        },
-      },
-    },
-  });
+jest.mock('react-native-device-info', () => ({
+  getVersion: jest.fn().mockReturnValue('1.0.0'),
+}));
+
+jest.mock('../../../../../core/Engine', () => ({
+  init: () => mockedEngine.init(),
+}));
+
+jest.mock(
+  '../../../../../core/Engine/controllers/remote-feature-flag-controller',
+  () => ({
+    isRemoteFeatureFlagOverrideActivated: false,
+  }),
+);
+
+describe('Predict Feature Flag Selectors', () => {
+  let mockHasMinimumRequiredVersion: jest.SpyInstance;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    delete process.env.MM_PREDICT_ENABLED;
+    mockHasMinimumRequiredVersion = jest.spyOn(
+      remoteFeatureFlagModule,
+      'hasMinimumRequiredVersion',
+    );
+    mockHasMinimumRequiredVersion.mockReturnValue(true);
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    delete process.env.MM_PREDICT_ENABLED;
+    mockHasMinimumRequiredVersion?.mockRestore();
   });
 
-  it.each([
-    { flag: true, expected: true },
-    { flag: false, expected: false },
-  ])('returns $expected when predictEnabled is $flag', ({ flag, expected }) => {
-    // Arrange
-    const mockState = createMockState({ [FEATURE_FLAG_NAME]: flag });
+  describe('selectPredictEnabledFlag', () => {
+    it('returns true for enabled version-gated flag with valid version', () => {
+      const result = selectPredictEnabledFlag(mockedState);
 
-    // Act
-    const result = selectPredictEnabledFlag(mockState);
+      expect(result).toBe(true);
+    });
 
-    // Assert
-    expect(result).toBe(expected);
+    describe('remote flag precedence', () => {
+      it('returns true when remote flag enabled overrides local flag false', () => {
+        mockHasMinimumRequiredVersion.mockReturnValue(true);
+        process.env.MM_PREDICT_ENABLED = 'false';
+        const stateWithEnabledRemoteFlag = {
+          engine: {
+            backgroundState: {
+              RemoteFeatureFlagController: {
+                remoteFeatureFlags: {
+                  predictTradingEnabled: {
+                    enabled: true,
+                    minimumVersion: '1.0.0',
+                  },
+                },
+                cacheTimestamp: 0,
+              },
+            },
+          },
+        };
+
+        const result = selectPredictEnabledFlag(stateWithEnabledRemoteFlag);
+
+        expect(result).toBe(true);
+      });
+
+      it('returns false when remote flag disabled overrides local flag true', () => {
+        mockHasMinimumRequiredVersion.mockReturnValue(true);
+        process.env.MM_PREDICT_ENABLED = 'true';
+        const stateWithDisabledRemoteFlag = {
+          engine: {
+            backgroundState: {
+              RemoteFeatureFlagController: {
+                remoteFeatureFlags: {
+                  predictTradingEnabled: {
+                    enabled: false,
+                    minimumVersion: '1.0.0',
+                  },
+                },
+                cacheTimestamp: 0,
+              },
+            },
+          },
+        };
+
+        const result = selectPredictEnabledFlag(stateWithDisabledRemoteFlag);
+
+        expect(result).toBe(false);
+      });
+
+      it('returns false when app version below minimum required version', () => {
+        mockHasMinimumRequiredVersion.mockReturnValue(false);
+        process.env.MM_PREDICT_ENABLED = 'true';
+        const stateWithVersionCheckFailure = {
+          engine: {
+            backgroundState: {
+              RemoteFeatureFlagController: {
+                remoteFeatureFlags: {
+                  predictTradingEnabled: {
+                    enabled: true,
+                    minimumVersion: '99.0.0',
+                  },
+                },
+                cacheTimestamp: 0,
+              },
+            },
+          },
+        };
+
+        const result = selectPredictEnabledFlag(stateWithVersionCheckFailure);
+
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('local flag fallback', () => {
+      it('falls back to local flag when remote flag is invalid', () => {
+        // Note: Cannot reliably test MM_PREDICT_ENABLED=true in Jest due to process.env limitations
+        // This tests the default case where the env var is not set (returns false)
+        const stateWithInvalidRemoteFlag = {
+          engine: {
+            backgroundState: {
+              RemoteFeatureFlagController: {
+                remoteFeatureFlags: {
+                  predictTradingEnabled: {
+                    enabled: 'invalid',
+                    minimumVersion: 123,
+                  },
+                },
+                cacheTimestamp: 0,
+              },
+            },
+          },
+        };
+
+        const result = selectPredictEnabledFlag(stateWithInvalidRemoteFlag);
+        expect(result).toBe(false);
+      });
+
+      it('returns false from local flag when remote flag is null', () => {
+        process.env.MM_PREDICT_ENABLED = 'false';
+        const stateWithInvalidRemoteFlag = {
+          engine: {
+            backgroundState: {
+              RemoteFeatureFlagController: {
+                remoteFeatureFlags: {
+                  predictTradingEnabled: null,
+                },
+                cacheTimestamp: 0,
+              },
+            },
+          },
+        };
+
+        const result = selectPredictEnabledFlag(stateWithInvalidRemoteFlag);
+
+        expect(result).toBe(false);
+      });
+
+      it('falls back to local flag when remote feature flags are empty', () => {
+        // Note: Cannot reliably test MM_PREDICT_ENABLED=true in Jest due to process.env limitations
+        // This tests the default case where the env var is not set (returns false)
+        const result = selectPredictEnabledFlag(mockedEmptyFlagsState);
+        expect(result).toBe(false);
+      });
+
+      it('returns false from local flag when controller is undefined', () => {
+        process.env.MM_PREDICT_ENABLED = 'false';
+        const stateWithUndefinedController = {
+          engine: {
+            backgroundState: {
+              RemoteFeatureFlagController: undefined,
+            },
+          },
+        };
+
+        const result = selectPredictEnabledFlag(stateWithUndefinedController);
+
+        expect(result).toBe(false);
+      });
+    });
   });
 
-  it('returns Override value when predictEnabled is not present', () => {
-    // Arrange
-    const mockState = createMockState({});
+  describe('predictTradingEnabled remote feature flag validation', () => {
+    const validRemoteFlag: VersionGatedFeatureFlag = {
+      enabled: true,
+      minimumVersion: '1.0.0',
+    };
 
-    // Act
-    const result = selectPredictEnabledFlag(mockState);
+    const disabledRemoteFlag: VersionGatedFeatureFlag = {
+      enabled: false,
+      minimumVersion: '1.0.0',
+    };
 
-    // Assert
-    expect(result).toBe(OVERRIDE_PREDICT_ENABLED_VALUE);
+    describe('valid flag scenarios', () => {
+      it('returns true when flag enabled and version check passes', () => {
+        const result = validatedVersionGatedFeatureFlag(validRemoteFlag);
+
+        expect(result).toBe(true);
+      });
+
+      it('returns false when flag enabled but version check fails', () => {
+        const flagWithHigherVersion: VersionGatedFeatureFlag = {
+          enabled: true,
+          minimumVersion: '99.0.0',
+        };
+
+        const result = validatedVersionGatedFeatureFlag(flagWithHigherVersion);
+
+        expect(result).toBe(false);
+      });
+
+      it('returns false when flag disabled but version check passes', () => {
+        mockHasMinimumRequiredVersion.mockReturnValue(true);
+
+        const result = validatedVersionGatedFeatureFlag(disabledRemoteFlag);
+
+        expect(result).toBe(false);
+        expect(mockHasMinimumRequiredVersion).not.toHaveBeenCalled();
+      });
+
+      it('returns false when flag disabled and version check fails', () => {
+        mockHasMinimumRequiredVersion.mockReturnValue(false);
+
+        const result = validatedVersionGatedFeatureFlag(disabledRemoteFlag);
+
+        expect(result).toBe(false);
+        expect(mockHasMinimumRequiredVersion).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('invalid flag scenarios', () => {
+      it('returns undefined when flag is null', () => {
+        const result = validatedVersionGatedFeatureFlag(
+          null as unknown as VersionGatedFeatureFlag,
+        );
+
+        expect(result).toBeUndefined();
+      });
+
+      it('returns undefined when flag is undefined', () => {
+        const result = validatedVersionGatedFeatureFlag(
+          undefined as unknown as VersionGatedFeatureFlag,
+        );
+
+        expect(result).toBeUndefined();
+      });
+
+      it('returns undefined when enabled property is missing', () => {
+        const malformedFlag = {
+          minimumVersion: '1.0.0',
+        } as VersionGatedFeatureFlag;
+
+        const result = validatedVersionGatedFeatureFlag(malformedFlag);
+
+        expect(result).toBeUndefined();
+      });
+
+      it('returns undefined when minimumVersion property is missing', () => {
+        const malformedFlag = {
+          enabled: true,
+        } as VersionGatedFeatureFlag;
+
+        const result = validatedVersionGatedFeatureFlag(malformedFlag);
+
+        expect(result).toBeUndefined();
+      });
+
+      it('returns undefined when enabled is string instead of boolean', () => {
+        const wrongTypeFlag = {
+          enabled: 'true',
+          minimumVersion: '1.0.0',
+        } as unknown as VersionGatedFeatureFlag;
+
+        const result = validatedVersionGatedFeatureFlag(wrongTypeFlag);
+
+        expect(result).toBeUndefined();
+      });
+
+      it('returns undefined when minimumVersion is number instead of string', () => {
+        const wrongTypeFlag = {
+          enabled: true,
+          minimumVersion: 100,
+        } as unknown as VersionGatedFeatureFlag;
+
+        const result = validatedVersionGatedFeatureFlag(wrongTypeFlag);
+
+        expect(result).toBeUndefined();
+      });
+
+      it('returns undefined when both properties have incorrect types', () => {
+        const wrongTypeFlag = {
+          enabled: 'true',
+          minimumVersion: 123,
+        } as unknown as VersionGatedFeatureFlag;
+
+        const result = validatedVersionGatedFeatureFlag(wrongTypeFlag);
+
+        expect(result).toBeUndefined();
+      });
+    });
   });
 });

--- a/app/components/UI/Predict/selectors/featureFlags/index.ts
+++ b/app/components/UI/Predict/selectors/featureFlags/index.ts
@@ -1,15 +1,29 @@
 import { createSelector } from 'reselect';
 import { selectRemoteFeatureFlags } from '../../../../../selectors/featureFlagController';
+import {
+  VersionGatedFeatureFlag,
+  validatedVersionGatedFeatureFlag,
+} from '../../../../../util/remoteFeatureFlag';
 
-export const OVERRIDE_PREDICT_ENABLED_VALUE = false;
-export const FEATURE_FLAG_NAME = 'predictEnabled';
-
+/**
+ * Selector for Predict trading feature enablement
+ *
+ * Uses version-gated feature flag `predictTradingEnabled` from remote config.
+ * Falls back to local environment variable MM_PREDICT_ENABLED if remote flag
+ * is unavailable or invalid.
+ *
+ * Version gating ensures users have minimum app version (7.60.0) to access feature.
+ *
+ * @returns {boolean} True if feature is enabled and version requirement is met
+ */
 export const selectPredictEnabledFlag = createSelector(
   selectRemoteFeatureFlags,
-  (remoteFlags) => {
-    if (FEATURE_FLAG_NAME in remoteFlags) {
-      return Boolean(remoteFlags[FEATURE_FLAG_NAME]);
-    }
-    return OVERRIDE_PREDICT_ENABLED_VALUE;
+  (remoteFeatureFlags) => {
+    const localFlag = process.env.MM_PREDICT_ENABLED === 'true';
+    const remoteFlag =
+      remoteFeatureFlags?.predictTradingEnabled as unknown as VersionGatedFeatureFlag;
+
+    // Fallback to local flag if remote flag is not available
+    return validatedVersionGatedFeatureFlag(remoteFlag) ?? localFlag;
   },
 );

--- a/app/components/Views/Wallet/index.test.tsx
+++ b/app/components/Views/Wallet/index.test.tsx
@@ -1258,7 +1258,10 @@ describe('Wallet', () => {
                   string,
                   Json
                 >),
-                predictEnabled: true,
+                predictTradingEnabled: {
+                  enabled: true,
+                  minimumVersion: '7.60.0',
+                },
               },
             },
           },
@@ -1296,7 +1299,10 @@ describe('Wallet', () => {
                   string,
                   Json
                 >),
-                predictEnabled: true,
+                predictTradingEnabled: {
+                  enabled: true,
+                  minimumVersion: '7.60.0',
+                },
               },
             },
           },
@@ -1331,7 +1337,10 @@ describe('Wallet', () => {
                   enabled: false,
                   minimumVersion: '1.0.0',
                 },
-                predictEnabled: true,
+                predictTradingEnabled: {
+                  enabled: true,
+                  minimumVersion: '7.60.0',
+                },
               },
             },
           },
@@ -1366,7 +1375,10 @@ describe('Wallet', () => {
                   string,
                   Json
                 >),
-                predictEnabled: false,
+                predictTradingEnabled: {
+                  enabled: false,
+                  minimumVersion: '7.60.0',
+                },
               },
             },
           },
@@ -1400,7 +1412,10 @@ describe('Wallet', () => {
                   string,
                   Json
                 >),
-                predictEnabled: false,
+                predictTradingEnabled: {
+                  enabled: false,
+                  minimumVersion: '7.60.0',
+                },
               },
             },
           },

--- a/e2e/api-mocking/helpers/remoteFeatureFlagsHelper.ts
+++ b/e2e/api-mocking/helpers/remoteFeatureFlagsHelper.ts
@@ -265,7 +265,10 @@ const DEFAULT_FEATURE_FLAGS_ARRAY: Record<string, unknown>[] = [
     walletFrameworkRpcFailoverEnabled: true,
   },
   {
-    predictEnabled: false,
+    predictTradingEnabled: {
+      enabled: true,
+      minimumVersion: '7.60.0',
+    },
   },
   {
     additionalNetworksBlacklist: [], // Empty by default, can be overridden in tests

--- a/e2e/api-mocking/helpers/remoteFeatureFlagsHelper.ts
+++ b/e2e/api-mocking/helpers/remoteFeatureFlagsHelper.ts
@@ -266,7 +266,7 @@ const DEFAULT_FEATURE_FLAGS_ARRAY: Record<string, unknown>[] = [
   },
   {
     predictTradingEnabled: {
-      enabled: true,
+      enabled: false,
       minimumVersion: '7.60.0',
     },
   },

--- a/e2e/api-mocking/mock-responses/feature-flags-mocks.ts
+++ b/e2e/api-mocking/mock-responses/feature-flags-mocks.ts
@@ -146,7 +146,10 @@ export const remoteFeatureMultichainAccountsAccountDetailsV2 = (
 });
 
 export const remoteFeatureFlagPredictEnabled = (enabled = true) => ({
-  predictEnabled: enabled,
+  predictTradingEnabled: {
+    enabled,
+    minimumVersion: '7.60.0',
+  },
 });
 
 export const remoteFeatureFlagSendRedesignDisabled = {


### PR DESCRIPTION
## **Description**

This PR migrates the Predict feature flag from a simple boolean flag to a version-gated feature flag structure, aligning it with the pattern used by Perps and other features.

**What is the reason for the change?**
The Predict feature needs version gating to ensure users have the minimum required app version (7.60.0) before accessing the feature. The previous implementation used a simple boolean flag (`predictEnabled`) which didn't support version checking.

**What is the improvement/solution?**

- Changed flag name from `predictEnabled` to `predictTradingEnabled` to follow naming conventions
- Implemented version-gated structure with `enabled` and `minimumVersion` properties
- Added environment variable fallback (`MM_PREDICT_ENABLED`) for local development
- Updated all references across the codebase (selectors, tests, mocks, E2E helpers)
- Ensured backward compatibility by maintaining the same boolean return type

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Predict feature flag version gating

  Scenario: user with app version below minimum cannot access Predict
    Given user has app version 7.59.0
    And remote feature flag predictTradingEnabled is enabled with minimumVersion "7.60.0"

    When user navigates to Wallet screen
    Then Predict feature should not be visible/accessible

  Scenario: user with app version at or above minimum can access Predict
    Given user has app version 7.60.0 or higher
    And remote feature flag predictTradingEnabled is enabled with minimumVersion "7.60.0"

    When user navigates to Wallet screen
    Then Predict feature should be visible and accessible

  Scenario: local environment variable overrides when remote flag unavailable
    Given remote feature flags are empty or invalid
    And MM_PREDICT_ENABLED environment variable is set to "true"

    When app initializes
    Then Predict feature should be enabled based on local flag

  Scenario: remote flag takes precedence over local flag
    Given remote feature flag predictTradingEnabled is explicitly disabled
    And MM_PREDICT_ENABLED environment variable is set to "true"

    When app initializes
    Then Predict feature should be disabled (remote flag overrides local)
```

## **Screenshots/Recordings**

Not applicable - This is an internal refactoring with no UI changes.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---

## **Technical Details**

### Files Modified (7 total)

1. **`app/components/UI/Predict/selectors/featureFlags/index.ts`**
   - Migrated from boolean flag to `VersionGatedFeatureFlag` structure
   - Changed flag name: `predictEnabled` → `predictTradingEnabled`
   - Added environment variable fallback: `MM_PREDICT_ENABLED`
   - Added comprehensive JSDoc documentation

2. **`app/components/UI/Predict/selectors/featureFlags/index.test.ts`**
   - Rewrote tests following unit testing guidelines (AAA pattern)
   - Added comprehensive test coverage for version gating
   - Added tests for remote flag precedence over local flags
   - Added tests for invalid flag scenarios
   - All 19 tests passing ✅

3. **`app/components/UI/Predict/mocks/remoteFeatureFlagMocks.ts`**
   - Updated mock structure to version-gated format

4. **`app/components/Views/Wallet/index.test.tsx`**
   - Updated 5 occurrences of `predictEnabled` → `predictTradingEnabled`

5. **`.js.env.example`**
   - Added `MM_PREDICT_ENABLED` environment variable example

6. **`e2e/api-mocking/helpers/remoteFeatureFlagsHelper.ts`**
   - Updated default mock to version-gated structure

7. **`e2e/api-mocking/mock-responses/feature-flags-mocks.ts`**
   - Updated `remoteFeatureFlagPredictEnabled` function

### Key Implementation Details

- **Flag Structure**: `{ enabled: boolean, minimumVersion: string }`
- **Backend Flag Name**: `predictTradingEnabled`
- **Minimum Version**: `7.60.0`
- **Local Fallback**: `MM_PREDICT_ENABLED` environment variable (defaults to `false`)
- **Validation**: Uses `validatedVersionGatedFeatureFlag()` utility for type checking and version validation

### Test Coverage

- ✅ Remote flag precedence over local flags
- ✅ Version gating validation
- ✅ Invalid flag type handling
- ✅ Fallback to local environment variable
- ✅ Edge cases (null, undefined, empty objects)

### Breaking Changes

None - The selector maintains the same boolean return type, ensuring backward compatibility with existing code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates Predict flag to version-gated `predictTradingEnabled` (with minimumVersion and `MM_PREDICT_ENABLED` fallback) and updates selectors, tests, and mocks accordingly.
> 
> - **Predict feature flag**:
>   - Rename `predictEnabled` → `predictTradingEnabled`.
>   - Adopt version-gated structure `{ enabled, minimumVersion }` (min app `7.60.0`).
>   - Update selector to validate remote flag and fallback to `MM_PREDICT_ENABLED`.
> - **Tests**:
>   - Add/expand unit tests for precedence, version gating, and invalid scenarios in `selectors/featureFlags`.
>   - Update `Wallet` tests to use `predictTradingEnabled` objects.
> - **Mocks/E2E**:
>   - Update Predict mocks and remote flags helpers to new structure.
>   - Add `MM_PREDICT_ENABLED` to `.js.env.example`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8997c9e743efa5fffb4600d7704620fe44e8177f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->