### PR TITLE
chore: prefer side effect acc group for opt in & link active acc group

### DIFF
--- a/app/components/UI/Rewards/hooks/useOptIn.ts
+++ b/app/components/UI/Rewards/hooks/useOptIn.ts
@@ -1,18 +1,21 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { handleRewardsErrorMessage } from '../utils';
-import Engine from '../../../../core/Engine';
 import { setCandidateSubscriptionId } from '../../../../reducers/rewards';
 import { MetaMetricsEvents, useMetrics } from '../../../hooks/useMetrics';
 import { UserProfileProperty } from '../../../../util/metrics/UserSettingsAnalyticsMetaData/UserProfileAnalyticsMetaData.types';
-import { selectMultichainAccountsState2Enabled } from '../../../../selectors/featureFlagController/multichainAccounts/enabledMultichainAccounts';
 import {
   selectSelectedAccountGroup,
   selectAccountGroupsByWallet,
   selectWalletByAccount,
+  selectSelectedAccountGroupInternalAccounts,
 } from '../../../../selectors/multichainAccounts/accountTreeController';
-import { useLinkAccountGroup } from './useLinkAccountGroup';
+import { selectInternalAccountsByGroupId } from '../../../../selectors/multichainAccounts/accounts';
 import { selectSelectedInternalAccount } from '../../../../selectors/accountsController';
+import Engine from '../../../../core/Engine';
+import { useLinkAccountGroup } from './useLinkAccountGroup';
+import { InternalAccount } from '@metamask/keyring-internal-api';
+import { AccountGroupId } from '@metamask/account-api';
 
 export interface UseOptinResult {
   /**
@@ -61,9 +64,20 @@ export const useOptin = (): UseOptinResult => {
       )?.data?.[0]?.id,
     [accountGroupsByWallet, currentAccountWalletId],
   );
-  const multichainAccountsState2Enabled = useSelector(
-    selectMultichainAccountsState2Enabled,
+  const activeGroupAccounts = useSelector(
+    selectSelectedAccountGroupInternalAccounts,
   );
+  const selectInternalAccountsByGroupIdSelector = useSelector(
+    selectInternalAccountsByGroupId,
+  );
+  const sideEffectAccounts = useMemo(() => {
+    if (!sideEffectAccountGroupIdToLink) {
+      return [];
+    }
+    return selectInternalAccountsByGroupIdSelector(
+      sideEffectAccountGroupIdToLink,
+    );
+  }, [sideEffectAccountGroupIdToLink, selectInternalAccountsByGroupIdSelector]);
 
   const handleOptin = useCallback(
     async ({
@@ -76,6 +90,7 @@ export const useOptin = (): UseOptinResult => {
       if (!accountGroup?.id) {
         return;
       }
+      const selectedAccountGroupId = accountGroup.id;
       const referred = Boolean(referralCode);
       const metricsProps = {
         referred,
@@ -94,11 +109,32 @@ export const useOptin = (): UseOptinResult => {
         setOptinLoading(true);
         setOptinError(null);
 
+        const accountsToOptIn =
+          sideEffectAccountGroupIdToLink && sideEffectAccounts.length > 0
+            ? sideEffectAccounts
+            : activeGroupAccounts;
+
+        const accountGroupToLinkAfterOptIn =
+          sideEffectAccountGroupIdToLink && sideEffectAccounts.length > 0
+            ? selectedAccountGroupId
+            : sideEffectAccountGroupIdToLink;
+
         subscriptionId = await Engine.controllerMessenger.call(
-          'RewardsController:optIn', // for active account group
+          'RewardsController:optIn',
+          accountsToOptIn as InternalAccount[],
           referralCode || undefined,
         );
+
         if (subscriptionId) {
+          if (accountGroupToLinkAfterOptIn) {
+            try {
+              await linkAccountGroup(
+                accountGroupToLinkAfterOptIn as AccountGroupId,
+              );
+            } catch {
+              // Failed to link first account group in same wallet.
+            }
+          }
           addTraitsToUser({
             [UserProfileProperty.HAS_REWARDS_OPTED_IN]: UserProfileProperty.ON,
             ...(referralCode && {
@@ -111,6 +147,10 @@ export const useOptin = (): UseOptinResult => {
               .addProperties(metricsProps)
               .build(),
           );
+        } else {
+          throw new Error(
+            'Failed to opt in any account from the account group',
+          );
         }
       } catch (error) {
         trackEvent(
@@ -120,23 +160,6 @@ export const useOptin = (): UseOptinResult => {
         );
         const errorMessage = handleRewardsErrorMessage(error);
         setOptinError(errorMessage);
-      }
-
-      if (
-        multichainAccountsState2Enabled &&
-        sideEffectAccountGroupIdToLink &&
-        subscriptionId
-      ) {
-        if (
-          sideEffectAccountGroupIdToLink &&
-          sideEffectAccountGroupIdToLink !== accountGroup?.id
-        ) {
-          try {
-            await linkAccountGroup(sideEffectAccountGroupIdToLink);
-          } catch {
-            // Failed to link first account group in same wallet.
-          }
-        }
       }
 
       if (subscriptionId) {
@@ -150,10 +173,11 @@ export const useOptin = (): UseOptinResult => {
       trackEvent,
       createEventBuilder,
       sideEffectAccountGroupIdToLink,
-      multichainAccountsState2Enabled,
-      dispatch,
+      sideEffectAccounts,
+      activeGroupAccounts,
       addTraitsToUser,
       linkAccountGroup,
+      dispatch,
     ],
   );
 

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -7348,11 +7348,7 @@ describe('RewardsController', () => {
       // Arrange
       const mockAccounts = [mockEvmInternalAccount, mockEvmInternalAccount2];
       mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (
-          method === 'AccountTreeController:getAccountsFromSelectedAccountGroup'
-        ) {
-          return mockAccounts;
-        } else if (method === 'KeyringController:signPersonalMessage') {
+        if (method === 'KeyringController:signPersonalMessage') {
           return Promise.resolve('0xsignature123');
         } else if (method === 'RewardsDataService:mobileOptin') {
           return Promise.resolve(mockOptinResponse);
@@ -7368,13 +7364,10 @@ describe('RewardsController', () => {
       }));
 
       // Act
-      const result = await controller.optIn();
+      const result = await controller.optIn(mockAccounts);
 
       // Assert
       expect(result).toBe(mockSubscriptionId);
-      expect(mockMessenger.call).toHaveBeenCalledWith(
-        'AccountTreeController:getAccountsFromSelectedAccountGroup',
-      );
       expect(mockMessenger.call).toHaveBeenCalledWith(
         'RewardsDataService:mobileOptin',
         expect.objectContaining({
@@ -7397,11 +7390,7 @@ describe('RewardsController', () => {
       const referralCode = 'REF123';
       const mockAccounts = [mockEvmInternalAccount];
       mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (
-          method === 'AccountTreeController:getAccountsFromSelectedAccountGroup'
-        ) {
-          return mockAccounts;
-        } else if (method === 'KeyringController:signPersonalMessage') {
+        if (method === 'KeyringController:signPersonalMessage') {
           return Promise.resolve('0xsignature123');
         } else if (method === 'RewardsDataService:mobileOptin') {
           const params = _args[0] as any;
@@ -7417,7 +7406,7 @@ describe('RewardsController', () => {
       }));
 
       // Act
-      const result = await controller.optIn(referralCode);
+      const result = await controller.optIn(mockAccounts, referralCode);
 
       // Assert
       expect(result).toBe(mockSubscriptionId);
@@ -7433,9 +7422,10 @@ describe('RewardsController', () => {
     it('should return null when rewards feature is disabled', async () => {
       // Arrange
       mockSelectRewardsEnabledFlag.mockReturnValue(false);
+      const mockAccounts = [mockEvmInternalAccount];
 
       // Act
-      const result = await controller.optIn();
+      const result = await controller.optIn(mockAccounts);
 
       // Assert
       expect(result).toBeNull();
@@ -7444,22 +7434,15 @@ describe('RewardsController', () => {
 
     it('should return null when no accounts found in selected account group', async () => {
       // Arrange
-      mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (
-          method === 'AccountTreeController:getAccountsFromSelectedAccountGroup'
-        ) {
-          return [];
-        }
-        return Promise.resolve();
-      });
+      const mockAccounts: InternalAccount[] = [];
 
       // Act
-      const result = await controller.optIn();
+      const result = await controller.optIn(mockAccounts);
 
       // Assert
       expect(result).toBeNull();
-      expect(mockMessenger.call).toHaveBeenCalledWith(
-        'AccountTreeController:getAccountsFromSelectedAccountGroup',
+      expect(mockLogger.log).toHaveBeenCalledWith(
+        'RewardsController: No accounts provided, skipping optin',
       );
     });
 
@@ -7467,11 +7450,7 @@ describe('RewardsController', () => {
       // Arrange
       const mockAccounts = [mockEvmInternalAccount, mockEvmInternalAccount2];
       mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (
-          method === 'AccountTreeController:getAccountsFromSelectedAccountGroup'
-        ) {
-          return mockAccounts;
-        } else if (method === 'KeyringController:signPersonalMessage') {
+        if (method === 'KeyringController:signPersonalMessage') {
           return Promise.reject(new Error('Signature failed'));
         }
         return Promise.resolve();
@@ -7483,7 +7462,7 @@ describe('RewardsController', () => {
       }));
 
       // Act & Assert
-      await expect(controller.optIn()).rejects.toThrow(
+      await expect(controller.optIn(mockAccounts)).rejects.toThrow(
         'Failed to opt in any account from the account group',
       );
     });
@@ -7495,11 +7474,7 @@ describe('RewardsController', () => {
 
       let callCount = 0;
       mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (
-          method === 'AccountTreeController:getAccountsFromSelectedAccountGroup'
-        ) {
-          return mockAccounts;
-        } else if (method === 'KeyringController:signPersonalMessage') {
+        if (method === 'KeyringController:signPersonalMessage') {
           return Promise.resolve('0xsignature123');
         } else if (method === 'RewardsDataService:mobileOptin') {
           callCount++;
@@ -7517,7 +7492,7 @@ describe('RewardsController', () => {
       }));
 
       // Act
-      const result = await controller.optIn();
+      const result = await controller.optIn(mockAccounts);
 
       // Assert
       expect(result).toBe(mockSubscriptionId);
@@ -7528,11 +7503,7 @@ describe('RewardsController', () => {
       // Arrange
       const mockAccounts = [mockEvmInternalAccount];
       mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (
-          method === 'AccountTreeController:getAccountsFromSelectedAccountGroup'
-        ) {
-          return mockAccounts;
-        } else if (method === 'KeyringController:signPersonalMessage') {
+        if (method === 'KeyringController:signPersonalMessage') {
           return Promise.resolve('0xsignature123');
         } else if (method === 'RewardsDataService:mobileOptin') {
           return Promise.reject(new Error('Optin service error'));
@@ -7546,7 +7517,7 @@ describe('RewardsController', () => {
       }));
 
       // Act & Assert
-      await expect(controller.optIn()).rejects.toThrow(
+      await expect(controller.optIn(mockAccounts)).rejects.toThrow(
         'Failed to opt in any account from the account group',
       );
     });
@@ -7555,11 +7526,7 @@ describe('RewardsController', () => {
       // Arrange
       const mockAccounts = [mockEvmInternalAccount];
       mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (
-          method === 'AccountTreeController:getAccountsFromSelectedAccountGroup'
-        ) {
-          return mockAccounts;
-        } else if (method === 'KeyringController:signPersonalMessage') {
+        if (method === 'KeyringController:signPersonalMessage') {
           return Promise.reject(new Error('Signature failed'));
         }
         return Promise.resolve();
@@ -7571,7 +7538,7 @@ describe('RewardsController', () => {
       }));
 
       // Act & Assert
-      await expect(controller.optIn()).rejects.toThrow(
+      await expect(controller.optIn(mockAccounts)).rejects.toThrow(
         'Failed to opt in any account from the account group',
       );
     });
@@ -7580,11 +7547,7 @@ describe('RewardsController', () => {
       // Arrange
       const mockAccounts = [mockEvmInternalAccount];
       mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (
-          method === 'AccountTreeController:getAccountsFromSelectedAccountGroup'
-        ) {
-          return mockAccounts;
-        } else if (method === 'KeyringController:signPersonalMessage') {
+        if (method === 'KeyringController:signPersonalMessage') {
           return Promise.resolve('0xsignature123');
         } else if (method === 'RewardsDataService:mobileOptin') {
           return Promise.resolve(mockOptinResponse);
@@ -7598,7 +7561,7 @@ describe('RewardsController', () => {
       }));
 
       // Act
-      const result = await controller.optIn();
+      const result = await controller.optIn(mockAccounts);
 
       // Assert
       expect(result).toBe(mockSubscriptionId);
@@ -7615,11 +7578,7 @@ describe('RewardsController', () => {
       // Arrange
       const mockAccounts = [mockEvmInternalAccount, mockEvmInternalAccount2];
       mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (
-          method === 'AccountTreeController:getAccountsFromSelectedAccountGroup'
-        ) {
-          return mockAccounts;
-        } else if (method === 'KeyringController:signPersonalMessage') {
+        if (method === 'KeyringController:signPersonalMessage') {
           return Promise.resolve('0xsignature123');
         } else if (method === 'RewardsDataService:mobileOptin') {
           // Only succeed for the first account
@@ -7640,7 +7599,7 @@ describe('RewardsController', () => {
       }));
 
       // Act
-      const result = await controller.optIn();
+      const result = await controller.optIn(mockAccounts);
 
       // Assert
       expect(result).toBe(mockSubscriptionId);
@@ -7658,11 +7617,7 @@ describe('RewardsController', () => {
       // Arrange
       const mockAccounts = [mockEvmInternalAccount, mockEvmInternalAccount2];
       mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (
-          method === 'AccountTreeController:getAccountsFromSelectedAccountGroup'
-        ) {
-          return mockAccounts;
-        } else if (method === 'KeyringController:signPersonalMessage') {
+        if (method === 'KeyringController:signPersonalMessage') {
           return Promise.resolve('0xsignature123');
         } else if (method === 'RewardsDataService:mobileOptin') {
           // Only succeed for the first account
@@ -7683,7 +7638,7 @@ describe('RewardsController', () => {
       }));
 
       // Act
-      const result = await controller.optIn();
+      const result = await controller.optIn(mockAccounts);
 
       // Assert
       expect(result).toBe(mockSubscriptionId); // Should still return the subscription ID even if linking fails
@@ -7699,11 +7654,7 @@ describe('RewardsController', () => {
       }));
 
       mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (
-          method === 'AccountTreeController:getAccountsFromSelectedAccountGroup'
-        ) {
-          return mockAccounts;
-        } else if (method === 'KeyringController:signPersonalMessage') {
+        if (method === 'KeyringController:signPersonalMessage') {
           return Promise.resolve('0xsignature123');
         } else if (method === 'RewardsDataService:mobileOptin') {
           return Promise.resolve(mockOptinResponse);
@@ -7717,7 +7668,7 @@ describe('RewardsController', () => {
       }));
 
       // Act
-      const result = await controller.optIn();
+      const result = await controller.optIn(mockAccounts);
 
       // Assert
       expect(result).toBe(mockSubscriptionId); // Should still succeed even if token storage fails
@@ -7742,11 +7693,7 @@ describe('RewardsController', () => {
       const mockAccounts = [mockSolanaAccount, mockEvmInternalAccount];
       const sortedAccounts = [mockEvmInternalAccount, mockSolanaAccount]; // EVM first
       mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (
-          method === 'AccountTreeController:getAccountsFromSelectedAccountGroup'
-        ) {
-          return mockAccounts;
-        } else if (method === 'KeyringController:signPersonalMessage') {
+        if (method === 'KeyringController:signPersonalMessage') {
           return Promise.resolve('0xsignature123');
         } else if (method === 'RewardsDataService:mobileOptin') {
           return Promise.resolve(mockOptinResponse);
@@ -7760,7 +7707,7 @@ describe('RewardsController', () => {
       }));
 
       // Act
-      const result = await controller.optIn();
+      const result = await controller.optIn(mockAccounts);
 
       // Assert
       expect(result).toBe(mockSubscriptionId); // Should try EVM account first due to sorting
@@ -7776,11 +7723,7 @@ describe('RewardsController', () => {
       // Arrange
       const mockAccounts = [mockEvmInternalAccount];
       mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (
-          method === 'AccountTreeController:getAccountsFromSelectedAccountGroup'
-        ) {
-          return mockAccounts;
-        } else if (method === 'KeyringController:signPersonalMessage') {
+        if (method === 'KeyringController:signPersonalMessage') {
           return Promise.resolve('0xsignature123');
         } else if (method === 'RewardsDataService:mobileOptin') {
           return Promise.resolve(mockOptinResponse);
@@ -7794,7 +7737,7 @@ describe('RewardsController', () => {
       }));
 
       // Act
-      const result = await controller.optIn();
+      const result = await controller.optIn(mockAccounts);
 
       // Assert
       expect(result).toBe(mockSubscriptionId); // Should not call mobileJoin since there are no remaining accounts
@@ -7812,11 +7755,7 @@ describe('RewardsController', () => {
       let callCount = 0;
 
       mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (
-          method === 'AccountTreeController:getAccountsFromSelectedAccountGroup'
-        ) {
-          return mockAccounts;
-        } else if (method === 'KeyringController:signPersonalMessage') {
+        if (method === 'KeyringController:signPersonalMessage') {
           return Promise.resolve('0xsignature123');
         } else if (method === 'RewardsDataService:mobileOptin') {
           callCount++;
@@ -7834,7 +7773,7 @@ describe('RewardsController', () => {
       }));
 
       // Act
-      const result = await controller.optIn();
+      const result = await controller.optIn(mockAccounts);
 
       // Assert
       expect(result).toBe(mockSubscriptionId);
@@ -7847,11 +7786,7 @@ describe('RewardsController', () => {
       const mockError = new InvalidTimestampError('Invalid timestamp', 12345);
 
       mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (
-          method === 'AccountTreeController:getAccountsFromSelectedAccountGroup'
-        ) {
-          return mockAccounts;
-        } else if (method === 'KeyringController:signPersonalMessage') {
+        if (method === 'KeyringController:signPersonalMessage') {
           return Promise.resolve('0xsignature123');
         } else if (method === 'RewardsDataService:mobileOptin') {
           throw mockError; // Always throw InvalidTimestampError
@@ -7865,7 +7800,7 @@ describe('RewardsController', () => {
       }));
 
       // Act & Assert
-      await expect(controller.optIn()).rejects.toThrow(
+      await expect(controller.optIn(mockAccounts)).rejects.toThrow(
         'Failed to opt in any account from the account group',
       );
     });
@@ -7876,11 +7811,7 @@ describe('RewardsController', () => {
       const mockError = new Error('Network error');
 
       mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (
-          method === 'AccountTreeController:getAccountsFromSelectedAccountGroup'
-        ) {
-          return mockAccounts;
-        } else if (method === 'KeyringController:signPersonalMessage') {
+        if (method === 'KeyringController:signPersonalMessage') {
           return Promise.resolve('0xsignature123');
         } else if (method === 'RewardsDataService:mobileOptin') {
           throw mockError;
@@ -7894,7 +7825,7 @@ describe('RewardsController', () => {
       }));
 
       // Act & Assert
-      await expect(controller.optIn()).rejects.toThrow(
+      await expect(controller.optIn(mockAccounts)).rejects.toThrow(
         'Failed to opt in any account from the account group',
       );
     });
@@ -7910,14 +7841,9 @@ describe('RewardsController', () => {
         return callCount === 1;
       });
 
-      mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (
-          method === 'AccountTreeController:getAccountsFromSelectedAccountGroup'
-        ) {
-          return mockAccounts;
-        }
-        return Promise.resolve();
-      });
+      mockMessenger.call.mockImplementation((_, ..._args): any =>
+        Promise.resolve(),
+      );
 
       // Mock sortAccounts
       jest.doMock('./utils/sortAccounts', () => ({
@@ -7925,7 +7851,7 @@ describe('RewardsController', () => {
       }));
 
       // Act & Assert
-      await expect(controller.optIn()).rejects.toThrow(
+      await expect(controller.optIn(mockAccounts)).rejects.toThrow(
         'Failed to opt in any account from the account group',
       );
     });
@@ -7940,11 +7866,7 @@ describe('RewardsController', () => {
         .mockReturnValue(null);
 
       mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (
-          method === 'AccountTreeController:getAccountsFromSelectedAccountGroup'
-        ) {
-          return mockAccounts;
-        } else if (method === 'KeyringController:signPersonalMessage') {
+        if (method === 'KeyringController:signPersonalMessage') {
           return Promise.resolve('0xsignature123');
         } else if (method === 'RewardsDataService:mobileOptin') {
           return Promise.resolve(mockOptinResponse);
@@ -7958,7 +7880,7 @@ describe('RewardsController', () => {
       }));
 
       // Act
-      const result = await controller.optIn();
+      const result = await controller.optIn(mockAccounts);
 
       // Assert
       expect(result).toBe(mockSubscriptionId); // Should still succeed even if convertInternalAccountToCaipAccountId returns null
@@ -7973,11 +7895,7 @@ describe('RewardsController', () => {
       };
 
       mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (
-          method === 'AccountTreeController:getAccountsFromSelectedAccountGroup'
-        ) {
-          return mockAccounts;
-        } else if (method === 'KeyringController:signPersonalMessage') {
+        if (method === 'KeyringController:signPersonalMessage') {
           return Promise.resolve('0xsignature123');
         } else if (method === 'RewardsDataService:mobileOptin') {
           return Promise.resolve(incompleteResponse);
@@ -7991,7 +7909,7 @@ describe('RewardsController', () => {
       }));
 
       // Act
-      const result = await controller.optIn();
+      const result = await controller.optIn(mockAccounts);
 
       // Assert
       expect(result).toBe(mockSubscriptionId); // Should still succeed even if sessionId is missing
@@ -8006,11 +7924,7 @@ describe('RewardsController', () => {
       };
 
       mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (
-          method === 'AccountTreeController:getAccountsFromSelectedAccountGroup'
-        ) {
-          return mockAccounts;
-        } else if (method === 'KeyringController:signPersonalMessage') {
+        if (method === 'KeyringController:signPersonalMessage') {
           return Promise.resolve('0xsignature123');
         } else if (method === 'RewardsDataService:mobileOptin') {
           return Promise.resolve(incompleteResponse);
@@ -8024,7 +7938,7 @@ describe('RewardsController', () => {
       }));
 
       // Act
-      const result = await controller.optIn();
+      const result = await controller.optIn(mockAccounts);
 
       // Assert
       expect(result).toBeNull(); // Should return null when subscription id is missing
@@ -8059,11 +7973,7 @@ describe('RewardsController', () => {
         .mockResolvedValue(mockSubscriptionId);
 
       mockMessenger.call.mockImplementation((method, ..._args): any => {
-        if (
-          method === 'AccountTreeController:getAccountsFromSelectedAccountGroup'
-        ) {
-          return mockAccounts;
-        } else if (method === 'KeyringController:signPersonalMessage') {
+        if (method === 'KeyringController:signPersonalMessage') {
           return Promise.resolve('0xsignature123');
         } else if (method === 'RewardsDataService:mobileOptin') {
           return Promise.reject(mockError);
@@ -8087,7 +7997,7 @@ describe('RewardsController', () => {
       }));
 
       // Act
-      const result = await testController.optIn();
+      const result = await testController.optIn(mockAccounts);
 
       // Assert
       expect(result).toBe(mockSubscriptionId);
@@ -8648,67 +8558,43 @@ describe('RewardsController', () => {
     describe('optIn edge cases', () => {
       it('should handle empty account group gracefully', async () => {
         // Arrange
-        mockMessenger.call.mockImplementation((method, ..._args): any => {
-          if (
-            method ===
-            'AccountTreeController:getAccountsFromSelectedAccountGroup'
-          ) {
-            return [];
-          }
-          return Promise.resolve();
-        });
+        const mockAccounts: InternalAccount[] = [];
 
         // Act
-        const result = await controller.optIn();
+        const result = await controller.optIn(mockAccounts);
 
         // Assert
         expect(result).toBeNull();
-        expect(mockMessenger.call).toHaveBeenCalledWith(
-          'AccountTreeController:getAccountsFromSelectedAccountGroup',
+        expect(mockLogger.log).toHaveBeenCalledWith(
+          'RewardsController: No accounts provided, skipping optin',
         );
       });
 
       it('should handle null account group gracefully', async () => {
         // Arrange
-        mockMessenger.call.mockImplementation((method, ..._args): any => {
-          if (
-            method ===
-            'AccountTreeController:getAccountsFromSelectedAccountGroup'
-          ) {
-            return null;
-          }
-          return Promise.resolve();
-        });
+        const mockAccounts = null as unknown as InternalAccount[];
 
         // Act
-        const result = await controller.optIn();
+        const result = await controller.optIn(mockAccounts);
 
         // Assert
         expect(result).toBeNull();
-        expect(mockMessenger.call).toHaveBeenCalledWith(
-          'AccountTreeController:getAccountsFromSelectedAccountGroup',
+        expect(mockLogger.log).toHaveBeenCalledWith(
+          'RewardsController: No accounts provided, skipping optin',
         );
       });
 
       it('should handle undefined account group gracefully', async () => {
         // Arrange
-        mockMessenger.call.mockImplementation((method, ..._args): any => {
-          if (
-            method ===
-            'AccountTreeController:getAccountsFromSelectedAccountGroup'
-          ) {
-            return undefined;
-          }
-          return Promise.resolve();
-        });
+        const mockAccounts = undefined as unknown as InternalAccount[];
 
         // Act
-        const result = await controller.optIn();
+        const result = await controller.optIn(mockAccounts);
 
         // Assert
         expect(result).toBeNull();
-        expect(mockMessenger.call).toHaveBeenCalledWith(
-          'AccountTreeController:getAccountsFromSelectedAccountGroup',
+        expect(mockLogger.log).toHaveBeenCalledWith(
+          'RewardsController: No accounts provided, skipping optin',
         );
       });
 
@@ -8729,15 +8615,9 @@ describe('RewardsController', () => {
         } as InternalAccount;
 
         const mockAccounts = [unsupportedAccount];
-        mockMessenger.call.mockImplementation((method, ..._args): any => {
-          if (
-            method ===
-            'AccountTreeController:getAccountsFromSelectedAccountGroup'
-          ) {
-            return mockAccounts;
-          }
-          return Promise.resolve();
-        });
+        mockMessenger.call.mockImplementation((_, ..._args): any =>
+          Promise.resolve(),
+        );
 
         // Mock sortAccounts
         jest.doMock('./utils/sortAccounts', () => ({
@@ -8745,7 +8625,7 @@ describe('RewardsController', () => {
         }));
 
         // Act & Assert
-        await expect(controller.optIn()).rejects.toThrow(
+        await expect(controller.optIn(mockAccounts)).rejects.toThrow(
           'Failed to opt in any account from the account group',
         );
       });
@@ -8768,12 +8648,7 @@ describe('RewardsController', () => {
         } as InternalAccount;
         const mockAccounts = [mockEvmInternalAccount];
         mockMessenger.call.mockImplementation((method, ..._args): any => {
-          if (
-            method ===
-            'AccountTreeController:getAccountsFromSelectedAccountGroup'
-          ) {
-            return mockAccounts;
-          } else if (method === 'KeyringController:signPersonalMessage') {
+          if (method === 'KeyringController:signPersonalMessage') {
             return Promise.resolve('0xsignature123');
           } else if (method === 'RewardsDataService:mobileOptin') {
             const params = _args[0] as any;
@@ -8792,7 +8667,7 @@ describe('RewardsController', () => {
         }));
 
         // Act
-        const result = await controller.optIn(longReferralCode);
+        const result = await controller.optIn(mockAccounts, longReferralCode);
 
         // Assert
         expect(result).toBe('test-subscription-id');
@@ -8816,12 +8691,7 @@ describe('RewardsController', () => {
         } as InternalAccount;
         const mockAccounts = [mockEvmInternalAccount];
         mockMessenger.call.mockImplementation((method, ..._args): any => {
-          if (
-            method ===
-            'AccountTreeController:getAccountsFromSelectedAccountGroup'
-          ) {
-            return mockAccounts;
-          } else if (method === 'KeyringController:signPersonalMessage') {
+          if (method === 'KeyringController:signPersonalMessage') {
             return Promise.resolve('0xsignature123');
           } else if (method === 'RewardsDataService:mobileOptin') {
             const params = _args[0] as any;
@@ -8840,7 +8710,10 @@ describe('RewardsController', () => {
         }));
 
         // Act
-        const result = await controller.optIn(specialReferralCode);
+        const result = await controller.optIn(
+          mockAccounts,
+          specialReferralCode,
+        );
 
         // Assert
         expect(result).toBe('test-subscription-id');

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -1927,9 +1927,13 @@ export class RewardsController extends BaseController<
 
   /**
    * Perform the complete opt-in process for rewards
+   * @param accounts - Array of internal accounts to opt in
    * @param referralCode - Optional referral code
    */
-  async optIn(referralCode?: string): Promise<string | null> {
+  async optIn(
+    accounts: InternalAccount[],
+    referralCode?: string,
+  ): Promise<string | null> {
     const rewardsEnabled = this.isRewardsFeatureEnabled();
     if (!rewardsEnabled) {
       Logger.log(
@@ -1938,14 +1942,8 @@ export class RewardsController extends BaseController<
       return null;
     }
 
-    const accounts = await this.messenger.call(
-      'AccountTreeController:getAccountsFromSelectedAccountGroup',
-    );
-
     if (!accounts || accounts.length === 0) {
-      Logger.log(
-        'RewardsController: No accounts found in selected account group, skipping optin',
-      );
+      Logger.log('RewardsController: No accounts provided, skipping optin');
       return null;
     }
 

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -717,7 +717,10 @@ export interface Patch {
  */
 export interface RewardsControllerOptInAction {
   type: 'RewardsController:optIn';
-  handler: (referralCode?: string) => Promise<string | null>;
+  handler: (
+    accounts: InternalAccount[],
+    referralCode?: string,
+  ) => Promise<string | null>;
 }
 
 /**


### PR DESCRIPTION
## **Description**

Right now when opting in, we will first attempt to opt in your active account, and then link the first account of your SRP. This PR changes this so that we opt in your first account of your SRP and then link your active account. Reasoning here is that we're heading towards a situation where both on extension and mobile users will be able to opt in for the same SRP. If for some reason on one of their devices their cache is still stale, it will be correctly updated when during op-tin we detect that the first account of their SRP is already tied to a subscription. The active account group will then be tied/linked to this subscription. Instead of creating a new subscription in the old implementation.

## **Changelog**

CHANGELOG entry: null

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Opt-in now prefers side-effect (first wallet) accounts, links the other group afterward, and `RewardsController:optIn` takes explicit accounts with updated tests and metrics.
> 
> - **Rewards opt-in flow (hook)**:
>   - Prefer `sideEffectAccounts` for `RewardsController:optIn`; otherwise use active group accounts.
>   - After successful opt-in, link the opposite group (`linkAccountGroup`) based on which accounts were used.
>   - Track additional metrics/traits on referral usage; throw error if no subscription ID returned.
> - **Controller API**:
>   - Change `RewardsController:optIn` signature to `(accounts: InternalAccount[], referralCode?)` and remove internal account-group lookup.
>   - Update log message for empty accounts; keep retry/ordering logic via `sortAccounts`.
>   - Update action type `RewardsControllerOptInAction` to new signature.
> - **Tests**:
>   - Rewrite `useOptIn` tests to cover side-effect vs active group paths, linking behavior, referral traits, and failure cases.
>   - Update controller tests to pass accounts explicitly and validate new behaviors across edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41bcb71d4c55e5d91f58f8b4511795dcc2b71e99. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->