### PR TITLE
test: fix snap test by using assigned port

### DIFF
--- a/e2e/framework/fixtures/FixtureUtils.ts
+++ b/e2e/framework/fixtures/FixtureUtils.ts
@@ -476,6 +476,22 @@ export function getTestDappLocalUrl() {
   return getDappUrl(0);
 }
 
+/**
+ * Gets the Anvil port for use during test execution.
+ * Automatically handles platform differences (Android uses fallback port, iOS uses actual allocated port).
+ *
+ * @returns The Anvil port to use in tests (8545 on Android, allocated port on iOS)
+ *
+ * @example
+ * // Get Anvil WebSocket URL
+ * const wsUrl = `ws://localhost:${getAnvilPortForTest()}`;
+ */
+export function getAnvilPortForTest(): number {
+  return device.getPlatform() === 'android'
+    ? DEFAULT_ANVIL_PORT
+    : getServerPort(ResourceType.ANVIL);
+}
+
 export function getGanachePort(): number {
   return getServerPort(ResourceType.GANACHE);
 }

--- a/e2e/specs/snaps/test-snap-network-access.spec.ts
+++ b/e2e/specs/snaps/test-snap-network-access.spec.ts
@@ -4,7 +4,7 @@ import FixtureBuilder from '../../framework/fixtures/FixtureBuilder';
 import { withFixtures } from '../../framework/fixtures/FixtureHelper';
 import TabBarComponent from '../../pages/wallet/TabBarComponent';
 import TestSnaps from '../../pages/Browser/TestSnaps';
-import { AnvilPort } from '../../framework/fixtures/FixtureUtils';
+import { getAnvilPortForTest } from '../../framework/fixtures/FixtureUtils';
 import { LocalNodeType } from '../../framework';
 import { defaultOptions } from '../../seeder/anvil-manager';
 
@@ -42,7 +42,7 @@ describe(FlaskBuildTests('Network Access Snap Tests'), () => {
         );
 
         // Use WebSockets
-        const webSocketUrl = `ws://localhost:${AnvilPort()}`;
+        const webSocketUrl = `ws://localhost:${getAnvilPortForTest()}`;
         await TestSnaps.fillMessage('webSocketUrlInput', webSocketUrl);
         await TestSnaps.tapButton('startWebSocket');
 

--- a/e2e/specs/snaps/test-snap-network-access.spec.ts
+++ b/e2e/specs/snaps/test-snap-network-access.spec.ts
@@ -22,7 +22,6 @@ describe(FlaskBuildTests('Network Access Snap Tests'), () => {
             type: LocalNodeType.anvil,
             options: {
               ...defaultOptions,
-              port: AnvilPort(),
               blockTime: 2,
             },
           },


### PR DESCRIPTION
… tests

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
- Since we added a port manager to allocate random ports we need to remove the reliance on AnvilPort() in this test


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a platform-aware Anvil port helper and updates the Snap network access test to use the allocated port instead of a hardcoded one.
> 
> - **E2E Tests**:
>   - Update `e2e/specs/snaps/test-snap-network-access.spec.ts` to use `getAnvilPortForTest()` for WebSocket URL and remove explicit `port` option in `localNodeOptions`.
> - **Fixtures/Utils**:
>   - Add `getAnvilPortForTest()` in `e2e/framework/fixtures/FixtureUtils.ts` to return `DEFAULT_ANVIL_PORT` on Android and the allocated `ANVIL` port on iOS, with JSDoc examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ccb55b4953a6f31a90851c0218a85d12960a2f8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->