### PR TITLE
fix: asset picker scroll in metamask pay on android

### DIFF
--- a/app/components/Views/confirmations/components/network-filter/network-filter.tsx
+++ b/app/components/Views/confirmations/components/network-filter/network-filter.tsx
@@ -5,7 +5,7 @@ import {
   Text,
   TextVariant,
 } from '@metamask/design-system-react-native';
-import { ScrollView, Pressable, ImageSourcePropType } from 'react-native';
+import { Pressable, ImageSourcePropType } from 'react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 
 import { strings } from '../../../../../../locales/i18n';
@@ -19,6 +19,7 @@ import {
   useNetworkFilter,
   NETWORK_FILTER_ALL,
 } from '../../hooks/send/useNetworkFilter';
+import { ScrollView } from 'react-native-gesture-handler';
 
 interface NetworkFilterTabProps {
   label: string;

--- a/app/components/Views/confirmations/components/send/asset/asset.tsx
+++ b/app/components/Views/confirmations/components/send/asset/asset.tsx
@@ -8,7 +8,6 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
-import { ScrollView } from 'react-native';
 
 import { useTheme } from '../../../../../../util/theme';
 import { strings } from '../../../../../../../locales/i18n';
@@ -24,6 +23,7 @@ import { NetworkFilter } from '../../network-filter';
 import { useEVMNfts } from '../../../hooks/send/useNfts';
 import { useAccountTokens } from '../../../hooks/send/useAccountTokens';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { ScrollView } from 'react-native-gesture-handler';
 
 export interface AssetProps {
   hideNfts?: boolean;
@@ -145,7 +145,11 @@ export const Asset: React.FC<AssetProps> = (props = {}) => {
         onExposeFilterControls={handleExposeFilterControls}
         onNetworkFilterChange={handleNetworkFilterChange}
       />
-      <ScrollView contentContainerStyle={{ paddingBottom: bottomOffset }}>
+      <ScrollView
+        contentContainerStyle={{
+          paddingBottom: bottomOffset,
+        }}
+      >
         {hasNoResults && hasActiveFilters ? (
           <Box twClassName="items-center py-8 px-4">
             <Text variant={TextVariant.BodyMd} twClassName="text-center mb-4">


### PR DESCRIPTION
## **Description**

Fix scrolling in the MetaMask Pay asset picker on Android.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#6147](https://github.com/MetaMask/MetaMask-planning/issues/6147)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches asset picker and network filter to use react-native-gesture-handler ScrollView to fix Android scrolling.
> 
> - **Mobile UI**:
>   - Replace `react-native` `ScrollView` with `react-native-gesture-handler` in `app/components/Views/confirmations/components/network-filter/network-filter.tsx` and `app/components/Views/confirmations/components/send/asset/asset.tsx`.
>   - Minor `ScrollView` prop formatting cleanup in `asset.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7e090188fe02ffc921116287a00af85f3331f33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->