### PR TITLE
feat: reward ways to earn for predict

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6737,6 +6737,16 @@
           "cta_label": "Add accounts"
         }
       },
+      "predict": {
+        "title": "Prediction markets",
+        "description": "20 points per $10 prediction",
+        "sheet": {
+          "title": "Prediction markets",
+          "points": "20 points per $10",
+          "description": "Earn points on every $10 you trade.",
+          "cta_label": "Browse markets"
+        }
+      },
       "card": {
         "title": "MetaMask Card",
         "description": "1 point per $1 spent",


### PR DESCRIPTION
## **Description**

This PR adds a predict ways to earn cta and bottom sheet. Only if the required predict feature flag is turned on.

## **Changelog**

CHANGELOG entry: rewards predict ways to earn cta

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/RWDS-787

## **Screenshots/Recordings**

### **After**

<img width="636" height="640" alt="image" src="https://github.com/user-attachments/assets/63cdf2a6-b005-49fe-b18f-7e4d9cdb1769" />

<img width="672" height="521" alt="image" src="https://github.com/user-attachments/assets/69d43c0b-09ee-4d45-acd1-a12a939ec8b4" />


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a feature-flagged Predict earning option with bottom sheet CTA, navigation to market list, and metrics tracking, plus comprehensive tests and i18n strings.
> 
> - **Rewards Overview — Ways to Earn**:
>   - **Predict entry (feature-flagged)**: Adds `WayToEarnType.PREDICT`, list item, bottom sheet content, and CTA handling in `WaysToEarn.tsx`.
>   - **Navigation**: Predict CTA navigates to `Routes.PREDICT.ROOT` → `MARKET_LIST`; list filtering honors `selectPredictEnabledFlag` alongside Card flag.
>   - **Metrics**: Tracks `REWARDS_PAGE_BUTTON_CLICKED` and `REWARDS_WAYS_TO_EARN_CTA_CLICKED` with `ways_to_earn_type` and `button_type`.
> - **Tests** (`WaysToEarn.test.tsx`):
>   - Covers Predict visibility (flag on/off), modal rendering, CTA navigation, and metrics assertions.
>   - Extends existing tests (Swap/Perps/Referral/Card) with metrics checks and CTA flows; validates enum values and hook configuration.
> - **Localization** (`locales/languages/en.json`):
>   - Adds Predict strings under `rewards.ways_to_earn.predict` (titles, descriptions, sheet, CTA).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8bfc2138558934120d92c7969717d0c902ada3bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->