### PR TITLE
feat: update metamask pay same chain duration

### DIFF
--- a/app/components/Views/confirmations/components/rows/bridge-time-row/bridge-time-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/bridge-time-row/bridge-time-row.test.tsx
@@ -83,7 +83,7 @@ describe('BridgeTimeRow', () => {
 
     const { getByText } = render();
 
-    expect(getByText('2 sec')).toBeDefined();
+    expect(getByText('< 10 sec')).toBeDefined();
   });
 
   it('renders skeleton if quotes loading', async () => {

--- a/app/components/Views/confirmations/components/rows/bridge-time-row/bridge-time-row.tsx
+++ b/app/components/Views/confirmations/components/rows/bridge-time-row/bridge-time-row.tsx
@@ -11,7 +11,7 @@ import {
 import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
 
-const SAME_CHAIN_DURATION_SECONDS = 2;
+const SAME_CHAIN_DURATION_SECONDS = '< 10';
 
 export function BridgeTimeRow() {
   const isLoading = useIsTransactionPayLoading();


### PR DESCRIPTION
## **Description**

Update the duration for same chain transactions in MetaMask Pay to from `2` to  `< 10`. 

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#6265](https://github.com/MetaMask/MetaMask-planning/issues/6265)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates same-chain transaction estimated time display from "2 sec" to "< 10 sec" and aligns tests.
> 
> - **Confirmations UI**:
>   - Update `BridgeTimeRow` same-chain estimate to display `"< 10 sec"` via `SAME_CHAIN_DURATION_SECONDS`.
> - **Tests**:
>   - Adjust expectation in `bridge-time-row.test.tsx` to `"< 10 sec"` for same-chain payment scenario.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c28393d5c2dd142e1f96da817a641462cb1f9d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->