### PR TITLE
fix(Predict): improve button layout and error messages

### DIFF
--- a/app/components/UI/Predict/components/PredictKeypad/PredictKeypad.tsx
+++ b/app/components/UI/Predict/components/PredictKeypad/PredictKeypad.tsx
@@ -143,7 +143,7 @@ const PredictKeypad = forwardRef<PredictKeypadHandles, PredictKeypadProps>(
 
     return (
       <View style={tw.style('py-4')}>
-        <View style={tw.style('px-4 mb-4')}>
+        <View style={tw.style('px-4 mb-3')}>
           {hasInsufficientFunds && onAddFunds ? (
             <Button
               variant={ButtonVariants.Primary}
@@ -159,28 +159,28 @@ const PredictKeypad = forwardRef<PredictKeypadHandles, PredictKeypadProps>(
                 size={ButtonSize.Md}
                 label="$20"
                 onPress={() => handleKeypadAmountPress(20)}
-                style={tw.style('flex-1')}
+                style={tw.style('flex-1 h-12')}
               />
               <Button
                 variant={ButtonVariants.Secondary}
                 size={ButtonSize.Md}
                 label="$50"
                 onPress={() => handleKeypadAmountPress(50)}
-                style={tw.style('flex-1')}
+                style={tw.style('flex-1 h-12')}
               />
               <Button
                 variant={ButtonVariants.Secondary}
                 size={ButtonSize.Md}
                 label="$100"
                 onPress={() => handleKeypadAmountPress(100)}
-                style={tw.style('flex-1')}
+                style={tw.style('flex-1 h-12')}
               />
               <Button
                 variant={ButtonVariants.Primary}
                 size={ButtonSize.Md}
                 label="Done"
                 onPress={handleDonePress}
-                style={tw.style('flex-1')}
+                style={tw.style('flex-1 h-12')}
               />
             </View>
           )}

--- a/app/components/UI/Predict/components/PredictMarketOutcome/PredictMarketOutcome.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarketOutcome/PredictMarketOutcome.test.tsx
@@ -495,4 +495,190 @@ describe('PredictMarketOutcome', () => {
       expect(getByText('Crypto Markets')).toBeOnTheScreen();
     });
   });
+
+  describe('Button Label Formatting', () => {
+    it('uses bullet separator when both token titles are 6 characters or less', () => {
+      const outcomeWithShortLabels: PredictOutcome = {
+        ...mockOutcome,
+        tokens: [
+          { id: 'token-yes', title: 'Short', price: 0.65 },
+          { id: 'token-no', title: 'Label', price: 0.35 },
+        ],
+      };
+
+      const { getByText } = renderWithProvider(
+        <PredictMarketOutcome
+          outcome={outcomeWithShortLabels}
+          market={mockMarket}
+        />,
+        { state: initialState },
+      );
+
+      expect(getByText(/Short/)).toBeOnTheScreen();
+      expect(getByText(/Label/)).toBeOnTheScreen();
+    });
+
+    it('uses newline separator when first token title exceeds 6 characters', () => {
+      const outcomeWithLongFirstLabel: PredictOutcome = {
+        ...mockOutcome,
+        tokens: [
+          { id: 'token-yes', title: 'VeryLongLabel', price: 0.65 },
+          { id: 'token-no', title: 'No', price: 0.35 },
+        ],
+      };
+
+      const { getByText } = renderWithProvider(
+        <PredictMarketOutcome
+          outcome={outcomeWithLongFirstLabel}
+          market={mockMarket}
+        />,
+        { state: initialState },
+      );
+
+      expect(getByText(/VeryLongLabel/)).toBeOnTheScreen();
+      expect(getByText(/65¢/)).toBeOnTheScreen();
+    });
+
+    it('uses newline separator when second token title exceeds 6 characters', () => {
+      const outcomeWithLongSecondLabel: PredictOutcome = {
+        ...mockOutcome,
+        tokens: [
+          { id: 'token-yes', title: 'Yes', price: 0.65 },
+          { id: 'token-no', title: 'VeryLongLabel', price: 0.35 },
+        ],
+      };
+
+      const { getByText } = renderWithProvider(
+        <PredictMarketOutcome
+          outcome={outcomeWithLongSecondLabel}
+          market={mockMarket}
+        />,
+        { state: initialState },
+      );
+
+      expect(getByText(/VeryLongLabel/)).toBeOnTheScreen();
+      expect(getByText(/35¢/)).toBeOnTheScreen();
+    });
+
+    it('uses newline separator when both token titles exceed 6 characters', () => {
+      const outcomeWithLongLabels: PredictOutcome = {
+        ...mockOutcome,
+        tokens: [
+          { id: 'token-yes', title: 'LongFirst', price: 0.65 },
+          { id: 'token-no', title: 'LongSecond', price: 0.35 },
+        ],
+      };
+
+      const { getByText } = renderWithProvider(
+        <PredictMarketOutcome
+          outcome={outcomeWithLongLabels}
+          market={mockMarket}
+        />,
+        { state: initialState },
+      );
+
+      expect(getByText(/LongFirst/)).toBeOnTheScreen();
+      expect(getByText(/LongSecond/)).toBeOnTheScreen();
+      expect(getByText(/65¢/)).toBeOnTheScreen();
+      expect(getByText(/35¢/)).toBeOnTheScreen();
+    });
+
+    it('uses bullet separator for token titles with exactly 6 characters', () => {
+      const outcomeWithExactLabels: PredictOutcome = {
+        ...mockOutcome,
+        tokens: [
+          { id: 'token-yes', title: 'Exact6', price: 0.65 },
+          { id: 'token-no', title: 'Size6!', price: 0.35 },
+        ],
+      };
+
+      const { getByText } = renderWithProvider(
+        <PredictMarketOutcome
+          outcome={outcomeWithExactLabels}
+          market={mockMarket}
+        />,
+        { state: initialState },
+      );
+
+      expect(getByText(/Exact6/)).toBeOnTheScreen();
+      expect(getByText(/Size6!/)).toBeOnTheScreen();
+      expect(getByText(/65¢/)).toBeOnTheScreen();
+    });
+
+    it('handles very long token titles gracefully', () => {
+      const outcomeWithVeryLongLabels: PredictOutcome = {
+        ...mockOutcome,
+        tokens: [
+          {
+            id: 'token-yes',
+            title: 'Very Long Label That Exceeds Maximum',
+            price: 0.65,
+          },
+          {
+            id: 'token-no',
+            title: 'Another Extremely Long Label',
+            price: 0.35,
+          },
+        ],
+      };
+
+      const { getByText } = renderWithProvider(
+        <PredictMarketOutcome
+          outcome={outcomeWithVeryLongLabels}
+          market={mockMarket}
+        />,
+        { state: initialState },
+      );
+
+      expect(
+        getByText(/Very Long Label That Exceeds Maximum/),
+      ).toBeOnTheScreen();
+      expect(getByText(/Another Extremely Long Label/)).toBeOnTheScreen();
+    });
+
+    it('renders buttons with correct interaction when labels are long', () => {
+      const outcomeWithLongLabels: PredictOutcome = {
+        ...mockOutcome,
+        tokens: [
+          { id: 'token-yes', title: 'LongYesLabel', price: 0.65 },
+          { id: 'token-no', title: 'LongNoLabel', price: 0.35 },
+        ],
+      };
+
+      const { getByText } = renderWithProvider(
+        <PredictMarketOutcome
+          outcome={outcomeWithLongLabels}
+          market={mockMarket}
+        />,
+        { state: initialState },
+      );
+
+      const yesButton = getByText(/LongYesLabel/);
+      const noButton = getByText(/LongNoLabel/);
+
+      fireEvent.press(yesButton);
+
+      expect(mockNavigate).toHaveBeenCalledWith('PredictModals', {
+        screen: 'PredictBuyPreview',
+        params: {
+          market: mockMarket,
+          outcome: outcomeWithLongLabels,
+          outcomeToken: outcomeWithLongLabels.tokens[0],
+          entryPoint: PredictEventValues.ENTRY_POINT.PREDICT_FEED,
+        },
+      });
+
+      fireEvent.press(noButton);
+
+      expect(mockNavigate).toHaveBeenCalledWith('PredictModals', {
+        screen: 'PredictBuyPreview',
+        params: {
+          market: mockMarket,
+          outcome: outcomeWithLongLabels,
+          outcomeToken: outcomeWithLongLabels.tokens[1],
+          entryPoint: PredictEventValues.ENTRY_POINT.PREDICT_FEED,
+        },
+      });
+    });
+  });
 });

--- a/app/components/UI/Predict/components/PredictMarketOutcome/PredictMarketOutcome.tsx
+++ b/app/components/UI/Predict/components/PredictMarketOutcome/PredictMarketOutcome.tsx
@@ -48,6 +48,8 @@ interface PredictMarketOutcomeProps {
   isClosed?: boolean;
 }
 
+const MAX_LABEL_LENGTH = 6;
+
 const PredictMarketOutcome: React.FC<PredictMarketOutcomeProps> = ({
   market,
   outcome,
@@ -86,6 +88,10 @@ const PredictMarketOutcome: React.FC<PredictMarketOutcomeProps> = ({
   const getImageUrl = (): string => outcome.image;
 
   const getVolumeDisplay = (): string => formatVolume(outcome.volume ?? 0);
+
+  const isBiggerLabel =
+    outcome.tokens[0].title.length > MAX_LABEL_LENGTH ||
+    outcome.tokens[1].title.length > MAX_LABEL_LENGTH;
 
   const handleBuy = (token: PredictOutcomeToken) => {
     executeGuardedAction(
@@ -187,26 +193,34 @@ const PredictMarketOutcome: React.FC<PredictMarketOutcomeProps> = ({
             size={ButtonSize.Md}
             width={ButtonWidthTypes.Full}
             label={
-              <Text style={tw.style('font-medium')} color={TextColor.Success}>
-                {outcome.tokens[0].title} •{' '}
+              <Text
+                style={tw.style('font-medium text-center')}
+                color={TextColor.Success}
+              >
+                {outcome.tokens[0].title}
+                {isBiggerLabel ? '\n' : ' • '}
                 {formatCents(outcome.tokens[0].price)}
               </Text>
             }
             onPress={() => handleBuy(outcome.tokens[0])}
-            style={styles.buttonYes}
+            style={[styles.buttonYes, isBiggerLabel && tw.style('h-18')]}
           />
           <Button
             variant={ButtonVariants.Secondary}
             size={ButtonSize.Md}
             width={ButtonWidthTypes.Full}
             label={
-              <Text style={tw.style('font-medium')} color={TextColor.Error}>
-                {outcome.tokens[1].title} •{' '}
+              <Text
+                style={tw.style('font-medium text-center')}
+                color={TextColor.Error}
+              >
+                {outcome.tokens[1].title}
+                {isBiggerLabel ? '\n' : ' • '}
                 {formatCents(outcome.tokens[1].price)}
               </Text>
             }
             onPress={() => handleBuy(outcome.tokens[1])}
-            style={styles.buttonNo}
+            style={[styles.buttonNo, isBiggerLabel && tw.style('h-18')]}
           />
         </View>
       )}

--- a/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.test.tsx
@@ -1042,10 +1042,9 @@ describe('PredictBuyPreview', () => {
       });
 
       // Error should show immediately even with keypad open
+      // maxBetAmount = balance - (providerFee + metamaskFee) = 50 - 1.5 = 48.5
       expect(
-        getByText(
-          'Insufficient funds. Lower the amount or add funds to continue.',
-        ),
+        getByText('Not enough funds. You can use up to $48.50.'),
       ).toBeOnTheScreen();
     });
 
@@ -1092,10 +1091,9 @@ describe('PredictBuyPreview', () => {
       expect(getByTestId('keypad')).toBeOnTheScreen();
 
       // Error message should be present
+      // maxBetAmount = balance - (providerFee + metamaskFee) = 50 - 1.5 = 48.5
       expect(
-        getByText(
-          'Insufficient funds. Lower the amount or add funds to continue.',
-        ),
+        getByText('Not enough funds. You can use up to $48.50.'),
       ).toBeOnTheScreen();
     });
 
@@ -1137,10 +1135,9 @@ describe('PredictBuyPreview', () => {
       });
 
       // Error message should be present even with keypad open
+      // maxBetAmount = balance - (providerFee + metamaskFee) = 50 - 1.5 = 48.5
       expect(
-        getByText(
-          'Insufficient funds. Lower the amount or add funds to continue.',
-        ),
+        getByText('Not enough funds. You can use up to $48.50.'),
       ).toBeOnTheScreen();
     });
 
@@ -1161,9 +1158,7 @@ describe('PredictBuyPreview', () => {
       });
 
       expect(
-        queryByText(
-          'Insufficient funds. Lower the amount or add funds to continue.',
-        ),
+        queryByText(/Not enough funds\. You can use up to/),
       ).not.toBeOnTheScreen();
     });
 
@@ -1186,10 +1181,9 @@ describe('PredictBuyPreview', () => {
       });
 
       // Error should show immediately
+      // maxBetAmount = balance - (providerFee + metamaskFee) = 100 - 15 = 85
       expect(
-        getByText(
-          'Insufficient funds. Lower the amount or add funds to continue.',
-        ),
+        getByText('Not enough funds. You can use up to $85.00.'),
       ).toBeOnTheScreen();
     });
 
@@ -1211,9 +1205,7 @@ describe('PredictBuyPreview', () => {
 
       // Should not show error while loading
       expect(
-        queryByText(
-          'Insufficient funds. Lower the amount or add funds to continue.',
-        ),
+        queryByText(/Not enough funds\. You can use up to/),
       ).not.toBeOnTheScreen();
     });
   });
@@ -1239,7 +1231,7 @@ describe('PredictBuyPreview', () => {
       const doneButton = getByText('Done');
       fireEvent.press(doneButton);
 
-      expect(getByText('Minimum bet is $1.00')).toBeOnTheScreen();
+      expect(getByText('Minimum amount is $1.00')).toBeOnTheScreen();
     });
 
     it('does not show minimum bet error when amount is exactly $1', () => {
@@ -1258,7 +1250,7 @@ describe('PredictBuyPreview', () => {
         });
       });
 
-      expect(queryByText('Minimum bet is $1.00')).not.toBeOnTheScreen();
+      expect(queryByText('Minimum amount is $1.00')).not.toBeOnTheScreen();
     });
 
     it('does not show minimum bet error when amount is $0', () => {
@@ -1270,7 +1262,7 @@ describe('PredictBuyPreview', () => {
       });
 
       // Amount starts at 0 - should not show error
-      expect(queryByText('Minimum bet is $1.00')).not.toBeOnTheScreen();
+      expect(queryByText('Minimum amount is $1.00')).not.toBeOnTheScreen();
     });
 
     it('does not show minimum bet error when insufficient funds error is shown', () => {
@@ -1294,12 +1286,11 @@ describe('PredictBuyPreview', () => {
 
       // Should show insufficient funds, not minimum bet
       // Note: Done button is replaced by Add funds when insufficient
+      // maxBetAmount = balance - (providerFee + metamaskFee) = 0.5 - 1.5 = -1
       expect(
-        getByText(
-          'Insufficient funds. Lower the amount or add funds to continue.',
-        ),
+        getByText('Not enough funds. You can use up to $-1.00.'),
       ).toBeOnTheScreen();
-      expect(queryByText('Minimum bet is $1.00')).not.toBeOnTheScreen();
+      expect(queryByText('Minimum amount is $1.00')).not.toBeOnTheScreen();
     });
 
     it('minimum bet error appears at bottom like insufficient funds error', () => {
@@ -1323,7 +1314,7 @@ describe('PredictBuyPreview', () => {
       fireEvent.press(doneButton);
 
       // Error should be visible at bottom
-      expect(getByText('Minimum bet is $1.00')).toBeOnTheScreen();
+      expect(getByText('Minimum amount is $1.00')).toBeOnTheScreen();
     });
   });
 
@@ -1697,10 +1688,9 @@ describe('PredictBuyPreview', () => {
         });
       });
 
+      // maxBetAmount = balance - (providerFee + metamaskFee) = 50 - 1.5 = 48.5
       expect(
-        getByText(
-          'Insufficient funds. Lower the amount or add funds to continue.',
-        ),
+        getByText('Not enough funds. You can use up to $48.50.'),
       ).toBeOnTheScreen();
     });
 
@@ -1723,7 +1713,7 @@ describe('PredictBuyPreview', () => {
       const doneButton = getByText('Done');
       fireEvent.press(doneButton);
 
-      expect(getByText('Minimum bet is $1.00')).toBeOnTheScreen();
+      expect(getByText('Minimum amount is $1.00')).toBeOnTheScreen();
     });
 
     it('renders only one error at a time - insufficient funds takes priority', () => {
@@ -1746,12 +1736,11 @@ describe('PredictBuyPreview', () => {
       });
 
       // Should show insufficient funds only
+      // maxBetAmount = balance - (providerFee + metamaskFee) = 0.3 - 1.5 = -1.2
       expect(
-        getByText(
-          'Insufficient funds. Lower the amount or add funds to continue.',
-        ),
+        getByText('Not enough funds. You can use up to $-1.20.'),
       ).toBeOnTheScreen();
-      expect(queryByText('Minimum bet is $1.00')).not.toBeOnTheScreen();
+      expect(queryByText('Minimum amount is $1.00')).not.toBeOnTheScreen();
     });
 
     it('does not render error when no validation issues', () => {
@@ -1770,11 +1759,9 @@ describe('PredictBuyPreview', () => {
       });
 
       expect(
-        queryByText(
-          'Insufficient funds. Lower the amount or add funds to continue.',
-        ),
+        queryByText(/Not enough funds\. You can use up to/),
       ).not.toBeOnTheScreen();
-      expect(queryByText('Minimum bet is $1.00')).not.toBeOnTheScreen();
+      expect(queryByText('Minimum amount is $1.00')).not.toBeOnTheScreen();
     });
   });
 
@@ -1796,10 +1783,9 @@ describe('PredictBuyPreview', () => {
       });
 
       // Verify error shows
+      // maxBetAmount = balance - (providerFee + metamaskFee) = 100 - 1.5 = 98.5
       expect(
-        getByText(
-          'Insufficient funds. Lower the amount or add funds to continue.',
-        ),
+        getByText('Not enough funds. You can use up to $98.50.'),
       ).toBeOnTheScreen();
 
       // Verify Add funds button shows
@@ -1834,7 +1820,7 @@ describe('PredictBuyPreview', () => {
       fireEvent.press(doneButton);
 
       // Verify minimum error shows
-      expect(getByText('Minimum bet is $1.00')).toBeOnTheScreen();
+      expect(getByText('Minimum amount is $1.00')).toBeOnTheScreen();
 
       // Increase amount
       const amountDisplay = getByText('0.5');
@@ -1848,7 +1834,7 @@ describe('PredictBuyPreview', () => {
       });
 
       // Error should clear
-      expect(queryByText('Minimum bet is $1.00')).not.toBeOnTheScreen();
+      expect(queryByText('Minimum amount is $1.00')).not.toBeOnTheScreen();
     });
 
     it('user flow: balance loads, then user enters amount, validation works', () => {
@@ -1891,10 +1877,9 @@ describe('PredictBuyPreview', () => {
         });
       });
 
+      // maxBetAmount = balance - (providerFee + metamaskFee) = 100 - 1.5 = 98.5
       expect(
-        getByText(
-          'Insufficient funds. Lower the amount or add funds to continue.',
-        ),
+        getByText('Not enough funds. You can use up to $98.50.'),
       ).toBeOnTheScreen();
     });
 
@@ -1959,9 +1944,7 @@ describe('PredictBuyPreview', () => {
 
       // Should NOT show error
       expect(
-        queryByText(
-          'Insufficient funds. Lower the amount or add funds to continue.',
-        ),
+        queryByText(/Not enough funds\. You can use up to/),
       ).not.toBeOnTheScreen();
     });
 
@@ -1982,10 +1965,9 @@ describe('PredictBuyPreview', () => {
       });
 
       // Should show error
+      // maxBetAmount = balance - (providerFee + metamaskFee) = 51.4 - 1.5 = 49.9
       expect(
-        getByText(
-          'Insufficient funds. Lower the amount or add funds to continue.',
-        ),
+        getByText('Not enough funds. You can use up to $49.90.'),
       ).toBeOnTheScreen();
     });
 
@@ -2012,7 +1994,7 @@ describe('PredictBuyPreview', () => {
       fireEvent.press(doneButton);
 
       // Should NOT show minimum error
-      expect(queryByText('Minimum bet is $1.00')).not.toBeOnTheScreen();
+      expect(queryByText('Minimum amount is $1.00')).not.toBeOnTheScreen();
 
       // Should show place bet button
       expect(getByText('Yes · 50¢')).toBeOnTheScreen();
@@ -2038,7 +2020,7 @@ describe('PredictBuyPreview', () => {
       fireEvent.press(doneButton);
 
       // Should show minimum error
-      expect(getByText('Minimum bet is $1.00')).toBeOnTheScreen();
+      expect(getByText('Minimum amount is $1.00')).toBeOnTheScreen();
     });
 
     it('handles very large balances', () => {
@@ -2071,10 +2053,9 @@ describe('PredictBuyPreview', () => {
       });
 
       // Should show error
+      // maxBetAmount = balance - (providerFee + metamaskFee) = 100 - 30 = 70
       expect(
-        getByText(
-          'Insufficient funds. Lower the amount or add funds to continue.',
-        ),
+        getByText('Not enough funds. You can use up to $70.00.'),
       ).toBeOnTheScreen();
     });
   });

--- a/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
+++ b/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
@@ -192,6 +192,8 @@ const PredictBuyPreview = () => {
     ? outcome.groupItemTitle
     : '';
 
+  const maxBetAmount = balance - (providerFee + metamaskFee);
+
   const separator = '·';
   const outcomeTokenLabel = `${outcomeToken?.title} at ${formatCents(
     preview?.sharePrice ?? outcomeToken?.price ?? 0,
@@ -351,7 +353,12 @@ const PredictBuyPreview = () => {
             color={TextColor.Error}
             style={tw.style('text-center')}
           >
-            {strings('predict.order.prediction_insufficient_funds')}
+            {strings('predict.order.prediction_insufficient_funds', {
+              amount: formatPrice(maxBetAmount, {
+                minimumDecimals: 2,
+                maximumDecimals: 2,
+              }),
+            })}
           </Text>
         </Box>
       );

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1918,8 +1918,8 @@
       "prediction_placed": "Prediction placed",
       "order_failed": "Order failed",
       "payments_made_in_usdc": "All payments are made in USDC",
-      "prediction_insufficient_funds": "Insufficient funds. Lower the amount or add funds to continue.",
-      "prediction_minimum_bet": "Minimum bet is {{amount}}",
+      "prediction_insufficient_funds": "Not enough funds. You can use up to {{amount}}.",
+      "prediction_minimum_bet": "Minimum amount is {{amount}}",
       "to_win": "To win",
       "order_failed_generic": "Transaction failed. Please try again."
     },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Adjust button heights and spacing in PredictKeypad for better UX
- Implement dynamic label formatting in PredictMarketOutcome buttons
  - Use bullet separator (•) when both labels are ≤6 characters
  - Use newline separator when either label exceeds 6 characters
  - Adjust button height dynamically based on label length
- Update insufficient funds message to show available balance
- Improve error message copy for better user understanding
  - "Not enough funds. You can use up to {amount}." (was "Insufficient funds...")
  - "Minimum amount is {amount}" (was "Minimum bet is {amount}")
- Add comprehensive test coverage for button label formatting scenarios

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines Predict keypad/button layout, adds dynamic outcome button label formatting, and updates Buy Preview errors to show max usable amount with new copy, plus tests and i18n updates.
> 
> - **Predict UI**:
>   - **Outcome buttons (`PredictMarketOutcome`)**: Add dynamic label formatting (bullet vs newline) with `MAX_LABEL_LENGTH=6`, center text, and increase button height when labels are long.
>   - **Keypad (`PredictKeypad`)**: Tighten spacing and set fixed heights for quick-amount and "Done" buttons.
> - **Buy Preview (`PredictBuyPreview`)**:
>   - Compute `maxBetAmount` and render updated error copy: "Not enough funds. You can use up to {{amount}}." and "Minimum amount is {{amount}}" via i18n.
> - **Tests**:
>   - Add comprehensive tests for outcome label formatting and update validation/error expectations across Buy Preview.
> - **i18n (`locales/languages/en.json`)**:
>   - Update `prediction_insufficient_funds` and `prediction_minimum_bet` strings to new copy with amount placeholders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f7bbb2d1b259a5429b5eae98dc69b02c00ae40b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->