### PR TITLE
feat: ways to earn musd deposits

### DIFF
--- a/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.test.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
+import { Linking } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { WaysToEarn, WayToEarnType } from './WaysToEarn';
 import Routes from '../../../../../../../constants/navigation/Routes';
 import { ModalType } from '../../../../components/RewardsBottomSheetModal';
 import { SwapBridgeNavigationLocation } from '../../../../../Bridge/hooks/useSwapBridgeNavigation';
 import { selectIsFirstTimePerpsUser } from '../../../../../Perps/selectors/perpsController';
-import { selectRewardsCardSpendFeatureFlags } from '../../../../../../../selectors/featureFlagController/rewards';
+import {
+  selectRewardsCardSpendFeatureFlags,
+  selectRewardsMusdDepositEnabledFlag,
+} from '../../../../../../../selectors/featureFlagController/rewards';
 import { selectPredictEnabledFlag } from '../../../../../Predict/selectors/featureFlags';
 import { MetaMetricsEvents } from '../../../../../../hooks/useMetrics';
 import { RewardsMetricsButtons } from '../../../../utils';
@@ -20,6 +24,7 @@ const mockCreateEventBuilder = jest.fn();
 let mockIsFirstTimePerpsUser = false;
 let mockIsCardSpendEnabled = false;
 let mockIsPredictEnabled = false;
+let mockIsMusdDepositEnabled = false;
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(),
@@ -113,6 +118,15 @@ jest.mock('../../../../../../../../locales/i18n', () => ({
       'rewards.ways_to_earn.card.sheet.description':
         'Earn points every time you use your MetaMask Card for purchases, plus 1% cash back (3% for Metal cardholders).',
       'rewards.ways_to_earn.card.sheet.cta_label': 'Manage Card',
+      // Deposit MUSD strings
+      'rewards.ways_to_earn.deposit_musd.title': 'Deposit mUSD',
+      'rewards.ways_to_earn.deposit_musd.description':
+        '2 points per $100 deposited',
+      'rewards.ways_to_earn.deposit_musd.sheet.title': 'Deposit mUSD',
+      'rewards.ways_to_earn.deposit_musd.sheet.points': '2 points per $100',
+      'rewards.ways_to_earn.deposit_musd.sheet.description':
+        'Earn points on every $100 mUSD you deposit.',
+      'rewards.ways_to_earn.deposit_musd.sheet.cta_label': 'Deposit mUSD',
     };
     return mockStrings[key] || key;
   }),
@@ -161,11 +175,15 @@ jest.mock(
 );
 
 describe('WaysToEarn', () => {
+  let openURLSpy: jest.SpyInstance;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    openURLSpy = jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined);
     mockIsFirstTimePerpsUser = false;
     mockIsCardSpendEnabled = false;
     mockIsPredictEnabled = false;
+    mockIsMusdDepositEnabled = false;
 
     mockUseNavigation.mockReturnValue({
       navigate: mockNavigate,
@@ -192,6 +210,9 @@ describe('WaysToEarn', () => {
       if (selector === selectPredictEnabledFlag) {
         return mockIsPredictEnabled;
       }
+      if (selector === selectRewardsMusdDepositEnabledFlag) {
+        return mockIsMusdDepositEnabled;
+      }
       return undefined;
     });
   });
@@ -217,6 +238,8 @@ describe('WaysToEarn', () => {
     expect(queryByText('Prediction markets')).not.toBeOnTheScreen();
     // MM Card Spend hidden when flag disabled
     expect(queryByText('MetaMask Card')).not.toBeOnTheScreen();
+    // Deposit mUSD hidden when flag disabled
+    expect(queryByText('Deposit mUSD')).not.toBeOnTheScreen();
   });
 
   it('displays correct descriptions for each earning way', () => {
@@ -230,6 +253,7 @@ describe('WaysToEarn', () => {
     expect(getByText('Earn points from past trades')).toBeOnTheScreen();
     expect(queryByText('20 points per $10 prediction')).not.toBeOnTheScreen();
     expect(queryByText('1 point per $1 spent')).not.toBeOnTheScreen();
+    expect(queryByText('Earn points on deposits')).not.toBeOnTheScreen();
   });
 
   it('opens referral bottom sheet modal when referral item is pressed', () => {
@@ -465,6 +489,7 @@ describe('WaysToEarn', () => {
       expect(WayToEarnType.LOYALTY).toBe('loyalty');
       expect(WayToEarnType.PREDICT).toBe('predict');
       expect(WayToEarnType.CARD).toBe('card');
+      expect(WayToEarnType.DEPOSIT_MUSD).toBe('deposit_musd');
     });
   });
 
@@ -580,6 +605,81 @@ describe('WaysToEarn', () => {
       // Assert
       expect(mockGoBack).toHaveBeenCalled();
       expect(mockNavigate).toHaveBeenCalledWith(Routes.CARD.ROOT);
+    });
+  });
+
+  describe('Deposit mUSD', () => {
+    it('shows Deposit mUSD earning way only when feature flag is enabled', () => {
+      // Arrange
+      const { queryByText, rerender } = render(<WaysToEarn />);
+
+      // Assert hidden by default
+      expect(queryByText('Deposit mUSD')).not.toBeOnTheScreen();
+
+      // Enable flag
+      mockIsMusdDepositEnabled = true;
+      rerender(<WaysToEarn />);
+
+      // Assert visible now
+      expect(queryByText('Deposit mUSD')).toBeOnTheScreen();
+      expect(queryByText('2 points per $100 deposited')).toBeOnTheScreen();
+    });
+
+    it('opens modal for deposit mUSD earning way when pressed', () => {
+      // Arrange
+      mockIsMusdDepositEnabled = true;
+      const { getByText } = render(<WaysToEarn />);
+      const depositMusdButton = getByText('Deposit mUSD');
+
+      // Act
+      fireEvent.press(depositMusdButton);
+
+      // Assert
+      expect(mockNavigate).toHaveBeenCalledWith(
+        Routes.MODAL.REWARDS_BOTTOM_SHEET_MODAL,
+        expect.objectContaining({
+          type: ModalType.Confirmation,
+          showIcon: false,
+          showCancelButton: false,
+          confirmAction: expect.objectContaining({
+            label: 'Deposit mUSD',
+            variant: 'Primary',
+          }),
+        }),
+      );
+      expect(mockTrackEvent).toHaveBeenCalled();
+      expect(mockCreateEventBuilder).toHaveBeenCalledWith(
+        MetaMetricsEvents.REWARDS_PAGE_BUTTON_CLICKED,
+      );
+    });
+
+    it('opens URL when deposit mUSD CTA is pressed', () => {
+      // Arrange
+      mockIsMusdDepositEnabled = true;
+      const { getByText } = render(<WaysToEarn />);
+      const depositMusdButton = getByText('Deposit mUSD');
+
+      // Act
+      fireEvent.press(depositMusdButton);
+
+      // Get the onPress handler from the modal navigation call
+      const modalCall = mockNavigate.mock.calls.find(
+        (call) => call[0] === Routes.MODAL.REWARDS_BOTTOM_SHEET_MODAL,
+      );
+      const confirmAction = modalCall?.[1]?.confirmAction;
+
+      // Execute the CTA action
+      confirmAction?.onPress();
+
+      // Assert
+      expect(mockGoBack).toHaveBeenCalled();
+      expect(openURLSpy).toHaveBeenCalledWith(
+        'https://app.turtle.xyz/campaigns',
+      );
+      expect(mockTrackEvent).toHaveBeenCalled();
+      expect(mockCreateEventBuilder).toHaveBeenCalledWith(
+        MetaMetricsEvents.REWARDS_WAYS_TO_EARN_CTA_CLICKED,
+      );
     });
   });
 

--- a/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.test.tsx
@@ -674,7 +674,7 @@ describe('WaysToEarn', () => {
       // Assert
       expect(mockGoBack).toHaveBeenCalled();
       expect(openURLSpy).toHaveBeenCalledWith(
-        'https://app.turtle.xyz/campaigns',
+        'https://go.metamask.io/turtle-musd',
       );
       expect(mockTrackEvent).toHaveBeenCalled();
       expect(mockCreateEventBuilder).toHaveBeenCalledWith(

--- a/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.tsx
+++ b/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { FlatList } from 'react-native';
+import { FlatList, Linking } from 'react-native';
 import {
   Box,
   Text,
@@ -27,7 +27,10 @@ import {
 } from '../../../../../Bridge/hooks/useSwapBridgeNavigation';
 import { useSelector } from 'react-redux';
 import { selectIsFirstTimePerpsUser } from '../../../../../Perps/selectors/perpsController';
-import { selectRewardsCardSpendFeatureFlags } from '../../../../../../../selectors/featureFlagController/rewards';
+import {
+  selectRewardsCardSpendFeatureFlags,
+  selectRewardsMusdDepositEnabledFlag,
+} from '../../../../../../../selectors/featureFlagController/rewards';
 import { selectPredictEnabledFlag } from '../../../../../Predict/selectors/featureFlags';
 import {
   MetaMetricsEvents,
@@ -42,6 +45,7 @@ export enum WayToEarnType {
   LOYALTY = 'loyalty',
   PREDICT = 'predict',
   CARD = 'card',
+  DEPOSIT_MUSD = 'deposit_musd',
 }
 
 interface WayToEarn {
@@ -87,6 +91,12 @@ const waysToEarn: WayToEarn[] = [
     title: strings('rewards.ways_to_earn.card.title'),
     description: strings('rewards.ways_to_earn.card.description'),
     icon: IconName.Card,
+  },
+  {
+    type: WayToEarnType.DEPOSIT_MUSD,
+    title: strings('rewards.ways_to_earn.deposit_musd.title'),
+    description: strings('rewards.ways_to_earn.deposit_musd.description'),
+    icon: IconName.Money,
   },
 ];
 
@@ -196,6 +206,21 @@ const getBottomSheetData = (type: WayToEarnType) => {
         ),
         ctaLabel: strings('rewards.ways_to_earn.card.sheet.cta_label'),
       };
+    case WayToEarnType.DEPOSIT_MUSD:
+      return {
+        title: (
+          <WaysToEarnSheetTitle
+            title={strings('rewards.ways_to_earn.deposit_musd.sheet.title')}
+            points={strings('rewards.ways_to_earn.deposit_musd.sheet.points')}
+          />
+        ),
+        description: (
+          <Text variant={TextVariant.BodyMd} twClassName="text-alternative">
+            {strings('rewards.ways_to_earn.deposit_musd.sheet.description')}
+          </Text>
+        ),
+        ctaLabel: strings('rewards.ways_to_earn.deposit_musd.sheet.cta_label'),
+      };
     default:
       throw new Error(`Unknown earning way type: ${type}`);
   }
@@ -206,6 +231,7 @@ export const WaysToEarn = () => {
   const isFirstTimePerpsUser = useSelector(selectIsFirstTimePerpsUser);
   const isCardSpendEnabled = useSelector(selectRewardsCardSpendFeatureFlags);
   const isPredictEnabled = useSelector(selectPredictEnabledFlag);
+  const isMusdDepositEnabled = useSelector(selectRewardsMusdDepositEnabledFlag);
   const { trackEvent, createEventBuilder } = useMetrics();
 
   // Use the swap/bridge navigation hook
@@ -251,6 +277,9 @@ export const WaysToEarn = () => {
       case WayToEarnType.CARD:
         navigation.navigate(Routes.CARD.ROOT);
         break;
+      case WayToEarnType.DEPOSIT_MUSD:
+        Linking.openURL('https://app.turtle.xyz/campaigns'); // TODO REPLACE WITH ACTUAL URL
+        break;
     }
   };
 
@@ -268,7 +297,8 @@ export const WaysToEarn = () => {
       case WayToEarnType.LOYALTY:
       case WayToEarnType.PERPS:
       case WayToEarnType.PREDICT:
-      case WayToEarnType.CARD: {
+      case WayToEarnType.CARD:
+      case WayToEarnType.DEPOSIT_MUSD: {
         const { title, description, ctaLabel } = getBottomSheetData(
           wayToEarn.type,
         );
@@ -309,6 +339,12 @@ export const WaysToEarn = () => {
               return false;
             }
             if (wte.type === WayToEarnType.PREDICT && !isPredictEnabled) {
+              return false;
+            }
+            if (
+              wte.type === WayToEarnType.DEPOSIT_MUSD &&
+              !isMusdDepositEnabled
+            ) {
               return false;
             }
             return true;

--- a/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.tsx
+++ b/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.tsx
@@ -278,7 +278,7 @@ export const WaysToEarn = () => {
         navigation.navigate(Routes.CARD.ROOT);
         break;
       case WayToEarnType.DEPOSIT_MUSD:
-        Linking.openURL('https://app.turtle.xyz/campaigns'); // TODO REPLACE WITH ACTUAL URL
+        Linking.openURL('https://go.metamask.io/turtle-musd');
         break;
     }
   };

--- a/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.tsx
+++ b/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.tsx
@@ -96,7 +96,7 @@ const waysToEarn: WayToEarn[] = [
     type: WayToEarnType.DEPOSIT_MUSD,
     title: strings('rewards.ways_to_earn.deposit_musd.title'),
     description: strings('rewards.ways_to_earn.deposit_musd.description'),
-    icon: IconName.Money,
+    icon: IconName.AttachMoney,
   },
 ];
 

--- a/app/selectors/featureFlagController/rewards/index.test.ts
+++ b/app/selectors/featureFlagController/rewards/index.test.ts
@@ -2,6 +2,7 @@ import {
   selectRewardsEnabledFlag,
   selectRewardsAnnouncementModalEnabledFlag,
   selectRewardsCardSpendFeatureFlags,
+  selectRewardsMusdDepositEnabledFlag,
 } from '.';
 import {
   VersionGatedFeatureFlag,
@@ -211,6 +212,55 @@ describe('Rewards Feature Flag Selectors', () => {
       expect(result).toBe(false);
     });
   });
+
+  describe('selectRewardsMusdDepositEnabledFlag', () => {
+    it('returns true when remote flag is valid and enabled', () => {
+      const result = selectRewardsMusdDepositEnabledFlag.resultFunc({
+        rewardsEnableMusdDeposit: {
+          enabled: true,
+          minimumVersion: '1.0.0',
+        },
+      });
+      expect(result).toBe(true);
+    });
+
+    it('returns false when remote flag is valid but disabled', () => {
+      const result = selectRewardsMusdDepositEnabledFlag.resultFunc({
+        rewardsEnableMusdDeposit: {
+          enabled: false,
+          minimumVersion: '1.0.0',
+        },
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false when version check fails', () => {
+      mockHasMinimumRequiredVersion.mockReturnValue(false);
+      const result = selectRewardsMusdDepositEnabledFlag.resultFunc({
+        rewardsEnableMusdDeposit: {
+          enabled: true,
+          minimumVersion: '99.0.0',
+        },
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false when remote flag is invalid', () => {
+      const result = selectRewardsMusdDepositEnabledFlag.resultFunc({
+        rewardsEnableMusdDeposit: {
+          enabled: 'invalid',
+          minimumVersion: 123,
+        },
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false when remote feature flags are empty', () => {
+      const result = selectRewardsMusdDepositEnabledFlag.resultFunc({});
+      expect(result).toBe(false);
+    });
+  });
+
   describe('validatedVersionGatedFeatureFlag', () => {
     const validRemoteFlag: VersionGatedFeatureFlag = {
       enabled: true,

--- a/app/selectors/featureFlagController/rewards/index.ts
+++ b/app/selectors/featureFlagController/rewards/index.ts
@@ -9,9 +9,11 @@ import { selectBasicFunctionalityEnabled } from '../../settings';
 
 const DEFAULT_REWARDS_ENABLED = false;
 const DEFAULT_CARD_SPEND_ENABLED = false;
+const DEFAULT_MUSD_DEPOSIT_ENABLED = false;
 export const FEATURE_FLAG_NAME = 'rewardsEnabled';
 export const ANNOUNCEMENT_MODAL_FLAG_NAME = 'rewardsAnnouncementModalEnabled';
 export const CARD_SPEND_FLAG_NAME = 'rewardsEnableCardSpend';
+export const MUSD_DEPOSIT_FLAG_NAME = 'rewardsEnableMusdDeposit';
 
 export const selectRewardsEnabledFlag = createSelector(
   selectRemoteFeatureFlags,
@@ -64,6 +66,23 @@ export const selectRewardsCardSpendFeatureFlags = createSelector(
     return (
       validatedVersionGatedFeatureFlag(cardSpendConfig) ??
       DEFAULT_CARD_SPEND_ENABLED
+    );
+  },
+);
+
+export const selectRewardsMusdDepositEnabledFlag = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) => {
+    if (!hasProperty(remoteFeatureFlags, MUSD_DEPOSIT_FLAG_NAME)) {
+      return DEFAULT_MUSD_DEPOSIT_ENABLED;
+    }
+    const musdDepositConfig = remoteFeatureFlags[
+      MUSD_DEPOSIT_FLAG_NAME
+    ] as unknown as VersionGatedFeatureFlag;
+
+    return (
+      validatedVersionGatedFeatureFlag(musdDepositConfig) ??
+      DEFAULT_MUSD_DEPOSIT_ENABLED
     );
   },
 );

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6771,6 +6771,16 @@
           "description": "Earn points every time you use your MetaMask Card for purchases, plus 1% cash back (3% for Metal cardholders).",
           "cta_label": "Manage Card"
         }
+      },
+      "deposit_musd": {
+        "title": "Deposit mUSD",
+        "description": "2 points per $100 deposited",
+        "sheet": {
+          "title": "Deposit mUSD",
+          "points": "2 points per $100",
+          "description": "Earn points on every $100 mUSD you deposit.",
+          "cta_label": "Deposit mUSD"
+        }
       }
     },
     "referral": {


### PR DESCRIPTION
## **Description**

This PR adds a mUSD ways to earn cta and bottom sheet. Only if the feature flag is turned on.

## **Changelog**

CHANGELOG entry: rewards earn musd ways to earn cta

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/RWDS-699

## **Screenshots/Recordings**

### **After**

<img width="643" height="685" alt="image" src="https://github.com/user-attachments/assets/65a14168-c6c1-49ca-bde1-fbf3dde8b341" />

<img width="710" height="516" alt="image" src="https://github.com/user-attachments/assets/15f96dab-4618-416c-ba47-e5cbee411f2a" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a flag-gated "Deposit mUSD" way to earn in Rewards with bottom sheet and external CTA link, plus selector, strings, and tests.
> 
> - **Rewards UI**:
>   - Add `WayToEarnType.DEPOSIT_MUSD` and list item in `app/components/UI/Rewards/.../WaysToEarn/WaysToEarn.tsx`.
>   - Show bottom sheet for `deposit_musd` with new copy; CTA opens external URL via `Linking.openURL('https://go.metamask.io/turtle-musd')`.
>   - Gate visibility in list rendering by `selectRewardsMusdDepositEnabledFlag`.
> - **Feature Flags/Selectors**:
>   - Add `MUSD_DEPOSIT_FLAG_NAME` and selector `selectRewardsMusdDepositEnabledFlag` in `app/selectors/featureFlagController/rewards/index.ts` with tests.
> - **Localization**:
>   - Add i18n strings under `rewards.ways_to_earn.deposit_musd.*` in `locales/languages/en.json`.
> - **Tests**:
>   - Extend `WaysToEarn.test.tsx` to cover flag gating, bottom sheet content, CTA behavior (including URL open), metrics events, and enum value.
>   - Add unit tests for the new selector in `app/selectors/featureFlagController/rewards/index.test.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e2e65cf6918dc721f555228a767cb7a496b27f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->