### PR TITLE
fix(predict): Reverts PR that caused chart to hide when selecting certain timeframes

### DIFF
--- a/app/components/UI/Predict/components/PredictDetailsChart/PredictDetailsChart.test.tsx
+++ b/app/components/UI/Predict/components/PredictDetailsChart/PredictDetailsChart.test.tsx
@@ -90,11 +90,6 @@ jest.mock('../../../../../util/theme', () => ({
 }));
 
 describe('PredictDetailsChart', () => {
-  const BASE_TIMESTAMP = 1_700_000_000_000;
-  const FORTY_FIVE_MINUTES_IN_MS = 45 * 60 * 1000;
-  const TWELVE_HOURS_IN_MS = 12 * 60 * 60 * 1000;
-  const TWENTY_FOUR_HOURS_IN_MS = 24 * 60 * 60 * 1000;
-
   const mockSingleSeries: ChartSeries[] = [
     {
       label: 'Outcome 1',
@@ -180,27 +175,7 @@ describe('PredictDetailsChart', () => {
     });
 
     it('highlights selected timeframe', () => {
-      const daySpanSeries: ChartSeries[] = [
-        {
-          label: 'Extended Outcome',
-          color: '#28C76F',
-          data: [
-            { timestamp: BASE_TIMESTAMP, value: 0.4 },
-            {
-              timestamp: BASE_TIMESTAMP + 18 * 60 * 60 * 1000,
-              value: 0.5,
-            },
-            {
-              timestamp: BASE_TIMESTAMP + 36 * 60 * 60 * 1000,
-              value: 0.6,
-            },
-          ],
-        },
-      ];
-      const { getByText } = setupTest({
-        data: daySpanSeries,
-        selectedTimeframe: '1d',
-      });
+      const { getByText } = setupTest({ selectedTimeframe: '1d' });
 
       expect(getByText('1D')).toBeOnTheScreen();
     });
@@ -221,124 +196,14 @@ describe('PredictDetailsChart', () => {
       expect(queryByText('Loading price history...')).not.toBeOnTheScreen();
     });
 
-    it('returns null when no data provided even with custom empty label', () => {
+    it('renders custom empty label when provided', () => {
       const customLabel = 'No data available';
-      const { queryByTestId, queryByText } = setupTest({
+      const { getByText } = setupTest({
         data: [{ label: 'Empty', color: '#000', data: [] }],
         emptyLabel: customLabel,
       });
 
-      expect(queryByTestId('line-chart')).toBeNull();
-      expect(queryByText(customLabel)).toBeNull();
-    });
-  });
-
-  describe('Timeframe filtering', () => {
-    it('returns null when all series fall outside selected timeframe', () => {
-      const dataOutsideTimeframe: ChartSeries[] = [
-        {
-          label: 'Outcome Short',
-          color: '#123456',
-          data: [
-            { timestamp: BASE_TIMESTAMP, value: 0.5 },
-            { timestamp: BASE_TIMESTAMP + 30 * 60 * 1000, value: 0.6 },
-          ],
-        },
-      ];
-
-      const { queryByTestId, queryByText } = setupTest({
-        data: dataOutsideTimeframe,
-        selectedTimeframe: '1d',
-        isLoading: false,
-      });
-
-      expect(queryByTestId('line-chart')).toBeNull();
-      expect(queryByText('1D')).toBeNull();
-    });
-
-    it('omits series that do not span selected timeframe', () => {
-      const longSpanSeriesA: ChartSeries = {
-        label: 'Outcome Long A',
-        color: '#28C76F',
-        data: [
-          { timestamp: BASE_TIMESTAMP, value: 0.4 },
-          {
-            timestamp: BASE_TIMESTAMP + TWELVE_HOURS_IN_MS,
-            value: 0.5,
-          },
-          {
-            timestamp: BASE_TIMESTAMP + TWENTY_FOUR_HOURS_IN_MS,
-            value: 0.6,
-          },
-        ],
-      };
-      const longSpanSeriesB: ChartSeries = {
-        label: 'Outcome Long B',
-        color: '#4459FF',
-        data: [
-          { timestamp: BASE_TIMESTAMP, value: 0.3 },
-          {
-            timestamp: BASE_TIMESTAMP + TWENTY_FOUR_HOURS_IN_MS,
-            value: 0.35,
-          },
-          {
-            timestamp: BASE_TIMESTAMP + 2 * TWENTY_FOUR_HOURS_IN_MS,
-            value: 0.38,
-          },
-        ],
-      };
-      const shortSpanSeries: ChartSeries = {
-        label: 'Outcome Short',
-        color: '#CA3542',
-        data: [
-          { timestamp: BASE_TIMESTAMP, value: 0.2 },
-          {
-            timestamp: BASE_TIMESTAMP + 30 * 60 * 1000,
-            value: 0.25,
-          },
-        ],
-      };
-
-      const { getAllByTestId, getByText, queryByText } = setupTest({
-        data: [longSpanSeriesA, longSpanSeriesB, shortSpanSeries],
-        selectedTimeframe: '1d',
-      });
-
-      expect(getAllByTestId('line-chart').length).toBeGreaterThan(0);
-      expect(getByText(/Outcome Long A/)).toBeOnTheScreen();
-      expect(getByText(/Outcome Long B/)).toBeOnTheScreen();
-      expect(queryByText('Outcome Short')).toBeNull();
-    });
-
-    it('renders series that cover at least half of selected timeframe span', () => {
-      const halfDaySpanSeries: ChartSeries = {
-        label: 'Outcome Half Day',
-        color: '#FFAA00',
-        data: [
-          { timestamp: BASE_TIMESTAMP, value: 0.45 },
-          {
-            timestamp: BASE_TIMESTAMP + TWELVE_HOURS_IN_MS,
-            value: 0.5,
-          },
-        ],
-      };
-
-      const { getByTestId } = setupTest({
-        data: [halfDaySpanSeries],
-        selectedTimeframe: '1d',
-      });
-
-      expect(getByTestId('line-chart')).toBeOnTheScreen();
-    });
-
-    it('hides chart when series contain no data points for selected timeframe', () => {
-      const { queryByTestId } = setupTest({
-        data: [{ label: 'Empty', color: '#000000', data: [] }],
-        selectedTimeframe: '1d',
-        isLoading: false,
-      });
-
-      expect(queryByTestId('line-chart')).toBeNull();
+      expect(getByText(customLabel)).toBeOnTheScreen();
     });
   });
 
@@ -432,9 +297,12 @@ describe('PredictDetailsChart', () => {
           data: [{ timestamp: 1640995200000, value: 0.5 }],
         },
       ];
-      const { queryByTestId } = setupTest({ data: singlePointData });
+      const { getByTestId } = setupTest({ data: singlePointData });
 
-      expect(queryByTestId('line-chart')).toBeNull();
+      const chartData = getByTestId('chart-data');
+      const data = JSON.parse(String(chartData.children[0]));
+
+      expect(data).toEqual([0.5]);
     });
 
     it('handles empty data array', () => {
@@ -445,9 +313,12 @@ describe('PredictDetailsChart', () => {
           data: [],
         },
       ];
-      const { queryByTestId } = setupTest({ data: emptyData });
+      const { getByTestId } = setupTest({ data: emptyData });
 
-      expect(queryByTestId('line-chart')).toBeNull();
+      const chartData = getByTestId('chart-data');
+      const data = JSON.parse(String(chartData.children[0]));
+
+      expect(data).toEqual(expect.arrayContaining([0]));
     });
 
     it('calculates correct chart bounds with padding', () => {
@@ -654,22 +525,16 @@ describe('PredictDetailsChart', () => {
             label: 'Series A',
             color: '#4459FF',
             data: [
-              { timestamp: BASE_TIMESTAMP, value: 0.3 },
-              {
-                timestamp: BASE_TIMESTAMP + FORTY_FIVE_MINUTES_IN_MS,
-                value: 0.7,
-              },
+              { timestamp: 1, value: 0.3 },
+              { timestamp: 2, value: 0.7 },
             ],
           },
           {
             label: 'Series B',
             color: '#FF6B6B',
             data: [
-              { timestamp: BASE_TIMESTAMP, value: 0.7 },
-              {
-                timestamp: BASE_TIMESTAMP + FORTY_FIVE_MINUTES_IN_MS,
-                value: 0.3,
-              },
+              { timestamp: 1, value: 0.7 },
+              { timestamp: 2, value: 0.3 },
             ],
           },
         ];
@@ -687,22 +552,16 @@ describe('PredictDetailsChart', () => {
             label: 'Close A',
             color: '#4459FF',
             data: [
-              { timestamp: BASE_TIMESTAMP, value: 0.5 },
-              {
-                timestamp: BASE_TIMESTAMP + FORTY_FIVE_MINUTES_IN_MS,
-                value: 0.501,
-              },
+              { timestamp: 1, value: 0.5 },
+              { timestamp: 2, value: 0.501 },
             ],
           },
           {
             label: 'Close B',
             color: '#FF6B6B',
             data: [
-              { timestamp: BASE_TIMESTAMP, value: 0.502 },
-              {
-                timestamp: BASE_TIMESTAMP + FORTY_FIVE_MINUTES_IN_MS,
-                value: 0.503,
-              },
+              { timestamp: 1, value: 0.502 },
+              { timestamp: 2, value: 0.503 },
             ],
           },
         ];
@@ -755,24 +614,12 @@ describe('PredictDetailsChart', () => {
           {
             label: 'Blue',
             color: '#0000FF',
-            data: [
-              { timestamp: BASE_TIMESTAMP, value: 0.5 },
-              {
-                timestamp: BASE_TIMESTAMP + FORTY_FIVE_MINUTES_IN_MS,
-                value: 0.55,
-              },
-            ],
+            data: [{ timestamp: 1, value: 0.5 }],
           },
           {
             label: 'Red',
             color: '#FF0000',
-            data: [
-              { timestamp: BASE_TIMESTAMP, value: 0.5 },
-              {
-                timestamp: BASE_TIMESTAMP + FORTY_FIVE_MINUTES_IN_MS,
-                value: 0.45,
-              },
-            ],
+            data: [{ timestamp: 1, value: 0.5 }],
           },
         ];
 
@@ -798,33 +645,24 @@ describe('PredictDetailsChart', () => {
             label: 'Series 1',
             color: '#4459FF',
             data: [
-              { timestamp: BASE_TIMESTAMP, value: 0.5 },
-              {
-                timestamp: BASE_TIMESTAMP + FORTY_FIVE_MINUTES_IN_MS,
-                value: 0.6,
-              },
+              { timestamp: 1, value: 0.5 },
+              { timestamp: 2, value: 0.6 },
             ],
           },
           {
             label: 'Series 2',
             color: '#FF6B6B',
             data: [
-              { timestamp: BASE_TIMESTAMP, value: 0.3 },
-              {
-                timestamp: BASE_TIMESTAMP + FORTY_FIVE_MINUTES_IN_MS,
-                value: 0.4,
-              },
+              { timestamp: 1, value: 0.3 },
+              { timestamp: 2, value: 0.4 },
             ],
           },
           {
             label: 'Series 3',
             color: '#F0B034',
             data: [
-              { timestamp: BASE_TIMESTAMP, value: 0.2 },
-              {
-                timestamp: BASE_TIMESTAMP + FORTY_FIVE_MINUTES_IN_MS,
-                value: 0.25,
-              },
+              { timestamp: 1, value: 0.2 },
+              { timestamp: 2, value: 0.25 },
             ],
           },
         ];

--- a/app/components/UI/Predict/components/PredictDetailsChart/utils.test.ts
+++ b/app/components/UI/Predict/components/PredictDetailsChart/utils.test.ts
@@ -5,7 +5,6 @@ import {
   CHART_HEIGHT,
   CHART_CONTENT_INSET,
   MAX_SERIES,
-  getTimeframeDurationMs,
   formatPriceHistoryLabel,
   formatTickValue,
 } from './utils';
@@ -36,35 +35,6 @@ describe('PredictDetailsChart utils', () => {
     it('exports line curve as a function', () => {
       expect(typeof LINE_CURVE).toBe('function');
       expect(LINE_CURVE.alpha).toBeDefined();
-    });
-  });
-
-  describe('getTimeframeDurationMs', () => {
-    it.each([
-      [PredictPriceHistoryInterval.ONE_HOUR, 60 * 60 * 1000],
-      [PredictPriceHistoryInterval.SIX_HOUR, 6 * 60 * 60 * 1000],
-      [PredictPriceHistoryInterval.ONE_DAY, 24 * 60 * 60 * 1000],
-      [PredictPriceHistoryInterval.ONE_WEEK, 7 * 24 * 60 * 60 * 1000],
-      [PredictPriceHistoryInterval.ONE_MONTH, 30 * 24 * 60 * 60 * 1000],
-    ])(
-      'returns expected duration for %s interval',
-      (interval: PredictPriceHistoryInterval, expectedDuration: number) => {
-        const result = getTimeframeDurationMs(interval);
-
-        expect(result).toBe(expectedDuration);
-      },
-    );
-
-    it('returns null for MAX interval', () => {
-      const result = getTimeframeDurationMs(PredictPriceHistoryInterval.MAX);
-
-      expect(result).toBeNull();
-    });
-
-    it('returns null for unknown interval', () => {
-      const result = getTimeframeDurationMs('unknown-interval');
-
-      expect(result).toBeNull();
     });
   });
 

--- a/app/components/UI/Predict/components/PredictDetailsChart/utils.ts
+++ b/app/components/UI/Predict/components/PredictDetailsChart/utils.ts
@@ -1,11 +1,6 @@
 import { curveCatmullRom } from 'd3-shape';
 import { PredictPriceHistoryInterval } from '../../types';
 
-const HOUR_IN_MS = 60 * 60 * 1000;
-const DAY_IN_MS = 24 * HOUR_IN_MS;
-const WEEK_IN_MS = 7 * DAY_IN_MS;
-const MONTH_IN_MS = 30 * DAY_IN_MS;
-
 export const DEFAULT_EMPTY_LABEL = '';
 export const LINE_CURVE = curveCatmullRom.alpha(0.2);
 export const CHART_HEIGHT = 192;
@@ -16,26 +11,6 @@ export const CHART_CONTENT_INSET = {
   right: 48,
 };
 export const MAX_SERIES = 3;
-
-export const getTimeframeDurationMs = (
-  interval: PredictPriceHistoryInterval | string,
-): number | null => {
-  switch (interval) {
-    case PredictPriceHistoryInterval.ONE_HOUR:
-      return HOUR_IN_MS;
-    case PredictPriceHistoryInterval.SIX_HOUR:
-      return 6 * HOUR_IN_MS;
-    case PredictPriceHistoryInterval.ONE_DAY:
-      return DAY_IN_MS;
-    case PredictPriceHistoryInterval.ONE_WEEK:
-      return WEEK_IN_MS;
-    case PredictPriceHistoryInterval.ONE_MONTH:
-      return MONTH_IN_MS;
-    case PredictPriceHistoryInterval.MAX:
-    default:
-      return null;
-  }
-};
 
 export const formatPriceHistoryLabel = (
   timestamp: number,

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -2394,7 +2394,9 @@ describe('PredictMarketDetails', () => {
 
       setupPredictMarketDetailsTest(marketWithPartialResolution);
 
-      expect(screen.getByTestId('predict-details-chart')).toBeOnTheScreen();
+      expect(
+        screen.queryByTestId('predict-details-chart'),
+      ).not.toBeOnTheScreen();
     });
 
     it('displays resolved outcomes count badge', () => {

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -1150,14 +1150,16 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
         {/* Header content - scrollable */}
         <Box twClassName="px-3 gap-4">
           {renderMarketStatus()}
-          <PredictDetailsChart
-            data={chartData}
-            timeframes={PRICE_HISTORY_TIMEFRAMES}
-            selectedTimeframe={selectedTimeframe}
-            onTimeframeChange={handleTimeframeChange}
-            isLoading={isPriceHistoryFetching}
-            emptyLabel={chartEmptyLabel}
-          />
+          {!multipleOpenOutcomesPartiallyResolved && (
+            <PredictDetailsChart
+              data={chartData}
+              timeframes={PRICE_HISTORY_TIMEFRAMES}
+              selectedTimeframe={selectedTimeframe}
+              onTimeframeChange={handleTimeframeChange}
+              isLoading={isPriceHistoryFetching}
+              emptyLabel={chartEmptyLabel}
+            />
+          )}
         </Box>
 
         {/* Show content skeleton while initial market data is fetching */}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Reverts commit adcd668525dabb11d59684e65ad8e147c9913977 which was causing the chart to incorrectly hide when selecting certain timeframes

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: NA

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Eliminates timeframe-span filtering that hid the price chart, shows empty state instead, and conditionally hides the chart when multiple open outcomes are partially resolved; updates utils and tests accordingly.
> 
> - **PredictDetailsChart (`PredictDetailsChart.tsx`)**:
>   - Remove timeframe-span filtering and `getTimeframeDurationMs` usage; always process `seriesToRender`.
>   - Stop returning `null`; render loading/empty states with `emptyLabel`.
>   - Keep up to `MAX_SERIES`; compute labels via `formatPriceHistoryLabel`.
>   - Tooltip/interaction logic retained; bounds/padding unchanged.
> - **Utils (`utils.ts`)**:
>   - Delete `getTimeframeDurationMs`; keep label formatting and tick value formatting.
> - **PredictMarketDetails (`PredictMarketDetails.tsx`)**:
>   - Conditionally render `PredictDetailsChart` only when `multipleOpenOutcomesPartiallyResolved` is false.
> - **Tests**:
>   - Update chart tests to reflect always-render behavior with loading/empty states and removed timeframe filtering.
>   - Remove tests for timeframe coverage and `getTimeframeDurationMs`.
>   - Add/adjust assertions reading `chart-data`; simplify timestamps; update market details tests to expect chart hidden for partially resolved markets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83ae10e91abeee79d1dc8aaa7e9c4c52325cf14c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->