### PR TITLE
feat(perps): update error screens for improved messaging

### DIFF
--- a/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.test.tsx
+++ b/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.test.tsx
@@ -41,7 +41,7 @@ jest.mock('../../../../../component-library/components/Icons/Icon', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     default: ({ name, ...props }: any) => <View {...props} testID={name} />,
     IconName: {
-      Details: 'Details',
+      SignalCellular: 'SignalCellular',
     },
     IconColor: {
       Muted: 'Muted',
@@ -146,7 +146,6 @@ describe('PerpsConnectionErrorView', () => {
     );
 
     expect(getByText('perps.errors.connectionFailed.title')).toBeTruthy();
-    expect(getByText('perps.errors.connectionFailed.description')).toBeTruthy();
     expect(getByText('perps.errors.connectionFailed.retry')).toBeTruthy();
   });
 

--- a/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.test.tsx
+++ b/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.test.tsx
@@ -41,7 +41,7 @@ jest.mock('../../../../../component-library/components/Icons/Icon', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     default: ({ name, ...props }: any) => <View {...props} testID={name} />,
     IconName: {
-      SignalCellular: 'SignalCellular',
+      Warning: 'Warning',
     },
     IconColor: {
       Muted: 'Muted',

--- a/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.tsx
+++ b/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.tsx
@@ -85,7 +85,7 @@ const PerpsConnectionErrorView: React.FC<PerpsConnectionErrorViewProps> = ({
     <View style={styles.container}>
       <View style={styles.errorContainer}>
         <Icon
-          name={IconName.Details}
+          name={IconName.SignalCellular}
           color={IconColor.Muted}
           size={IconSize.Xl}
           style={styles.errorIcon}
@@ -97,14 +97,6 @@ const PerpsConnectionErrorView: React.FC<PerpsConnectionErrorViewProps> = ({
           style={styles.errorTitle}
         >
           {strings('perps.errors.connectionFailed.title')}
-        </Text>
-
-        <Text
-          variant={TextVariant.BodyMD}
-          color={TextColor.Muted}
-          style={styles.errorMessage}
-        >
-          {strings('perps.errors.connectionFailed.description')}
         </Text>
 
         {/* Only show debug details in development */}

--- a/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.tsx
+++ b/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.tsx
@@ -85,7 +85,7 @@ const PerpsConnectionErrorView: React.FC<PerpsConnectionErrorViewProps> = ({
     <View style={styles.container}>
       <View style={styles.errorContainer}>
         <Icon
-          name={IconName.SignalCellular}
+          name={IconName.WifiOff}
           color={IconColor.Muted}
           size={IconSize.Xl}
           style={styles.errorIcon}

--- a/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.tsx
+++ b/app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.tsx
@@ -85,7 +85,7 @@ const PerpsConnectionErrorView: React.FC<PerpsConnectionErrorViewProps> = ({
     <View style={styles.container}>
       <View style={styles.errorContainer}>
         <Icon
-          name={IconName.WifiOff}
+          name={IconName.Warning}
           color={IconColor.Muted}
           size={IconSize.Xl}
           style={styles.errorIcon}

--- a/app/components/UI/Perps/components/PerpsErrorState/PerpsErrorState.test.tsx
+++ b/app/components/UI/Perps/components/PerpsErrorState/PerpsErrorState.test.tsx
@@ -17,9 +17,6 @@ describe('PerpsErrorState', () => {
       expect(
         getByText(strings('perps.errors.connectionFailed.title')),
       ).toBeTruthy();
-      expect(
-        getByText(strings('perps.errors.connectionFailed.description')),
-      ).toBeTruthy();
 
       const retryButton = getByText(
         strings('perps.errors.connectionFailed.retry'),

--- a/app/components/UI/Perps/components/PerpsErrorState/PerpsErrorState.tsx
+++ b/app/components/UI/Perps/components/PerpsErrorState/PerpsErrorState.tsx
@@ -45,9 +45,9 @@ const PerpsErrorState: React.FC<PerpsErrorStateProps> = ({
     switch (errorType) {
       case PerpsErrorType.CONNECTION_FAILED:
         return {
-          icon: IconName.Wifi,
+          icon: IconName.SignalCellular,
           title: strings('perps.errors.connectionFailed.title'),
-          description: strings('perps.errors.connectionFailed.description'),
+          description: undefined,
           primaryAction: {
             label: strings('perps.errors.connectionFailed.retry'),
             onPress: onRetry,
@@ -97,13 +97,15 @@ const PerpsErrorState: React.FC<PerpsErrorStateProps> = ({
         >
           {errorContent.title}
         </Text>
-        <Text
-          variant={TextVariant.BodyMD}
-          color={TextColor.Muted}
-          style={styles.description}
-        >
-          {errorContent.description}
-        </Text>
+        {errorContent.description && (
+          <Text
+            variant={TextVariant.BodyMD}
+            color={TextColor.Muted}
+            style={styles.description}
+          >
+            {errorContent.description}
+          </Text>
+        )}
         {errorContent.primaryAction?.onPress && (
           <Button
             variant={ButtonVariants.Primary}

--- a/app/components/UI/Perps/components/PerpsErrorState/PerpsErrorState.tsx
+++ b/app/components/UI/Perps/components/PerpsErrorState/PerpsErrorState.tsx
@@ -45,7 +45,7 @@ const PerpsErrorState: React.FC<PerpsErrorStateProps> = ({
     switch (errorType) {
       case PerpsErrorType.CONNECTION_FAILED:
         return {
-          icon: IconName.SignalCellular,
+          icon: IconName.Warning,
           title: strings('perps.errors.connectionFailed.title'),
           description: undefined,
           primaryAction: {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1332,10 +1332,10 @@
       "orderLeverageReductionFailed": "You cannot reduce your leverage",
       "connectionTimeout": "Connection timed out. Please check your network and try again.",
       "connectionFailed": {
-        "title": "Perps is temporarily offline",
+        "title": "Couldn't connect to perps",
         "description": "We're working to get it back online soon.",
-        "retry": "Retry",
-        "go_back": "Go Back"
+        "retry": "Try again",
+        "go_back": "Go back"
       },
       "networkError": {
         "title": "Network Error",


### PR DESCRIPTION
## **Description**

Updated the perps error screens to match the new design specifications when connection issues occur. The changes improve the user experience by providing clearer, more concise error messaging with updated iconography.

**What changed:**
- Replaced the details icon with a signal/waveform icon (SignalCellular) to better represent connection issues
- Updated error title from "Perps is temporarily offline" to "Couldn't connect to perps"
- Removed the description text for a cleaner UI
- Updated button labels: "Retry" � "Try again" and "Go Back" � "Go back"

**Why:**
The previous error screen design didn't clearly communicate connection issues to users. The new design provides a more intuitive visual indicator (signal icon) and more actionable copy that better matches user expectations during network failures.

## **Changelog**

CHANGELOG entry: Updated perps connection error screen with new design and improved messaging

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2020

## **Manual testing steps**

```gherkin
Feature: Perps connection error handling

  Scenario: user encounters a connection error when accessing perps
    Given user has the MetaMask mobile app open
    And user navigates to the perps feature

    When perps fails to connect due to network issues
    Then user sees an error screen with:
      - A signal/waveform icon
      - Title "Couldn't connect to perps"
      - "Try again" button (primary)
      - "Go back" button (secondary)

    When user taps "Try again"
    Then the app attempts to reconnect to perps

    When user taps "Go back"
    Then user navigates back to the previous screen

  Scenario: connection automatically recovers
    Given user is viewing the perps connection error screen

    When network connection is restored
    Then perps automatically reconnects
    And user sees the perps interface
```

## **Screenshots/Recordings**

### **Before**

Previous design:
- Details/info icon
- Title: "Perps is temporarily offline"
- Description: "We're working to get it back online soon."
- Button: "Retry"

### **After**

New design:
- Signal/waveform icon (SignalCellular)
- Title: "Couldn't connect to perps"
- No description text
- Buttons: "Try again" and "Go back"

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---

## **Technical Details**

### Files Modified

1. **Components:**
   - `app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.tsx`
   - `app/components/UI/Perps/components/PerpsErrorState/PerpsErrorState.tsx`

2. **Localization:**
   - `locales/languages/en.json`

3. **Tests:**
   - `app/components/UI/Perps/components/PerpsConnectionErrorView/PerpsConnectionErrorView.test.tsx`
   - `app/components/UI/Perps/components/PerpsErrorState/PerpsErrorState.test.tsx`

### Test Results

 All ESLint checks pass
 All Jest tests pass (15/15)
  - PerpsConnectionErrorView: 7/7 tests
  - PerpsErrorState: 8/8 tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refreshes perps connection error screens with a warning icon, no description, updated title/buttons, and aligned tests/i18n.
> 
> - **Perps UI**:
>   - `PerpsConnectionErrorView`: switch icon to `IconName.Warning`, remove description text, retain debug details; keep primary/secondary actions; adjust navigation/back handling unchanged.
>   - `PerpsErrorState`: use `IconName.Warning` for `CONNECTION_FAILED`, omit description; conditionally render description for other errors.
> - **Localization (`locales/languages/en.json`)**:
>   - Update `perps.errors.connectionFailed` copy: title → "Couldn't connect to perps", buttons → "Try again" / "Go back".
> - **Tests**:
>   - Update expectations to match removed description and new icon; adjust icon mock to expose `Warning`; ensure retry/back buttons and loading states verified.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c49c54bcd513650bd4957c98bc4e9564f93cd96. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->