### PR TITLE
fix: Skip `No MM fee` badge on `PayWithModal` assets

### DIFF
--- a/app/components/UI/Bridge/components/TokenSelectorItem.tsx
+++ b/app/components/UI/Bridge/components/TokenSelectorItem.tsx
@@ -109,6 +109,7 @@ interface TokenSelectorItemProps {
   isSelected?: boolean;
   shouldShowBalance?: boolean;
   children?: React.ReactNode;
+  skipNoFeeBadge?: boolean;
 }
 
 export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
@@ -119,6 +120,7 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
   isSelected = false,
   shouldShowBalance = true,
   children,
+  skipNoFeeBadge = false,
 }) => {
   const { styles } = useStyles(createStyles, { isSelected });
   const noFeeAssets = useSelector((state: RootState) =>
@@ -216,7 +218,7 @@ export const TokenSelectorItem: React.FC<TokenSelectorItemProps> = ({
             >
               <Text variant={TextVariant.BodyLGMedium}>{token.symbol}</Text>
               {label && <Tag label={label} />}
-              {isNoFeeAsset && (
+              {!skipNoFeeBadge && isNoFeeAsset && (
                 <TagBase
                   shape={TagShape.Rectangle}
                   severity={TagSeverity.Info}

--- a/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
@@ -104,6 +104,7 @@ export function PayWithModal() {
           networkName={networkName}
           networkImageSource={networkImageSource}
           isSelected={isSelected}
+          skipNoFeeBadge
         />
       );
     },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to remove `No MM fee` badge from `PayWithModal` assets.

Important note: This PR will only be merged into `7.59.0` as a short living fix because `7.60.0` and onwards using different components in `PayWithModal`

More context: https://consensys.slack.com/archives/C09T0L3SHCY/p1763028938360049?thread_ts=1763020915.213569&cid=C09T0L3SHCY

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/mobile-planning/issues/2372

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a `skipNoFeeBadge` prop to `TokenSelectorItem` and uses it in `PayWithModal` to suppress the “No MM fee” badge for listed assets.
> 
> - **UI**
>   - `app/components/UI/Bridge/components/TokenSelectorItem.tsx`
>     - Add optional `skipNoFeeBadge` prop (default `false`).
>     - Gate rendering of `bridge.no_mm_fee` tag with `!skipNoFeeBadge && isNoFeeAsset`.
>   - `app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx`
>     - Pass `skipNoFeeBadge` to `TokenSelectorItem` so Pay With asset list hides the “No MM fee” badge.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70940db4ef1445fc94ef9c7e38c3d03ed1cf6235. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->