### PR TITLE
fix(predict): optimistic updates when querying claimable positions

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -586,6 +586,12 @@ export class PolymarketProvider implements PredictProvider {
     apiPosition: PredictPosition,
     update: OptimisticPositionUpdate,
   ): boolean {
+    // If API position is claimable, it's always updated since we cannot
+    // perform updates on claimable positions, other than REMOVE
+    if (apiPosition.claimable) {
+      return true;
+    }
+
     const { expectedSize } = update;
 
     // Use a small tolerance for floating point comparison (0.1%)

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -603,9 +603,11 @@ export class PolymarketProvider implements PredictProvider {
   private applyOptimisticPositionUpdates({
     address,
     positions,
+    claimable,
   }: {
     address: string;
     positions: PredictPosition[];
+    claimable: boolean;
   }): PredictPosition[] {
     const optimisticUpdates =
       this.#optimisticPositionUpdatesByAddress.get(address);
@@ -660,7 +662,7 @@ export class PolymarketProvider implements PredictProvider {
               // API not yet updated, use optimistic position
               result[apiPositionIndex] = update.optimisticPosition;
             }
-          } else if (update.optimisticPosition) {
+          } else if (update.optimisticPosition && !claimable) {
             // New position not in API yet, add optimistic position
             result.push(update.optimisticPosition);
           }
@@ -751,6 +753,7 @@ export class PolymarketProvider implements PredictProvider {
     const positionsWithOptimisticUpdates = this.applyOptimisticPositionUpdates({
       address,
       positions: parsedPositions,
+      claimable,
     });
 
     return positionsWithOptimisticUpdates;

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -1470,7 +1470,7 @@ export class PolymarketProvider implements PredictProvider {
       transaction: {
         params: {
           to: MATIC_CONTRACTS.collateral as Hex,
-          data: callData as Hex,
+          data: callData,
         },
         type: TransactionType.predictWithdraw,
       },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixed a bug in the Predict feature where optimistic position updates were incorrectly applied when querying for claimable positions. Previously, when calling `getPositions({claimable: false})` after creating or updating a position optimistically, the API would return no results (as expected, since newly created/updated positions are not claimable), but the code would still inject the optimistic position into the results. This caused positions to incorrectly appear as claimable when they were not.

The fix ensures that CREATE/UPDATE optimistic updates are only applied to non-claimable position queries, since it's impossible to create or update a position that is immediately claimable.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Predict optimistic position updates

  Scenario: user creates a position and queries claimable positions
    Given the user has created a new Predict position optimistically
    And the API has not yet returned the created position

    When user queries positions with claimable: false
    Then the optimistic position should not appear in the results
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- Optimistic positions would incorrectly appear when querying with claimable: false -->

### **After**

<!-- Optimistic positions are correctly excluded from claimable queries -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents optimistic CREATE/UPDATE positions from appearing in claimable queries and short-circuits updates for claimable API positions; minor withdraw param typing tweak.
> 
> - **Predict/PolymarketProvider**:
>   - **Optimistic updates**:
>     - `applyOptimisticPositionUpdates` now accepts `claimable` and avoids adding optimistic positions when `claimable` is true.
>     - `isApiPositionUpdated` treats claimable API positions as already updated.
>     - `getPositions` passes `claimable` into `applyOptimisticPositionUpdates`.
>   - **Withdraw**:
>     - Use `callData` directly in transaction params (`prepareWithdraw`), removing unnecessary `Hex` cast.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b12627b173872791fb413c04d232a19777a6b65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->