### PR TITLE
fix: switching networks from dapp permissions dapp icon has no effect

### DIFF
--- a/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.test.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.test.tsx
@@ -449,7 +449,7 @@ describe('MultichainPermissionsSummary', () => {
       params: expect.objectContaining({
         hostInfo: expect.objectContaining({
           metadata: expect.objectContaining({
-            origin: 'mock-dapp.example.com',
+            origin: 'https://mock-dapp.example.com',
           }),
         }),
         onRevokeAll: expect.any(Function),
@@ -475,7 +475,7 @@ describe('MultichainPermissionsSummary', () => {
       params: expect.objectContaining({
         hostInfo: expect.objectContaining({
           metadata: expect.objectContaining({
-            origin: 'mock-dapp.example.com',
+            origin: 'https://mock-dapp.example.com',
           }),
         }),
         onRevokeAll: expect.any(Function),

--- a/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.tsx
+++ b/app/components/Views/MultichainAccounts/MultichainPermissionsSummary/MultichainPermissionsSummary.tsx
@@ -132,7 +132,7 @@ const MultichainPermissionsSummary = ({
 
   const hostname = useMemo(() => {
     try {
-      return new URL(currentPageInformation.url).hostname;
+      return new URL(currentPageInformation.url).origin;
     } catch {
       return currentPageInformation.url;
     }
@@ -252,9 +252,7 @@ const MultichainPermissionsSummary = ({
                 params: {
                   hostInfo: {
                     metadata: {
-                      origin:
-                        currentPageInformation?.url &&
-                        new URL(currentPageInformation?.url).hostname,
+                      origin: hostname,
                     },
                   },
                   connectionDateTime: new Date().getTime(),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

While connected to a dapp, if the user tries to switch networks from dapp permissions, this has no effect. When switching networks, the icon displayed is always the same. This happens because `MultichainPermissionsSummary.tsx` uses `.hostname` while `SelectedNetworkController` stores domains by origin (e.g., "https://example.com"). This mismatch prevents the lookup from finding the per-dapp network.

This PR proposes a fix by using `.origin` instead.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix issue where switching networks from dapp permissions dapp icon has no effect

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/22423

## **Manual testing steps**

```gherkin
Feature: fix switching networks from dapp permissions dapp icon having no effect

  Scenario: user switches network
    Given it's done via top right icon of In App Browser

    When user switches network
    Then network icon should update accordingly
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/472ff108-8e39-4a96-899a-93c9983bb260

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces hostname with full URL origin for dapp host handling in MultichainPermissionsSummary, updating navigation params and tests.
> 
> - **MultichainPermissionsSummary**:
>   - Compute `hostname` as `URL.origin` instead of `URL.hostname`.
>   - Pass origin to `useNetworkInfo`, titles, and navigation params for `CONNECTION_DETAILS` and `REVOKE_ALL_ACCOUNT_PERMISSIONS` (`hostInfo.metadata.origin`).
> - **Tests**:
>   - Update expectations to use `https://mock-dapp.example.com` for `origin` in navigation assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffbe2d115fc9167c11830c9930cdaccef8874f51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->