### PR TITLE
feat: migrate features to new arch

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -100,13 +100,9 @@ import {
   PerpsScreenStack,
   PerpsModalStack,
   PerpsTutorialCarousel,
-  selectPerpsEnabledFlag,
 } from '../../UI/Perps';
-import {
-  PredictScreenStack,
-  PredictModalStack,
-  selectPredictEnabledFlag,
-} from '../../UI/Predict';
+import { PredictScreenStack, PredictModalStack } from '../../UI/Predict';
+import { useFeatureFlag, FeatureFlagNames } from '../../hooks/useFeatureFlag';
 import { selectAssetsTrendingTokensEnabled } from '../../../selectors/featureFlagController/assetsTrendingTokens';
 import PerpsPositionTransactionView from '../../UI/Perps/Views/PerpsTransactionsView/PerpsPositionTransactionView';
 import PerpsOrderTransactionView from '../../UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView';
@@ -921,11 +917,15 @@ const SampleFeatureFlow = () => (
 
 const MainNavigator = () => {
   // Get feature flag state for conditional Perps screen registration
-  const perpsEnabledFlag = useSelector(selectPerpsEnabledFlag);
+  const perpsEnabledFlag = useFeatureFlag(
+    FeatureFlagNames.perpsPerpTradingEnabled,
+  );
   const isEvmSelected = useSelector(selectIsEvmNetworkSelected);
   const isPerpsEnabled = useMemo(() => perpsEnabledFlag, [perpsEnabledFlag]);
   // Get feature flag state for conditional Predict screen registration
-  const predictEnabledFlag = useSelector(selectPredictEnabledFlag);
+  const predictEnabledFlag = useFeatureFlag(
+    FeatureFlagNames.predictTradingEnabled,
+  );
   const isPredictEnabled = useMemo(
     () => predictEnabledFlag,
     [predictEnabledFlag],

--- a/app/components/UI/Earn/components/EarnTokenList/EarnTokenList.test.tsx
+++ b/app/components/UI/Earn/components/EarnTokenList/EarnTokenList.test.tsx
@@ -19,15 +19,20 @@ import { getMockUseEarnTokens } from '../../__mocks__/earnMockData';
 import { EARN_EXPERIENCES } from '../../constants/experiences';
 import * as useEarnTokensHook from '../../hooks/useEarnTokens';
 import * as useEarnNetworkPollingHook from '../../hooks/useEarnNetworkPolling';
+import { selectStablecoinLendingEnabledFlag } from '../../selectors/featureFlags';
 import {
-  selectPooledStakingEnabledFlag,
-  selectStablecoinLendingEnabledFlag,
-} from '../../selectors/featureFlags';
+  useFeatureFlag,
+  FeatureFlagNames,
+} from '../../../../../components/hooks/useFeatureFlag';
 import { EarnTokenDetails } from '../../types/lending.types';
 
 jest.mock('../../selectors/featureFlags', () => ({
-  selectPooledStakingEnabledFlag: jest.fn().mockImplementation(() => true),
   selectStablecoinLendingEnabledFlag: jest.fn().mockImplementation(() => true),
+}));
+
+jest.mock('../../../../../../components/hooks/useFeatureFlag', () => ({
+  useFeatureFlag: jest.fn().mockReturnValue(true),
+  FeatureFlagNames,
 }));
 
 jest.mock('../../../../../core/Engine', () => ({
@@ -140,9 +145,7 @@ describe('EarnTokenList', () => {
     (
       selectStablecoinLendingEnabledFlag as unknown as jest.Mock
     ).mockReturnValue(true);
-    (selectPooledStakingEnabledFlag as unknown as jest.Mock).mockReturnValue(
-      true,
-    );
+    (useFeatureFlag as unknown as jest.Mock).mockReturnValue(true);
 
     jest
       .spyOn(ReactNative.Image, 'getSize')
@@ -491,9 +494,7 @@ describe('EarnTokenList', () => {
   describe('ETH token filtering based on pooled staking status', () => {
     it('filters out ETH tokens that are not staked when pooled staking is disabled', () => {
       // Mock pooled staking as disabled
-      (selectPooledStakingEnabledFlag as unknown as jest.Mock).mockReturnValue(
-        false,
-      );
+      (useFeatureFlag as unknown as jest.Mock).mockReturnValue(false);
 
       const mockTokens = [
         {
@@ -550,9 +551,7 @@ describe('EarnTokenList', () => {
 
     it('shows ETH tokens that are staked when pooled staking is disabled', () => {
       // Mock pooled staking as disabled
-      (selectPooledStakingEnabledFlag as unknown as jest.Mock).mockReturnValue(
-        false,
-      );
+      (useFeatureFlag as unknown as jest.Mock).mockReturnValue(false);
 
       const mockTokens = [
         {
@@ -609,9 +608,7 @@ describe('EarnTokenList', () => {
 
     it('shows ETH tokens that are not staked when pooled staking is enabled', () => {
       // Mock pooled staking as enabled
-      (selectPooledStakingEnabledFlag as unknown as jest.Mock).mockReturnValue(
-        true,
-      );
+      (useFeatureFlag as unknown as jest.Mock).mockReturnValue(true);
 
       const mockTokens = [
         {
@@ -668,9 +665,7 @@ describe('EarnTokenList', () => {
 
     it('shows non-ETH tokens regardless of pooled staking status', () => {
       // Mock pooled staking as disabled
-      (selectPooledStakingEnabledFlag as unknown as jest.Mock).mockReturnValue(
-        false,
-      );
+      (useFeatureFlag as unknown as jest.Mock).mockReturnValue(false);
 
       const mockTokens = [
         {

--- a/app/components/UI/Earn/components/EarnTokenList/EarnTokenList.test.tsx
+++ b/app/components/UI/Earn/components/EarnTokenList/EarnTokenList.test.tsx
@@ -28,12 +28,18 @@ import { EarnTokenDetails } from '../../types/lending.types';
 
 jest.mock('../../selectors/featureFlags', () => ({
   selectStablecoinLendingEnabledFlag: jest.fn().mockImplementation(() => true),
+  selectPooledStakingEnabledFlag: jest.fn().mockImplementation(() => true),
 }));
 
-jest.mock('../../../../../../components/hooks/useFeatureFlag', () => ({
-  useFeatureFlag: jest.fn().mockReturnValue(true),
-  FeatureFlagNames,
-}));
+jest.mock('../../../../../components/hooks/useFeatureFlag', () => {
+  const actual = jest.requireActual(
+    '../../../../../components/hooks/useFeatureFlag',
+  );
+  return {
+    ...actual,
+    useFeatureFlag: jest.fn().mockReturnValue(true),
+  };
+});
 
 jest.mock('../../../../../core/Engine', () => ({
   context: {
@@ -145,7 +151,14 @@ describe('EarnTokenList', () => {
     (
       selectStablecoinLendingEnabledFlag as unknown as jest.Mock
     ).mockReturnValue(true);
-    (useFeatureFlag as unknown as jest.Mock).mockReturnValue(true);
+    (useFeatureFlag as unknown as jest.Mock).mockImplementation(
+      (flagName: string) => {
+        if (flagName === FeatureFlagNames.earnPooledStakingEnabled) {
+          return true;
+        }
+        return true;
+      },
+    );
 
     jest
       .spyOn(ReactNative.Image, 'getSize')

--- a/app/components/UI/Earn/components/EarnTokenList/index.tsx
+++ b/app/components/UI/Earn/components/EarnTokenList/index.tsx
@@ -34,10 +34,11 @@ import Engine from '../../../../../core/Engine';
 import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import useEarnTokens from '../../hooks/useEarnTokens';
 import { useSelector } from 'react-redux';
+import { selectStablecoinLendingEnabledFlag } from '../../selectors/featureFlags';
 import {
-  selectPooledStakingEnabledFlag,
-  selectStablecoinLendingEnabledFlag,
-} from '../../selectors/featureFlags';
+  useFeatureFlag,
+  FeatureFlagNames,
+} from '../../../../../components/hooks/useFeatureFlag';
 import useEarnNetworkPolling from '../../hooks/useEarnNetworkPolling';
 import { EARN_INPUT_VIEW_ACTIONS } from '../../Views/EarnInputView/EarnInputView.types';
 import EarnDepositTokenListItem from '../EarnDepositTokenListItem';
@@ -99,7 +100,9 @@ const EarnTokenList = () => {
   const bottomSheetRef = useRef<BottomSheetRef>(null);
   const traceEndedRef = useRef(false);
 
-  const isPooledStakingEnabled = useSelector(selectPooledStakingEnabledFlag);
+  const isPooledStakingEnabled = useFeatureFlag(
+    FeatureFlagNames.earnPooledStakingEnabled,
+  );
   const { includeReceiptTokens } = params?.tokenFilter ?? {};
 
   const { earnTokens, earnOutputTokens, earnableTotalFiatFormatted } =

--- a/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.test.tsx
@@ -11,10 +11,7 @@ import {
   selectRewardsCardSpendFeatureFlags,
   selectRewardsMusdDepositEnabledFlag,
 } from '../../../../../../../selectors/featureFlagController/rewards';
-import {
-  useFeatureFlag,
-  FeatureFlagNames,
-} from '../../../../../../../components/hooks/useFeatureFlag';
+import { useFeatureFlag } from '../../../../../../../components/hooks/useFeatureFlag';
 import { MetaMetricsEvents } from '../../../../../../hooks/useMetrics';
 import { RewardsMetricsButtons } from '../../../../utils';
 
@@ -62,10 +59,15 @@ jest.mock('../../../../../../hooks/useMetrics', () => ({
 }));
 
 // Mock useFeatureFlag hook
-jest.mock('../../../../../../components/hooks/useFeatureFlag', () => ({
-  useFeatureFlag: jest.fn(),
-  FeatureFlagNames,
-}));
+jest.mock('../../../../../../../components/hooks/useFeatureFlag', () => {
+  const actual = jest.requireActual(
+    '../../../../../../../components/hooks/useFeatureFlag',
+  );
+  return {
+    useFeatureFlag: jest.fn(),
+    FeatureFlagNames: actual.FeatureFlagNames,
+  };
+});
 
 // Mock getNativeAssetForChainId
 jest.mock('@metamask/bridge-controller', () => ({
@@ -515,6 +517,7 @@ describe('WaysToEarn', () => {
 
       // Enable flag
       mockIsPredictEnabled = true;
+      mockUseFeatureFlag.mockReturnValue(mockIsPredictEnabled);
       rerender(<WaysToEarn />);
 
       // Assert visible now
@@ -525,6 +528,7 @@ describe('WaysToEarn', () => {
     it('opens modal for predict earning way when pressed', () => {
       // Arrange
       mockIsPredictEnabled = true;
+      mockUseFeatureFlag.mockReturnValue(mockIsPredictEnabled);
       const { getByText } = render(<WaysToEarn />);
       const predictButton = getByText('Prediction markets');
 
@@ -553,6 +557,7 @@ describe('WaysToEarn', () => {
     it('navigates to predict market list when predict CTA is pressed', () => {
       // Arrange
       mockIsPredictEnabled = true;
+      mockUseFeatureFlag.mockReturnValue(mockIsPredictEnabled);
       const { getByText } = render(<WaysToEarn />);
       const predictButton = getByText('Prediction markets');
 

--- a/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.test.tsx
@@ -11,7 +11,10 @@ import {
   selectRewardsCardSpendFeatureFlags,
   selectRewardsMusdDepositEnabledFlag,
 } from '../../../../../../../selectors/featureFlagController/rewards';
-import { selectPredictEnabledFlag } from '../../../../../Predict/selectors/featureFlags';
+import {
+  useFeatureFlag,
+  FeatureFlagNames,
+} from '../../../../../../../components/hooks/useFeatureFlag';
 import { MetaMetricsEvents } from '../../../../../../hooks/useMetrics';
 import { RewardsMetricsButtons } from '../../../../utils';
 
@@ -58,6 +61,12 @@ jest.mock('../../../../../../hooks/useMetrics', () => ({
   },
 }));
 
+// Mock useFeatureFlag hook
+jest.mock('../../../../../../components/hooks/useFeatureFlag', () => ({
+  useFeatureFlag: jest.fn(),
+  FeatureFlagNames,
+}));
+
 // Mock getNativeAssetForChainId
 jest.mock('@metamask/bridge-controller', () => ({
   getNativeAssetForChainId: jest.fn(() => ({
@@ -69,6 +78,10 @@ jest.mock('@metamask/bridge-controller', () => ({
 
 const mockUseNavigation = useNavigation as jest.MockedFunction<
   typeof useNavigation
+>;
+
+const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<
+  typeof useFeatureFlag
 >;
 
 // Mock i18n strings
@@ -207,14 +220,13 @@ describe('WaysToEarn', () => {
       if (selector === selectRewardsCardSpendFeatureFlags) {
         return mockIsCardSpendEnabled;
       }
-      if (selector === selectPredictEnabledFlag) {
-        return mockIsPredictEnabled;
-      }
       if (selector === selectRewardsMusdDepositEnabledFlag) {
         return mockIsMusdDepositEnabled;
       }
       return undefined;
     });
+    // Mock useFeatureFlag for predict flag
+    mockUseFeatureFlag.mockReturnValue(mockIsPredictEnabled);
   });
 
   it('renders the component title', () => {

--- a/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.tsx
+++ b/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/WaysToEarn.tsx
@@ -31,7 +31,10 @@ import {
   selectRewardsCardSpendFeatureFlags,
   selectRewardsMusdDepositEnabledFlag,
 } from '../../../../../../../selectors/featureFlagController/rewards';
-import { selectPredictEnabledFlag } from '../../../../../Predict/selectors/featureFlags';
+import {
+  useFeatureFlag,
+  FeatureFlagNames,
+} from '../../../../../../hooks/useFeatureFlag';
 import { PredictEventValues } from '../../../../../Predict/constants/eventNames';
 import {
   MetaMetricsEvents,
@@ -231,7 +234,9 @@ export const WaysToEarn = () => {
   const navigation = useNavigation();
   const isFirstTimePerpsUser = useSelector(selectIsFirstTimePerpsUser);
   const isCardSpendEnabled = useSelector(selectRewardsCardSpendFeatureFlags);
-  const isPredictEnabled = useSelector(selectPredictEnabledFlag);
+  const isPredictEnabled = useFeatureFlag(
+    FeatureFlagNames.predictTradingEnabled,
+  );
   const isMusdDepositEnabled = useSelector(selectRewardsMusdDepositEnabledFlag);
   const { trackEvent, createEventBuilder } = useMetrics();
 

--- a/app/components/UI/Stake/components/StakeButton/StakeButton.test.tsx
+++ b/app/components/UI/Stake/components/StakeButton/StakeButton.test.tsx
@@ -17,10 +17,7 @@ import { RootState } from '../../../../../reducers';
 import { SolScope } from '@metamask/keyring-api';
 import Engine from '../../../../../core/Engine';
 import { selectStablecoinLendingEnabledFlag } from '../../../Earn/selectors/featureFlags';
-import {
-  useFeatureFlag,
-  FeatureFlagNames,
-} from '../../../../../components/hooks/useFeatureFlag';
+import { useFeatureFlag } from '../../../../../components/hooks/useFeatureFlag';
 import { TokenI } from '../../../Tokens/types';
 import { EARN_EXPERIENCES } from '../../../Earn/constants/experiences';
 
@@ -89,10 +86,15 @@ jest.mock('../../../Earn/selectors/featureFlags', () => ({
   selectStablecoinLendingEnabledFlag: jest.fn().mockReturnValue(true),
 }));
 
-jest.mock('../../../../../components/hooks/useFeatureFlag', () => ({
-  useFeatureFlag: jest.fn().mockReturnValue(true),
-  FeatureFlagNames,
-}));
+jest.mock('../../../../../components/hooks/useFeatureFlag', () => {
+  const actual = jest.requireActual(
+    '../../../../../components/hooks/useFeatureFlag',
+  );
+  return {
+    useFeatureFlag: jest.fn().mockReturnValue(true),
+    FeatureFlagNames: actual.FeatureFlagNames,
+  };
+});
 
 jest.mock('../../../../../selectors/earnController/earn', () => {
   const { EARN_EXPERIENCES } = jest.requireActual(

--- a/app/components/UI/Stake/components/StakeButton/StakeButton.test.tsx
+++ b/app/components/UI/Stake/components/StakeButton/StakeButton.test.tsx
@@ -16,14 +16,19 @@ import useStakingEligibility from '../../hooks/useStakingEligibility';
 import { RootState } from '../../../../../reducers';
 import { SolScope } from '@metamask/keyring-api';
 import Engine from '../../../../../core/Engine';
+import { selectStablecoinLendingEnabledFlag } from '../../../Earn/selectors/featureFlags';
 import {
-  selectPooledStakingEnabledFlag,
-  selectStablecoinLendingEnabledFlag,
-} from '../../../Earn/selectors/featureFlags';
+  useFeatureFlag,
+  FeatureFlagNames,
+} from '../../../../../components/hooks/useFeatureFlag';
 import { TokenI } from '../../../Tokens/types';
 import { EARN_EXPERIENCES } from '../../../Earn/constants/experiences';
 
 const mockNavigate = jest.fn();
+
+const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<
+  typeof useFeatureFlag
+>;
 
 const MOCK_APR_VALUES: { [symbol: string]: string } = {
   Ethereum: '2.3',
@@ -81,8 +86,12 @@ jest.mock('../../../../../util/environment', () => ({
 
 // Mock the feature flags selector
 jest.mock('../../../Earn/selectors/featureFlags', () => ({
-  selectPooledStakingEnabledFlag: jest.fn().mockReturnValue(true),
   selectStablecoinLendingEnabledFlag: jest.fn().mockReturnValue(true),
+}));
+
+jest.mock('../../../../../components/hooks/useFeatureFlag', () => ({
+  useFeatureFlag: jest.fn().mockReturnValue(true),
+  FeatureFlagNames,
 }));
 
 jest.mock('../../../../../selectors/earnController/earn', () => {
@@ -331,11 +340,7 @@ describe('StakeButton', () => {
   });
 
   it('does not render button when all earn experiences are disabled', () => {
-    (
-      selectPooledStakingEnabledFlag as jest.MockedFunction<
-        typeof selectPooledStakingEnabledFlag
-      >
-    ).mockReturnValue(false);
+    mockUseFeatureFlag.mockReturnValue(false);
     (
       selectStablecoinLendingEnabledFlag as jest.MockedFunction<
         typeof selectStablecoinLendingEnabledFlag
@@ -348,11 +353,7 @@ describe('StakeButton', () => {
   });
 
   it('does not render button when all pooled staking experience is disabled and token is ETH', () => {
-    (
-      selectPooledStakingEnabledFlag as jest.MockedFunction<
-        typeof selectPooledStakingEnabledFlag
-      >
-    ).mockReturnValue(false);
+    mockUseFeatureFlag.mockReturnValue(false);
     (
       selectStablecoinLendingEnabledFlag as jest.MockedFunction<
         typeof selectStablecoinLendingEnabledFlag

--- a/app/components/UI/Stake/components/StakeButton/index.tsx
+++ b/app/components/UI/Stake/components/StakeButton/index.tsx
@@ -22,10 +22,11 @@ import { useTheme } from '../../../../../util/theme';
 import { MetaMetricsEvents, useMetrics } from '../../../../hooks/useMetrics';
 import { EARN_EXPERIENCES } from '../../../Earn/constants/experiences';
 import useEarnTokens from '../../../Earn/hooks/useEarnTokens';
+import { selectStablecoinLendingEnabledFlag } from '../../../Earn/selectors/featureFlags';
 import {
-  selectPooledStakingEnabledFlag,
-  selectStablecoinLendingEnabledFlag,
-} from '../../../Earn/selectors/featureFlags';
+  useFeatureFlag,
+  FeatureFlagNames,
+} from '../../../../../components/hooks/useFeatureFlag';
 import createStyles from '../../../Tokens/styles';
 import { BrowserTab, TokenI } from '../../../Tokens/types';
 import { EVENT_LOCATIONS } from '../../constants/events';
@@ -53,7 +54,9 @@ const StakeButtonContent = ({ asset }: StakeButtonProps) => {
   const { isEligible } = useStakingEligibility();
   const { isStakingSupportedChain } = useStakingChain();
 
-  const isPooledStakingEnabled = useSelector(selectPooledStakingEnabledFlag);
+  const isPooledStakingEnabled = useFeatureFlag(
+    FeatureFlagNames.earnPooledStakingEnabled,
+  );
   const isStablecoinLendingEnabled = useSelector(
     selectStablecoinLendingEnabledFlag,
   );

--- a/app/components/UI/Stake/components/StakingBalance/StakingBalance.test.tsx
+++ b/app/components/UI/Stake/components/StakingBalance/StakingBalance.test.tsx
@@ -24,7 +24,7 @@ import { EARN_EXPERIENCES } from '../../../Earn/constants/experiences';
 import {
   useFeatureFlag,
   FeatureFlagNames,
-} from '../../../../../../components/hooks/useFeatureFlag';
+} from '../../../../../components/hooks/useFeatureFlag';
 import { TokenI } from '../../../Tokens/types';
 
 const mockEarnTokenPair = getMockUseEarnTokens(EARN_EXPERIENCES.POOLED_STAKING);
@@ -180,18 +180,22 @@ jest.mock('../../../../../core/Engine', () => ({
 }));
 
 jest.mock('../../../Earn/selectors/featureFlags', () => ({
+  selectPooledStakingEnabledFlag: jest.fn().mockReturnValue(true),
   selectStablecoinLendingEnabledFlag: jest.fn(),
   selectPooledStakingServiceInterruptionBannerEnabledFlag: jest
     .fn()
     .mockReturnValue(false),
 }));
 
-jest.mock('../../../../../../components/hooks/useFeatureFlag', () => ({
-  useFeatureFlag: jest.fn(),
-  FeatureFlagNames: {
-    earnPooledStakingEnabled: 'earnPooledStakingEnabled',
-  },
-}));
+jest.mock('../../../../../components/hooks/useFeatureFlag', () => {
+  const actual = jest.requireActual(
+    '../../../../../components/hooks/useFeatureFlag',
+  );
+  return {
+    ...actual,
+    useFeatureFlag: jest.fn(),
+  };
+});
 
 afterEach(() => {
   jest.clearAllMocks();

--- a/app/components/UI/Stake/components/StakingBalance/StakingBalance.tsx
+++ b/app/components/UI/Stake/components/StakingBalance/StakingBalance.tsx
@@ -49,7 +49,10 @@ import UnstakingBanner from './StakingBanners/UnstakeBanner/UnstakeBanner';
 import StakingButtons from './StakingButtons/StakingButtons';
 import StakingCta from './StakingCta/StakingCta';
 import { filterExitRequests } from './utils';
-import { selectPooledStakingEnabledFlag } from '../../../Earn/selectors/featureFlags';
+import {
+  useFeatureFlag,
+  FeatureFlagNames,
+} from '../../../../../components/hooks/useFeatureFlag';
 import PercentageChange from '../../../../../component-library/components-temp/Price/PercentageChange';
 import { useTokenPricePercentageChange } from '../../../Tokens/hooks/useTokenPricePercentageChange';
 import StakingEarnings from '../StakingEarnings';
@@ -70,7 +73,9 @@ const StakingBalanceContent = ({ asset }: StakingBalanceProps) => {
     selectNetworkConfigurationByChainId(state, asset.chainId as Hex),
   );
 
-  const isPooledStakingEnabled = useSelector(selectPooledStakingEnabledFlag);
+  const isPooledStakingEnabled = useFeatureFlag(
+    FeatureFlagNames.earnPooledStakingEnabled,
+  );
 
   const { isEligible: isEligibleForPooledStaking } = useStakingEligibility();
 

--- a/app/components/UI/Stake/components/StakingBalance/StakingButtons/StakingButtons.test.tsx
+++ b/app/components/UI/Stake/components/StakingBalance/StakingButtons/StakingButtons.test.tsx
@@ -77,8 +77,19 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 jest.mock('../../../../Earn/selectors/featureFlags', () => ({
+  selectPooledStakingEnabledFlag: jest.fn().mockReturnValue(true),
   selectStablecoinLendingEnabledFlag: jest.fn(),
 }));
+
+jest.mock('../../../../../../components/hooks/useFeatureFlag', () => {
+  const actual = jest.requireActual(
+    '../../../../../../components/hooks/useFeatureFlag',
+  );
+  return {
+    useFeatureFlag: jest.fn().mockReturnValue(true),
+    FeatureFlagNames: actual.FeatureFlagNames,
+  };
+});
 
 jest.mock('../../../../../../components/hooks/useFeatureFlag', () => ({
   useFeatureFlag: jest.fn(),

--- a/app/components/UI/Stake/components/StakingBalance/StakingButtons/StakingButtons.test.tsx
+++ b/app/components/UI/Stake/components/StakingBalance/StakingButtons/StakingButtons.test.tsx
@@ -16,18 +16,16 @@ import {
   ParamListBase,
 } from '@react-navigation/native';
 import { MOCK_ETH_MAINNET_ASSET } from '../../../__mocks__/stakeMockData';
-import {
-  selectPooledStakingEnabledFlag,
-  selectStablecoinLendingEnabledFlag,
-} from '../../../../Earn/selectors/featureFlags';
+import { selectStablecoinLendingEnabledFlag } from '../../../../Earn/selectors/featureFlags';
+import { useFeatureFlag } from '../../../../../../components/hooks/useFeatureFlag';
 import { TokenI } from '../../../../Tokens/types';
 import { EARN_EXPERIENCES } from '../../../../Earn/constants/experiences';
 import { getMockUseEarnTokens } from '../../../../Earn/__mocks__/earnMockData';
 
 const mockEarnTokenPair = getMockUseEarnTokens(EARN_EXPERIENCES.POOLED_STAKING);
 
-type MockSelectPooledStakingEnabledFlagSelector = jest.MockedFunction<
-  typeof selectPooledStakingEnabledFlag
+const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<
+  typeof useFeatureFlag
 >;
 
 const MOCK_APR_VALUES: { [symbol: string]: string } = {
@@ -79,8 +77,14 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 jest.mock('../../../../Earn/selectors/featureFlags', () => ({
-  selectPooledStakingEnabledFlag: jest.fn(),
   selectStablecoinLendingEnabledFlag: jest.fn(),
+}));
+
+jest.mock('../../../../../../components/hooks/useFeatureFlag', () => ({
+  useFeatureFlag: jest.fn(),
+  FeatureFlagNames: {
+    earnPooledStakingEnabled: 'earnPooledStakingEnabled',
+  },
 }));
 
 jest.mock('../../../../../../core/Engine', () => ({
@@ -141,9 +145,7 @@ describe('StakingButtons', () => {
       dispatch: jest.fn(),
     } as unknown as NavigationProp<ParamListBase>);
 
-    (
-      selectPooledStakingEnabledFlag as MockSelectPooledStakingEnabledFlagSelector
-    ).mockReturnValue(true);
+    mockUseFeatureFlag.mockReturnValue(true);
     (
       selectStablecoinLendingEnabledFlag as jest.MockedFunction<
         typeof selectStablecoinLendingEnabledFlag
@@ -166,9 +168,7 @@ describe('StakingButtons', () => {
   });
 
   it('should not render stake/stake more button if pooled staking is disabled', () => {
-    (
-      selectPooledStakingEnabledFlag as MockSelectPooledStakingEnabledFlagSelector
-    ).mockReturnValue(false);
+    mockUseFeatureFlag.mockReturnValue(false);
 
     const props = {
       style: {},

--- a/app/components/UI/Stake/components/StakingBalance/StakingButtons/StakingButtons.tsx
+++ b/app/components/UI/Stake/components/StakingBalance/StakingButtons/StakingButtons.tsx
@@ -44,7 +44,7 @@ const StakingButtons = ({
   const chainId = useSelector(selectEvmChainId);
   const isPooledStakingEnabled = useFeatureFlag(
     FeatureFlagNames.earnPooledStakingEnabled,
-  );
+  ) as boolean;
 
   const { isStakingSupportedChain } = useStakingChain();
 

--- a/app/components/UI/Stake/components/StakingBalance/StakingButtons/StakingButtons.tsx
+++ b/app/components/UI/Stake/components/StakingBalance/StakingButtons/StakingButtons.tsx
@@ -13,7 +13,10 @@ import { RootState } from '../../../../../../reducers';
 import { earnSelectors } from '../../../../../../selectors/earnController';
 import { selectEvmChainId } from '../../../../../../selectors/networkController';
 import { MetaMetricsEvents, useMetrics } from '../../../../../hooks/useMetrics';
-import { selectPooledStakingEnabledFlag } from '../../../../Earn/selectors/featureFlags';
+import {
+  useFeatureFlag,
+  FeatureFlagNames,
+} from '../../../../../../components/hooks/useFeatureFlag';
 import { TokenI } from '../../../../Tokens/types';
 import { EVENT_LOCATIONS } from '../../../constants/events';
 import useStakingChain from '../../../hooks/useStakingChain';
@@ -39,7 +42,9 @@ const StakingButtons = ({
   const { trackEvent, createEventBuilder } = useMetrics();
 
   const chainId = useSelector(selectEvmChainId);
-  const isPooledStakingEnabled = useSelector(selectPooledStakingEnabledFlag);
+  const isPooledStakingEnabled = useFeatureFlag(
+    FeatureFlagNames.earnPooledStakingEnabled,
+  );
 
   const { isStakingSupportedChain } = useStakingChain();
 

--- a/app/components/Views/ActivityView/index.js
+++ b/app/components/Views/ActivityView/index.js
@@ -52,8 +52,7 @@ import { useTheme } from '../../../util/theme';
 import TabBar from '../../Base/TabBar';
 import { getTransactionsNavbarOptions } from '../../UI/Navbar';
 import { createNetworkManagerNavDetails } from '../../UI/NetworkManager';
-import { selectPerpsEnabledFlag } from '../../UI/Perps';
-import { selectPredictEnabledFlag } from '../../UI/Predict/selectors/featureFlags';
+import { useFeatureFlag, FeatureFlagNames } from '../../hooks/useFeatureFlag';
 import PredictTransactionsView from '../../UI/Predict/views/PredictTransactionsView/PredictTransactionsView';
 import PerpsTransactionsView from '../../UI/Perps/Views/PerpsTransactionsView';
 import { PerpsConnectionProvider } from '../../UI/Perps/providers/PerpsConnectionProvider';
@@ -176,13 +175,17 @@ const ActivityView = () => {
 
   const tabViewRef = useRef();
   const params = useParams();
-  const perpsEnabledFlag = useSelector(selectPerpsEnabledFlag);
+  const perpsEnabledFlag = useFeatureFlag(
+    FeatureFlagNames.perpsPerpTradingEnabled,
+  );
   const isPerpsEnabled = useMemo(
     () => perpsEnabledFlag && isEvmSelected,
     [perpsEnabledFlag, isEvmSelected],
   );
   const [activeTabIndex, setActiveTabIndex] = useState(0);
-  const predictEnabledFlag = useSelector(selectPredictEnabledFlag);
+  const predictEnabledFlag = useFeatureFlag(
+    FeatureFlagNames.predictTradingEnabled,
+  );
   const isPredictEnabled = useMemo(
     () => predictEnabledFlag,
     [predictEnabledFlag],

--- a/app/components/Views/FeatureFlagOverride/FeatureFlagOverride.test.tsx
+++ b/app/components/Views/FeatureFlagOverride/FeatureFlagOverride.test.tsx
@@ -75,6 +75,18 @@ jest.mock('../../../util/feature-flags', () => ({
   isMinimumRequiredVersionSupported: jest.fn(),
 }));
 
+// Mock FeatureFlagNames to include testFlag for testing
+jest.mock('../../hooks/useFeatureFlag', () => {
+  const actual = jest.requireActual('../../hooks/useFeatureFlag');
+  return {
+    ...actual,
+    FeatureFlagNames: {
+      ...actual.FeatureFlagNames,
+      testFlag: 'testFlag',
+    },
+  };
+});
+
 describe('FeatureFlagOverride', () => {
   let mockNavigation: ReturnType<typeof useNavigation>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/app/components/Views/FeatureFlagOverride/FeatureFlagOverride.test.tsx
+++ b/app/components/Views/FeatureFlagOverride/FeatureFlagOverride.test.tsx
@@ -10,7 +10,6 @@ import {
   FeatureFlagInfo,
   isMinimumRequiredVersionSupported,
 } from '../../../util/feature-flags';
-import { FeatureFlagNames } from '../../hooks/useFeatureFlag';
 
 // Mock all dependencies
 jest.mock('@react-navigation/native', () => ({
@@ -659,7 +658,7 @@ describe('FeatureFlagOverride', () => {
       (isMinimumRequiredVersionSupported as jest.Mock).mockReturnValue(false);
 
       const versionFlag = createMockFeatureFlag(
-        FeatureFlagNames.rewardsEnabled,
+        'testFlag',
         'boolean with minimumVersion',
         {
           enabled: true,
@@ -787,13 +786,7 @@ describe('FeatureFlagOverride', () => {
         setOverride: jest.fn(),
         removeOverride: jest.fn(),
         clearAllOverrides: jest.fn(),
-        featureFlagsList: [
-          createMockFeatureFlag(
-            FeatureFlagNames.rewardsEnabled,
-            'boolean',
-            false,
-          ),
-        ],
+        featureFlagsList: [createMockFeatureFlag('testFlag', 'boolean', false)],
       });
 
       render(<FeatureFlagOverride />);

--- a/app/components/Views/Settings/DeveloperOptions/index.test.tsx
+++ b/app/components/Views/Settings/DeveloperOptions/index.test.tsx
@@ -1,15 +1,24 @@
 import { backgroundState } from '../../../../util/test/initial-root-state';
 import DeveloperOptions from './';
 import { renderScreen } from '../../../../util/test/renderWithProvider';
+import {
+  useFeatureFlag,
+  FeatureFlagNames,
+} from '../../../hooks/useFeatureFlag';
 
-const mockSelectPerpsEnabledFlag = jest.fn();
+const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<
+  typeof useFeatureFlag
+>;
 
-jest.mock('../../../UI/Perps/selectors/featureFlags', () => ({
-  selectPerpsEnabledFlag: () => mockSelectPerpsEnabledFlag(),
-}));
+jest.mock('../../../hooks/useFeatureFlag', () => {
+  const actual = jest.requireActual('../../../hooks/useFeatureFlag');
+  return {
+    ...actual,
+    useFeatureFlag: jest.fn(),
+  };
+});
 
 const initialState = {
-  DeveloperOptions: {},
   engine: {
     backgroundState,
   },
@@ -18,7 +27,12 @@ const initialState = {
 describe('DeveloperOptions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockSelectPerpsEnabledFlag.mockReturnValue(true);
+    mockUseFeatureFlag.mockImplementation((flagName) => {
+      if (flagName === FeatureFlagNames.perpsPerpTradingEnabled) {
+        return true;
+      }
+      return false;
+    });
   });
 
   it('renders correctly', () => {
@@ -31,7 +45,12 @@ describe('DeveloperOptions', () => {
   });
 
   it('does not render PerpsDeveloperOptionsSection when Perps is not enabled', () => {
-    mockSelectPerpsEnabledFlag.mockReturnValue(false);
+    mockUseFeatureFlag.mockImplementation((flagName) => {
+      if (flagName === FeatureFlagNames.perpsPerpTradingEnabled) {
+        return false;
+      }
+      return false;
+    });
 
     const { queryByText } = renderScreen(
       DeveloperOptions,

--- a/app/components/Views/Settings/DeveloperOptions/index.tsx
+++ b/app/components/Views/Settings/DeveloperOptions/index.tsx
@@ -30,7 +30,7 @@ const DeveloperOptions = () => {
 
   const isPerpsEnabled = useFeatureFlag(
     FeatureFlagNames.perpsPerpTradingEnabled,
-  );
+  ) as boolean;
 
   useEffect(
     () => {

--- a/app/components/Views/Settings/DeveloperOptions/index.tsx
+++ b/app/components/Views/Settings/DeveloperOptions/index.tsx
@@ -13,8 +13,10 @@ import SentryTest from './SentryTest';
 import SampleFeatureDevSettingsEntryPoint from '../../../../features/SampleFeature/components/views/SampleFeatureDevSettingsEntryPoint/SampleFeatureDevSettingsEntryPoint';
 ///: END:ONLY_INCLUDE_IF
 import { PerpsDeveloperOptionsSection } from '../../../UI/Perps/components/PerpsDeveloperOptionsSection/PerpsDeveloperOptionsSection';
-import { useSelector } from 'react-redux';
-import { selectPerpsEnabledFlag } from '../../../UI/Perps';
+import {
+  useFeatureFlag,
+  FeatureFlagNames,
+} from '../../../hooks/useFeatureFlag';
 import { ConfirmationsDeveloperOptions } from '../../confirmations/components/developer/confirmations-developer-options';
 
 const DeveloperOptions = () => {
@@ -26,7 +28,9 @@ const DeveloperOptions = () => {
   const { colors } = theme;
   const { styles } = useStyles(styleSheet, { theme });
 
-  const isPerpsEnabled = useSelector(selectPerpsEnabledFlag);
+  const isPerpsEnabled = useFeatureFlag(
+    FeatureFlagNames.perpsPerpTradingEnabled,
+  );
 
   useEffect(
     () => {

--- a/app/components/Views/TradeWalletActions/TradeWalletActions.test.tsx
+++ b/app/components/Views/TradeWalletActions/TradeWalletActions.test.tsx
@@ -14,14 +14,10 @@ import {
 } from '../../../util/test/accountsControllerTestUtils';
 import { backgroundState } from '../../../util/test/initial-root-state';
 import { mockNetworkState } from '../../../util/test/network';
-import {
-  selectPooledStakingEnabledFlag,
-  selectStablecoinLendingEnabledFlag,
-} from '../../UI/Earn/selectors/featureFlags';
+import { selectStablecoinLendingEnabledFlag } from '../../UI/Earn/selectors/featureFlags';
 import { EarnTokenDetails } from '../../UI/Earn/types/lending.types';
-import { selectPerpsEnabledFlag } from '../../UI/Perps';
 import { selectIsFirstTimePerpsUser } from '../../UI/Perps/selectors/perpsController';
-import { selectPredictEnabledFlag } from '../../UI/Predict';
+import { useFeatureFlag, FeatureFlagNames } from '../../hooks/useFeatureFlag';
 import { selectIsEvmNetworkSelected } from '../../../selectors/multichainNetworkController';
 import TradeWalletActions from './TradeWalletActions';
 
@@ -29,21 +25,21 @@ jest.mock('react-native-device-info', () => ({
   getVersion: jest.fn().mockReturnValue('1.0.0'),
 }));
 
-jest.mock('../../UI/Perps', () => ({
-  selectPerpsEnabledFlag: jest.fn(),
-}));
-
 jest.mock('../../UI/Perps/selectors/perpsController', () => ({
   selectIsFirstTimePerpsUser: jest.fn(),
 }));
 
-jest.mock('../../UI/Predict', () => ({
-  selectPredictEnabledFlag: jest.fn(),
-}));
-
 jest.mock('../../UI/Earn/selectors/featureFlags', () => ({
   selectStablecoinLendingEnabledFlag: jest.fn(),
-  selectPooledStakingEnabledFlag: jest.fn(),
+}));
+
+jest.mock('../../hooks/useFeatureFlag', () => ({
+  useFeatureFlag: jest.fn(),
+  FeatureFlagNames: {
+    perpsPerpTradingEnabled: 'perpsPerpTradingEnabled',
+    predictTradingEnabled: 'predictTradingEnabled',
+    earnPooledStakingEnabled: 'earnPooledStakingEnabled',
+  },
 }));
 
 jest.mock('../../../selectors/earnController/earn', () => ({
@@ -248,6 +244,10 @@ const mockInitialState: DeepPartial<RootState> = {
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
 
+const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<
+  typeof useFeatureFlag
+>;
+
 jest.mock('@react-navigation/native', () => {
   const actualReactNavigation = jest.requireActual('@react-navigation/native');
   return {
@@ -361,11 +361,12 @@ describe('TradeWalletActions', () => {
         typeof selectStablecoinLendingEnabledFlag
       >
     ).mockReturnValue(true);
-    (
-      selectPooledStakingEnabledFlag as jest.MockedFunction<
-        typeof selectPooledStakingEnabledFlag
-      >
-    ).mockReturnValue(false);
+    mockUseFeatureFlag.mockImplementation((flagName) => {
+      if (flagName === FeatureFlagNames.earnPooledStakingEnabled) {
+        return false;
+      }
+      return false;
+    });
 
     (
       earnSelectors.selectEarnTokens as jest.MockedFunction<
@@ -408,11 +409,12 @@ describe('TradeWalletActions', () => {
   });
 
   it('should render the Perpetuals button if the Perps feature flag is enabled', () => {
-    (
-      selectPerpsEnabledFlag as jest.MockedFunction<
-        typeof selectPerpsEnabledFlag
-      >
-    ).mockReturnValue(true);
+    mockUseFeatureFlag.mockImplementation((flagName) => {
+      if (flagName === FeatureFlagNames.perpsPerpTradingEnabled) {
+        return true;
+      }
+      return false;
+    });
 
     const { getByTestId } = renderScreen(
       TradeWalletActions,
@@ -430,11 +432,12 @@ describe('TradeWalletActions', () => {
   });
 
   it('should render the Predict button if the Predict feature flag is enabled', () => {
-    (
-      selectPredictEnabledFlag as jest.MockedFunction<
-        typeof selectPredictEnabledFlag
-      >
-    ).mockReturnValue(true);
+    mockUseFeatureFlag.mockImplementation((flagName) => {
+      if (flagName === FeatureFlagNames.predictTradingEnabled) {
+        return true;
+      }
+      return false;
+    });
 
     const { getByTestId } = renderScreen(
       TradeWalletActions,
@@ -452,11 +455,12 @@ describe('TradeWalletActions', () => {
   });
 
   it('should set up perps navigation to markets for returning users', () => {
-    (
-      selectPerpsEnabledFlag as jest.MockedFunction<
-        typeof selectPerpsEnabledFlag
-      >
-    ).mockReturnValue(true);
+    mockUseFeatureFlag.mockImplementation((flagName) => {
+      if (flagName === FeatureFlagNames.perpsPerpTradingEnabled) {
+        return true;
+      }
+      return false;
+    });
     (
       selectIsFirstTimePerpsUser as jest.MockedFunction<
         typeof selectIsFirstTimePerpsUser
@@ -483,11 +487,12 @@ describe('TradeWalletActions', () => {
   });
 
   it('should set up perps navigation to tutorial for first-time users', () => {
-    (
-      selectPerpsEnabledFlag as jest.MockedFunction<
-        typeof selectPerpsEnabledFlag
-      >
-    ).mockReturnValue(true);
+    mockUseFeatureFlag.mockImplementation((flagName) => {
+      if (flagName === FeatureFlagNames.perpsPerpTradingEnabled) {
+        return true;
+      }
+      return false;
+    });
     (
       selectIsFirstTimePerpsUser as jest.MockedFunction<
         typeof selectIsFirstTimePerpsUser
@@ -510,11 +515,12 @@ describe('TradeWalletActions', () => {
   });
 
   it.skip('should navigate to Predict markets when user presses Predict button', async () => {
-    (
-      selectPredictEnabledFlag as jest.MockedFunction<
-        typeof selectPredictEnabledFlag
-      >
-    ).mockReturnValue(true);
+    mockUseFeatureFlag.mockImplementation((flagName) => {
+      if (flagName === FeatureFlagNames.predictTradingEnabled) {
+        return true;
+      }
+      return false;
+    });
 
     const { getByTestId } = renderScreen(
       TradeWalletActions,
@@ -551,21 +557,16 @@ describe('TradeWalletActions', () => {
         typeof selectStablecoinLendingEnabledFlag
       >
     ).mockReturnValue(true);
-    (
-      selectPooledStakingEnabledFlag as jest.MockedFunction<
-        typeof selectPooledStakingEnabledFlag
-      >
-    ).mockReturnValue(true);
-    (
-      selectPerpsEnabledFlag as jest.MockedFunction<
-        typeof selectPerpsEnabledFlag
-      >
-    ).mockReturnValue(true);
-    (
-      selectPredictEnabledFlag as jest.MockedFunction<
-        typeof selectPredictEnabledFlag
-      >
-    ).mockReturnValue(true);
+    mockUseFeatureFlag.mockImplementation((flagName) => {
+      if (
+        flagName === FeatureFlagNames.earnPooledStakingEnabled ||
+        flagName === FeatureFlagNames.perpsPerpTradingEnabled ||
+        flagName === FeatureFlagNames.predictTradingEnabled
+      ) {
+        return true;
+      }
+      return false;
+    });
     (selectCanSignTransactions as unknown as jest.Mock).mockReturnValue(false);
 
     const mockStateWithoutSigningAndStablecoinLendingEnabled: DeepPartial<RootState> =
@@ -627,12 +628,13 @@ describe('TradeWalletActions', () => {
     expect(mockOnDismiss).not.toHaveBeenCalled();
   });
 
-  it('should show Predict button on non-EVM networks', () => {
-    (
-      selectPredictEnabledFlag as jest.MockedFunction<
-        typeof selectPredictEnabledFlag
-      >
-    ).mockReturnValue(true);
+  it('should not show Predict button on non-EVM networks', () => {
+    mockUseFeatureFlag.mockImplementation((flagName) => {
+      if (flagName === FeatureFlagNames.predictTradingEnabled) {
+        return true;
+      }
+      return false;
+    });
     (
       selectIsEvmNetworkSelected as jest.MockedFunction<
         typeof selectIsEvmNetworkSelected

--- a/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
+++ b/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
@@ -92,10 +92,10 @@ function TradeWalletActions() {
   const canSignTransactions = useSelector(selectCanSignTransactions);
   const isPerpsEnabled = useFeatureFlag(
     FeatureFlagNames.perpsPerpTradingEnabled,
-  );
+  ) as boolean;
   const isPredictEnabled = useFeatureFlag(
     FeatureFlagNames.predictTradingEnabled,
-  );
+  ) as boolean;
   const isEvmSelected = useSelector(selectIsEvmNetworkSelected);
 
   const isStablecoinLendingEnabled = useSelector(

--- a/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
+++ b/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
@@ -42,12 +42,8 @@ import {
   useSwapBridgeNavigation,
 } from '../../UI/Bridge/hooks/useSwapBridgeNavigation';
 import { EARN_INPUT_VIEW_ACTIONS } from '../../UI/Earn/Views/EarnInputView/EarnInputView.types';
-import {
-  selectPooledStakingEnabledFlag,
-  selectStablecoinLendingEnabledFlag,
-} from '../../UI/Earn/selectors/featureFlags';
-import { selectPerpsEnabledFlag } from '../../UI/Perps';
-import { selectPredictEnabledFlag } from '../../UI/Predict';
+import { selectStablecoinLendingEnabledFlag } from '../../UI/Earn/selectors/featureFlags';
+import { useFeatureFlag, FeatureFlagNames } from '../../hooks/useFeatureFlag';
 import { PredictEventValues } from '../../UI/Predict/constants/eventNames';
 import { EVENT_LOCATIONS as STAKE_EVENT_LOCATIONS } from '../../UI/Stake/constants/events';
 import { MetaMetricsEvents, useMetrics } from '../../hooks/useMetrics';
@@ -86,14 +82,20 @@ function TradeWalletActions() {
   const isSwapsEnabled = useSelector((state: RootState) =>
     selectIsSwapsEnabled(state),
   );
-  const isPooledStakingEnabled = useSelector(selectPooledStakingEnabledFlag);
+  const isPooledStakingEnabled = useFeatureFlag(
+    FeatureFlagNames.earnPooledStakingEnabled,
+  );
 
   const { trackEvent, createEventBuilder } = useMetrics();
   const navigation = useNavigation();
 
   const canSignTransactions = useSelector(selectCanSignTransactions);
-  const isPerpsEnabled = useSelector(selectPerpsEnabledFlag);
-  const isPredictEnabled = useSelector(selectPredictEnabledFlag);
+  const isPerpsEnabled = useFeatureFlag(
+    FeatureFlagNames.perpsPerpTradingEnabled,
+  );
+  const isPredictEnabled = useFeatureFlag(
+    FeatureFlagNames.predictTradingEnabled,
+  );
   const isEvmSelected = useSelector(selectIsEvmNetworkSelected);
 
   const isStablecoinLendingEnabled = useSelector(

--- a/app/components/Views/Wallet/index.test.tsx
+++ b/app/components/Views/Wallet/index.test.tsx
@@ -50,25 +50,33 @@ jest.mock(
   }),
 );
 
-// Mock the Perps feature flag selector - will be controlled per test
+// Mock the Perps feature flag - will be controlled per test
 let mockPerpsEnabled = true;
 let mockPerpsGTMModalEnabled = false;
 jest.mock('../../UI/Perps/selectors/featureFlags', () => ({
-  selectPerpsEnabledFlag: jest.fn(() => mockPerpsEnabled),
   selectPerpsServiceInterruptionBannerEnabledFlag: jest.fn(() => false),
   selectPerpsGtmOnboardingModalEnabledFlag: jest.fn(
     () => mockPerpsGTMModalEnabled,
   ),
 }));
 
-// Mock the Predict feature flag selector - will be controlled per test
+// Mock the Predict feature flag - will be controlled per test
 let mockPredictEnabled = true;
 let mockPredictGTMModalEnabled = false;
 jest.mock('../../UI/Predict/selectors/featureFlags', () => ({
-  selectPredictEnabledFlag: jest.fn(() => mockPredictEnabled),
   selectPredictGtmOnboardingModalEnabledFlag: jest.fn(
     () => mockPredictGTMModalEnabled,
   ),
+}));
+
+// Mock useFeatureFlag hook
+jest.mock('../../hooks/useFeatureFlag', () => ({
+  useFeatureFlag: jest.fn(),
+  FeatureFlagNames: {
+    perpsPerpTradingEnabled: 'perpsPerpTradingEnabled',
+    predictTradingEnabled: 'predictTradingEnabled',
+    carouselBanners: 'carouselBanners',
+  },
 }));
 
 // Create shared mock reference for TabsList
@@ -102,6 +110,7 @@ import { MOCK_ACCOUNTS_CONTROLLER_STATE } from '../../../util/test/accountsContr
 import { WalletViewSelectorsIDs } from '../../../../e2e/selectors/wallet/WalletView.selectors';
 import Engine from '../../../core/Engine';
 import { useSelector } from 'react-redux';
+import { useFeatureFlag, FeatureFlagNames } from '../../hooks/useFeatureFlag';
 import { mockedPerpsFeatureFlagsEnabledState } from '../../UI/Perps/mocks/remoteFeatureFlagMocks';
 import { initialState as cardInitialState } from '../../../core/redux/slices/card';
 import { NavigationProp, ParamListBase } from '@react-navigation/native';
@@ -1069,6 +1078,23 @@ describe('Wallet', () => {
       mockPerpsGTMModalEnabled = false;
       mockPredictEnabled = true;
       mockPredictGTMModalEnabled = false;
+
+      // Set up useFeatureFlag mock
+      const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<
+        typeof useFeatureFlag
+      >;
+      mockUseFeatureFlag.mockImplementation((flagName) => {
+        if (flagName === FeatureFlagNames.perpsPerpTradingEnabled) {
+          return mockPerpsEnabled;
+        }
+        if (flagName === FeatureFlagNames.predictTradingEnabled) {
+          return mockPredictEnabled;
+        }
+        if (flagName === FeatureFlagNames.carouselBanners) {
+          return true; // Default to enabled
+        }
+        return false;
+      });
     });
 
     afterEach(() => {

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -170,19 +170,13 @@ import {
   useNetworksByNamespace,
 } from '../../hooks/useNetworksByNamespace/useNetworksByNamespace';
 import { useNetworkSelection } from '../../hooks/useNetworkSelection/useNetworkSelection';
-import {
-  selectPerpsEnabledFlag,
-  selectPerpsGtmOnboardingModalEnabledFlag,
-} from '../../UI/Perps';
+import { selectPerpsGtmOnboardingModalEnabledFlag } from '../../UI/Perps';
 import PerpsTabView from '../../UI/Perps/Views/PerpsTabView';
-import {
-  selectPredictEnabledFlag,
-  selectPredictGtmOnboardingModalEnabledFlag,
-} from '../../UI/Predict/selectors/featureFlags';
+import { selectPredictGtmOnboardingModalEnabledFlag } from '../../UI/Predict/selectors/featureFlags';
 import PredictTabView from '../../UI/Predict/views/PredictTabView';
 import { InitSendLocation } from '../confirmations/constants/send';
 import { useSendNavigation } from '../confirmations/hooks/useSendNavigation';
-import { selectCarouselBannersFlag } from '../../UI/Carousel/selectors/featureFlags';
+import { useFeatureFlag, FeatureFlagNames } from '../../hooks/useFeatureFlag';
 import { SolScope } from '@metamask/keyring-api';
 import { selectSelectedInternalAccountByScope } from '../../../selectors/multichainAccounts/accounts';
 import { EVM_SCOPE } from '../../UI/Earn/constants/networks';
@@ -247,7 +241,9 @@ interface WalletTokensTabViewProps {
 }
 
 const WalletTokensTabView = React.memo((props: WalletTokensTabViewProps) => {
-  const isPerpsFlagEnabled = useSelector(selectPerpsEnabledFlag);
+  const isPerpsFlagEnabled = useFeatureFlag(
+    FeatureFlagNames.perpsPerpTradingEnabled,
+  );
   const isEvmSelected = useSelector(selectIsEvmNetworkSelected);
   const isMultichainAccountsState2Enabled = useSelector(
     selectMultichainAccountsState2Enabled,
@@ -261,7 +257,9 @@ const WalletTokensTabView = React.memo((props: WalletTokensTabViewProps) => {
       (isEvmSelected || isMultichainAccountsState2Enabled),
     [isPerpsFlagEnabled, isEvmSelected, isMultichainAccountsState2Enabled],
   );
-  const isPredictFlagEnabled = useSelector(selectPredictEnabledFlag);
+  const isPredictFlagEnabled = useFeatureFlag(
+    FeatureFlagNames.predictTradingEnabled,
+  );
   const isPredictEnabled = useMemo(
     () => isPredictFlagEnabled,
     [isPredictFlagEnabled],
@@ -515,12 +513,16 @@ const Wallet = ({
   const walletRef = useRef(null);
   const theme = useTheme();
 
-  const isPerpsFlagEnabled = useSelector(selectPerpsEnabledFlag);
+  const isPerpsFlagEnabled = useFeatureFlag(
+    FeatureFlagNames.perpsPerpTradingEnabled,
+  );
   const isPerpsGTMModalEnabled = useSelector(
     selectPerpsGtmOnboardingModalEnabledFlag,
   );
 
-  const isPredictFlagEnabled = useSelector(selectPredictEnabledFlag);
+  const isPredictFlagEnabled = useFeatureFlag(
+    FeatureFlagNames.predictTradingEnabled,
+  );
   const isPredictGTMModalEnabled = useSelector(
     selectPredictGtmOnboardingModalEnabledFlag,
   );
@@ -955,7 +957,9 @@ const Wallet = ({
   const isTokenDetectionEnabled = useSelector(selectUseTokenDetection);
   const isPopularNetworks = useSelector(selectIsPopularNetwork);
   const detectedTokens = useSelector(selectDetectedTokens) as TokenI[];
-  const isCarouselBannersEnabled = useSelector(selectCarouselBannersFlag);
+  const isCarouselBannersEnabled = useFeatureFlag(
+    FeatureFlagNames.carouselBanners,
+  );
 
   const allDetectedTokens = useSelector(
     selectAllDetectedTokensFlat,

--- a/app/components/Views/WalletActions/WalletActions.test.tsx
+++ b/app/components/Views/WalletActions/WalletActions.test.tsx
@@ -14,35 +14,31 @@ import {
 } from '../../../util/test/accountsControllerTestUtils';
 import { backgroundState } from '../../../util/test/initial-root-state';
 import { mockNetworkState } from '../../../util/test/network';
-import {
-  selectPooledStakingEnabledFlag,
-  selectStablecoinLendingEnabledFlag,
-} from '../../UI/Earn/selectors/featureFlags';
+import { selectStablecoinLendingEnabledFlag } from '../../UI/Earn/selectors/featureFlags';
 import { EarnTokenDetails } from '../../UI/Earn/types/lending.types';
 import WalletActions from './WalletActions';
-import { selectPerpsEnabledFlag } from '../../UI/Perps';
 import { selectIsFirstTimePerpsUser } from '../../UI/Perps/selectors/perpsController';
-import { selectPredictEnabledFlag } from '../../UI/Predict/selectors/featureFlags';
+import { useFeatureFlag, FeatureFlagNames } from '../../hooks/useFeatureFlag';
 
 jest.mock('react-native-device-info', () => ({
   getVersion: jest.fn().mockReturnValue('1.0.0'),
-}));
-
-jest.mock('../../UI/Perps', () => ({
-  selectPerpsEnabledFlag: jest.fn(),
 }));
 
 jest.mock('../../UI/Perps/selectors/perpsController', () => ({
   selectIsFirstTimePerpsUser: jest.fn(),
 }));
 
-jest.mock('../../UI/Predict/selectors/featureFlags', () => ({
-  selectPredictEnabledFlag: jest.fn(),
-}));
-
 jest.mock('../../UI/Earn/selectors/featureFlags', () => ({
   selectStablecoinLendingEnabledFlag: jest.fn(),
-  selectPooledStakingEnabledFlag: jest.fn(),
+}));
+
+jest.mock('../../hooks/useFeatureFlag', () => ({
+  useFeatureFlag: jest.fn(),
+  FeatureFlagNames: {
+    perpsPerpTradingEnabled: 'perpsPerpTradingEnabled',
+    predictTradingEnabled: 'predictTradingEnabled',
+    earnPooledStakingEnabled: 'earnPooledStakingEnabled',
+  },
 }));
 
 jest.mock('../../../selectors/earnController/earn', () => ({
@@ -243,6 +239,10 @@ const mockInitialState: DeepPartial<RootState> = {
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
 
+const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<
+  typeof useFeatureFlag
+>;
+
 jest.mock('@react-navigation/native', () => {
   const actualReactNavigation = jest.requireActual('@react-navigation/native');
   return {
@@ -271,6 +271,8 @@ describe('WalletActions', () => {
   beforeEach(() => {
     // Clear all mocks first for test isolation
     jest.clearAllMocks();
+    // Default mock: all feature flags disabled
+    mockUseFeatureFlag.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -364,11 +366,12 @@ describe('WalletActions', () => {
         typeof selectStablecoinLendingEnabledFlag
       >
     ).mockReturnValue(true);
-    (
-      selectPooledStakingEnabledFlag as jest.MockedFunction<
-        typeof selectPooledStakingEnabledFlag
-      >
-    ).mockReturnValue(false);
+    mockUseFeatureFlag.mockImplementation((flagName) => {
+      if (flagName === FeatureFlagNames.earnPooledStakingEnabled) {
+        return false;
+      }
+      return false;
+    });
 
     (
       earnSelectors.selectEarnTokens as jest.MockedFunction<
@@ -405,11 +408,12 @@ describe('WalletActions', () => {
   });
 
   it('should render the Perpetuals button if the Perps feature flag is enabled', () => {
-    (
-      selectPerpsEnabledFlag as jest.MockedFunction<
-        typeof selectPerpsEnabledFlag
-      >
-    ).mockReturnValue(true);
+    mockUseFeatureFlag.mockImplementation((flagName) => {
+      if (flagName === FeatureFlagNames.perpsPerpTradingEnabled) {
+        return true;
+      }
+      return false;
+    });
 
     const { getByTestId } = renderWithProvider(<WalletActions />, {
       state: mockInitialState,
@@ -421,11 +425,12 @@ describe('WalletActions', () => {
   });
 
   it('should navigate to Perps markets when returning user presses Perpetuals button', async () => {
-    (
-      selectPerpsEnabledFlag as jest.MockedFunction<
-        typeof selectPerpsEnabledFlag
-      >
-    ).mockReturnValue(true);
+    mockUseFeatureFlag.mockImplementation((flagName) => {
+      if (flagName === FeatureFlagNames.perpsPerpTradingEnabled) {
+        return true;
+      }
+      return false;
+    });
     (
       selectIsFirstTimePerpsUser as jest.MockedFunction<
         typeof selectIsFirstTimePerpsUser
@@ -453,11 +458,12 @@ describe('WalletActions', () => {
   });
 
   it('should navigate to Perps tutorial when first-time user presses Perpetuals button', async () => {
-    (
-      selectPerpsEnabledFlag as jest.MockedFunction<
-        typeof selectPerpsEnabledFlag
-      >
-    ).mockReturnValue(true);
+    mockUseFeatureFlag.mockImplementation((flagName) => {
+      if (flagName === FeatureFlagNames.perpsPerpTradingEnabled) {
+        return true;
+      }
+      return false;
+    });
     (
       selectIsFirstTimePerpsUser as jest.MockedFunction<
         typeof selectIsFirstTimePerpsUser
@@ -480,11 +486,12 @@ describe('WalletActions', () => {
   });
 
   it('should render the Predict button if the Predict feature flag is enabled', () => {
-    (
-      selectPredictEnabledFlag as jest.MockedFunction<
-        typeof selectPredictEnabledFlag
-      >
-    ).mockReturnValue(true);
+    mockUseFeatureFlag.mockImplementation((flagName) => {
+      if (flagName === FeatureFlagNames.predictTradingEnabled) {
+        return true;
+      }
+      return false;
+    });
 
     const { getByTestId } = renderWithProvider(<WalletActions />, {
       state: mockInitialState,
@@ -496,11 +503,12 @@ describe('WalletActions', () => {
   });
 
   it('should call the onPredict function when the Predict button is pressed', async () => {
-    (
-      selectPredictEnabledFlag as jest.MockedFunction<
-        typeof selectPredictEnabledFlag
-      >
-    ).mockReturnValue(true);
+    mockUseFeatureFlag.mockImplementation((flagName) => {
+      if (flagName === FeatureFlagNames.predictTradingEnabled) {
+        return true;
+      }
+      return false;
+    });
 
     const { getByTestId } = renderWithProvider(<WalletActions />, {
       state: mockInitialState,
@@ -528,21 +536,16 @@ describe('WalletActions', () => {
         typeof selectStablecoinLendingEnabledFlag
       >
     ).mockReturnValue(true);
-    (
-      selectPooledStakingEnabledFlag as jest.MockedFunction<
-        typeof selectPooledStakingEnabledFlag
-      >
-    ).mockReturnValue(true);
-    (
-      selectPerpsEnabledFlag as jest.MockedFunction<
-        typeof selectPerpsEnabledFlag
-      >
-    ).mockReturnValue(true);
-    (
-      selectPredictEnabledFlag as jest.MockedFunction<
-        typeof selectPredictEnabledFlag
-      >
-    ).mockReturnValue(true);
+    mockUseFeatureFlag.mockImplementation((flagName) => {
+      if (
+        flagName === FeatureFlagNames.earnPooledStakingEnabled ||
+        flagName === FeatureFlagNames.perpsPerpTradingEnabled ||
+        flagName === FeatureFlagNames.predictTradingEnabled
+      ) {
+        return true;
+      }
+      return false;
+    });
     (selectCanSignTransactions as unknown as jest.Mock).mockReturnValue(false);
 
     // Import and mock selectIsSwapsEnabled to return false when can't sign

--- a/app/components/Views/WalletActions/WalletActions.tsx
+++ b/app/components/Views/WalletActions/WalletActions.tsx
@@ -24,13 +24,9 @@ import styleSheet from './WalletActions.styles';
 import { useMetrics } from '../../../components/hooks/useMetrics';
 import { selectCanSignTransactions } from '../../../selectors/accountsController';
 import { EVENT_LOCATIONS as STAKE_EVENT_LOCATIONS } from '../../UI/Stake/constants/events';
-import {
-  selectPooledStakingEnabledFlag,
-  selectStablecoinLendingEnabledFlag,
-} from '../../UI/Earn/selectors/featureFlags';
-import { selectPerpsEnabledFlag } from '../../UI/Perps';
+import { selectStablecoinLendingEnabledFlag } from '../../UI/Earn/selectors/featureFlags';
 import { PerpsEventValues } from '../../UI/Perps/constants/eventNames';
-import { selectPredictEnabledFlag } from '../../UI/Predict/selectors/featureFlags';
+import { useFeatureFlag, FeatureFlagNames } from '../../hooks/useFeatureFlag';
 import { PredictEventValues } from '../../UI/Predict/constants/eventNames';
 import { EARN_INPUT_VIEW_ACTIONS } from '../../UI/Earn/Views/EarnInputView/EarnInputView.types';
 import { earnSelectors } from '../../../selectors/earnController/earn';
@@ -47,7 +43,9 @@ const WalletActions = () => {
   const { styles } = useStyles(styleSheet, {});
   const sheetRef = useRef<BottomSheetRef>(null);
   const { navigate } = useNavigation();
-  const isPooledStakingEnabled = useSelector(selectPooledStakingEnabledFlag);
+  const isPooledStakingEnabled = useFeatureFlag(
+    FeatureFlagNames.earnPooledStakingEnabled,
+  );
   const { earnTokens } = useSelector(earnSelectors.selectEarnTokens);
 
   const isFirstTimePerpsUser = useSelector(selectIsFirstTimePerpsUser);
@@ -58,8 +56,12 @@ const WalletActions = () => {
   const isSwapsEnabled = useSelector((state: RootState) =>
     selectIsSwapsEnabled(state),
   );
-  const isPerpsEnabled = useSelector(selectPerpsEnabledFlag);
-  const isPredictEnabled = useSelector(selectPredictEnabledFlag);
+  const isPerpsEnabled = useFeatureFlag(
+    FeatureFlagNames.perpsPerpTradingEnabled,
+  );
+  const isPredictEnabled = useFeatureFlag(
+    FeatureFlagNames.predictTradingEnabled,
+  );
   const isEvmSelected = useSelector(selectIsEvmNetworkSelected);
   const { trackEvent, createEventBuilder } = useMetrics();
   const canSignTransactions = useSelector(selectCanSignTransactions);

--- a/app/components/Views/WalletActions/WalletActions.tsx
+++ b/app/components/Views/WalletActions/WalletActions.tsx
@@ -58,10 +58,10 @@ const WalletActions = () => {
   );
   const isPerpsEnabled = useFeatureFlag(
     FeatureFlagNames.perpsPerpTradingEnabled,
-  );
+  ) as boolean;
   const isPredictEnabled = useFeatureFlag(
     FeatureFlagNames.predictTradingEnabled,
-  );
+  ) as boolean;
   const isEvmSelected = useSelector(selectIsEvmNetworkSelected);
   const { trackEvent, createEventBuilder } = useMetrics();
   const canSignTransactions = useSelector(selectCanSignTransactions);

--- a/app/components/hooks/useFeatureFlag.ts
+++ b/app/components/hooks/useFeatureFlag.ts
@@ -3,8 +3,18 @@ import { useFeatureFlagOverride } from '../../contexts/FeatureFlagOverrideContex
 import { selectBasicFunctionalityEnabled } from '../../selectors/settings';
 
 export enum FeatureFlagNames {
-  rewardsEnabled = 'rewardsEnabled',
   otaUpdatesEnabled = 'otaUpdatesEnabled',
+  rewardsEnableCardSpend = 'rewardsEnableCardSpend',
+  rewardsEnableMusdDeposit = 'rewardsEnableMusdDeposit',
+  cardFeature = 'cardFeature', //remote config
+  sampleFeatureCounterEnabled = 'sampleFeatureCounterEnabled',
+  bridgeConfigV2 = 'bridgeConfigV2', //remote config
+  depositConfig = 'depositConfig', //remote config
+  earnPooledStakingEnabled = 'earnPooledStakingEnabled',
+  predictTradingEnabled = 'predictTradingEnabled',
+  perpsPerpTradingEnabled = 'perpsPerpTradingEnabled',
+  confirmationsPay = 'confirmations_pay', //remote config
+  carouselBanners = 'carouselBanners',
 }
 
 export const useFeatureFlag = (key: FeatureFlagNames) => {

--- a/app/features/SampleFeature/components/views/SampleFeature.test.tsx
+++ b/app/features/SampleFeature/components/views/SampleFeature.test.tsx
@@ -3,7 +3,7 @@ import { View } from 'react-native';
 import renderWithProvider from '../../../../util/test/renderWithProvider';
 import SampleFeature from './SampleFeature';
 import initialRootState from '../../../../util/test/initial-root-state';
-import { selectSampleFeatureCounterEnabled } from '../../selectors/sampleFeatureCounter';
+import { useFeatureFlag } from '../../../../components/hooks/useFeatureFlag';
 
 /**
  * Mock implementation for react-native Linking module
@@ -16,10 +16,13 @@ jest.mock('react-native/Libraries/Linking/Linking', () => ({
 }));
 
 /**
- * Mock the feature flag selector to control test scenarios
+ * Mock the feature flag hook to control test scenarios
  */
-jest.mock('../../selectors/sampleFeatureCounter', () => ({
-  selectSampleFeatureCounterEnabled: jest.fn(),
+jest.mock('../../../../components/hooks/useFeatureFlag', () => ({
+  useFeatureFlag: jest.fn(),
+  FeatureFlagNames: {
+    sampleFeatureCounterEnabled: 'sampleFeatureCounterEnabled',
+  },
 }));
 
 /**
@@ -51,10 +54,9 @@ jest.mock('./SamplePetNames/SamplePetNames', () => ({
  * @group SampleFeature
  */
 describe('SampleFeature', () => {
-  const mockSelectSampleFeatureCounterEnabled =
-    selectSampleFeatureCounterEnabled as jest.MockedFunction<
-      typeof selectSampleFeatureCounterEnabled
-    >;
+  const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<
+    typeof useFeatureFlag
+  >;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -67,7 +69,7 @@ describe('SampleFeature', () => {
    */
   it('matches rendered snapshot when feature flag is enabled', () => {
     // Arrange
-    mockSelectSampleFeatureCounterEnabled.mockReturnValue(true);
+    mockUseFeatureFlag.mockReturnValue(true);
 
     // Act
     const { toJSON } = renderWithProvider(<SampleFeature />, {
@@ -85,7 +87,7 @@ describe('SampleFeature', () => {
    */
   it('matches rendered snapshot when feature flag is disabled', () => {
     // Arrange
-    mockSelectSampleFeatureCounterEnabled.mockReturnValue(false);
+    mockUseFeatureFlag.mockReturnValue(false);
 
     // Act
     const { toJSON } = renderWithProvider(<SampleFeature />, {

--- a/app/features/SampleFeature/components/views/SampleFeature.tsx
+++ b/app/features/SampleFeature/components/views/SampleFeature.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
 
 import { strings } from '../../../../../locales/i18n';
 import Text, {
@@ -14,7 +13,10 @@ import { useStyles } from '../../../../component-library/hooks';
 import styleSheet from './SampleFeature.styles';
 import { baseStyles } from '../../../../styles/common';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
-import { selectSampleFeatureCounterEnabled } from '../../selectors/sampleFeatureCounter';
+import {
+  useFeatureFlag,
+  FeatureFlagNames,
+} from '../../../../components/hooks/useFeatureFlag';
 
 /**
  * SampleFeature Component
@@ -44,7 +46,9 @@ import { selectSampleFeatureCounterEnabled } from '../../selectors/sampleFeature
 const SampleFeature = () => {
   const { styles } = useStyles(styleSheet, {});
   const { networkName, networkImageSource } = useSampleNetwork();
-  const isCounterEnabled = useSelector(selectSampleFeatureCounterEnabled);
+  const isCounterEnabled = useFeatureFlag(
+    FeatureFlagNames.sampleFeatureCounterEnabled,
+  );
 
   return (
     <KeyboardAwareScrollView

--- a/app/features/SampleFeature/components/views/SampleFeature.tsx
+++ b/app/features/SampleFeature/components/views/SampleFeature.tsx
@@ -48,7 +48,7 @@ const SampleFeature = () => {
   const { networkName, networkImageSource } = useSampleNetwork();
   const isCounterEnabled = useFeatureFlag(
     FeatureFlagNames.sampleFeatureCounterEnabled,
-  );
+  ) as boolean;
 
   return (
     <KeyboardAwareScrollView


### PR DESCRIPTION
## **Description**

This PR migrates whitelisted feature flags from the old selector-based pattern to the new `useFeatureFlag` hook architecture. This aligns with the project's feature flag guidelines that require using the hook instead of creating feature flag selectors.

**Reason for change:**
- The codebase has standardized on using the `useFeatureFlag` hook for feature flag access
- The old pattern of using selectors (`selectPooledStakingEnabledFlag`, `selectPerpsEnabledFlag`, `selectPredictEnabledFlag`) violates the current feature flag guidelines
- Migrating to the hook pattern provides better consistency, maintainability, and supports the feature flag override functionality

**Improvement/Solution:**
- Replaced all instances of feature flag selectors with the `useFeatureFlag` hook
- Updated components to use `FeatureFlagNames` enum values instead of selector functions
- Migrated the following feature flags:
  - `earnPooledStakingEnabled` (previously `selectPooledStakingEnabledFlag`)
  - `perpsPerpTradingEnabled` (previously `selectPerpsEnabledFlag`)
  - `predictTradingEnabled` (previously `selectPredictEnabledFlag`)
- Updated all related test files to mock the new hook pattern
- Fixed TypeScript compilation errors and test failures

**Components affected:**
- `WalletActions` and `TradeWalletActions` components
- Stake-related components (`StakeButton`, `StakingBalance`, `StakingButtons`)
- Earn components (`EarnTokenList`, `WaysToEarn`)
- `DeveloperOptions` settings view
- `SampleFeature` component
- Various other views and components

## **Changelog**

CHANGELOG entry: null

*(This is an internal refactoring that does not affect end-user functionality)*

## **Related issues**

Fixes:

## **Manual testing steps**
rkin
Feature: Feature flag migration to new architecture

  Scenario: User views wallet actions with feature flags enabled

    Given the app is running with feature flags enabled for pooled staking, perps trading, and predict trading

    When user navigates to the wallet screen

    Then the wallet actions should display correctly with all feature-gated options visible

  Scenario: User views developer options with perps feature flag

    Given the app is running with perps trading feature flag enabled

    When user navigates to Settings > Developer Options

    Then the Perps developer options section should be visible

  Scenario: User views stake components with pooled staking feature flag

    Given the app is running with pooled staking feature flag enabled

    When user navigates to stake-related screens

    Then all stake components should render correctly and show pooled staking options

  Scenario: User overrides feature flags in developer options

    Given the app is running

    When user navigates to Settings > Developer Options > Feature Flag Override

    Then user can override feature flags and see the changes reflected in the app
## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/ad1def2a-cfd7-4251-a62c-ae509f8523fa

https://github.com/user-attachments/assets/47bda0ab-7c46-4e77-b468-8ca7fa41f05d

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).

- [x] I've completed the PR template to the best of my ability

- [x] I've included tests if applicable

- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable

- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).

- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace selector-based feature flags with the useFeatureFlag hook and FeatureFlagNames enum across key views/components; update tests and add new flags to the enum.
> 
> - **Feature Flags Migration**
>   - Replace `useSelector(select*EnabledFlag)` with `useFeatureFlag(FeatureFlagNames.*)` for `perpsPerpTradingEnabled`, `predictTradingEnabled`, `earnPooledStakingEnabled`, and `carouselBanners`.
>   - Expand `FeatureFlagNames` enum and centralize flag access in `app/components/hooks/useFeatureFlag.ts`.
> - **Components Updated**
>   - Navigation and views: `MainNavigator`, `ActivityView`, `Wallet`, `DeveloperOptions`.
>   - Wallet actions: `WalletActions`, `TradeWalletActions` (earn/perps/predict gating via hook).
>   - Earn/Stake flows: `EarnTokenList`, `StakeButton`, `StakingBalance`, `StakingButtons`.
>   - Rewards: `WaysToEarn` (Predict gating via hook).
>   - Sample feature: `SampleFeature` (counter gating via hook).
> - **Tests**
>   - Update unit tests to mock `useFeatureFlag` instead of selectors across affected files.
>   - Adjust assertions and setups to reflect new flag sources.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02c0ef81e08864cbc152c38c5c42cb3b2e4ed6b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->