### PR TITLE
fix(perps): race condition sometime preventing loading hip-3 positions cp-7.59.0

### DIFF
--- a/app/components/UI/Perps/components/PerpsWatchlistMarkets/PerpsWatchlistMarkets.tsx
+++ b/app/components/UI/Perps/components/PerpsWatchlistMarkets/PerpsWatchlistMarkets.tsx
@@ -63,6 +63,7 @@ const PerpsWatchlistMarkets: React.FC<PerpsWatchlistMarketsProps> = ({
     ({ item }: { item: PerpsMarketData }) => (
       <PerpsMarketRowItem
         market={item}
+        showBadge={false}
         onPress={() => handleMarketPress(item)}
       />
     ),

--- a/app/components/UI/Perps/controllers/providers/HyperLiquidProvider.ts
+++ b/app/components/UI/Perps/controllers/providers/HyperLiquidProvider.ts
@@ -3676,6 +3676,13 @@ export class HyperLiquidProvider implements IPerpsProvider {
       this.ensureClientsInitialized();
       this.clientService.ensureInitialized();
 
+      // CRITICAL: Build asset mapping on first call to ensure DEX discovery
+      // This must happen BEFORE any WebSocket subscriptions receive data
+      // Otherwise HIP-3 positions will be filtered out due to empty discoveredDexNames
+      if (this.coinToAssetId.size === 0) {
+        await this.buildAssetMapping();
+      }
+
       // Path 1: Symbol filtering - group by DEX and fetch in parallel
       if (params?.symbols && params.symbols.length > 0) {
         DevLogger.log(

--- a/app/components/UI/Perps/hooks/usePerpsMarkets.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarkets.ts
@@ -50,7 +50,7 @@ export interface UsePerpsMarketsOptions {
   skipInitialFetch?: boolean;
   /**
    * Show markets with zero or invalid volume
-   * @default false
+   * @default __DEV__ (true in development, false in production)
    */
   showZeroVolume?: boolean;
 }
@@ -112,7 +112,7 @@ export const usePerpsMarkets = (
     enablePolling = false,
     pollingInterval = 60000, // 1 minute default
     skipInitialFetch = false,
-    showZeroVolume = false,
+    showZeroVolume = __DEV__, // Show zero-volume markets in development mode
   } = options;
 
   const streamManager = usePerpsStream();

--- a/app/components/UI/Perps/services/HyperLiquidSubscriptionService.ts
+++ b/app/components/UI/Perps/services/HyperLiquidSubscriptionService.ts
@@ -159,6 +159,7 @@ export class HyperLiquidSubscriptionService {
     this.walletService = walletService;
     this.hip3Enabled = hip3Enabled ?? false;
     this.enabledDexs = enabledDexs ?? [];
+    this.discoveredDexNames = enabledDexs ?? [];
     this.allowlistMarkets = allowlistMarkets ?? [];
     this.blocklistMarkets = blocklistMarkets ?? [];
   }

--- a/app/components/UI/Perps/utils/marketDataTransform.test.ts
+++ b/app/components/UI/Perps/utils/marketDataTransform.test.ts
@@ -357,7 +357,7 @@ describe('marketDataTransform', () => {
       expect(result[0].marketType).toBe('commodity');
     });
 
-    it('handles unmapped HIP-3 DEX with marketSource but no marketType', () => {
+    it('handles unmapped HIP-3 DEX - defaults to equity marketType', () => {
       const unknownDexAsset = {
         name: 'unknown:ASSET1',
         maxLeverage: 10,
@@ -376,7 +376,7 @@ describe('marketDataTransform', () => {
       expect(result).toHaveLength(1);
       expect(result[0].symbol).toBe('unknown:ASSET1');
       expect(result[0].marketSource).toBe('unknown');
-      expect(result[0].marketType).toBeUndefined();
+      expect(result[0].marketType).toBe('equity');
     });
 
     it('handles main DEX assets with no marketSource or marketType', () => {

--- a/app/components/UI/Perps/utils/marketDataTransform.ts
+++ b/app/components/UI/Perps/utils/marketDataTransform.ts
@@ -224,16 +224,21 @@ export function transformMarketData(
       fundingRate = fundingData.predictedFundingRate;
     }
 
-    // Extract DEX and determine market type for badge display
+    // Extract DEX and base symbol for display
+    // e.g., "flx:TSLA" → { dex: "flx", symbol: "TSLA" }
     const { dex } = parseAssetName(symbol);
     const marketSource = dex || undefined;
 
-    // Simple per-asset lookup from feature flag (e.g., 'xyz:GOLD' → 'commodity')
-    const marketType: MarketType | undefined = assetMarketTypes?.[symbol];
+    // Determine market type:
+    // 1. Check explicit mapping (e.g., 'xyz:GOLD' → 'commodity')
+    // 2. Default HIP-3 DEX markets to 'equity' (stocks) if not mapped
+    // 3. Main DEX markets remain undefined (crypto)
+    const marketType: MarketType | undefined =
+      assetMarketTypes?.[symbol] || (dex ? 'equity' : undefined);
 
     return {
       symbol,
-      name: symbol, // HyperLiquid uses symbol as name
+      name: symbol,
       maxLeverage: `${asset.maxLeverage}x`,
       price: isNaN(currentPrice)
         ? PERPS_CONSTANTS.FALLBACK_PRICE_DISPLAY


### PR DESCRIPTION
## **Description**

This PR fixes HIP-3 market loading and visibility issues in the Perps feature:

1. **What is the reason for the change?**
   - HIP-3 positions were not loading on app startup due to race condition in DEX discovery
   - Development testing was difficult without seeing zero-volume markets

2. **What is the improvement/solution?**
   - HIP-3 DEX markets now default to `marketType: 'equity'` (with explicit override support)
   - Position loading now ensures `buildAssetMapping()` runs before WebSocket subscriptions
   - Development mode now shows all markets by default (`showZeroVolume = __DEV__`)

## **Changelog**

CHANGELOG entry: Fixed HIP-3 markets not appearing in Stocks tab and positions not loading on startup

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2066
Fixes: https://github.com/MetaMask/metamask-mobile/issues/22650
## **Manual testing steps**

```gherkin
Feature: HIP-3 Market and Position Loading

  Scenario: User views HIP-3 markets in Stocks tab
    Given user has HIP-3 enabled
    And xyz DEX is in enabled list

    When user navigates to Perps > Stocks tab
    Then all 12 xyz markets should be visible
    And markets should show equity badge

  Scenario: User's HIP-3 positions load on startup
    Given user has open HIP-3 positions

    When user opens the app
    Then HIP-3 positions should load immediately
    And positions should appear in positions list
```

## **Screenshots/Recordings**

### **Before**

- Only 4/12 xyz markets visible in Stocks tab
- HIP-3 positions not loading on startup

### **After**

- All 12/12 xyz markets visible in Stocks tab
- HIP-3 positions load reliably on startup

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures HIP-3 DEX discovery and asset mapping occur before subscriptions, defaults HIP-3 markets to equity, enables zero-volume markets in dev, and hides badges in the watchlist.
> 
> - **Perps Provider / Subscriptions**:
>   - Build asset mapping on first `getMarkets()` to avoid HIP-3 discovery race before WebSocket subscriptions.
>   - Initialize `discoveredDexNames` from `enabledDexs` in `HyperLiquidSubscriptionService`.
> - **Market Data Transform**:
>   - Default unmapped HIP-3 DEX markets to `marketType: 'equity'`; updated unit tests accordingly.
> - **Hook**:
>   - `usePerpsMarkets`: `showZeroVolume` now defaults to `__DEV__` (dev shows zero-volume markets).
> - **UI**:
>   - `PerpsWatchlistMarkets`: pass `showBadge=false` to `PerpsMarketRowItem`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b03cab8d151990870fd36abe99a149796b62540. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->