### PR TITLE
fix: pay hide testnet assets in metamask pay

### DIFF
--- a/app/components/Views/confirmations/utils/transaction-pay.test.ts
+++ b/app/components/Views/confirmations/utils/transaction-pay.test.ts
@@ -1,4 +1,5 @@
 import {
+  CHAIN_IDS,
   TransactionMeta,
   TransactionType,
 } from '@metamask/transaction-controller';
@@ -253,6 +254,19 @@ describe('Transaction Pay Utils', () => {
 
       const result = getAvailableTokens({
         tokens: [tokenWithWrongAccountType] as AssetType[],
+      });
+
+      expect(result).toStrictEqual([]);
+    });
+
+    it('does not return token if on testnet', async () => {
+      const tokenOnTestNet = {
+        ...TOKEN_MOCK,
+        chainId: CHAIN_IDS.SEPOLIA,
+      } as AssetType;
+
+      const result = getAvailableTokens({
+        tokens: [tokenOnTestNet] as AssetType[],
       });
 
       expect(result).toStrictEqual([]);

--- a/app/components/Views/confirmations/utils/transaction-pay.ts
+++ b/app/components/Views/confirmations/utils/transaction-pay.ts
@@ -14,6 +14,7 @@ import {
 import { getNativeTokenAddress } from './asset';
 import { strings } from '../../../../../locales/i18n';
 import { BigNumber } from 'bignumber.js';
+import { isTestNet } from '../../../../util/networks';
 
 const FOUR_BYTE_TOKEN_TRANSFER = '0xa9059cbb';
 
@@ -93,7 +94,8 @@ export function getAvailableTokens({
     .filter((token) => {
       if (
         token.standard !== TokenStandard.ERC20 ||
-        !token.accountType?.includes('eip155')
+        !token.accountType?.includes('eip155') ||
+        (token.chainId && isTestNet(token.chainId))
       ) {
         return false;
       }


### PR DESCRIPTION
## **Description**

Hide tokens on testnet chains in the asset picker used by MetaMask Pay.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#6262](https://github.com/MetaMask/MetaMask-planning/issues/6262)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Filters out testnet-chain tokens from `getAvailableTokens` and adds a unit test to validate the behavior.
> 
> - **Confirmations Utils**:
>   - Update `getAvailableTokens` in `app/components/Views/confirmations/utils/transaction-pay.ts` to exclude tokens on testnets using `isTestNet(chainId)`.
> - **Tests**:
>   - Add test in `app/components/Views/confirmations/utils/transaction-pay.test.ts` to assert testnet tokens are not returned; import `CHAIN_IDS` for `SEPOLIA`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72944f5e0092ef3eb49a05cc723c358f83de2f5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->