### PR TITLE
fix(perps): rerender tabs when the amount of tabs changes cp-7.59.0

### DIFF
--- a/app/components/UI/Perps/components/PerpsMarketTabs/PerpsMarketTabs.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketTabs/PerpsMarketTabs.tsx
@@ -669,7 +669,10 @@ const PerpsMarketTabs: React.FC<PerpsMarketTabsProps> = ({
   }, [selectedTooltip, handleTooltipClose]);
 
   // Key for TabsList to force remount when tab count changes
-  const tabsKey = useMemo(() => `tabs-${tabs.length}`, [tabs.length]);
+  const tabsKey = useMemo(
+    () => `tabs-${tabs.length}-${tabsToRender.length}`,
+    [tabs.length, tabsToRender.length],
+  );
 
   // Calculate active index for TabsList
   const activeIndex = useMemo(() => {


### PR DESCRIPTION
## **Description**

This PR fixes an issue in the Perps Market Tabs component where the TabsList wasn't properly re-rendering when the number of visible tabs changed.


## **Changelog**


CHANGELOG entry: Fixed an issue where perps market tabs would not update correctly when the number of visible tabs changed

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-1982

## **Manual testing steps**

```gherkin
Feature: Perps Market Tabs Rendering

  Scenario: user switches between market states that affect tab visibility
    Given user is on the perps market details view with active position
    
    When user closes their position or opens new positions
    Then the tabs should correctly update to reflect the current state (position tab should appear/disappear)
    And the active tab selection should remain consistent
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->


### **Before**

<!-- [screenshots/recordings] -->
No visible change

### **After**

<!-- [screenshots/recordings] -->
No visible change

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `TabsList` remounts when the number of visible tabs changes by incorporating `tabsToRender.length` into the component key.
> 
> - **Perps UI**:
>   - **Tabs re-rendering**: Update `tabsKey` in `PerpsMarketTabs.tsx` to `tabs-${tabs.length}-${tabsToRender.length}` so `TabsList` remounts when the visible tab count changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e03f2b26e538e22c02100cb8dac9f6c4346206a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->