### PR TITLE
Fix pull request review branch filter

### DIFF
--- a/.github/workflows/release-pr-approval.yml
+++ b/.github/workflows/release-pr-approval.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   release-pr-approval:
+    if: >
+      startsWith(github.event.pull_request.base.ref, 'Version-v') ||
+      startsWith(github.event.pull_request.base.ref, 'release/')
     runs-on: ubuntu-latest
     steps:
       - name: Require Release Team approval


### PR DESCRIPTION
Add a branch condition to the `release-pr-approval` job to prevent `pull_request_review` events from triggering for non-release branches.

The `pull_request_review` event does not inherit branch filters from the `pull_request` event, causing the workflow to trigger for reviews on all PRs regardless of their target branch. This change adds a job-level condition to explicitly check the base branch, ensuring the workflow only runs for PRs targeting `Version-v*` or `release/*` branches.

---
<a href="https://cursor.com/background-agent?bcId=bc-53c49cee-ee4e-44c7-ae80-76b861a6cff2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-53c49cee-ee4e-44c7-ae80-76b861a6cff2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

