### PR TITLE
fix(bridge): cp-7.59.0 prevent crash when fetching icons for unsupported chains

### DIFF
--- a/app/components/UI/Bridge/utils/index.test.ts
+++ b/app/components/UI/Bridge/utils/index.test.ts
@@ -71,18 +71,18 @@ describe('Bridge Utils', () => {
       LINEA_CHAIN_ID,
     ];
 
-    it('should return true when bridge is active and chain ID is allowed', () => {
+    it('return true when bridge is active and chain ID is allowed', () => {
       supportedChainIds.forEach((chainId) => {
         expect(isBridgeAllowed(chainId)).toBe(true);
       });
     });
 
-    it('should return false when bridge is active but chain ID is not allowed', () => {
+    it('return false when bridge is active but chain ID is not allowed', () => {
       const unsupportedChainId = '0x1234' as Hex;
       expect(isBridgeAllowed(unsupportedChainId)).toBe(false);
     });
 
-    it('should return false when bridge is inactive', () => {
+    it('return false when bridge is inactive', () => {
       Object.defineProperty(AppConstants.BRIDGE, 'ACTIVE', {
         get: () => false,
       });
@@ -92,7 +92,7 @@ describe('Bridge Utils', () => {
       });
     });
 
-    it('should handle invalid chain ID formats', () => {
+    it('handle invalid chain ID formats', () => {
       const invalidChainIds = ['0x123' as Hex, '0x' as Hex];
 
       invalidChainIds.forEach((chainId) => {
@@ -100,7 +100,7 @@ describe('Bridge Utils', () => {
       });
     });
 
-    it('should handle edge cases', () => {
+    it('handle edge cases', () => {
       // Test with malformed chain ID
       expect(
         isBridgeAllowed(

--- a/app/components/UI/Bridge/utils/index.test.ts
+++ b/app/components/UI/Bridge/utils/index.test.ts
@@ -15,6 +15,10 @@ import {
 import { Hex } from '@metamask/utils';
 import { SolScope } from '@metamask/keyring-api';
 import Engine from '../../../../core/Engine';
+import {
+  formatAddressToAssetId,
+  isNonEvmChainId,
+} from '@metamask/bridge-controller';
 
 jest.mock('../../../../core/AppConstants', () => ({
   __esModule: true,
@@ -32,9 +36,21 @@ jest.mock('../../../../core/Engine', () => ({
   },
 }));
 
+jest.mock('@metamask/bridge-controller', () => ({
+  ...jest.requireActual('@metamask/bridge-controller'),
+  formatAddressToAssetId: jest.fn(),
+  isNonEvmChainId: jest.fn(),
+}));
+
 const mockWipeBridgeStatus = Engine.context.BridgeStatusController
   .wipeBridgeStatus as jest.MockedFunction<
   typeof Engine.context.BridgeStatusController.wipeBridgeStatus
+>;
+
+const mockFormatAddressToAssetId =
+  formatAddressToAssetId as jest.MockedFunction<typeof formatAddressToAssetId>;
+const mockIsNonEvmChainId = isNonEvmChainId as jest.MockedFunction<
+  typeof isNonEvmChainId
 >;
 
 describe('Bridge Utils', () => {
@@ -99,7 +115,9 @@ describe('Bridge Utils', () => {
     const testAddressLowercase = testAddress.toLowerCase();
     const evmChainId = ETH_CHAIN_ID;
 
-    it('should call wipeBridgeStatus twice for EVM chains (original and lowercase address)', () => {
+    it('calls wipeBridgeStatus twice for EVM chains with original and lowercase address', () => {
+      mockIsNonEvmChainId.mockReturnValue(false);
+
       wipeBridgeStatus(testAddress, evmChainId);
 
       expect(mockWipeBridgeStatus).toHaveBeenCalledTimes(2);
@@ -113,7 +131,9 @@ describe('Bridge Utils', () => {
       });
     });
 
-    it('should call wipeBridgeStatus only once for Solana chains (original address only)', () => {
+    it('calls wipeBridgeStatus once for Solana chains with original address only', () => {
+      mockIsNonEvmChainId.mockReturnValue(true);
+
       wipeBridgeStatus(testAddress, SolScope.Mainnet);
 
       expect(mockWipeBridgeStatus).toHaveBeenCalledTimes(1);
@@ -125,77 +145,110 @@ describe('Bridge Utils', () => {
   });
 
   describe('getTokenIconUrl', () => {
-    it('should return token icon URL for native token on Ethereum', () => {
-      // Arrange
-      const nativeTokenAddress = '0x0000000000000000000000000000000000000000';
+    beforeEach(() => {
+      mockIsNonEvmChainId.mockReturnValue(false);
+    });
 
-      // Act
+    it('returns token icon URL for native token on Ethereum', () => {
+      const nativeTokenAddress = '0x0000000000000000000000000000000000000000';
+      mockFormatAddressToAssetId.mockReturnValue('eip155:1/slip44:60');
+
       const result = getTokenIconUrl(nativeTokenAddress, ETH_CHAIN_ID);
 
-      // Assert
       expect(result).toBe(
         'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/slip44/60.png',
       );
     });
 
-    it('should return token icon URL for ERC20 token on Ethereum', () => {
-      // Arrange
+    it('returns token icon URL for ERC20 token on Ethereum', () => {
       const usdcAddress = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+      mockFormatAddressToAssetId.mockReturnValue(
+        'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      );
 
-      // Act
       const result = getTokenIconUrl(usdcAddress, ETH_CHAIN_ID);
 
-      // Assert
       expect(result).toBe(
         'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.png',
       );
     });
 
-    it('should return token icon URL for Solana native token', () => {
-      // Arrange
+    it('returns token icon URL for Solana native token', () => {
       const solNativeAddress = '0x0000000000000000000000000000000000000000';
+      mockIsNonEvmChainId.mockReturnValue(true);
+      mockFormatAddressToAssetId.mockReturnValue(
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+      );
 
-      // Act
       const result = getTokenIconUrl(solNativeAddress, SolScope.Mainnet);
 
-      // Assert
       expect(result).toBe(
         'https://static.cx.metamask.io/api/v2/tokenIcons/assets/solana/5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44/501.png',
       );
     });
 
-    it('should return token icon URL for Solana SPL token', () => {
-      // Arrange
+    it('returns token icon URL for Solana SPL token', () => {
       const usdcSolanaAddress = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+      mockIsNonEvmChainId.mockReturnValue(true);
+      mockFormatAddressToAssetId.mockReturnValue(
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+      );
 
-      // Act
       const result = getTokenIconUrl(usdcSolanaAddress, SolScope.Mainnet);
 
-      // Assert
       expect(result).toBe(
         'https://static.cx.metamask.io/api/v2/tokenIcons/assets/solana/5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v.png',
       );
     });
 
-    it('should return undefined for invalid address', () => {
-      // Arrange
-      const invalidAddress = 'invalid';
+    it('returns undefined when formatAddressToAssetId returns null', () => {
+      const address = '0x1234567890123456789012345678901234567890';
+      // @ts-expect-error Testing null return value
+      mockFormatAddressToAssetId.mockReturnValue(null);
 
-      // Act
-      const result = getTokenIconUrl(invalidAddress, ETH_CHAIN_ID);
+      const result = getTokenIconUrl(address, ETH_CHAIN_ID);
 
-      // Assert
       expect(result).toBeUndefined();
     });
 
-    it('should return native token icon URL for empty address', () => {
-      // Arrange
-      const emptyAddress = '';
+    it('returns undefined when formatAddressToAssetId returns undefined', () => {
+      const address = '0x1234567890123456789012345678901234567890';
+      mockFormatAddressToAssetId.mockReturnValue(undefined);
 
-      // Act
+      const result = getTokenIconUrl(address, ETH_CHAIN_ID);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when formatAddressToAssetId throws error for unsupported chain', () => {
+      const address = '0x1234567890123456789012345678901234567890';
+      const unsupportedChainId = '0x9999' as Hex;
+      mockFormatAddressToAssetId.mockImplementation(() => {
+        throw new Error('Unsupported chain');
+      });
+
+      const result = getTokenIconUrl(address, unsupportedChainId);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when formatAddressToAssetId throws error for invalid address format', () => {
+      const invalidAddress = 'invalid-address-format';
+      mockFormatAddressToAssetId.mockImplementation(() => {
+        throw new Error('Invalid address format');
+      });
+
+      const result = getTokenIconUrl(invalidAddress, ETH_CHAIN_ID);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns token icon URL for empty address when formatAddressToAssetId succeeds', () => {
+      const emptyAddress = '';
+      mockFormatAddressToAssetId.mockReturnValue('eip155:1/slip44:60');
+
       const result = getTokenIconUrl(emptyAddress, ETH_CHAIN_ID);
 
-      // Assert
       expect(result).toBe(
         'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/slip44/60.png',
       );

--- a/app/components/UI/Bridge/utils/index.ts
+++ b/app/components/UI/Bridge/utils/index.ts
@@ -68,11 +68,19 @@ export const getTokenIconUrl = (
   const isEvmChain = !isNonEvmChainId(chainId);
   const formattedAddress = isEvmChain ? address.toLowerCase() : address;
 
-  const assetId = formatAddressToAssetId(formattedAddress, chainId);
-  if (!assetId) {
+  try {
+    const assetId = formatAddressToAssetId(formattedAddress, chainId);
+    if (!assetId) {
+      return undefined;
+    }
+    return `https://static.cx.metamask.io/api/v2/tokenIcons/assets/${assetId
+      .split(':')
+      .join('/')}.png`;
+  } catch (error) {
+    // formatAddressToAssetId may throw for unsupported chains. This is expected behavior,
+    // so we gracefully handle it by returning undefined rather than propagating the error.
+    // This prevents the app from crashing when attempting to fetch icons for tokens on
+    // chains that aren't yet supported by the tokenIcons API.
     return undefined;
   }
-  return `https://static.cx.metamask.io/api/v2/tokenIcons/assets/${assetId
-    .split(':')
-    .join('/')}.png`;
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Fixed a crash in the Bridge feature that occurred when attempting to fetch token icons for chains not supported by the tokenIcons API. 

**The Problem:**
The `getTokenIconUrl` function in `app/components/UI/Bridge/utils/index.ts` was calling `formatAddressToAssetId` from `@metamask/bridge-controller`, which throws errors for unsupported chains. This unhandled error was causing the app to crash when users attempted to open the Card home screen.

The crash occurred through the following chain: Card home uses the `useTokensWithBalance` hook, which calls `getTokenIconUrl` in the background to fetch icons for all tokens. When processing tokens on unsupported chains, `formatAddressToAssetId` would throw an uncaught exception that propagated up the stack and crashed the app, making the entire Card feature inaccessible to users.

**The Solution:**
Added proper error handling by wrapping the `formatAddressToAssetId` call in a try-catch block. The function now gracefully returns `undefined` instead of propagating the error, preventing app crashes. Also enhanced the inline documentation to clearly explain why this error suppression is expected and necessary.

Additionally, added comprehensive test coverage for all error scenarios including unsupported chains, invalid address formats, and null/undefined return values.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed crash when fetching token icons for unsupported chains in Bridge

## **Related issues**

Fixes: #22475

## **Manual testing steps**

As a Card holder, open the Card home screen and check if the fail still happening.
should see the card-related info like balance and selected asset, without any crashes or failures.

```gherkin
Feature: Card home screen loads with tokens on unsupported chains

  Scenario: Card home displays correctly with tokens on unsupported chains
    Given the user is logged into MetaMask Mobile
    And the user has an active Card
    And the user has tokens on chains not supported by the tokenIcons API
    
    When the user navigates to the Card home screen
    Then the Card home screen loads successfully without crashes
    And the Card balance is displayed correctly
    And the selected asset information is visible
    And token list is rendered (with or without icons for unsupported chains)
    And all Card functionality remains operational
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/4ae409f8-9e7d-4258-8e07-a4a85b78db58

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/320c71a2-5fcb-495f-b576-148fb0a7661c

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wraps token icon URL generation in try/catch to return undefined on errors and adds comprehensive tests for EVM/Solana behavior and error cases.
> 
> - **Bridge utils**:
>   - Wrap `getTokenIconUrl` call to `formatAddressToAssetId` in a try/catch and return `undefined` on errors; retain EVM lowercasing and URL formatting.
> - **Tests** (`app/components/UI/Bridge/utils/index.test.ts`):
>   - Mock `formatAddressToAssetId` and `isNonEvmChainId` from `@metamask/bridge-controller`.
>   - Add cases for `getTokenIconUrl` covering native/ERC20 (EVM), Solana native/SPL, `null`/`undefined` returns, and thrown errors (unsupported chain, invalid address).
>   - Verify `wipeBridgeStatus` behavior: twice for EVM (original + lowercase) and once for Solana; minor test description cleanups.
>   - Keep `isBridgeAllowed` tests intact with minor wording tweaks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7809aee3f8fca977d92829af7919a7c54e3cf97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->