### PR TITLE
fix: run discovery and alignment upon unlock for all wallets cp-7.59.0

### DIFF
--- a/app/core/Authentication/Authentication.test.ts
+++ b/app/core/Authentication/Authentication.test.ts
@@ -568,6 +568,7 @@ describe('Authentication', () => {
 
       afterEach(() => {
         jest.restoreAllMocks();
+        mockIsMultichainAccountsState2Enabled.mockReturnValue(false);
       });
 
       it('completes wallet creation when discovery fails', async () => {
@@ -644,6 +645,7 @@ describe('Authentication', () => {
 
       describe('retryDiscoveryIfPending behavior', () => {
         let mockAttemptAccountDiscovery: jest.SpyInstance;
+        let mockAttemptMultichainAccountWalletDiscovery: jest.SpyInstance;
 
         beforeEach(() => {
           // Spy on the private method
@@ -655,10 +657,20 @@ describe('Authentication', () => {
               'attemptAccountDiscovery',
             )
             .mockResolvedValue(undefined);
+
+          mockAttemptMultichainAccountWalletDiscovery = jest
+            .spyOn(
+              Authentication as unknown as {
+                attemptMultichainAccountWalletDiscovery: () => Promise<void>;
+              },
+              'attemptMultichainAccountWalletDiscovery',
+            )
+            .mockResolvedValue(undefined);
         });
 
         afterEach(() => {
           mockAttemptAccountDiscovery.mockRestore();
+          mockAttemptMultichainAccountWalletDiscovery.mockRestore();
         });
 
         it('calls attemptAccountDiscovery when flag is set to true', async () => {
@@ -899,6 +911,36 @@ describe('Authentication', () => {
             jest.runAllTimers();
             expect(mockDispatch).toHaveBeenCalledWith(logOut());
           }
+        });
+
+        it('runs discovery and alignment on all HD wallets - state 2', async () => {
+          const Engine = jest.requireMock('../Engine');
+          Engine.context.KeyringController.state.keyrings = [
+            { type: KeyringTypes.hd, metadata: { id: 'test-keyring-1' } },
+            { type: KeyringTypes.hd, metadata: { id: 'test-keyring-2' } },
+            // Should not run discovery for this one.
+            { type: KeyringTypes.simple, metadata: { id: 'test-keyring-3' } },
+          ];
+
+          mockIsMultichainAccountsState2Enabled.mockReturnValue(true);
+
+          const mockCredentials = { username: 'test', password: 'test' };
+          SecureKeychain.getGenericPassword = jest
+            .fn()
+            .mockReturnValue(mockCredentials);
+
+          await Authentication.appTriggeredAuth();
+
+          // We should have ran discovery + alignment on all HD keyrings only.
+          expect(
+            mockAttemptMultichainAccountWalletDiscovery,
+          ).toHaveBeenCalledTimes(2);
+          expect(
+            mockAttemptMultichainAccountWalletDiscovery,
+          ).toHaveBeenNthCalledWith(1, 'test-keyring-1');
+          expect(
+            mockAttemptMultichainAccountWalletDiscovery,
+          ).toHaveBeenNthCalledWith(2, 'test-keyring-2');
         });
       });
     });

--- a/app/core/Authentication/Authentication.ts
+++ b/app/core/Authentication/Authentication.ts
@@ -125,6 +125,16 @@ class AuthenticationService {
   }
 
   /**
+   * This method gets the entropy source IDs for all HD wallets.
+   * @returns All known entropy source IDs.
+   */
+  private getEntropySourceIds(): EntropySourceId[] {
+    return Engine.context.KeyringController.state.keyrings
+      .filter((keyring) => keyring.type === KeyringTypes.hd)
+      .map((keyring) => keyring.metadata.id);
+  }
+
+  /**
    * This method recreates the vault upon login if user is new and is not using the latest encryption lib
    * @param password - password entered on login
    */
@@ -228,9 +238,19 @@ class AuthenticationService {
 
   private retryDiscoveryIfPending = async (): Promise<void> => {
     if (isMultichainAccountsState2Enabled()) {
-      // We just re-run the same discovery here. Each wallets know their highest group index and restart
-      // the discovery from there, thus acting as a "retry".
-      await this.attemptMultichainAccountWalletDiscovery();
+      // We just re-run the same discovery here.
+      // 1. Each wallets know their highest group index and restart the discovery from
+      // there, thus acting naturally as a "retry".
+      // 2. Running the discovery every time allow to auto-discover accounts that could
+      // have been added on external wallets.
+      // 3. We run the alignment at the end of the discovery, thus, automatically
+      // creating accounts for new account providers.
+      await Promise.allSettled(
+        this.getEntropySourceIds().map(
+          async (entropySource) =>
+            await this.attemptMultichainAccountWalletDiscovery(entropySource),
+        ),
+      );
     } else {
       await Promise.all(
         Object.values(WalletClientType).map(async (clientType) => {


### PR DESCRIPTION
## **Description**

Since the introduction of the BIP-44 feature, we now run discovery after every unlock (which also run an alignment after having discovered accounts or not).

Though, we were only doing it for the primary wallet, thus, preventing to run alignment for other wallets, which prevented those other wallets to automatically create missing accounts on new providers (such as Bitcoin).

## **Changelog**

CHANGELOG entry: Now run discovery on all wallets after every unlock (used to be on the primary wallet only)

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Discovery for every HD wallets

  Scenario: user gets new Bitcoin accounts
    Given it has upgraded his app and has multiple HD wallets

    When user unlocks
    Then it automatically run account discovery and alignment for all HD wallets, resulting in new Bitcoin accounts being added (after upgrading)
```

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> On unlock (state 2), concurrently re-run multichain discovery and alignment for all HD wallets, with tests validating HD-only execution.
> 
> - **Authentication**:
>   - Add `getEntropySourceIds()` to collect all HD wallet entropy IDs from `KeyringController.state.keyrings`.
>   - Update `retryDiscoveryIfPending()` (state 2 enabled):
>     - Run `attemptMultichainAccountWalletDiscovery` for each HD wallet via `Promise.allSettled`, enabling discovery/alignment across all HD keyrings.
>     - Keep legacy per-client retry path for non-state-2.
> - **Tests (`app/core/Authentication/Authentication.test.ts`)**:
>   - Add spies for `attemptMultichainAccountWalletDiscovery` and verify it runs for each HD keyring only.
>   - Ensure `mockIsMultichainAccountsState2Enabled` resets after tests; minor setup/teardown adjustments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95624bddc944d5e2e7b6b6b7599d0d938c4f00fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->