### PR TITLE
fix: asset value metric in metamask pay

### DIFF
--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.test.ts
@@ -11,18 +11,19 @@ import {
   tokenAddress1Mock,
 } from '../../__mocks__/controllers/other-controllers-mock';
 import { useTransactionPayToken } from './useTransactionPayToken';
-import { useTokenAmount } from '../useTokenAmount';
 import { act } from '@testing-library/react-native';
 import { updateConfirmationMetric } from '../../../../../core/redux/slices/confirmationMetrics';
 import { TransactionType } from '@metamask/transaction-controller';
 import { useAutomaticTransactionPayToken } from './useAutomaticTransactionPayToken';
 import {
   TransactionPayQuote,
+  TransactionPayRequiredToken,
   TransactionPayStrategy,
 } from '@metamask/transaction-pay-controller';
 import { Json } from '@metamask/utils';
 import {
   useTransactionPayQuotes,
+  useTransactionPayRequiredTokens,
   useTransactionPayTotals,
 } from './useTransactionPayData';
 
@@ -72,10 +73,12 @@ function runHook({ type }: { type?: TransactionType } = {}) {
 
 describe('useTransactionPayMetrics', () => {
   const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
-  const useTokenAmountMock = jest.mocked(useTokenAmount);
   const updateConfirmationMetricMock = jest.mocked(updateConfirmationMetric);
   const useTransactionPayQuotesMock = jest.mocked(useTransactionPayQuotes);
   const useTransactionPayTotalsMock = jest.mocked(useTransactionPayTotals);
+  const useTransactionPayRequiredTokensMock = jest.mocked(
+    useTransactionPayRequiredTokens,
+  );
 
   const useAutomaticTransactionPayTokenMock = jest.mocked(
     useAutomaticTransactionPayToken,
@@ -89,9 +92,11 @@ describe('useTransactionPayMetrics', () => {
       setPayToken: noop as never,
     });
 
-    useTokenAmountMock.mockReturnValue({
-      amountPrecise: TOKEN_AMOUNT_MOCK,
-    } as ReturnType<typeof useTokenAmount>);
+    useTransactionPayRequiredTokensMock.mockReturnValue([
+      {
+        amountHuman: TOKEN_AMOUNT_MOCK,
+      } as TransactionPayRequiredToken,
+    ]);
 
     updateConfirmationMetricMock.mockReturnValue({
       type: 'test',
@@ -192,7 +197,7 @@ describe('useTransactionPayMetrics', () => {
       params: {
         properties: expect.objectContaining({
           mm_pay_use_case: 'perps_deposit',
-          simulation_sending_assets_total_value: TOKEN_AMOUNT_MOCK,
+          simulation_sending_assets_total_value: 1.23,
         }),
         sensitiveProperties: {},
       },
@@ -220,7 +225,7 @@ describe('useTransactionPayMetrics', () => {
       params: {
         properties: expect.objectContaining({
           mm_pay_use_case: 'predict_deposit',
-          simulation_sending_assets_total_value: TOKEN_AMOUNT_MOCK,
+          simulation_sending_assets_total_value: 1.23,
         }),
         sensitiveProperties: {},
       },


### PR DESCRIPTION
## **Description**

Fix the generation of the `simulation_sending_assets_total_value` property by reading it from the required tokens.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#6245](https://github.com/MetaMask/MetaMask-planning/issues/6245)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Compute `simulation_sending_assets_total_value` from required tokens instead of `useTokenAmount`, updating hook logic and tests accordingly.
> 
> - **Metrics hook (`useTransactionPayMetrics`)**:
>   - Replace `useTokenAmount` with `useTransactionPayRequiredTokens` to derive primary required token and compute `sendingValue` from `amountHuman`.
>   - Set `simulation_sending_assets_total_value` for `perps_deposit` and `predict_deposit` using the derived numeric value.
>   - Keep existing quote, fee, strategy, and dust metrics logic intact.
> - **Tests (`useTransactionPayMetrics.test.ts`)**:
>   - Mock `useTransactionPayRequiredTokens` and expect numeric `simulation_sending_assets_total_value` (e.g., `1.23`).
>   - Remove reliance on `useTokenAmount`; adjust mocks and expectations for quotes/steps, dust, token list size, and fees.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d1b8fd220a2be274a8809b4f0050c787bc42698. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->