### PR TITLE
chore: remove rewards predict feature flag

### DIFF
--- a/app/components/UI/Predict/components/PredictFeeSummary/PredictFeeSummary.test.tsx
+++ b/app/components/UI/Predict/components/PredictFeeSummary/PredictFeeSummary.test.tsx
@@ -173,25 +173,9 @@ describe('PredictFeeSummary', () => {
   });
 
   describe('Rewards Row', () => {
-    it('does not display rewards row when shouldShowRewards is false', () => {
+    it('displays rewards row', () => {
       const props = {
         ...defaultProps,
-        shouldShowRewards: false,
-        estimatedPoints: 100,
-      };
-
-      const { queryByText, queryByTestId } = render(
-        <PredictFeeSummary {...props} />,
-      );
-
-      expect(queryByText('Est. points')).toBeNull();
-      expect(queryByTestId('rewards-animation')).toBeNull();
-    });
-
-    it('displays rewards row when shouldShowRewards is true', () => {
-      const props = {
-        ...defaultProps,
-        shouldShowRewards: true,
         estimatedPoints: 50,
       };
 
@@ -206,7 +190,6 @@ describe('PredictFeeSummary', () => {
     it('displays correct estimated points value', () => {
       const props = {
         ...defaultProps,
-        shouldShowRewards: true,
         estimatedPoints: 123,
       };
 
@@ -218,7 +201,6 @@ describe('PredictFeeSummary', () => {
     it('displays zero points when estimatedPoints is 0', () => {
       const props = {
         ...defaultProps,
-        shouldShowRewards: true,
         estimatedPoints: 0,
       };
 
@@ -232,7 +214,6 @@ describe('PredictFeeSummary', () => {
     it('renders rewards row after Total row', () => {
       const props = {
         ...defaultProps,
-        shouldShowRewards: true,
         estimatedPoints: 50,
       };
 

--- a/app/components/UI/Predict/components/PredictFeeSummary/PredictFeeSummary.tsx
+++ b/app/components/UI/Predict/components/PredictFeeSummary/PredictFeeSummary.tsx
@@ -27,7 +27,6 @@ interface PredictFeeSummaryProps {
   providerFee: number;
   metamaskFee: number;
   total: number;
-  shouldShowRewards?: boolean;
   estimatedPoints?: number;
   isLoadingRewards?: boolean;
   hasRewardsError?: boolean;
@@ -39,7 +38,6 @@ const PredictFeeSummary: React.FC<PredictFeeSummaryProps> = ({
   metamaskFee,
   providerFee,
   total,
-  shouldShowRewards = false,
   estimatedPoints = 0,
   isLoadingRewards = false,
   hasRewardsError = false,
@@ -87,54 +85,52 @@ const PredictFeeSummary: React.FC<PredictFeeSummaryProps> = ({
       </Box>
 
       {/* Estimated Points Row */}
-      {shouldShowRewards && (
-        <KeyValueRow
-          field={{
-            label: {
-              text: strings('predict.fee_summary.estimated_points'),
-              variant: TextVariant.BodyMD,
-              color: TextColor.Default,
-            },
+      <KeyValueRow
+        field={{
+          label: {
+            text: strings('predict.fee_summary.estimated_points'),
+            variant: TextVariant.BodyMD,
+            color: TextColor.Default,
+          },
+          tooltip: {
+            title: strings('predict.fee_summary.points_tooltip'),
+            content: `${strings(
+              'predict.fee_summary.points_tooltip_content_1',
+            )}\n\n${strings('predict.fee_summary.points_tooltip_content_2')}`,
+            size: TooltipSizes.Sm,
+            iconName: IconName.Info,
+          },
+        }}
+        value={{
+          label: (
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              justifyContent={BoxJustifyContent.Center}
+              gap={1}
+            >
+              <RewardsAnimations
+                value={estimatedPoints}
+                state={
+                  isLoadingRewards
+                    ? RewardAnimationState.Loading
+                    : hasRewardsError
+                      ? RewardAnimationState.ErrorState
+                      : RewardAnimationState.Idle
+                }
+              />
+            </Box>
+          ),
+          ...(hasRewardsError && {
             tooltip: {
-              title: strings('predict.fee_summary.points_tooltip'),
-              content: `${strings(
-                'predict.fee_summary.points_tooltip_content_1',
-              )}\n\n${strings('predict.fee_summary.points_tooltip_content_2')}`,
+              title: strings('predict.fee_summary.points_error'),
+              content: strings('predict.fee_summary.points_error_content'),
               size: TooltipSizes.Sm,
               iconName: IconName.Info,
             },
-          }}
-          value={{
-            label: (
-              <Box
-                flexDirection={BoxFlexDirection.Row}
-                alignItems={BoxAlignItems.Center}
-                justifyContent={BoxJustifyContent.Center}
-                gap={1}
-              >
-                <RewardsAnimations
-                  value={estimatedPoints}
-                  state={
-                    isLoadingRewards
-                      ? RewardAnimationState.Loading
-                      : hasRewardsError
-                        ? RewardAnimationState.ErrorState
-                        : RewardAnimationState.Idle
-                  }
-                />
-              </Box>
-            ),
-            ...(hasRewardsError && {
-              tooltip: {
-                title: strings('predict.fee_summary.points_error'),
-                content: strings('predict.fee_summary.points_error_content'),
-                size: TooltipSizes.Sm,
-                iconName: IconName.Info,
-              },
-            }),
-          }}
-        />
-      )}
+          }),
+        }}
+      />
     </Box>
   );
 };

--- a/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.test.tsx
@@ -103,20 +103,6 @@ jest.mock('../../hooks/usePredictDeposit', () => ({
   }),
 }));
 
-// Mock rewards feature flag selector
-const mockRewardsPredictEnabledState = { value: false };
-jest.mock('../../../../../selectors/featureFlagController/rewards', () => {
-  const actual = jest.requireActual(
-    '../../../../../selectors/featureFlagController/rewards',
-  );
-  return {
-    ...actual,
-    selectRewardsPredictEnabledFlag: jest.fn(
-      () => mockRewardsPredictEnabledState.value,
-    ),
-  };
-});
-
 // Mock Skeleton component
 jest.mock(
   '../../../../../component-library/components/Skeleton/Skeleton',
@@ -326,7 +312,6 @@ describe('PredictBuyPreview', () => {
     mockBalanceLoading = false;
     mockMetamaskFee = 0.5;
     mockProviderFee = 1.0;
-    mockRewardsPredictEnabledState.value = false;
 
     // Setup default mocks
     mockUseNavigation.mockReturnValue(mockNavigation);
@@ -2198,122 +2183,6 @@ describe('PredictBuyPreview', () => {
 
       // Renders custom token (uses preview sharePrice 0.5, not outcomeToken price)
       expect(getByText('Maybe at 50¢')).toBeOnTheScreen();
-    });
-  });
-
-  describe('Rewards Calculation', () => {
-    it('calculates estimated points as metamask fee times 100 rounded', () => {
-      mockRewardsPredictEnabledState.value = true;
-      mockMetamaskFee = 0.5;
-      const mockStore = {
-        ...initialState,
-      };
-
-      const { rerender } = renderWithProvider(<PredictBuyPreview />, {
-        state: mockStore,
-      });
-
-      // Enter amount to trigger calculation
-      act(() => {
-        capturedOnChange?.({
-          value: '10',
-          valueAsNumber: 10,
-        });
-      });
-
-      rerender(<PredictBuyPreview />);
-
-      // Expected: 0.5 * 100 = 50 points
-      // This is verified indirectly through props passed to PredictFeeSummary
-    });
-
-    it('rounds estimated points to nearest integer', () => {
-      mockRewardsPredictEnabledState.value = true;
-      mockMetamaskFee = 1.234;
-
-      renderWithProvider(<PredictBuyPreview />, {
-        state: initialState,
-      });
-
-      // Expected: 1.234 * 100 = 123.4 → 123 points
-    });
-
-    it('calculates zero points when metamask fee is zero', () => {
-      mockRewardsPredictEnabledState.value = true;
-      mockMetamaskFee = 0;
-
-      renderWithProvider(<PredictBuyPreview />, {
-        state: initialState,
-      });
-
-      // Expected: 0 * 100 = 0 points
-    });
-
-    it('recalculates points when metamask fee changes', () => {
-      mockRewardsPredictEnabledState.value = true;
-      mockMetamaskFee = 0.5;
-
-      const { rerender } = renderWithProvider(<PredictBuyPreview />, {
-        state: initialState,
-      });
-
-      // Change fee
-      mockMetamaskFee = 1.0;
-
-      rerender(<PredictBuyPreview />);
-
-      // Expected: 1.0 * 100 = 100 points
-    });
-  });
-
-  describe('Rewards Display', () => {
-    it('shows rewards when feature flag is enabled and amount is entered', () => {
-      mockRewardsPredictEnabledState.value = true;
-      mockMetamaskFee = 0.5;
-
-      renderWithProvider(<PredictBuyPreview />, {
-        state: initialState,
-      });
-
-      // Enter amount
-      act(() => {
-        capturedOnChange?.({
-          value: '10',
-          valueAsNumber: 10,
-        });
-      });
-
-      // shouldShowRewards = true when rewardsEnabled && currentValue > 0
-    });
-
-    it('does not show rewards when feature flag is disabled', () => {
-      mockRewardsPredictEnabledState.value = false;
-      mockMetamaskFee = 0.5;
-
-      renderWithProvider(<PredictBuyPreview />, {
-        state: initialState,
-      });
-
-      // Enter amount
-      act(() => {
-        capturedOnChange?.({
-          value: '10',
-          valueAsNumber: 10,
-        });
-      });
-
-      // shouldShowRewards = false when rewardsEnabled is false
-    });
-
-    it('does not show rewards when amount is zero', () => {
-      mockRewardsPredictEnabledState.value = true;
-
-      renderWithProvider(<PredictBuyPreview />, {
-        state: initialState,
-      });
-
-      // No amount entered (currentValue = 0)
-      // shouldShowRewards = false when currentValue is 0
     });
   });
 

--- a/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
+++ b/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
@@ -30,7 +30,6 @@ import {
   ScrollView,
   TouchableOpacity,
 } from 'react-native';
-import { useSelector } from 'react-redux';
 import Button, {
   ButtonSize,
   ButtonVariants,
@@ -63,7 +62,6 @@ import { usePredictDeposit } from '../../hooks/usePredictDeposit';
 import Skeleton from '../../../../../component-library/components/Skeleton/Skeleton';
 import { strings } from '../../../../../../locales/i18n';
 import ButtonHero from '../../../../../component-library/components-temp/Buttons/ButtonHero';
-import { selectRewardsPredictEnabledFlag } from '../../../../../selectors/featureFlagController/rewards';
 
 const PredictBuyPreview = () => {
   const tw = useTailwind();
@@ -75,9 +73,6 @@ const PredictBuyPreview = () => {
     useRoute<RouteProp<PredictNavigationParamList, 'PredictBuyPreview'>>();
 
   const { market, outcome, outcomeToken, entryPoint } = route.params;
-
-  // Rewards feature flag
-  const rewardsEnabled = useSelector(selectRewardsPredictEnabledFlag);
 
   // Prepare analytics properties
   const analyticsProperties = useMemo(
@@ -190,9 +185,6 @@ const PredictBuyPreview = () => {
     () => Math.round(metamaskFee * 100),
     [metamaskFee],
   );
-
-  // Show rewards row if feature is enabled and we have a valid amount
-  const shouldShowRewards = rewardsEnabled && currentValue > 0;
 
   // Validation constants and states
   const MINIMUM_BET = 1; // $1 minimum bet
@@ -520,7 +512,6 @@ const PredictBuyPreview = () => {
         total={total}
         metamaskFee={metamaskFee}
         providerFee={providerFee}
-        shouldShowRewards={shouldShowRewards}
         estimatedPoints={estimatedPoints}
         isLoadingRewards={isCalculating && isUserInputChange}
         hasRewardsError={false}

--- a/app/selectors/featureFlagController/rewards/index.test.ts
+++ b/app/selectors/featureFlagController/rewards/index.test.ts
@@ -2,7 +2,6 @@ import {
   selectRewardsEnabledFlag,
   selectRewardsAnnouncementModalEnabledFlag,
   selectRewardsCardSpendFeatureFlags,
-  selectRewardsPredictEnabledFlag,
 } from '.';
 import {
   VersionGatedFeatureFlag,
@@ -209,54 +208,6 @@ describe('Rewards Feature Flag Selectors', () => {
 
     it('returns false when remote feature flags are empty', () => {
       const result = selectRewardsCardSpendFeatureFlags.resultFunc({});
-      expect(result).toBe(false);
-    });
-  });
-
-  describe('selectRewardsPredictEnabledFlag', () => {
-    it('returns true when remote flag is valid and enabled', () => {
-      const result = selectRewardsPredictEnabledFlag.resultFunc({
-        rewardsEnablePredict: {
-          enabled: true,
-          minimumVersion: '1.0.0',
-        },
-      });
-      expect(result).toBe(true);
-    });
-
-    it('returns false when remote flag is valid but disabled', () => {
-      const result = selectRewardsPredictEnabledFlag.resultFunc({
-        rewardsEnablePredict: {
-          enabled: false,
-          minimumVersion: '1.0.0',
-        },
-      });
-      expect(result).toBe(false);
-    });
-
-    it('returns false when version check fails', () => {
-      mockHasMinimumRequiredVersion.mockReturnValue(false);
-      const result = selectRewardsPredictEnabledFlag.resultFunc({
-        rewardsEnablePredict: {
-          enabled: true,
-          minimumVersion: '99.0.0',
-        },
-      });
-      expect(result).toBe(false);
-    });
-
-    it('returns false when remote flag is invalid', () => {
-      const result = selectRewardsPredictEnabledFlag.resultFunc({
-        rewardsEnablePredict: {
-          enabled: 'invalid',
-          minimumVersion: 123,
-        },
-      });
-      expect(result).toBe(false);
-    });
-
-    it('returns false when remote feature flags are empty', () => {
-      const result = selectRewardsPredictEnabledFlag.resultFunc({});
       expect(result).toBe(false);
     });
   });

--- a/app/selectors/featureFlagController/rewards/index.ts
+++ b/app/selectors/featureFlagController/rewards/index.ts
@@ -12,7 +12,6 @@ const DEFAULT_CARD_SPEND_ENABLED = false;
 export const FEATURE_FLAG_NAME = 'rewardsEnabled';
 export const ANNOUNCEMENT_MODAL_FLAG_NAME = 'rewardsAnnouncementModalEnabled';
 export const CARD_SPEND_FLAG_NAME = 'rewardsEnableCardSpend';
-export const REWARDS_PREDICT_ENABLED_FLAG_NAME = 'rewardsEnablePredict';
 
 export const selectRewardsEnabledFlag = createSelector(
   selectRemoteFeatureFlags,
@@ -66,19 +65,5 @@ export const selectRewardsCardSpendFeatureFlags = createSelector(
       validatedVersionGatedFeatureFlag(cardSpendConfig) ??
       DEFAULT_CARD_SPEND_ENABLED
     );
-  },
-);
-
-export const selectRewardsPredictEnabledFlag = createSelector(
-  selectRemoteFeatureFlags,
-  (remoteFeatureFlags) => {
-    if (!hasProperty(remoteFeatureFlags, REWARDS_PREDICT_ENABLED_FLAG_NAME)) {
-      return false;
-    }
-    const remoteFlag = remoteFeatureFlags[
-      REWARDS_PREDICT_ENABLED_FLAG_NAME
-    ] as unknown as VersionGatedFeatureFlag;
-
-    return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
   },
 );


### PR DESCRIPTION
## **Description**

Removes the recently introduced rewards predict feature flag. We will support reward estimations for predictions when it's released so it doesn't make sense to have a dedicated flag for it.

## **Changelog**

CHANGELOG entry: null

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the rewards predict feature flag and unconditionally displays estimated points in Predict fee summaries.
> 
> - **Predict UI**:
>   - `PredictFeeSummary`: remove `shouldShowRewards` prop and always render the `estimated_points` row with tooltip and reward animation; preserve loading/error tooltip handling.
>   - `PredictBuyPreview`: drop Redux rewards flag usage and conditional rendering; compute `estimatedPoints` from `metamaskFee` and pass to `PredictFeeSummary`.
> - **Selectors**:
>   - Remove `selectRewardsPredictEnabledFlag` and its flag key; delete associated tests.
> - **Tests**:
>   - Update `PredictFeeSummary.test.tsx` to always expect rewards row; remove gating assertions.
>   - Clean up `PredictBuyPreview.test.tsx` by removing rewards-flag mocks and tests; keep fee, validation, and flow tests intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a80ce28505bbdd1ad2a440eaca76067c677fb557. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->