### PR TITLE
fix: cp-7.59.0 Fix layout of small devices in asset amount

### DIFF
--- a/app/components/Views/confirmations/components/send/amount/amount.styles.ts
+++ b/app/components/Views/confirmations/components/send/amount/amount.styles.ts
@@ -30,17 +30,16 @@ export const styleSheet = (params: {
   theme: Theme;
   vars: {
     contentLength: number;
-    isNFT: boolean;
   };
 }) => {
   const {
     theme,
-    vars: { contentLength, isNFT },
+    vars: { contentLength },
   } = params;
   return StyleSheet.create({
-    balanceSection: {
+    balanceText: {
       alignSelf: 'center',
-      marginBottom: isNFT ? 40 : 60,
+      marginTop: 16,
     },
     container: {
       backgroundColor: theme.colors.background.default,
@@ -60,7 +59,6 @@ export const styleSheet = (params: {
     inputSection: {
       flexDirection: FlexDirection.Row,
       justifyContent: JustifyContent.center,
-      marginTop: isNFT ? 0 : 80,
       width: '100%',
     },
     inputText: {
@@ -76,7 +74,6 @@ export const styleSheet = (params: {
     nftImage: { alignSelf: 'center', height: 100, width: 100 },
     nftImageWrapper: {
       alignItems: AlignItems.center,
-      marginTop: 32,
       width: '100%',
     },
     tokenSymbolWrapper: {
@@ -84,8 +81,10 @@ export const styleSheet = (params: {
       width: '50%',
     },
     topSection: {
+      flex: 1,
+      alignContent: 'center',
+      justifyContent: 'center',
       paddingHorizontal: 8,
-      paddingVertical: 32,
     },
   });
 };

--- a/app/components/Views/confirmations/components/send/amount/amount.tsx
+++ b/app/components/Views/confirmations/components/send/amount/amount.tsx
@@ -52,7 +52,6 @@ export const Amount = () => {
   const assetDisplaySymbol = assetSymbol ?? (isNFT ? 'NFT' : '');
   const { styles } = useStyles(styleSheet, {
     contentLength: amount.length + assetDisplaySymbol.length,
-    isNFT,
   });
   const isIos = Device.isIos();
   const { setAmountInputTypeFiat, setAmountInputTypeToken } =
@@ -163,19 +162,16 @@ export const Amount = () => {
             </TagBase>
           </TouchableOpacity>
         )}
+        <Text
+          style={styles.balanceText}
+          color={TextColor.Alternative}
+        >{`${balance} ${balanceUnit} ${strings('send.available')}`}</Text>
       </View>
-      <View>
-        <View style={styles.balanceSection}>
-          <Text
-            color={TextColor.Alternative}
-          >{`${balance} ${balanceUnit} ${strings('send.available')}`}</Text>
-        </View>
-        <AmountKeyboard
-          amount={amount}
-          fiatMode={fiatMode}
-          updateAmount={setAmount}
-        />
-      </View>
+      <AmountKeyboard
+        amount={amount}
+        fiatMode={fiatMode}
+        updateAmount={setAmount}
+      />
     </SafeAreaView>
   );
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

After recent changes on keypad component keypad component was overflowing and not letting users to click "0" button.

This PR aims to fix layout in send flow amount page.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/22702

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/3396b9d5-1dab-45d5-aa77-489c4cef4e65



### **After**

Small devices: 

<img width="517" height="1019" alt="after 6" src="https://github.com/user-attachments/assets/f84a6a1d-3962-4e9b-8663-2c1b03d556fb" />

<img width="517" height="1019" alt="after2" src="https://github.com/user-attachments/assets/973a1ac6-2ae1-4404-8ccb-e35e46b23451" />

<img width="561" height="1063" alt="after 3" src="https://github.com/user-attachments/assets/86a8bd4c-6bce-4f84-9e62-a543cecaac71" />

Larger devices: 

<img width="559" height="1062" alt="after 5" src="https://github.com/user-attachments/assets/56c42edd-f46e-43c0-bb11-950f000312d0" />

<img width="559" height="1062" alt="after1" src="https://github.com/user-attachments/assets/7e682ab4-bd70-40a8-87ed-8f662816f8b4" />

<img width="515" height="1018" alt="after 4" src="https://github.com/user-attachments/assets/d3cb8197-b576-43d5-9c62-48ef1ccdbc1e" />


## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors the send amount screen layout to center content, move balance display and keyboard, and remove NFT-specific spacing in styles.
> 
> - **Send Amount UI** (`amount.tsx`):
>   - Reorganize layout: wrap header content in `topSection` and move `AmountKeyboard` outside it.
>   - Display `balanceDisplayValue` using new `styles.balanceText` within the top section.
>   - Stop passing `isNFT` to styles.
> - **Styles** (`amount.styles.ts`):
>   - Replace `balanceSection` with `balanceText`; remove NFT-dependent margins and input offsets.
>   - Make `topSection` flexible (`flex: 1`) and center content; remove vertical padding.
>   - Keep input sizing via `getFontSizeForInputLength` but simplify layout by removing unused spacing.
>   - Remove `marginTop` from `nftImageWrapper`; drop conditional `inputSection` margin.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2ea8821b4af6640c2ce8c4faff1cacba550fcd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->