### PR TITLE
fix(predict): update pending deposits to store batch IDs instead

### DIFF
--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -2757,22 +2757,22 @@ describe('PredictController', () => {
         controller.updateStateForTesting((state) => {
           state.pendingDeposits = {
             [providerId]: {
-              [address]: true,
+              [address]: 'batch-id-123',
             },
           };
         });
 
         // Verify transaction exists
         expect(controller.state.pendingDeposits[providerId][address]).toBe(
-          true,
+          'batch-id-123',
         );
 
         // Clear deposit transaction
         controller.clearPendingDeposit({ providerId });
 
-        // Verify transaction is cleared
-        expect(controller.state.pendingDeposits[providerId][address]).toBe(
-          false,
+        // Verify transaction is cleared (deleted, not set to false)
+        expect(controller.state.pendingDeposits[providerId]?.[address]).toBe(
+          undefined,
         );
       });
     });
@@ -2791,10 +2791,10 @@ describe('PredictController', () => {
           controller.clearPendingDeposit({ providerId }),
         ).not.toThrow();
 
-        // Should set to false
+        // Verify deposit transaction remains undefined
         const address = '0x1234567890123456789012345678901234567890';
-        expect(controller.state.pendingDeposits[providerId][address]).toBe(
-          false,
+        expect(controller.state.pendingDeposits[providerId]?.[address]).toBe(
+          undefined,
         );
       });
     });
@@ -2808,12 +2808,13 @@ describe('PredictController', () => {
       withController(({ controller, messenger }) => {
         const providerId = 'polymarket';
         const address = '0x1234567890123456789012345678901234567890';
+        const existingBatchId = 'existing-batch-id';
 
         // Set up deposit transaction
         controller.updateStateForTesting((state) => {
           state.pendingDeposits = {
             [providerId]: {
-              [address]: true,
+              [address]: existingBatchId,
             },
           };
         });
@@ -2873,14 +2874,15 @@ describe('PredictController', () => {
           providerId,
         });
 
-        // Verify depositTransaction was stored with correct structure
+        // Verify depositTransaction was stored with batch ID
         expect(controller.state.pendingDeposits[providerId][address]).toBe(
-          true,
+          mockBatchId,
         );
       });
     });
 
     it('clears previous deposit transaction when starting new deposit', async () => {
+      const oldBatchId = 'old-batch';
       const newBatchId = 'new-batch';
       const providerId = 'polymarket';
       const address = '0x1234567890123456789012345678901234567890';
@@ -2906,24 +2908,24 @@ describe('PredictController', () => {
         controller.updateStateForTesting((state) => {
           state.pendingDeposits = {
             [providerId]: {
-              [address]: true,
+              [address]: oldBatchId,
             },
           };
         });
 
         // Verify old transaction exists
         expect(controller.state.pendingDeposits[providerId][address]).toBe(
-          true,
+          oldBatchId,
         );
 
-        // Start new deposit (should clear and set to false first, then true)
+        // Start new deposit (should clear old batch and set to new batch ID)
         await controller.depositWithConfirmation({
           providerId,
         });
 
-        // Verify new transaction is set
+        // Verify new transaction is set with new batch ID
         expect(controller.state.pendingDeposits[providerId][address]).toBe(
-          true,
+          newBatchId,
         );
       });
     });

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -1500,9 +1500,9 @@ export class PredictController extends BaseController<
       }
 
       this.update((state) => {
-        state.pendingDeposits[params.providerId] = {
-          [signer.address]: 'pending',
-        };
+        state.pendingDeposits[params.providerId] =
+          state.pendingDeposits[params.providerId] || {};
+        state.pendingDeposits[params.providerId][signer.address] = 'pending';
       });
 
       const batchResult = await addTransactionBatch({
@@ -1527,9 +1527,9 @@ export class PredictController extends BaseController<
       }
 
       this.update((state) => {
-        state.pendingDeposits[params.providerId] = {
-          [signer.address]: batchId,
-        };
+        state.pendingDeposits[params.providerId] =
+          state.pendingDeposits[params.providerId] || {};
+        state.pendingDeposits[params.providerId][signer.address] = batchId;
       });
 
       return {

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -1541,6 +1541,8 @@ export class PredictController extends BaseController<
     } catch (error) {
       const e = ensureError(error);
       if (e.message.includes('User denied transaction signature')) {
+        // Clear pending state before returning
+        this.clearPendingDeposit({ providerId: params.providerId });
         // ignore error, as the user cancelled the tx
         return {
           success: true,

--- a/app/components/UI/Predict/hooks/usePredictDeposit.ts
+++ b/app/components/UI/Predict/hooks/usePredictDeposit.ts
@@ -35,7 +35,7 @@ export const usePredictDeposit = ({
 
   const { deposit: depositWithConfirmation } = usePredictTrading();
 
-  const isDepositPending = useSelector(
+  const depositBatchId = useSelector(
     selectPredictPendingDepositByAddress({
       providerId,
       address: selectedInternalAccountAddress,
@@ -144,6 +144,6 @@ export const usePredictDeposit = ({
 
   return {
     deposit,
-    isDepositPending,
+    isDepositPending: !!depositBatchId,
   };
 };

--- a/app/components/UI/Predict/hooks/usePredictDepositToasts.tsx
+++ b/app/components/UI/Predict/hooks/usePredictDepositToasts.tsx
@@ -20,11 +20,24 @@ export const usePredictDepositToasts = ({
   const { deposit } = usePredictDeposit();
   const navigation = useNavigation();
 
+  const selectedInternalAccountAddress = useSelector(
+    selectSelectedInternalAccountAddress,
+  );
+
+  const depositBatchId = useSelector(
+    selectPredictPendingDepositByAddress({
+      providerId,
+      address: selectedInternalAccountAddress ?? '',
+    }),
+  );
+
   usePredictToasts({
     onConfirmed: () => {
       loadBalance({ isRefresh: true });
     },
     transactionType: TransactionType.predictDeposit,
+    transactionBatchId:
+      depositBatchId !== 'pending' ? depositBatchId : undefined,
     pendingToastConfig: {
       title: strings('predict.deposit.adding_funds'),
       description: strings('predict.deposit.in_progress_description'),

--- a/app/components/UI/Predict/hooks/usePredictDepositToasts.tsx
+++ b/app/components/UI/Predict/hooks/usePredictDepositToasts.tsx
@@ -8,6 +8,9 @@ import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
 import { useNavigation } from '@react-navigation/native';
 import Routes from '../../../../constants/navigation/Routes';
 import { formatPrice } from '../utils/format';
+import { getEvmAccountFromSelectedAccountGroup } from '../utils/accounts';
+import { useSelector } from 'react-redux';
+import { selectPredictPendingDepositByAddress } from '../selectors/predictController';
 
 interface UsePredictDepositToastsParams {
   providerId?: string;
@@ -20,14 +23,13 @@ export const usePredictDepositToasts = ({
   const { deposit } = usePredictDeposit();
   const navigation = useNavigation();
 
-  const selectedInternalAccountAddress = useSelector(
-    selectSelectedInternalAccountAddress,
-  );
+  const selectedInternalAccountAddress =
+    getEvmAccountFromSelectedAccountGroup();
 
   const depositBatchId = useSelector(
     selectPredictPendingDepositByAddress({
       providerId,
-      address: selectedInternalAccountAddress ?? '',
+      address: selectedInternalAccountAddress?.address ?? '',
     }),
   );
 

--- a/app/components/UI/Predict/hooks/usePredictToasts.tsx
+++ b/app/components/UI/Predict/hooks/usePredictToasts.tsx
@@ -50,12 +50,14 @@ interface UsePredictToastsParams {
   pendingToastConfig?: PendingToastConfig;
   confirmedToastConfig: ConfirmedToastConfig;
   errorToastConfig: ErrorToastConfig;
+  transactionBatchId?: string;
   clearTransaction?: () => void;
   onConfirmed?: () => void;
 }
 
 export const usePredictToasts = ({
   transactionType,
+  transactionBatchId,
   pendingToastConfig,
   confirmedToastConfig,
   errorToastConfig,
@@ -176,10 +178,17 @@ export const usePredictToasts = ({
     }: {
       transactionMeta: TransactionMeta;
     }) => {
-      const isTargetTransaction = transactionMeta?.nestedTransactions?.some(
-        (tx) => tx.type === transactionType,
-      );
-      if (!isTargetTransaction) {
+      const isTargetTransaction =
+        transactionMeta.batchId === transactionBatchId;
+
+      const isTargetNestedTransaction =
+        transactionMeta?.nestedTransactions?.some(
+          (tx) => tx.type === transactionType,
+        );
+
+      if (transactionBatchId && !isTargetTransaction) {
+        return;
+      } else if (!isTargetNestedTransaction) {
         return;
       }
 
@@ -222,6 +231,7 @@ export const usePredictToasts = ({
     showErrorToast,
     showPendingToast,
     toastRef,
+    transactionBatchId,
     transactionType,
   ]);
 

--- a/app/components/UI/Predict/selectors/predictController/index.ts
+++ b/app/components/UI/Predict/selectors/predictController/index.ts
@@ -70,7 +70,7 @@ const selectPredictPendingDepositByAddress = ({
 }) =>
   createSelector(
     selectPredictPendingDeposits,
-    (pendingDeposits) => pendingDeposits[providerId]?.[address] || false,
+    (pendingDeposits) => pendingDeposits[providerId]?.[address] || undefined,
   );
 
 const selectPredictAccountMeta = createSelector(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Change pendingDeposits state from boolean flags to batch ID strings
- Update selector to return undefined instead of false for cleared deposits
- Add batch ID tracking to deposit toasts for better transaction matching
- Update hook to convert batch ID to boolean for backward compatibility
- Delete deposit entries instead of setting to false when clearing
- Add 'pending' state before batch ID is assigned
- Clear deposit state on errors in depositWithConfirmation
- Fix all related tests to expect batch ID strings and undefined values

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch pending deposit tracking from booleans to batch IDs, update toasts/selectors to use batch IDs, and adjust controller logic and tests accordingly.
> 
> - **PredictController**:
>   - Change `state.pendingDeposits` to map addresses to batch ID `string` (was `boolean`).
>   - On deposit: clear previous entry, set to `'pending'`, then replace with real `batchId`; validate chain ID; clear pending on errors/user cancel.
>   - `clearPendingDeposit` now deletes address entry instead of setting `false`.
> - **Hooks**:
>   - `usePredictDeposit`: selector now returns batch ID; exposes `isDepositPending` via `!!batchId`.
>   - `usePredictDepositToasts`: reads batch ID and passes `transactionBatchId` (ignores `'pending'`).
>   - `usePredictToasts`: accepts optional `transactionBatchId` and matches by `batchId` when provided, otherwise falls back to nested type; handles clear on status changes.
> - **Selectors**:
>   - `selectPredictPendingDepositByAddress` returns `string | undefined` (was `boolean | false`).
> - **Tests**:
>   - Update deposit tests to expect batch IDs and `undefined` after clear; add cases for preserving state on different `batchId` and replacing old batch on new deposit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c554f3c5a5f9343fc0a6fac938188da3bc5a5eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->