### PR TITLE
feat: add use-feature-flag

### DIFF
--- a/app/components/UI/BackupAlert/BackupAlert.test.tsx
+++ b/app/components/UI/BackupAlert/BackupAlert.test.tsx
@@ -36,6 +36,8 @@ describe('BackupAlert', () => {
       {
         state: initialState,
       },
+      true,
+      false,
     );
     expect(toJSON()).toMatchSnapshot();
   });
@@ -46,6 +48,8 @@ describe('BackupAlert', () => {
       {
         state: initialState,
       },
+      true,
+      false,
     );
     const rightButton = getByTestId(PROTECT_WALLET_BUTTON);
     fireEvent.press(rightButton);

--- a/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.test.tsx
@@ -256,6 +256,10 @@ jest.mock('../../../../../component-library/components/Skeleton', () => {
   };
 });
 
+jest.mock('../../../../../contexts/FeatureFlagOverrideContext', () => ({
+  FeatureFlagOverrideProvider: jest.fn(({ children }) => children),
+}));
+
 jest.mock('react-native', () => {
   const RN = jest.requireActual('react-native');
   return {

--- a/app/components/UI/Stake/components/GasImpactModal/GasImpactModal.test.tsx
+++ b/app/components/UI/Stake/components/GasImpactModal/GasImpactModal.test.tsx
@@ -94,6 +94,9 @@ const renderGasImpactModal = () =>
     <SafeAreaProvider initialMetrics={initialMetrics}>
       <GasImpactModal {...props} />,
     </SafeAreaProvider>,
+    undefined,
+    true,
+    false,
   );
 
 describe('GasImpactModal', () => {

--- a/app/components/UI/TransactionHeader/index.test.tsx
+++ b/app/components/UI/TransactionHeader/index.test.tsx
@@ -66,6 +66,8 @@ describe('TransactionHeader', () => {
     const wrapper = renderWithProvider(
       <TransactionHeader {...defaultProps} />,
       { state: mockInitialState },
+      true,
+      false,
     );
     expect(wrapper).toMatchSnapshot();
   });
@@ -84,6 +86,8 @@ describe('TransactionHeader', () => {
         }}
       />,
       { state: mockInitialState },
+      true,
+      false,
     );
 
     expect(

--- a/app/components/Views/FeatureFlagOverride/FeatureFlagOverride.test.tsx
+++ b/app/components/Views/FeatureFlagOverride/FeatureFlagOverride.test.tsx
@@ -6,7 +6,10 @@ import FeatureFlagOverride from './FeatureFlagOverride';
 import { useFeatureFlagOverride } from '../../../contexts/FeatureFlagOverrideContext';
 import { useFeatureFlagStats } from '../../../hooks/useFeatureFlagStats';
 import { getNavigationOptionsTitle } from '../../UI/Navbar';
-import { FeatureFlagInfo , isMinimumRequiredVersionSupported } from '../../../util/feature-flags';
+import {
+  FeatureFlagInfo,
+  isMinimumRequiredVersionSupported,
+} from '../../../util/feature-flags';
 import { FeatureFlagNames } from '../../hooks/useFeatureFlag';
 
 // Mock all dependencies
@@ -142,9 +145,7 @@ describe('FeatureFlagOverride', () => {
     });
 
     // Default mock for version support
-    (
-      isMinimumRequiredVersionSupported as jest.Mock
-    ).mockReturnValue(true);
+    (isMinimumRequiredVersionSupported as jest.Mock).mockReturnValue(true);
   });
 
   describe('Component Rendering', () => {
@@ -599,9 +600,7 @@ describe('FeatureFlagOverride', () => {
 
   describe('Boolean with MinimumVersion Flag', () => {
     it('disables switch when version is not supported and flag is not in FeatureFlagNames', () => {
-      (
-        isMinimumRequiredVersionSupported as jest.Mock
-      ).mockReturnValue(false);
+      (isMinimumRequiredVersionSupported as jest.Mock).mockReturnValue(false);
 
       const versionFlag = createMockFeatureFlag(
         'unsupportedVersionFlag',
@@ -629,9 +628,7 @@ describe('FeatureFlagOverride', () => {
     });
 
     it('enables switch when version is supported even if flag is not in FeatureFlagNames', () => {
-      (
-        isMinimumRequiredVersionSupported as jest.Mock
-      ).mockReturnValue(true);
+      (isMinimumRequiredVersionSupported as jest.Mock).mockReturnValue(true);
 
       const versionFlag = createMockFeatureFlag(
         'supportedVersionFlag',
@@ -659,9 +656,7 @@ describe('FeatureFlagOverride', () => {
     });
 
     it('enables switch when flag is in FeatureFlagNames even if version is not supported', () => {
-      (
-        isMinimumRequiredVersionSupported as jest.Mock
-      ).mockReturnValue(false);
+      (isMinimumRequiredVersionSupported as jest.Mock).mockReturnValue(false);
 
       const versionFlag = createMockFeatureFlag(
         FeatureFlagNames.rewardsEnabled,
@@ -721,9 +716,7 @@ describe('FeatureFlagOverride', () => {
     });
 
     it('displays version support indicator correctly when version is supported', () => {
-      (
-        isMinimumRequiredVersionSupported as jest.Mock
-      ).mockReturnValue(true);
+      (isMinimumRequiredVersionSupported as jest.Mock).mockReturnValue(true);
 
       const versionFlag = createMockFeatureFlag(
         'versionFlag',
@@ -747,9 +740,7 @@ describe('FeatureFlagOverride', () => {
     });
 
     it('displays version support indicator correctly when version is not supported', () => {
-      (
-        isMinimumRequiredVersionSupported as jest.Mock
-      ).mockReturnValue(false);
+      (isMinimumRequiredVersionSupported as jest.Mock).mockReturnValue(false);
 
       const versionFlag = createMockFeatureFlag(
         'versionFlag',

--- a/app/components/Views/FeatureFlagOverride/FeatureFlagOverride.test.tsx
+++ b/app/components/Views/FeatureFlagOverride/FeatureFlagOverride.test.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react-native';
+import { Alert } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import FeatureFlagOverride from './FeatureFlagOverride';
 import { useFeatureFlagOverride } from '../../../contexts/FeatureFlagOverrideContext';
 import { useFeatureFlagStats } from '../../../hooks/useFeatureFlagStats';
 import { getNavigationOptionsTitle } from '../../UI/Navbar';
-import { FeatureFlagInfo } from '../../../util/feature-flags';
+import { FeatureFlagInfo , isMinimumRequiredVersionSupported } from '../../../util/feature-flags';
+import { FeatureFlagNames } from '../../hooks/useFeatureFlag';
 
 // Mock all dependencies
 jest.mock('@react-navigation/native', () => ({
@@ -61,6 +63,16 @@ jest.mock('@metamask/design-system-twrnc-preset', () => ({
   }),
 }));
 
+// Mock Alert
+const mockAlert = jest.fn();
+jest.spyOn(Alert, 'alert').mockImplementation(mockAlert);
+
+// Mock feature flags utility
+jest.mock('../../../util/feature-flags', () => ({
+  ...jest.requireActual('../../../util/feature-flags'),
+  isMinimumRequiredVersionSupported: jest.fn(),
+}));
+
 describe('FeatureFlagOverride', () => {
   let mockNavigation: ReturnType<typeof useNavigation>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -112,6 +124,7 @@ describe('FeatureFlagOverride', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockAlert.mockClear();
 
     mockNavigation = {
       setOptions: jest.fn(),
@@ -127,6 +140,11 @@ describe('FeatureFlagOverride', () => {
       clearAllOverrides: jest.fn(),
       featureFlagsList: createMockFeatureFlags(),
     });
+
+    // Default mock for version support
+    (
+      isMinimumRequiredVersionSupported as jest.Mock
+    ).mockReturnValue(true);
   });
 
   describe('Component Rendering', () => {
@@ -576,6 +594,344 @@ describe('FeatureFlagOverride', () => {
       // Note: The actual state reset would be handled by the useFeatureFlagOverride hook
       // This test verifies that the reset button is accessible and can be pressed
       expect(resetButton).toBeTruthy();
+    });
+  });
+
+  describe('Boolean with MinimumVersion Flag', () => {
+    it('disables switch when version is not supported and flag is not in FeatureFlagNames', () => {
+      (
+        isMinimumRequiredVersionSupported as jest.Mock
+      ).mockReturnValue(false);
+
+      const versionFlag = createMockFeatureFlag(
+        'unsupportedVersionFlag',
+        'boolean with minimumVersion',
+        {
+          enabled: true,
+          minimumVersion: '2.0.0',
+        },
+      );
+
+      (useFeatureFlagOverride as jest.Mock).mockReturnValue({
+        setOverride: jest.fn(),
+        removeOverride: jest.fn(),
+        clearAllOverrides: jest.fn(),
+        featureFlagsList: [versionFlag],
+      });
+
+      render(<FeatureFlagOverride />);
+
+      const switches = screen.getAllByRole('switch');
+      const versionSwitch = switches.find(
+        (switchElement) => switchElement.props.value === true,
+      );
+      expect(versionSwitch?.props.disabled).toBe(true);
+    });
+
+    it('enables switch when version is supported even if flag is not in FeatureFlagNames', () => {
+      (
+        isMinimumRequiredVersionSupported as jest.Mock
+      ).mockReturnValue(true);
+
+      const versionFlag = createMockFeatureFlag(
+        'supportedVersionFlag',
+        'boolean with minimumVersion',
+        {
+          enabled: true,
+          minimumVersion: '1.0.0',
+        },
+      );
+
+      (useFeatureFlagOverride as jest.Mock).mockReturnValue({
+        setOverride: jest.fn(),
+        removeOverride: jest.fn(),
+        clearAllOverrides: jest.fn(),
+        featureFlagsList: [versionFlag],
+      });
+
+      render(<FeatureFlagOverride />);
+
+      const switches = screen.getAllByRole('switch');
+      const versionSwitch = switches.find(
+        (switchElement) => switchElement.props.value === true,
+      );
+      expect(versionSwitch?.props.disabled).toBe(false);
+    });
+
+    it('enables switch when flag is in FeatureFlagNames even if version is not supported', () => {
+      (
+        isMinimumRequiredVersionSupported as jest.Mock
+      ).mockReturnValue(false);
+
+      const versionFlag = createMockFeatureFlag(
+        FeatureFlagNames.rewardsEnabled,
+        'boolean with minimumVersion',
+        {
+          enabled: true,
+          minimumVersion: '2.0.0',
+        },
+      );
+
+      (useFeatureFlagOverride as jest.Mock).mockReturnValue({
+        setOverride: jest.fn(),
+        removeOverride: jest.fn(),
+        clearAllOverrides: jest.fn(),
+        featureFlagsList: [versionFlag],
+      });
+
+      render(<FeatureFlagOverride />);
+
+      const switches = screen.getAllByRole('switch');
+      const versionSwitch = switches.find(
+        (switchElement) => switchElement.props.value === true,
+      );
+      expect(versionSwitch?.props.disabled).toBe(false);
+    });
+
+    it('handles toggle for boolean with minimumVersion flag', () => {
+      const mockSetOverride = jest.fn();
+      const versionFlagValue = {
+        enabled: false,
+        minimumVersion: '1.0.0',
+      };
+
+      (useFeatureFlagOverride as jest.Mock).mockReturnValue({
+        setOverride: mockSetOverride,
+        removeOverride: jest.fn(),
+        clearAllOverrides: jest.fn(),
+        featureFlagsList: [
+          createMockFeatureFlag(
+            'versionFlag',
+            'boolean with minimumVersion',
+            versionFlagValue,
+          ),
+        ],
+      });
+
+      render(<FeatureFlagOverride />);
+
+      const switches = screen.getAllByRole('switch');
+      const versionSwitch = switches[0];
+      fireEvent(versionSwitch, 'valueChange', true);
+
+      expect(mockSetOverride).toHaveBeenCalledWith('versionFlag', {
+        enabled: true,
+        minimumVersion: '1.0.0',
+      });
+    });
+
+    it('displays version support indicator correctly when version is supported', () => {
+      (
+        isMinimumRequiredVersionSupported as jest.Mock
+      ).mockReturnValue(true);
+
+      const versionFlag = createMockFeatureFlag(
+        'versionFlag',
+        'boolean with minimumVersion',
+        {
+          enabled: true,
+          minimumVersion: '1.0.0',
+        },
+      );
+
+      (useFeatureFlagOverride as jest.Mock).mockReturnValue({
+        setOverride: jest.fn(),
+        removeOverride: jest.fn(),
+        clearAllOverrides: jest.fn(),
+        featureFlagsList: [versionFlag],
+      });
+
+      render(<FeatureFlagOverride />);
+
+      expect(screen.getByText('Minimum Version: 1.0.0')).toBeTruthy();
+    });
+
+    it('displays version support indicator correctly when version is not supported', () => {
+      (
+        isMinimumRequiredVersionSupported as jest.Mock
+      ).mockReturnValue(false);
+
+      const versionFlag = createMockFeatureFlag(
+        'versionFlag',
+        'boolean with minimumVersion',
+        {
+          enabled: true,
+          minimumVersion: '2.0.0',
+        },
+      );
+
+      (useFeatureFlagOverride as jest.Mock).mockReturnValue({
+        setOverride: jest.fn(),
+        removeOverride: jest.fn(),
+        clearAllOverrides: jest.fn(),
+        featureFlagsList: [versionFlag],
+      });
+
+      render(<FeatureFlagOverride />);
+
+      expect(screen.getByText('Minimum Version: 2.0.0')).toBeTruthy();
+    });
+  });
+
+  describe('Boolean Flag Disabled State', () => {
+    it('disables boolean switch when flag is not in FeatureFlagNames', () => {
+      (useFeatureFlagOverride as jest.Mock).mockReturnValue({
+        setOverride: jest.fn(),
+        removeOverride: jest.fn(),
+        clearAllOverrides: jest.fn(),
+        featureFlagsList: [
+          createMockFeatureFlag('unknownBooleanFlag', 'boolean', false),
+        ],
+      });
+
+      render(<FeatureFlagOverride />);
+
+      const switches = screen.getAllByRole('switch');
+      const booleanSwitch = switches[0];
+      expect(booleanSwitch.props.disabled).toBe(true);
+    });
+
+    it('enables boolean switch when flag is in FeatureFlagNames', () => {
+      (useFeatureFlagOverride as jest.Mock).mockReturnValue({
+        setOverride: jest.fn(),
+        removeOverride: jest.fn(),
+        clearAllOverrides: jest.fn(),
+        featureFlagsList: [
+          createMockFeatureFlag(
+            FeatureFlagNames.rewardsEnabled,
+            'boolean',
+            false,
+          ),
+        ],
+      });
+
+      render(<FeatureFlagOverride />);
+
+      const switches = screen.getAllByRole('switch');
+      const booleanSwitch = switches[0];
+      expect(booleanSwitch.props.disabled).toBe(false);
+    });
+  });
+
+  describe('Empty State Messages', () => {
+    it('shows correct message when search and type filter both active with no results', () => {
+      (useFeatureFlagOverride as jest.Mock).mockReturnValue({
+        setOverride: jest.fn(),
+        removeOverride: jest.fn(),
+        clearAllOverrides: jest.fn(),
+        featureFlagsList: [
+          createMockFeatureFlag('onlyString', 'string', 'value'),
+        ],
+      });
+
+      render(<FeatureFlagOverride />);
+
+      const searchInput = screen.getByPlaceholderText(
+        'Search feature flags...',
+      );
+      fireEvent.changeText(searchInput, 'nonexistent');
+
+      const filterButton = screen.getByText('All (1)');
+      fireEvent.press(filterButton);
+
+      expect(
+        screen.getByText('No boolean feature flags match your search.'),
+      ).toBeTruthy();
+    });
+
+    it('shows correct message when only type filter is active with no results', () => {
+      (useFeatureFlagOverride as jest.Mock).mockReturnValue({
+        setOverride: jest.fn(),
+        removeOverride: jest.fn(),
+        clearAllOverrides: jest.fn(),
+        featureFlagsList: [
+          createMockFeatureFlag('onlyString', 'string', 'value'),
+        ],
+      });
+
+      render(<FeatureFlagOverride />);
+
+      const filterButton = screen.getByText('All (1)');
+      fireEvent.press(filterButton);
+
+      expect(
+        screen.getByText('No boolean feature flags available.'),
+      ).toBeTruthy();
+    });
+
+    it('shows correct message when only search is active with no results', () => {
+      (useFeatureFlagOverride as jest.Mock).mockReturnValue({
+        setOverride: jest.fn(),
+        removeOverride: jest.fn(),
+        clearAllOverrides: jest.fn(),
+        featureFlagsList: createMockFeatureFlags(),
+      });
+
+      render(<FeatureFlagOverride />);
+
+      const searchInput = screen.getByPlaceholderText(
+        'Search feature flags...',
+      );
+      fireEvent.changeText(searchInput, 'nonexistent');
+
+      expect(
+        screen.getByText('No feature flags match your search.'),
+      ).toBeTruthy();
+    });
+  });
+
+  describe('Default Case in renderValueEditor', () => {
+    it('renders default text display for unknown flag types', () => {
+      // Create a flag with a type that doesn't match any case
+      // We'll use 'boolean' type but with a value that might trigger default
+      (useFeatureFlagOverride as jest.Mock).mockReturnValue({
+        setOverride: jest.fn(),
+        removeOverride: jest.fn(),
+        clearAllOverrides: jest.fn(),
+        featureFlagsList: [
+          {
+            key: 'unknownTypeFlag',
+            value: 'some value',
+            originalValue: 'some value',
+            type: 'boolean' as FeatureFlagInfo['type'],
+            description: undefined,
+            isOverridden: false,
+          },
+        ],
+      });
+
+      render(<FeatureFlagOverride />);
+
+      // The component should still render the flag
+      expect(screen.getByText('unknownTypeFlag')).toBeTruthy();
+    });
+  });
+
+  describe('Filtered Count Display', () => {
+    it('shows filtered count when type filter is active', () => {
+      render(<FeatureFlagOverride />);
+
+      const filterButton = screen.getByText('All (6)');
+      fireEvent.press(filterButton);
+
+      expect(screen.getByText('Showing: 2 flags')).toBeTruthy();
+    });
+
+    it('shows filtered count when search is active', () => {
+      render(<FeatureFlagOverride />);
+
+      const searchInput = screen.getByPlaceholderText(
+        'Search feature flags...',
+      );
+      fireEvent.changeText(searchInput, 'boolean');
+
+      expect(screen.getByText('Showing: 1 flags')).toBeTruthy();
+    });
+
+    it('does not show filtered count when no filters are active', () => {
+      render(<FeatureFlagOverride />);
+
+      expect(screen.queryByText(/Showing: \d+ flags/)).toBeNull();
     });
   });
 });

--- a/app/components/Views/FeatureFlagOverride/FeatureFlagOverride.tsx
+++ b/app/components/Views/FeatureFlagOverride/FeatureFlagOverride.tsx
@@ -23,6 +23,7 @@ import {
 } from '../../../util/feature-flags';
 import { useFeatureFlagOverride } from '../../../contexts/FeatureFlagOverrideContext';
 import { useFeatureFlagStats } from '../../../hooks/useFeatureFlagStats';
+import { FeatureFlagNames } from '../../hooks/useFeatureFlag';
 
 interface FeatureFlagRowProps {
   flag: FeatureFlagInfo;
@@ -56,13 +57,19 @@ const FeatureFlagRow: React.FC<FeatureFlagRowProps> = ({ flag, onToggle }) => {
           <Box twClassName="items-end">
             <Switch
               value={(localValue as MinimumVersionFlagValue).enabled}
-              disabled //={!isVersionSupported} TODO: Uncomment this when we support overrides for minimum version
+              disabled={
+                !isVersionSupported &&
+                !Object.values(FeatureFlagNames).includes(
+                  flag.key as FeatureFlagNames,
+                )
+              }
               onValueChange={(newValue: boolean) => {
-                setLocalValue({
+                const updatedValue = {
                   ...(localValue as MinimumVersionFlagValue),
                   enabled: newValue,
-                });
-                onToggle(flag.key, newValue);
+                };
+                setLocalValue(updatedValue);
+                onToggle(flag.key, updatedValue);
               }}
               trackColor={{
                 true: theme.colors.primary.default,
@@ -89,7 +96,11 @@ const FeatureFlagRow: React.FC<FeatureFlagRowProps> = ({ flag, onToggle }) => {
       case 'boolean':
         return (
           <Switch
-            disabled
+            disabled={
+              !Object.values(FeatureFlagNames).includes(
+                flag.key as FeatureFlagNames,
+              )
+            }
             value={localValue as boolean}
             onValueChange={(newValue: boolean) => {
               setLocalValue(newValue);

--- a/app/components/Views/MultichainAccounts/IntroModal/LearnMoreBottomSheet.test.tsx
+++ b/app/components/Views/MultichainAccounts/IntroModal/LearnMoreBottomSheet.test.tsx
@@ -77,6 +77,9 @@ describe('LearnMoreBottomSheet', () => {
   it('renders correctly with all elements', () => {
     const { getByTestId } = renderWithProvider(
       <LearnMoreBottomSheet onClose={mockOnClose} />,
+      undefined,
+      true,
+      false,
     );
 
     expect(
@@ -105,6 +108,9 @@ describe('LearnMoreBottomSheet', () => {
   it('displays correct title', () => {
     const { getByTestId } = renderWithProvider(
       <LearnMoreBottomSheet onClose={mockOnClose} />,
+      undefined,
+      true,
+      false,
     );
 
     expect(
@@ -115,6 +121,9 @@ describe('LearnMoreBottomSheet', () => {
   it('displays correct description', () => {
     const { getByTestId } = renderWithProvider(
       <LearnMoreBottomSheet onClose={mockOnClose} />,
+      undefined,
+      true,
+      false,
     );
 
     expect(
@@ -125,6 +134,9 @@ describe('LearnMoreBottomSheet', () => {
   it('displays correct checkbox label', () => {
     const { getByTestId } = renderWithProvider(
       <LearnMoreBottomSheet onClose={mockOnClose} />,
+      undefined,
+      true,
+      false,
     );
 
     expect(
@@ -137,6 +149,9 @@ describe('LearnMoreBottomSheet', () => {
   it('displays correct confirm button label', () => {
     const { getByTestId } = renderWithProvider(
       <LearnMoreBottomSheet onClose={mockOnClose} />,
+      undefined,
+      true,
+      false,
     );
 
     expect(
@@ -149,6 +164,9 @@ describe('LearnMoreBottomSheet', () => {
   it('renders confirm button', () => {
     const { getByTestId } = renderWithProvider(
       <LearnMoreBottomSheet onClose={mockOnClose} />,
+      undefined,
+      true,
+      false,
     );
 
     const confirmButton = getByTestId(
@@ -160,6 +178,9 @@ describe('LearnMoreBottomSheet', () => {
   it('handles back button press', () => {
     const { getByTestId } = renderWithProvider(
       <LearnMoreBottomSheet onClose={mockOnClose} />,
+      undefined,
+      true,
+      false,
     );
 
     const backButton = getByTestId(
@@ -173,6 +194,9 @@ describe('LearnMoreBottomSheet', () => {
   it('handles close button press', () => {
     const { getByTestId } = renderWithProvider(
       <LearnMoreBottomSheet onClose={mockOnClose} />,
+      undefined,
+      true,
+      false,
     );
 
     const closeButton = getByTestId(
@@ -186,6 +210,9 @@ describe('LearnMoreBottomSheet', () => {
   it('handles checkbox press and toggles state', () => {
     const { getByTestId } = renderWithProvider(
       <LearnMoreBottomSheet onClose={mockOnClose} />,
+      undefined,
+      true,
+      false,
     );
 
     const checkbox = getByTestId(LEARN_MORE_BOTTOM_SHEET_TEST_IDS.CHECKBOX);
@@ -206,6 +233,9 @@ describe('LearnMoreBottomSheet', () => {
   it('handles confirm button press when checkbox is checked', () => {
     const { getByTestId } = renderWithProvider(
       <LearnMoreBottomSheet onClose={mockOnClose} />,
+      undefined,
+      true,
+      false,
     );
 
     const checkbox = getByTestId(LEARN_MORE_BOTTOM_SHEET_TEST_IDS.CHECKBOX);
@@ -226,6 +256,9 @@ describe('LearnMoreBottomSheet', () => {
   it('does not navigate when confirm button pressed without checkbox checked', () => {
     const { getByTestId } = renderWithProvider(
       <LearnMoreBottomSheet onClose={mockOnClose} />,
+      undefined,
+      true,
+      false,
     );
 
     const confirmButton = getByTestId(
@@ -253,6 +286,9 @@ describe('LearnMoreBottomSheet', () => {
 
     const { getByTestId } = renderWithProvider(
       <LearnMoreBottomSheet onClose={mockOnClose} />,
+      undefined,
+      true,
+      false,
     );
 
     const checkbox = getByTestId(LEARN_MORE_BOTTOM_SHEET_TEST_IDS.CHECKBOX);

--- a/app/components/hooks/useFeatureFlag.test.ts
+++ b/app/components/hooks/useFeatureFlag.test.ts
@@ -1,0 +1,161 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useSelector } from 'react-redux';
+import { useFeatureFlag, FeatureFlagNames } from './useFeatureFlag';
+import { useFeatureFlagOverride } from '../../contexts/FeatureFlagOverrideContext';
+import { selectBasicFunctionalityEnabled } from '../../selectors/settings';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../../contexts/FeatureFlagOverrideContext', () => ({
+  useFeatureFlagOverride: jest.fn(),
+}));
+
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+const mockUseFeatureFlagOverride =
+  useFeatureFlagOverride as jest.MockedFunction<typeof useFeatureFlagOverride>;
+
+describe('useFeatureFlag', () => {
+  let mockGetFeatureFlag: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockGetFeatureFlag = jest.fn();
+    mockUseFeatureFlagOverride.mockReturnValue({
+      getFeatureFlag: mockGetFeatureFlag,
+    } as unknown as ReturnType<typeof useFeatureFlagOverride>);
+  });
+
+  describe('when basic functionality is disabled', () => {
+    it('returns false without calling getFeatureFlag', () => {
+      mockUseSelector.mockReturnValue(false);
+
+      const { result } = renderHook(() =>
+        useFeatureFlag(FeatureFlagNames.rewardsEnabled),
+      );
+
+      expect(result.current).toBe(false);
+      expect(mockUseSelector).toHaveBeenCalledWith(
+        selectBasicFunctionalityEnabled,
+      );
+      expect(mockGetFeatureFlag).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when basic functionality is enabled', () => {
+    beforeEach(() => {
+      mockUseSelector.mockReturnValue(true);
+    });
+
+    it('returns true when getFeatureFlag returns true', () => {
+      mockGetFeatureFlag.mockReturnValue(true);
+
+      const { result } = renderHook(() =>
+        useFeatureFlag(FeatureFlagNames.rewardsEnabled),
+      );
+
+      expect(result.current).toBe(true);
+      expect(mockGetFeatureFlag).toHaveBeenCalledWith(
+        FeatureFlagNames.rewardsEnabled,
+      );
+      expect(mockGetFeatureFlag).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns false when getFeatureFlag returns false', () => {
+      mockGetFeatureFlag.mockReturnValue(false);
+
+      const { result } = renderHook(() =>
+        useFeatureFlag(FeatureFlagNames.rewardsEnabled),
+      );
+
+      expect(result.current).toBe(false);
+      expect(mockGetFeatureFlag).toHaveBeenCalledWith(
+        FeatureFlagNames.rewardsEnabled,
+      );
+      expect(mockGetFeatureFlag).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns undefined when getFeatureFlag returns undefined', () => {
+      mockGetFeatureFlag.mockReturnValue(undefined);
+
+      const { result } = renderHook(() =>
+        useFeatureFlag(FeatureFlagNames.rewardsEnabled),
+      );
+
+      expect(result.current).toBeUndefined();
+      expect(mockGetFeatureFlag).toHaveBeenCalledWith(
+        FeatureFlagNames.rewardsEnabled,
+      );
+      expect(mockGetFeatureFlag).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls getFeatureFlag with the correct feature flag key', () => {
+      mockGetFeatureFlag.mockReturnValue(true);
+
+      renderHook(() => useFeatureFlag(FeatureFlagNames.rewardsEnabled));
+
+      expect(mockGetFeatureFlag).toHaveBeenCalledWith(
+        FeatureFlagNames.rewardsEnabled,
+      );
+    });
+
+    it('calls useSelector with selectBasicFunctionalityEnabled selector', () => {
+      mockGetFeatureFlag.mockReturnValue(true);
+
+      renderHook(() => useFeatureFlag(FeatureFlagNames.rewardsEnabled));
+
+      expect(mockUseSelector).toHaveBeenCalledWith(
+        selectBasicFunctionalityEnabled,
+      );
+      expect(mockUseSelector).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns false when basic functionality is null', () => {
+      mockUseSelector.mockReturnValue(null as unknown as boolean);
+
+      const { result } = renderHook(() =>
+        useFeatureFlag(FeatureFlagNames.rewardsEnabled),
+      );
+
+      expect(result.current).toBe(false);
+      expect(mockGetFeatureFlag).not.toHaveBeenCalled();
+    });
+
+    it('returns false when basic functionality is undefined', () => {
+      mockUseSelector.mockReturnValue(undefined as unknown as boolean);
+
+      const { result } = renderHook(() =>
+        useFeatureFlag(FeatureFlagNames.rewardsEnabled),
+      );
+
+      expect(result.current).toBe(false);
+      expect(mockGetFeatureFlag).not.toHaveBeenCalled();
+    });
+
+    it('returns false when basic functionality is 0', () => {
+      mockUseSelector.mockReturnValue(0 as unknown as boolean);
+
+      const { result } = renderHook(() =>
+        useFeatureFlag(FeatureFlagNames.rewardsEnabled),
+      );
+
+      expect(result.current).toBe(false);
+      expect(mockGetFeatureFlag).not.toHaveBeenCalled();
+    });
+
+    it('returns false when basic functionality is empty string', () => {
+      mockUseSelector.mockReturnValue('' as unknown as boolean);
+
+      const { result } = renderHook(() =>
+        useFeatureFlag(FeatureFlagNames.rewardsEnabled),
+      );
+
+      expect(result.current).toBe(false);
+      expect(mockGetFeatureFlag).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/components/hooks/useFeatureFlag.test.ts
+++ b/app/components/hooks/useFeatureFlag.test.ts
@@ -1,6 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { useSelector } from 'react-redux';
-import { useFeatureFlag, FeatureFlagNames } from './useFeatureFlag';
 import { useFeatureFlagOverride } from '../../contexts/FeatureFlagOverrideContext';
 import { selectBasicFunctionalityEnabled } from '../../selectors/settings';
 
@@ -11,6 +10,28 @@ jest.mock('react-redux', () => ({
 jest.mock('../../contexts/FeatureFlagOverrideContext', () => ({
   useFeatureFlagOverride: jest.fn(),
 }));
+
+// Mock the useFeatureFlag module with mocked FeatureFlagNames enum
+jest.mock('./useFeatureFlag', () => {
+  const actual = jest.requireActual('./useFeatureFlag');
+  return {
+    ...actual,
+    FeatureFlagNames: {
+      mockedFlagEnabled: 'mockedFlagEnabled',
+    } as typeof actual.FeatureFlagNames,
+  };
+});
+
+import { useFeatureFlag, FeatureFlagNames } from './useFeatureFlag';
+
+// Type for the mocked FeatureFlagNames enum
+type MockedFeatureFlagNames = typeof FeatureFlagNames & {
+  mockedFlagEnabled: 'mockedFlagEnabled';
+};
+
+// Create a typed reference to the mocked flag
+const MOCKED_FLAG = (FeatureFlagNames as MockedFeatureFlagNames)
+  .mockedFlagEnabled as FeatureFlagNames;
 
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 const mockUseFeatureFlagOverride =
@@ -32,9 +53,7 @@ describe('useFeatureFlag', () => {
     it('returns false without calling getFeatureFlag', () => {
       mockUseSelector.mockReturnValue(false);
 
-      const { result } = renderHook(() =>
-        useFeatureFlag(FeatureFlagNames.rewardsEnabled),
-      );
+      const { result } = renderHook(() => useFeatureFlag(MOCKED_FLAG));
 
       expect(result.current).toBe(false);
       expect(mockUseSelector).toHaveBeenCalledWith(
@@ -52,59 +71,45 @@ describe('useFeatureFlag', () => {
     it('returns true when getFeatureFlag returns true', () => {
       mockGetFeatureFlag.mockReturnValue(true);
 
-      const { result } = renderHook(() =>
-        useFeatureFlag(FeatureFlagNames.rewardsEnabled),
-      );
+      const { result } = renderHook(() => useFeatureFlag(MOCKED_FLAG));
 
       expect(result.current).toBe(true);
-      expect(mockGetFeatureFlag).toHaveBeenCalledWith(
-        FeatureFlagNames.rewardsEnabled,
-      );
+      expect(mockGetFeatureFlag).toHaveBeenCalledWith(MOCKED_FLAG);
       expect(mockGetFeatureFlag).toHaveBeenCalledTimes(1);
     });
 
     it('returns false when getFeatureFlag returns false', () => {
       mockGetFeatureFlag.mockReturnValue(false);
 
-      const { result } = renderHook(() =>
-        useFeatureFlag(FeatureFlagNames.rewardsEnabled),
-      );
+      const { result } = renderHook(() => useFeatureFlag(MOCKED_FLAG));
 
       expect(result.current).toBe(false);
-      expect(mockGetFeatureFlag).toHaveBeenCalledWith(
-        FeatureFlagNames.rewardsEnabled,
-      );
+      expect(mockGetFeatureFlag).toHaveBeenCalledWith(MOCKED_FLAG);
       expect(mockGetFeatureFlag).toHaveBeenCalledTimes(1);
     });
 
     it('returns undefined when getFeatureFlag returns undefined', () => {
       mockGetFeatureFlag.mockReturnValue(undefined);
 
-      const { result } = renderHook(() =>
-        useFeatureFlag(FeatureFlagNames.rewardsEnabled),
-      );
+      const { result } = renderHook(() => useFeatureFlag(MOCKED_FLAG));
 
       expect(result.current).toBeUndefined();
-      expect(mockGetFeatureFlag).toHaveBeenCalledWith(
-        FeatureFlagNames.rewardsEnabled,
-      );
+      expect(mockGetFeatureFlag).toHaveBeenCalledWith(MOCKED_FLAG);
       expect(mockGetFeatureFlag).toHaveBeenCalledTimes(1);
     });
 
     it('calls getFeatureFlag with the correct feature flag key', () => {
       mockGetFeatureFlag.mockReturnValue(true);
 
-      renderHook(() => useFeatureFlag(FeatureFlagNames.rewardsEnabled));
+      renderHook(() => useFeatureFlag(MOCKED_FLAG));
 
-      expect(mockGetFeatureFlag).toHaveBeenCalledWith(
-        FeatureFlagNames.rewardsEnabled,
-      );
+      expect(mockGetFeatureFlag).toHaveBeenCalledWith(MOCKED_FLAG);
     });
 
     it('calls useSelector with selectBasicFunctionalityEnabled selector', () => {
       mockGetFeatureFlag.mockReturnValue(true);
 
-      renderHook(() => useFeatureFlag(FeatureFlagNames.rewardsEnabled));
+      renderHook(() => useFeatureFlag(MOCKED_FLAG));
 
       expect(mockUseSelector).toHaveBeenCalledWith(
         selectBasicFunctionalityEnabled,
@@ -117,9 +122,7 @@ describe('useFeatureFlag', () => {
     it('returns false when basic functionality is null', () => {
       mockUseSelector.mockReturnValue(null as unknown as boolean);
 
-      const { result } = renderHook(() =>
-        useFeatureFlag(FeatureFlagNames.rewardsEnabled),
-      );
+      const { result } = renderHook(() => useFeatureFlag(MOCKED_FLAG));
 
       expect(result.current).toBe(false);
       expect(mockGetFeatureFlag).not.toHaveBeenCalled();
@@ -128,9 +131,7 @@ describe('useFeatureFlag', () => {
     it('returns false when basic functionality is undefined', () => {
       mockUseSelector.mockReturnValue(undefined as unknown as boolean);
 
-      const { result } = renderHook(() =>
-        useFeatureFlag(FeatureFlagNames.rewardsEnabled),
-      );
+      const { result } = renderHook(() => useFeatureFlag(MOCKED_FLAG));
 
       expect(result.current).toBe(false);
       expect(mockGetFeatureFlag).not.toHaveBeenCalled();
@@ -139,9 +140,7 @@ describe('useFeatureFlag', () => {
     it('returns false when basic functionality is 0', () => {
       mockUseSelector.mockReturnValue(0 as unknown as boolean);
 
-      const { result } = renderHook(() =>
-        useFeatureFlag(FeatureFlagNames.rewardsEnabled),
-      );
+      const { result } = renderHook(() => useFeatureFlag(MOCKED_FLAG));
 
       expect(result.current).toBe(false);
       expect(mockGetFeatureFlag).not.toHaveBeenCalled();
@@ -150,9 +149,7 @@ describe('useFeatureFlag', () => {
     it('returns false when basic functionality is empty string', () => {
       mockUseSelector.mockReturnValue('' as unknown as boolean);
 
-      const { result } = renderHook(() =>
-        useFeatureFlag(FeatureFlagNames.rewardsEnabled),
-      );
+      const { result } = renderHook(() => useFeatureFlag(MOCKED_FLAG));
 
       expect(result.current).toBe(false);
       expect(mockGetFeatureFlag).not.toHaveBeenCalled();

--- a/app/components/hooks/useFeatureFlag.ts
+++ b/app/components/hooks/useFeatureFlag.ts
@@ -1,0 +1,16 @@
+import { useSelector } from 'react-redux';
+import { useFeatureFlagOverride } from '../../../contexts/FeatureFlagOverrideContext';
+import { selectBasicFunctionalityEnabled } from '../../../selectors/settings';
+
+export enum FeatureFlagNames {}
+
+export const useFeatureFlag = (key: FeatureFlagNames) => {
+  const { getFeatureFlag } = useFeatureFlagOverride();
+  const isBasicFunctionalityEnabled = useSelector(
+    selectBasicFunctionalityEnabled,
+  );
+  if (!isBasicFunctionalityEnabled) {
+    return false;
+  }
+  return getFeatureFlag(key);
+};

--- a/app/components/hooks/useFeatureFlag.ts
+++ b/app/components/hooks/useFeatureFlag.ts
@@ -1,8 +1,10 @@
 import { useSelector } from 'react-redux';
-import { useFeatureFlagOverride } from '../../../contexts/FeatureFlagOverrideContext';
-import { selectBasicFunctionalityEnabled } from '../../../selectors/settings';
+import { useFeatureFlagOverride } from '../../contexts/FeatureFlagOverrideContext';
+import { selectBasicFunctionalityEnabled } from '../../selectors/settings';
 
-export enum FeatureFlagNames {}
+export enum FeatureFlagNames {
+  rewardsEnabled = 'rewardsEnabled',
+}
 
 export const useFeatureFlag = (key: FeatureFlagNames) => {
   const { getFeatureFlag } = useFeatureFlagOverride();

--- a/app/contexts/FeatureFlagOverrideContext.test.tsx
+++ b/app/contexts/FeatureFlagOverrideContext.test.tsx
@@ -145,16 +145,6 @@ describe('FeatureFlagOverrideContext', () => {
       expect(result.current.featureFlags).toEqual({});
       expect(result.current.featureFlagsList).toEqual([]);
     });
-
-    it('throws error when Redux selector returns null due to implementation bug', () => {
-      mockUseSelector.mockReturnValue(null);
-
-      expect(() => {
-        renderHook(() => useFeatureFlagOverride(), {
-          wrapper: createWrapper,
-        });
-      }).toThrow('Cannot convert undefined or null to object');
-    });
   });
 
   describe('Override Management', () => {

--- a/app/contexts/FeatureFlagOverrideContext.tsx
+++ b/app/contexts/FeatureFlagOverrideContext.tsx
@@ -52,7 +52,11 @@ export const FeatureFlagOverrideProvider: React.FC<
   FeatureFlagOverrideProviderProps
 > = ({ children }) => {
   // Get the initial feature flags from Redux
-  const rawFeatureFlags = useSelector(selectRemoteFeatureFlags);
+  const rawFeatureFlagsSelected = useSelector(selectRemoteFeatureFlags);
+  const rawFeatureFlags = useMemo(
+    () => rawFeatureFlagsSelected || {},
+    [rawFeatureFlagsSelected],
+  );
   const toastContext = useContext(ToastContext);
   const toastRef = toastContext?.toastRef;
 


### PR DESCRIPTION
<!--

Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.

-->



## **Description**



<!--

Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:

1. What is the reason for the change?

2. What is the improvement/solution?

-->

This PR introduces a new `useFeatureFlag` hook that provides a standardized way to access feature flags with built-in basic functionality checks. The hook ensures that feature flags respect the `basicFunctionalityEnabled` setting before returning their values.

**Key changes:**

1. **New `useFeatureFlag` hook** (`app/components/hooks/useFeatureFlag.ts`):
   - Provides a type-safe interface for accessing feature flags via the `FeatureFlagNames` enum
   - Automatically checks if basic functionality is enabled before returning flag values
   - Returns `false` if basic functionality is disabled, regardless of the flag's actual value
   - Currently includes `rewardsEnabled` in the enum, with the ability to extend for future flags

2. **Performance optimization in `FeatureFlagOverrideContext`**:
   - Added `useMemo` to memoize raw feature flags from Redux selector
   - Prevents unnecessary re-renders when the selector returns the same reference

3. **Test infrastructure improvements**:
   - Updated `renderWithProvider` to include `FeatureFlagOverrideProvider` by default
   - Added optional `includeFeatureFlagOverrideProvider` parameter for test flexibility
   - Updated multiple test files to work with the new provider setup

4. **FeatureFlagOverride UI updates**:
   - Now uses the `FeatureFlagNames` enum to validate which flags can be toggled
   - Ensures consistency between the hook and the override UI

**Reason for change:**
- Standardizes feature flag access across the codebase
- Ensures feature flags respect basic functionality settings
- Improves type safety and reduces potential runtime errors
- Provides a foundation for future feature flag additions

**Improvement/solution:**
- Centralized feature flag access logic reduces code duplication
- Type-safe enum prevents typos and invalid flag names
- Automatic basic functionality check ensures consistent behavior
- Better test infrastructure supports feature flag testing



## **Changelog**



<!--

If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:

1. Write `CHANGELOG entry: null`

2. Label with `no-changelog`



If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:

`CHANGELOG entry: Added a new tab for users to see their NFTs`

`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`



(This helps the Release Engineer do their job more quickly and accurately)

-->



CHANGELOG entry: null



## **Related issues**



Fixes:



## **Manual testing steps**



```gherkin

Feature: Feature flag hook and context improvements



  Scenario: useFeatureFlag hook respects basic functionality setting

    Given the app is running with basic functionality disabled

    When a component uses the useFeatureFlag hook to check rewardsEnabled

    Then the hook should return false regardless of the actual flag value



  Scenario: useFeatureFlag hook returns correct flag value when basic functionality is enabled

    Given the app is running with basic functionality enabled

    When a component uses the useFeatureFlag hook to check rewardsEnabled

    Then the hook should return the actual feature flag value from the override context



  Scenario: FeatureFlagOverrideProvider is included in test renders by default

    Given a test uses renderWithProvider to render a component

    When the component is rendered

    Then the FeatureFlagOverrideProvider should be available in the component tree



  Scenario: Feature flag context memoization prevents unnecessary re-renders

    Given the FeatureFlagOverrideContext is mounted

    When the Redux selector returns the same feature flags object reference

    Then the context should not trigger unnecessary re-renders of consuming components



  Scenario: FeatureFlagOverride UI validates flags using FeatureFlagNames enum

    Given the Feature Flag Override screen is open

    When viewing a feature flag that is in the FeatureFlagNames enum

    Then the flag toggle should be enabled and functional

```



## **Screenshots/Recordings**



<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->



### **Before**



<!-- [screenshots/recordings] -->



### **After**



<!-- [screenshots/recordings] -->



## **Pre-merge author checklist**



- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).

- [x] I've completed the PR template to the best of my ability

- [x] I've included tests if applicable

- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable

- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.



## **Pre-merge reviewer checklist**



- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).

- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a type-safe useFeatureFlag hook with basic-functionality guard, memoizes remote flags in the override context, integrates the provider into test utilities, and updates the override UI to gate toggles by enum and minimum version with expanded tests.
> 
> - **Hooks**
>   - Add `useFeatureFlag` with `FeatureFlagNames` enum and basic-functionality check (`app/components/hooks/useFeatureFlag.ts`).
> - **Context**
>   - Memoize `selectRemoteFeatureFlags` result and default to `{}` to prevent null/undefined issues in `FeatureFlagOverrideProvider`.
> - **UI (Feature Flag Override)**
>   - Gate boolean and versioned-boolean switches: enable only for keys in `FeatureFlagNames`; for versioned flags also require supported `minimumVersion` unless whitelisted.
>   - For versioned booleans, toggle now updates and passes the full `{ enabled, minimumVersion }` object; show version support indicator.
> - **Test Infra**
>   - Update `renderWithProvider` to include `FeatureFlagOverrideProvider` by default with an opt-out flag; adjust affected tests.
> - **Tests**
>   - Add comprehensive tests for `useFeatureFlag` behavior and override UI (search/filter/empty states, gating, version handling, counts).
>   - Update existing tests to work with the new provider setup and mocks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c547063efd4f33e891fb302dc739939b473e7598. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->