### PR TITLE
chore: remove rewards predict feature flag

### DIFF
--- a/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.test.tsx
@@ -103,20 +103,6 @@ jest.mock('../../hooks/usePredictDeposit', () => ({
   }),
 }));
 
-// Mock rewards feature flag selector
-const mockRewardsPredictEnabledState = { value: false };
-jest.mock('../../../../../selectors/featureFlagController/rewards', () => {
-  const actual = jest.requireActual(
-    '../../../../../selectors/featureFlagController/rewards',
-  );
-  return {
-    ...actual,
-    selectRewardsPredictEnabledFlag: jest.fn(
-      () => mockRewardsPredictEnabledState.value,
-    ),
-  };
-});
-
 // Mock Skeleton component
 jest.mock(
   '../../../../../component-library/components/Skeleton/Skeleton',
@@ -326,7 +312,6 @@ describe('PredictBuyPreview', () => {
     mockBalanceLoading = false;
     mockMetamaskFee = 0.5;
     mockProviderFee = 1.0;
-    mockRewardsPredictEnabledState.value = false;
 
     // Setup default mocks
     mockUseNavigation.mockReturnValue(mockNavigation);
@@ -2203,7 +2188,6 @@ describe('PredictBuyPreview', () => {
 
   describe('Rewards Calculation', () => {
     it('calculates estimated points as metamask fee times 100 rounded', () => {
-      mockRewardsPredictEnabledState.value = true;
       mockMetamaskFee = 0.5;
       const mockStore = {
         ...initialState,
@@ -2228,7 +2212,6 @@ describe('PredictBuyPreview', () => {
     });
 
     it('rounds estimated points to nearest integer', () => {
-      mockRewardsPredictEnabledState.value = true;
       mockMetamaskFee = 1.234;
 
       renderWithProvider(<PredictBuyPreview />, {
@@ -2239,7 +2222,6 @@ describe('PredictBuyPreview', () => {
     });
 
     it('calculates zero points when metamask fee is zero', () => {
-      mockRewardsPredictEnabledState.value = true;
       mockMetamaskFee = 0;
 
       renderWithProvider(<PredictBuyPreview />, {
@@ -2250,7 +2232,6 @@ describe('PredictBuyPreview', () => {
     });
 
     it('recalculates points when metamask fee changes', () => {
-      mockRewardsPredictEnabledState.value = true;
       mockMetamaskFee = 0.5;
 
       const { rerender } = renderWithProvider(<PredictBuyPreview />, {
@@ -2267,8 +2248,7 @@ describe('PredictBuyPreview', () => {
   });
 
   describe('Rewards Display', () => {
-    it('shows rewards when feature flag is enabled and amount is entered', () => {
-      mockRewardsPredictEnabledState.value = true;
+    it('shows rewards when amount is entered', () => {
       mockMetamaskFee = 0.5;
 
       renderWithProvider(<PredictBuyPreview />, {
@@ -2286,28 +2266,7 @@ describe('PredictBuyPreview', () => {
       // shouldShowRewards = true when rewardsEnabled && currentValue > 0
     });
 
-    it('does not show rewards when feature flag is disabled', () => {
-      mockRewardsPredictEnabledState.value = false;
-      mockMetamaskFee = 0.5;
-
-      renderWithProvider(<PredictBuyPreview />, {
-        state: initialState,
-      });
-
-      // Enter amount
-      act(() => {
-        capturedOnChange?.({
-          value: '10',
-          valueAsNumber: 10,
-        });
-      });
-
-      // shouldShowRewards = false when rewardsEnabled is false
-    });
-
     it('does not show rewards when amount is zero', () => {
-      mockRewardsPredictEnabledState.value = true;
-
       renderWithProvider(<PredictBuyPreview />, {
         state: initialState,
       });

--- a/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
+++ b/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
@@ -30,7 +30,6 @@ import {
   ScrollView,
   TouchableOpacity,
 } from 'react-native';
-import { useSelector } from 'react-redux';
 import Button, {
   ButtonSize,
   ButtonVariants,
@@ -63,7 +62,6 @@ import { usePredictDeposit } from '../../hooks/usePredictDeposit';
 import Skeleton from '../../../../../component-library/components/Skeleton/Skeleton';
 import { strings } from '../../../../../../locales/i18n';
 import ButtonHero from '../../../../../component-library/components-temp/Buttons/ButtonHero';
-import { selectRewardsPredictEnabledFlag } from '../../../../../selectors/featureFlagController/rewards';
 
 const PredictBuyPreview = () => {
   const tw = useTailwind();
@@ -75,9 +73,6 @@ const PredictBuyPreview = () => {
     useRoute<RouteProp<PredictNavigationParamList, 'PredictBuyPreview'>>();
 
   const { market, outcome, outcomeToken, entryPoint } = route.params;
-
-  // Rewards feature flag
-  const rewardsEnabled = useSelector(selectRewardsPredictEnabledFlag);
 
   // Prepare analytics properties
   const analyticsProperties = useMemo(
@@ -191,8 +186,8 @@ const PredictBuyPreview = () => {
     [metamaskFee],
   );
 
-  // Show rewards row if feature is enabled and we have a valid amount
-  const shouldShowRewards = rewardsEnabled && currentValue > 0;
+  // Show rewards row if we have a valid amount
+  const shouldShowRewards = currentValue > 0;
 
   // Validation constants and states
   const MINIMUM_BET = 1; // $1 minimum bet

--- a/app/selectors/featureFlagController/rewards/index.test.ts
+++ b/app/selectors/featureFlagController/rewards/index.test.ts
@@ -2,7 +2,6 @@ import {
   selectRewardsEnabledFlag,
   selectRewardsAnnouncementModalEnabledFlag,
   selectRewardsCardSpendFeatureFlags,
-  selectRewardsPredictEnabledFlag,
 } from '.';
 import {
   VersionGatedFeatureFlag,
@@ -212,55 +211,6 @@ describe('Rewards Feature Flag Selectors', () => {
       expect(result).toBe(false);
     });
   });
-
-  describe('selectRewardsPredictEnabledFlag', () => {
-    it('returns true when remote flag is valid and enabled', () => {
-      const result = selectRewardsPredictEnabledFlag.resultFunc({
-        rewardsEnablePredict: {
-          enabled: true,
-          minimumVersion: '1.0.0',
-        },
-      });
-      expect(result).toBe(true);
-    });
-
-    it('returns false when remote flag is valid but disabled', () => {
-      const result = selectRewardsPredictEnabledFlag.resultFunc({
-        rewardsEnablePredict: {
-          enabled: false,
-          minimumVersion: '1.0.0',
-        },
-      });
-      expect(result).toBe(false);
-    });
-
-    it('returns false when version check fails', () => {
-      mockHasMinimumRequiredVersion.mockReturnValue(false);
-      const result = selectRewardsPredictEnabledFlag.resultFunc({
-        rewardsEnablePredict: {
-          enabled: true,
-          minimumVersion: '99.0.0',
-        },
-      });
-      expect(result).toBe(false);
-    });
-
-    it('returns false when remote flag is invalid', () => {
-      const result = selectRewardsPredictEnabledFlag.resultFunc({
-        rewardsEnablePredict: {
-          enabled: 'invalid',
-          minimumVersion: 123,
-        },
-      });
-      expect(result).toBe(false);
-    });
-
-    it('returns false when remote feature flags are empty', () => {
-      const result = selectRewardsPredictEnabledFlag.resultFunc({});
-      expect(result).toBe(false);
-    });
-  });
-
   describe('validatedVersionGatedFeatureFlag', () => {
     const validRemoteFlag: VersionGatedFeatureFlag = {
       enabled: true,

--- a/app/selectors/featureFlagController/rewards/index.ts
+++ b/app/selectors/featureFlagController/rewards/index.ts
@@ -12,7 +12,6 @@ const DEFAULT_CARD_SPEND_ENABLED = false;
 export const FEATURE_FLAG_NAME = 'rewardsEnabled';
 export const ANNOUNCEMENT_MODAL_FLAG_NAME = 'rewardsAnnouncementModalEnabled';
 export const CARD_SPEND_FLAG_NAME = 'rewardsEnableCardSpend';
-export const REWARDS_PREDICT_ENABLED_FLAG_NAME = 'rewardsEnablePredict';
 
 export const selectRewardsEnabledFlag = createSelector(
   selectRemoteFeatureFlags,
@@ -66,19 +65,5 @@ export const selectRewardsCardSpendFeatureFlags = createSelector(
       validatedVersionGatedFeatureFlag(cardSpendConfig) ??
       DEFAULT_CARD_SPEND_ENABLED
     );
-  },
-);
-
-export const selectRewardsPredictEnabledFlag = createSelector(
-  selectRemoteFeatureFlags,
-  (remoteFeatureFlags) => {
-    if (!hasProperty(remoteFeatureFlags, REWARDS_PREDICT_ENABLED_FLAG_NAME)) {
-      return false;
-    }
-    const remoteFlag = remoteFeatureFlags[
-      REWARDS_PREDICT_ENABLED_FLAG_NAME
-    ] as unknown as VersionGatedFeatureFlag;
-
-    return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
   },
 );


### PR DESCRIPTION
## **Description**

Removes the recently introduced rewards predict feature flag. We will support reward estimations for predictions when it's released so it doesn't make sense to have a dedicated flag for it.

## **Changelog**

CHANGELOG entry: null

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the Predict rewards feature flag and selector, ungates rewards display in `PredictBuyPreview`, and updates tests accordingly.
> 
> - **Predict UI**:
>   - Remove `useSelector` usage and `selectRewardsPredictEnabledFlag` gating from `PredictBuyPreview.tsx`; rewards now show when `currentValue > 0`.
> - **Feature Flags**:
>   - Delete `selectRewardsPredictEnabledFlag` and related constant from `app/selectors/featureFlagController/rewards`.
> - **Tests**:
>   - Update `PredictBuyPreview.test.tsx` to drop rewards flag mocks and expectations; rewards shown based solely on amount.
>   - Remove tests for `selectRewardsPredictEnabledFlag` in `selectors/featureFlagController/rewards/index.test.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acf05bf02457e44b1652bdd3d75dfbd32a35ed0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->