### PR TITLE
feat(predict): calculate net deposit amount after deducting fees

### DIFF
--- a/app/components/UI/Predict/hooks/usePredictDepositToasts.tsx
+++ b/app/components/UI/Predict/hooks/usePredictDepositToasts.tsx
@@ -7,7 +7,7 @@ import { usePredictBalance } from './usePredictBalance';
 import { POLYMARKET_PROVIDER_ID } from '../providers/polymarket/constants';
 import { useNavigation } from '@react-navigation/native';
 import Routes from '../../../../constants/navigation/Routes';
-import { formatPrice } from '../utils/format';
+import { formatPrice, calculateNetAmount } from '../utils/format';
 import { getEvmAccountFromSelectedAccountGroup } from '../utils/accounts';
 import { useSelector } from 'react-redux';
 import { selectPredictPendingDepositByAddress } from '../selectors/predictController';
@@ -52,10 +52,18 @@ export const usePredictDepositToasts = ({
       description: strings('predict.deposit.account_ready_description', {
         amount: '{amount}',
       }),
-      getAmount: (transactionMeta) =>
-        formatPrice(transactionMeta.metamaskPay?.totalFiat ?? 0, {
-          maximumDecimals: 2,
-        }) ?? 'Balance',
+      getAmount: (transactionMeta) => {
+        const netAmount = calculateNetAmount({
+          totalFiat: transactionMeta.metamaskPay?.totalFiat,
+          bridgeFeeFiat: transactionMeta.metamaskPay?.bridgeFeeFiat,
+          networkFeeFiat: transactionMeta.metamaskPay?.networkFeeFiat,
+        });
+        return (
+          formatPrice(netAmount, {
+            maximumDecimals: 2,
+          }) ?? 'Balance'
+        );
+      },
     },
     errorToastConfig: {
       title: strings('predict.deposit.error_title'),

--- a/app/components/UI/Predict/utils/format.test.ts
+++ b/app/components/UI/Predict/utils/format.test.ts
@@ -8,6 +8,7 @@ import {
   getRecurrence,
   formatCents,
   formatPositionSize,
+  calculateNetAmount,
 } from './format';
 import { Recurrence, PredictSeries } from '../types';
 
@@ -1253,6 +1254,203 @@ describe('format utils', () => {
       });
 
       expect(result).toBe('5');
+    });
+  });
+
+  describe('calculateNetAmount', () => {
+    it('calculates net amount by subtracting fees from total', () => {
+      const params = {
+        totalFiat: '10.00',
+        bridgeFeeFiat: '0.50',
+        networkFeeFiat: '0.25',
+      };
+
+      const result = calculateNetAmount(params);
+
+      expect(result).toBe('9.25');
+    });
+
+    it('calculates net amount with high precision decimal values', () => {
+      const params = {
+        totalFiat: '1.04361142938843253220839271649743403',
+        bridgeFeeFiat: '0.036399',
+        networkFeeFiat: '0.008024478270232503211154803918368',
+      };
+
+      const result = calculateNetAmount(params);
+
+      expect(result).toBe('0.9991879511181999');
+    });
+
+    it('returns "0" when total equals sum of fees', () => {
+      const params = {
+        totalFiat: '1.00',
+        bridgeFeeFiat: '0.50',
+        networkFeeFiat: '0.50',
+      };
+
+      const result = calculateNetAmount(params);
+
+      expect(result).toBe('0');
+    });
+
+    it('returns "0" when fees exceed total', () => {
+      const params = {
+        totalFiat: '1.00',
+        bridgeFeeFiat: '0.75',
+        networkFeeFiat: '0.50',
+      };
+
+      const result = calculateNetAmount(params);
+
+      expect(result).toBe('0');
+    });
+
+    it('returns "0" when totalFiat is undefined', () => {
+      const params = {
+        bridgeFeeFiat: '0.50',
+        networkFeeFiat: '0.25',
+      };
+
+      const result = calculateNetAmount(params);
+
+      expect(result).toBe('0');
+    });
+
+    it('treats missing bridgeFeeFiat as zero', () => {
+      const params = {
+        totalFiat: '10.00',
+        networkFeeFiat: '0.25',
+      };
+
+      const result = calculateNetAmount(params);
+
+      expect(result).toBe('9.75');
+    });
+
+    it('treats missing networkFeeFiat as zero', () => {
+      const params = {
+        totalFiat: '10.00',
+        bridgeFeeFiat: '0.50',
+      };
+
+      const result = calculateNetAmount(params);
+
+      expect(result).toBe('9.5');
+    });
+
+    it('returns full total when both fees are missing', () => {
+      const params = {
+        totalFiat: '10.00',
+      };
+
+      const result = calculateNetAmount(params);
+
+      expect(result).toBe('10');
+    });
+
+    it('returns "0" when all parameters are undefined', () => {
+      const params = {};
+
+      const result = calculateNetAmount(params);
+
+      expect(result).toBe('0');
+    });
+
+    it('returns "0" when totalFiat is invalid string', () => {
+      const params = {
+        totalFiat: 'invalid',
+        bridgeFeeFiat: '0.50',
+        networkFeeFiat: '0.25',
+      };
+
+      const result = calculateNetAmount(params);
+
+      expect(result).toBe('0');
+    });
+
+    it('returns "0" when bridgeFeeFiat is invalid string', () => {
+      const params = {
+        totalFiat: '10.00',
+        bridgeFeeFiat: 'invalid',
+        networkFeeFiat: '0.25',
+      };
+
+      const result = calculateNetAmount(params);
+
+      expect(result).toBe('0');
+    });
+
+    it('returns "0" when networkFeeFiat is invalid string', () => {
+      const params = {
+        totalFiat: '10.00',
+        bridgeFeeFiat: '0.50',
+        networkFeeFiat: 'invalid',
+      };
+
+      const result = calculateNetAmount(params);
+
+      expect(result).toBe('0');
+    });
+
+    it('calculates correctly when fees are zero', () => {
+      const params = {
+        totalFiat: '10.00',
+        bridgeFeeFiat: '0',
+        networkFeeFiat: '0',
+      };
+
+      const result = calculateNetAmount(params);
+
+      expect(result).toBe('10');
+    });
+
+    it('calculates correctly when only bridge fee exists', () => {
+      const params = {
+        totalFiat: '10.00',
+        bridgeFeeFiat: '2.50',
+        networkFeeFiat: '0',
+      };
+
+      const result = calculateNetAmount(params);
+
+      expect(result).toBe('7.5');
+    });
+
+    it('calculates correctly when only network fee exists', () => {
+      const params = {
+        totalFiat: '10.00',
+        bridgeFeeFiat: '0',
+        networkFeeFiat: '3.25',
+      };
+
+      const result = calculateNetAmount(params);
+
+      expect(result).toBe('6.75');
+    });
+
+    it('handles very small decimal amounts precisely', () => {
+      const params = {
+        totalFiat: '0.001',
+        bridgeFeeFiat: '0.0001',
+        networkFeeFiat: '0.0002',
+      };
+
+      const result = calculateNetAmount(params);
+
+      expect(result).toBe('0.0007');
+    });
+
+    it('handles large amounts correctly', () => {
+      const params = {
+        totalFiat: '1000000.00',
+        bridgeFeeFiat: '50.00',
+        networkFeeFiat: '25.00',
+      };
+
+      const result = calculateNetAmount(params);
+
+      expect(result).toBe('999925');
     });
   });
 });

--- a/app/components/UI/Predict/utils/format.ts
+++ b/app/components/UI/Predict/utils/format.ts
@@ -78,6 +78,53 @@ export const formatPrice = (
 };
 
 /**
+ * Calculates the net amount after deducting bridge and network fees from the total fiat amount
+ * @param params - Object containing fee and total amount information
+ * @param params.totalFiat - Total fiat amount as string
+ * @param params.bridgeFeeFiat - Bridge fee amount as string
+ * @param params.networkFeeFiat - Network fee amount as string
+ * @returns Net amount as string after deducting fees, or "0" if calculation fails
+ * @example
+ * calculateNetAmount({
+ *   totalFiat: "1.04361142938843253220839271649743403",
+ *   bridgeFeeFiat: "0.036399",
+ *   networkFeeFiat: "0.008024478270232503211154803918368"
+ * }) => "0.999187951118199"
+ */
+export const calculateNetAmount = (params: {
+  totalFiat?: string;
+  bridgeFeeFiat?: string;
+  networkFeeFiat?: string;
+}): string => {
+  const { totalFiat, bridgeFeeFiat, networkFeeFiat } = params;
+
+  // totalFiat is required - return "0" if missing or invalid
+  if (!totalFiat) {
+    return '0';
+  }
+
+  const total = parseFloat(totalFiat);
+  if (isNaN(total)) {
+    return '0';
+  }
+
+  // Treat missing fees as 0, but validate they are numbers if provided
+  const bridgeFee = bridgeFeeFiat ? parseFloat(bridgeFeeFiat) : 0;
+  const networkFee = networkFeeFiat ? parseFloat(networkFeeFiat) : 0;
+
+  // Return "0" if any provided fee is invalid
+  if (isNaN(bridgeFee) || isNaN(networkFee)) {
+    return '0';
+  }
+
+  // Calculate net amount: totalFiat - bridgeFee - networkFee
+  const netAmount = total - bridgeFee - networkFee;
+
+  // Ensure we don't return negative amounts
+  return netAmount > 0 ? netAmount.toString() : '0';
+};
+
+/**
  * Formats a volume value with appropriate suffix based on magnitude
  * @param volume - Raw numeric volume value
  * @returns Formatted string with suffix:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Add calculateNetAmount utility function to format.ts
- Calculate net amount as totalFiat - bridgeFeeFiat - networkFeeFiat
- Add comprehensive test coverage with 17 test cases covering:
  - Happy path calculations with high precision decimals
  - Edge cases (zero fees, missing parameters)
  - Error conditions (invalid inputs, NaN values)
  - Negative amount protection
- Update usePredictDepositToasts to display net amount instead of total
- Ensure missing fees are treated as zero (practical approach)
- Return "0" for invalid or missing totalFiat

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `calculateNetAmount` and updates deposit toast to show net fiat after fees, with comprehensive tests.
> 
> - **Utils**:
>   - Add `calculateNetAmount` in `app/components/UI/Predict/utils/format.ts` to compute net fiat (`totalFiat - bridgeFeeFiat - networkFeeFiat`) with validation and non-negative guard.
> - **UI**:
>   - Update `usePredictDepositToasts` to display net amount in confirmed toast using `calculateNetAmount` + `formatPrice`.
> - **Tests**:
>   - Expand `format.test.ts` with extensive cases for `calculateNetAmount` (valid, precision, missing/invalid inputs, zero/large values).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3d56a6150f3ef81294320f71a0b9c5ea69c2d41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->