### PR TITLE
fix: cp-7.59.0 metamask pay with non-evm token filter

### DIFF
--- a/app/components/Views/confirmations/hooks/tokens/useTokenWithBalance.ts
+++ b/app/components/Views/confirmations/hooks/tokens/useTokenWithBalance.ts
@@ -3,19 +3,29 @@ import { useSelector } from 'react-redux';
 import { selectSingleTokenByAddressAndChainId } from '../../../../../selectors/tokensController';
 import { RootState } from '../../../../../reducers';
 import { selectSingleTokenBalance } from '../../../../../selectors/tokenBalancesController';
-import { selectSelectedInternalAccountAddress } from '../../../../../selectors/accountsController';
 import { toChecksumAddress } from '../../../../../util/address';
 import { useTokenFiatRate } from './useTokenFiatRates';
 import { BigNumber } from 'bignumber.js';
 import { useMemo } from 'react';
 import useFiatFormatter from '../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
-import { selectAccountBalanceByChainId } from '../../../../../selectors/accountTrackerController';
+import { selectAccountsByChainId } from '../../../../../selectors/accountTrackerController';
 import { selectConversionRateByChainId } from '../../../../../selectors/currencyRateController';
 import { selectTickerByChainId } from '../../../../../selectors/networkController';
 import { getNativeTokenAddress } from '../../utils/asset';
+import { selectSelectedAccountGroupInternalAccounts } from '../../../../../selectors/multichainAccounts/accountTreeController';
+import { selectSelectedInternalAccountAddress } from '../../../../../selectors/accountsController';
 
 export function useTokenWithBalance(tokenAddress: Hex, chainId: Hex) {
   const selectedAddress = useSelector(selectSelectedInternalAccountAddress);
+
+  const internalAccounts = useSelector(
+    selectSelectedAccountGroupInternalAccounts,
+  );
+
+  const selectedEvmAddress =
+    (internalAccounts.find((a) => a.type === 'eip155:eoa')?.address as Hex) ??
+    selectedAddress;
+
   const fiatFormatter = useFiatFormatter();
   const nativeTokenAddress = getNativeTokenAddress(chainId);
 
@@ -26,7 +36,7 @@ export function useTokenWithBalance(tokenAddress: Hex, chainId: Hex) {
   const tokenBalanceResult = useSelector((state: RootState) =>
     selectSingleTokenBalance(
       state,
-      selectedAddress as Hex,
+      selectedEvmAddress,
       chainId,
       toChecksumAddress(tokenAddress),
     ),
@@ -38,9 +48,13 @@ export function useTokenWithBalance(tokenAddress: Hex, chainId: Hex) {
 
   const tokenFiatRate = useTokenFiatRate(tokenAddress, chainId);
 
-  const nativeBalanceResult = useSelector((state: RootState) =>
-    selectAccountBalanceByChainId(state, chainId),
-  );
+  const accountsByChainId = useSelector(selectAccountsByChainId);
+
+  const nativeBalanceResult = Object.entries(
+    accountsByChainId?.[chainId] ?? {},
+  ).find(
+    ([address]) => address.toLowerCase() === selectedEvmAddress.toLowerCase(),
+  )?.[1];
 
   const conversionRate = useSelector((state: RootState) =>
     selectConversionRateByChainId(state, chainId),

--- a/app/selectors/tokensController.test.ts
+++ b/app/selectors/tokensController.test.ts
@@ -23,6 +23,7 @@ describe('TokensController Selectors', () => {
     allTokens: {
       '0x1': {
         '0xAddress1': [mockToken],
+        '0xAddress2': [mockToken2],
       },
     },
     allDetectedTokens: {
@@ -241,7 +242,10 @@ describe('TokensController Selectors', () => {
 
   describe('selectAllTokensFlat', () => {
     it('returns all tokens as a flat array', () => {
-      expect(selectAllTokensFlat(mockRootState)).toStrictEqual([mockToken]);
+      expect(selectAllTokensFlat(mockRootState)).toStrictEqual([
+        mockToken,
+        mockToken2,
+      ]);
     });
 
     it('returns an empty array if no tokens are present', () => {
@@ -361,10 +365,19 @@ describe('TokensController Selectors', () => {
     it('returns undefined if no token exists for the given address and chain ID', () => {
       const token = selectSingleTokenByAddressAndChainId(
         mockRootState,
-        '0xAddress1',
+        '0xToken3',
         '0x2',
       );
       expect(token).toBeUndefined();
+    });
+
+    it('returns token not from selected address', () => {
+      const token = selectSingleTokenByAddressAndChainId(
+        mockRootState,
+        '0xToken2',
+        '0x1',
+      );
+      expect(token).toStrictEqual(mockToken2);
     });
   });
 });

--- a/app/selectors/tokensController.ts
+++ b/app/selectors/tokensController.ts
@@ -216,14 +216,12 @@ export const selectTransformedTokens = createSelector(
 
 export const selectSingleTokenByAddressAndChainId = createSelector(
   selectAllTokens,
-  selectSelectedInternalAccountAddress,
   (_state: RootState, tokenAddress: Hex) => tokenAddress,
   (_state: RootState, _tokenAddress: Hex, chainId: Hex) => chainId,
-  (allTokens, selectedAddress, tokenAddress, chainId) => {
-    if (!selectedAddress) return undefined;
-
-    const tokensForAddressAndChain =
-      allTokens[chainId]?.[selectedAddress] ?? [];
+  (allTokens, tokenAddress, chainId) => {
+    const tokensForAddressAndChain = Object.values(
+      allTokens[chainId] ?? {},
+    ).flat();
 
     return tokensForAddressAndChain.find(
       (token) => token.address.toLowerCase() === tokenAddress.toLowerCase(),


### PR DESCRIPTION
## **Description**

Prevent infinite loading when selecting non-EVM token filter, then starting a Perps deposit. 

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#22673](https://github.com/MetaMask/metamask-mobile/issues/22673)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use the EVM EOA address when computing balances and update the token selector to find a token by address across all accounts for a chain, with tests adjusted accordingly.
> 
> - **Hooks**
>   - `useTokenWithBalance`:
>     - Determine `selectedEvmAddress` from `selectSelectedAccountGroupInternalAccounts` (fallback to selected address).
>     - Use `selectedEvmAddress` for `selectSingleTokenBalance` and native balance lookup.
>     - Replace `selectAccountBalanceByChainId` with `selectAccountsByChainId` and derive native balance via address match.
> - **Selectors**
>   - `selectSingleTokenByAddressAndChainId`: search all addresses under the given `chainId` (no longer limited to selected address).
> - **Tests**
>   - Expand fixtures with tokens on multiple addresses and chains.
>   - Update expectations for `selectAllTokensFlat` and `selectSingleTokenByAddressAndChainId` (including token from non-selected address).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83286a037157c88a8758b2d029391d76397f2dd9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->