### PR TITLE
fix(predict): hide unrealized pnl if the user has 0 positions

### DIFF
--- a/app/components/UI/Predict/hooks/useUnrealizedPnL.test.tsx
+++ b/app/components/UI/Predict/hooks/useUnrealizedPnL.test.tsx
@@ -14,6 +14,7 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 const mockGetUnrealizedPnL = jest.fn();
+const mockGetPositions = jest.fn();
 
 // Mock DevLogger
 jest.mock('../../../../core/SDKConnect/utils/DevLogger', () => ({
@@ -26,6 +27,7 @@ jest.mock('../../../../core/Engine', () => ({
   context: {
     PredictController: {
       getUnrealizedPnL: mockGetUnrealizedPnL,
+      getPositions: mockGetPositions,
     },
     AccountTreeController: {
       getAccountsFromSelectedAccountGroup: jest.fn(() => [
@@ -50,6 +52,7 @@ interface MockEngine {
   context: {
     PredictController?: {
       getUnrealizedPnL: jest.Mock;
+      getPositions: jest.Mock;
     };
     AccountTreeController?: {
       getAccountsFromSelectedAccountGroup: jest.Mock;
@@ -68,9 +71,12 @@ describe('useUnrealizedPnL', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // Default: return positions with at least one item so tests pass by default
+    mockGetPositions.mockResolvedValue([{ id: 'position-1' }]);
     engine.context = {
       PredictController: {
         getUnrealizedPnL: mockGetUnrealizedPnL,
+        getPositions: mockGetPositions,
       },
       AccountTreeController: {
         getAccountsFromSelectedAccountGroup: jest.fn(() => [
@@ -258,6 +264,110 @@ describe('useUnrealizedPnL', () => {
     expect(mockGetUnrealizedPnL).toHaveBeenNthCalledWith(2, {
       address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
       providerId: 'other-provider',
+    });
+  });
+
+  describe('positions-based visibility', () => {
+    it('returns null when user has no positions', async () => {
+      mockGetUnrealizedPnL.mockResolvedValue(basePnL);
+      mockGetPositions.mockResolvedValue([]);
+
+      const { result } = renderHook(() => useUnrealizedPnL());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.unrealizedPnL).toBeNull();
+      expect(result.current.error).toBeNull();
+      expect(mockGetPositions).toHaveBeenCalledWith({
+        providerId: undefined,
+        limit: 1,
+        offset: 0,
+        claimable: false,
+      });
+    });
+
+    it('returns unrealized P&L when user has positions', async () => {
+      mockGetUnrealizedPnL.mockResolvedValue(basePnL);
+      mockGetPositions.mockResolvedValue([
+        { id: 'position-1' },
+        { id: 'position-2' },
+      ]);
+
+      const { result } = renderHook(() => useUnrealizedPnL());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.unrealizedPnL).toEqual(basePnL);
+      expect(result.current.error).toBeNull();
+    });
+
+    it('calls getPositions with providerId when specified', async () => {
+      mockGetUnrealizedPnL.mockResolvedValue(basePnL);
+      mockGetPositions.mockResolvedValue([{ id: 'position-1' }]);
+
+      const { result } = renderHook(() =>
+        useUnrealizedPnL({
+          providerId: 'polymarket',
+        }),
+      );
+
+      await waitFor(() => {
+        expect(result.current.unrealizedPnL).toEqual(basePnL);
+      });
+
+      expect(mockGetPositions).toHaveBeenCalledWith({
+        providerId: 'polymarket',
+        limit: 1,
+        offset: 0,
+        claimable: false,
+      });
+    });
+
+    it('returns null when getUnrealizedPnL returns null and user has positions', async () => {
+      mockGetUnrealizedPnL.mockResolvedValue(null);
+      mockGetPositions.mockResolvedValue([{ id: 'position-1' }]);
+
+      const { result } = renderHook(() => useUnrealizedPnL());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.unrealizedPnL).toBeNull();
+      expect(result.current.error).toBeNull();
+    });
+
+    it('returns null when both getUnrealizedPnL and getPositions return empty', async () => {
+      mockGetUnrealizedPnL.mockResolvedValue(null);
+      mockGetPositions.mockResolvedValue([]);
+
+      const { result } = renderHook(() => useUnrealizedPnL());
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.unrealizedPnL).toBeNull();
+      expect(result.current.error).toBeNull();
+    });
+
+    it('calls both getUnrealizedPnL and getPositions in parallel', async () => {
+      mockGetUnrealizedPnL.mockResolvedValue(basePnL);
+      mockGetPositions.mockResolvedValue([{ id: 'position-1' }]);
+
+      renderHook(() => useUnrealizedPnL());
+
+      await waitFor(() => {
+        expect(mockGetUnrealizedPnL).toHaveBeenCalled();
+        expect(mockGetPositions).toHaveBeenCalled();
+      });
+
+      expect(mockGetUnrealizedPnL).toHaveBeenCalledTimes(1);
+      expect(mockGetPositions).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/app/components/UI/Predict/hooks/useUnrealizedPnL.tsx
+++ b/app/components/UI/Predict/hooks/useUnrealizedPnL.tsx
@@ -75,13 +75,21 @@ export const useUnrealizedPnL = (
         }
         setError(null);
 
-        const unrealizedPnLData =
-          await Engine.context.PredictController.getUnrealizedPnL({
+        const [unrealizedPnLData, positions] = await Promise.all([
+          Engine.context.PredictController.getUnrealizedPnL({
             address: address ?? selectedInternalAccountAddress,
             providerId,
-          });
+          }),
+          Engine.context.PredictController.getPositions({
+            providerId,
+            limit: 1,
+            offset: 0,
+            claimable: false,
+          }),
+        ]);
 
-        setUnrealizedPnL(unrealizedPnLData ?? null);
+        const _unrealizedPnL = unrealizedPnLData ?? null;
+        setUnrealizedPnL(positions.length > 0 ? _unrealizedPnL : null);
 
         DevLogger.log('useUnrealizedPnL: Loaded unrealized P&L', {
           unrealizedPnL: unrealizedPnLData,


### PR DESCRIPTION
## **Description**

This PR fixes an issue where unrealized P&L was being displayed even when users had no active positions. The fix ensures that unrealized P&L is only shown when the user has at least one position, preventing confusing or misleading information from being displayed.

**What is the reason for the change?**

Users were seeing unrealized P&L data displayed even when they had no positions, which could be confusing since P&L is meaningless without any active positions.

In addition, Polymarket uPnL API endpoint seems to give us bogus information when we have 0 positions.

**What is the improvement/solution?**

The `useUnrealizedPnL` hook now fetches both unrealized P&L data and the user's positions in parallel. The unrealized P&L is only displayed if `positions.length > 0`, ensuring users only see relevant P&L information when they have active positions.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Unrealized P&L visibility based on positions

  Scenario: user has no positions
    Given user is logged in with an account
    And user has no active positions

    When user navigates to the Predict screen
    Then unrealized P&L section is not displayed

  Scenario: user has active positions
    Given user is logged in with an account
    And user has at least one active position

    When user navigates to the Predict screen
    Then unrealized P&L section is displayed with current P&L data
```

## **Screenshots/Recordings**

### **Before**

<!-- Unrealized P&L displayed even with 0 positions -->

### **After**


https://github.com/user-attachments/assets/cba5278e-09fe-4f75-9eb3-a17771d3174d





## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Only show unrealized PnL when the user has at least one position, fetching PnL and positions concurrently.
> 
> - **Predict Hook (`app/components/UI/Predict/hooks/useUnrealizedPnL.tsx`)**
>   - Fetches `getUnrealizedPnL` and `getPositions` in parallel via `Promise.all`.
>   - Sets `unrealizedPnL` to `null` when `positions.length === 0`; otherwise uses fetched P&L.
>   - Calls `getPositions` with `{ providerId, limit: 1, offset: 0, claimable: false }`.
> - **Tests (`app/components/UI/Predict/hooks/useUnrealizedPnL.test.tsx`)**
>   - Add mocks and coverage for positions-based visibility (no positions => `null`, with positions => show P&L).
>   - Verify `getPositions` is called with the correct params and provider-specific calls.
>   - Assert parallel invocation of `getUnrealizedPnL` and `getPositions`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b77e7f4204c7cf6d93c0dde35f046969366b07c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->