### PR TITLE
fix: cp-7.59.0 Fix submit loading for nonEVM send transactions 

### DIFF
--- a/app/components/Views/confirmations/components/send/recipient/recipient.tsx
+++ b/app/components/Views/confirmations/components/send/recipient/recipient.tsx
@@ -70,10 +70,11 @@ export const Recipient = () => {
       }
       setIsSubmittingTransaction(true);
       setPastedRecipient(undefined);
-      handleSubmitPress(resolvedAddress || to);
       captureRecipientSelected(
         isPasted ? RecipientInputMethod.Pasted : RecipientInputMethod.Manual,
       );
+      await handleSubmitPress(resolvedAddress || to);
+      setIsSubmittingTransaction(false);
     },
     [
       to,
@@ -113,7 +114,7 @@ export const Recipient = () => {
         | typeof RecipientInputMethod.SelectAccount
         | typeof RecipientInputMethod.SelectContact,
     ) =>
-      (recipient: RecipientType) => {
+      async (recipient: RecipientType) => {
         if (isSubmittingTransaction) {
           return;
         }
@@ -125,8 +126,9 @@ export const Recipient = () => {
         const selectedAddress = recipient.address;
         setIsRecipientSelectedFromList(true);
         updateTo(selectedAddress);
-        handleSubmitPress(selectedAddress);
         captureRecipientSelected(recipientInputMethod);
+        await handleSubmitPress(selectedAddress);
+        setIsSubmittingTransaction(false);
       },
     [
       updateTo,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

NonEVM transacion confirmations are getting stuck on recipient page after cancelling the transaction confirmation.

The reason why this is not happening on EVM is the recipient route is unmounting when it navigates to EVM confirmation but for nonEVM recipient page is still there, not reset submit loading state persist and it doesn't allow you to submit again.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/22699

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/57ea1d2d-d43a-4f1a-89f6-ad45e0742813



### **After**


https://github.com/user-attachments/assets/cd09d89d-adff-4f8a-a48c-ced51374adca



## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Await submit and clear `isSubmittingTransaction` in recipient review and list-selection flows to prevent stuck loading.
> 
> - **Send/Recipient (`recipient.tsx`)**:
>   - Make `handleReview` and `onRecipientSelected(...)` async and `await` `handleSubmitPress(...)`.
>   - After awaiting, explicitly call `setIsSubmittingTransaction(false)` to reset submit/loading state.
>   - Preserve prechecks and guards; no other logic changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 112ad13e9ebbc60c99594a740bfda78975d52ef2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->