### PR TITLE
fix: trim whitespace from amount input in PaymentRequest component

### DIFF
--- a/app/components/UI/PaymentRequest/index.js
+++ b/app/components/UI/PaymentRequest/index.js
@@ -669,6 +669,8 @@ class PaymentRequest extends PureComponent {
     const { conversionRate, contractExchangeRates, currentCurrency } =
       this.props;
     const currencySymbol = currencySymbols[currentCurrency];
+    // Normalize amount: trim whitespace and replace comma with period
+    amount = amount?.replace(',', '.')?.trim();
     const exchangeRate =
       selectedAsset &&
       selectedAsset.address &&
@@ -682,9 +684,9 @@ class PaymentRequest extends PureComponent {
       conversionRate &&
       (exchangeRate || selectedAsset.isETH)
     ) {
-      res = this.handleFiatPrimaryCurrency(amount?.replace(',', '.'));
+      res = this.handleFiatPrimaryCurrency(amount);
     } else {
-      res = this.handleETHPrimaryCurrency(amount?.replace(',', '.'));
+      res = this.handleETHPrimaryCurrency(amount);
     }
     const { cryptoAmount, symbol } = res;
     if (amount && amount[0] === currencySymbol) amount = amount.substr(1);

--- a/app/components/UI/PaymentRequest/index.test.tsx
+++ b/app/components/UI/PaymentRequest/index.test.tsx
@@ -216,6 +216,29 @@ describe('PaymentRequest', () => {
     expect(amountInput.props.value).toBe('1.5');
   });
 
+  it('trims leading and trailing spaces from amount input', async () => {
+    const { getByText, getByPlaceholderText } = renderComponent();
+
+    await userEvent.press(getByText('ETH'));
+
+    const amountInput = getByPlaceholderText('0.00');
+    fireEvent.changeText(amountInput, '  1.5  ');
+
+    expect(amountInput.props.value).toBe('1.5');
+  });
+
+  it('handles whitespace-only input without throwing', async () => {
+    const { getByText, getByPlaceholderText } = renderComponent();
+
+    await userEvent.press(getByText('ETH'));
+
+    const amountInput = getByPlaceholderText('0.00');
+
+    expect(() => {
+      fireEvent.changeText(amountInput, '   ');
+    }).not.toThrow();
+  });
+
   it('displays an error when an invalid amount is entered', async () => {
     const { getByText, getByPlaceholderText, queryByText } = renderComponent();
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR prevents errors when the not trimmed amount is passed to balanceToFiat and other conversion functions.

Now both `handleETHPrimaryCurrency` and `handleFiatPrimaryCurrency` receive the amount with leading/trailing spaces stripped via .trim() before processing. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/17369
https://consensyssoftware.atlassian.net/browse/TMCU-128

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalizes amount input (trim and comma-to-dot) in PaymentRequest and adds tests for whitespace handling.
> 
> - **PaymentRequest (`app/components/UI/PaymentRequest/index.js`)**
>   - Normalize `amount` in `updateAmount`: trim whitespace and replace `,` with `.`.
>   - Pass normalized `amount` to `handleFiatPrimaryCurrency` and `handleETHPrimaryCurrency`.
> - **Tests (`app/components/UI/PaymentRequest/index.test.tsx`)**
>   - Add tests to verify trimming of leading/trailing spaces.
>   - Add test to ensure whitespace-only input does not throw.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c777e28f4a0038f77eade3ecaf342da4086c502d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->