### PR TITLE
fix(e2e): add Android delay handling for confirm button tap

### DIFF
--- a/e2e/pages/Browser/Confirmations/FooterActions.ts
+++ b/e2e/pages/Browser/Confirmations/FooterActions.ts
@@ -1,6 +1,7 @@
 import { ConfirmationFooterSelectorIDs } from '../../../selectors/Confirmation/ConfirmationView.selectors';
 import Matchers from '../../../framework/Matchers';
 import Gestures from '../../../framework/Gestures';
+import TestHelpers from '../../../helpers';
 
 class FooterActions {
   get confirmButton(): DetoxElement {
@@ -14,10 +15,14 @@ class FooterActions {
   }
 
   async tapConfirmButton(): Promise<void> {
+    const isAndroid = device.getPlatform() === 'android';
+    // Android needs extra delay to avoid element being obscured by bottom toast notifications
+    // eslint-disable-next-line no-restricted-syntax
+    if (isAndroid) await TestHelpers.delay(3000);
     await Gestures.waitAndTap(this.confirmButton, {
       elemDescription: 'Confirm button',
       delay: 1800,
-      waitForElementToDisappear: device.getPlatform() === 'android',
+      waitForElementToDisappear: isAndroid,
     });
   }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

- Addresses some flakiness in the send asset test.
- iOS handles element obstruction more gracefully so we dont need the same checks. 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an Android-only delay and consolidated platform check before tapping the confirm button in e2e `FooterActions` to mitigate element obstruction.
> 
> - **E2E (Browser Confirmations)**
>   - In `e2e/pages/Browser/Confirmations/FooterActions.ts`:
>     - Add Android-only `TestHelpers.delay(3000)` before `confirm` tap to avoid bottom toast obstruction.
>     - Refactor platform check to `isAndroid` and use it for `waitForElementToDisappear`.
>     - Import `TestHelpers` to support the delay.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 342eb25a1cc43e50d8e05947cbe4343b3f4ee805. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->