### PR TITLE
fix(e2e): clean up Android adb reverse 

### DIFF
--- a/e2e/framework/fixtures/FixtureHelper.ts
+++ b/e2e/framework/fixtures/FixtureHelper.ts
@@ -13,6 +13,7 @@ import {
   getFixturesServerPort,
   startResourceWithRetry,
   startMultiInstanceResourceWithRetry,
+  removeAllAndroidPortForwarding,
 } from './FixtureUtils';
 import Utilities from '../../framework/Utilities';
 import TestHelpers from '../../helpers';
@@ -687,6 +688,18 @@ export async function withFixtures(
           cleanupErrors.push(cleanupError as Error);
         }
       }
+    }
+
+    // Clean up all Android adb reverse port forwarding
+    // This ensures no stale bindings remain for the next test
+    try {
+      await removeAllAndroidPortForwarding();
+    } catch (cleanupError) {
+      logger.warn(
+        'Error during Android port forwarding cleanup (non-critical):',
+        cleanupError,
+      );
+      // Don't add to cleanupErrors as this is a non-critical cleanup operation
     }
 
     if (!skipReactNativeReload) {

--- a/e2e/framework/fixtures/FixtureUtils.ts
+++ b/e2e/framework/fixtures/FixtureUtils.ts
@@ -54,38 +54,58 @@ function getFallbackPort(resourceType: ResourceType): number {
 }
 
 /**
- * Removes all adb reverse bindings for the current device.
+ * Removes specific test port bindings for the current device.
  * This is called at the start of tests to clean up any stale bindings from previous failed tests.
+ *
+ * IMPORTANT: We only remove known fallback ports to avoid interfering with Detox's
+ * own port management. Using --remove-all would remove Detox's ports and cause errors.
  */
 export async function cleanupAllAndroidPortForwarding(): Promise<void> {
-  try {
-    // Only remove port forwarding on Android
-    if (device.getPlatform() !== 'android') {
-      return;
-    }
-
-    // Skip on BrowserStack
-    if (isBrowserStack()) {
-      return;
-    }
-
-    // Get device ID to target specific device (important for CI with multiple devices)
-    const deviceId = device.id || '';
-    const deviceFlag = deviceId ? `-s ${deviceId}` : '';
-
-    const command = `adb ${deviceFlag} reverse --remove-all`;
-
-    logger.debug(`Cleaning up all port forwards before test: ${command}`);
-    await execAsync(command);
-
-    logger.debug('✓ Cleaned up all Android port forwarding');
-  } catch (error) {
-    // Don't throw on cleanup errors - just log them
-    // There might not be any bindings to remove
-    logger.debug(
-      `Note: Could not clean up port forwarding (likely none existed): ${error instanceof Error ? error.message : String(error)}`,
-    );
+  // Only remove port forwarding on Android
+  if (device.getPlatform() !== 'android') {
+    return;
   }
+
+  // Skip on BrowserStack
+  if (isBrowserStack()) {
+    return;
+  }
+
+  // Get device ID to target specific device (important for CI with multiple devices)
+  const deviceId = device.id || '';
+  const deviceFlag = deviceId ? `-s ${deviceId}` : '';
+
+  // Clean up only the specific fallback ports we use
+  // This prevents conflicts with Detox's own port management
+  const fallbackPorts = [
+    FALLBACK_FIXTURE_SERVER_PORT, // 12345
+    FALLBACK_COMMAND_QUEUE_SERVER_PORT, // 12346
+    FALLBACK_MOCKSERVER_PORT, // 8000
+    FALLBACK_GANACHE_PORT, // 8546
+    DEFAULT_ANVIL_PORT, // 8545
+    FALLBACK_DAPP_SERVER_PORT, // 8085
+    FALLBACK_DAPP_SERVER_PORT + 1, // 8086 (dapp-server-1)
+    FALLBACK_DAPP_SERVER_PORT + 2, // 8087 (dapp-server-2)
+  ];
+
+  logger.debug('Cleaning up test port forwards before test...');
+
+  for (const port of fallbackPorts) {
+    try {
+      const command = `adb ${deviceFlag} reverse --remove tcp:${port}`;
+      await execAsync(command);
+      logger.debug(`✓ Removed port forwarding for tcp:${port}`);
+    } catch (error) {
+      // Silently ignore "not found" errors - the port might not have been forwarded
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      if (!errorMessage.includes('not found')) {
+        logger.debug(`Note: Could not remove tcp:${port}: ${errorMessage}`);
+      }
+    }
+  }
+
+  logger.debug('✓ Cleaned up test port forwarding');
 }
 
 /**

--- a/e2e/framework/fixtures/FixtureUtils.ts
+++ b/e2e/framework/fixtures/FixtureUtils.ts
@@ -54,46 +54,6 @@ function getFallbackPort(resourceType: ResourceType): number {
 }
 
 /**
- * Removes an existing adb reverse binding for a specific port.
- * This is needed to handle cases where a previous test didn't clean up properly
- * or when ports are reused in CI environments.
- *
- * @param fallbackPort - The fallback port to remove the binding for
- */
-async function removeAndroidPortForwarding(
-  fallbackPort: number,
-): Promise<void> {
-  try {
-    // Only remove port forwarding on Android
-    if (device.getPlatform() !== 'android') {
-      return;
-    }
-
-    // Skip on BrowserStack
-    if (isBrowserStack()) {
-      return;
-    }
-
-    // Get device ID to target specific device (important for CI with multiple devices)
-    const deviceId = device.id || '';
-    const deviceFlag = deviceId ? `-s ${deviceId}` : '';
-
-    const command = `adb ${deviceFlag} reverse --remove tcp:${fallbackPort}`;
-
-    logger.debug(`Removing port forward: ${command}`);
-    await execAsync(command);
-
-    logger.debug(`✓ Removed Android port forwarding for port ${fallbackPort}`);
-  } catch (error) {
-    // Don't throw on cleanup errors - just log them
-    // The port might not have been forwarded in the first place
-    logger.debug(
-      `Note: Could not remove port forwarding for port ${fallbackPort} (may not exist): ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
-}
-
-/**
  * Removes all adb reverse bindings for the current device.
  * This is called during test cleanup to ensure no stale bindings remain.
  */
@@ -190,8 +150,6 @@ async function setupAndroidPortForwarding(
     ) {
       fallbackPort += instanceIndex;
     }
-    // This handles cases where a previous test didn't clean up properly
-    await removeAndroidPortForwarding(fallbackPort);
 
     // Get device ID to target specific device (important for CI with multiple devices)
     const deviceId = device.id || '';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

- Fix issue where subsequent tests are failing due to `Error: Command failed: "/opt/android-sdk/platform-tools/adb" -s emulator-17452 reverse tcp:46721 tcp:46721 adb: error: cannot bind listener: Address a...
`

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Cleanly removes stale Android adb reverse bindings for known test ports before running fixtures to prevent port binding conflicts.
> 
> - **E2E Infrastructure**:
>   - Add `cleanupAllAndroidPortForwarding()` in `e2e/framework/fixtures/FixtureUtils.ts` to remove specific fallback adb reverse bindings on Android (skips BrowserStack, targets current device).
>   - Invoke cleanup at the start of `withFixtures()` in `e2e/framework/fixtures/FixtureHelper.ts`; import added.
>   - Limits removals to known fallback ports (`fixture`, `command-queue`, `mock`, `ganache`, `anvil`, `dapp-server` instances) to avoid interfering with Detox.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b5837e5ab2fdec394c6ecc90d7bda076711b9b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->