### PR TITLE
chore: improve swaps token list mounting performance

### DIFF
--- a/app/component-library/hooks/useStyles.ts
+++ b/app/component-library/hooks/useStyles.ts
@@ -7,17 +7,31 @@ import { Theme } from '../../util/theme/models';
  * Hook that handles both passing style sheet variables into style sheet and memoization.
  *
  * @param styleSheet Return value of useStyles hook.
- * @param vars Variables of styleSheet function.
+ * @param vars Variables of styleSheet function (optional).
  * @returns StyleSheet object.
  */
-export const useStyles = <R, V>(
+// Overload: when vars is provided
+export function useStyles<R, V>(
   styleSheet: (params: { theme: Theme; vars: V }) => R,
   vars: V,
-): { styles: R; theme: Theme } => {
+): { styles: R; theme: Theme };
+
+// Overload: when vars is not provided
+export function useStyles<R>(styleSheet: (params: { theme: Theme }) => R): {
+  styles: R;
+  theme: Theme;
+};
+
+export function useStyles<R, V>(
+  styleSheet:
+    | ((params: { theme: Theme; vars: V }) => R)
+    | ((params: { theme: Theme }) => R),
+  vars?: V,
+): { styles: R; theme: Theme } {
   const theme = useAppThemeFromContext();
   const styles = useMemo(
-    () => styleSheet({ theme, vars }),
+    () => styleSheet({ theme, vars: vars as V }),
     [styleSheet, theme, vars],
   );
   return { styles, theme };
-};
+}

--- a/app/components/UI/Bridge/components/BridgeDestTokenSelector/__snapshots__/BridgeDestTokenSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeDestTokenSelector/__snapshots__/BridgeDestTokenSelector.test.tsx.snap
@@ -550,7 +550,7 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                                   "paddingHorizontal": 4,
                                 }
                               }
-                              handlerTag={1}
+                              handlerTag={-1}
                               handlerType="NativeViewGestureHandler"
                               horizontal={true}
                               onGestureHandlerEvent={[Function]}
@@ -886,7 +886,13 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                           </View>
                           <View>
                             <RCTScrollView
-                              ListEmptyComponent={[Function]}
+                              ListEmptyComponent={
+                                {
+                                  "$$typeof": Symbol(react.memo),
+                                  "compare": null,
+                                  "type": [Function],
+                                }
+                              }
                               bounces={true}
                               collapsable={false}
                               data={

--- a/app/components/UI/Bridge/components/BridgeDestTokenSelector/index.tsx
+++ b/app/components/UI/Bridge/components/BridgeDestTokenSelector/index.tsx
@@ -49,9 +49,9 @@ const createStyles = () =>
       marginRight: 12,
     },
   });
-export const BridgeDestTokenSelector: React.FC = () => {
+export const BridgeDestTokenSelector: React.FC = React.memo(() => {
   const dispatch = useDispatch();
-  const { styles } = useStyles(createStyles, {});
+  const { styles } = useStyles(createStyles);
   const navigation = useNavigation();
   const bridgeViewMode = useSelector(selectBridgeViewMode);
 
@@ -59,11 +59,21 @@ export const BridgeDestTokenSelector: React.FC = () => {
   const selectedDestToken = useSelector(selectDestToken);
   const selectedDestChainId = useSelector(selectSelectedDestChainId);
   const selectedSourceToken = useSelector(selectSourceToken);
+
+  const balanceChainIds = useMemo(
+    () => (selectedDestChainId ? [selectedDestChainId] : []),
+    [selectedDestChainId],
+  );
+  const tokensToExclude = useMemo(
+    () => (selectedSourceToken ? [selectedSourceToken] : []),
+    [selectedSourceToken],
+  );
   const { allTokens, tokensToRender, pending } = useTokens({
     topTokensChainId: selectedDestChainId,
-    balanceChainIds: selectedDestChainId ? [selectedDestChainId] : [],
-    tokensToExclude: selectedSourceToken ? [selectedSourceToken] : [],
+    balanceChainIds,
+    tokensToExclude,
   });
+
   const handleTokenPress = useCallback(
     (token: BridgeToken) => {
       dispatch(setDestToken(token));
@@ -155,14 +165,18 @@ export const BridgeDestTokenSelector: React.FC = () => {
     ],
   );
 
+  const networksBar = useMemo(
+    () =>
+      bridgeViewMode === BridgeViewMode.Bridge ||
+      bridgeViewMode === BridgeViewMode.Unified ? (
+        <BridgeDestNetworksBar />
+      ) : undefined,
+    [bridgeViewMode],
+  );
+
   return (
     <BridgeTokenSelectorBase
-      networksBar={
-        bridgeViewMode === BridgeViewMode.Bridge ||
-        bridgeViewMode === BridgeViewMode.Unified ? (
-          <BridgeDestNetworksBar />
-        ) : undefined
-      }
+      networksBar={networksBar}
       renderTokenItem={renderToken}
       allTokens={allTokens}
       tokensToRender={tokensToRender}
@@ -171,4 +185,6 @@ export const BridgeDestTokenSelector: React.FC = () => {
       scrollResetKey={selectedDestChainId}
     />
   );
-};
+});
+
+BridgeDestTokenSelector.displayName = 'BridgeDestTokenSelector';

--- a/app/components/UI/Bridge/components/BridgeSourceTokenSelector/__snapshots__/BridgeSourceTokenSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeSourceTokenSelector/__snapshots__/BridgeSourceTokenSelector.test.tsx.snap
@@ -891,7 +891,13 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                           </View>
                           <View>
                             <RCTScrollView
-                              ListEmptyComponent={[Function]}
+                              ListEmptyComponent={
+                                {
+                                  "$$typeof": Symbol(react.memo),
+                                  "compare": null,
+                                  "type": [Function],
+                                }
+                              }
                               bounces={true}
                               collapsable={false}
                               data={

--- a/app/components/UI/Bridge/components/BridgeSourceTokenSelector/index.tsx
+++ b/app/components/UI/Bridge/components/BridgeSourceTokenSelector/index.tsx
@@ -34,7 +34,7 @@ import { BridgeToken, BridgeViewMode } from '../../types';
 import { useSwitchNetworks } from '../../../../Views/NetworkSelector/useSwitchNetworks';
 import { useNetworkInfo } from '../../../../../selectors/selectedNetworkController';
 
-export const BridgeSourceTokenSelector: React.FC = () => {
+export const BridgeSourceTokenSelector: React.FC = React.memo(() => {
   const dispatch = useDispatch();
   const navigation = useNavigation();
   const bridgeViewMode = useSelector(selectBridgeViewMode);
@@ -79,10 +79,14 @@ export const BridgeSourceTokenSelector: React.FC = () => {
       : undefined;
   }
 
+  const tokenToExclude = useMemo(
+    () => (selectedDestToken ? [selectedDestToken] : []),
+    [selectedDestToken],
+  );
   const { allTokens, tokensToRender, pending } = useTokens({
     topTokensChainId: selectedSourceToken?.chainId,
     balanceChainIds,
-    tokensToExclude: selectedDestToken ? [selectedDestToken] : [],
+    tokensToExclude: tokenToExclude,
   });
 
   const handleTokenPress = useCallback(
@@ -167,18 +171,28 @@ export const BridgeSourceTokenSelector: React.FC = () => {
     [selectedSourceChainIds, sortedSourceNetworks],
   );
 
+  const networksBar = useMemo(
+    () =>
+      isBridgeOrUnified ? (
+        <BridgeSourceNetworksBar
+          networksToShow={networksToShow}
+          networkConfigurations={allNetworkConfigurations}
+          selectedSourceChainIds={selectedSourceChainIds as Hex[]}
+          enabledSourceChains={enabledSourceChains}
+        />
+      ) : undefined,
+    [
+      isBridgeOrUnified,
+      networksToShow,
+      allNetworkConfigurations,
+      selectedSourceChainIds,
+      enabledSourceChains,
+    ],
+  );
+
   return (
     <BridgeTokenSelectorBase
-      networksBar={
-        isBridgeOrUnified ? (
-          <BridgeSourceNetworksBar
-            networksToShow={networksToShow}
-            networkConfigurations={allNetworkConfigurations}
-            selectedSourceChainIds={selectedSourceChainIds as Hex[]}
-            enabledSourceChains={enabledSourceChains}
-          />
-        ) : undefined
-      }
+      networksBar={networksBar}
       renderTokenItem={renderItem}
       allTokens={allTokens}
       tokensToRender={tokensToRender}
@@ -186,4 +200,6 @@ export const BridgeSourceTokenSelector: React.FC = () => {
       chainIdToFetchMetadata={selectedChainId}
     />
   );
-};
+});
+
+BridgeSourceTokenSelector.displayName = 'BridgeSourceTokenSelector';

--- a/app/components/UI/Bridge/components/BridgeTokenSelectorBase.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelectorBase.tsx
@@ -63,7 +63,7 @@ const createStyles = (params: { theme: Theme }) => {
   });
 };
 
-export const SkeletonItem = () => {
+export const SkeletonItem = React.memo(() => {
   const { styles } = useStyles(createStyles, {});
 
   return (
@@ -81,9 +81,9 @@ export const SkeletonItem = () => {
       </Box>
     </Box>
   );
-};
+});
 
-export const LoadingSkeleton = () => {
+export const LoadingSkeleton = React.memo(() => {
   const { styles } = useStyles(createStyles, {});
 
   return (
@@ -97,7 +97,7 @@ export const LoadingSkeleton = () => {
       <SkeletonItem />
     </Box>
   );
-};
+});
 
 interface BridgeTokenSelectorBaseProps {
   networksBar: React.ReactNode;
@@ -120,154 +120,156 @@ interface BridgeTokenSelectorBaseProps {
   scrollResetKey?: string | Hex | CaipChainId;
 }
 
-export const BridgeTokenSelectorBase: React.FC<
-  BridgeTokenSelectorBaseProps
-> = ({
-  networksBar,
-  renderTokenItem,
-  allTokens,
-  tokensToRender,
-  pending,
-  chainIdToFetchMetadata: chainId,
-  title,
-  scrollResetKey,
-}) => {
-  const { styles, theme } = useStyles(createStyles, {});
-  const {
-    searchString,
-    setSearchString,
-    searchResults,
-    debouncedSearchString,
-  } = useTokenSearch({
-    tokens: allTokens || [],
-  });
+export const BridgeTokenSelectorBase: React.FC<BridgeTokenSelectorBaseProps> =
+  React.memo(
+    ({
+      networksBar,
+      renderTokenItem,
+      allTokens,
+      tokensToRender,
+      pending,
+      chainIdToFetchMetadata: chainId,
+      title,
+      scrollResetKey,
+    }) => {
+      const { styles, theme } = useStyles(createStyles);
+      const {
+        searchString,
+        setSearchString,
+        searchResults,
+        debouncedSearchString,
+      } = useTokenSearch({
+        tokens: allTokens || [],
+      });
 
-  const {
-    assetMetadata: unlistedAssetMetadata,
-    pending: unlistedAssetMetadataPending,
-  } = useAssetMetadata(
-    debouncedSearchString,
-    Boolean(debouncedSearchString && searchResults.length === 0),
-    chainId,
-  );
+      const {
+        assetMetadata: unlistedAssetMetadata,
+        pending: unlistedAssetMetadataPending,
+      } = useAssetMetadata(
+        debouncedSearchString,
+        Boolean(debouncedSearchString && searchResults.length === 0),
+        chainId,
+      );
 
-  const tokensToRenderWithSearch = useMemo(() => {
-    if (!searchString) {
-      return tokensToRender;
-    }
+      const tokensToRenderWithSearch = useMemo(() => {
+        if (!searchString) {
+          return tokensToRender;
+        }
 
-    if (searchResults.length > 0) {
-      return searchResults;
-    }
+        if (searchResults.length > 0) {
+          return searchResults;
+        }
 
-    return unlistedAssetMetadata ? [unlistedAssetMetadata] : [];
-  }, [searchString, searchResults, tokensToRender, unlistedAssetMetadata]);
+        return unlistedAssetMetadata ? [unlistedAssetMetadata] : [];
+      }, [searchString, searchResults, tokensToRender, unlistedAssetMetadata]);
 
-  const keyExtractor = useCallback(
-    (token: BridgeToken | null, index: number) =>
-      token ? `${token.chainId}-${token.address}` : `skeleton-${index}`,
-    [],
-  );
+      const keyExtractor = useCallback(
+        (token: BridgeToken | null, index: number) =>
+          token ? `${token.chainId}-${token.address}` : `skeleton-${index}`,
+        [],
+      );
 
-  const handleSearchTextChange = useCallback(
-    (text: string) => {
-      setSearchString(text);
+      const handleSearchTextChange = useCallback(
+        (text: string) => {
+          setSearchString(text);
+        },
+        [setSearchString],
+      );
+
+      const renderEmptyList = useMemo(
+        () => (
+          <Box style={styles.emptyList}>
+            <Text color={TextColor.Alternative}>
+              {strings('swaps.no_tokens_result', {
+                searchString: debouncedSearchString,
+              })}
+            </Text>
+          </Box>
+        ),
+        [debouncedSearchString, styles],
+      );
+
+      const sheetRef = useRef<BottomSheetRef>(null);
+      const dismissModal = useCallback((): void => {
+        sheetRef.current?.onCloseBottomSheet();
+      }, []);
+
+      const shouldRenderOverallLoading = useMemo(
+        () =>
+          (pending && allTokens?.length === 0) || unlistedAssetMetadataPending,
+        [pending, unlistedAssetMetadataPending, allTokens],
+      );
+
+      // We show the tokens with balance immediately, but we need to wait for the top tokens to load
+      // So we show a few skeletons for the top tokens
+      const tokensToRenderWithSearchAndSkeletons: (BridgeToken | null)[] =
+        useMemo(() => {
+          if (pending && tokensToRenderWithSearch?.length > 0) {
+            return [...tokensToRenderWithSearch, ...Array(4).fill(null)];
+          }
+
+          return tokensToRenderWithSearch;
+        }, [pending, tokensToRenderWithSearch]);
+
+      const placeholderTextColor = theme.colors.text.alternative;
+
+      return (
+        <BottomSheet
+          ref={sheetRef}
+          isFullscreen
+          keyboardAvoidingViewEnabled={false}
+        >
+          <BottomSheetHeader
+            onClose={dismissModal}
+            closeButtonProps={{
+              testID: 'bridge-token-selector-close-button',
+            }}
+          >
+            {title ?? strings('bridge.select_token')}
+          </BottomSheetHeader>
+
+          <Box style={styles.buttonContainer} gap={20}>
+            {networksBar}
+
+            <TextFieldSearch
+              value={searchString}
+              onChangeText={handleSearchTextChange}
+              placeholder={strings('swaps.search_token')}
+              testID="bridge-token-search-input"
+              style={styles.searchInput}
+              placeholderTextColor={placeholderTextColor}
+            />
+          </Box>
+
+          {/* Need this extra View to fix tokens not being reliably pressable on Android hardware, no idea why */}
+          <View>
+            <ListComponent
+              style={styles.tokensList}
+              key={scrollResetKey}
+              data={
+                shouldRenderOverallLoading
+                  ? []
+                  : tokensToRenderWithSearchAndSkeletons
+              }
+              renderItem={renderTokenItem}
+              keyExtractor={keyExtractor}
+              ListEmptyComponent={
+                debouncedSearchString && !shouldRenderOverallLoading
+                  ? renderEmptyList
+                  : LoadingSkeleton
+              }
+              showsVerticalScrollIndicator
+              showsHorizontalScrollIndicator={false}
+              bounces
+              scrollEnabled
+              removeClippedSubviews
+              maxToRenderPerBatch={20}
+              windowSize={10}
+              initialNumToRender={20}
+              keyboardShouldPersistTaps="always"
+            />
+          </View>
+        </BottomSheet>
+      );
     },
-    [setSearchString],
   );
-
-  const renderEmptyList = useMemo(
-    () => (
-      <Box style={styles.emptyList}>
-        <Text color={TextColor.Alternative}>
-          {strings('swaps.no_tokens_result', {
-            searchString: debouncedSearchString,
-          })}
-        </Text>
-      </Box>
-    ),
-    [debouncedSearchString, styles],
-  );
-
-  const sheetRef = useRef<BottomSheetRef>(null);
-  const dismissModal = (): void => {
-    sheetRef.current?.onCloseBottomSheet();
-  };
-
-  const shouldRenderOverallLoading = useMemo(
-    () => (pending && allTokens?.length === 0) || unlistedAssetMetadataPending,
-    [pending, unlistedAssetMetadataPending, allTokens],
-  );
-
-  // We show the tokens with balance immediately, but we need to wait for the top tokens to load
-  // So we show a few skeletons for the top tokens
-  const tokensToRenderWithSearchAndSkeletons: (BridgeToken | null)[] =
-    useMemo(() => {
-      if (pending && tokensToRenderWithSearch?.length > 0) {
-        return [...tokensToRenderWithSearch, ...Array(4).fill(null)];
-      }
-
-      return tokensToRenderWithSearch;
-    }, [pending, tokensToRenderWithSearch]);
-
-  const placeholderTextColor = theme.colors.text.alternative;
-
-  return (
-    <BottomSheet
-      ref={sheetRef}
-      isFullscreen
-      keyboardAvoidingViewEnabled={false}
-    >
-      <BottomSheetHeader
-        onClose={dismissModal}
-        closeButtonProps={{
-          testID: 'bridge-token-selector-close-button',
-        }}
-      >
-        {title ?? strings('bridge.select_token')}
-      </BottomSheetHeader>
-
-      <Box style={styles.buttonContainer} gap={20}>
-        {networksBar}
-
-        <TextFieldSearch
-          value={searchString}
-          onChangeText={handleSearchTextChange}
-          placeholder={strings('swaps.search_token')}
-          testID="bridge-token-search-input"
-          style={styles.searchInput}
-          placeholderTextColor={placeholderTextColor}
-        />
-      </Box>
-
-      {/* Need this extra View to fix tokens not being reliably pressable on Android hardware, no idea why */}
-      <View>
-        <ListComponent
-          style={styles.tokensList}
-          key={scrollResetKey}
-          data={
-            shouldRenderOverallLoading
-              ? []
-              : tokensToRenderWithSearchAndSkeletons
-          }
-          renderItem={renderTokenItem}
-          keyExtractor={keyExtractor}
-          ListEmptyComponent={
-            debouncedSearchString && !shouldRenderOverallLoading
-              ? renderEmptyList
-              : LoadingSkeleton
-          }
-          showsVerticalScrollIndicator
-          showsHorizontalScrollIndicator={false}
-          bounces
-          scrollEnabled
-          removeClippedSubviews
-          maxToRenderPerBatch={20}
-          windowSize={10}
-          initialNumToRender={20}
-          keyboardShouldPersistTaps="always"
-        />
-      </View>
-    </BottomSheet>
-  );
-};

--- a/app/components/UI/Bridge/components/TokenInputArea/index.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/index.tsx
@@ -440,3 +440,5 @@ export const TokenInputArea = forwardRef<
     );
   },
 );
+
+TokenInputArea.displayName = 'TokenInputArea';

--- a/app/components/UI/Bridge/hooks/useNonEvmTokensWithBalance/useNonEvmTokensWithBalance.ts
+++ b/app/components/UI/Bridge/hooks/useNonEvmTokensWithBalance/useNonEvmTokensWithBalance.ts
@@ -1,8 +1,7 @@
 import { useSelector } from 'react-redux';
 import { RootState } from '../../../../../reducers';
-import { selectMultichainTokenListForAccountAnyChain } from '../../../../../selectors/multichain';
+import { selectMultichainTokenListForAccountsAnyChain } from '../../../../../selectors/multichain';
 import { useNonEvmAccounts } from '../useNonEvmAccounts';
-import { useMemo } from 'react';
 
 /**
  * Hook to get non-EVM tokens from all non-EVM accounts
@@ -10,23 +9,9 @@ import { useMemo } from 'react';
  */
 export const useNonEvmTokensWithBalance = () => {
   const nonEvmAccounts = useNonEvmAccounts();
-  const nonEvmTokens = useSelector(
-    useMemo(
-      () => (state: RootState) => {
-        const tokens: ReturnType<
-          typeof selectMultichainTokenListForAccountAnyChain
-        > = [];
-        for (const account of nonEvmAccounts) {
-          const tokensForAccount = selectMultichainTokenListForAccountAnyChain(
-            state,
-            account,
-          );
-          tokens.push(...tokensForAccount);
-        }
-        return tokens;
-      },
-      [nonEvmAccounts],
-    ),
+
+  const nonEvmTokens = useSelector((state: RootState) =>
+    selectMultichainTokenListForAccountsAnyChain(state, nonEvmAccounts),
   );
 
   return nonEvmTokens;

--- a/app/components/UI/Bridge/hooks/useTokenSearch/index.ts
+++ b/app/components/UI/Bridge/hooks/useTokenSearch/index.ts
@@ -1,9 +1,12 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import Fuse from 'fuse.js';
+import { throttle } from 'lodash';
 import { BridgeToken } from '../../types';
 import { useDebouncedValue } from '../../../../hooks/useDebouncedValue';
 
+const THROTTLE_MS = 1250; // Throttle token updates to max once per second
 const MAX_TOKENS_RESULTS = 20;
+
 interface UseTokenSearchProps {
   tokens: BridgeToken[];
 }
@@ -20,26 +23,38 @@ export function useTokenSearch({
 }: UseTokenSearchProps): UseTokenSearchResult {
   const [searchString, setSearchString] = useState('');
   const debouncedSearchString = useDebouncedValue<string>(searchString);
+  // We start with empty array to avoid initial expensive initialization of Fuse instance,
+  // because it's immediately replaced with new instance during intial 1s anyway (useAsyncResult in useTopTokens triggest it)
+  const [throttledTokens, setThrottledTokens] = useState<BridgeToken[]>([]);
 
-  const tokenFuse = useMemo(
-    () =>
-      new Fuse(tokens || [], {
-        shouldSort: true,
-        threshold: 0.45,
-        location: 0,
-        distance: 100,
-        maxPatternLength: 32,
-        minMatchCharLength: 1,
-        keys: ['symbol', 'name', 'address'],
-      }),
-    [tokens],
-  );
+  // Create stable throttled setter that persists across renders
+  const throttledSetTokens = useRef(
+    throttle((newTokens: BridgeToken[]) => {
+      setThrottledTokens(newTokens);
+    }, THROTTLE_MS),
+  ).current;
+
+  useEffect(() => {
+    throttledSetTokens(tokens);
+  }, [tokens, throttledSetTokens]);
+
+  const tokenFuse = useMemo(() => {
+    const result = new Fuse(throttledTokens || [], {
+      shouldSort: true,
+      threshold: 0.45,
+      location: 0,
+      distance: 100,
+      maxPatternLength: 32,
+      minMatchCharLength: 1,
+      keys: ['symbol', 'name', 'address'],
+    });
+    return result;
+  }, [throttledTokens]);
 
   const tokenSearchResults = useMemo(
     () =>
       tokenFuse
-        .search(debouncedSearchString)
-        .slice(0, MAX_TOKENS_RESULTS)
+        .search(debouncedSearchString, { limit: MAX_TOKENS_RESULTS })
         .sort((a, b) => {
           // Sort results by balance fiat in descending order
           const balanceA = a.tokenFiatAmount ?? 0;

--- a/app/components/UI/Bridge/hooks/useTokens.ts
+++ b/app/components/UI/Bridge/hooks/useTokens.ts
@@ -1,3 +1,5 @@
+import { useCallback, useMemo } from 'react';
+
 import { useTokensWithBalance } from './useTokensWithBalance';
 import { Hex, CaipChainId } from '@metamask/utils';
 import { useTopTokens } from './useTopTokens';
@@ -15,7 +17,6 @@ interface UseTokensProps {
   balanceChainIds?: (Hex | CaipChainId)[];
   tokensToExclude?: { address: string; chainId: Hex | CaipChainId }[];
 }
-
 /**
  * Hook to get tokens for the bridge
  * @param {Object} params - The parameters object
@@ -41,78 +42,96 @@ export function useTokens({
     chainId: topTokensChainId,
   });
 
-  const getTokenKey = (token: {
-    address: string;
-    chainId: Hex | CaipChainId;
-  }) => {
-    // Use the shared utility for non-EVM normalization to ensure consistent deduplication
-    let normalizedAddress = isNonEvmChainId(token.chainId)
-      ? formatAddressToAssetId(token.address, token.chainId)
-      : token.address.toLowerCase();
+  const getTokenKey = useCallback(
+    (token: { address: string; chainId: Hex | CaipChainId }) => {
+      // Use the shared utility for non-EVM normalization to ensure consistent deduplication
+      let normalizedAddress = isNonEvmChainId(token.chainId)
+        ? formatAddressToAssetId(token.address, token.chainId)
+        : token.address.toLowerCase();
 
-    if (!normalizedAddress) {
-      throw new Error(
-        `Invalid token address: ${token.address} for chain ID: ${token.chainId}`,
-      );
-    }
+      if (!normalizedAddress) {
+        throw new Error(
+          `Invalid token address: ${token.address} for chain ID: ${token.chainId}`,
+        );
+      }
 
-    // Normalize the native token address for Polygon
-    // Prevents duplicate tokens with different addresses from
-    // rendering in the UI
-    if (normalizedAddress === POLYGON_NATIVE_TOKEN) {
-      normalizedAddress = zeroAddress();
-    }
+      // Normalize the native token address for Polygon
+      // Prevents duplicate tokens with different addresses from
+      // rendering in the UI
+      if (normalizedAddress === POLYGON_NATIVE_TOKEN) {
+        normalizedAddress = zeroAddress();
+      }
 
-    return `${normalizedAddress}-${token.chainId}`;
-  };
+      return `${normalizedAddress}-${token.chainId}`;
+    },
+    [],
+  );
 
   // Create Sets for O(1) lookups
-  const tokensWithBalanceSet = new Set(
-    tokensWithBalance.map((token) => getTokenKey(token)),
+  const tokensWithBalanceSet = useMemo(
+    () => new Set(tokensWithBalance.map((token) => getTokenKey(token))),
+    [tokensWithBalance, getTokenKey],
   );
-  const excludedTokensSet = new Set(
-    tokensToExclude?.map((token) => getTokenKey(token)) ?? [],
+  const excludedTokensSet = useMemo(
+    () => new Set(tokensToExclude?.map((token) => getTokenKey(token)) ?? []),
+    [tokensToExclude, getTokenKey],
   );
 
   // Combine and filter tokens in a single pass
-  const tokensWithoutBalance = (topTokens ?? [])
-    .concat(remainingTokens ?? [])
-    .filter((token) => {
-      if (!isTradableToken(token)) {
-        return false;
-      }
+  const tokensWithoutBalance = useMemo(
+    () =>
+      (topTokens ?? [])
+        .concat(remainingTokens ?? [])
+        .filter((token) => {
+          if (!isTradableToken(token)) {
+            return false;
+          }
 
-      const tokenKey = getTokenKey(token);
-      return !tokensWithBalanceSet.has(tokenKey);
-    });
+          const tokenKey = getTokenKey(token);
+          return !tokensWithBalanceSet.has(tokenKey);
+        }),
+    [topTokens, remainingTokens, getTokenKey, tokensWithBalanceSet],
+  );
 
   // Combine tokens with balance and filtered tokens and filter out excluded tokens
-  const allTokens = tokensWithBalance
-    .concat(tokensWithoutBalance)
-    .filter((token) => {
-      if (!isTradableToken(token)) {
-        return false;
-      }
+  const allTokens = useMemo(
+    () =>
+      tokensWithBalance.concat(tokensWithoutBalance).filter((token) => {
+        if (!isTradableToken(token)) {
+          return false;
+        }
 
-      const tokenKey = getTokenKey(token);
-      return !excludedTokensSet.has(tokenKey);
-    });
-
-  const tokensToRender = tokensWithBalance
-    .concat(
-      topTokens?.filter((token) => {
         const tokenKey = getTokenKey(token);
-        return !tokensWithBalanceSet.has(tokenKey);
-      }) ?? [],
-    )
-    .filter((token) => {
-      if (!isTradableToken(token)) {
-        return false;
-      }
+        return !excludedTokensSet.has(tokenKey);
+      }),
+    [tokensWithBalance, tokensWithoutBalance, getTokenKey, excludedTokensSet],
+  );
 
-      const tokenKey = getTokenKey(token);
-      return !excludedTokensSet.has(tokenKey);
-    });
+  const tokensToRender = useMemo(
+    () =>
+      tokensWithBalance
+        .concat(
+          topTokens?.filter((token) => {
+            const tokenKey = getTokenKey(token);
+            return !tokensWithBalanceSet.has(tokenKey);
+          }) ?? [],
+        )
+        .filter((token) => {
+          if (!isTradableToken(token)) {
+            return false;
+          }
+
+          const tokenKey = getTokenKey(token);
+          return !excludedTokensSet.has(tokenKey);
+        }),
+    [
+      tokensWithBalance,
+      topTokens,
+      getTokenKey,
+      tokensWithBalanceSet,
+      excludedTokensSet,
+    ],
+  );
 
   return { allTokens, tokensToRender, pending };
 }

--- a/app/components/UI/Bridge/hooks/useTokens.ts
+++ b/app/components/UI/Bridge/hooks/useTokens.ts
@@ -80,16 +80,14 @@ export function useTokens({
   // Combine and filter tokens in a single pass
   const tokensWithoutBalance = useMemo(
     () =>
-      (topTokens ?? [])
-        .concat(remainingTokens ?? [])
-        .filter((token) => {
-          if (!isTradableToken(token)) {
-            return false;
-          }
+      (topTokens ?? []).concat(remainingTokens ?? []).filter((token) => {
+        if (!isTradableToken(token)) {
+          return false;
+        }
 
-          const tokenKey = getTokenKey(token);
-          return !tokensWithBalanceSet.has(tokenKey);
-        }),
+        const tokenKey = getTokenKey(token);
+        return !tokensWithBalanceSet.has(tokenKey);
+      }),
     [topTokens, remainingTokens, getTokenKey, tokensWithBalanceSet],
   );
 

--- a/app/components/UI/Bridge/hooks/useTokensWithBalance/index.ts
+++ b/app/components/UI/Bridge/hooks/useTokensWithBalance/index.ts
@@ -26,6 +26,10 @@ import { selectSelectedAccountGroupInternalAccounts } from '../../../../../selec
 import { EthScope } from '@metamask/keyring-api';
 import { useNonEvmTokensWithBalance } from '../useNonEvmTokensWithBalance';
 import { getTokenIconUrl } from '../../utils';
+import {
+  formatAddressToAssetId,
+  isNonEvmChainId,
+} from '@metamask/bridge-controller';
 
 interface CalculateFiatBalancesParams {
   assets: TokenI[];
@@ -204,6 +208,7 @@ export const useTokensWithBalance: ({
       .map((token, i) => {
         const evmBalance = evmBalances?.[i]?.balance;
         const nonEvmBalance = renderNumber(token.balance ?? '0');
+        const chainId = token.chainId as Hex | CaipChainId;
 
         const evmBalanceFiat = evmBalances?.[i]?.balanceFiat;
         const nonEvmBalanceFiat = renderFiat(
@@ -219,11 +224,11 @@ export const useTokensWithBalance: ({
           name: token.name,
           decimals: token.decimals,
           symbol: token.isETH ? 'ETH' : token.symbol, // TODO: not sure why symbol is ETHEREUM, will also break the token icon for ETH
-          chainId: token.chainId as Hex | CaipChainId,
+          chainId,
           image:
             getTokenIconUrl(
-              token.address,
-              token.chainId as Hex | CaipChainId,
+              formatAddressToAssetId(token.address, chainId),
+              isNonEvmChainId(chainId),
             ) || token.image,
           tokenFiatAmount: evmTokenFiatAmount ?? nonEvmTokenFiatAmount,
           balance: evmBalance ?? nonEvmBalance,

--- a/app/components/UI/Bridge/utils/index.test.ts
+++ b/app/components/UI/Bridge/utils/index.test.ts
@@ -15,6 +15,10 @@ import {
 import { Hex } from '@metamask/utils';
 import { SolScope } from '@metamask/keyring-api';
 import Engine from '../../../../core/Engine';
+import {
+  formatAddressToAssetId,
+  isNonEvmChainId,
+} from '@metamask/bridge-controller';
 
 jest.mock('../../../../core/AppConstants', () => ({
   __esModule: true,
@@ -128,9 +132,16 @@ describe('Bridge Utils', () => {
     it('should return token icon URL for native token on Ethereum', () => {
       // Arrange
       const nativeTokenAddress = '0x0000000000000000000000000000000000000000';
+      const nativeTokenAssetId = formatAddressToAssetId(
+        nativeTokenAddress,
+        ETH_CHAIN_ID,
+      );
 
       // Act
-      const result = getTokenIconUrl(nativeTokenAddress, ETH_CHAIN_ID);
+      const result = getTokenIconUrl(
+        nativeTokenAssetId,
+        isNonEvmChainId(ETH_CHAIN_ID),
+      );
 
       // Assert
       expect(result).toBe(
@@ -141,9 +152,13 @@ describe('Bridge Utils', () => {
     it('should return token icon URL for ERC20 token on Ethereum', () => {
       // Arrange
       const usdcAddress = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+      const usdcAssetId = formatAddressToAssetId(usdcAddress, ETH_CHAIN_ID);
 
       // Act
-      const result = getTokenIconUrl(usdcAddress, ETH_CHAIN_ID);
+      const result = getTokenIconUrl(
+        usdcAssetId,
+        isNonEvmChainId(ETH_CHAIN_ID),
+      );
 
       // Assert
       expect(result).toBe(
@@ -154,9 +169,15 @@ describe('Bridge Utils', () => {
     it('should return token icon URL for Solana native token', () => {
       // Arrange
       const solNativeAddress = '0x0000000000000000000000000000000000000000';
-
+      const solNativeAssetId = formatAddressToAssetId(
+        solNativeAddress,
+        SolScope.Mainnet,
+      );
       // Act
-      const result = getTokenIconUrl(solNativeAddress, SolScope.Mainnet);
+      const result = getTokenIconUrl(
+        solNativeAssetId,
+        isNonEvmChainId(SolScope.Mainnet),
+      );
 
       // Assert
       expect(result).toBe(
@@ -167,9 +188,16 @@ describe('Bridge Utils', () => {
     it('should return token icon URL for Solana SPL token', () => {
       // Arrange
       const usdcSolanaAddress = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+      const usdcSolanaAssetId = formatAddressToAssetId(
+        usdcSolanaAddress,
+        SolScope.Mainnet,
+      );
 
       // Act
-      const result = getTokenIconUrl(usdcSolanaAddress, SolScope.Mainnet);
+      const result = getTokenIconUrl(
+        usdcSolanaAssetId,
+        isNonEvmChainId(SolScope.Mainnet),
+      );
 
       // Assert
       expect(result).toBe(
@@ -180,9 +208,16 @@ describe('Bridge Utils', () => {
     it('should return undefined for invalid address', () => {
       // Arrange
       const invalidAddress = 'invalid';
+      const invalidAssetId = formatAddressToAssetId(
+        invalidAddress,
+        ETH_CHAIN_ID,
+      );
 
       // Act
-      const result = getTokenIconUrl(invalidAddress, ETH_CHAIN_ID);
+      const result = getTokenIconUrl(
+        invalidAssetId,
+        isNonEvmChainId(ETH_CHAIN_ID),
+      );
 
       // Assert
       expect(result).toBeUndefined();
@@ -191,9 +226,12 @@ describe('Bridge Utils', () => {
     it('should return native token icon URL for empty address', () => {
       // Arrange
       const emptyAddress = '';
-
+      const emptyAssetId = formatAddressToAssetId(emptyAddress, ETH_CHAIN_ID);
       // Act
-      const result = getTokenIconUrl(emptyAddress, ETH_CHAIN_ID);
+      const result = getTokenIconUrl(
+        emptyAssetId,
+        isNonEvmChainId(ETH_CHAIN_ID),
+      );
 
       // Assert
       expect(result).toBe(

--- a/app/components/UI/Bridge/utils/index.ts
+++ b/app/components/UI/Bridge/utils/index.ts
@@ -1,6 +1,6 @@
 import { CaipChainId, SolScope } from '@metamask/keyring-api';
 import AppConstants from '../../../../core/AppConstants';
-import { Hex } from '@metamask/utils';
+import { CaipAssetType, Hex } from '@metamask/utils';
 import {
   ARBITRUM_CHAIN_ID,
   AVALANCHE_CHAIN_ID,
@@ -14,10 +14,7 @@ import {
   SEI_CHAIN_ID,
 } from '@metamask/swaps-controller/dist/constants';
 import Engine from '../../../../core/Engine';
-import {
-  formatAddressToAssetId,
-  isNonEvmChainId,
-} from '@metamask/bridge-controller';
+import { isNonEvmChainId } from '@metamask/bridge-controller';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 
 const ALLOWED_CHAIN_IDS: (Hex | CaipChainId)[] = [
@@ -62,17 +59,14 @@ export const wipeBridgeStatus = (
 };
 
 export const getTokenIconUrl = (
-  address: string,
-  chainId: Hex | CaipChainId,
+  assetId: CaipAssetType | undefined,
+  isNonEvmChain: boolean,
 ) => {
-  const isEvmChain = !isNonEvmChainId(chainId);
-  const formattedAddress = isEvmChain ? address.toLowerCase() : address;
-
-  const assetId = formatAddressToAssetId(formattedAddress, chainId);
   if (!assetId) {
     return undefined;
   }
-  return `https://static.cx.metamask.io/api/v2/tokenIcons/assets/${assetId
+  const formattedAddress = isNonEvmChain ? assetId : assetId.toLowerCase();
+  return `https://static.cx.metamask.io/api/v2/tokenIcons/assets/${formattedAddress
     .split(':')
     .join('/')}.png`;
 };

--- a/app/selectors/currencyRateController.ts
+++ b/app/selectors/currencyRateController.ts
@@ -34,7 +34,7 @@ export const selectConversionRate = createSelector(
   },
 );
 
-export const selectCurrencyRates = createSelector(
+export const selectCurrencyRates = createDeepEqualSelector(
   selectCurrencyRateControllerState,
   (currencyRateControllerState: CurrencyRateState) =>
     currencyRateControllerState?.currencyRates,


### PR DESCRIPTION
## **Description**

Lot of small fixes all around Swaps to improve mounting performance of `TokenList`. It improved mounting performance by ~300ms and responsiveness (JS FPS >30) by more than ~1s (check video for comparison) . It also greatly reduced numbers of rerenders of whole component which is always win for performance.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open Swaps source/dest token list
2. All tokens are rendered correctly
3. Search works

## **Screenshots/Recordings**


https://github.com/user-attachments/assets/91254381-5f7b-4b6b-b5b1-ec6ced820bbe


### **Before**

9 rerenders during opening of tokens list:

<img width="308" height="361" alt="Screenshot 2025-11-10 at 14 34 37" src="https://github.com/user-attachments/assets/b77261ad-0079-4e49-acb9-7baec7287c13" />

### **After**

Only 2 rerenders after optimizations:

<img width="301" height="222" alt="Screenshot 2025-11-10 at 15 09 59" src="https://github.com/user-attachments/assets/6696aac8-2905-4899-9a9b-fc48b48ae646" />

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Speeds up Bridge token selectors by heavy memoization and throttled search, updates selectors, and refactors token icon URL usage to reduce re-renders and work.
> 
> - **Bridge UI (Token Selectors)**:
>   - Wrap `BridgeDestTokenSelector`, `BridgeSourceTokenSelector`, and `BridgeTokenSelectorBase` in `React.memo`; memoize `networksBar`, params, and handlers; cancel debounced presses on unmount.
>   - Memoize skeleton components; add `TokenInputArea.displayName`.
> - **Hooks**:
>   - `useTokenSearch`: throttle token list updates, construct `Fuse` from throttled tokens, use search `limit`.
>   - `useTokens`: memoize key builders/sets; filter/merge tokens with fewer re-computations.
>   - `useTokensWithBalance`: build icon URLs via assetId + non-EVM flag; minor chainId/image calc tweaks.
>   - `useNonEvmTokensWithBalance`: switch to `selectMultichainTokenListForAccountsAnyChain`.
> - **Utils**:
>   - Change `getTokenIconUrl(address, chainId)` to `getTokenIconUrl(assetId, isNonEvmChain)`; update all call sites and tests.
> - **Selectors**:
>   - Make `selectCurrencyRates` deep-equal memoized.
>   - Add `selectMultichainTokenListForAccountsAnyChain`; remove per-account variant.
> - **Library**:
>   - `useStyles` now supports optional `vars` via overloads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e2642228cf4a49da4218422ad438ca12dfc4245. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->