### PR TITLE
feat(predict): Adds fee exemption message

### DIFF
--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -3093,5 +3093,65 @@ describe('PredictMarketDetails', () => {
         screen.getByText('predict.market_details.fee_exemption'),
       ).toBeOnTheScreen();
     });
+
+    it('removes fee exemption message when market updates without Middle East tag', async () => {
+      const { usePredictMarket } = jest.requireMock(
+        '../../hooks/usePredictMarket',
+      );
+
+      const marketWithMiddleEastTag = createMockMarket({
+        status: 'open',
+        tags: ['Middle East', 'Politics'],
+        outcomes: [
+          {
+            id: 'outcome-1',
+            title: 'Yes',
+            tokens: [
+              { id: 'token-1', title: 'Yes', price: 0.65 },
+              { id: 'token-2', title: 'No', price: 0.35 },
+            ],
+            volume: 1000000,
+          },
+        ],
+      });
+
+      const { rerender } = setupPredictMarketDetailsTest(
+        marketWithMiddleEastTag,
+      );
+
+      expect(
+        screen.getByText('predict.market_details.fee_exemption'),
+      ).toBeOnTheScreen();
+
+      const marketWithoutMiddleEastTag = createMockMarket({
+        status: 'open',
+        tags: ['Politics'],
+        outcomes: [
+          {
+            id: 'outcome-1',
+            title: 'Yes',
+            tokens: [
+              { id: 'token-1', title: 'Yes', price: 0.65 },
+              { id: 'token-2', title: 'No', price: 0.35 },
+            ],
+            volume: 1000000,
+          },
+        ],
+      });
+
+      usePredictMarket.mockReturnValue({
+        market: marketWithoutMiddleEastTag,
+        isFetching: false,
+        refetch: jest.fn(),
+      });
+
+      rerender(<PredictMarketDetails />);
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText('predict.market_details.fee_exemption'),
+        ).not.toBeOnTheScreen();
+      });
+    });
   });
 });

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -55,22 +55,6 @@ jest.mock('@react-navigation/stack', () => ({
   }),
 }));
 
-jest.mock('@metamask/design-system-twrnc-preset', () => {
-  const mockTw = jest.fn((strings) => {
-    // Handle template literal usage
-    if (Array.isArray(strings) && strings.raw) {
-      return strings.join('');
-    }
-    // Handle function call usage
-    return strings;
-  });
-  mockTw.style = jest.fn((...args) => args.flat().filter(Boolean).join(' '));
-
-  return {
-    useTailwind: jest.fn(() => mockTw),
-  };
-});
-
 jest.mock('@metamask/design-system-react-native', () => {
   const { View } = jest.requireActual('react-native');
   return {
@@ -480,8 +464,6 @@ function createMockMarket(overrides = {}) {
   const mergedMarket = {
     ...defaultMarket,
     ...overrides,
-    // Ensure tags is always an array to prevent undefined.includes() errors
-    tags: overrides.tags === undefined ? defaultMarket.tags : overrides.tags,
   };
 
   const normalizedOutcomes =

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -110,6 +110,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
   const insets = useSafeAreaInsets();
   const [isResolvedExpanded, setIsResolvedExpanded] = useState<boolean>(false);
   const [isRefreshing, setIsRefreshing] = useState<boolean>(false);
+  const [isFeeExemption, setIsFeeExemption] = useState<boolean>(false);
 
   const { marketId, entryPoint, title, image } = route.params || {};
   const resolvedMarketId = marketId;
@@ -196,6 +197,12 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
       setSelectedTimeframe(PredictPriceHistoryInterval.MAX);
     }
   }, [market?.status]);
+
+  useEffect(() => {
+    if (market?.tags.includes('Middle East')) {
+      setIsFeeExemption(true);
+    }
+  }, [market?.tags]);
 
   // Tabs become ready when both market and positions queries have resolved
   const tabsReady = useMemo(
@@ -1127,7 +1134,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
 
   return (
     <SafeAreaView
-      style={tw.style('flex-1 bg-default')}
+      style={tw.style('flex-1 bg-default', isFeeExemption ? 'pb-6' : '')}
       edges={['left', 'right', 'bottom']}
       testID={PredictMarketDetailsSelectorsIDs.SCREEN}
     >
@@ -1177,6 +1184,19 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
       <Box twClassName="px-3 bg-default border-t border-muted">
         {renderActionButtons()}
       </Box>
+      {isFeeExemption && (
+        <Box
+          style={tw`absolute inset-x-0 bottom-4 pb-3`}
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          justifyContent={BoxJustifyContent.Center}
+          twClassName="gap-1"
+        >
+          <Text variant={TextVariant.BodyXS} color={TextColor.Alternative}>
+            {strings('predict.market_details.fee_exemption')}
+          </Text>
+        </Box>
+      )}
     </SafeAreaView>
   );
 };

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -110,7 +110,6 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
   const insets = useSafeAreaInsets();
   const [isResolvedExpanded, setIsResolvedExpanded] = useState<boolean>(false);
   const [isRefreshing, setIsRefreshing] = useState<boolean>(false);
-  const [isFeeExemption, setIsFeeExemption] = useState<boolean>(false);
 
   const { marketId, entryPoint, title, image } = route.params || {};
   const resolvedMarketId = marketId;
@@ -198,11 +197,8 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
     }
   }, [market?.status]);
 
-  useEffect(() => {
-    if (market?.tags.includes('Middle East')) {
-      setIsFeeExemption(true);
-    }
-  }, [market?.tags]);
+  // check if market has fee exemption (note: worth moveing to a const or util at some point))
+  const isFeeExemption = market?.tags?.includes('Middle East') ?? false;
 
   // Tabs become ready when both market and positions queries have resolved
   const tabsReady = useMemo(

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1784,7 +1784,8 @@
       "lost": "Lost",
       "market_unavailable": "Market unavailable",
       "amount_on_outcome": "${{amount}} on {{outcome}}",
-      "outcome_at_price": "{{outcome}} at {{price}}¢"
+      "outcome_at_price": "{{outcome}} at {{price}}¢",
+      "fee_exemption": "We don't charge any fees on this market."
     },
     "tab": {
       "no_predictions_description": "Your predictions will appear here, showing your stake and market movement.",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Adds fee exemption message

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: [PRED-288](https://consensyssoftware.atlassian.net/browse/PRED-288)

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="420" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-11-13 at 17 07 10" src="https://github.com/user-attachments/assets/9e3f900c-4e4e-46d6-9405-c4054a5bb300" />

<img width="420" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-11-13 at 17 07 28" src="https://github.com/user-attachments/assets/478205c3-eabe-407a-8dd2-e6b96ad1fe33" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[PRED-288]: https://consensyssoftware.atlassian.net/browse/PRED-288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Displays a fee‑exemption message on markets tagged "Middle East", with i18n support and comprehensive tests.
> 
> - **Predict UI**:
>   - Adds fee‑exemption banner in `PredictMarketDetails.tsx` when `market.tags` includes `"Middle East"` and adjusts container padding (`SafeAreaView` uses `pb-6` when active).
> - **i18n**:
>   - Adds `predict.market_details.fee_exemption` to `locales/languages/en.json`.
> - **Tests**:
>   - Extends `PredictMarketDetails.test.tsx` with cases covering presence/absence of banner across tag states (including undefined/empty), closed/open markets, multiple tags, and live market updates; sets default `tags: []` in `createMockMarket`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f0b95732fd7990aa1880ccea2d24fa1baa0223e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->