### PR TITLE
feat(predict): geoblock DE and RO

### DIFF
--- a/app/components/UI/Predict/constants/geoblock.test.ts
+++ b/app/components/UI/Predict/constants/geoblock.test.ts
@@ -1,0 +1,30 @@
+import { GEO_BLOCKED_COUNTRIES } from './geoblock';
+
+describe('GEO_BLOCKED_COUNTRIES', () => {
+  it('contains DE', () => {
+    const hasDE = GEO_BLOCKED_COUNTRIES.some(
+      (region) => region.country === 'DE',
+    );
+
+    expect(hasDE).toBe(true);
+  });
+
+  it('contains RO', () => {
+    const hasRO = GEO_BLOCKED_COUNTRIES.some(
+      (region) => region.country === 'RO',
+    );
+
+    expect(hasRO).toBe(true);
+  });
+
+  it('has exactly 2 entries', () => {
+    expect(GEO_BLOCKED_COUNTRIES).toHaveLength(2);
+  });
+
+  it('has country property for each entry', () => {
+    GEO_BLOCKED_COUNTRIES.forEach((region) => {
+      expect(region).toHaveProperty('country');
+      expect(typeof region.country).toBe('string');
+    });
+  });
+});

--- a/app/components/UI/Predict/constants/geoblock.ts
+++ b/app/components/UI/Predict/constants/geoblock.ts
@@ -1,0 +1,12 @@
+interface Region {
+  country: string;
+}
+
+export const GEO_BLOCKED_COUNTRIES: Region[] = [
+  {
+    country: 'DE',
+  },
+  {
+    country: 'RO',
+  },
+];

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -1355,6 +1355,199 @@ describe('PredictController', () => {
         expect(mockSecondProvider.isEligible).toHaveBeenCalled();
       });
     });
+
+    describe('local geoblocking', () => {
+      it('sets eligibility to false when provider returns eligible but country is DE', async () => {
+        await withController(async ({ controller }) => {
+          mockPolymarketProvider.isEligible.mockResolvedValue({
+            isEligible: true,
+            country: 'DE',
+          });
+
+          await controller.refreshEligibility();
+
+          expect(controller.state.eligibility.polymarket).toEqual({
+            eligible: false,
+            country: 'DE',
+          });
+          expect(mockPolymarketProvider.isEligible).toHaveBeenCalled();
+        });
+      });
+
+      it('sets eligibility to false when provider returns eligible but country is RO', async () => {
+        await withController(async ({ controller }) => {
+          mockPolymarketProvider.isEligible.mockResolvedValue({
+            isEligible: true,
+            country: 'RO',
+          });
+
+          await controller.refreshEligibility();
+
+          expect(controller.state.eligibility.polymarket).toEqual({
+            eligible: false,
+            country: 'RO',
+          });
+          expect(mockPolymarketProvider.isEligible).toHaveBeenCalled();
+        });
+      });
+
+      it('sets eligibility to true when provider returns eligible and country is US', async () => {
+        await withController(async ({ controller }) => {
+          mockPolymarketProvider.isEligible.mockResolvedValue({
+            isEligible: true,
+            country: 'US',
+          });
+
+          await controller.refreshEligibility();
+
+          expect(controller.state.eligibility.polymarket).toEqual({
+            eligible: true,
+            country: 'US',
+          });
+          expect(mockPolymarketProvider.isEligible).toHaveBeenCalled();
+        });
+      });
+
+      it('sets eligibility to false when provider returns ineligible regardless of country', async () => {
+        await withController(async ({ controller }) => {
+          mockPolymarketProvider.isEligible.mockResolvedValue({
+            isEligible: false,
+            country: 'US',
+          });
+
+          await controller.refreshEligibility();
+
+          expect(controller.state.eligibility.polymarket).toEqual({
+            eligible: false,
+            country: 'US',
+          });
+          expect(mockPolymarketProvider.isEligible).toHaveBeenCalled();
+        });
+      });
+
+      it('sets eligibility to true when provider returns eligible without country', async () => {
+        await withController(async ({ controller }) => {
+          mockPolymarketProvider.isEligible.mockResolvedValue({
+            isEligible: true,
+            country: undefined,
+          });
+
+          await controller.refreshEligibility();
+
+          expect(controller.state.eligibility.polymarket).toEqual({
+            eligible: true,
+            country: undefined,
+          });
+          expect(mockPolymarketProvider.isEligible).toHaveBeenCalled();
+        });
+      });
+
+      it('sets eligibility to true when provider returns eligible with null country', async () => {
+        await withController(async ({ controller }) => {
+          mockPolymarketProvider.isEligible.mockResolvedValue({
+            isEligible: true,
+            country: null as any,
+          });
+
+          await controller.refreshEligibility();
+
+          expect(controller.state.eligibility.polymarket).toEqual({
+            eligible: true,
+            country: null,
+          });
+          expect(mockPolymarketProvider.isEligible).toHaveBeenCalled();
+        });
+      });
+
+      it('sets eligibility to true when provider returns eligible with empty string country', async () => {
+        await withController(async ({ controller }) => {
+          mockPolymarketProvider.isEligible.mockResolvedValue({
+            isEligible: true,
+            country: '',
+          });
+
+          await controller.refreshEligibility();
+
+          expect(controller.state.eligibility.polymarket).toEqual({
+            eligible: true,
+            country: '',
+          });
+          expect(mockPolymarketProvider.isEligible).toHaveBeenCalled();
+        });
+      });
+    });
+  });
+
+  describe('isLocallyGeoblocked', () => {
+    it('returns true for blocked country DE', () => {
+      withController(({ controller }) => {
+        const region = { country: 'DE' };
+
+        const result = (controller as any).isLocallyGeoblocked(region);
+
+        expect(result).toBe(true);
+      });
+    });
+
+    it('returns true for blocked country RO', () => {
+      withController(({ controller }) => {
+        const region = { country: 'RO' };
+
+        const result = (controller as any).isLocallyGeoblocked(region);
+
+        expect(result).toBe(true);
+      });
+    });
+
+    it('returns false for non-blocked country US', () => {
+      withController(({ controller }) => {
+        const region = { country: 'US' };
+
+        const result = (controller as any).isLocallyGeoblocked(region);
+
+        expect(result).toBe(false);
+      });
+    });
+
+    it('returns false for empty string country code', () => {
+      withController(({ controller }) => {
+        const region = { country: '' };
+
+        const result = (controller as any).isLocallyGeoblocked(region);
+
+        expect(result).toBe(false);
+      });
+    });
+
+    it('returns false for lowercase blocked country code de', () => {
+      withController(({ controller }) => {
+        const region = { country: 'de' };
+
+        const result = (controller as any).isLocallyGeoblocked(region);
+
+        expect(result).toBe(false);
+      });
+    });
+
+    it('returns false for country code with extra spaces', () => {
+      withController(({ controller }) => {
+        const region = { country: ' DE ' };
+
+        const result = (controller as any).isLocallyGeoblocked(region);
+
+        expect(result).toBe(false);
+      });
+    });
+
+    it('returns false for partial match DES', () => {
+      withController(({ controller }) => {
+        const region = { country: 'DES' };
+
+        const result = (controller as any).isLocallyGeoblocked(region);
+
+        expect(result).toBe(false);
+      });
+    });
   });
 
   describe('multiple providers', () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR adds local geoblocking functionality for Germany (DE) and Romania (RO) to the Predict feature.

**What is the reason for the change?**
The Predict feature needs to comply with regional regulations by restricting access for users in specific countries. While the provider (Polymarket) performs its own eligibility checks, we need an additional layer of local geoblocking to ensure compliance.

**What is the improvement/solution?**

- Created a new constants file (`geoblock.ts`) that defines the list of geo-blocked countries
- Added a private method `isLocallyGeoblocked()` to check if a user's country is in the blocked list
- Modified the `refreshEligibility()` method to apply local geoblocking after the provider's eligibility check
- When a provider returns `isEligible: true` but the country is in our blocked list, we override it to `isEligible: false`
- The user's country code is preserved in the state for tracking and analytics purposes

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Predict geoblocking for DE and RO

  Scenario: user from Germany is blocked from using Predict
    Given app is running with Predict feature enabled
    And user's location is detected as Germany (DE)

    When user attempts to access Predict feature
    Then user sees geoblocking message indicating feature is not available in their region

  Scenario: user from Romania is blocked from using Predict
    Given app is running with Predict feature enabled
    And user's location is detected as Romania (RO)

    When user attempts to access Predict feature
    Then user sees geoblocking message indicating feature is not available in their region

  Scenario: user from United States can access Predict
    Given app is running with Predict feature enabled
    And user's location is detected as United States (US)

    When user attempts to access Predict feature
    Then user successfully accesses the Predict feature

  Scenario: provider blocks user but local check passes
    Given app is running with Predict feature enabled
    And provider's eligibility check returns ineligible

    When user attempts to access Predict feature
    Then user sees geoblocking message regardless of local geoblocking status
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- No geoblocking - users from DE and RO could access Predict if provider allowed -->

### **After**

<!-- Users from DE and RO are blocked even if provider allows access -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---

## **Test Coverage**

This PR includes comprehensive unit and integration tests:

### Unit Tests (7 tests)

- `isLocallyGeoblocked()` method with DE, RO, and non-blocked countries
- Edge cases: empty string, lowercase, extra spaces, partial matches

### Integration Tests (7 tests)

- `refreshEligibility()` with local geoblocking logic
- Provider eligible + locally blocked countries (DE, RO)
- Provider eligible + allowed countries (US)
- Provider ineligible scenarios
- Edge cases: undefined, null, empty string countries

### Constants Tests (4 tests)

- Validation of GEO_BLOCKED_COUNTRIES array structure and contents

**Total: 18 new tests, all passing ✅**

### Files Changed

- `app/components/UI/Predict/constants/geoblock.ts` (new file)
- `app/components/UI/Predict/controllers/PredictController.ts` (modified)
- `app/components/UI/Predict/controllers/PredictController.test.ts` (tests added)
- `app/components/UI/Predict/constants/geoblock.test.ts` (new test file)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a local geo-block list (DE, RO) and updates PredictController to override provider eligibility based on it, with comprehensive unit tests.
> 
> - **PredictController (`controllers/PredictController.ts`)**:
>   - Add `GEO_BLOCKED_COUNTRIES` import and private `isLocallyGeoblocked()`.
>   - Update `refreshEligibility()` to override provider `isEligible` to false when country is locally blocked; preserve `country` in state.
> - **Constants (`constants/geoblock.ts`)**:
>   - New `GEO_BLOCKED_COUNTRIES` list with `DE` and `RO`.
> - **Tests**:
>   - New `constants/geoblock.test.ts` validating structure and entries.
>   - Expanded `PredictController.test.ts` covering local geoblocking flows (DE/RO block, allowed countries, undefined/null/empty), and `isLocallyGeoblocked` edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84cfbae05cf011fda06ec1ba9211061040e6d1e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->