### PR TITLE
fix: rewards animation goes off screen in swaps details sections

### DIFF
--- a/app/components/UI/Bridge/components/BridgeRewardsAnimation/BridgeRewardsAnimation.styles.ts
+++ b/app/components/UI/Bridge/components/BridgeRewardsAnimation/BridgeRewardsAnimation.styles.ts
@@ -1,0 +1,47 @@
+import { StyleSheet } from 'react-native';
+import { Theme } from '../../../../../util/theme/models';
+
+const ICON_WIDTH = 16;
+const ICON_HEIGHT = 16;
+
+export const bridgeRewardsAnimationStyles = (params: {
+  theme: Theme;
+  vars: {
+    isErrorState: boolean;
+    iconPosition: number;
+  };
+}) => {
+  const {
+    theme: { colors },
+    vars: { isErrorState, iconPosition },
+  } = params;
+
+  return StyleSheet.create({
+    container: {
+      flexDirection: 'row',
+      position: 'relative',
+      alignItems: 'center',
+      minHeight: ICON_HEIGHT,
+    },
+    riveIcon: {
+      position: 'absolute',
+      zIndex: 2,
+      left: iconPosition, // Dynamic: 0 (loading) or -20 (idle)
+    },
+    riveSize: {
+      width: ICON_WIDTH,
+      height: ICON_HEIGHT,
+    },
+    textContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      // Text starts after icon + gap
+      // Loading: icon at 0-16px, text at 20px (4px gap)
+      // Idle: icon at -20 to -4px, text at 0px (4px gap)
+      marginLeft: iconPosition + ICON_WIDTH + 4,
+    },
+    counterText: {
+      color: isErrorState ? colors.text.alternative : colors.text.default,
+    },
+  });
+};

--- a/app/components/UI/Bridge/components/BridgeRewardsAnimation/BridgeRewardsAnimation.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeRewardsAnimation/BridgeRewardsAnimation.test.tsx
@@ -1,0 +1,351 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { BridgeRewardsAnimation } from './BridgeRewardsAnimation';
+import { useBridgeRewardsAnimation } from './useBridgeRewardsAnimation';
+import { BridgeRewardAnimationState } from './types';
+
+// Mock the hook
+jest.mock('./useBridgeRewardsAnimation');
+
+// Mock Rive
+jest.mock('rive-react-native', () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+  Alignment: { CenterRight: 'CenterRight' },
+  Fit: { FitHeight: 'FitHeight' },
+}));
+
+// Mock design system
+jest.mock('@metamask/design-system-react-native', () => ({
+  Text: 'Text',
+  TextVariant: {
+    BodyMd: 'BodyMd',
+  },
+}));
+
+// Mock theme
+jest.mock('../../../../../util/theme', () => ({
+  useTheme: jest.fn(() => ({
+    colors: {
+      text: {
+        default: '#000000',
+        alternative: '#666666',
+      },
+    },
+  })),
+}));
+
+// Mock useStyles
+jest.mock('../../../../../component-library/hooks', () => ({
+  useStyles: jest.fn((styleSheet, vars) => {
+    const mockTheme = {
+      colors: {
+        text: {
+          default: '#000000',
+          alternative: '#666666',
+        },
+      },
+    };
+    // Call styleSheet with proper structure
+    const styles = styleSheet({ theme: mockTheme, vars });
+    return {
+      styles: {
+        container: styles.container || {},
+        riveIcon: styles.riveIcon || {},
+        riveSize: styles.riveSize || { width: 16, height: 16 },
+        textContainer: styles.textContainer || {},
+        counterText: styles.counterText || {},
+      },
+    };
+  }),
+}));
+
+const mockUseBridgeRewardsAnimation =
+  useBridgeRewardsAnimation as jest.MockedFunction<
+    typeof useBridgeRewardsAnimation
+  >;
+
+describe('BridgeRewardsAnimation', () => {
+  const defaultHookReturn = {
+    riveRef: { current: null },
+    animatedStyle: { opacity: 1 },
+    iconPosition: -20,
+    displayValue: 0,
+    displayText: null,
+    hideValue: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseBridgeRewardsAnimation.mockReturnValue(defaultHookReturn);
+  });
+
+  describe('Rendering', () => {
+    it('renders without crashing', () => {
+      const { toJSON } = render(<BridgeRewardsAnimation value={0} />);
+
+      expect(toJSON()).toBeTruthy();
+    });
+
+    it('renders with value', () => {
+      mockUseBridgeRewardsAnimation.mockReturnValue({
+        ...defaultHookReturn,
+        displayValue: 100,
+      });
+
+      const { getByText } = render(<BridgeRewardsAnimation value={100} />);
+
+      expect(getByText('100')).toBeTruthy();
+    });
+
+    it('renders formatted value', () => {
+      mockUseBridgeRewardsAnimation.mockReturnValue({
+        ...defaultHookReturn,
+        displayValue: 1000,
+      });
+
+      const { getByText } = render(<BridgeRewardsAnimation value={1000} />);
+
+      expect(getByText('1,000')).toBeTruthy();
+    });
+  });
+
+  describe('Loading State', () => {
+    it('hides value when hideValue is true', () => {
+      mockUseBridgeRewardsAnimation.mockReturnValue({
+        ...defaultHookReturn,
+        hideValue: true,
+        displayValue: 100,
+      });
+
+      const { queryByText } = render(
+        <BridgeRewardsAnimation
+          value={100}
+          state={BridgeRewardAnimationState.Loading}
+        />,
+      );
+
+      expect(queryByText('100')).toBeNull();
+    });
+
+    it('passes loading state to hook', () => {
+      render(
+        <BridgeRewardsAnimation
+          value={100}
+          state={BridgeRewardAnimationState.Loading}
+        />,
+      );
+
+      expect(mockUseBridgeRewardsAnimation).toHaveBeenCalledWith({
+        value: 100,
+        state: BridgeRewardAnimationState.Loading,
+      });
+    });
+  });
+
+  describe('Idle State', () => {
+    it('shows value in idle state', () => {
+      mockUseBridgeRewardsAnimation.mockReturnValue({
+        ...defaultHookReturn,
+        displayValue: 50,
+        hideValue: false,
+      });
+
+      const { getByText } = render(
+        <BridgeRewardsAnimation
+          value={50}
+          state={BridgeRewardAnimationState.Idle}
+        />,
+      );
+
+      expect(getByText('50')).toBeTruthy();
+    });
+
+    it('passes idle state to hook', () => {
+      render(
+        <BridgeRewardsAnimation
+          value={50}
+          state={BridgeRewardAnimationState.Idle}
+        />,
+      );
+
+      expect(mockUseBridgeRewardsAnimation).toHaveBeenCalledWith({
+        value: 50,
+        state: BridgeRewardAnimationState.Idle,
+      });
+    });
+  });
+
+  describe('Error State', () => {
+    it('shows error text', () => {
+      mockUseBridgeRewardsAnimation.mockReturnValue({
+        ...defaultHookReturn,
+        displayText: "Couldn't Load",
+        hideValue: false,
+      });
+
+      const { getByText } = render(
+        <BridgeRewardsAnimation
+          value={100}
+          state={BridgeRewardAnimationState.ErrorState}
+        />,
+      );
+
+      expect(getByText("Couldn't Load")).toBeTruthy();
+    });
+
+    it('passes error state to hook', () => {
+      render(
+        <BridgeRewardsAnimation
+          value={100}
+          state={BridgeRewardAnimationState.ErrorState}
+        />,
+      );
+
+      expect(mockUseBridgeRewardsAnimation).toHaveBeenCalledWith({
+        value: 100,
+        state: BridgeRewardAnimationState.ErrorState,
+      });
+    });
+  });
+
+  describe('Icon Positioning', () => {
+    it('applies correct icon position from hook', () => {
+      mockUseBridgeRewardsAnimation.mockReturnValue({
+        ...defaultHookReturn,
+        iconPosition: 0,
+      });
+
+      render(<BridgeRewardsAnimation value={100} />);
+
+      // Check that styles are computed with iconPosition
+      expect(mockUseBridgeRewardsAnimation).toHaveBeenCalled();
+    });
+
+    it('handles negative icon position', () => {
+      mockUseBridgeRewardsAnimation.mockReturnValue({
+        ...defaultHookReturn,
+        iconPosition: -20,
+      });
+
+      const { toJSON } = render(<BridgeRewardsAnimation value={100} />);
+
+      expect(toJSON()).toBeTruthy();
+    });
+  });
+
+  describe('Memoization', () => {
+    it('does not re-render when unrelated props change', () => {
+      const { rerender } = render(
+        <BridgeRewardsAnimation
+          value={100}
+          state={BridgeRewardAnimationState.Idle}
+        />,
+      );
+
+      const callCount = mockUseBridgeRewardsAnimation.mock.calls.length;
+
+      // Re-render with same props
+      rerender(
+        <BridgeRewardsAnimation
+          value={100}
+          state={BridgeRewardAnimationState.Idle}
+        />,
+      );
+
+      // Should not call hook again due to memoization
+      expect(mockUseBridgeRewardsAnimation.mock.calls.length).toBe(callCount);
+    });
+
+    it('re-renders when value changes', () => {
+      const { rerender } = render(<BridgeRewardsAnimation value={100} />);
+
+      const callCount = mockUseBridgeRewardsAnimation.mock.calls.length;
+
+      // Re-render with different value
+      rerender(<BridgeRewardsAnimation value={200} />);
+
+      // Should call hook again
+      expect(mockUseBridgeRewardsAnimation.mock.calls.length).toBeGreaterThan(
+        callCount,
+      );
+    });
+
+    it('re-renders when state changes', () => {
+      const { rerender } = render(
+        <BridgeRewardsAnimation
+          value={100}
+          state={BridgeRewardAnimationState.Idle}
+        />,
+      );
+
+      const callCount = mockUseBridgeRewardsAnimation.mock.calls.length;
+
+      // Re-render with different state
+      rerender(
+        <BridgeRewardsAnimation
+          value={100}
+          state={BridgeRewardAnimationState.Loading}
+        />,
+      );
+
+      // Should call hook again
+      expect(mockUseBridgeRewardsAnimation.mock.calls.length).toBeGreaterThan(
+        callCount,
+      );
+    });
+  });
+
+  describe('Text Display', () => {
+    it('displays text when displayText is set', () => {
+      mockUseBridgeRewardsAnimation.mockReturnValue({
+        ...defaultHookReturn,
+        displayText: 'Custom Text',
+        hideValue: false,
+      });
+
+      const { getByText } = render(<BridgeRewardsAnimation value={100} />);
+
+      expect(getByText('Custom Text')).toBeTruthy();
+    });
+
+    it('prioritizes displayText over displayValue', () => {
+      mockUseBridgeRewardsAnimation.mockReturnValue({
+        ...defaultHookReturn,
+        displayText: 'Error Message',
+        displayValue: 100,
+        hideValue: false,
+      });
+
+      const { getByText, queryByText } = render(
+        <BridgeRewardsAnimation value={100} />,
+      );
+
+      expect(getByText('Error Message')).toBeTruthy();
+      expect(queryByText('100')).toBeNull();
+    });
+
+    it('shows empty string when hideValue is true', () => {
+      mockUseBridgeRewardsAnimation.mockReturnValue({
+        ...defaultHookReturn,
+        displayValue: 100,
+        hideValue: true,
+      });
+
+      const { getByText } = render(<BridgeRewardsAnimation value={100} />);
+
+      expect(getByText('')).toBeTruthy();
+    });
+  });
+
+  describe('Default State', () => {
+    it('defaults to Idle state when state prop is not provided', () => {
+      render(<BridgeRewardsAnimation value={100} />);
+
+      expect(mockUseBridgeRewardsAnimation).toHaveBeenCalledWith({
+        value: 100,
+        state: BridgeRewardAnimationState.Idle,
+      });
+    });
+  });
+});

--- a/app/components/UI/Bridge/components/BridgeRewardsAnimation/BridgeRewardsAnimation.tsx
+++ b/app/components/UI/Bridge/components/BridgeRewardsAnimation/BridgeRewardsAnimation.tsx
@@ -1,0 +1,74 @@
+import React, { useMemo } from 'react';
+import { View } from 'react-native';
+import Rive, { Alignment, Fit } from 'rive-react-native';
+import Animated from 'react-native-reanimated';
+import { Text, TextVariant } from '@metamask/design-system-react-native';
+import { useStyles } from '../../../../../component-library/hooks';
+import { useTheme } from '../../../../../util/theme';
+import { useBridgeRewardsAnimation } from './useBridgeRewardsAnimation';
+import { BridgeRewardAnimationState } from './types';
+import { bridgeRewardsAnimationStyles } from './BridgeRewardsAnimation.styles';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, import/no-commonjs
+const RewardsIconAnimation = require('../../../../../animations/rewards_icon_animations.riv');
+
+interface BridgeRewardsAnimationProps {
+  value: number;
+  state?: BridgeRewardAnimationState;
+}
+
+export const BridgeRewardsAnimation: React.FC<BridgeRewardsAnimationProps> =
+  React.memo(
+    ({ value, state = BridgeRewardAnimationState.Idle }) => {
+      const theme = useTheme();
+      const isErrorState = state === BridgeRewardAnimationState.ErrorState;
+
+      // Use default formatting for Bridge
+      const formatter = useMemo(() => new Intl.NumberFormat('en-US'), []);
+
+      const {
+        riveRef,
+        animatedStyle,
+        iconPosition,
+        displayValue,
+        displayText,
+        hideValue,
+      } = useBridgeRewardsAnimation({
+        value,
+        state,
+      });
+
+      const { styles } = useStyles(bridgeRewardsAnimationStyles, {
+        theme,
+        isErrorState,
+        iconPosition,
+      });
+
+      return (
+        <View style={styles.container}>
+          <View style={styles.riveIcon}>
+            <Rive
+              ref={riveRef}
+              source={RewardsIconAnimation}
+              fit={Fit.FitHeight}
+              alignment={Alignment.CenterRight}
+              style={styles.riveSize}
+            />
+          </View>
+
+          {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+          <Animated.View style={[styles.textContainer, animatedStyle] as any}>
+            <Text variant={TextVariant.BodyMd} style={styles.counterText}>
+              {displayText || (hideValue ? '' : formatter.format(displayValue))}
+            </Text>
+          </Animated.View>
+        </View>
+      );
+    },
+    (prevProps, nextProps) =>
+      // Only re-render if value or state actually changed
+      prevProps.value === nextProps.value &&
+      prevProps.state === nextProps.state,
+  );
+
+BridgeRewardsAnimation.displayName = 'BridgeRewardsAnimation';

--- a/app/components/UI/Bridge/components/BridgeRewardsAnimation/types.ts
+++ b/app/components/UI/Bridge/components/BridgeRewardsAnimation/types.ts
@@ -1,0 +1,5 @@
+export enum BridgeRewardAnimationState {
+  Loading = 'loading',
+  ErrorState = 'error',
+  Idle = 'idle',
+}

--- a/app/components/UI/Bridge/components/BridgeRewardsAnimation/useBridgeRewardsAnimation.test.ts
+++ b/app/components/UI/Bridge/components/BridgeRewardsAnimation/useBridgeRewardsAnimation.test.ts
@@ -1,0 +1,217 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useBridgeRewardsAnimation } from './useBridgeRewardsAnimation';
+import { BridgeRewardAnimationState } from './types';
+
+// Mock Reanimated
+jest.mock('react-native-reanimated', () => {
+  const Reanimated = jest.requireActual('react-native-reanimated/mock');
+  return Reanimated;
+});
+
+// Mock Rive
+jest.mock('rive-react-native', () => ({
+  Alignment: { CenterRight: 'CenterRight' },
+  Fit: { FitHeight: 'FitHeight' },
+}));
+
+// Mock strings
+jest.mock('../../../../../../locales/i18n', () => ({
+  strings: jest.fn((key: string) => {
+    if (key === 'rewards.animation.could_not_load') {
+      return "Couldn't Load";
+    }
+    return key;
+  }),
+}));
+
+describe('useBridgeRewardsAnimation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Initialization', () => {
+    it('initializes with default values', () => {
+      const { result } = renderHook(() =>
+        useBridgeRewardsAnimation({
+          value: 0,
+        }),
+      );
+
+      expect(result.current.displayValue).toBe(0);
+      expect(result.current.displayText).toBeNull();
+      expect(result.current.hideValue).toBe(false);
+      expect(result.current.iconPosition).toBe(-20);
+      expect(result.current.riveRef).toBeDefined();
+    });
+
+    it('initializes with custom value', () => {
+      const { result } = renderHook(() =>
+        useBridgeRewardsAnimation({
+          value: 100,
+        }),
+      );
+
+      expect(result.current.displayValue).toBe(0);
+      expect(result.current.iconPosition).toBe(-20);
+    });
+  });
+
+  describe('State Prop', () => {
+    it('accepts Loading state', () => {
+      const { result } = renderHook(() =>
+        useBridgeRewardsAnimation({
+          value: 100,
+          state: BridgeRewardAnimationState.Loading,
+        }),
+      );
+
+      expect(result.current).toBeDefined();
+    });
+
+    it('accepts Idle state', () => {
+      const { result } = renderHook(() =>
+        useBridgeRewardsAnimation({
+          value: 100,
+          state: BridgeRewardAnimationState.Idle,
+        }),
+      );
+
+      expect(result.current).toBeDefined();
+    });
+
+    it('accepts ErrorState', () => {
+      const { result } = renderHook(() =>
+        useBridgeRewardsAnimation({
+          value: 100,
+          state: BridgeRewardAnimationState.ErrorState,
+        }),
+      );
+
+      expect(result.current).toBeDefined();
+    });
+  });
+
+  describe('Return Values', () => {
+    it('returns riveRef', () => {
+      const { result } = renderHook(() =>
+        useBridgeRewardsAnimation({ value: 100 }),
+      );
+
+      expect(result.current.riveRef).toBeDefined();
+      expect(result.current.riveRef.current).toBeDefined();
+    });
+
+    it('returns animatedStyle', () => {
+      const { result } = renderHook(() =>
+        useBridgeRewardsAnimation({ value: 100 }),
+      );
+
+      expect(result.current.animatedStyle).toBeDefined();
+    });
+
+    it('returns numeric iconPosition', () => {
+      const { result } = renderHook(() =>
+        useBridgeRewardsAnimation({ value: 100 }),
+      );
+
+      expect(typeof result.current.iconPosition).toBe('number');
+    });
+
+    it('returns numeric displayValue', () => {
+      const { result } = renderHook(() =>
+        useBridgeRewardsAnimation({ value: 100 }),
+      );
+
+      expect(typeof result.current.displayValue).toBe('number');
+    });
+
+    it('returns displayText as string or null', () => {
+      const { result } = renderHook(() =>
+        useBridgeRewardsAnimation({ value: 100 }),
+      );
+
+      const { displayText } = result.current;
+      expect(displayText === null || typeof displayText === 'string').toBe(
+        true,
+      );
+    });
+
+    it('returns hideValue as boolean', () => {
+      const { result } = renderHook(() =>
+        useBridgeRewardsAnimation({ value: 100 }),
+      );
+
+      expect(typeof result.current.hideValue).toBe('boolean');
+    });
+  });
+
+  describe('Value Changes', () => {
+    it('handles value updates', () => {
+      const { rerender } = renderHook(
+        ({ value }) => useBridgeRewardsAnimation({ value }),
+        { initialProps: { value: 50 } },
+      );
+
+      act(() => {
+        rerender({ value: 100 });
+      });
+
+      // No errors thrown
+      expect(true).toBe(true);
+    });
+
+    it('handles zero value', () => {
+      const { result } = renderHook(() =>
+        useBridgeRewardsAnimation({
+          value: 0,
+          state: BridgeRewardAnimationState.Idle,
+        }),
+      );
+
+      expect(result.current.displayValue).toBe(0);
+    });
+
+    it('handles large values', () => {
+      const { result } = renderHook(() =>
+        useBridgeRewardsAnimation({
+          value: 999999,
+        }),
+      );
+
+      expect(result.current).toBeDefined();
+    });
+  });
+
+  describe('State Transitions', () => {
+    it('handles state changes', () => {
+      const { rerender } = renderHook(
+        ({ state }) =>
+          useBridgeRewardsAnimation({
+            value: 100,
+            state,
+          }),
+        {
+          initialProps: { state: BridgeRewardAnimationState.Loading },
+        },
+      );
+
+      act(() => {
+        rerender({ state: BridgeRewardAnimationState.Idle });
+      });
+
+      // No errors thrown
+      expect(true).toBe(true);
+    });
+
+    it('handles unmount without errors', () => {
+      const { unmount } = renderHook(() =>
+        useBridgeRewardsAnimation({
+          value: 100,
+          state: BridgeRewardAnimationState.Loading,
+        }),
+      );
+
+      expect(() => unmount()).not.toThrow();
+    });
+  });
+});

--- a/app/components/UI/Bridge/components/BridgeRewardsAnimation/useBridgeRewardsAnimation.ts
+++ b/app/components/UI/Bridge/components/BridgeRewardsAnimation/useBridgeRewardsAnimation.ts
@@ -1,0 +1,205 @@
+import { useRef, useEffect, useState, useCallback } from 'react';
+import { RiveRef } from 'rive-react-native';
+import {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  AnimatedStyle,
+  useAnimatedReaction,
+  runOnJS,
+  useDerivedValue,
+} from 'react-native-reanimated';
+import { strings } from '../../../../../../locales/i18n';
+import { BridgeRewardAnimationState } from './types';
+
+// Rive animation constants
+const STATE_MACHINE_NAME = 'Rewards_Icon';
+const ANIMATION_DURATION = 200;
+
+enum RewardsIconTriggers {
+  RefreshLeft = 'Refresh_left',
+  DisableRight = 'Disable_right',
+}
+
+interface UseBridgeRewardsAnimationParams {
+  value: number;
+  state?: BridgeRewardAnimationState;
+}
+
+interface UseBridgeRewardsAnimationResult {
+  riveRef: React.RefObject<RiveRef>;
+  animatedStyle: AnimatedStyle;
+  iconPosition: number; // Direct value instead of animated style
+  displayValue: number;
+  displayText: string | null;
+  hideValue: boolean;
+}
+
+/**
+ * Simplified rewards animation hook for Bridge
+ * Only handles Loading, ErrorState, and Idle states
+ */
+export const useBridgeRewardsAnimation = ({
+  value,
+  state = BridgeRewardAnimationState.Idle,
+}: UseBridgeRewardsAnimationParams): UseBridgeRewardsAnimationResult => {
+  const riveRef = useRef<RiveRef>(null);
+  const animatedValue = useSharedValue(0);
+  const animatedIconPosition = useSharedValue(-20); // Start at idle position
+  const isAnimating = useSharedValue(false);
+
+  const [displayValue, setDisplayValue] = useState(0);
+  const [displayText, setDisplayText] = useState<string | null>(null);
+  const [hideValue, setHideValue] = useState(false);
+  const [iconPosition, setIconPosition] = useState(-20);
+
+  // Note: We DON'T auto-animate value changes here
+  // Animation is controlled explicitly in the state machine below
+
+  // Sync iconPosition state when animated position changes (for style calculation)
+  useAnimatedReaction(
+    () => Math.round(animatedIconPosition.value),
+    (currentPos, previousPos) => {
+      if (currentPos !== previousPos) {
+        runOnJS(setIconPosition)(currentPos);
+      }
+    },
+    [animatedIconPosition],
+  );
+
+  const triggerRiveAnimation = useCallback((trigger: RewardsIconTriggers) => {
+    try {
+      riveRef.current?.fireState(STATE_MACHINE_NAME, trigger);
+    } catch (error) {
+      console.warn(`Error triggering Rive animation (${trigger}):`, error);
+    }
+  }, []);
+
+  // Handle state changes with proper sequencing
+  useEffect(() => {
+    const timeouts: NodeJS.Timeout[] = [];
+
+    const addTimeout = (callback: () => void, delay: number) => {
+      const timeout = setTimeout(callback, delay);
+      timeouts.push(timeout);
+      return timeout;
+    };
+
+    // Ensure Rive component is loaded
+    addTimeout(() => {
+      if (!riveRef.current) return;
+
+      switch (state) {
+        case BridgeRewardAnimationState.Loading:
+          // Immediately freeze the value at 0 (stop any ongoing animation)
+          animatedValue.value = 0;
+          setDisplayValue(0);
+
+          // Step 1: Wait 50ms
+          addTimeout(() => {
+            // Step 2: Hide text and animate icon to right (smoother)
+            setHideValue(true);
+            setDisplayText(null);
+            animatedIconPosition.value = withTiming(0, {
+              duration: ANIMATION_DURATION,
+            });
+            triggerRiveAnimation(RewardsIconTriggers.DisableRight);
+          }, 50);
+          break;
+
+        case BridgeRewardAnimationState.ErrorState:
+          animatedIconPosition.value = withTiming(-20, {
+            duration: ANIMATION_DURATION,
+          });
+          setHideValue(false);
+          setDisplayText(strings('rewards.animation.could_not_load'));
+          triggerRiveAnimation(RewardsIconTriggers.DisableRight);
+          break;
+
+        case BridgeRewardAnimationState.Idle:
+        default:
+          // Step 1: Animate icon left immediately (smoother)
+          animatedIconPosition.value = withTiming(-20, {
+            duration: ANIMATION_DURATION,
+          });
+          triggerRiveAnimation(
+            value > 0
+              ? RewardsIconTriggers.RefreshLeft
+              : RewardsIconTriggers.DisableRight,
+          );
+
+          // Step 2: Wait 50ms, then show text and start countdown
+          addTimeout(() => {
+            setHideValue(false);
+            setDisplayText(null);
+            // Start counting from 0 to target value
+            isAnimating.value = true;
+            animatedValue.value = 0;
+            animatedValue.value = withTiming(
+              value,
+              {
+                duration: ANIMATION_DURATION * 4, // Slower, smoother countdown (800ms)
+              },
+              () => {
+                isAnimating.value = false;
+              },
+            );
+          }, 50);
+          break;
+      }
+    }, 100);
+
+    return () => {
+      timeouts.forEach(clearTimeout);
+    };
+  }, [
+    state,
+    value,
+    animatedValue,
+    animatedIconPosition,
+    isAnimating,
+    triggerRiveAnimation,
+  ]);
+
+  // Derive rounded value on UI thread (more efficient)
+  const roundedValue = useDerivedValue(
+    () => Math.round(animatedValue.value),
+    [animatedValue],
+  );
+
+  // Only update display value when rounded value changes (reduces re-renders)
+  const updateDisplayValue = useCallback((newValue: number) => {
+    setDisplayValue(newValue);
+  }, []);
+
+  useAnimatedReaction(
+    () => roundedValue.value,
+    (currentValue, previousValue) => {
+      // Only update if value actually changed (prevents unnecessary re-renders)
+      if (currentValue !== previousValue) {
+        runOnJS(updateDisplayValue)(currentValue);
+      }
+    },
+    [roundedValue],
+  );
+
+  // Animated style for number text with subtle bounce effect
+  const animatedStyle = useAnimatedStyle(() => {
+    const bounce = isAnimating.value ? 1.02 : 1; // Reduced bounce for smoothness
+    return {
+      opacity: 1,
+      transform: [
+        { scale: withTiming(bounce, { duration: ANIMATION_DURATION }) },
+      ],
+    };
+  });
+
+  return {
+    riveRef,
+    animatedStyle,
+    iconPosition,
+    displayValue,
+    displayText,
+    hideValue,
+  };
+};

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
@@ -31,12 +31,11 @@ import {
 } from '../../../../../core/redux/slices/bridge';
 import { getIntlNumberFormatter } from '../../../../../util/intl';
 import { useRewards } from '../../hooks/useRewards';
-import RewardsAnimations, {
-  RewardAnimationState,
-} from '../../../Rewards/components/RewardPointsAnimation';
 import QuoteCountdownTimer from '../QuoteCountdownTimer';
 import QuoteDetailsRecipientKeyValueRow from '../QuoteDetailsRecipientKeyValueRow/QuoteDetailsRecipientKeyValueRow';
 import { toSentenceCase } from '../../../../../util/string';
+import { BridgeRewardsAnimation } from '../BridgeRewardsAnimation/BridgeRewardsAnimation';
+import { BridgeRewardAnimationState } from '../BridgeRewardsAnimation/types';
 
 if (
   Platform.OS === 'android' &&
@@ -287,23 +286,16 @@ const QuoteDetailsCard: React.FC = () => {
             }}
             value={{
               label: (
-                <Box
-                  flexDirection={BoxFlexDirection.Row}
-                  alignItems={BoxAlignItems.Center}
-                  justifyContent={BoxJustifyContent.Center}
-                  gap={1}
-                >
-                  <RewardsAnimations
-                    value={estimatedPoints ?? 0}
-                    state={
-                      isRewardsLoading
-                        ? RewardAnimationState.Loading
-                        : hasRewardsError
-                          ? RewardAnimationState.ErrorState
-                          : RewardAnimationState.Idle
-                    }
-                  />
-                </Box>
+                <BridgeRewardsAnimation
+                  value={estimatedPoints ?? 0}
+                  state={
+                    isRewardsLoading
+                      ? BridgeRewardAnimationState.Loading
+                      : hasRewardsError
+                        ? BridgeRewardAnimationState.ErrorState
+                        : BridgeRewardAnimationState.Idle
+                  }
+                />
               ),
               ...(hasRewardsError && {
                 tooltip: {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix rewards animation.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fixes rewards animation going off screen in swaps details sections

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3425

## **Manual testing steps**

```gherkin
Ensure that the rewards animation is rendered correctly and does not goes off screen.
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/3646cf23-ce86-49f3-8dd4-237cffb442d2



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a new Rive-driven BridgeRewardsAnimation and swaps it into QuoteDetailsCard to fix positioning, with supporting hook, styles, types, and tests.
> 
> - **UI (Bridge)**
>   - Add `BridgeRewardsAnimation` with Rive (`Rewards_Icon`) and number formatting; handles `loading`, `error`, and `idle` via `BridgeRewardAnimationState`.
>   - New styles `BridgeRewardsAnimation.styles.ts` with dynamic `iconPosition` and text offset; error coloring.
>   - Integrate into `QuoteDetailsCard` replacing previous rewards animation; map loading/error/idle states from rewards data.
> - **Logic**
>   - New hook `useBridgeRewardsAnimation` managing Rive triggers, icon position, value countdown, and animated text style; memoized rendering.
> - **Tests**
>   - Add unit tests for component (`BridgeRewardsAnimation.test.tsx`) and hook (`useBridgeRewardsAnimation.test.ts`) covering states, formatting, positioning, and memoization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e08162b50cb39d8745f9b5831e33f627cdec5348. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->