### PR TITLE
fix(predict): Use the outcome title on a single market cards

### DIFF
--- a/app/components/UI/Predict/components/PredictMarketSingle/PredictMarketSingle.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSingle/PredictMarketSingle.tsx
@@ -236,7 +236,7 @@ const PredictMarketSingle: React.FC<PredictMarketSingleProps> = ({
             width={ButtonWidthTypes.Full}
             label={
               <Text style={tw.style('font-medium')} color={TextColor.Success}>
-                {strings('predict.buy_yes')}
+                {outcome.tokens[0].title}
               </Text>
             }
             onPress={() => handleBuy(outcome.tokens[0])}
@@ -248,7 +248,7 @@ const PredictMarketSingle: React.FC<PredictMarketSingleProps> = ({
             width={ButtonWidthTypes.Full}
             label={
               <Text style={tw.style('font-medium')} color={TextColor.Error}>
-                {strings('predict.buy_no')}
+                {outcome.tokens[1].title}
               </Text>
             }
             onPress={() => handleBuy(outcome.tokens[1])}

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { ReactTestInstance } from 'react-test-renderer';
 import { screen, fireEvent, waitFor, act } from '@testing-library/react-native';
 import { InteractionManager } from 'react-native';
 import {
@@ -416,7 +417,7 @@ jest.mock('../../../../../component-library/components/Icons/Icon', () => {
 });
 
 function createMockMarket(overrides = {}) {
-  return {
+  const defaultMarket = {
     id: 'market-1',
     title: 'Will Bitcoin reach $100k by end of 2024?',
     image: 'https://example.com/bitcoin.png',
@@ -430,7 +431,13 @@ function createMockMarket(overrides = {}) {
         tokens: [
           {
             id: 'token-1',
+            title: 'Yes',
             price: 0.65,
+          },
+          {
+            id: 'token-2',
+            title: 'No',
+            price: 0.35,
           },
         ],
         volume: 1000000,
@@ -441,14 +448,60 @@ function createMockMarket(overrides = {}) {
         groupItemTitle: 'No',
         tokens: [
           {
-            id: 'token-2',
+            id: 'token-3',
+            title: 'No',
             price: 0.35,
           },
         ],
         volume: 500000,
       },
     ],
+  };
+
+  const mergedMarket = {
+    ...defaultMarket,
     ...overrides,
+  };
+
+  const normalizedOutcomes =
+    mergedMarket.outcomes?.map((outcome, outcomeIndex) => {
+      const fallbackOutcomeTitle =
+        outcome.title ?? `Outcome ${outcomeIndex + 1}`;
+
+      return {
+        ...outcome,
+        groupItemTitle: outcome.groupItemTitle ?? fallbackOutcomeTitle,
+        tokens: (outcome.tokens ?? []).map((token, tokenIndex) => {
+          let tokenTitle = token.title;
+
+          if (!tokenTitle) {
+            if (outcomeIndex === 0 && tokenIndex === 0) {
+              tokenTitle = 'Yes';
+            } else if (outcomeIndex === 0 && tokenIndex === 1) {
+              tokenTitle = 'No';
+            } else {
+              tokenTitle =
+                outcome.groupItemTitle ??
+                outcome.title ??
+                `Token ${tokenIndex + 1}`;
+
+              if (tokenIndex > 0 && tokenTitle === fallbackOutcomeTitle) {
+                tokenTitle = `${tokenTitle} ${tokenIndex + 1}`;
+              }
+            }
+          }
+
+          return {
+            ...token,
+            title: tokenTitle,
+          };
+        }),
+      };
+    }) ?? [];
+
+  return {
+    ...mergedMarket,
+    outcomes: normalizedOutcomes,
   };
 }
 
@@ -611,6 +664,37 @@ function setupPredictMarketDetailsTest(
     mockRoute,
   };
 }
+
+const collapseWhitespace = (text: string) => text.replace(/\s+/g, '');
+
+const extractText = (node: React.ReactNode): string => {
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node);
+  }
+
+  if (Array.isArray(node)) {
+    return node.map(extractText).join('');
+  }
+
+  if (React.isValidElement(node)) {
+    return extractText(node.props.children);
+  }
+
+  return '';
+};
+
+const getActionButtonText = (button: ReactTestInstance) =>
+  collapseWhitespace(extractText(button.props.children));
+
+const getActionButtons = () =>
+  screen
+    .getAllByTestId('button')
+    .filter((button) => getActionButtonText(button).includes('¢'));
+
+const findActionButtonByPrice = (price: number) =>
+  getActionButtons().find(
+    (button) => getActionButtonText(button) === `•${price}¢`,
+  );
 
 describe('PredictMarketDetails', () => {
   afterEach(() => {
@@ -848,7 +932,10 @@ describe('PredictMarketDetails', () => {
           {
             id: 'outcome-1',
             title: 'Yes',
-            tokens: [{ id: 'token-1', price: 0.65 }],
+            tokens: [
+              { id: 'token-1', title: 'Yes', price: 0.65 },
+              { id: 'token-2', title: 'No', price: 0.35 },
+            ],
             volume: 1000000,
           },
         ],
@@ -856,12 +943,11 @@ describe('PredictMarketDetails', () => {
 
       setupPredictMarketDetailsTest(singleOutcomeMarket);
 
-      expect(
-        screen.getByText(/predict\.market_details\.yes\s*•\s*65¢/),
-      ).toBeOnTheScreen();
-      expect(
-        screen.getByText(/predict\.market_details\.no\s*•\s*35¢/),
-      ).toBeOnTheScreen();
+      const actionButtons = getActionButtons();
+      const buttonLabels = actionButtons.map(getActionButtonText);
+
+      expect(actionButtons).toHaveLength(2);
+      expect(buttonLabels).toEqual(expect.arrayContaining(['•65¢', '•35¢']));
     });
 
     it('calculates percentage correctly from market price', () => {
@@ -871,7 +957,10 @@ describe('PredictMarketDetails', () => {
           {
             id: 'outcome-1',
             title: 'Yes',
-            tokens: [{ id: 'token-1', price: 0.75 }],
+            tokens: [
+              { id: 'token-1', title: 'Yes', price: 0.75 },
+              { id: 'token-2', title: 'No', price: 0.25 },
+            ],
             volume: 1000000,
           },
         ],
@@ -879,12 +968,10 @@ describe('PredictMarketDetails', () => {
 
       setupPredictMarketDetailsTest(marketWithDifferentPrice);
 
-      expect(
-        screen.getByText(/predict\.market_details\.yes\s*•\s*75¢/),
-      ).toBeOnTheScreen();
-      expect(
-        screen.getByText(/predict\.market_details\.no\s*•\s*25¢/),
-      ).toBeOnTheScreen();
+      const actionButtons = getActionButtons();
+      const buttonLabels = actionButtons.map(getActionButtonText);
+
+      expect(buttonLabels).toEqual(expect.arrayContaining(['•75¢', '•25¢']));
     });
   });
 
@@ -918,7 +1005,10 @@ describe('PredictMarketDetails', () => {
           {
             id: 'outcome-1',
             title: 'Yes',
-            tokens: [{ id: 'token-1', price: 0.65 }],
+            tokens: [
+              { id: 'token-1', title: 'Yes', price: 0.65 },
+              { id: 'token-2', title: 'No', price: 0.35 },
+            ],
             volume: 1000000,
           },
         ],
@@ -927,9 +1017,10 @@ describe('PredictMarketDetails', () => {
       setupPredictMarketDetailsTest(singleOutcomeMarket);
 
       // The component now shows the percentage in the action buttons instead of a separate text
-      expect(
-        screen.getByText(/predict\.market_details\.yes\s*•\s*65¢/),
-      ).toBeOnTheScreen();
+      const actionButtons = getActionButtons();
+      const buttonLabels = actionButtons.map(getActionButtonText);
+
+      expect(buttonLabels).toContain('•65¢');
     });
 
     it('handles missing price data gracefully', () => {
@@ -939,7 +1030,10 @@ describe('PredictMarketDetails', () => {
           {
             id: 'outcome-1',
             title: 'Yes',
-            tokens: [{ id: 'token-1', price: undefined }],
+            tokens: [
+              { id: 'token-1', title: 'Yes', price: undefined },
+              { id: 'token-2', title: 'No', price: 0.35 },
+            ],
             volume: 1000000,
           },
         ],
@@ -948,9 +1042,10 @@ describe('PredictMarketDetails', () => {
       setupPredictMarketDetailsTest(marketWithoutPrice);
 
       // The component now shows 0% in the action buttons when price is undefined
-      expect(
-        screen.getByText(/predict\.market_details\.yes\s*•\s*0¢/),
-      ).toBeOnTheScreen();
+      const actionButtons = getActionButtons();
+      const buttonLabels = actionButtons.map(getActionButtonText);
+
+      expect(buttonLabels).toEqual(expect.arrayContaining(['•0¢', '•100¢']));
     });
   });
 
@@ -1064,7 +1159,10 @@ describe('PredictMarketDetails', () => {
           {
             id: 'outcome-1',
             title: 'Yes',
-            tokens: [{ id: 'token-1', price: 0.65 }],
+            tokens: [
+              { id: 'token-1', title: 'Yes', price: 0.65 },
+              { id: 'token-2', title: 'No', price: 0.35 },
+            ],
             volume: 1000000,
           },
         ],
@@ -1073,10 +1171,9 @@ describe('PredictMarketDetails', () => {
       const { mockNavigate } =
         setupPredictMarketDetailsTest(singleOutcomeMarket);
 
-      const yesButton = screen.getByText(
-        /predict\.market_details\.yes\s*•\s*65¢/,
-      );
-      fireEvent.press(yesButton);
+      const yesButton = findActionButtonByPrice(65);
+      expect(yesButton).toBeDefined();
+      fireEvent.press(yesButton as ReactTestInstance);
 
       expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
         screen: Routes.PREDICT.MODALS.BUY_PREVIEW,
@@ -1097,8 +1194,8 @@ describe('PredictMarketDetails', () => {
             id: 'outcome-1',
             title: 'Yes',
             tokens: [
-              { id: 'token-1', price: 0.65 },
-              { id: 'token-2', price: 0.35 },
+              { id: 'token-1', title: 'Yes', price: 0.65 },
+              { id: 'token-2', title: 'No', price: 0.35 },
             ],
             volume: 1000000,
           },
@@ -1108,10 +1205,9 @@ describe('PredictMarketDetails', () => {
       const { mockNavigate } =
         setupPredictMarketDetailsTest(singleOutcomeMarket);
 
-      const noButton = screen.getByText(
-        /predict\.market_details\.no\s*•\s*35¢/,
-      );
-      fireEvent.press(noButton);
+      const noButton = findActionButtonByPrice(35);
+      expect(noButton).toBeDefined();
+      fireEvent.press(noButton as ReactTestInstance);
 
       expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
         screen: Routes.PREDICT.MODALS.BUY_PREVIEW,
@@ -1294,7 +1390,10 @@ describe('PredictMarketDetails', () => {
           {
             id: 'outcome-1',
             title: 'Yes',
-            tokens: [{ id: 'token-1', price: 0.65 }],
+            tokens: [
+              { id: 'token-1', title: 'Yes', price: 0.65 },
+              { id: 'token-2', title: 'No', price: 0.35 },
+            ],
             volume: 1000000,
           },
         ],
@@ -1303,9 +1402,10 @@ describe('PredictMarketDetails', () => {
       setupPredictMarketDetailsTest(singleOutcomeMarket);
 
       // The component now shows the percentage in the action buttons instead of a separate text
-      expect(
-        screen.getByText(/predict\.market_details\.yes\s*•\s*65¢/),
-      ).toBeOnTheScreen();
+      const actionButtons = getActionButtons();
+      const buttonLabels = actionButtons.map(getActionButtonText);
+
+      expect(buttonLabels).toContain('•65¢');
     });
 
     it('renders action buttons only for single outcome markets', () => {
@@ -1315,7 +1415,10 @@ describe('PredictMarketDetails', () => {
           {
             id: 'outcome-1',
             title: 'Yes',
-            tokens: [{ id: 'token-1', price: 0.65 }],
+            tokens: [
+              { id: 'token-1', title: 'Yes', price: 0.65 },
+              { id: 'token-2', title: 'No', price: 0.35 },
+            ],
             volume: 1000000,
           },
         ],
@@ -1323,12 +1426,10 @@ describe('PredictMarketDetails', () => {
 
       setupPredictMarketDetailsTest(singleOutcomeMarket);
 
-      expect(
-        screen.getByText(/predict\.market_details\.yes\s*•\s*65¢/),
-      ).toBeOnTheScreen();
-      expect(
-        screen.getByText(/predict\.market_details\.no\s*•\s*35¢/),
-      ).toBeOnTheScreen();
+      const actionButtons = getActionButtons();
+      const buttonLabels = actionButtons.map(getActionButtonText);
+
+      expect(buttonLabels).toEqual(expect.arrayContaining(['•65¢', '•35¢']));
     });
   });
 
@@ -1482,7 +1583,10 @@ describe('PredictMarketDetails', () => {
           {
             id: 'outcome-1',
             title: 'Yes',
-            tokens: [{ id: 'token-1', price: undefined }],
+            tokens: [
+              { id: 'token-1', title: 'Yes', price: undefined },
+              { id: 'token-2', title: 'No', price: 0.35 },
+            ],
             volume: 1000000,
           },
         ],
@@ -1491,9 +1595,11 @@ describe('PredictMarketDetails', () => {
       setupPredictMarketDetailsTest(marketWithUndefinedPrice);
 
       // The component now shows 0% in the action buttons when price is undefined
-      expect(
-        screen.getByText(/predict\.market_details\.yes\s*•\s*0¢/),
-      ).toBeOnTheScreen();
+      const yesButton = findActionButtonByPrice(0);
+      const noButton = findActionButtonByPrice(100);
+
+      expect(yesButton).toBeDefined();
+      expect(noButton).toBeDefined();
     });
   });
 
@@ -1900,7 +2006,10 @@ describe('PredictMarketDetails', () => {
           {
             id: 'outcome-1',
             title: 'Yes',
-            tokens: [{ id: 'token-1', price: 0.65 }],
+            tokens: [
+              { id: 'token-1', title: 'Yes', price: 0.65 },
+              { id: 'token-2', title: 'No', price: 0.35 },
+            ],
             volume: 1000000,
           },
         ],
@@ -1909,10 +2018,9 @@ describe('PredictMarketDetails', () => {
       const { mockNavigate } =
         setupPredictMarketDetailsTest(singleOutcomeMarket);
 
-      const yesButton = screen.getByText(
-        /predict\.market_details\.yes\s*•\s*65¢/,
-      );
-      fireEvent.press(yesButton);
+      const yesButton = findActionButtonByPrice(65);
+      expect(yesButton).toBeDefined();
+      fireEvent.press(yesButton as ReactTestInstance);
 
       expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
         screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,
@@ -1934,8 +2042,8 @@ describe('PredictMarketDetails', () => {
             id: 'outcome-1',
             title: 'Yes',
             tokens: [
-              { id: 'token-1', price: 0.65 },
-              { id: 'token-2', price: 0.35 },
+              { id: 'token-1', title: 'Yes', price: 0.65 },
+              { id: 'token-2', title: 'No', price: 0.35 },
             ],
             volume: 1000000,
           },
@@ -1945,10 +2053,9 @@ describe('PredictMarketDetails', () => {
       const { mockNavigate } =
         setupPredictMarketDetailsTest(singleOutcomeMarket);
 
-      const noButton = screen.getByText(
-        /predict\.market_details\.no\s*•\s*35¢/,
-      );
-      fireEvent.press(noButton);
+      const noButton = findActionButtonByPrice(35);
+      expect(noButton).toBeDefined();
+      fireEvent.press(noButton as ReactTestInstance);
 
       expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
         screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,
@@ -1962,7 +2069,10 @@ describe('PredictMarketDetails', () => {
           {
             id: 'outcome-1',
             title: 'Yes',
-            tokens: [{ id: 'token-1', price: 0.65 }],
+            tokens: [
+              { id: 'token-1', title: 'Yes', price: 0.65 },
+              { id: 'token-2', title: 'No', price: 0.35 },
+            ],
             volume: 1000000,
           },
         ],
@@ -1974,10 +2084,9 @@ describe('PredictMarketDetails', () => {
         { eligibility: { isEligible: false } },
       );
 
-      const yesButton = screen.getByText(
-        /predict\.market_details\.yes\s*•\s*65¢/,
-      );
-      fireEvent.press(yesButton);
+      const yesButton = findActionButtonByPrice(65);
+      expect(yesButton).toBeDefined();
+      fireEvent.press(yesButton as ReactTestInstance);
 
       expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
         screen: Routes.PREDICT.MODALS.UNAVAILABLE,
@@ -1992,8 +2101,8 @@ describe('PredictMarketDetails', () => {
             id: 'outcome-1',
             title: 'Yes',
             tokens: [
-              { id: 'token-1', price: 0.65 },
-              { id: 'token-2', price: 0.35 },
+              { id: 'token-1', title: 'Yes', price: 0.65 },
+              { id: 'token-2', title: 'No', price: 0.35 },
             ],
             volume: 1000000,
           },
@@ -2006,10 +2115,9 @@ describe('PredictMarketDetails', () => {
         { eligibility: { isEligible: false } },
       );
 
-      const noButton = screen.getByText(
-        /predict\.market_details\.no\s*•\s*35¢/,
-      );
-      fireEvent.press(noButton);
+      const noButton = findActionButtonByPrice(35);
+      expect(noButton).toBeDefined();
+      fireEvent.press(noButton as ReactTestInstance);
 
       expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
         screen: Routes.PREDICT.MODALS.UNAVAILABLE,
@@ -2030,7 +2138,10 @@ describe('PredictMarketDetails', () => {
           {
             id: 'outcome-1',
             title: 'Yes',
-            tokens: [{ id: 'token-1', price: 0.65 }],
+            tokens: [
+              { id: 'token-1', title: 'Yes', price: 0.65 },
+              { id: 'token-2', title: 'No', price: 0.35 },
+            ],
             volume: 1000000,
           },
         ],
@@ -2042,10 +2153,9 @@ describe('PredictMarketDetails', () => {
         { eligibility: { isEligible: false } },
       );
 
-      const yesButton = screen.getByText(
-        /predict\.market_details\.yes\s*•\s*65¢/,
-      );
-      fireEvent.press(yesButton);
+      const yesButton = findActionButtonByPrice(65);
+      expect(yesButton).toBeDefined();
+      fireEvent.press(yesButton as ReactTestInstance);
 
       expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
         screen: Routes.PREDICT.MODALS.UNAVAILABLE,
@@ -2073,8 +2183,8 @@ describe('PredictMarketDetails', () => {
             id: 'outcome-1',
             title: 'Yes',
             tokens: [
-              { id: 'token-1', price: 0.65 },
-              { id: 'token-2', price: 0.35 },
+              { id: 'token-1', title: 'Yes', price: 0.65 },
+              { id: 'token-2', title: 'No', price: 0.35 },
             ],
             volume: 1000000,
           },
@@ -2087,10 +2197,9 @@ describe('PredictMarketDetails', () => {
         { eligibility: { isEligible: false } },
       );
 
-      const noButton = screen.getByText(
-        /predict\.market_details\.no\s*•\s*35¢/,
-      );
-      fireEvent.press(noButton);
+      const noButton = findActionButtonByPrice(35);
+      expect(noButton).toBeDefined();
+      fireEvent.press(noButton as ReactTestInstance);
 
       expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
         screen: Routes.PREDICT.MODALS.UNAVAILABLE,

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -904,8 +904,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
                 style={tw.style('flex-1 bg-success-muted')}
                 label={
                   <Text style={tw.style('font-bold')} color={TextColor.Success}>
-                    {strings('predict.market_details.yes')} •{' '}
-                    {getYesPercentage()}¢
+                    {firstOpenOutcome?.tokens[0].title} • {getYesPercentage()}¢
                   </Text>
                 }
                 onPress={() =>
@@ -922,7 +921,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
                 style={tw.style('flex-1 bg-error-muted')}
                 label={
                   <Text style={tw.style('font-bold')} color={TextColor.Error}>
-                    {strings('predict.market_details.no')} •{' '}
+                    {firstOpenOutcome?.tokens[1].title} •{' '}
                     {100 - getYesPercentage()}¢
                   </Text>
                 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Fixes an issue wherein Yes | No (vs the outcome titles) were hardcoded on both the single market cards and market details action button

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: NA

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="420" alt="image" src="https://github.com/user-attachments/assets/ccd1866f-c93a-48e9-9484-64f6e484331a" />

<img width="420" alt="image" src="https://github.com/user-attachments/assets/7a06c75c-a07f-47ce-b0e5-09949146c982" />


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace hardcoded Yes/No with outcome token titles on single market cards and market details action buttons; update tests and helpers accordingly.
> 
> - **UI (Predict)**:
>   - **Single Market Card (`PredictMarketSingle.tsx`)**: Button labels now use `outcome.tokens[0].title` and `outcome.tokens[1].title` instead of localized Yes/No.
>   - **Market Details (`PredictMarketDetails.tsx`)**: Action button labels now display `firstOpenOutcome?.tokens[0|1].title` alongside price (e.g., `• XX¢`).
> - **Tests (`PredictMarketDetails.test.tsx`)**:
>   - Enhanced `createMockMarket` to include/normalize token `title`s.
>   - Added utilities to extract button text and find action buttons by price.
>   - Updated assertions and interactions to use token titles and `•XX¢` labels; expanded edge-case coverage (undefined price, eligibility/balance flows).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4869734fa3697e8d6c3ad6eb09b03aec083778b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->