### PR TITLE
feat: rewards activity compatible with predict and deposit musd

### DIFF
--- a/app/components/UI/Rewards/components/Tabs/ActivityTab/ActivityEventRow.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/ActivityTab/ActivityEventRow.test.tsx
@@ -8,6 +8,7 @@ import { getEventDetails } from '../../../utils/eventDetailsUtils';
 import { IconName } from '@metamask/design-system-react-native';
 import TEST_ADDRESS from '../../../../../../constants/address';
 import { useActivityDetailsConfirmAction } from '../../../hooks/useActivityDetailsConfirmAction';
+import { REWARDS_VIEW_SELECTORS } from '../../../Views/RewardsView.constants';
 
 // Mock the utility functions
 jest.mock('../../../utils/formatUtils', () => ({
@@ -15,6 +16,16 @@ jest.mock('../../../utils/formatUtils', () => ({
   formatNumber: jest
     .fn()
     .mockImplementation((value) => value?.toString() || '0'),
+  formatRewardsMusdDepositPayloadDate: jest.fn((isoDate: string) => {
+    // Mock implementation that formats the date
+    const date = new Date(`${isoDate}T00:00:00Z`);
+    return new Intl.DateTimeFormat('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      timeZone: 'UTC',
+    }).format(date);
+  }),
 }));
 
 jest.mock('../../../utils/eventDetailsUtils', () => ({
@@ -191,6 +202,34 @@ describe('ActivityEventRow', () => {
             txHash: '0xabc123def456789012345678901234567890abcd',
           },
           updatedAt: new Date('2025-09-15T10:30:00.000Z'),
+          ...overrides,
+        } as PointsEventDto;
+
+      case 'PREDICT':
+        return {
+          id: 'predict-event-1',
+          timestamp: new Date('2025-09-15T10:30:00.000Z'),
+          type: 'PREDICT' as const,
+          value: 20,
+          bonus: null,
+          accountAddress: '0x069060A475c76C77427CcC8CbD7eCB0B293f5beD',
+          payload: null,
+          updatedAt: new Date('2025-09-15T10:30:00.000Z'),
+          ...overrides,
+        } as PointsEventDto;
+
+      case 'MUSD_DEPOSIT':
+        return {
+          id: 'musd-deposit-event-1',
+          timestamp: new Date('2025-11-11T10:30:00.000Z'),
+          type: 'MUSD_DEPOSIT' as const,
+          value: 10,
+          bonus: null,
+          accountAddress: '0x069060A475c76C77427CcC8CbD7eCB0B293f5beD',
+          payload: {
+            date: '2025-11-11',
+          },
+          updatedAt: new Date('2025-11-11T10:30:00.000Z'),
           ...overrides,
         } as PointsEventDto;
 
@@ -515,6 +554,30 @@ describe('ActivityEventRow', () => {
       expect(getByText('+15')).toBeOnTheScreen();
       expect(getByText('+50%')).toBeOnTheScreen();
       expect(mockGetEventDetails).toHaveBeenCalledWith(event, TEST_ADDRESS);
+    });
+
+    it('renders PREDICT event without description', () => {
+      // Arrange
+      const event = createMockEvent({ type: 'PREDICT' });
+      mockGetEventDetails.mockReturnValue({
+        title: 'Predict',
+        details: undefined,
+        icon: IconName.Speedometer,
+      });
+
+      // Act
+      const { getByText, getByTestId } = render(
+        <ActivityEventRow event={event} accountName={TEST_ADDRESS} />,
+      );
+
+      // Assert
+      expect(getByText('Predict')).toBeOnTheScreen();
+      expect(getByText('+20')).toBeOnTheScreen();
+      const detailsElement = getByTestId(
+        `${REWARDS_VIEW_SELECTORS.ACTIVITY_EVENT_ROW_DETAILS}-${undefined}`,
+      );
+      expect(detailsElement.props.children).toBeUndefined();
+      expect(detailsElement).toHaveTextContent('');
     });
   });
 

--- a/app/components/UI/Rewards/components/Tabs/ActivityTab/ActivityEventRow.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/ActivityTab/ActivityEventRow.test.tsx
@@ -16,16 +16,25 @@ jest.mock('../../../utils/formatUtils', () => ({
   formatNumber: jest
     .fn()
     .mockImplementation((value) => value?.toString() || '0'),
-  formatRewardsMusdDepositPayloadDate: jest.fn((isoDate: string) => {
-    // Mock implementation that formats the date
-    const date = new Date(`${isoDate}T00:00:00Z`);
-    return new Intl.DateTimeFormat('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      timeZone: 'UTC',
-    }).format(date);
-  }),
+  formatRewardsMusdDepositPayloadDate: jest.fn(
+    (isoDate: string | undefined) => {
+      // Mock implementation that matches the real implementation behavior
+      if (
+        !isoDate ||
+        typeof isoDate !== 'string' ||
+        !/^\d{4}-\d{2}-\d{2}$/.test(isoDate)
+      ) {
+        return null;
+      }
+      const date = new Date(`${isoDate}T00:00:00Z`);
+      return new Intl.DateTimeFormat('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        timeZone: 'UTC',
+      }).format(date);
+    },
+  ),
 }));
 
 jest.mock('../../../utils/eventDetailsUtils', () => ({

--- a/app/components/UI/Rewards/components/Tabs/ActivityTab/EventDetails/ActivityDetailsSheet.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/ActivityTab/EventDetails/ActivityDetailsSheet.test.tsx
@@ -37,6 +37,7 @@ jest.mock('../../../../../../../../locales/i18n', () => ({
       'rewards.events.points_base': 'Base',
       'rewards.events.points_boost': 'Boost',
       'rewards.events.points_total': 'Total',
+      'rewards.events.for_deposit_period': 'For deposit period',
     };
     return t[key] || key;
   }),
@@ -46,6 +47,16 @@ jest.mock('../../../../../../../../locales/i18n', () => ({
 jest.mock('../../../../utils/formatUtils', () => ({
   formatRewardsDate: jest.fn(() => 'Sep 9, 2025'),
   formatNumber: jest.fn((n: number) => n.toString()),
+  formatRewardsMusdDepositPayloadDate: jest.fn((isoDate: string) => {
+    // Mock implementation that formats the date
+    const date = new Date(`${isoDate}T00:00:00Z`);
+    return new Intl.DateTimeFormat('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      timeZone: 'UTC',
+    }).format(date);
+  }),
 }));
 
 // Mock eventDetailsUtils
@@ -138,6 +149,29 @@ describe('ActivityDetailsSheet', () => {
       // Verify CardEventDetails specific content
       expect(screen.getByText('Amount')).toBeTruthy();
       expect(screen.getByText('43.25 USDC')).toBeTruthy();
+    });
+
+    it('renders MusdDepositEventDetails for MUSD_DEPOSIT event type', () => {
+      const musdDepositEvent: Extract<
+        PointsEventDto,
+        { type: 'MUSD_DEPOSIT' }
+      > = {
+        ...baseEvent,
+        type: 'MUSD_DEPOSIT',
+        payload: {
+          date: '2025-11-11',
+        },
+      };
+
+      render(
+        <ActivityDetailsSheet event={musdDepositEvent} accountName="Primary" />,
+      );
+
+      // Verify GenericEventDetails content is rendered (base component)
+      expect(screen.getByText('Details')).toBeTruthy();
+      // Verify MusdDepositEventDetails specific content
+      expect(screen.getByText('For deposit period')).toBeTruthy();
+      expect(screen.getByText('Nov 11, 2025')).toBeTruthy();
     });
 
     it('renders GenericEventDetails for other event types', () => {

--- a/app/components/UI/Rewards/components/Tabs/ActivityTab/EventDetails/ActivityDetailsSheet.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/ActivityTab/EventDetails/ActivityDetailsSheet.test.tsx
@@ -47,16 +47,25 @@ jest.mock('../../../../../../../../locales/i18n', () => ({
 jest.mock('../../../../utils/formatUtils', () => ({
   formatRewardsDate: jest.fn(() => 'Sep 9, 2025'),
   formatNumber: jest.fn((n: number) => n.toString()),
-  formatRewardsMusdDepositPayloadDate: jest.fn((isoDate: string) => {
-    // Mock implementation that formats the date
-    const date = new Date(`${isoDate}T00:00:00Z`);
-    return new Intl.DateTimeFormat('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      timeZone: 'UTC',
-    }).format(date);
-  }),
+  formatRewardsMusdDepositPayloadDate: jest.fn(
+    (isoDate: string | undefined) => {
+      // Mock implementation that matches the real implementation behavior
+      if (
+        !isoDate ||
+        typeof isoDate !== 'string' ||
+        !/^\d{4}-\d{2}-\d{2}$/.test(isoDate)
+      ) {
+        return null;
+      }
+      const date = new Date(`${isoDate}T00:00:00Z`);
+      return new Intl.DateTimeFormat('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        timeZone: 'UTC',
+      }).format(date);
+    },
+  ),
 }));
 
 // Mock eventDetailsUtils

--- a/app/components/UI/Rewards/components/Tabs/ActivityTab/EventDetails/ActivityDetailsSheet.tsx
+++ b/app/components/UI/Rewards/components/Tabs/ActivityTab/EventDetails/ActivityDetailsSheet.tsx
@@ -8,6 +8,7 @@ import { getEventDetails } from '../../../../utils/eventDetailsUtils';
 import { GenericEventDetails } from './GenericEventDetails';
 import { SwapEventDetails } from './SwapEventDetails';
 import { CardEventDetails } from './CardEventDetails';
+import { MusdDepositEventDetails } from './MusdDepositEventDetails';
 import { PointsEventDto } from '../../../../../../../core/Engine/controllers/rewards-controller/types';
 
 interface ActivityDetailsSheetProps {
@@ -26,6 +27,10 @@ export const ActivityDetailsSheet: React.FC<ActivityDetailsSheetProps> = ({
       return <SwapEventDetails event={event} accountName={accountName} />;
     case 'CARD':
       return <CardEventDetails event={event} accountName={accountName} />;
+    case 'MUSD_DEPOSIT':
+      return (
+        <MusdDepositEventDetails event={event} accountName={accountName} />
+      );
     default:
       return <GenericEventDetails event={event} accountName={accountName} />;
   }

--- a/app/components/UI/Rewards/components/Tabs/ActivityTab/EventDetails/MusdDepositEventDetails.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/ActivityTab/EventDetails/MusdDepositEventDetails.test.tsx
@@ -34,16 +34,25 @@ jest.mock('../../../../../../../../locales/i18n', () => ({
 jest.mock('../../../../utils/formatUtils', () => ({
   formatRewardsDate: jest.fn(() => 'Sep 9, 2025'),
   formatNumber: jest.fn((n: number) => n.toString()),
-  formatRewardsMusdDepositPayloadDate: jest.fn((isoDate: string) => {
-    // Mock implementation that formats the date
-    const date = new Date(`${isoDate}T00:00:00Z`);
-    return new Intl.DateTimeFormat('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      timeZone: 'UTC',
-    }).format(date);
-  }),
+  formatRewardsMusdDepositPayloadDate: jest.fn(
+    (isoDate: string | undefined) => {
+      // Mock implementation that matches the real implementation behavior
+      if (
+        !isoDate ||
+        typeof isoDate !== 'string' ||
+        !/^\d{4}-\d{2}-\d{2}$/.test(isoDate)
+      ) {
+        return null;
+      }
+      const date = new Date(`${isoDate}T00:00:00Z`);
+      return new Intl.DateTimeFormat('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        timeZone: 'UTC',
+      }).format(date);
+    },
+  ),
 }));
 
 // Mock SVG used in the component to avoid native rendering issues

--- a/app/components/UI/Rewards/components/Tabs/ActivityTab/EventDetails/MusdDepositEventDetails.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/ActivityTab/EventDetails/MusdDepositEventDetails.test.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
+import { MusdDepositEventDetails } from './MusdDepositEventDetails';
+import { AvatarAccountType } from '../../../../../../../component-library/components/Avatars/Avatar';
+import TEST_ADDRESS from '../../../../../../../constants/address';
+import { PointsEventDto } from '../../../../../../../core/Engine/controllers/rewards-controller/types';
+import { formatRewardsMusdDepositPayloadDate } from '../../../../utils/formatUtils';
+
+// Mock react-redux
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+
+// Mock i18n strings used by GenericEventDetails and MusdDepositEventDetails
+jest.mock('../../../../../../../../locales/i18n', () => ({
+  strings: jest.fn((key: string) => {
+    const t: Record<string, string> = {
+      'rewards.events.details': 'Details',
+      'rewards.events.date': 'Date',
+      'rewards.events.account': 'Account',
+      'rewards.events.points': 'Points',
+      'rewards.events.points_base': 'Base',
+      'rewards.events.points_boost': 'Boost',
+      'rewards.events.points_total': 'Total',
+      'rewards.events.for_deposit_period': 'For deposit period',
+    };
+    return t[key] || key;
+  }),
+}));
+
+// Mock format utils used by GenericEventDetails and MusdDepositEventDetails
+jest.mock('../../../../utils/formatUtils', () => ({
+  formatRewardsDate: jest.fn(() => 'Sep 9, 2025'),
+  formatNumber: jest.fn((n: number) => n.toString()),
+  formatRewardsMusdDepositPayloadDate: jest.fn((isoDate: string) => {
+    // Mock implementation that formats the date
+    const date = new Date(`${isoDate}T00:00:00Z`);
+    return new Intl.DateTimeFormat('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      timeZone: 'UTC',
+    }).format(date);
+  }),
+}));
+
+// Mock SVG used in the component to avoid native rendering issues
+jest.mock(
+  '../../../../../../../images/rewards/metamask-rewards-points.svg',
+  () => 'SvgMock',
+);
+
+describe('MusdDepositEventDetails', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSelector.mockReturnValue(AvatarAccountType.JazzIcon);
+  });
+
+  const baseMusdDepositEvent: Extract<
+    PointsEventDto,
+    { type: 'MUSD_DEPOSIT' }
+  > = {
+    id: 'musd-deposit-1',
+    timestamp: new Date('2025-09-09T09:09:33.000Z'),
+    type: 'MUSD_DEPOSIT',
+    value: 100,
+    bonus: null,
+    accountAddress: TEST_ADDRESS,
+    updatedAt: new Date('2025-09-09T09:09:33.000Z'),
+    payload: {
+      date: '2025-11-11',
+    },
+  };
+
+  it('renders deposit period row when payload.date exists', () => {
+    render(
+      <MusdDepositEventDetails
+        event={baseMusdDepositEvent}
+        accountName="Primary"
+      />,
+    );
+
+    // Verify GenericEventDetails header is rendered
+    expect(screen.getByText('Details')).toBeTruthy();
+
+    // Verify deposit period label and formatted date are displayed
+    expect(screen.getByText('For deposit period')).toBeTruthy();
+    expect(screen.getByText('Nov 11, 2025')).toBeTruthy();
+  });
+
+  it('does not render deposit period row when payload is null', () => {
+    const eventWithoutPayload: Extract<
+      PointsEventDto,
+      { type: 'MUSD_DEPOSIT' }
+    > = {
+      ...baseMusdDepositEvent,
+      payload: null,
+    };
+
+    render(
+      <MusdDepositEventDetails
+        event={eventWithoutPayload}
+        accountName="Primary"
+      />,
+    );
+
+    // Verify GenericEventDetails content is rendered
+    expect(screen.getByText('Details')).toBeTruthy();
+
+    // Verify deposit period row is not displayed when payload is null
+    expect(screen.queryByText('For deposit period')).toBeNull();
+  });
+
+  it('renders base points and total correctly', () => {
+    const eventWithBonus: Extract<PointsEventDto, { type: 'MUSD_DEPOSIT' }> = {
+      ...baseMusdDepositEvent,
+      value: 500,
+      bonus: { bonusPoints: 100, bips: 0, bonuses: [] },
+    };
+
+    render(
+      <MusdDepositEventDetails event={eventWithBonus} accountName="Primary" />,
+    );
+
+    // Verify points section from GenericEventDetails
+    expect(screen.getByText('Points')).toBeTruthy();
+
+    // Base = value - bonus = 500 - 100 = 400
+    expect(screen.getByText('Base')).toBeTruthy();
+    expect(screen.getByText('400')).toBeTruthy();
+
+    // Boost
+    expect(screen.getByText('Boost')).toBeTruthy();
+    expect(screen.getByText('100')).toBeTruthy();
+
+    // Total
+    expect(screen.getByText('Total')).toBeTruthy();
+    expect(screen.getByText('500')).toBeTruthy();
+  });
+
+  it('displays account name when provided', () => {
+    render(
+      <MusdDepositEventDetails
+        event={baseMusdDepositEvent}
+        accountName="Deposit Account"
+      />,
+    );
+
+    // Verify account name is displayed
+    expect(screen.getByText('Account')).toBeTruthy();
+    expect(screen.getByText('Deposit Account')).toBeTruthy();
+  });
+
+  it('calls formatRewardsMusdDepositPayloadDate with correct ISO date string', () => {
+    const mockFormatRewardsMusdDepositPayloadDate =
+      formatRewardsMusdDepositPayloadDate as jest.MockedFunction<
+        typeof formatRewardsMusdDepositPayloadDate
+      >;
+    mockFormatRewardsMusdDepositPayloadDate.mockReturnValue('Dec 25, 2025');
+
+    const eventWithDate: Extract<PointsEventDto, { type: 'MUSD_DEPOSIT' }> = {
+      ...baseMusdDepositEvent,
+      payload: {
+        date: '2025-12-25',
+      },
+    };
+
+    render(
+      <MusdDepositEventDetails event={eventWithDate} accountName="Primary" />,
+    );
+
+    // Verify the formatter was called with the correct ISO date string
+    expect(mockFormatRewardsMusdDepositPayloadDate).toHaveBeenCalledWith(
+      '2025-12-25',
+    );
+
+    // Verify the formatted date is displayed
+    expect(screen.getByText('Dec 25, 2025')).toBeTruthy();
+  });
+});

--- a/app/components/UI/Rewards/components/Tabs/ActivityTab/EventDetails/MusdDepositEventDetails.tsx
+++ b/app/components/UI/Rewards/components/Tabs/ActivityTab/EventDetails/MusdDepositEventDetails.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import {
+  Text,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../../../locales/i18n';
+import { GenericEventDetails, DetailsRow } from './GenericEventDetails';
+import {
+  PointsEventDto,
+  MusdDepositEventPayload,
+} from '../../../../../../../core/Engine/controllers/rewards-controller/types';
+import { formatRewardsMusdDepositPayloadDate } from '../../../../utils/formatUtils';
+
+interface MusdDepositEventDetailsProps {
+  event: PointsEventDto & {
+    type: 'MUSD_DEPOSIT';
+    payload: MusdDepositEventPayload | null;
+  };
+  accountName?: string;
+}
+
+export const MusdDepositEventDetails: React.FC<
+  MusdDepositEventDetailsProps
+> = ({ event, accountName }) => {
+  const payload = event.payload;
+
+  const formattedDate = formatRewardsMusdDepositPayloadDate(payload?.date);
+  const extraDetails = formattedDate ? (
+    <DetailsRow label={strings('rewards.events.for_deposit_period')}>
+      <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+        {formattedDate}
+      </Text>
+    </DetailsRow>
+  ) : null;
+
+  return (
+    <GenericEventDetails
+      event={event}
+      accountName={accountName}
+      extraDetails={extraDetails}
+    />
+  );
+};

--- a/app/components/UI/Rewards/utils/eventDetailsUtils.test.ts
+++ b/app/components/UI/Rewards/utils/eventDetailsUtils.test.ts
@@ -16,7 +16,7 @@ import {
 
 // Mock i18n strings
 jest.mock('../../../../../locales/i18n', () => ({
-  strings: jest.fn((key: string) => {
+  strings: jest.fn((key: string, params?: Record<string, string>) => {
     const t: Record<string, string> = {
       'rewards.events.to': 'to',
       'rewards.events.type.swap': 'Swap',
@@ -29,20 +29,37 @@ jest.mock('../../../../../locales/i18n', () => ({
       'rewards.events.type.close_position': 'Closed position',
       'rewards.events.type.take_profit': 'Take profit',
       'rewards.events.type.stop_loss': 'Stop loss',
+      'rewards.events.type.predict': 'Prediction',
+      'rewards.events.type.musd_deposit': 'mUSD deposit',
+      'rewards.events.musd_deposit_for': 'For {{date}}',
       'rewards.events.type.uncategorized_event': 'Uncategorized event',
       'perps.market.long': 'Long',
       'perps.market.short': 'Short',
     };
-    return t[key] || key;
+    const template = t[key] || key;
+    if (params && template.includes('{{date}}')) {
+      return template.replace('{{date}}', params.date || '');
+    }
+    return template;
   }),
   default: {
     locale: 'en-US',
   },
 }));
 
-// Mock formatNumber utility
+// Mock formatUtils
 jest.mock('./formatUtils', () => ({
   formatNumber: jest.fn((value: number) => value.toString()),
+  formatRewardsMusdDepositPayloadDate: jest.fn((isoDate: string) => {
+    // Mock implementation that formats the date
+    const date = new Date(`${isoDate}T00:00:00Z`);
+    return new Intl.DateTimeFormat('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      timeZone: 'UTC',
+    }).format(date);
+  }),
 }));
 
 describe('eventDetailsUtils', () => {
@@ -479,6 +496,20 @@ describe('eventDetailsUtils', () => {
             type: 'CARD' as const,
             payload: payload as (PointsEventDto & { type: 'CARD' })['payload'],
           };
+        case 'PREDICT':
+          return {
+            ...baseEvent,
+            type: 'PREDICT' as const,
+            payload: null,
+          };
+        case 'MUSD_DEPOSIT':
+          return {
+            ...baseEvent,
+            type: 'MUSD_DEPOSIT' as const,
+            payload: payload as (PointsEventDto & {
+              type: 'MUSD_DEPOSIT';
+            })['payload'],
+          };
         default:
           return {
             ...baseEvent,
@@ -837,6 +868,175 @@ describe('eventDetailsUtils', () => {
           title: 'One-time bonus',
           details: undefined,
           icon: IconName.Gift,
+        });
+      });
+    });
+
+    describe('PREDICT events', () => {
+      it('returns correct details for PREDICT event', () => {
+        const event = createMockEvent('PREDICT');
+
+        const result = getEventDetails(event, TEST_ADDRESS);
+
+        expect(result).toEqual({
+          title: 'Prediction',
+          details: undefined,
+          icon: IconName.Speedometer,
+        });
+      });
+    });
+
+    describe('MUSD_DEPOSIT events', () => {
+      it('returns correct details for MUSD_DEPOSIT event with date', () => {
+        // Given a MUSD_DEPOSIT event with a date
+        const event = createMockEvent('MUSD_DEPOSIT', {
+          date: '2025-01-15',
+        });
+
+        // When getting event details
+        const result = getEventDetails(event, TEST_ADDRESS);
+
+        // Then it should return mUSD deposit details with formatted date
+        expect(result).toEqual({
+          title: 'mUSD deposit',
+          details: 'For Jan 15, 2025',
+          icon: IconName.Coin,
+        });
+      });
+
+      it('returns correct details for MUSD_DEPOSIT event with different date format', () => {
+        // Given a MUSD_DEPOSIT event with a different date
+        const event = createMockEvent('MUSD_DEPOSIT', {
+          date: '2025-11-11',
+        });
+
+        // When getting event details
+        const result = getEventDetails(event, TEST_ADDRESS);
+
+        // Then it should return mUSD deposit details with formatted date
+        expect(result).toEqual({
+          title: 'mUSD deposit',
+          details: 'For Nov 11, 2025',
+          icon: IconName.Coin,
+        });
+      });
+
+      it('returns undefined details for MUSD_DEPOSIT event without payload', () => {
+        // Given a MUSD_DEPOSIT event without payload
+        const event = createMockEvent('MUSD_DEPOSIT', null);
+
+        // When getting event details
+        const result = getEventDetails(event, TEST_ADDRESS);
+
+        // Then it should return mUSD deposit title with undefined details
+        expect(result).toEqual({
+          title: 'mUSD deposit',
+          details: undefined,
+          icon: IconName.Coin,
+        });
+      });
+
+      it('returns undefined details for MUSD_DEPOSIT event with payload but no date', () => {
+        // Given a MUSD_DEPOSIT event with payload but no date
+        const event = createMockEvent('MUSD_DEPOSIT', {
+          // @ts-expect-error - We are testing the function with undefined date
+          date: undefined,
+        });
+
+        // When getting event details
+        const result = getEventDetails(event, TEST_ADDRESS);
+
+        // Then it should return mUSD deposit title with undefined details
+        expect(result).toEqual({
+          title: 'mUSD deposit',
+          details: undefined,
+          icon: IconName.Coin,
+        });
+      });
+
+      it('returns undefined details for MUSD_DEPOSIT event with date that is not a string', () => {
+        // Given a MUSD_DEPOSIT event with date that is not a string
+        const event = createMockEvent('MUSD_DEPOSIT', {
+          // @ts-expect-error - We are testing the function with non-string date
+          date: 20250115,
+        });
+
+        // When getting event details
+        const result = getEventDetails(event, TEST_ADDRESS);
+
+        // Then it should return mUSD deposit title with undefined details
+        expect(result).toEqual({
+          title: 'mUSD deposit',
+          details: undefined,
+          icon: IconName.Coin,
+        });
+      });
+
+      it('returns undefined details for MUSD_DEPOSIT event with date that does not match YYYY-MM-DD format', () => {
+        // Given a MUSD_DEPOSIT event with date in wrong format
+        const event = createMockEvent('MUSD_DEPOSIT', {
+          date: '2025-1-15', // Missing leading zero in month
+        });
+
+        // When getting event details
+        const result = getEventDetails(event, TEST_ADDRESS);
+
+        // Then it should return mUSD deposit title with undefined details
+        expect(result).toEqual({
+          title: 'mUSD deposit',
+          details: undefined,
+          icon: IconName.Coin,
+        });
+      });
+
+      it('returns undefined details for MUSD_DEPOSIT event with date in ISO format with time', () => {
+        // Given a MUSD_DEPOSIT event with date in ISO format with time
+        const event = createMockEvent('MUSD_DEPOSIT', {
+          date: '2025-01-15T00:00:00Z', // ISO format with time
+        });
+
+        // When getting event details
+        const result = getEventDetails(event, TEST_ADDRESS);
+
+        // Then it should return mUSD deposit title with undefined details
+        expect(result).toEqual({
+          title: 'mUSD deposit',
+          details: undefined,
+          icon: IconName.Coin,
+        });
+      });
+
+      it('returns undefined details for MUSD_DEPOSIT event with invalid date string', () => {
+        // Given a MUSD_DEPOSIT event with invalid date string
+        const event = createMockEvent('MUSD_DEPOSIT', {
+          date: 'invalid-date',
+        });
+
+        // When getting event details
+        const result = getEventDetails(event, TEST_ADDRESS);
+
+        // Then it should return mUSD deposit title with undefined details
+        expect(result).toEqual({
+          title: 'mUSD deposit',
+          details: undefined,
+          icon: IconName.Coin,
+        });
+      });
+
+      it('returns undefined details for MUSD_DEPOSIT event with empty date string', () => {
+        // Given a MUSD_DEPOSIT event with empty date string
+        const event = createMockEvent('MUSD_DEPOSIT', {
+          date: '',
+        });
+
+        // When getting event details
+        const result = getEventDetails(event, TEST_ADDRESS);
+
+        // Then it should return mUSD deposit title with undefined details
+        expect(result).toEqual({
+          title: 'mUSD deposit',
+          details: undefined,
+          icon: IconName.Coin,
         });
       });
     });

--- a/app/components/UI/Rewards/utils/eventDetailsUtils.test.ts
+++ b/app/components/UI/Rewards/utils/eventDetailsUtils.test.ts
@@ -50,16 +50,26 @@ jest.mock('../../../../../locales/i18n', () => ({
 // Mock formatUtils
 jest.mock('./formatUtils', () => ({
   formatNumber: jest.fn((value: number) => value.toString()),
-  formatRewardsMusdDepositPayloadDate: jest.fn((isoDate: string) => {
-    // Mock implementation that formats the date
-    const date = new Date(`${isoDate}T00:00:00Z`);
-    return new Intl.DateTimeFormat('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      timeZone: 'UTC',
-    }).format(date);
-  }),
+  formatRewardsMusdDepositPayloadDate: jest.fn(
+    (isoDate: string | undefined) => {
+      // Mock implementation that matches the real implementation behavior
+      if (
+        !isoDate ||
+        typeof isoDate !== 'string' ||
+        !/^\d{4}-\d{2}-\d{2}$/.test(isoDate)
+      ) {
+        return null;
+      }
+      // Mock implementation that formats the date
+      const date = new Date(`${isoDate}T00:00:00Z`);
+      return new Intl.DateTimeFormat('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        timeZone: 'UTC',
+      }).format(date);
+    },
+  ),
 }));
 
 describe('eventDetailsUtils', () => {

--- a/app/components/UI/Rewards/utils/eventDetailsUtils.ts
+++ b/app/components/UI/Rewards/utils/eventDetailsUtils.ts
@@ -11,6 +11,7 @@ import { isNullOrUndefined } from '@metamask/utils';
 import { formatUnits } from 'viem';
 import { formatWithThreshold } from '../../../../util/assets';
 import { PerpsEventType } from './eventConstants';
+import { formatRewardsMusdDepositPayloadDate } from './formatUtils';
 
 /**
  * Formats an asset amount with proper decimals
@@ -212,6 +213,26 @@ export const getEventDetails = (
         details: undefined,
         icon: IconName.Gift,
       };
+    case 'PREDICT':
+      return {
+        title: strings('rewards.events.type.predict'),
+        details: undefined,
+        icon: IconName.Speedometer,
+      };
+    case 'MUSD_DEPOSIT': {
+      const formattedDate = formatRewardsMusdDepositPayloadDate(
+        event.payload?.date,
+      );
+      return {
+        title: strings('rewards.events.type.musd_deposit'),
+        details: formattedDate
+          ? strings('rewards.events.musd_deposit_for', {
+              date: formattedDate,
+            })
+          : undefined,
+        icon: IconName.Coin,
+      };
+    }
     default:
       return {
         title: strings('rewards.events.type.uncategorized_event'),

--- a/app/components/UI/Rewards/utils/formatUtils.test.ts
+++ b/app/components/UI/Rewards/utils/formatUtils.test.ts
@@ -8,6 +8,8 @@ import {
   formatNumber,
   getIconName,
   formatUrl,
+  formatUTCDate,
+  formatRewardsMusdDepositPayloadDate,
 } from './formatUtils';
 import { IconName } from '@metamask/design-system-react-native';
 import { getTimeDifferenceFromNow } from '../../../../util/date';
@@ -748,6 +750,382 @@ describe('formatUtils', () => {
           'unpkg.com',
         );
       });
+    });
+  });
+
+  describe('formatUTCDate', () => {
+    it('formats ISO date string in default locale (en-US)', () => {
+      // Given an ISO date string
+      const isoDate = '2025-11-11';
+
+      // When formatting the date
+      const result = formatUTCDate(isoDate);
+
+      // Then it should return formatted date in en-US format
+      expect(result).toMatch(/11\/11\/2025|11\.11\.2025|Nov 11, 2025/);
+    });
+
+    it('formats ISO date string with custom locale', () => {
+      // Given an ISO date string and French locale
+      const isoDate = '2025-11-11';
+      const locale = 'fr-FR';
+
+      // When formatting the date
+      const result = formatUTCDate(isoDate, locale);
+
+      // Then it should return formatted date in French format
+      expect(result).toMatch(/11\/11\/2025|11\.11\.2025/);
+    });
+
+    it('formats ISO date string with custom options', () => {
+      // Given an ISO date string with custom formatting options
+      const isoDate = '2025-11-11';
+      const options: Intl.DateTimeFormatOptions = {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      };
+
+      // When formatting the date
+      const result = formatUTCDate(isoDate, 'en-US', options);
+
+      // Then it should return formatted date with long month name
+      expect(result).toBe('November 11, 2025');
+    });
+
+    it('handles dates at year boundaries correctly', () => {
+      // Given dates at year boundaries
+      const newYear = '2025-01-01';
+      const endYear = '2025-12-31';
+
+      // When formatting the dates
+      const newYearResult = formatUTCDate(newYear);
+      const endYearResult = formatUTCDate(endYear);
+
+      // Then they should be formatted correctly
+      expect(newYearResult).toMatch(/1\/1\/2025|1\.1\.2025|Jan 1, 2025/);
+      expect(endYearResult).toMatch(/12\/31\/2025|31\.12\.2025|Dec 31, 2025/);
+    });
+
+    it('prevents timezone shifts by using UTC', () => {
+      // Given an ISO date string
+      const isoDate = '2025-11-11';
+
+      // When formatting the date
+      const result = formatUTCDate(isoDate, 'en-US');
+
+      // Then it should always show November 11 regardless of local timezone
+      // The date should be interpreted as midnight UTC
+      expect(result).toMatch(/11/);
+    });
+
+    it('handles leap year dates correctly', () => {
+      // Given a leap year date
+      const leapYearDate = '2024-02-29';
+
+      // When formatting the date
+      const result = formatUTCDate(leapYearDate);
+
+      // Then it should format correctly
+      expect(result).toMatch(/29/);
+    });
+
+    it('uses default options when custom options are provided', () => {
+      // Given an ISO date string with partial custom options
+      const isoDate = '2025-11-11';
+      const options: Intl.DateTimeFormatOptions = {
+        month: 'short',
+      };
+
+      // When formatting the date
+      const result = formatUTCDate(isoDate, 'en-US', options);
+
+      // Then it should merge with default options (year, day, timeZone)
+      expect(result).toMatch(/Nov/);
+      expect(result).toMatch(/11/);
+      expect(result).toMatch(/2025/);
+    });
+
+    it('handles different locales correctly', () => {
+      // Given an ISO date string
+      const isoDate = '2025-11-11';
+
+      // When formatting with different locales
+      const enResult = formatUTCDate(isoDate, 'en-US');
+      const deResult = formatUTCDate(isoDate, 'de-DE');
+      const jaResult = formatUTCDate(isoDate, 'ja-JP');
+
+      // Then they should be formatted according to locale conventions
+      expect(enResult).toBeTruthy();
+      expect(deResult).toBeTruthy();
+      expect(jaResult).toBeTruthy();
+      // All should contain the date components
+      expect(enResult).toMatch(/11/);
+      expect(deResult).toMatch(/11/);
+      expect(jaResult).toMatch(/11/);
+    });
+  });
+
+  describe('formatRewardsMusdDepositPayloadDate', () => {
+    it('formats ISO date string for mUSD deposit with default locale', () => {
+      // Given an ISO date string
+      const isoDate = '2025-11-11';
+
+      // When formatting the date
+      const result = formatRewardsMusdDepositPayloadDate(isoDate);
+
+      // Then it should return formatted date with short month name
+      expect(result).toMatch(/Nov 11, 2025|11 Nov 2025/);
+    });
+
+    it('formats ISO date string for mUSD deposit with custom locale', () => {
+      // Given an ISO date string and French locale
+      const isoDate = '2025-11-11';
+      const locale = 'fr-FR';
+
+      // When formatting the date
+      const result = formatRewardsMusdDepositPayloadDate(isoDate, locale);
+
+      // Then it should return formatted date in French format
+      expect(result).toMatch(/nov\.|nov/);
+      expect(result).toMatch(/11/);
+      expect(result).toMatch(/2025/);
+    });
+
+    it('formats date with correct format (year, short month, day)', () => {
+      // Given an ISO date string
+      const isoDate = '2025-12-25';
+
+      // When formatting the date
+      const result = formatRewardsMusdDepositPayloadDate(isoDate, 'en-US');
+
+      // Then it should have year, short month, and day
+      expect(result).toMatch(/Dec/);
+      expect(result).toMatch(/25/);
+      expect(result).toMatch(/2025/);
+    });
+
+    it('handles dates at month boundaries', () => {
+      // Given dates at month boundaries
+      const firstOfMonth = '2025-01-01';
+      const lastOfMonth = '2025-01-31';
+
+      // When formatting the dates
+      const firstResult = formatRewardsMusdDepositPayloadDate(firstOfMonth);
+      const lastResult = formatRewardsMusdDepositPayloadDate(lastOfMonth);
+
+      // Then they should be formatted correctly
+      expect(firstResult).toMatch(/Jan/);
+      expect(firstResult).toMatch(/1/);
+      expect(lastResult).toMatch(/Jan/);
+      expect(lastResult).toMatch(/31/);
+    });
+
+    it('prevents timezone shifts by using UTC', () => {
+      // Given an ISO date string
+      const isoDate = '2025-11-11';
+
+      // When formatting the date
+      const result = formatRewardsMusdDepositPayloadDate(isoDate);
+
+      // Then it should always show the correct date regardless of local timezone
+      expect(result).toMatch(/Nov/);
+      expect(result).toMatch(/11/);
+    });
+
+    it('uses I18n.locale as default when no locale provided', () => {
+      // Given an ISO date string without locale
+      const isoDate = '2025-11-11';
+
+      // When formatting the date
+      const result = formatRewardsMusdDepositPayloadDate(isoDate);
+
+      // Then it should use the default locale from I18n
+      expect(result).toBeTruthy();
+      expect(result).toMatch(/11/);
+    });
+
+    it('returns null for undefined input', () => {
+      // Given undefined input
+      const isoDate = undefined;
+
+      // When formatting the date
+      const result = formatRewardsMusdDepositPayloadDate(isoDate);
+
+      // Then it should return null
+      expect(result).toBeNull();
+    });
+
+    it('returns null for empty string', () => {
+      // Given an empty string
+      const isoDate = '';
+
+      // When formatting the date
+      const result = formatRewardsMusdDepositPayloadDate(isoDate);
+
+      // Then it should return null
+      expect(result).toBeNull();
+    });
+
+    it('returns null for non-string input', () => {
+      // Given non-string inputs
+      const numberInput = 20251111 as unknown as string;
+      const objectInput = { date: '2025-11-11' } as unknown as string;
+      const arrayInput = ['2025', '11', '11'] as unknown as string;
+
+      // When formatting the dates
+      const numberResult = formatRewardsMusdDepositPayloadDate(numberInput);
+      const objectResult = formatRewardsMusdDepositPayloadDate(objectInput);
+      const arrayResult = formatRewardsMusdDepositPayloadDate(arrayInput);
+
+      // Then they should all return null
+      expect(numberResult).toBeNull();
+      expect(objectResult).toBeNull();
+      expect(arrayResult).toBeNull();
+    });
+
+    it('returns null for invalid date format - wrong separator', () => {
+      // Given date strings with wrong separators
+      const slashDate = '2025/11/11';
+      const dotDate = '2025.11.11';
+      const spaceDate = '2025 11 11';
+
+      // When formatting the dates
+      const slashResult = formatRewardsMusdDepositPayloadDate(slashDate);
+      const dotResult = formatRewardsMusdDepositPayloadDate(dotDate);
+      const spaceResult = formatRewardsMusdDepositPayloadDate(spaceDate);
+
+      // Then they should all return null
+      expect(slashResult).toBeNull();
+      expect(dotResult).toBeNull();
+      expect(spaceResult).toBeNull();
+    });
+
+    it('returns null for invalid date format - wrong length', () => {
+      // Given date strings with wrong length
+      const shortDate = '2025-11';
+      const longDate = '2025-11-11-12';
+      const noSeparators = '20251111';
+
+      // When formatting the dates
+      const shortResult = formatRewardsMusdDepositPayloadDate(shortDate);
+      const longResult = formatRewardsMusdDepositPayloadDate(longDate);
+      const noSeparatorsResult =
+        formatRewardsMusdDepositPayloadDate(noSeparators);
+
+      // Then they should all return null
+      expect(shortResult).toBeNull();
+      expect(longResult).toBeNull();
+      expect(noSeparatorsResult).toBeNull();
+    });
+
+    it('returns null for invalid date format - non-numeric characters', () => {
+      // Given date strings with non-numeric characters
+      const textDate = 'abcd-ef-gh';
+      const mixedDate = '2025-1a-11';
+      const lettersDate = 'YYYY-MM-DD';
+
+      // When formatting the dates
+      const textResult = formatRewardsMusdDepositPayloadDate(textDate);
+      const mixedResult = formatRewardsMusdDepositPayloadDate(mixedDate);
+      const lettersResult = formatRewardsMusdDepositPayloadDate(lettersDate);
+
+      // Then they should all return null
+      expect(textResult).toBeNull();
+      expect(mixedResult).toBeNull();
+      expect(lettersResult).toBeNull();
+    });
+
+    it('returns null for invalid date format - incomplete date parts', () => {
+      // Given date strings with incomplete parts
+      const oneDigitYear = '5-11-11';
+      const oneDigitMonth = '2025-1-11';
+      const oneDigitDay = '2025-11-1';
+      const twoDigitYear = '25-11-11';
+
+      // When formatting the dates
+      const oneDigitYearResult =
+        formatRewardsMusdDepositPayloadDate(oneDigitYear);
+      const oneDigitMonthResult =
+        formatRewardsMusdDepositPayloadDate(oneDigitMonth);
+      const oneDigitDayResult =
+        formatRewardsMusdDepositPayloadDate(oneDigitDay);
+      const twoDigitYearResult =
+        formatRewardsMusdDepositPayloadDate(twoDigitYear);
+
+      // Then they should all return null
+      expect(oneDigitYearResult).toBeNull();
+      expect(oneDigitMonthResult).toBeNull();
+      expect(oneDigitDayResult).toBeNull();
+      expect(twoDigitYearResult).toBeNull();
+    });
+
+    it('returns null for date with extra whitespace', () => {
+      // Given date strings with whitespace
+      const leadingSpace = ' 2025-11-11';
+      const trailingSpace = '2025-11-11 ';
+      const bothSpaces = ' 2025-11-11 ';
+
+      // When formatting the dates
+      const leadingResult = formatRewardsMusdDepositPayloadDate(leadingSpace);
+      const trailingResult = formatRewardsMusdDepositPayloadDate(trailingSpace);
+      const bothResult = formatRewardsMusdDepositPayloadDate(bothSpaces);
+
+      // Then they should all return null
+      expect(leadingResult).toBeNull();
+      expect(trailingResult).toBeNull();
+      expect(bothResult).toBeNull();
+    });
+
+    it('handles leap year dates correctly', () => {
+      // Given a leap year date
+      const leapYearDate = '2024-02-29';
+
+      // When formatting the date
+      const result = formatRewardsMusdDepositPayloadDate(leapYearDate);
+
+      // Then it should format correctly
+      expect(result).toBeTruthy();
+      expect(result).toMatch(/Feb/);
+      expect(result).toMatch(/29/);
+      expect(result).toMatch(/2024/);
+    });
+
+    it('handles dates at year boundaries correctly', () => {
+      // Given dates at year boundaries
+      const newYear = '2025-01-01';
+      const endYear = '2025-12-31';
+
+      // When formatting the dates
+      const newYearResult = formatRewardsMusdDepositPayloadDate(newYear);
+      const endYearResult = formatRewardsMusdDepositPayloadDate(endYear);
+
+      // Then they should be formatted correctly
+      expect(newYearResult).toBeTruthy();
+      expect(newYearResult).toMatch(/Jan/);
+      expect(newYearResult).toMatch(/1/);
+      expect(endYearResult).toBeTruthy();
+      expect(endYearResult).toMatch(/Dec/);
+      expect(endYearResult).toMatch(/31/);
+    });
+
+    it('handles different locales correctly', () => {
+      // Given an ISO date string
+      const isoDate = '2025-11-11';
+
+      // When formatting with different locales
+      const enResult = formatRewardsMusdDepositPayloadDate(isoDate, 'en-US');
+      const deResult = formatRewardsMusdDepositPayloadDate(isoDate, 'de-DE');
+      const jaResult = formatRewardsMusdDepositPayloadDate(isoDate, 'ja-JP');
+
+      // Then they should be formatted according to locale conventions
+      expect(enResult).toBeTruthy();
+      expect(deResult).toBeTruthy();
+      expect(jaResult).toBeTruthy();
+      // All should contain the date components
+      expect(enResult).toMatch(/11/);
+      expect(deResult).toMatch(/11/);
+      expect(jaResult).toMatch(/11/);
     });
   });
 });

--- a/app/components/UI/Rewards/utils/formatUtils.ts
+++ b/app/components/UI/Rewards/utils/formatUtils.ts
@@ -41,6 +41,58 @@ export const formatRewardsDate = (
     minute: '2-digit',
   }).format(date);
 
+/**
+ * Formats a "YYYY-MM-DD" date string into a localized format without timezone shifts.
+ * @param isoDate - The date string in "YYYY-MM-DD" format.
+ * @param locale - The locale to format for (e.g., 'en-US', 'fr-FR').
+ * @param options - Optional Intl.DateTimeFormat options.
+ * @returns The localized date string.
+ */
+export const formatUTCDate = (
+  isoDate: string,
+  locale: string = I18n.locale,
+  options: Intl.DateTimeFormatOptions = {},
+): string => {
+  // Create a date at midnight UTC
+  const date = new Date(`${isoDate}T00:00:00Z`);
+
+  const defaultOptions: Intl.DateTimeFormatOptions = {
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    timeZone: 'UTC', // Ensure UTC interpretation
+  };
+
+  const finalOptions = { ...defaultOptions, ...options };
+
+  return new Intl.DateTimeFormat(locale, finalOptions).format(date);
+};
+
+/**
+ * Formats a date for mUSD deposit payload
+ * @param isoDate - The date string in "YYYY-MM-DD" format
+ * @param locale - Optional locale string, defaults to I18n.locale
+ * @returns Formatted date string specifically for mUSD deposit payload, or null if invalid
+ */
+export const formatRewardsMusdDepositPayloadDate = (
+  isoDate: string | undefined,
+  locale: string = I18n.locale,
+): string | null => {
+  if (
+    !isoDate ||
+    typeof isoDate !== 'string' ||
+    !/^\d{4}-\d{2}-\d{2}$/.test(isoDate)
+  ) {
+    return null;
+  }
+
+  return formatUTCDate(isoDate, locale, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+};
+
 export const formatTimeRemaining = (endDate: Date): string | null => {
   const { days, hours, minutes } = getTimeDifferenceFromNow(endDate.getTime());
 

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -283,6 +283,17 @@ export interface CardEventPayload {
 }
 
 /**
+ * mUSD deposit event payload
+ */
+export interface MusdDepositEventPayload {
+  /**
+   * Date of the deposit
+   * @example '2025-11-11'
+   */
+  date: string;
+}
+
+/**
  * Base points event interface
  */
 interface BasePointsEventDto {
@@ -343,6 +354,14 @@ export type PointsEventDto = BasePointsEventDto &
     | {
         type: 'CARD';
         payload: CardEventPayload | null;
+      }
+    | {
+        type: 'PREDICT';
+        payload: null;
+      }
+    | {
+        type: 'MUSD_DEPOSIT';
+        payload: MusdDepositEventPayload | null;
       }
     | {
         type: 'REFERRAL' | 'SIGN_UP_BONUS' | 'LOYALTY_BONUS' | 'ONE_TIME_BONUS';

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6592,6 +6592,8 @@
     "activity_empty_link": "See ways to earn",
     "events": {
       "to": "to",
+      "musd_deposit_for": "For {{date}}",
+      "for_deposit_period": "For deposit period",
       "type": {
         "swap": "Swap",
         "perps": "Perps",
@@ -6605,6 +6607,8 @@
         "close_position": "Closed position",
         "take_profit": "TP/SL",
         "stop_loss": "TP/SL",
+        "predict": "Prediction",
+        "musd_deposit": "mUSD deposit",
         "uncategorized_event": "Uncategorized event"
       },
       "date": "Date",


### PR DESCRIPTION
## **Description**

This PR makes it so that the activity grid in rewards can identify predict and deposit musd type events.

## **Changelog**

CHANGELOG entry: feat rewards activity grid predict and deposit musd

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/RWDS-697

## **Screenshots/Recordings**

### **After**

<img width="469" height="154" alt="image" src="https://github.com/user-attachments/assets/ae81b968-8f99-4392-9704-7e2b20b4df66" />

<img width="544" height="448" alt="image" src="https://github.com/user-attachments/assets/e874d717-ba16-4488-ac87-7c7bf71cfd4c" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Rewards Activity support for PREDICT and MUSD_DEPOSIT events, including UI details, date formatting utilities, types, i18n strings, and comprehensive tests.
> 
> - **Rewards Activity UI**:
>   - Add `MUSD_DEPOSIT` handling in `ActivityDetailsSheet` via new `MusdDepositEventDetails` component.
>   - Ensure `PREDICT` events render without description in `ActivityEventRow`.
> - **Utils**:
>   - Update `getEventDetails` to support `PREDICT` and `MUSD_DEPOSIT` (with formatted "For {{date}}" detail and icons).
>   - Add `formatUTCDate` and `formatRewardsMusdDepositPayloadDate` in `utils/formatUtils`.
> - **Types**:
>   - Introduce `MusdDepositEventPayload` and extend `PointsEventDto` union with `PREDICT` and `MUSD_DEPOSIT`.
> - **i18n**:
>   - Add strings for prediction, mUSD deposit, and deposit-period/date labels in `locales/languages/en.json`.
> - **Tests**:
>   - New/expanded tests for `ActivityEventRow`, `ActivityDetailsSheet`, `MusdDepositEventDetails`, `eventDetailsUtils`, and `formatUtils`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99d004afcb4d5c0602c6bb8e24ae6cc137a1ebab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->