### PR TITLE
fix: prevent concurrency for `createAccount` for Snap account providers cp-7.59.0

### DIFF
--- a/app/core/Engine/controllers/multichain-account-service/multichain-account-service-init.ts
+++ b/app/core/Engine/controllers/multichain-account-service/multichain-account-service-init.ts
@@ -4,6 +4,7 @@ import {
   BtcAccountProvider,
   TrxAccountProvider,
   AccountProviderWrapper,
+  SOL_ACCOUNT_PROVIDER_NAME,
 } from '@metamask/multichain-account-service';
 import { ControllerInitFunction } from '../../types';
 import Engine from '../../Engine';
@@ -25,11 +26,27 @@ export const multichainAccountServiceInit: ControllerInitFunction<
   MultichainAccountServiceMessenger,
   MultichainAccountServiceInitMessenger
 > = ({ controllerMessenger, initMessenger }) => {
+  const snapAccountProviderConfig = {
+    // READ THIS CAREFULLY:
+    // We using 1 to prevent any concurrent `keyring_createAccount` requests, that make sure
+    // we prevent any desync between Snap's accounts and Metamask's accounts.
+    maxConcurrency: 1,
+    // Re-use the default config for the rest:
+    discovery: {
+      timeoutMs: 2000,
+      maxAttempts: 3,
+      backOffMs: 1000,
+    },
+    createAccounts: {
+      timeoutMs: 3000,
+    },
+  };
+
   /// BEGIN:ONLY_INCLUDE_IF(bitcoin)
   // Create Bitcoin provider wrapped for feature flag control
   const btcProvider = new AccountProviderWrapper(
     controllerMessenger,
-    new BtcAccountProvider(controllerMessenger),
+    new BtcAccountProvider(controllerMessenger, snapAccountProviderConfig),
   );
   /// END:ONLY_INCLUDE_IF
 
@@ -37,7 +54,7 @@ export const multichainAccountServiceInit: ControllerInitFunction<
   // Create Tron provider wrapped for feature flag control
   const trxProvider = new AccountProviderWrapper(
     controllerMessenger,
-    new TrxAccountProvider(controllerMessenger),
+    new TrxAccountProvider(controllerMessenger, snapAccountProviderConfig),
   );
   /// END:ONLY_INCLUDE_IF
 
@@ -53,6 +70,9 @@ export const multichainAccountServiceInit: ControllerInitFunction<
   const controller = new MultichainAccountService({
     messenger: controllerMessenger,
     providers,
+    providerConfigs: {
+      [SOL_ACCOUNT_PROVIDER_NAME]: snapAccountProviderConfig,
+    },
   });
 
   // Handle provider feature flags


### PR DESCRIPTION
## **Description**

It seems that having concurrent calls to `keyring_createAccount` cause some synchronization issues between Snap's accounts and MetaMask accounts. We're not sure of the real root cause yet for this, but preventing concurrent calls seems to mitigate (or even completely prevent) this kind of issues.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces single-concurrency createAccount and shared timeouts for Snap-backed BTC/TRX providers and SOL via providerConfigs.
> 
> - **Multichain Account Service** (`app/core/Engine/controllers/multichain-account-service/multichain-account-service-init.ts`):
>   - **New Snap provider config**: `maxConcurrency: 1` plus discovery/create timeouts.
>   - **Providers**:
>     - Pass config to `new BtcAccountProvider(...)` and `new TrxAccountProvider(...)` via `AccountProviderWrapper`.
>   - **Service config**:
>     - Add `providerConfigs` with `[SOL_ACCOUNT_PROVIDER_NAME]` mapped to the same Snap config.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8be27eb77eb194f01d65a5281379ada144c1840a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->