### PR TITLE
feat(STX-263): support gasless swaps with 7702

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
@@ -24,8 +24,6 @@ import { MOCK_ENTROPY_SOURCE as mockEntropySource } from '../../../../../util/te
 import { RootState } from '../../../../../reducers';
 import { mockQuoteWithMetadata } from '../../_mocks_/bridgeQuoteWithMetadata';
 import { BridgeViewMode } from '../../types';
-import { useGasIncluded } from '../../hooks/useGasIncluded';
-import { useIsSendBundleSupported } from '../../hooks/useIsSendBundleSupported';
 
 // Mock the account-tree-controller file that imports the problematic module
 jest.mock(
@@ -262,16 +260,6 @@ jest.mock('../../hooks/useBridgeQuoteData', () => ({
     .mockImplementation(() => mockUseBridgeQuoteData),
 }));
 
-// Mock useGasIncluded hook
-jest.mock('../../hooks/useGasIncluded', () => ({
-  useGasIncluded: jest.fn(),
-}));
-
-// Mock useIsSendBundleSupported hook (dependency of useGasIncluded)
-jest.mock('../../hooks/useIsSendBundleSupported', () => ({
-  useIsSendBundleSupported: jest.fn().mockReturnValue(false),
-}));
-
 jest.mock('../../../../../util/address', () => ({
   ...jest.requireActual('../../../../../util/address'),
   isHardwareAccount: jest.fn(),
@@ -292,14 +280,27 @@ jest.mock('react-native-fade-in-image', () => {
   };
 });
 
+// Mock gas included support hooks
+const mockUseIsGasIncludedSTXSendBundleSupported = jest.fn();
+jest.mock(
+  '../../hooks/useIsGasIncludedSTXSendBundleSupported/index.ts',
+  () => ({
+    useIsGasIncludedSTXSendBundleSupported: (chainId?: string) =>
+      mockUseIsGasIncludedSTXSendBundleSupported(chainId),
+  }),
+);
+
+const mockUseIsGasIncluded7702Supported = jest.fn();
+jest.mock('../../hooks/useIsGasIncluded7702Supported/index.ts', () => ({
+  useIsGasIncluded7702Supported: (chainId?: string) =>
+    mockUseIsGasIncluded7702Supported(chainId),
+}));
+
 describe('BridgeView', () => {
   const token2Address = '0x0000000000000000000000000000000000000002' as Hex;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    // Set default mock values
-    (useGasIncluded as jest.Mock).mockReturnValue(undefined);
-    (useIsSendBundleSupported as jest.Mock).mockReturnValue(false);
   });
 
   it('renders', async () => {
@@ -1613,100 +1614,39 @@ describe('BridgeView', () => {
     });
   });
 
-  describe('gasIncluded functionality', () => {
-    it('calls useGasIncluded hook with source chain ID', () => {
-      const testState = createBridgeTestState({
-        bridgeReducerOverrides: {
+  describe('gas included support hooks', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('calls gas included support hooks with source token chain ID', () => {
+      const testState = {
+        ...mockState,
+        bridge: {
+          ...mockState.bridge,
           sourceToken: {
             address: '0x0000000000000000000000000000000000000000',
-            chainId: '0x1',
+            chainId: '0x1' as Hex,
             decimals: 18,
+            image: '',
+            name: 'Ether',
             symbol: 'ETH',
           },
         },
-      });
+      };
 
       renderScreen(
         BridgeView,
-        { name: Routes.BRIDGE.ROOT },
-        { state: testState },
-      );
-
-      expect(useGasIncluded).toHaveBeenCalledWith('0x1');
-    });
-
-    it('calls useGasIncluded with undefined when source token not set', () => {
-      const testState = createBridgeTestState({
-        bridgeReducerOverrides: {
-          sourceToken: undefined,
+        {
+          name: Routes.BRIDGE.ROOT,
         },
-      });
-
-      renderScreen(
-        BridgeView,
-        { name: Routes.BRIDGE.ROOT },
         { state: testState },
       );
 
-      expect(useGasIncluded).toHaveBeenCalledWith(undefined);
-    });
-
-    it('updates gasIncluded when source chain changes', () => {
-      const testState = createBridgeTestState({
-        bridgeReducerOverrides: {
-          sourceToken: {
-            address: '0x0000000000000000000000000000000000000000',
-            chainId: '0x1',
-            decimals: 18,
-            symbol: 'ETH',
-          },
-        },
-      });
-
-      const { store } = renderScreen(
-        BridgeView,
-        { name: Routes.BRIDGE.ROOT },
-        { state: testState },
+      expect(mockUseIsGasIncludedSTXSendBundleSupported).toHaveBeenCalledWith(
+        '0x1',
       );
-
-      // Change source token to different chain
-      act(() => {
-        store.dispatch(
-          setSourceToken({
-            address: '0x0000000000000000000000000000000000000000',
-            chainId: '0xa', // Optimism
-            decimals: 18,
-            symbol: 'ETH',
-          }),
-        );
-      });
-
-      // useGasIncluded should be called with the new chain ID
-      expect(useGasIncluded).toHaveBeenCalledWith('0xa');
-    });
-
-    it('calls useGasIncluded with non-EVM chainId directly', () => {
-      const testState = createBridgeTestState({
-        bridgeReducerOverrides: {
-          sourceToken: {
-            address: 'SomeNonEvmAddress',
-            chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
-            decimals: 9,
-            symbol: 'SOL',
-          },
-        },
-      });
-
-      renderScreen(
-        BridgeView,
-        { name: Routes.BRIDGE.ROOT },
-        { state: testState },
-      );
-
-      // Hook receives the raw chainId and handles filtering internally
-      expect(useGasIncluded).toHaveBeenCalledWith(
-        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
-      );
+      expect(mockUseIsGasIncluded7702Supported).toHaveBeenCalledWith('0x1');
     });
   });
 });

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -81,9 +81,10 @@ import { BRIDGE_MM_FEE_RATE } from '@metamask/bridge-controller';
 import { isNullOrUndefined, Hex } from '@metamask/utils';
 import { useBridgeQuoteEvents } from '../../hooks/useBridgeQuoteEvents/index.ts';
 import { SwapsKeypad } from '../../components/SwapsKeypad/index.tsx';
-import { useGasIncluded } from '../../hooks/useGasIncluded';
 import { getGasFeesSponsoredNetworkEnabled } from '../../../../../selectors/featureFlagController/gasFeesSponsored';
 import { FLipQuoteButton } from '../../components/FlipQuoteButton/index.tsx';
+import { useIsGasIncludedSTXSendBundleSupported } from '../../hooks/useIsGasIncludedSTXSendBundleSupported/index.ts';
+import { useIsGasIncluded7702Supported } from '../../hooks/useIsGasIncluded7702Supported/index.ts';
 
 export interface BridgeRouteParams {
   sourcePage: string;
@@ -140,8 +141,11 @@ const BridgeView = () => {
 
   const updateQuoteParams = useBridgeQuoteRequest();
 
-  // Update gasIncluded state based on source chain capabilities
-  useGasIncluded(sourceToken?.chainId);
+  // Update isGasIncludedSTXSendBundleSupported state based on source chain capabilities
+  useIsGasIncludedSTXSendBundleSupported(sourceToken?.chainId);
+
+  // Update isGasIncluded7702Supported state
+  useIsGasIncluded7702Supported(sourceToken?.chainId);
 
   const initialSourceToken = route.params?.sourceToken;
   const initialSourceAmount = route.params?.sourceAmount;

--- a/app/components/UI/Bridge/_mocks_/bridgeReducerState.ts
+++ b/app/components/UI/Bridge/_mocks_/bridgeReducerState.ts
@@ -29,7 +29,8 @@ export const mockBridgeReducerState: BridgeState = {
   selectedDestChainId: '0xa',
   slippage: '0.5',
   isSubmittingTx: false,
-  gasIncluded: false,
+  isGasIncludedSTXSendBundleSupported: false,
+  isGasIncluded7702Supported: false,
   bridgeViewMode: BridgeViewMode.Bridge,
   isSelectingRecipient: false,
 };

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.test.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.test.tsx
@@ -341,6 +341,47 @@ describe('QuoteDetailsCard', () => {
     expect(getByText('0.5%')).toBeDefined();
   });
 
+  it('displays "Included" fee when gasIncluded7702 is true', () => {
+    // Temporarily replace the mock with one that has gasIncluded7702 = true
+    const mockModule = jest.requireMock('../../hooks/useBridgeQuoteData');
+    const originalImpl = mockModule.useBridgeQuoteData.getMockImplementation();
+
+    mockModule.useBridgeQuoteData.mockImplementation(() => ({
+      quoteFetchError: null,
+      activeQuote: {
+        ...mockQuotes[0],
+        quote: {
+          ...mockQuotes[0].quote,
+          gasIncluded: false,
+          gasIncluded7702: true,
+        },
+      },
+      destTokenAmount: '24.44',
+      isLoading: false,
+      formattedQuoteData: {
+        networkFee: '0.01',
+        estimatedTime: '1 min',
+        rate: '1 ETH = 24.4 USDC',
+        priceImpact: '-0.06%',
+        slippage: '0.5%',
+      },
+    }));
+
+    const { getByText } = renderScreen(
+      QuoteDetailsCard,
+      {
+        name: Routes.BRIDGE.ROOT,
+      },
+      { state: testState },
+    );
+
+    // Verify "Included" text is displayed
+    expect(getByText(strings('bridge.included'))).toBeDefined();
+
+    // Restore original implementation
+    mockModule.useBridgeQuoteData.mockImplementation(originalImpl);
+  });
+
   it('displays "Included" fee when gasIncluded is true', () => {
     // Temporarily replace the mock with one that has gasIncluded = true
     const mockModule = jest.requireMock('../../hooks/useBridgeQuoteData');
@@ -492,6 +533,7 @@ describe('QuoteDetailsCard', () => {
           ...mockQuotes[0].quote,
           priceData: { ...mockQuotes[0].quote.priceData, priceImpact: '15.0' },
           gasIncluded: false,
+          gasIncluded7702: false,
         },
       },
       destTokenAmount: '24.44',
@@ -554,6 +596,7 @@ describe('QuoteDetailsCard', () => {
           ...mockQuotes[0].quote,
           priceData: { ...mockQuotes[0].quote.priceData, priceImpact: '0.1' },
           gasIncluded: false,
+          gasIncluded7702: false,
         },
       },
       destTokenAmount: '24.44',
@@ -588,6 +631,7 @@ describe('QuoteDetailsCard', () => {
           ...mockQuotes[0].quote,
           priceData: { ...mockQuotes[0].quote.priceData, priceImpact: '25.0' },
           gasIncluded: true,
+          gasIncluded7702: false,
         },
       },
       destTokenAmount: '24.44',

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
@@ -139,6 +139,8 @@ const QuoteDetailsCard: React.FC = () => {
   const { networkFee, rate, priceImpact, slippage } = formattedQuoteData;
 
   const gasIncluded = !!activeQuote?.quote.gasIncluded;
+  const gasIncluded7702 = !!activeQuote?.quote.gasIncluded7702;
+  const isGasless = gasIncluded7702 || gasIncluded;
 
   const formattedMinToTokenAmount = intlNumberFormatter.format(
     parseFloat(activeQuote?.minToTokenAmount?.amount || '0'),
@@ -207,7 +209,7 @@ const QuoteDetailsCard: React.FC = () => {
               },
             }}
           />
-        ) : activeQuote?.quote.gasIncluded ? (
+        ) : isGasless ? (
           <Box
             flexDirection={BoxFlexDirection.Row}
             alignItems={BoxAlignItems.Center}
@@ -331,7 +333,7 @@ const QuoteDetailsCard: React.FC = () => {
               },
               tooltip: {
                 title: strings('bridge.price_impact_info_title'),
-                content: gasIncluded
+                content: isGasless
                   ? strings('bridge.price_impact_info_gasless_description')
                   : strings('bridge.price_impact_info_description'),
                 size: TooltipSizes.Sm,

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/index.ts
@@ -182,13 +182,15 @@ export const useBridgeQuoteData = ({
   );
 
   // Check if price impact warning should be shown
+  const isGasless =
+    activeQuote?.quote.gasIncluded || activeQuote?.quote.gasIncluded7702;
   const shouldShowPriceImpactWarning = Boolean(
     activeQuote?.quote.priceData?.priceImpact !== undefined &&
       bridgeFeatureFlags?.priceImpactThreshold &&
-      ((activeQuote?.quote.gasIncluded &&
+      ((isGasless &&
         Number(activeQuote?.quote.priceData?.priceImpact) >=
           bridgeFeatureFlags.priceImpactThreshold.gasless) ||
-        (!activeQuote?.quote.gasIncluded &&
+        (!isGasless &&
           Number(activeQuote?.quote.priceData?.priceImpact) >=
             bridgeFeatureFlags.priceImpactThreshold.normal)),
   );

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteData/useBridgeQuoteData.test.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteData/useBridgeQuoteData.test.ts
@@ -132,11 +132,12 @@ describe('useBridgeQuoteData', () => {
   });
 
   it.each([
-    [true, false],
-    [false, true],
+    [true, false, false],
+    [false, true, false],
+    [false, false, true],
   ])(
-    'returns shouldShowPriceImpactWarning=true when priceImpact exceeds threshold and gasIncluded=%s',
-    (gasIncluded, shouldShowPriceImpactWarning) => {
+    'returns shouldShowPriceImpactWarning based on priceImpact exceeding threshold when gasIncluded=%s and gasIncluded7702=%s',
+    (gasIncluded, gasIncluded7702, shouldShowPriceImpactWarning) => {
       // Set up mock for this specific test
       (selectBridgeQuotes as unknown as jest.Mock).mockImplementationOnce(
         () => ({
@@ -146,6 +147,7 @@ describe('useBridgeQuoteData', () => {
               ...mockQuoteWithMetadata.quote,
               priceData: { priceImpact: '0.20' },
               gasIncluded,
+              gasIncluded7702,
             },
           },
           alternativeQuotes: [],

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts
@@ -9,7 +9,7 @@ import {
   selectSelectedDestChainId,
   selectSlippage,
   selectDestAddress,
-  selectGasIncluded,
+  selectGasIncludedQuoteParams,
 } from '../../../../../core/redux/slices/bridge';
 import { getDecimalChainId } from '../../../../../util/networks';
 import { calcTokenValue } from '../../../../../util/transactions';
@@ -46,7 +46,9 @@ export const useBridgeQuoteRequest = () => {
     latestAtomicBalance: latestSourceBalance?.atomicBalance,
   });
 
-  const gasIncluded = useSelector(selectGasIncluded);
+  const { gasIncluded, gasIncluded7702 } = useSelector(
+    selectGasIncludedQuoteParams,
+  );
 
   /**
    * Updates quote parameters in the bridge controller
@@ -80,7 +82,7 @@ export const useBridgeQuoteRequest = () => {
       walletAddress,
       destWalletAddress: destAddress ?? walletAddress,
       gasIncluded,
-      gasIncluded7702: false, // TODO: https://consensyssoftware.atlassian.net/browse/STX-263
+      gasIncluded7702,
       insufficientBal,
     };
 
@@ -98,6 +100,7 @@ export const useBridgeQuoteRequest = () => {
     destAddress,
     context,
     gasIncluded,
+    gasIncluded7702,
     insufficientBal,
   ]);
 

--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/useBridgeQuoteRequest.test.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/useBridgeQuoteRequest.test.ts
@@ -377,10 +377,10 @@ describe('useBridgeQuoteRequest', () => {
   });
 
   describe('gasIncluded parameter', () => {
-    it('includes gasIncluded true in quote request when enabled', async () => {
+    it('includes gasIncluded true in quote request when STX send bundle is supported', async () => {
       const testState = createBridgeTestState({
         bridgeReducerOverrides: {
-          gasIncluded: true,
+          isGasIncludedSTXSendBundleSupported: true,
         },
       });
 
@@ -401,10 +401,10 @@ describe('useBridgeQuoteRequest', () => {
       );
     });
 
-    it('includes gasIncluded false in quote request when disabled', async () => {
+    it('includes gasIncluded false in quote request when STX send bundle is not supported', async () => {
       const testState = createBridgeTestState({
         bridgeReducerOverrides: {
-          gasIncluded: false,
+          isGasIncludedSTXSendBundleSupported: false,
         },
       });
 
@@ -425,7 +425,44 @@ describe('useBridgeQuoteRequest', () => {
       );
     });
 
-    it('includes gasIncluded7702 false in quote request', async () => {
+    it('includes gasIncluded7702 true in quote request when 7702 is supported for swap', async () => {
+      const testState = createBridgeTestState({
+        bridgeReducerOverrides: {
+          isGasIncluded7702Supported: true,
+          // Need to set up a swap scenario (same chain) for 7702 to be enabled
+          sourceToken: {
+            address: '0xSourceToken',
+            chainId: '0x1',
+            decimals: 18,
+            symbol: 'SRC',
+          },
+          destToken: {
+            address: '0xDestToken',
+            chainId: '0x1', // Same chain as source for swap
+            decimals: 18,
+            symbol: 'DEST',
+          },
+        },
+      });
+
+      const { result } = renderHookWithProvider(() => useBridgeQuoteRequest(), {
+        state: testState,
+      });
+
+      await act(async () => {
+        await result.current();
+        jest.advanceTimersByTime(DEBOUNCE_WAIT);
+      });
+
+      expect(spyUpdateBridgeQuoteRequestParams).toHaveBeenCalledWith(
+        expect.objectContaining({
+          gasIncluded7702: true,
+        }),
+        undefined,
+      );
+    });
+
+    it('includes gasIncluded7702 false in quote request when 7702 is not supported', async () => {
       const testState = createBridgeTestState();
 
       const { result } = renderHookWithProvider(() => useBridgeQuoteRequest(), {

--- a/app/components/UI/Bridge/hooks/useHasSufficientGas/index.ts
+++ b/app/components/UI/Bridge/hooks/useHasSufficientGas/index.ts
@@ -21,11 +21,13 @@ interface Props {
 export const useHasSufficientGas = ({ quote }: Props): boolean | null => {
   const gasIncluded = quote?.quote.gasIncluded;
   const gasSponsored = quote?.quote?.gasSponsored;
+  const gasIncluded7702 = quote?.quote.gasIncluded7702;
+  const isGasless = gasIncluded7702 || gasIncluded;
 
   const sourceChainId = quote?.quote.srcChainId;
 
   let hexOrCaipChainId: CaipChainId | Hex | undefined;
-  if (sourceChainId && !gasIncluded && !gasSponsored) {
+  if (sourceChainId && !isGasless && !gasSponsored) {
     if (isNonEvmChainId(sourceChainId)) {
       hexOrCaipChainId = formatChainIdToCaip(sourceChainId);
     } else {
@@ -33,7 +35,7 @@ export const useHasSufficientGas = ({ quote }: Props): boolean | null => {
     }
   }
   const sourceChainNativeAsset =
-    hexOrCaipChainId && !gasIncluded && !gasSponsored
+    hexOrCaipChainId && !isGasless && !gasSponsored
       ? getNativeSourceToken(hexOrCaipChainId)
       : undefined;
 
@@ -43,7 +45,7 @@ export const useHasSufficientGas = ({ quote }: Props): boolean | null => {
     decimals: sourceChainNativeAsset?.decimals,
   });
 
-  if (gasIncluded || gasSponsored) {
+  if (isGasless || gasSponsored) {
     return true;
   }
 
@@ -55,7 +57,7 @@ export const useHasSufficientGas = ({ quote }: Props): boolean | null => {
       : null;
 
   const atomicGasFee =
-    effectiveGasFee && !gasIncluded
+    effectiveGasFee && !isGasless
       ? ethers.utils.parseUnits(
           effectiveGasFee,
           sourceChainNativeAsset?.decimals,

--- a/app/components/UI/Bridge/hooks/useHasSufficientGas/useHasSufficientGas.test.ts
+++ b/app/components/UI/Bridge/hooks/useHasSufficientGas/useHasSufficientGas.test.ts
@@ -17,10 +17,51 @@ describe('useHasSufficientGas', () => {
   });
 
   describe('when gas is included in the quote', () => {
-    it('should return true when gasIncluded is true', () => {
+    it('returns true when gasIncluded is true', () => {
       const mockQuote: ReturnType<typeof useBridgeQuoteData>['activeQuote'] = {
         quote: {
           gasIncluded: true,
+          gasIncluded7702: false,
+          srcChainId: '0x1',
+        },
+        gasFee: {
+          effective: { amount: '0.001' },
+        },
+      } as unknown as ReturnType<typeof useBridgeQuoteData>['activeQuote'];
+
+      const { result } = renderHookWithProvider(
+        () => useHasSufficientGas({ quote: mockQuote }),
+        { state: {} },
+      );
+
+      expect(result.current).toBe(true);
+    });
+
+    it('returns true when gasIncluded7702 is true', () => {
+      const mockQuote: ReturnType<typeof useBridgeQuoteData>['activeQuote'] = {
+        quote: {
+          gasIncluded: false,
+          gasIncluded7702: true,
+          srcChainId: '0x1',
+        },
+        gasFee: {
+          effective: { amount: '0.001' },
+        },
+      } as unknown as ReturnType<typeof useBridgeQuoteData>['activeQuote'];
+
+      const { result } = renderHookWithProvider(
+        () => useHasSufficientGas({ quote: mockQuote }),
+        { state: {} },
+      );
+
+      expect(result.current).toBe(true);
+    });
+
+    it('returns true when both gasIncluded and gasIncluded7702 are true', () => {
+      const mockQuote: ReturnType<typeof useBridgeQuoteData>['activeQuote'] = {
+        quote: {
+          gasIncluded: true,
+          gasIncluded7702: true,
           srcChainId: '0x1',
         },
         gasFee: {
@@ -44,6 +85,7 @@ describe('useHasSufficientGas', () => {
           {
             quote: {
               gasIncluded: false,
+              gasIncluded7702: false,
               srcChainId: '0x1',
             },
             gasFee: {
@@ -70,6 +112,7 @@ describe('useHasSufficientGas', () => {
           {
             quote: {
               gasIncluded: false,
+              gasIncluded7702: false,
               srcChainId: '0x1',
             },
             gasFee: {
@@ -96,6 +139,7 @@ describe('useHasSufficientGas', () => {
           {
             quote: {
               gasIncluded: false,
+              gasIncluded7702: false,
               srcChainId: '0x1',
             },
             gasFee: {
@@ -123,6 +167,7 @@ describe('useHasSufficientGas', () => {
           {
             quote: {
               gasIncluded: false,
+              gasIncluded7702: false,
               srcChainId: '0x1',
             },
             gasFee: {
@@ -145,6 +190,7 @@ describe('useHasSufficientGas', () => {
           {
             quote: {
               gasIncluded: false,
+              gasIncluded7702: false,
               srcChainId: '0x1',
             },
             gasFee: {
@@ -170,6 +216,7 @@ describe('useHasSufficientGas', () => {
           {
             quote: {
               gasIncluded: false,
+              gasIncluded7702: false,
               srcChainId: '0x1',
             },
             gasFee: {
@@ -197,6 +244,7 @@ describe('useHasSufficientGas', () => {
           {
             quote: {
               gasIncluded: false,
+              gasIncluded7702: false,
               srcChainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
             },
             gasFee: {
@@ -223,6 +271,7 @@ describe('useHasSufficientGas', () => {
           {
             quote: {
               gasIncluded: false,
+              gasIncluded7702: false,
               srcChainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
             },
             gasFee: {

--- a/app/components/UI/Bridge/hooks/useInsufficientBalance/index.ts
+++ b/app/components/UI/Bridge/hooks/useInsufficientBalance/index.ts
@@ -38,7 +38,8 @@ const useIsInsufficientBalance = ({
   const minSolBalance = useSelector(selectMinSolBalance);
 
   const bestQuote = quotes?.recommendedQuote;
-  const { gasIncluded, gasSponsored } = bestQuote?.quote ?? {};
+  const { gasIncluded, gasIncluded7702, gasSponsored } = bestQuote?.quote ?? {};
+  const isGasless = gasIncluded7702 || gasIncluded;
 
   const isValidAmount =
     amount !== undefined && amount !== '.' && token?.decimals;
@@ -61,7 +62,7 @@ const useIsInsufficientBalance = ({
     !hasValidDecimals ||
     !token ||
     !latestAtomicBalance ||
-    !!gasIncluded ||
+    !!isGasless ||
     !!gasSponsored
   ) {
     return false;
@@ -80,7 +81,7 @@ const useIsInsufficientBalance = ({
   // For native tokens (ETH, MATIC, etc.), gas comes from the SAME balance we're spending,
   // so we need to ensure: balance >= sourceAmount + gasAmount
   let atomicGasFee = BigNumber.from(0);
-  if (isNativeToken && !gasIncluded) {
+  if (isNativeToken && !isGasless) {
     const gasAmount = bestQuote?.gasFee?.effective?.amount;
     const effectiveGasFee = isNumberValue(gasAmount)
       ? // we guard against null and undefined values of gasAmount when checked isNumberValue
@@ -100,7 +101,7 @@ const useIsInsufficientBalance = ({
     const remainingBalance = latestAtomicBalance.sub(inputAmount);
     isInsufficientBalance =
       isInsufficientBalance || remainingBalance.lt(minSolBalanceLamports);
-  } else if (isNativeToken && !gasIncluded && atomicGasFee.gt(0)) {
+  } else if (isNativeToken && !isGasless && atomicGasFee.gt(0)) {
     // Native tokens (ETH, MATIC, etc.): check balance >= sourceAmount + gasAmount
     // Example: User has 1 ETH, wants to send 1 ETH, needs 0.01 ETH gas = insufficient
     const totalRequired = inputAmount.add(atomicGasFee);

--- a/app/components/UI/Bridge/hooks/useIsGasIncluded7702Supported/index.ts
+++ b/app/components/UI/Bridge/hooks/useIsGasIncluded7702Supported/index.ts
@@ -1,0 +1,51 @@
+import { useEffect, useMemo } from 'react';
+import { useDispatch } from 'react-redux';
+import { Hex, CaipChainId } from '@metamask/utils';
+import { setIsGasIncluded7702Supported } from '../../../../../core/redux/slices/bridge';
+import { useAsyncResult } from '../../../../hooks/useAsyncResult';
+import { isRelaySupported } from '../../../../../util/transactions/transaction-relay';
+import {
+  formatChainIdToHex,
+  isNonEvmChainId,
+} from '@metamask/bridge-controller';
+
+/**
+ * Hook that determines if 7702 gasless support is available for bridge/swap.
+ * Should be used at the page level (e.g., BridgeView) to avoid repeated calculations.
+ *
+ * Requirement for 7702:
+ * - Relay must be supported (for 7702 delegation)
+ *
+ * @param chainId - The chain ID to check (can be Hex, CAIP, or other format) - only EVM chains are supported
+ */
+export const useIsGasIncluded7702Supported = (
+  chainId?: Hex | CaipChainId | string,
+) => {
+  const dispatch = useDispatch();
+
+  // Only check gasIncluded for EVM chains
+  const evmChainId = useMemo(() => {
+    if (!chainId || isNonEvmChainId(chainId)) {
+      return undefined;
+    }
+    return formatChainIdToHex(chainId);
+  }, [chainId]);
+
+  // Fetch relay support
+  const { value: isRelaySupportedForChain } = useAsyncResult(async () => {
+    if (!evmChainId) {
+      return false;
+    }
+
+    return isRelaySupported(evmChainId as Hex);
+  }, [evmChainId]);
+
+  // 7702 is available when ALL conditions are met
+  const isGasIncluded7702Supported = Boolean(
+    evmChainId && !!isRelaySupportedForChain,
+  );
+
+  useEffect(() => {
+    dispatch(setIsGasIncluded7702Supported(isGasIncluded7702Supported));
+  }, [isGasIncluded7702Supported, dispatch]);
+};

--- a/app/components/UI/Bridge/hooks/useIsGasIncluded7702Supported/useIsGasIncluded7702Supported.test.ts
+++ b/app/components/UI/Bridge/hooks/useIsGasIncluded7702Supported/useIsGasIncluded7702Supported.test.ts
@@ -1,0 +1,173 @@
+import { waitFor } from '@testing-library/react-native';
+import { Hex } from '@metamask/utils';
+import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
+import { useIsGasIncluded7702Supported } from './index';
+import { isRelaySupported } from '../../../../../util/transactions/transaction-relay';
+import configureStore from '../../../../../util/test/configureStore';
+
+// Mock dependencies
+jest.mock('../../../../../util/transactions/transaction-relay');
+
+const mockIsRelaySupported = jest.mocked(isRelaySupported);
+
+describe('useIsGasIncluded7702Supported', () => {
+  const MAINNET_CHAIN_ID = '0x1' as Hex;
+  const SOLANA_CHAIN_ID = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+
+  // Helper to assert state updates
+  const expectGasIncluded7702State = async (
+    store: ReturnType<typeof configureStore>,
+    expected: boolean,
+  ) => {
+    await waitFor(() => {
+      const state = store.getState();
+      expect(state.bridge.isGasIncluded7702Supported).toBe(expected);
+    });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsRelaySupported.mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('when all requirements are met', () => {
+    it('updates gasIncluded7702 to true when relay supported', async () => {
+      mockIsRelaySupported.mockResolvedValue(true);
+
+      const { store } = renderHookWithProvider(
+        () => useIsGasIncluded7702Supported(MAINNET_CHAIN_ID),
+        { state: {} },
+      );
+
+      await expectGasIncluded7702State(store, true);
+    });
+
+    it('calls isRelaySupported with correct chainId', async () => {
+      mockIsRelaySupported.mockResolvedValue(true);
+
+      renderHookWithProvider(
+        () => useIsGasIncluded7702Supported(MAINNET_CHAIN_ID),
+        { state: {} },
+      );
+
+      await waitFor(() => {
+        expect(mockIsRelaySupported).toHaveBeenCalledWith(MAINNET_CHAIN_ID);
+      });
+    });
+  });
+
+  describe('when chainId is undefined', () => {
+    it('updates isGasIncluded7702Supported to false when chainId is undefined', async () => {
+      mockIsRelaySupported.mockResolvedValue(true);
+
+      const { store } = renderHookWithProvider(
+        () => useIsGasIncluded7702Supported(undefined),
+        { state: {} },
+      );
+
+      await expectGasIncluded7702State(store, false);
+    });
+
+    it('does not call isRelaySupported when chainId is undefined', async () => {
+      renderHookWithProvider(() => useIsGasIncluded7702Supported(undefined), {
+        state: {},
+      });
+
+      await waitFor(() => {
+        expect(mockIsRelaySupported).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('when chainId is non-EVM', () => {
+    it('updates isGasIncluded7702Supported to false for Solana chain', async () => {
+      const { store } = renderHookWithProvider(
+        () => useIsGasIncluded7702Supported(SOLANA_CHAIN_ID),
+        { state: {} },
+      );
+
+      await expectGasIncluded7702State(store, false);
+    });
+
+    it('does not call isRelaySupported for non-EVM chains', async () => {
+      renderHookWithProvider(
+        () => useIsGasIncluded7702Supported(SOLANA_CHAIN_ID),
+        { state: {} },
+      );
+
+      await waitFor(() => {
+        expect(mockIsRelaySupported).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('when relay is not supported', () => {
+    it('updates isGasIncluded7702Supported to false when relay returns false', async () => {
+      mockIsRelaySupported.mockResolvedValue(false);
+
+      const { store } = renderHookWithProvider(
+        () => useIsGasIncluded7702Supported(MAINNET_CHAIN_ID),
+        { state: {} },
+      );
+
+      await expectGasIncluded7702State(store, false);
+    });
+  });
+
+  describe('when handling CAIP chain IDs', () => {
+    it('updates isGasIncluded7702Supported to true with CAIP format chain ID', async () => {
+      const CAIP_MAINNET = 'eip155:1';
+      mockIsRelaySupported.mockResolvedValue(true);
+
+      const { store } = renderHookWithProvider(
+        () => useIsGasIncluded7702Supported(CAIP_MAINNET),
+        { state: {} },
+      );
+
+      await expectGasIncluded7702State(store, true);
+    });
+  });
+
+  describe('when initial state updates', () => {
+    it('updates isGasIncluded7702Supported when conditions change from true to false', async () => {
+      mockIsRelaySupported.mockResolvedValue(true);
+
+      const { store } = renderHookWithProvider(
+        () => useIsGasIncluded7702Supported(MAINNET_CHAIN_ID),
+        { state: {} },
+      );
+
+      await waitFor(() => {
+        expect(store.getState().bridge.isGasIncluded7702Supported).toBe(true);
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles case-insensitive chainId matching', async () => {
+      mockIsRelaySupported.mockResolvedValue(true);
+
+      const { store } = renderHookWithProvider(
+        () => useIsGasIncluded7702Supported('0X1' as Hex),
+        { state: {} },
+      );
+
+      await expectGasIncluded7702State(store, true);
+    });
+
+    it('updates isGasIncluded7702Supported to false when relay support is undefined', async () => {
+      mockIsRelaySupported.mockResolvedValue(undefined as unknown as boolean);
+
+      const { store } = renderHookWithProvider(
+        () => useIsGasIncluded7702Supported(MAINNET_CHAIN_ID),
+        { state: {} },
+      );
+
+      await expectGasIncluded7702State(store, false);
+    });
+  });
+});

--- a/app/components/UI/Bridge/hooks/useIsGasIncludedSTXSendBundleSupported/index.ts
+++ b/app/components/UI/Bridge/hooks/useIsGasIncludedSTXSendBundleSupported/index.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { setGasIncluded } from '../../../../../core/redux/slices/bridge';
+import { setIsGasIncludedSTXSendBundleSupported } from '../../../../../core/redux/slices/bridge';
 import { selectShouldUseSmartTransaction } from '../../../../../selectors/smartTransactionsController';
 import { useIsSendBundleSupported } from '../useIsSendBundleSupported';
 import { RootState } from '../../../../../reducers';
@@ -11,15 +11,17 @@ import {
 } from '@metamask/bridge-controller';
 
 /**
- * Hook that calculates and updates gasIncluded state for bridge and swap transactions.
+ * Hook that calculates and updates isGasIncludedSTXSendBundleSupported state for bridge and swap transactions.
  * Should be used at the page level (e.g., BridgeView) to avoid repeated calculations.
  *
  * Returns true only when BOTH smart transactions are enabled AND sendBundle is supported.
- * Only applies to EVM chains - non-EVM chains will always have gasIncluded set to false.
+ * Only applies to EVM chains - non-EVM chains will always have isGasIncludedSTXSendBundleSupported set to false.
  *
- * @param chainId - The chain ID to check gasIncluded support for (can be Hex, CAIP, or other format)
+ * @param chainId - The chain ID to check isGasIncludedSTXSendBundleSupported for (can be Hex, CAIP, or other format)
  */
-export const useGasIncluded = (chainId?: Hex | CaipChainId | string) => {
+export const useIsGasIncludedSTXSendBundleSupported = (
+  chainId?: Hex | CaipChainId | string,
+) => {
   const dispatch = useDispatch();
 
   // Only check gasIncluded for EVM chains
@@ -36,11 +38,11 @@ export const useGasIncluded = (chainId?: Hex | CaipChainId | string) => {
     selectShouldUseSmartTransaction(state, evmChainId),
   );
 
-  // gasIncluded is true only when BOTH smart transactions are enabled AND sendBundle is supported
-  const gasIncluded =
+  // isGasIncludedSupported is true only when BOTH smart transactions are enabled AND sendBundle is supported
+  const isGasIncludedSupported =
     shouldUseSmartTransaction && Boolean(isSendBundleSupportedForChain);
 
   useEffect(() => {
-    dispatch(setGasIncluded(gasIncluded));
-  }, [gasIncluded, dispatch]);
+    dispatch(setIsGasIncludedSTXSendBundleSupported(isGasIncludedSupported));
+  }, [isGasIncludedSupported, dispatch]);
 };

--- a/app/components/UI/Bridge/hooks/useIsGasIncludedSTXSendBundleSupported/useIsGasIncludedSTXSendBundleSupported.test.ts
+++ b/app/components/UI/Bridge/hooks/useIsGasIncludedSTXSendBundleSupported/useIsGasIncludedSTXSendBundleSupported.test.ts
@@ -1,5 +1,5 @@
 import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
-import { useGasIncluded } from './index';
+import { useIsGasIncludedSTXSendBundleSupported } from './index';
 import { useIsSendBundleSupported } from '../useIsSendBundleSupported';
 import { selectShouldUseSmartTransaction } from '../../../../../selectors/smartTransactionsController';
 import { Hex } from '@metamask/utils';
@@ -18,23 +18,23 @@ const mockSelectShouldUseSmartTransaction =
     typeof selectShouldUseSmartTransaction
   >;
 
-describe('useGasIncluded', () => {
+describe('useIsGasIncludedSTXSendBundleSupported', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   describe('when both smart transactions and sendBundle are supported', () => {
-    it('updates state with gasIncluded true for Ethereum mainnet', () => {
+    it('updates state with isGasIncludedSTXSendBundleSupported true for Ethereum mainnet', () => {
       mockSelectShouldUseSmartTransaction.mockReturnValue(true);
       mockUseIsSendBundleSupported.mockReturnValue(true);
 
       const { store } = renderHookWithProvider(
-        () => useGasIncluded('0x1' as Hex),
+        () => useIsGasIncludedSTXSendBundleSupported('0x1' as Hex),
         { state: {} },
       );
 
       const state = store.getState();
-      expect(state.bridge.gasIncluded).toBe(true);
+      expect(state.bridge.isGasIncludedSTXSendBundleSupported).toBe(true);
     });
 
     it('updates state with gasIncluded true for Optimism chain', () => {
@@ -42,42 +42,42 @@ describe('useGasIncluded', () => {
       mockUseIsSendBundleSupported.mockReturnValue(true);
 
       const { store } = renderHookWithProvider(
-        () => useGasIncluded('0xa' as Hex),
+        () => useIsGasIncludedSTXSendBundleSupported('0xa' as Hex),
         { state: {} },
       );
 
       const state = store.getState();
-      expect(state.bridge.gasIncluded).toBe(true);
+      expect(state.bridge.isGasIncludedSTXSendBundleSupported).toBe(true);
     });
   });
 
   describe('when smart transactions are not supported', () => {
-    it('updates state with gasIncluded false when smart transactions disabled', () => {
+    it('updates state with isGasIncludedSTXSendBundleSupported false when smart transactions disabled', () => {
       mockSelectShouldUseSmartTransaction.mockReturnValue(false);
       mockUseIsSendBundleSupported.mockReturnValue(true);
 
       const { store } = renderHookWithProvider(
-        () => useGasIncluded('0x1' as Hex),
+        () => useIsGasIncludedSTXSendBundleSupported('0x1' as Hex),
         { state: {} },
       );
 
       const state = store.getState();
-      expect(state.bridge.gasIncluded).toBe(false);
+      expect(state.bridge.isGasIncludedSTXSendBundleSupported).toBe(false);
     });
   });
 
   describe('when sendBundle is not supported', () => {
-    it('updates state with gasIncluded false when sendBundle not supported', () => {
+    it('updates state with isGasIncludedSTXSendBundleSupported false when sendBundle not supported', () => {
       mockSelectShouldUseSmartTransaction.mockReturnValue(true);
       mockUseIsSendBundleSupported.mockReturnValue(false);
 
       const { store } = renderHookWithProvider(
-        () => useGasIncluded('0x1' as Hex),
+        () => useIsGasIncludedSTXSendBundleSupported('0x1' as Hex),
         { state: {} },
       );
 
       const state = store.getState();
-      expect(state.bridge.gasIncluded).toBe(false);
+      expect(state.bridge.isGasIncludedSTXSendBundleSupported).toBe(false);
     });
 
     it('updates state with gasIncluded false when sendBundle returns undefined', () => {
@@ -85,71 +85,74 @@ describe('useGasIncluded', () => {
       mockUseIsSendBundleSupported.mockReturnValue(undefined);
 
       const { store } = renderHookWithProvider(
-        () => useGasIncluded('0x1' as Hex),
+        () => useIsGasIncludedSTXSendBundleSupported('0x1' as Hex),
         { state: {} },
       );
 
       const state = store.getState();
-      expect(state.bridge.gasIncluded).toBe(false);
+      expect(state.bridge.isGasIncludedSTXSendBundleSupported).toBe(false);
     });
 
-    it('updates state with gasIncluded false when sendBundle returns null', () => {
+    it('updates state with isGasIncludedSTXSendBundleSupported false when sendBundle returns null', () => {
       mockSelectShouldUseSmartTransaction.mockReturnValue(true);
       mockUseIsSendBundleSupported.mockReturnValue(null as unknown as boolean);
 
       const { store } = renderHookWithProvider(
-        () => useGasIncluded('0x1' as Hex),
+        () => useIsGasIncludedSTXSendBundleSupported('0x1' as Hex),
         { state: {} },
       );
 
       const state = store.getState();
-      expect(state.bridge.gasIncluded).toBe(false);
+      expect(state.bridge.isGasIncludedSTXSendBundleSupported).toBe(false);
     });
   });
 
   describe('when both smart transactions and sendBundle are not supported', () => {
-    it('updates state with gasIncluded false', () => {
+    it('updates state with isGasIncludedSTXSendBundleSupported false', () => {
       mockSelectShouldUseSmartTransaction.mockReturnValue(false);
       mockUseIsSendBundleSupported.mockReturnValue(false);
 
       const { store } = renderHookWithProvider(
-        () => useGasIncluded('0x1' as Hex),
+        () => useIsGasIncludedSTXSendBundleSupported('0x1' as Hex),
         { state: {} },
       );
 
       const state = store.getState();
-      expect(state.bridge.gasIncluded).toBe(false);
+      expect(state.bridge.isGasIncludedSTXSendBundleSupported).toBe(false);
     });
   });
 
   describe('when chainId is undefined', () => {
-    it('updates state with gasIncluded false when chainId is undefined', () => {
+    it('updates state with isGasIncludedSTXSendBundleSupported false when chainId is undefined', () => {
       mockSelectShouldUseSmartTransaction.mockReturnValue(false);
       mockUseIsSendBundleSupported.mockReturnValue(false);
 
       const { store } = renderHookWithProvider(
-        () => useGasIncluded(undefined),
+        () => useIsGasIncludedSTXSendBundleSupported(undefined),
         { state: {} },
       );
 
       const state = store.getState();
-      expect(state.bridge.gasIncluded).toBe(false);
+      expect(state.bridge.isGasIncludedSTXSendBundleSupported).toBe(false);
     });
   });
 
   describe('when chainId is non-EVM', () => {
-    it('updates state with gasIncluded false for Solana mainnet', () => {
+    it('updates state with isGasIncludedSTXSendBundleSupported false for Solana mainnet', () => {
       // When evmChainId is undefined, mocks should return false
       mockSelectShouldUseSmartTransaction.mockReturnValue(false);
       mockUseIsSendBundleSupported.mockReturnValue(false);
 
       const { store } = renderHookWithProvider(
-        () => useGasIncluded('solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'),
+        () =>
+          useIsGasIncludedSTXSendBundleSupported(
+            'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+          ),
         { state: {} },
       );
 
       const state = store.getState();
-      expect(state.bridge.gasIncluded).toBe(false);
+      expect(state.bridge.isGasIncludedSTXSendBundleSupported).toBe(false);
     });
 
     it('calls useIsSendBundleSupported with undefined for non-EVM chains', () => {
@@ -157,7 +160,10 @@ describe('useGasIncluded', () => {
       mockUseIsSendBundleSupported.mockReturnValue(false);
 
       renderHookWithProvider(
-        () => useGasIncluded('solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'),
+        () =>
+          useIsGasIncludedSTXSendBundleSupported(
+            'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+          ),
         { state: {} },
       );
 
@@ -171,25 +177,25 @@ describe('useGasIncluded', () => {
       mockUseIsSendBundleSupported.mockReturnValue(true);
 
       const { store, rerender } = renderHookWithProvider(
-        () => useGasIncluded('0x1' as Hex),
+        () => useIsGasIncludedSTXSendBundleSupported('0x1' as Hex),
         { state: {} },
       );
 
       // Initial state
       let state = store.getState();
-      expect(state.bridge.gasIncluded).toBe(true);
+      expect(state.bridge.isGasIncludedSTXSendBundleSupported).toBe(true);
 
       // Change conditions - smart transactions not supported on new chain
       mockSelectShouldUseSmartTransaction.mockReturnValue(false);
       mockUseIsSendBundleSupported.mockReturnValue(false);
 
       act(() => {
-        rerender(() => useGasIncluded('0x1' as Hex));
+        rerender(() => useIsGasIncludedSTXSendBundleSupported('0x1' as Hex));
       });
 
       // State should be updated to false
       state = store.getState();
-      expect(state.bridge.gasIncluded).toBe(false);
+      expect(state.bridge.isGasIncludedSTXSendBundleSupported).toBe(false);
     });
   });
 });

--- a/app/core/redux/slices/bridge/index.test.ts
+++ b/app/core/redux/slices/bridge/index.test.ts
@@ -10,6 +10,7 @@ import reducer, {
   selectBridgeViewMode,
   setDestToken,
   selectBip44DefaultPair,
+  selectGasIncludedQuoteParams,
 } from '.';
 import {
   BridgeToken,
@@ -50,7 +51,8 @@ describe('bridge slice', () => {
         destAmount: undefined,
         sourceToken: undefined,
         destToken: undefined,
-        gasIncluded: false,
+        isGasIncludedSTXSendBundleSupported: false,
+        isGasIncluded7702Supported: false,
         destAddress: undefined,
         selectedSourceChainIds: undefined,
         selectedDestChainId: undefined,
@@ -383,6 +385,70 @@ describe('bridge slice', () => {
       const result = selectBip44DefaultPair(mockState as unknown as RootState);
 
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe('selectGasIncludedQuoteParams', () => {
+    it('returns gasIncluded true with 7702 false when STX send bundle is supported', () => {
+      const mockState = {
+        bridge: {
+          ...initialState,
+          isGasIncludedSTXSendBundleSupported: true,
+          isGasIncluded7702Supported: true,
+        },
+      } as RootState;
+
+      const result = selectGasIncludedQuoteParams(mockState);
+
+      expect(result).toEqual({ gasIncluded: true, gasIncluded7702: false });
+    });
+
+    it('returns gasIncluded true with 7702 true for swap when 7702 is supported', () => {
+      const mockState = {
+        bridge: {
+          ...initialState,
+          sourceToken: mockToken,
+          destToken: { ...mockDestToken, chainId: mockToken.chainId },
+          isGasIncludedSTXSendBundleSupported: false,
+          isGasIncluded7702Supported: true,
+        },
+      } as RootState;
+
+      const result = selectGasIncludedQuoteParams(mockState);
+
+      expect(result).toEqual({ gasIncluded: true, gasIncluded7702: true });
+    });
+
+    it('returns gasIncluded false with 7702 false for swap without 7702 support', () => {
+      const mockState = {
+        bridge: {
+          ...initialState,
+          sourceToken: mockToken,
+          destToken: { ...mockDestToken, chainId: mockToken.chainId },
+          isGasIncludedSTXSendBundleSupported: false,
+          isGasIncluded7702Supported: false,
+        },
+      } as RootState;
+
+      const result = selectGasIncludedQuoteParams(mockState);
+
+      expect(result).toEqual({ gasIncluded: false, gasIncluded7702: false });
+    });
+
+    it('returns gasIncluded false with 7702 false for bridge mode', () => {
+      const mockState = {
+        bridge: {
+          ...initialState,
+          sourceToken: mockToken,
+          destToken: mockDestToken,
+          isGasIncludedSTXSendBundleSupported: false,
+          isGasIncluded7702Supported: true,
+        },
+      } as RootState;
+
+      const result = selectGasIncludedQuoteParams(mockState);
+
+      expect(result).toEqual({ gasIncluded: false, gasIncluded7702: false });
     });
   });
 });

--- a/app/util/transactions/hooks/delegation-7702-publish.test.ts
+++ b/app/util/transactions/hooks/delegation-7702-publish.test.ts
@@ -13,9 +13,11 @@ import {
 import {
   GasFeeToken,
   TransactionController,
-  TransactionControllerUpdateTransactionAction,
+  TransactionControllerState,
   TransactionMeta,
   TransactionType,
+  TransactionControllerGetStateAction,
+  TransactionControllerUpdateTransactionAction,
 } from '@metamask/transaction-controller';
 import { getDeleGatorEnvironment } from '../../../core/Delegation';
 import { TransactionControllerInitMessenger } from '../../../core/Engine/messengers/transaction-controller-messenger';
@@ -75,6 +77,7 @@ type RootMessenger = Messenger<
   | DelegationControllerSignDelegationAction
   | KeyringControllerSignEip7702AuthorizationAction
   | KeyringControllerSignTypedMessageAction
+  | TransactionControllerGetStateAction
   | TransactionControllerUpdateTransactionAction,
   never
 >;
@@ -105,6 +108,9 @@ describe('Delegation 7702 Publish Hook', () => {
   const getNextNonceMock: jest.MockedFn<
     (address: string, networkClientId: NetworkClientId) => Promise<Hex>
   > = jest.fn();
+  const getStateMock: jest.MockedFn<
+    TransactionControllerGetStateAction['handler']
+  > = jest.fn();
   const updateTransactionMock: jest.MockedFn<
     TransactionControllerUpdateTransactionAction['handler']
   > = jest.fn();
@@ -120,6 +126,7 @@ describe('Delegation 7702 Publish Hook', () => {
       | DelegationControllerSignDelegationAction
       | KeyringControllerSignEip7702AuthorizationAction
       | KeyringControllerSignTypedMessageAction
+      | TransactionControllerGetStateAction
       | TransactionControllerUpdateTransactionAction,
       never,
       RootMessenger
@@ -134,6 +141,7 @@ describe('Delegation 7702 Publish Hook', () => {
         'KeyringController:signTypedMessage',
         'BridgeStatusController:getState',
         'DelegationController:signDelegation',
+        'TransactionController:getState',
         'TransactionController:updateTransaction',
       ],
       events: [],
@@ -151,6 +159,10 @@ describe('Delegation 7702 Publish Hook', () => {
     rootMessenger.registerActionHandler(
       'DelegationController:signDelegation',
       signDelegationControllerMock,
+    );
+    rootMessenger.registerActionHandler(
+      'TransactionController:getState',
+      getStateMock,
     );
     rootMessenger.registerActionHandler(
       'TransactionController:updateTransaction',
@@ -176,6 +188,9 @@ describe('Delegation 7702 Publish Hook', () => {
       status: RelayStatus.Success,
       transactionHash: TRANSACTION_HASH_MOCK,
     });
+    getStateMock.mockReturnValue({
+      transactions: [],
+    } as unknown as TransactionControllerState);
   });
 
   describe('returns empty result if', () => {
@@ -544,18 +559,45 @@ describe('Delegation 7702 Publish Hook', () => {
       },
     ]);
 
-    const result = await hookClass.getHook()(
-      {
-        ...TRANSACTION_META_MOCK,
-        gasFeeTokens: [GAS_FEE_TOKEN_MOCK],
-        selectedGasFeeToken: GAS_FEE_TOKEN_MOCK.tokenAddress,
-      },
-      SIGNED_TX_MOCK,
-    );
+    const txMeta = {
+      ...TRANSACTION_META_MOCK,
+      id: 'test-tx-id',
+      gasFeeTokens: [GAS_FEE_TOKEN_MOCK],
+      selectedGasFeeToken: GAS_FEE_TOKEN_MOCK.tokenAddress,
+    };
+
+    getStateMock.mockReturnValue({
+      transactions: [txMeta],
+    } as unknown as TransactionControllerState);
+
+    const result = await hookClass.getHook()(txMeta, SIGNED_TX_MOCK);
 
     expect(result).toStrictEqual({
       transactionHash: TRANSACTION_HASH_MOCK,
     });
+
+    expect(updateTransactionMock).toHaveBeenCalledTimes(2);
+
+    expect(updateTransactionMock).toHaveBeenNthCalledWith(
+      1,
+      {
+        ...txMeta,
+        txParams: {
+          ...txMeta.txParams,
+          nonce: undefined,
+        },
+      },
+      'Delegation7702PublishHook - Remove nonce from transaction before relay',
+    );
+
+    expect(updateTransactionMock).toHaveBeenNthCalledWith(
+      2,
+      {
+        ...txMeta,
+        isIntentComplete: true,
+      },
+      'Delegation7702PublishHook - Set isIntentComplete after relay confirmed',
+    );
   });
 
   it('includes authorization list if not upgraded', async () => {

--- a/app/util/transactions/hooks/delegation-7702-publish.ts
+++ b/app/util/transactions/hooks/delegation-7702-publish.ts
@@ -202,6 +202,24 @@ export class Delegation7702PublishHook {
 
     log('Relay request', relayRequest);
 
+    const initialTxMeta = this.#messenger
+      .call('TransactionController:getState')
+      .transactions.find((tx) => tx.id === transactionMeta.id);
+
+    if (initialTxMeta) {
+      this.#messenger.call(
+        'TransactionController:updateTransaction',
+        {
+          ...initialTxMeta,
+          txParams: {
+            ...initialTxMeta.txParams,
+            nonce: undefined,
+          },
+        },
+        'Delegation7702PublishHook - Remove nonce from transaction before relay',
+      );
+    }
+
     const { uuid } = await submitRelayTransaction(relayRequest);
 
     const { transactionHash, status } = await waitForRelayResult({
@@ -215,16 +233,22 @@ export class Delegation7702PublishHook {
     }
 
     // Mark 7702 relay transaction as intent complete so PendingTransactionTracker
-    // skips dropped checks, matching transaction-pay-controller
-    const updatedTransactionMeta = {
-      ...transactionMeta,
-      isIntentComplete: true,
-    };
-    await this.#messenger.call(
-      'TransactionController:updateTransaction',
-      updatedTransactionMeta,
-      'Intent complete after 7702 relay transaction success',
-    );
+    // skips dropped checks
+    log('Setting isIntentComplete after relay success', transactionMeta.id);
+    const finalTxMeta = this.#messenger
+      .call('TransactionController:getState')
+      .transactions.find((tx) => tx.id === transactionMeta.id);
+
+    if (finalTxMeta) {
+      this.#messenger.call(
+        'TransactionController:updateTransaction',
+        {
+          ...finalTxMeta,
+          isIntentComplete: true,
+        },
+        'Delegation7702PublishHook - Set isIntentComplete after relay confirmed',
+      );
+    }
 
     return {
       transactionHash,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR enabled gasless swaps with EIP-7702. This is enable only for Swaps (Bridges are explicitly excluded). It also enable automatic smart account upgrade if the user did not upgraded beforehand. 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: add support for gas-included swaps with EIP-7702

## **Related issues**

https://consensyssoftware.atlassian.net/browse/STX-263

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user performs a gasless swap
    Given the user is active on a networks with EIP-7702 support and the feature enabled (Base or Arbitrum)
    And the user has <a smart account/no smart account> in the network and no gas
    When user requests a quote for a swap on the chain
    Then the swap quote indicates the gas fees are included
    When the user submit the swap
    Then the swap is executed successfully
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds EIP-7702 gasless swap support with new capability hooks and selectors, updates quote/fee logic and relay flow, and replaces legacy gasIncluded state.
> 
> - **State/Selectors (bridge slice)**
>   - Replace `gasIncluded` with `isGasIncludedSTXSendBundleSupported` and `isGasIncluded7702Supported` in `BridgeState`.
>   - Add `selectGasIncludedQuoteParams` to derive `gasIncluded`/`gasIncluded7702` (prioritize STX send bundle; use 7702 for same-chain swaps).
>   - Export selectors for both support flags; update initial state and tests.
> 
> - **Hooks**
>   - Add `useIsGasIncludedSTXSendBundleSupported` and `useIsGasIncluded7702Supported` to set capability flags from chain features.
>   - Update `useBridgeQuoteRequest` to use `selectGasIncludedQuoteParams` and send both `gasIncluded` and `gasIncluded7702`.
>   - Update `useBridgeQuoteData` price impact logic to treat gasless when `gasIncluded` or `gasIncluded7702`.
>   - Update `useHasSufficientGas` and `useInsufficientBalance` to treat 7702 as gasless.
> 
> - **UI**
>   - `BridgeView`: call new gas-included support hooks based on `sourceToken?.chainId`.
>   - `QuoteDetailsCard`: show “Included” network fee and gasless price-impact tooltip when `gasIncluded7702` (or `gasIncluded`).
> 
> - **Relay/7702 publish hook**
>   - In `delegation-7702-publish`: fetch tx state, clear nonce before relay, and mark `isIntentComplete` after success; support gasless/sponsored flows without gas fee tokens.
> 
> - **Tests**
>   - Comprehensive updates and new tests for selectors, hooks, UI, and 7702 relay behavior (including nonce clearing and intent complete).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f70cd6e9a277565da614fac0c7647b6f62f7dff0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->