### PR TITLE
chore: remove rewards ff for predict buy preview

### DIFF
--- a/app/components/UI/Predict/components/PredictFeeSummary/PredictFeeSummary.test.tsx
+++ b/app/components/UI/Predict/components/PredictFeeSummary/PredictFeeSummary.test.tsx
@@ -173,25 +173,9 @@ describe('PredictFeeSummary', () => {
   });
 
   describe('Rewards Row', () => {
-    it('does not display rewards row when shouldShowRewards is false', () => {
+    it('always displays rewards row when not disabled', () => {
       const props = {
         ...defaultProps,
-        shouldShowRewards: false,
-        estimatedPoints: 100,
-      };
-
-      const { queryByText, queryByTestId } = render(
-        <PredictFeeSummary {...props} />,
-      );
-
-      expect(queryByText('Est. points')).toBeNull();
-      expect(queryByTestId('rewards-animation')).toBeNull();
-    });
-
-    it('displays rewards row when shouldShowRewards is true', () => {
-      const props = {
-        ...defaultProps,
-        shouldShowRewards: true,
         estimatedPoints: 50,
       };
 
@@ -206,7 +190,6 @@ describe('PredictFeeSummary', () => {
     it('displays correct estimated points value', () => {
       const props = {
         ...defaultProps,
-        shouldShowRewards: true,
         estimatedPoints: 123,
       };
 
@@ -218,7 +201,6 @@ describe('PredictFeeSummary', () => {
     it('displays zero points when estimatedPoints is 0', () => {
       const props = {
         ...defaultProps,
-        shouldShowRewards: true,
         estimatedPoints: 0,
       };
 
@@ -226,13 +208,58 @@ describe('PredictFeeSummary', () => {
 
       expect(getByText('0 points')).toBeOnTheScreen();
     });
+
+    it('displays loading state when isLoadingRewards is true', () => {
+      const props = {
+        ...defaultProps,
+        estimatedPoints: 50,
+        isLoadingRewards: true,
+      };
+
+      const { getByText, getByTestId } = render(
+        <PredictFeeSummary {...props} />,
+      );
+
+      expect(getByText('Est. points')).toBeOnTheScreen();
+      expect(getByTestId('rewards-animation')).toBeOnTheScreen();
+    });
+
+    it('displays error state when hasRewardsError is true', () => {
+      const props = {
+        ...defaultProps,
+        estimatedPoints: 50,
+        hasRewardsError: true,
+      };
+
+      const { getByText, getByTestId } = render(
+        <PredictFeeSummary {...props} />,
+      );
+
+      expect(getByText('Est. points')).toBeOnTheScreen();
+      expect(getByTestId('rewards-animation')).toBeOnTheScreen();
+    });
+
+    it('displays idle state when not loading and no error', () => {
+      const props = {
+        ...defaultProps,
+        estimatedPoints: 50,
+        isLoadingRewards: false,
+        hasRewardsError: false,
+      };
+
+      const { getByText, getByTestId } = render(
+        <PredictFeeSummary {...props} />,
+      );
+
+      expect(getByText('Est. points')).toBeOnTheScreen();
+      expect(getByTestId('rewards-animation')).toBeOnTheScreen();
+    });
   });
 
   describe('Rewards Row Position', () => {
     it('renders rewards row after Total row', () => {
       const props = {
         ...defaultProps,
-        shouldShowRewards: true,
         estimatedPoints: 50,
       };
 

--- a/app/components/UI/Predict/components/PredictFeeSummary/PredictFeeSummary.tsx
+++ b/app/components/UI/Predict/components/PredictFeeSummary/PredictFeeSummary.tsx
@@ -27,7 +27,6 @@ interface PredictFeeSummaryProps {
   providerFee: number;
   metamaskFee: number;
   total: number;
-  shouldShowRewards?: boolean;
   estimatedPoints?: number;
   isLoadingRewards?: boolean;
   hasRewardsError?: boolean;
@@ -39,7 +38,6 @@ const PredictFeeSummary: React.FC<PredictFeeSummaryProps> = ({
   metamaskFee,
   providerFee,
   total,
-  shouldShowRewards = false,
   estimatedPoints = 0,
   isLoadingRewards = false,
   hasRewardsError = false,
@@ -87,54 +85,52 @@ const PredictFeeSummary: React.FC<PredictFeeSummaryProps> = ({
       </Box>
 
       {/* Estimated Points Row */}
-      {shouldShowRewards && (
-        <KeyValueRow
-          field={{
-            label: {
-              text: strings('predict.fee_summary.estimated_points'),
-              variant: TextVariant.BodyMD,
-              color: TextColor.Default,
-            },
+      <KeyValueRow
+        field={{
+          label: {
+            text: strings('predict.fee_summary.estimated_points'),
+            variant: TextVariant.BodyMD,
+            color: TextColor.Default,
+          },
+          tooltip: {
+            title: strings('predict.fee_summary.points_tooltip'),
+            content: `${strings(
+              'predict.fee_summary.points_tooltip_content_1',
+            )}\n\n${strings('predict.fee_summary.points_tooltip_content_2')}`,
+            size: TooltipSizes.Sm,
+            iconName: IconName.Info,
+          },
+        }}
+        value={{
+          label: (
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              justifyContent={BoxJustifyContent.Center}
+              gap={1}
+            >
+              <RewardsAnimations
+                value={estimatedPoints}
+                state={
+                  isLoadingRewards
+                    ? RewardAnimationState.Loading
+                    : hasRewardsError
+                      ? RewardAnimationState.ErrorState
+                      : RewardAnimationState.Idle
+                }
+              />
+            </Box>
+          ),
+          ...(hasRewardsError && {
             tooltip: {
-              title: strings('predict.fee_summary.points_tooltip'),
-              content: `${strings(
-                'predict.fee_summary.points_tooltip_content_1',
-              )}\n\n${strings('predict.fee_summary.points_tooltip_content_2')}`,
+              title: strings('predict.fee_summary.points_error'),
+              content: strings('predict.fee_summary.points_error_content'),
               size: TooltipSizes.Sm,
               iconName: IconName.Info,
             },
-          }}
-          value={{
-            label: (
-              <Box
-                flexDirection={BoxFlexDirection.Row}
-                alignItems={BoxAlignItems.Center}
-                justifyContent={BoxJustifyContent.Center}
-                gap={1}
-              >
-                <RewardsAnimations
-                  value={estimatedPoints}
-                  state={
-                    isLoadingRewards
-                      ? RewardAnimationState.Loading
-                      : hasRewardsError
-                        ? RewardAnimationState.ErrorState
-                        : RewardAnimationState.Idle
-                  }
-                />
-              </Box>
-            ),
-            ...(hasRewardsError && {
-              tooltip: {
-                title: strings('predict.fee_summary.points_error'),
-                content: strings('predict.fee_summary.points_error_content'),
-                size: TooltipSizes.Sm,
-                iconName: IconName.Info,
-              },
-            }),
-          }}
-        />
-      )}
+          }),
+        }}
+      />
     </Box>
   );
 };

--- a/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.test.tsx
@@ -2248,10 +2248,10 @@ describe('PredictBuyPreview', () => {
   });
 
   describe('Rewards Display', () => {
-    it('shows rewards when feature flag is enabled and amount is entered', () => {
+    it('always shows rewards row when amount is entered', () => {
       mockMetamaskFee = 0.5;
 
-      renderWithProvider(<PredictBuyPreview />, {
+      const { getByText } = renderWithProvider(<PredictBuyPreview />, {
         state: initialState,
       });
 
@@ -2263,34 +2263,27 @@ describe('PredictBuyPreview', () => {
         });
       });
 
-      // shouldShowRewards = true when rewardsEnabled && currentValue > 0
+      // Press done to show fee summary
+      const doneButton = getByText('Done');
+      fireEvent.press(doneButton);
+
+      // Rewards row should always be visible when not disabled
+      expect(getByText('Est. points')).toBeOnTheScreen();
     });
 
-    it('does not show rewards when feature flag is disabled', () => {
-      mockMetamaskFee = 0.5;
+    it('shows rewards row even when amount is zero', () => {
+      mockMetamaskFee = 0;
 
-      renderWithProvider(<PredictBuyPreview />, {
+      const { getByText } = renderWithProvider(<PredictBuyPreview />, {
         state: initialState,
       });
 
-      // Enter amount
-      act(() => {
-        capturedOnChange?.({
-          value: '10',
-          valueAsNumber: 10,
-        });
-      });
+      // Press done to show fee summary (even with 0 amount)
+      const doneButton = getByText('Done');
+      fireEvent.press(doneButton);
 
-      // shouldShowRewards = false when rewardsEnabled is false
-    });
-
-    it('does not show rewards when amount is zero', () => {
-      renderWithProvider(<PredictBuyPreview />, {
-        state: initialState,
-      });
-
-      // No amount entered (currentValue = 0)
-      // shouldShowRewards = false when currentValue is 0
+      // Rewards row should always be visible when not disabled
+      expect(getByText('Est. points')).toBeOnTheScreen();
     });
   });
 

--- a/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
+++ b/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
@@ -30,7 +30,6 @@ import {
   ScrollView,
   TouchableOpacity,
 } from 'react-native';
-import { useSelector } from 'react-redux';
 import Button, {
   ButtonSize,
   ButtonVariants,
@@ -63,7 +62,6 @@ import { usePredictDeposit } from '../../hooks/usePredictDeposit';
 import Skeleton from '../../../../../component-library/components/Skeleton/Skeleton';
 import { strings } from '../../../../../../locales/i18n';
 import ButtonHero from '../../../../../component-library/components-temp/Buttons/ButtonHero';
-import { selectRewardsEnabledFlag } from '../../../../../selectors/featureFlagController/rewards';
 
 const PredictBuyPreview = () => {
   const tw = useTailwind();
@@ -75,9 +73,6 @@ const PredictBuyPreview = () => {
     useRoute<RouteProp<PredictNavigationParamList, 'PredictBuyPreview'>>();
 
   const { market, outcome, outcomeToken, entryPoint } = route.params;
-
-  // Rewards feature flag
-  const rewardsEnabled = useSelector(selectRewardsEnabledFlag);
 
   // Prepare analytics properties
   const analyticsProperties = useMemo(
@@ -190,9 +185,6 @@ const PredictBuyPreview = () => {
     () => Math.round(metamaskFee * 100),
     [metamaskFee],
   );
-
-  // Show rewards row if feature is enabled and we have a valid amount
-  const shouldShowRewards = rewardsEnabled && currentValue > 0;
 
   // Validation constants and states
   const MINIMUM_BET = 1; // $1 minimum bet
@@ -520,7 +512,6 @@ const PredictBuyPreview = () => {
         total={total}
         metamaskFee={metamaskFee}
         providerFee={providerFee}
-        shouldShowRewards={shouldShowRewards}
         estimatedPoints={estimatedPoints}
         isLoadingRewards={isCalculating && isUserInputChange}
         hasRewardsError={false}


### PR DESCRIPTION
## **Description**

We're in the process of removing the rewards feature flag in this [PR](https://github.com/MetaMask/metamask-mobile/pull/22318). Since that PR can't progress into the merge queue because of a recently introduced usage in the predict view(s), this PR removes this usage. After this has been merged in, the goal would be to:

- Fully support estimations for predict before it goes live
- Worst case, have a new dedicated flag for predict estimations that is turned off if we don't support estimations for predict when it goes live

## **Changelog**

CHANGELOG entry: null

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the rewards feature flag from Predict views and always renders the Estimated Points row (with loading/error states), updating components and tests accordingly.
> 
> - **Predict UI**:
>   - `PredictFeeSummary`: remove `shouldShowRewards` prop and always render `Estimated Points` row when not disabled; keep tooltip for points and conditional error tooltip; maintain loading/error/idle animation states.
>   - `PredictBuyPreview`: remove feature-flag usage (`selectRewardsEnabledFlag`) and `shouldShowRewards` logic/prop; continue calculating `estimatedPoints` from MetaMask fee; pass rewards state directly to `PredictFeeSummary`.
> - **Tests**:
>   - Update `PredictFeeSummary.test.tsx` and `PredictBuyPreview.test.tsx` to assert rewards row is always shown (including zero amount) and cover loading/error/idle states; remove feature-flag-dependent cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5fb916deabfe9f1cc31ead3a47a9b310d323305. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->