### PR TITLE
feat: ui experience enhancements in createpassword screen

### DIFF
--- a/app/components/Views/ChoosePassword/__snapshots__/index.test.tsx.snap
+++ b/app/components/Views/ChoosePassword/__snapshots__/index.test.tsx.snap
@@ -173,7 +173,7 @@ exports[`ChoosePassword render matches snapshot 1`] = `
                 {
                   "alignItems": "center",
                   "backgroundColor": "#ffffff",
-                  "borderColor": "#b7bbc8",
+                  "borderColor": "#4459ff",
                   "borderRadius": 8,
                   "borderWidth": 1,
                   "flexDirection": "row",
@@ -194,7 +194,7 @@ exports[`ChoosePassword render matches snapshot 1`] = `
                 <TextInput
                   autoCapitalize="none"
                   autoComplete="new-password"
-                  autoFocus={false}
+                  autoFocus={true}
                   editable={true}
                   keyboardAppearance="light"
                   onBlur={[Function]}
@@ -411,7 +411,6 @@ exports[`ChoosePassword render matches snapshot 1`] = `
                 "flexDirection": "row",
                 "gap": 8,
                 "justifyContent": "flex-start",
-                "marginBottom": 16,
                 "marginTop": 8,
                 "padding": 16,
               }
@@ -524,7 +523,6 @@ exports[`ChoosePassword render matches snapshot 1`] = `
               {
                 "flexDirection": "column",
                 "marginBottom": 16,
-                "marginTop": "auto",
                 "rowGap": 18,
                 "width": "100%",
               }

--- a/app/components/Views/ChoosePassword/index.js
+++ b/app/components/Views/ChoosePassword/index.js
@@ -715,7 +715,6 @@ class ChoosePassword extends PureComponent {
       canSubmit =
         passwordsMatch && isSelected && password.length >= MIN_PASSWORD_LENGTH;
     }
-    const previousScreen = this.props.route.params?.[PREVIOUS_SCREEN];
     const colors = this.context.colors || mockTheme.colors;
     const themeAppearance = this.context.themeAppearance || 'light';
     const styles = createStyles(colors);

--- a/app/components/Views/ChoosePassword/index.js
+++ b/app/components/Views/ChoosePassword/index.js
@@ -127,7 +127,6 @@ const createStyles = (colors) =>
       width: '100%',
       flexDirection: 'column',
       rowGap: 18,
-      marginTop: 'auto',
       marginBottom: Platform.select({
         ios: 16,
         android: 24,
@@ -140,7 +139,6 @@ const createStyles = (colors) =>
       justifyContent: 'flex-start',
       gap: 8,
       marginTop: 8,
-      marginBottom: 16,
       backgroundColor: colors.background.section,
       borderRadius: 8,
       padding: 16,
@@ -788,6 +786,7 @@ class ChoosePassword extends PureComponent {
                     {strings('choose_password.password')}
                   </Label>
                   <TextField
+                    autoFocus
                     secureTextEntry={this.state.showPasswordIndex.includes(0)}
                     value={password}
                     onChangeText={this.onPasswordChange}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
* UI experience enhancements in createpassword screen
* Open keyboard by default when screen opens and focus on textInput automatically.
* Create Password button visibility
* Jira: https://consensyssoftware.atlassian.net/browse/SL-299
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:  UI experience enhancements in createpassword screen
CHANGELOG entry:  Open keyboard by default when screen opens and focus on textInput automatically.
CHANGELOG entry:  Create Password button visibility

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: UI experience enhancements in createpassword screen

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/bcc47231-d545-433f-b78e-22c6c8364f51


<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/10bb584e-6262-41ca-ba55-864ad6186c1c




<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds autofocus to the password field, disables and validates confirm input with error messaging, replaces CTAs with component-library Buttons, and tweaks layout/styling.
> 
> - **ChoosePassword UI/UX**:
>   - **Password field**: enable `autoFocus`; focused border color updated to primary (`#4459ff`).
>   - **Confirm password**: now disabled until a password is entered; adds mismatch error state/text; sets `returnKeyType="done"` and dismisses keyboard on submit; adds accessibility label.
>   - **Submit CTA**: replaced `TouchableOpacity` with `Button`; enabled only when passwords match and meet `MIN_PASSWORD_LENGTH` (and checkbox selected unless social login).
>   - **Checkbox/learn more**: uses `Button` for link-style label; shows marketing opt-in copy for social login; keeps "Learn more" link.
>   - **Styling**: minor layout tweaks (remove some margins, adjust containers); snapshots updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00cba6249aa01d2688aaa373e18b0b309fe51c45. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->