### PR TITLE
fix(predict): Resolves issue with details chart incorrectly hiding

### DIFF
--- a/app/components/UI/Predict/components/PredictDetailsChart/PredictDetailsChart.tsx
+++ b/app/components/UI/Predict/components/PredictDetailsChart/PredictDetailsChart.tsx
@@ -30,7 +30,11 @@ import {
   CHART_CONTENT_INSET,
   MAX_SERIES,
   formatPriceHistoryLabel,
+  getTimeframeDurationMs,
 } from './utils';
+
+const MIN_SERIES_POINTS = 2;
+const MIN_TIMEFRAME_COVERAGE_RATIO = 0.5;
 
 export interface ChartSeries {
   label: string;
@@ -275,27 +279,68 @@ const PredictDetailsChart: React.FC<PredictDetailsChartProps> = ({
 
   // Limit to MAX_SERIES
   const seriesToRender = React.useMemo(() => data.slice(0, MAX_SERIES), [data]);
-  const isSingleSeries = seriesToRender.length === 1;
-  const isMultipleSeries = seriesToRender.length > 1;
+  const timeframeDurationMs = React.useMemo(
+    () => getTimeframeDurationMs(selectedTimeframe),
+    [selectedTimeframe],
+  );
+  const seriesWithinTimeframe = React.useMemo(() => {
+    if (timeframeDurationMs === null) {
+      return seriesToRender;
+    }
 
+    return seriesToRender.filter((series) => {
+      if (!series.data?.length) {
+        return false;
+      }
+
+      const timestampsInMs = series.data
+        .map((point) => Number(point.timestamp))
+        .filter((timestamp) => Number.isFinite(timestamp))
+        .map((timestamp) =>
+          timestamp > 1_000_000_000_000 ? timestamp : timestamp * 1000,
+        );
+
+      if (!timestampsInMs.length) {
+        return false;
+      }
+
+      if (timestampsInMs.length < MIN_SERIES_POINTS) {
+        return false;
+      }
+
+      const minTimestamp = Math.min(...timestampsInMs);
+      const maxTimestamp = Math.max(...timestampsInMs);
+      const span = maxTimestamp - minTimestamp;
+
+      const coverageRatio = span / timeframeDurationMs;
+
+      return coverageRatio >= MIN_TIMEFRAME_COVERAGE_RATIO;
+    });
+  }, [seriesToRender, timeframeDurationMs]);
   // Process data with labels
   const seriesWithLabels = React.useMemo(
     () =>
-      seriesToRender.map((series) => ({
+      seriesWithinTimeframe.map((series) => ({
         ...series,
         data: series.data.map((point) => ({
           ...point,
           label: formatPriceHistoryLabel(point.timestamp, selectedTimeframe),
         })),
       })),
-    [seriesToRender, selectedTimeframe],
+    [seriesWithinTimeframe, selectedTimeframe],
   );
+
+  const isSingleSeries = seriesWithLabels.length === 1;
+  const isMultipleSeries = seriesWithLabels.length > 1;
 
   // Filter out empty series
   const nonEmptySeries = seriesWithLabels.filter(
     (series) => series.data.length > 0,
   );
   const hasData = nonEmptySeries.length > 0;
+
+  const shouldHideChart =
+    !isLoading && (!hasData || seriesWithinTimeframe.length === 0);
 
   // Calculate chart bounds
   const chartValues = hasData
@@ -404,6 +449,10 @@ const PredictDetailsChart: React.FC<PredictDetailsChartProps> = ({
       }),
     [updatePosition],
   );
+
+  if (shouldHideChart) {
+    return null;
+  }
 
   const renderGraph = () => {
     if (isLoading || !hasData) {

--- a/app/components/UI/Predict/components/PredictDetailsChart/utils.test.ts
+++ b/app/components/UI/Predict/components/PredictDetailsChart/utils.test.ts
@@ -5,6 +5,7 @@ import {
   CHART_HEIGHT,
   CHART_CONTENT_INSET,
   MAX_SERIES,
+  getTimeframeDurationMs,
   formatPriceHistoryLabel,
   formatTickValue,
 } from './utils';
@@ -35,6 +36,35 @@ describe('PredictDetailsChart utils', () => {
     it('exports line curve as a function', () => {
       expect(typeof LINE_CURVE).toBe('function');
       expect(LINE_CURVE.alpha).toBeDefined();
+    });
+  });
+
+  describe('getTimeframeDurationMs', () => {
+    it.each([
+      [PredictPriceHistoryInterval.ONE_HOUR, 60 * 60 * 1000],
+      [PredictPriceHistoryInterval.SIX_HOUR, 6 * 60 * 60 * 1000],
+      [PredictPriceHistoryInterval.ONE_DAY, 24 * 60 * 60 * 1000],
+      [PredictPriceHistoryInterval.ONE_WEEK, 7 * 24 * 60 * 60 * 1000],
+      [PredictPriceHistoryInterval.ONE_MONTH, 30 * 24 * 60 * 60 * 1000],
+    ])(
+      'returns expected duration for %s interval',
+      (interval: PredictPriceHistoryInterval, expectedDuration: number) => {
+        const result = getTimeframeDurationMs(interval);
+
+        expect(result).toBe(expectedDuration);
+      },
+    );
+
+    it('returns null for MAX interval', () => {
+      const result = getTimeframeDurationMs(PredictPriceHistoryInterval.MAX);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for unknown interval', () => {
+      const result = getTimeframeDurationMs('unknown-interval');
+
+      expect(result).toBeNull();
     });
   });
 

--- a/app/components/UI/Predict/components/PredictDetailsChart/utils.ts
+++ b/app/components/UI/Predict/components/PredictDetailsChart/utils.ts
@@ -1,6 +1,11 @@
 import { curveCatmullRom } from 'd3-shape';
 import { PredictPriceHistoryInterval } from '../../types';
 
+const HOUR_IN_MS = 60 * 60 * 1000;
+const DAY_IN_MS = 24 * HOUR_IN_MS;
+const WEEK_IN_MS = 7 * DAY_IN_MS;
+const MONTH_IN_MS = 30 * DAY_IN_MS;
+
 export const DEFAULT_EMPTY_LABEL = '';
 export const LINE_CURVE = curveCatmullRom.alpha(0.2);
 export const CHART_HEIGHT = 192;
@@ -11,6 +16,26 @@ export const CHART_CONTENT_INSET = {
   right: 48,
 };
 export const MAX_SERIES = 3;
+
+export const getTimeframeDurationMs = (
+  interval: PredictPriceHistoryInterval | string,
+): number | null => {
+  switch (interval) {
+    case PredictPriceHistoryInterval.ONE_HOUR:
+      return HOUR_IN_MS;
+    case PredictPriceHistoryInterval.SIX_HOUR:
+      return 6 * HOUR_IN_MS;
+    case PredictPriceHistoryInterval.ONE_DAY:
+      return DAY_IN_MS;
+    case PredictPriceHistoryInterval.ONE_WEEK:
+      return WEEK_IN_MS;
+    case PredictPriceHistoryInterval.ONE_MONTH:
+      return MONTH_IN_MS;
+    case PredictPriceHistoryInterval.MAX:
+    default:
+      return null;
+  }
+};
 
 export const formatPriceHistoryLabel = (
   timestamp: number,

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -2277,9 +2277,7 @@ describe('PredictMarketDetails', () => {
 
       setupPredictMarketDetailsTest(marketWithPartialResolution);
 
-      expect(
-        screen.queryByTestId('predict-details-chart'),
-      ).not.toBeOnTheScreen();
+      expect(screen.getByTestId('predict-details-chart')).toBeOnTheScreen();
     });
 
     it('displays resolved outcomes count badge', () => {

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -1137,16 +1137,14 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
         {/* Header content - scrollable */}
         <Box twClassName="px-3 gap-4">
           {renderMarketStatus()}
-          {!multipleOpenOutcomesPartiallyResolved && (
-            <PredictDetailsChart
-              data={chartData}
-              timeframes={PRICE_HISTORY_TIMEFRAMES}
-              selectedTimeframe={selectedTimeframe}
-              onTimeframeChange={handleTimeframeChange}
-              isLoading={isPriceHistoryFetching}
-              emptyLabel={chartEmptyLabel}
-            />
-          )}
+          <PredictDetailsChart
+            data={chartData}
+            timeframes={PRICE_HISTORY_TIMEFRAMES}
+            selectedTimeframe={selectedTimeframe}
+            onTimeframeChange={handleTimeframeChange}
+            isLoading={isPriceHistoryFetching}
+            emptyLabel={chartEmptyLabel}
+          />
         </Box>
 
         {/* Show content skeleton while initial market data is fetching */}


### PR DESCRIPTION


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Resolves issue with details chart incorrectly hiding 
- Now it only hides in an a hybrid market scenario wherein resolved outcomes are attempted to be rendered to the chart that an incomplete time series relative to the selected timeframe

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: [PRED-296](https://consensyssoftware.atlassian.net/browse/PRED-296)

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/45cce31c-b7cb-4ff6-8cfc-bd9848d052ad



https://github.com/user-attachments/assets/84dd5823-48ff-4ce0-b7b0-8354436c314b



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[PRED-296]: https://consensyssoftware.atlassian.net/browse/PRED-296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds timeframe-aware series filtering to PredictDetailsChart, hides it only when no eligible data exists, introduces timeframe duration utility, and always renders the chart in market details with updated tests.
> 
> - **PredictDetailsChart**:
>   - Timeframe-aware filtering: compute `seriesWithinTimeframe` using `getTimeframeDurationMs`, require `>= 2` points and `>= 50%` coverage; drop series not spanning selected timeframe.
>   - Visibility: return `null` only when not loading and no eligible data; previously shown empty label now hidden in such cases.
>   - Data processing updated to use filtered series; maintains bounds, legend, tooltip logic.
> - **Utils**:
>   - Add `getTimeframeDurationMs(interval)` for `1H/6H/1D/1W/1M`, `null` for `MAX`/unknown.
> - **PredictMarketDetails**:
>   - Always renders `PredictDetailsChart` (removes conditional hide for partially resolved outcomes).
> - **Tests**:
>   - Expand unit tests for timeframe coverage, visibility, collision cases, colors, overlays; add utility tests for timeframe durations; adjust expectations to new hide/show behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55153b2b3f469e4074aa2469a2602fd60aeedc1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->