### PR TITLE
fix: Exclude token transfers from marking them as a swap tx cp-7.59.0

### DIFF
--- a/app/util/transactions/index.js
+++ b/app/util/transactions/index.js
@@ -1761,6 +1761,12 @@ export const getIsSwapApproveOrSwapTransaction = (
     return false;
   }
 
+  // Exclude token transfers (e.g., WETH sends) - these are not swap transactions
+  const fourByteSignature = getFourByteSignature(data);
+  if (fourByteSignature === TRANSFER_FUNCTION_SIGNATURE) {
+    return false;
+  }
+
   const isLegacySwap = origin === process.env.MM_FOX_CODE;
   const isUnifiedSwap = origin === ORIGIN_METAMASK;
 

--- a/app/util/transactions/index.test.ts
+++ b/app/util/transactions/index.test.ts
@@ -3,7 +3,7 @@ import BN from 'bnjs4';
 
 /* eslint-disable-next-line import/no-namespace */
 import * as controllerUtilsModule from '@metamask/controller-utils';
-import { ERC721, ERC1155 } from '@metamask/controller-utils';
+import { ERC721, ERC1155, ORIGIN_METAMASK } from '@metamask/controller-utils';
 
 import { handleMethodData } from '../../util/transaction-controller';
 
@@ -1222,6 +1222,29 @@ describe('Transactions utils :: getIsSwapApproveOrSwapTransaction', () => {
       dappTxMeta.transaction.to,
       dappTxMeta.chainId,
     );
+    expect(result).toBe(false);
+  });
+  it('returns false if the transaction is a token transfer from swap origin', () => {
+    const tokenTransferFromSwapOrigin = {
+      chainId: '0x1',
+      origin: ORIGIN_METAMASK,
+      transaction: {
+        from: '0xc5fe6ef47965741f6f7a4734bf784bf3ae3f2452',
+        data: '0xa9059cbb000000000000000000000000dc738206f559bdae106894a62876a119e470aee20000000000000000000000000000000000000000000000000de0b6b3a7640000',
+        gas: '0xc350',
+        nonce: '0x10',
+        to: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+        value: '0x0',
+      },
+    };
+
+    const result = getIsSwapApproveOrSwapTransaction(
+      tokenTransferFromSwapOrigin.transaction.data,
+      tokenTransferFromSwapOrigin.origin,
+      tokenTransferFromSwapOrigin.transaction.to,
+      tokenTransferFromSwapOrigin.chainId,
+    );
+
     expect(result).toBe(false);
   });
 });


### PR DESCRIPTION
## **Description**
There was a problem when trying to send WETH, it didn't show the Confirmation page, but it was stuck on a spinning wheel. 

This PR excludes token transfers from marking them as a swap tx, which solves the issue.

## **Changelog**

CHANGELOG entry: Fix sending WETH

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/22357

## **Manual testing steps**
1. Try to send WETH on Ethereum mainnet
2. You can see the Confirmation overview page before sending the transaction

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stops classifying ERC20 `transfer` calls as swap/approve transactions and adds tests to cover this case.
> 
> - **Transactions utils**:
>   - Update `getIsSwapApproveOrSwapTransaction` to return `false` for ERC20 token transfers (`TRANSFER_FUNCTION_SIGNATURE`).
> - **Tests**:
>   - Import `ORIGIN_METAMASK` and add test ensuring token transfers from swap origin are not flagged as swaps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c94b3f97b9bb2840ca48af917f66c3e0e4271c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->