### PR TITLE
feat(perps): handle funding payments tooltip

### DIFF
--- a/app/components/UI/Perps/components/PerpsBottomSheetTooltip/PerpsBottomSheetTooltip.types.ts
+++ b/app/components/UI/Perps/components/PerpsBottomSheetTooltip/PerpsBottomSheetTooltip.types.ts
@@ -43,6 +43,7 @@ export type PerpsTooltipContentKey =
   | 'receive'
   | 'open_interest'
   | 'funding_rate'
+  | 'funding_payments'
   | 'geo_block'
   | 'estimated_pnl'
   | 'limit_price'

--- a/app/components/UI/Perps/components/PerpsBottomSheetTooltip/content/contentRegistry.ts
+++ b/app/components/UI/Perps/components/PerpsBottomSheetTooltip/content/contentRegistry.ts
@@ -24,6 +24,7 @@ export const tooltipContentRegistry: ContentRegistry = {
   margin: undefined,
   open_interest: undefined,
   funding_rate: undefined,
+  funding_payments: undefined,
   geo_block: undefined,
   estimated_pnl: undefined,
   limit_price: undefined,

--- a/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
+++ b/app/components/UI/Perps/components/PerpsPositionCard/PerpsPositionCard.tsx
@@ -478,7 +478,7 @@ const PerpsPositionCard: React.FC<PerpsPositionCardProps> = ({
                   </Text>
                   {onTooltipPress && (
                     <TouchableOpacity
-                      onPress={() => onTooltipPress('funding_rate')}
+                      onPress={() => onTooltipPress('funding_payments')}
                     >
                       <Icon
                         name={IconName.Info}

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1477,6 +1477,10 @@
         "title": "Funding rate",
         "content": "An hourly fee paid between traders to keep prices in line with the market. If the rate is positive, longs pay shorts. If negative, shorts pay longs."
       },
+      "funding_payments": {
+        "title": "Funding payments",
+        "content": "This is the amount you've paid in funding fees since the position was opened. Funding is paid or received every hour to keep the perp price close to the actual token price."
+      },
       "geo_block": {
         "title": "Perps unavailable in your region",
         "content": "Perps trading isn't available in your location due to local restrictions or sanctions."


### PR DESCRIPTION
## **Description**

Adjusted the funding tooltip copy in the position component to display position-specific information. Previously, both the position card's "Funding Cost" and the market statistics "Funding Rate" used the same generic tooltip explaining funding rates. This change adds a dedicated tooltip for funding payments that clarifies it represents the cumulative amount paid/received since the position opened.

**Changes:**
- Added new `funding_payments` tooltip type
- Updated position card to use the new tooltip
- Market statistics continues to use the existing `funding_rate` tooltip

## **Changelog**

CHANGELOG entry: Updated funding tooltip in position component to show position-specific information

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1880

## **Manual testing steps**

```gherkin
Feature: Funding payments tooltip in position component

  Scenario: user views funding tooltip in position card
    Given user has an open perp position
    And the position card displays the "Funding" field with an info icon

    When user taps the info icon next to "Funding" in the position card
    Then the tooltip displays title "Funding payments"
    And the tooltip content reads "This is the amount you've paid in funding fees since the position was opened. Funding is paid or received every hour to keep the perp price close to the actual token price."

  Scenario: user views funding rate tooltip in market statistics
    Given user is viewing market statistics for a perp

    When user taps the info icon next to "Funding rate"
    Then the tooltip displays title "Funding rate"
    And the tooltip content describes the general funding rate concept
```

## **Screenshots/Recordings**

### **Before**

Position card showed generic funding rate tooltip (same as market statistics)

### **After**

Position card shows position-specific funding payments tooltip with cumulative payment context

https://github.com/user-attachments/assets/65db42a1-68fc-4758-950f-ad1dd79e1030


## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable (N/A - localization change only)
- [x] I've documented my code using JSDoc format if applicable (N/A)
- [x] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed)
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a new `funding_payments` tooltip and switches the position card’s funding info icon to use it, with corresponding registry and locale updates.
> 
> - **Perps Tooltips**:
>   - Add new content key `funding_payments` to `PerpsTooltipContentKey` and register in `contentRegistry`.
> - **Position Card**:
>   - Change funding info icon handler from `funding_rate` to `funding_payments` in `PerpsPositionCard`.
> - **Localization**:
>   - Add `perps.tooltips.funding_payments` strings (title and content) in `en.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2149df2a53009a2ffc7babe63e0f7c301ddb63b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->