### PR TITLE
feat: clicking src/dest swap flipper should invert token amounts from previosuly fetched quote

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -513,7 +513,7 @@ const BridgeView = () => {
             <Box style={styles.arrowCircle}>
               <ButtonIcon
                 iconName={IconName.SwapVertical}
-                onPress={handleSwitchTokens}
+                onPress={handleSwitchTokens(destTokenAmount)}
                 disabled={!destChainId || !destToken}
                 testID="arrow-button"
                 size={ButtonIconSizes.Lg}

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useEffect } from 'react';
+import { useCallback, useMemo } from 'react';
 import Engine from '../../../../../core/Engine';
 import { type GenericQuoteRequest } from '@metamask/bridge-controller';
 import { useSelector } from 'react-redux';
@@ -46,12 +46,6 @@ export const useBridgeQuoteRequest = () => {
     latestAtomicBalance: latestSourceBalance?.atomicBalance,
   });
 
-  // Use a ref to track the latest insufficientBal value without triggering callback recreation
-  const insufficientBalRef = useRef(insufficientBal);
-  useEffect(() => {
-    insufficientBalRef.current = insufficientBal;
-  }, [insufficientBal]);
-
   const gasIncluded = useSelector(selectGasIncluded);
 
   /**
@@ -87,7 +81,7 @@ export const useBridgeQuoteRequest = () => {
       destWalletAddress: destAddress ?? walletAddress,
       gasIncluded,
       gasIncluded7702: false, // TODO: https://consensyssoftware.atlassian.net/browse/STX-263
-      insufficientBal: insufficientBalRef.current,
+      insufficientBal,
     };
 
     await Engine.context.BridgeController.updateBridgeQuoteRequestParams(
@@ -104,6 +98,7 @@ export const useBridgeQuoteRequest = () => {
     destAddress,
     context,
     gasIncluded,
+    insufficientBal,
   ]);
 
   // Create a stable debounced function that persists across renders

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/useBridgeQuoteRequest.test.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/useBridgeQuoteRequest.test.ts
@@ -6,6 +6,9 @@ import Engine from '../../../../../core/Engine';
 import { act } from '@testing-library/react-native';
 import { isSolanaChainId } from '@metamask/bridge-controller';
 import { selectSourceWalletAddress } from '../../../../../selectors/bridge';
+import useIsInsufficientBalance from '../useInsufficientBalance';
+import { useLatestBalance } from '../useLatestBalance';
+import { BigNumber } from 'ethers';
 
 // Mock isSolanaChainId
 jest.mock('@metamask/bridge-controller', () => ({
@@ -56,6 +59,16 @@ jest.mock('../../../../../selectors/bridge', () => ({
   selectSourceWalletAddress: jest.fn(),
 }));
 
+// Mock the balance hooks
+jest.mock('../useInsufficientBalance', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('../useLatestBalance', () => ({
+  useLatestBalance: jest.fn(),
+}));
+
 jest.useFakeTimers();
 const spyUpdateBridgeQuoteRequestParams = jest.spyOn(
   Engine.context.BridgeController,
@@ -67,6 +80,15 @@ const mockSelectSourceWalletAddress =
     typeof selectSourceWalletAddress
   >;
 
+const mockUseIsInsufficientBalance =
+  useIsInsufficientBalance as jest.MockedFunction<
+    typeof useIsInsufficientBalance
+  >;
+
+const mockUseLatestBalance = useLatestBalance as jest.MockedFunction<
+  typeof useLatestBalance
+>;
+
 describe('useBridgeQuoteRequest', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -76,6 +98,14 @@ describe('useBridgeQuoteRequest', () => {
     mockSelectSourceWalletAddress.mockReturnValue(
       '0x1234567890123456789012345678901234567890',
     );
+
+    // Mock balance hooks with default values
+    mockUseLatestBalance.mockReturnValue({
+      displayBalance: '10',
+      atomicBalance: BigNumber.from('10000000000000000000'), // 10 ETH in wei
+    });
+
+    mockUseIsInsufficientBalance.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -413,6 +443,96 @@ describe('useBridgeQuoteRequest', () => {
         }),
         undefined,
       );
+    });
+  });
+
+  describe('insufficientBal parameter', () => {
+    it('includes insufficientBal false when balance is sufficient', async () => {
+      mockUseIsInsufficientBalance.mockReturnValue(false);
+      const testState = createBridgeTestState({
+        bridgeReducerOverrides: {
+          sourceAmount: '1.0',
+        },
+      });
+
+      const { result } = renderHookWithProvider(() => useBridgeQuoteRequest(), {
+        state: testState,
+      });
+
+      await act(async () => {
+        await result.current();
+        jest.advanceTimersByTime(DEBOUNCE_WAIT);
+      });
+
+      expect(spyUpdateBridgeQuoteRequestParams).toHaveBeenCalledWith(
+        expect.objectContaining({
+          insufficientBal: false,
+        }),
+        undefined,
+      );
+    });
+
+    it('includes insufficientBal true when balance is insufficient', async () => {
+      mockUseIsInsufficientBalance.mockReturnValue(true);
+      mockUseLatestBalance.mockReturnValue({
+        displayBalance: '0.1',
+        atomicBalance: BigNumber.from('100000000000000000'), // 0.1 ETH in wei
+      });
+
+      const testState = createBridgeTestState({
+        bridgeReducerOverrides: {
+          sourceAmount: '1000.0', // More than available balance
+        },
+      });
+
+      const { result } = renderHookWithProvider(() => useBridgeQuoteRequest(), {
+        state: testState,
+      });
+
+      await act(async () => {
+        await result.current();
+        jest.advanceTimersByTime(DEBOUNCE_WAIT);
+      });
+
+      expect(spyUpdateBridgeQuoteRequestParams).toHaveBeenCalledWith(
+        expect.objectContaining({
+          insufficientBal: true,
+        }),
+        undefined,
+      );
+    });
+
+    it('passes correct parameters to useIsInsufficientBalance hook', async () => {
+      mockUseIsInsufficientBalance.mockReturnValue(false);
+      const testState = createBridgeTestState({
+        bridgeReducerOverrides: {
+          sourceAmount: '5.5',
+        },
+      });
+
+      renderHookWithProvider(() => useBridgeQuoteRequest(), {
+        state: testState,
+      });
+
+      expect(mockUseIsInsufficientBalance).toHaveBeenCalledWith({
+        amount: '5.5',
+        token: testState.bridge.sourceToken,
+        latestAtomicBalance: BigNumber.from('10000000000000000000'),
+      });
+    });
+
+    it('passes correct token parameters to useLatestBalance hook', async () => {
+      const testState = createBridgeTestState();
+
+      renderHookWithProvider(() => useBridgeQuoteRequest(), {
+        state: testState,
+      });
+
+      expect(mockUseLatestBalance).toHaveBeenCalledWith({
+        address: testState.bridge.sourceToken?.address,
+        decimals: testState.bridge.sourceToken?.decimals,
+        chainId: testState.bridge.sourceToken?.chainId,
+      });
     });
   });
 });

--- a/app/components/UI/Bridge/hooks/useSwitchTokens/index.ts
+++ b/app/components/UI/Bridge/hooks/useSwitchTokens/index.ts
@@ -5,6 +5,7 @@ import {
   selectDestToken,
   selectSourceToken,
   setSelectedDestChainId,
+  setSourceAmount,
 } from '../../../../../core/redux/slices/bridge';
 import { useNetworkInfo } from '../../../../../selectors/selectedNetworkController';
 import { useSwitchNetworks } from '../../../../Views/NetworkSelector/useSwitchNetworks';
@@ -37,7 +38,7 @@ export const useSwitchTokens = () => {
     selectEvmNetworkConfigurationsByChainId,
   );
 
-  const handleSwitchTokens = async () => {
+  const handleSwitchTokens = (destTokenAmount?: string) => async () => {
     // Reset BridgeController state to prevent stale quotes
     if (Engine.context.BridgeController?.resetState) {
       Engine.context.BridgeController.resetState();
@@ -47,6 +48,8 @@ export const useSwitchTokens = () => {
     if (sourceToken && destToken) {
       dispatch(setSourceToken(destToken));
       dispatch(setDestToken(sourceToken));
+      // Swap amounts
+      dispatch(setSourceAmount(destTokenAmount));
 
       if (sourceToken.chainId !== destToken.chainId) {
         dispatch(setSelectedDestChainId(sourceToken.chainId));


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Currently, the input amount persists after clicking the source/destination flipper on Mobile. Ideally, the token amounts and tokens should flip. We introduce this functionality with this PR.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:  clicking src/dest swap flipper should invert token amounts from previosuly fetched quote

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3265

## **Manual testing steps**

```gherkin
- Ensure clicking flip src/dest button swaps the amounts as well as the tokens.
- While quotes are fetching, if user click the flip amount, it should set the source amount to zero.
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/1f50b741-fd31-4c26-a272-d8605726719f


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Swapping tokens now also inverts amounts from the latest quote, and bridge quote requests now pass the current insufficient balance flag with expanded tests.
> 
> - **Bridge UI**:
>   - `BridgeView/index.tsx`: Swap button now calls `handleSwitchTokens(destTokenAmount)` so flipping tokens also swaps amounts.
> - **Token Switch Logic**:
>   - `useSwitchTokens`: Accepts optional `destTokenAmount`; dispatches `setSourceAmount(destTokenAmount)` when flipping, resets controller state, and preserves network switching logic.
>   - Tests updated/added to cover amount swapping, clearing when absent, and existing EVM/Non-EVM paths.
> - **Quote Request**:
>   - `useBridgeQuoteRequest`: Simplifies state handling; directly computes and passes `insufficientBal` in `updateBridgeQuoteRequestParams` and adds it to dependencies; retains debouncing.
>   - Tests expanded to validate `insufficientBal`, balance hook parameters, and `gasIncluded` behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f373d7fba7210c1844ee4485b11d463880e6dc45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->