### PR TITLE
fix: Fix Predict Navigation to Cash Out and Single Market

### DIFF
--- a/app/components/UI/Predict/components/PredictMarketSingle/PredictMarketSingle.test.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSingle/PredictMarketSingle.test.tsx
@@ -311,14 +311,11 @@ describe('PredictMarketSingle', () => {
     );
     fireEvent.press(marketTitle);
 
-    expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
-      screen: Routes.PREDICT.MARKET_DETAILS,
-      params: {
-        marketId: mockMarket.id,
-        entryPoint: PredictEventValues.ENTRY_POINT.PREDICT_FEED,
-        title: mockMarket.title,
-        image: mockMarket.image,
-      },
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MARKET_DETAILS, {
+      marketId: mockMarket.id,
+      entryPoint: PredictEventValues.ENTRY_POINT.PREDICT_FEED,
+      title: mockMarket.title,
+      image: mockMarket.image,
     });
   });
 

--- a/app/components/UI/Predict/components/PredictMarketSingle/PredictMarketSingle.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSingle/PredictMarketSingle.tsx
@@ -191,14 +191,11 @@ const PredictMarketSingle: React.FC<PredictMarketSingleProps> = ({
     <TouchableOpacity
       testID={testID}
       onPress={() => {
-        navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
-          screen: Routes.PREDICT.MARKET_DETAILS,
-          params: {
-            marketId: market.id,
-            entryPoint,
-            title: market.title,
-            image: getImageUrl(),
-          },
+        navigation.navigate(Routes.PREDICT.MARKET_DETAILS, {
+          marketId: market.id,
+          entryPoint,
+          title: market.title,
+          image: getImageUrl(),
         });
       }}
     >

--- a/app/components/UI/Predict/components/PredictPositionDetail/PredictPositionDetail.test.tsx
+++ b/app/components/UI/Predict/components/PredictPositionDetail/PredictPositionDetail.test.tsx
@@ -242,13 +242,13 @@ describe('PredictPositionDetail', () => {
 
     fireEvent.press(screen.getByText('Cash out'));
 
-    expect(global.__mockNavigate).toHaveBeenCalledWith('PREDICT_MODALS_ROOT', {
-      screen: 'PREDICT_SELL_PREVIEW',
-      params: expect.objectContaining({
+    expect(global.__mockNavigate).toHaveBeenCalledWith(
+      'PREDICT_SELL_PREVIEW',
+      expect.objectContaining({
         position: expect.objectContaining({ id: 'pos-1' }),
         outcome: expect.objectContaining({ id: 'outcome-1' }),
       }),
-    });
+    );
   });
 
   describe('optimistic updates UI', () => {

--- a/app/components/UI/Predict/components/PredictPositionDetail/PredictPositionDetail.tsx
+++ b/app/components/UI/Predict/components/PredictPositionDetail/PredictPositionDetail.tsx
@@ -67,14 +67,11 @@ const PredictPosition: React.FC<PredictPositionProps> = ({
         const _outcome = market?.outcomes.find(
           (o) => o.id === position.outcomeId,
         );
-        navigate(Routes.PREDICT.MODALS.ROOT, {
-          screen: Routes.PREDICT.MODALS.SELL_PREVIEW,
-          params: {
-            market,
-            position,
-            outcome: _outcome,
-            entryPoint: PredictEventValues.ENTRY_POINT.PREDICT_MARKET_DETAILS,
-          },
+        navigate(Routes.PREDICT.MODALS.SELL_PREVIEW, {
+          market,
+          position,
+          outcome: _outcome,
+          entryPoint: PredictEventValues.ENTRY_POINT.PREDICT_MARKET_DETAILS,
         });
       },
       { attemptedAction: PredictEventValues.ATTEMPTED_ACTION.CASHOUT },

--- a/app/components/UI/Predict/routes/index.tsx
+++ b/app/components/UI/Predict/routes/index.tsx
@@ -28,8 +28,8 @@ const PredictModalStack = () => (
     }}
   >
     <ModalStack.Screen
-      name={Routes.PREDICT.MODALS.GTM_MODAL}
-      component={PredictGTMModal}
+      name={Routes.PREDICT.MODALS.UNAVAILABLE}
+      component={PredictUnavailableModal}
       options={{
         cardStyleInterpolator: ({ current }) => ({
           cardStyle: {
@@ -39,8 +39,8 @@ const PredictModalStack = () => (
       }}
     />
     <ModalStack.Screen
-      name={Routes.PREDICT.MODALS.UNAVAILABLE}
-      component={PredictUnavailableModal}
+      name={Routes.PREDICT.MODALS.GTM_MODAL}
+      component={PredictGTMModal}
       options={{
         cardStyleInterpolator: ({ current }) => ({
           cardStyle: {

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.test.tsx
@@ -1367,15 +1367,15 @@ describe('PredictMarketDetails', () => {
       const cashOutButton = screen.getByText('predict.cash_out');
       fireEvent.press(cashOutButton);
 
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.MODALS.ROOT, {
-        screen: Routes.PREDICT.MODALS.SELL_PREVIEW,
-        params: {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        Routes.PREDICT.MODALS.SELL_PREVIEW,
+        {
           position: mockPosition,
           outcome: expect.any(Object),
           market: expect.any(Object),
           entryPoint: 'predict_market_details',
         },
-      });
+      );
     });
 
     it('handles Yes button press for betting', () => {


### PR DESCRIPTION
# Fix Predict Navigation to Cash Out and Single Market

## Overview

This PR fixes navigation issues in the Predict feature that prevented users from properly navigating to the cash out flow and single market details screens. This was caused because cash out modal and Single market details modal are not on the ROOT navigator.

CHANGELOG entry: null

## Problem

Users were unable to navigate correctly to:
- **Cash out flow**: When attempting to sell positions
- **Single market details**: When viewing market information

**Root Cause**: The cash out modal and Single market details modal are not on the ROOT navigator

## Changes

### Files Modified

1. **`app/components/UI/Predict/routes/index.tsx`**
   - Swapped the order of `UNAVAILABLE` and `GTM_MODAL` screen declarations

2. **`app/components/UI/Predict/components/PredictMarketSingle/PredictMarketSingle.tsx`**
   - Updated navigation calls to work with new modal stack order
   - Restores navigation to single market details screen

3. **`app/components/UI/Predict/components/PredictPositionDetail/PredictPositionDetail.tsx`**
   - Updated navigation calls to work with new modal stack order
   - Restores navigation to cash out flow
## Testing

### Manual Testing - Cash Out Flow
1. Navigate to Predict feature
2. Open an active position
3. Tap "Cash out" button
4. **Expected**: Cash out screen should display correctly
5. **Previously**: Navigation was blocked or failed

### Manual Testing - Single Market
1. Navigate to Predict feature
2. Tap on any market to view details
3. **Expected**: Single market details screen should display
4. **Previously**: Navigation was blocked or failed

### Verification
- ✅ Cash out flow navigates correctly
- ✅ Single market details navigates correctly
- ✅ No regression in modal functionality (UNAVAILABLE, GTM)
- ✅ All other Predict navigation flows work as expected

## Impact

- **Medium Risk**: Fixes critical navigation blocking issues
- **No API Changes**: Internal navigation structure only
- **User Impact**: Restores cash out and market details functionality
- **No Breaking Changes**: Only fixes existing broken navigation


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Predict navigation to push `MARKET_DETAILS` and `SELL_PREVIEW` directly (not via `MODALS.ROOT`) and reorders modal stack; adjusts tests accordingly.
> 
> - **Navigation**:
>   - `PredictMarketSingle`: onPress navigates to `Routes.PREDICT.MARKET_DETAILS` with params (no `MODALS.ROOT`).
>   - `PredictPositionDetail`: cash out navigates to `Routes.PREDICT.MODALS.SELL_PREVIEW` directly (no `MODALS.ROOT`).
> - **Routes**:
>   - Reorders modal stack screens: `UNAVAILABLE` declared before `GTM_MODAL`.
> - **Tests**:
>   - Update expectations for navigation calls in `PredictMarketSingle.test.tsx`, `PredictPositionDetail.test.tsx`, and `PredictMarketDetails.test.tsx` to match direct navigation and reordered modals.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75a984d57ccb46a4ecd3c07f762bc7495f97aebf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->