### PR TITLE
fix: swaps navigation issue when changing source token

### DIFF
--- a/app/components/Views/Asset/index.js
+++ b/app/components/Views/Asset/index.js
@@ -431,7 +431,8 @@ class Asset extends PureComponent {
         if (
           (this.txs.length === 0 && !this.state.transactionsUpdated) ||
           this.txs.length !== filteredTransactions.length ||
-          this.chainId !== chainId
+          this.chainId !== chainId ||
+          this.state.loading // Ensure loading is reset even if nothing else changed
         ) {
           this.txs = filteredTransactions;
           this.txsPending = [];
@@ -512,7 +513,8 @@ class Asset extends PureComponent {
           (this.txs.length === 0 && !this.state.transactionsUpdated) ||
           this.txs.length !== filteredTransactions.length ||
           this.chainId !== chainId ||
-          this.didTxStatusesChange(newPendingTxs)
+          this.didTxStatusesChange(newPendingTxs) ||
+          this.state.loading // Ensure loading is reset even if nothing else changed
         ) {
           this.txs = filteredTransactions;
           this.txsPending = newPendingTxs;
@@ -525,7 +527,7 @@ class Asset extends PureComponent {
           });
         }
       }
-    } else if (!this.state.transactionsUpdated) {
+    } else if (!this.state.transactionsUpdated || this.state.loading) {
       this.setState({ transactionsUpdated: true, loading: false });
     }
     this.isNormalizing = false;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR fixes issue with swaps navigation from token view, when the source token is changed to different network.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug with swaps navigation from token view, when the source token is changed to different network.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-7

## **Manual testing steps**

```gherkin
Feature: Swap Solana

  Scenario: user swaps solana token
    Given user onboarded

    When user goes to Solana token page
    Then Clicks Swap
    Then Changes source token to Ethereum EVM
    Then clicks back button
    Then the Solana token page should be displayed correctly (before it was stuck at loading screen)
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/e58c0455-9600-4161-a126-8f3717cf05f5


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/310b593e-6708-486c-9dce-eb5ccabe5bc2


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the asset view reliably clears the loading state by considering `state.loading` in transaction update conditions for both EVM and non-EVM flows.
> 
> - **Asset view (`app/components/Views/Asset/index.js`)**:
>   - **Transaction normalization**:
>     - Include `this.state.loading` in update conditions for non-EVM and EVM paths to force state updates when only loading needs reset.
>     - Clear loading even when no new transactions by expanding the fallback condition.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15d58f97e037795c8667a8f63a4c2611548bbc25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->