### PR TITLE
fix: handle swipe in confirmations on android

### DIFF
--- a/app/components/Views/confirmations/hooks/ui/useClearConfirmationOnBackSwipe.test.ts
+++ b/app/components/Views/confirmations/hooks/ui/useClearConfirmationOnBackSwipe.test.ts
@@ -132,10 +132,22 @@ describe('useClearConfirmationOnBackSwipe', () => {
       expect(mockBackHandlerRemove).toHaveBeenCalledTimes(1);
     });
 
-    it('does not set up iOS gesture listener', () => {
+    it('adds a gestureEnd listener when mounted', () => {
       renderHook(() => useClearConfirmationOnBackSwipe());
 
-      expect(mockAddListener).not.toHaveBeenCalled();
+      expect(mockAddListener).toHaveBeenCalledTimes(1);
+      expect(mockAddListener).toHaveBeenCalledWith(
+        'gestureEnd',
+        expect.any(Function),
+      );
+    });
+
+    it('calls onReject when gestureEnd event is triggered', () => {
+      renderHook(() => useClearConfirmationOnBackSwipe());
+      const gestureEndCallback = mockAddListener.mock.calls[0][1];
+      gestureEndCallback();
+
+      expect(mockOnReject).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/app/components/Views/confirmations/hooks/ui/useClearConfirmationOnBackSwipe.ts
+++ b/app/components/Views/confirmations/hooks/ui/useClearConfirmationOnBackSwipe.ts
@@ -14,7 +14,7 @@ const useClearConfirmationOnBackSwipe = () => {
   const { onReject } = useConfirmActions();
 
   useEffect(() => {
-    if (isFullScreenConfirmation && Device.isIos()) {
+    if (isFullScreenConfirmation) {
       const unsubscribe = navigation.addListener('gestureEnd', () => {
         onReject();
       });


### PR DESCRIPTION
## **Description**

Reject confirmation if swipe on Android, previously only applied to iOS.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#6141](https://github.com/MetaMask/MetaMask-planning/issues/6141)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands `gestureEnd` listener to all full-screen confirmations (not just iOS) to trigger `onReject`, and updates tests accordingly.
> 
> - **Hook `useClearConfirmationOnBackSwipe`**
>   - Apply `navigation.addListener('gestureEnd', ...)` whenever `isFullScreenConfirmation` is true (removed iOS-only guard) to call `onReject`.
> - **Tests `useClearConfirmationOnBackSwipe.test.ts`**
>   - Expect `gestureEnd` listener to be registered and to invoke `onReject`.
>   - Verify unsubscribe on unmount for iOS path and no Android back handler on iOS.
>   - On Android, continue asserting hardware back press handling and also assert `gestureEnd` behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abde76ba2615f68e82f84878814e333f14d81eba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->