### PR TITLE
fix: add specific error message for duplicate SRP imports

### DIFF
--- a/app/components/Views/ImportNewSecretRecoveryPhrase/index.test.tsx
+++ b/app/components/Views/ImportNewSecretRecoveryPhrase/index.test.tsx
@@ -605,6 +605,49 @@ describe('ImportNewSecretRecoveryPhrase', () => {
       mockAlert.mockRestore();
     });
 
+    it('displays error when import fails with duplicate account', async () => {
+      const mockAlert = jest.spyOn(Alert, 'alert');
+      mockImportNewSecretRecoveryPhrase.mockRejectedValueOnce(
+        new Error(
+          'KeyringController - The account you are trying to import is a duplicate',
+        ),
+      );
+      mockGetString.mockResolvedValue(valid12WordMnemonic);
+
+      const { getByTestId, getByText } = renderScreen(
+        ImportNewSecretRecoveryPhrase,
+        { name: 'ImportNewSecretRecoveryPhrase' },
+        {
+          state: initialState,
+        },
+      );
+
+      const pasteButton = getByText(messages.import_from_seed.paste);
+
+      await act(async () => {
+        await fireEvent.press(pasteButton);
+      });
+
+      await waitFor(() => {
+        const importButton = getByTestId(ImportSRPIDs.IMPORT_BUTTON);
+        expect(importButton.props.disabled).toBe(false);
+      });
+
+      const importButton = getByTestId(ImportSRPIDs.IMPORT_BUTTON);
+
+      await act(async () => {
+        await fireEvent.press(importButton);
+      });
+
+      await waitFor(() => {
+        expect(mockAlert).toHaveBeenCalledWith(
+          messages.import_new_secret_recovery_phrase.error_duplicate_account,
+        );
+      });
+
+      mockAlert.mockRestore();
+    });
+
     it('displays generic error when import fails', async () => {
       const mockAlert = jest.spyOn(Alert, 'alert');
       mockImportNewSecretRecoveryPhrase.mockRejectedValueOnce(

--- a/app/components/Views/ImportNewSecretRecoveryPhrase/index.tsx
+++ b/app/components/Views/ImportNewSecretRecoveryPhrase/index.tsx
@@ -238,17 +238,24 @@ const ImportNewSecretRecoveryPhrase = () => {
 
       navigation.navigate('WalletView');
     } catch (e) {
-      if (
-        (e as Error)?.message === 'This mnemonic has already been imported.'
-      ) {
-        Alert.alert(
-          strings('import_new_secret_recovery_phrase.error_duplicate_srp'),
-        );
-      } else {
-        Alert.alert(
-          strings('import_new_secret_recovery_phrase.error_title'),
-          strings('import_new_secret_recovery_phrase.error_message'),
-        );
+      switch ((e as Error)?.message) {
+        case 'This mnemonic has already been imported.':
+          Alert.alert(
+            strings('import_new_secret_recovery_phrase.error_duplicate_srp'),
+          );
+          break;
+        case 'KeyringController - The account you are trying to import is a duplicate':
+          Alert.alert(
+            strings(
+              'import_new_secret_recovery_phrase.error_duplicate_account',
+            ),
+          );
+          break;
+        default:
+          Alert.alert(
+            strings('import_new_secret_recovery_phrase.error_title'),
+            strings('import_new_secret_recovery_phrase.error_message'),
+          );
       }
       setLoading(false);
     }

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3834,6 +3834,7 @@
     "error_multiple_srp_word_error_3": " are incorrect or misspelled.",
     "error_invalid_srp": "Invalid Secret Recovery Phrase",
     "error_duplicate_srp": "This Secret Recovery Phrase has already been imported.",
+    "error_duplicate_account": "The account you are trying to import is a duplicate.",
     "invalid_qr_code_title": "Invalid QR Code",
     "invalid_qr_code_message": "The QR code does not contain a valid Secret Recovery Phrase",
     "success_1": "Wallet",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix error message when trying to import an SRP with an account that is already imported via private key

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-491

## **Manual testing steps**

1. Import private key account
2. Import SRP that includes this private key account
3. Verify that the error message "The account you are trying to import is a duplicate." is shown

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="925" height="903" alt="image" src="https://github.com/user-attachments/assets/77abb409-feac-4ba4-92bd-387d122928dd" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds explicit handling and user-facing message when an SRP import fails due to a duplicate account, with tests and i18n updates.
> 
> - **Import SRP View (`app/components/Views/ImportNewSecretRecoveryPhrase/index.tsx`)**:
>   - Refactor error handling to `switch` and add case for `KeyringController - The account you are trying to import is a duplicate`, showing `error_duplicate_account` alert.
> - **Tests (`app/components/Views/ImportNewSecretRecoveryPhrase/index.test.tsx`)**:
>   - Add test to assert duplicate account import error triggers the correct alert.
> - **Localization (`locales/languages/en.json`)**:
>   - Add `import_new_secret_recovery_phrase.error_duplicate_account` copy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f43d802a731223ae38e89bed49f7c2c11a593cad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->