### PR TITLE
fix: apply expo patch to fix Android e2e

### DIFF
--- a/.yarn/patches/expo-updates-npm-0.27.4-2a215516d7.patch
+++ b/.yarn/patches/expo-updates-npm-0.27.4-2a215516d7.patch
@@ -1,0 +1,50 @@
+diff --git a/android/src/main/java/expo/modules/updates/UpdatesPackage.kt b/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
+index f697c9822c32544ddfcd62e218c09555bcb2915d..2c29988517b294b26714bccd371f5e836dd3b834 100644
+--- a/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
++++ b/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
+@@ -1,6 +1,5 @@
+ package expo.modules.updates
+ 
+-import android.app.Application
+ import android.content.Context
+ import androidx.annotation.UiThread
+ import androidx.annotation.WorkerThread
+@@ -8,7 +7,6 @@ import com.facebook.react.ReactActivity
+ import com.facebook.react.ReactNativeHost
+ import com.facebook.react.bridge.ReactContext
+ import com.facebook.react.devsupport.interfaces.DevSupportManager
+-import expo.modules.core.interfaces.ApplicationLifecycleListener
+ import expo.modules.core.interfaces.Package
+ import expo.modules.core.interfaces.ReactActivityHandler
+ import expo.modules.core.interfaces.ReactNativeHostHandler
+@@ -94,30 +92,6 @@ class UpdatesPackage : Package {
+     return listOf(handler)
+   }
+ 
+-  override fun createApplicationLifecycleListeners(context: Context): List<ApplicationLifecycleListener> {
+-    val handler = object : ApplicationLifecycleListener {
+-      override fun onCreate(application: Application) {
+-        super.onCreate(application)
+-        if (isRunningAndroidTest()) {
+-          // Preload updates to prevent Detox ANR
+-          UpdatesController.initialize(context)
+-          UpdatesController.instance.launchAssetFile
+-        }
+-      }
+-    }
+-
+-    return listOf(handler)
+-  }
+-
+-  private fun isRunningAndroidTest(): Boolean {
+-    try {
+-      Class.forName("androidx.test.espresso.Espresso")
+-      return true
+-    } catch (_: ClassNotFoundException) {
+-    }
+-    return false
+-  }
+-
+   companion object {
+     private val TAG = UpdatesPackage::class.java.simpleName
+     val isUsingNativeDebug = BuildConfig.EX_UPDATES_NATIVE_DEBUG

--- a/package.json
+++ b/package.json
@@ -371,7 +371,7 @@
     "expo-haptics": "~14.0.1",
     "expo-image": "~2.0.7",
     "expo-sensors": "~14.0.2",
-    "expo-updates": "~0.27.4",
+    "expo-updates": "patch:expo-updates@npm%3A0.27.4#~/.yarn/patches/expo-updates-npm-0.27.4-2a215516d7.patch",
     "fast-equals": "^5.2.2",
     "fuse.js": "3.4.4",
     "he": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -27983,7 +27983,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-updates@npm:~0.27.4":
+"expo-updates@npm:0.27.4":
   version: 0.27.4
   resolution: "expo-updates@npm:0.27.4"
   dependencies:
@@ -28007,6 +28007,33 @@ __metadata:
   bin:
     expo-updates: bin/cli.js
   checksum: 10/ea72f84525305ed0c32cafdec60b215bfd769236ecba1646bed1a647e3eb78a752853ffbe128b6365b6d7d87ddde738e377e3c9396a1688da36d7ccc1e1a182f
+  languageName: node
+  linkType: hard
+
+"expo-updates@patch:expo-updates@npm%3A0.27.4#~/.yarn/patches/expo-updates-npm-0.27.4-2a215516d7.patch":
+  version: 0.27.4
+  resolution: "expo-updates@patch:expo-updates@npm%3A0.27.4#~/.yarn/patches/expo-updates-npm-0.27.4-2a215516d7.patch::version=0.27.4&hash=06aea5"
+  dependencies:
+    "@expo/code-signing-certificates": "npm:0.0.5"
+    "@expo/config": "npm:~10.0.11"
+    "@expo/config-plugins": "npm:~9.0.17"
+    "@expo/spawn-async": "npm:^1.7.2"
+    arg: "npm:4.1.0"
+    chalk: "npm:^4.1.2"
+    expo-eas-client: "npm:~0.13.3"
+    expo-manifests: "npm:~0.15.7"
+    expo-structured-headers: "npm:~4.0.0"
+    expo-updates-interface: "npm:~1.0.0"
+    fast-glob: "npm:^3.3.2"
+    fbemitter: "npm:^3.0.0"
+    ignore: "npm:^5.3.1"
+    resolve-from: "npm:^5.0.0"
+  peerDependencies:
+    expo: "*"
+    react: "*"
+  bin:
+    expo-updates: bin/cli.js
+  checksum: 10/eb1ab10382100932f37200f0abad34c1d9635ab0e40dc8633cbe50a56a10e766e0be4a60a5213882c686941ad89421dcd191e4d13d9c32a590431b615b1e40d2
   languageName: node
   linkType: hard
 
@@ -34549,7 +34576,7 @@ __metadata:
     expo-haptics: "npm:~14.0.1"
     expo-image: "npm:~2.0.7"
     expo-sensors: "npm:~14.0.2"
-    expo-updates: "npm:~0.27.4"
+    expo-updates: "patch:expo-updates@npm%3A0.27.4#~/.yarn/patches/expo-updates-npm-0.27.4-2a215516d7.patch"
     fast-equals: "npm:^5.2.2"
     fs-extra: "npm:^10.1.0"
     fuse.js: "npm:3.4.4"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Android e2e tests are failing after expo-updates is implemented. According to Expo: 
```
detox has its intrusive logic to react native apps and it breaks the assumption in expo-updates. we migrated to maestro and removed a workaround for detox in https://github.com/expo/expo/pull/37707
```
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="1487" height="602" alt="Screenshot 2025-11-11 at 2 24 02 PM" src="https://github.com/user-attachments/assets/9a7b3bd3-cd98-4d59-ab5f-6e334c4d1083" />

<!-- [screenshots/recordings] -->

### **After**
<img width="1486" height="692" alt="Screenshot 2025-11-11 at 2 38 26 PM" src="https://github.com/user-attachments/assets/cff2b1f2-e5b1-4b38-95ae-0df81f974dc2" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Applies a Yarn patch to expo-updates@0.27.4 that removes Android test lifecycle preload logic in UpdatesPackage and updates dependencies to use the patched package.
> 
> - **Android (expo-updates)**:
>   - In `android/src/main/java/expo/modules/updates/UpdatesPackage.kt`, remove `createApplicationLifecycleListeners` and `isRunningAndroidTest`, and drop related imports.
> - **Build/Dependencies**:
>   - Change `package.json` to use `expo-updates` as a Yarn `patch:` dependency.
>   - Update `yarn.lock` to reference the patched `expo-updates` package.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6621d7e05e8e144d4e493878531f6cc5dbf98056. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->