### PR TITLE
chore: use dedicated ff for predict rewards estimation

### DIFF
--- a/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.test.tsx
@@ -103,6 +103,20 @@ jest.mock('../../hooks/usePredictDeposit', () => ({
   }),
 }));
 
+// Mock rewards feature flag selector
+const mockRewardsPredictEnabledState = { value: false };
+jest.mock('../../../../../selectors/featureFlagController/rewards', () => {
+  const actual = jest.requireActual(
+    '../../../../../selectors/featureFlagController/rewards',
+  );
+  return {
+    ...actual,
+    selectRewardsPredictEnabledFlag: jest.fn(
+      () => mockRewardsPredictEnabledState.value,
+    ),
+  };
+});
+
 // Mock Skeleton component
 jest.mock(
   '../../../../../component-library/components/Skeleton/Skeleton',
@@ -312,6 +326,7 @@ describe('PredictBuyPreview', () => {
     mockBalanceLoading = false;
     mockMetamaskFee = 0.5;
     mockProviderFee = 1.0;
+    mockRewardsPredictEnabledState.value = false;
 
     // Setup default mocks
     mockUseNavigation.mockReturnValue(mockNavigation);
@@ -2188,6 +2203,7 @@ describe('PredictBuyPreview', () => {
 
   describe('Rewards Calculation', () => {
     it('calculates estimated points as metamask fee times 100 rounded', () => {
+      mockRewardsPredictEnabledState.value = true;
       mockMetamaskFee = 0.5;
       const mockStore = {
         ...initialState,
@@ -2212,6 +2228,7 @@ describe('PredictBuyPreview', () => {
     });
 
     it('rounds estimated points to nearest integer', () => {
+      mockRewardsPredictEnabledState.value = true;
       mockMetamaskFee = 1.234;
 
       renderWithProvider(<PredictBuyPreview />, {
@@ -2222,6 +2239,7 @@ describe('PredictBuyPreview', () => {
     });
 
     it('calculates zero points when metamask fee is zero', () => {
+      mockRewardsPredictEnabledState.value = true;
       mockMetamaskFee = 0;
 
       renderWithProvider(<PredictBuyPreview />, {
@@ -2232,6 +2250,7 @@ describe('PredictBuyPreview', () => {
     });
 
     it('recalculates points when metamask fee changes', () => {
+      mockRewardsPredictEnabledState.value = true;
       mockMetamaskFee = 0.5;
 
       const { rerender } = renderWithProvider(<PredictBuyPreview />, {
@@ -2249,6 +2268,7 @@ describe('PredictBuyPreview', () => {
 
   describe('Rewards Display', () => {
     it('shows rewards when feature flag is enabled and amount is entered', () => {
+      mockRewardsPredictEnabledState.value = true;
       mockMetamaskFee = 0.5;
 
       renderWithProvider(<PredictBuyPreview />, {
@@ -2267,6 +2287,7 @@ describe('PredictBuyPreview', () => {
     });
 
     it('does not show rewards when feature flag is disabled', () => {
+      mockRewardsPredictEnabledState.value = false;
       mockMetamaskFee = 0.5;
 
       renderWithProvider(<PredictBuyPreview />, {
@@ -2285,6 +2306,8 @@ describe('PredictBuyPreview', () => {
     });
 
     it('does not show rewards when amount is zero', () => {
+      mockRewardsPredictEnabledState.value = true;
+
       renderWithProvider(<PredictBuyPreview />, {
         state: initialState,
       });

--- a/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
+++ b/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
@@ -63,7 +63,7 @@ import { usePredictDeposit } from '../../hooks/usePredictDeposit';
 import Skeleton from '../../../../../component-library/components/Skeleton/Skeleton';
 import { strings } from '../../../../../../locales/i18n';
 import ButtonHero from '../../../../../component-library/components-temp/Buttons/ButtonHero';
-import { selectRewardsEnabledFlag } from '../../../../../selectors/featureFlagController/rewards';
+import { selectRewardsPredictEnabledFlag } from '../../../../../selectors/featureFlagController/rewards';
 
 const PredictBuyPreview = () => {
   const tw = useTailwind();
@@ -77,7 +77,7 @@ const PredictBuyPreview = () => {
   const { market, outcome, outcomeToken, entryPoint } = route.params;
 
   // Rewards feature flag
-  const rewardsEnabled = useSelector(selectRewardsEnabledFlag);
+  const rewardsEnabled = useSelector(selectRewardsPredictEnabledFlag);
 
   // Prepare analytics properties
   const analyticsProperties = useMemo(

--- a/app/selectors/featureFlagController/rewards/index.test.ts
+++ b/app/selectors/featureFlagController/rewards/index.test.ts
@@ -2,6 +2,7 @@ import {
   selectRewardsEnabledFlag,
   selectRewardsAnnouncementModalEnabledFlag,
   selectRewardsCardSpendFeatureFlags,
+  selectRewardsPredictEnabledFlag,
 } from '.';
 import {
   VersionGatedFeatureFlag,
@@ -211,6 +212,55 @@ describe('Rewards Feature Flag Selectors', () => {
       expect(result).toBe(false);
     });
   });
+
+  describe('selectRewardsPredictEnabledFlag', () => {
+    it('returns true when remote flag is valid and enabled', () => {
+      const result = selectRewardsPredictEnabledFlag.resultFunc({
+        rewardsEnablePredict: {
+          enabled: true,
+          minimumVersion: '1.0.0',
+        },
+      });
+      expect(result).toBe(true);
+    });
+
+    it('returns false when remote flag is valid but disabled', () => {
+      const result = selectRewardsPredictEnabledFlag.resultFunc({
+        rewardsEnablePredict: {
+          enabled: false,
+          minimumVersion: '1.0.0',
+        },
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false when version check fails', () => {
+      mockHasMinimumRequiredVersion.mockReturnValue(false);
+      const result = selectRewardsPredictEnabledFlag.resultFunc({
+        rewardsEnablePredict: {
+          enabled: true,
+          minimumVersion: '99.0.0',
+        },
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false when remote flag is invalid', () => {
+      const result = selectRewardsPredictEnabledFlag.resultFunc({
+        rewardsEnablePredict: {
+          enabled: 'invalid',
+          minimumVersion: 123,
+        },
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false when remote feature flags are empty', () => {
+      const result = selectRewardsPredictEnabledFlag.resultFunc({});
+      expect(result).toBe(false);
+    });
+  });
+
   describe('validatedVersionGatedFeatureFlag', () => {
     const validRemoteFlag: VersionGatedFeatureFlag = {
       enabled: true,

--- a/app/selectors/featureFlagController/rewards/index.ts
+++ b/app/selectors/featureFlagController/rewards/index.ts
@@ -12,6 +12,7 @@ const DEFAULT_CARD_SPEND_ENABLED = false;
 export const FEATURE_FLAG_NAME = 'rewardsEnabled';
 export const ANNOUNCEMENT_MODAL_FLAG_NAME = 'rewardsAnnouncementModalEnabled';
 export const CARD_SPEND_FLAG_NAME = 'rewardsEnableCardSpend';
+export const REWARDS_PREDICT_ENABLED_FLAG_NAME = 'rewardsEnablePredict';
 
 export const selectRewardsEnabledFlag = createSelector(
   selectRemoteFeatureFlags,
@@ -65,5 +66,19 @@ export const selectRewardsCardSpendFeatureFlags = createSelector(
       validatedVersionGatedFeatureFlag(cardSpendConfig) ??
       DEFAULT_CARD_SPEND_ENABLED
     );
+  },
+);
+
+export const selectRewardsPredictEnabledFlag = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) => {
+    if (!hasProperty(remoteFeatureFlags, REWARDS_PREDICT_ENABLED_FLAG_NAME)) {
+      return false;
+    }
+    const remoteFlag = remoteFeatureFlags[
+      REWARDS_PREDICT_ENABLED_FLAG_NAME
+    ] as unknown as VersionGatedFeatureFlag;
+
+    return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
   },
 );


### PR DESCRIPTION
## **Description**

Use a dedicated feature flag for predict reward point estimations.

## **Changelog**

CHANGELOG entry: null

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches PredictBuyPreview to use dedicated `rewardsEnablePredict` flag via `selectRewardsPredictEnabledFlag` and adds selector + tests; rewards display now gated by this flag.
> 
> - **Predict UI**:
>   - Update `PredictBuyPreview.tsx` to use `selectRewardsPredictEnabledFlag` (replacing `selectRewardsEnabledFlag`) to gate rewards estimation display.
>   - Continue calculating `estimatedPoints` from `metamaskFee`; show rewards row only when flag enabled and amount > 0.
> - **Feature Flags**:
>   - Add `REWARDS_PREDICT_ENABLED_FLAG_NAME` (`rewardsEnablePredict`) and new selector `selectRewardsPredictEnabledFlag` in `selectors/featureFlagController/rewards`.
>   - Extend tests in `selectors/.../rewards/index.test.ts` to cover valid/invalid/version cases for the new flag.
> - **Tests**:
>   - Modify `PredictBuyPreview.test.tsx` to mock `selectRewardsPredictEnabledFlag` and add tests for rewards calculation/display behavior based on the flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31951c1558a9c71d89d403861256291ea906da68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->