### PR TITLE
fix: Pass provider param to ChoosePassword page

### DIFF
--- a/app/components/Views/AccountStatus/index.tsx
+++ b/app/components/Views/AccountStatus/index.tsx
@@ -52,6 +52,7 @@ interface AccountRouteParams {
   accountName?: string;
   oauthLoginSuccess?: boolean;
   onboardingTraceCtx?: TraceContext;
+  provider?: string;
 }
 
 const AccountStatus = ({
@@ -66,6 +67,7 @@ const AccountStatus = ({
     ?.oauthLoginSuccess;
   const onboardingTraceCtx = (route.params as AccountRouteParams)
     ?.onboardingTraceCtx;
+  const provider = (route.params as AccountRouteParams)?.provider;
 
   // check for small screen size
   const isSmallScreen = Dimensions.get('window').width < 375;
@@ -128,6 +130,7 @@ const AccountStatus = ({
         [PREVIOUS_SCREEN]: previousScreen,
         oauthLoginSuccess,
         onboardingTraceCtx,
+        provider,
       }),
     );
     track(

--- a/app/components/Views/Onboarding/index.js
+++ b/app/components/Views/Onboarding/index.js
@@ -498,6 +498,7 @@ class Onboarding extends PureComponent {
             accountName: result.accountName,
             oauthLoginSuccess: true,
             onboardingTraceCtx: this.onboardingTraceCtx,
+            provider,
           });
         } else {
           trace({
@@ -515,6 +516,7 @@ class Onboarding extends PureComponent {
                 accountName: result.accountName,
                 oauthLoginSuccess: true,
                 onboardingTraceCtx: this.onboardingTraceCtx,
+                provider,
               },
             );
           } else {
@@ -523,6 +525,7 @@ class Onboarding extends PureComponent {
               [PREVIOUS_SCREEN]: ONBOARDING,
               oauthLoginSuccess: true,
               onboardingTraceCtx: this.onboardingTraceCtx,
+              provider,
             });
           }
         }
@@ -553,6 +556,7 @@ class Onboarding extends PureComponent {
             accountName: result.accountName,
             oauthLoginSuccess: true,
             onboardingTraceCtx: this.onboardingTraceCtx,
+            provider,
           });
         }
       }

--- a/app/components/Views/SocialLoginIosUser/index.tsx
+++ b/app/components/Views/SocialLoginIosUser/index.tsx
@@ -33,11 +33,12 @@ const SocialLoginIosUser: React.FC<SocialLoginIosUserProps> = ({ type }) => {
   const navigation = useNavigation<StackNavigationProp<ParamListBase>>();
   const route = useRoute();
 
-  const { accountName, oauthLoginSuccess, onboardingTraceCtx } =
+  const { accountName, oauthLoginSuccess, onboardingTraceCtx, provider } =
     (route.params as {
       accountName?: string;
       oauthLoginSuccess?: boolean;
       onboardingTraceCtx?: unknown;
+      provider?: string;
     }) || {};
 
   const handleSetMetaMaskPin = () => {
@@ -46,6 +47,7 @@ const SocialLoginIosUser: React.FC<SocialLoginIosUserProps> = ({ type }) => {
       oauthLoginSuccess,
       onboardingTraceCtx,
       accountName,
+      provider,
     });
   };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

the `provider` param was not properly passed to the ChoosePassword page. This PR fixes this.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SL-301

## **Manual testing steps**
1. Create a new social login account
2. Choose your password
3. A segment event called 'Wallet Setup Completed' should have a prop named 'account_type' with 'google' or 'apple' in its value

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Forwards the `provider` route param across onboarding flows, ensuring it’s passed to `ChoosePassword`, account status redirects, and iOS social login success screens.
> 
> - **Onboarding navigation**
>   - Pass `provider` in navigations after social login: `AccountAlreadyExists`, `AccountNotFound`, iOS `SOCIAL_LOGIN_SUCCESS_NEW_USER`, and Android `ChoosePassword` (`app/components/Views/Onboarding/index.js`).
>   - Add `provider` to `AccountStatus` route params and forward it when redirecting to `Rehydrate` or `ChoosePassword` (`app/components/Views/AccountStatus/index.tsx`).
>   - Read `provider` from route and include it when navigating to `CHOOSE_PASSWORD` on iOS social login success (`app/components/Views/SocialLoginIosUser/index.tsx`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e88d31cabae5806e479d9ac11481eda9ef5a967. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->