### PR TITLE
fix: transition to BIP-44 selectors for rewards row cp-7.59.0

### DIFF
--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.test.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.test.tsx
@@ -135,6 +135,35 @@ jest.mock(
   }),
 );
 
+jest.mock('../../../../../selectors/multichainAccounts/accounts', () => ({
+  selectSelectedInternalAccountByScope: () => (scope: string) => {
+    // Return appropriate account based on the scope
+    if (scope.startsWith('solana:')) {
+      return {
+        id: 'solanaAccountId',
+        address: 'pXwSggYaFeUryz86UoCs9ugZ4VWoZ7R1U5CVhxYjL61',
+        name: 'Solana Account',
+        type: 'snap',
+        scopes: ['solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'],
+        metadata: {
+          lastSelected: 0,
+        },
+      };
+    }
+    // Default to EVM account
+    return {
+      id: 'evmAccountId',
+      address: '0x1234567890123456789012345678901234567890',
+      name: 'Account 1',
+      type: 'eip155:eoa',
+      scopes: ['eip155:1'],
+      metadata: {
+        lastSelected: 0,
+      },
+    };
+  },
+}));
+
 jest.mock(
   '../../../../../selectors/featureFlagController/multichainAccounts',
   () => ({

--- a/app/components/UI/Bridge/hooks/useRewards/useRewards.ts
+++ b/app/components/UI/Bridge/hooks/useRewards/useRewards.ts
@@ -12,8 +12,8 @@ import {
   selectDestToken,
   selectSourceAmount,
 } from '../../../../../core/redux/slices/bridge';
-import { selectSelectedInternalAccountFormattedAddress } from '../../../../../selectors/accountsController';
-import { selectChainId } from '../../../../../selectors/networkController';
+import { selectSelectedInternalAccountByScope } from '../../../../../selectors/multichainAccounts/accounts';
+import { getFormattedAddressFromInternalAccount } from '../../../../../core/Multichain/utils';
 import { formatChainIdToCaip } from '@metamask/bridge-controller';
 import {
   toCaipAccountId,
@@ -104,10 +104,19 @@ export const useRewards = ({
   const sourceToken = useSelector(selectSourceToken);
   const destToken = useSelector(selectDestToken);
   const sourceAmount = useSelector(selectSourceAmount);
-  const selectedAddress = useSelector(
-    selectSelectedInternalAccountFormattedAddress,
+  const getSelectedAccountByScope = useSelector(
+    selectSelectedInternalAccountByScope,
   );
-  const currentChainId = useSelector(selectChainId);
+
+  const sourceChainId = sourceToken?.chainId
+    ? formatChainIdToCaip(sourceToken.chainId)
+    : undefined;
+  const selectedAccount = sourceChainId
+    ? getSelectedAccountByScope(sourceChainId)
+    : undefined;
+  const selectedAddress = selectedAccount
+    ? getFormattedAddressFromInternalAccount(selectedAccount)
+    : undefined;
 
   const estimatePoints = useCallback(async () => {
     // Skip if no active quote or missing required data
@@ -117,7 +126,7 @@ export const useRewards = ({
       !destToken ||
       !sourceAmount ||
       !selectedAddress ||
-      !currentChainId
+      !sourceChainId
     ) {
       setEstimatedPoints(null);
       return;
@@ -141,7 +150,7 @@ export const useRewards = ({
       // Format account to CAIP-10
       const caipAccount = formatAccountToCaipAccountId(
         selectedAddress,
-        currentChainId,
+        sourceChainId,
       );
 
       if (!caipAccount) {
@@ -232,7 +241,7 @@ export const useRewards = ({
     destToken,
     sourceAmount,
     selectedAddress,
-    currentChainId,
+    sourceChainId,
   ]);
 
   // Estimate points when dependencies change


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Fix issue where rewards calculations were broken for Solana by transitioning to BIP-44 compliant account selectors.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/22741

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use scope-based multichain account selector and CAIP-formatted chain IDs to compute rewards, with tests updated accordingly.
> 
> - **Bridge Rewards (useRewards)**
>   - Replace `selectSelectedInternalAccountFormattedAddress`/`selectChainId` with `selectSelectedInternalAccountByScope` and `getFormattedAddressFromInternalAccount`.
>   - Derive `sourceChainId` via `formatChainIdToCaip` and use it when formatting CAIP-10 accounts.
>   - Update dependencies and guards in `estimatePoints` to use `sourceChainId` and selected account by scope.
> - **Tests**
>   - Add mocks for `selectSelectedInternalAccountByScope` returning Solana/EVM accounts based on scope.
>   - Ensure rewards row scenarios use the new selector and CAIP chain handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab9db651d6bd464de396d528e183c04cc9a6dcba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->