### PR TITLE
fix(ramps):validate release version number before query

### DIFF
--- a/.github/scripts/close-release-bug-report-issue.ts
+++ b/.github/scripts/close-release-bug-report-issue.ts
@@ -92,6 +92,10 @@ async function retrieveOpenBugReportIssue(
     }
   | undefined
 > {
+  // Validate releaseVersionNumber before using in the query
+  if (!/^\d+\.\d+\.\d+$/.test(releaseVersionNumber)) {
+    throw new Error(`Invalid release version number: "${releaseVersionNumber}"`);
+  }
   const retrieveOpenBugReportIssueQuery = `
   query RetrieveOpenBugReportIssue {
     search(query: "repo:${repoOwner}/${repoName} type:issue is:open in:title v${releaseVersionNumber} Bug Report", type: ISSUE, first: 1) {

--- a/e2e/framework/DappServer.ts
+++ b/e2e/framework/DappServer.ts
@@ -5,6 +5,7 @@ import serveHandler from 'serve-handler';
 import { getLocalHost } from './fixtures/FixtureUtils';
 import { DappVariants } from './Constants';
 import path from 'path';
+import PortManager, { ResourceType } from './PortManager';
 
 const logger = createLogger({
   name: 'DappServer',
@@ -16,19 +17,22 @@ export default class DappServer implements Resource {
   private _server: http.Server | undefined;
   private _rootDirectory: string;
   private dappVariant: DappVariants;
+  private dappCounter: number;
 
   constructor({
-    port,
+    dappCounter,
     rootDirectory,
     dappVariant,
   }: {
-    port: number;
+    dappCounter: number;
     rootDirectory: string;
     dappVariant: DappVariants;
   }) {
     this.dappVariant = dappVariant;
     this._rootDirectory = rootDirectory;
-    this._serverPort = port;
+    this.dappCounter = dappCounter;
+    // Port will be allocated when start() is called via PortManager
+    this._serverPort = 0; // Placeholder, will be set in start()
   }
 
   async stop(): Promise<void> {
@@ -49,15 +53,24 @@ export default class DappServer implements Resource {
       });
     }
     this._serverStatus = ServerStatus.STOPPED;
+    // Release the port after server is stopped
+    if (this._serverPort > 0) {
+      const instanceId = `dapp-server-${this.dappCounter}`;
+      PortManager.getInstance().releaseMultiInstancePort(
+        ResourceType.DAPP_SERVER,
+        instanceId,
+      );
+    }
     logger.debug(
       `Dapp server ${this.dappVariant} stopped on port ${this._serverPort}`,
     );
   }
 
+  setServerPort(port: number): void {
+    this._serverPort = port;
+  }
+
   async start(): Promise<void> {
-    logger.debug(
-      `Starting dapp server ${this.dappVariant} on port ${this._serverPort}`,
-    );
     if (this._serverStatus === ServerStatus.STARTED) {
       logger.debug(
         `Dapp server ${this.dappVariant} already started on port ${this._serverPort}`,
@@ -65,7 +78,11 @@ export default class DappServer implements Resource {
       return;
     }
 
-    return new Promise((resolve, reject) => {
+    logger.debug(
+      `Starting dapp server ${this.dappVariant} on port ${this._serverPort}`,
+    );
+
+    await new Promise<void>((resolve, reject) => {
       this._server = http.createServer(
         async (
           request: http.IncomingMessage,
@@ -75,18 +92,6 @@ export default class DappServer implements Resource {
             response.statusCode = 404;
             response.end('Not Found');
             return;
-          }
-
-          if (request.url.startsWith('/node_modules/')) {
-            request.url = request.url.substr(14);
-            const nodeModulesDir = path.resolve(
-              __dirname,
-              '../../node_modules',
-            );
-            return serveHandler(request, response, {
-              directoryListing: false,
-              public: nodeModulesDir,
-            });
           }
 
           // Handle test-dapp-multichain URLs by removing the prefix

--- a/e2e/specs/multichain/connections/helpers.ts
+++ b/e2e/specs/multichain/connections/helpers.ts
@@ -32,7 +32,8 @@ export const requestPermissions = async ({
   });
 
   await bodyElement.runScript(
-    `(el) => { window.ethereum.request(${requestPermissionsRequest}); }`,
+    (el, request) => { window.ethereum.request(request); },
+    requestPermissionsRequest,
   );
   logger.debug('Done requestPermissions');
 };

--- a/e2e/specs/multichain/connections/helpers.ts
+++ b/e2e/specs/multichain/connections/helpers.ts
@@ -32,8 +32,12 @@ export const requestPermissions = async ({
   });
 
   await bodyElement.runScript(
-    (el, request) => { window.ethereum.request(request); },
+    `(el, request) => {
+      const parsedRequest = JSON.parse(request);
+      window.ethereum.request(parsedRequest);
+    }`,
     requestPermissionsRequest,
   );
+
   logger.debug('Done requestPermissions');
 };


### PR DESCRIPTION
Add validation for release version number format.



### Description
fix issue #22302 must ensure that user-controlled input (`releaseVersionNumber`) is strictly validated before being interpolated into the GraphQL query string. Given that the intended format is semantic versioning (`x.y.z`), we should reject any input that fails to match `^\d+\.\d+\.\d+$` and ensure this invariant is preserved even if the branch name extraction step is skipped or altered in the future.  validate `releaseVersionNumber` just before using it in the query (in `retrieveOpenBugReportIssue`), using a full type/character check. If the check fails, throw an error or return undefined to prevent malformed input from reaching the query.  

## **Related issues**

Fixes: #22302 


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves safety and e2e stability.
> 
> - **GitHub Action script**: Validates `releaseVersionNumber` (`x.y.z`) before interpolating into the GraphQL search query, throwing on invalid input.
> - **e2e DappServer**: Switches to `PortManager` with `dappCounter` for per-instance port allocation/release; adds `setServerPort`; awaits server start; removes legacy `/node_modules` serving; releases ports on stop.
> - **Multichain helpers**: `runScript` now passes a serialized request argument and parses it in-page before calling `window.ethereum.request`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0ed3128e0fa413745b663618f576fceb2d20064. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->