### PR TITLE
fix(ramp): sell navigation

### DIFF
--- a/app/components/UI/Ramp/hooks/useRampNavigation.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampNavigation.test.ts
@@ -212,7 +212,30 @@ describe('useRampNavigation', () => {
     });
 
     describe('smart routing based on routing decision', () => {
-      it('navigates to deposit when routing decision is DEPOSIT', () => {
+      it('navigates to deposit when routing decision is DEPOSIT and mode is AGGREGATOR and params specify BUY', () => {
+        mockRampRoutingDecision = UnifiedRampRoutingType.DEPOSIT;
+        const mockNavDetails = [Routes.DEPOSIT.ID] as const;
+        mockCreateDepositNavigationDetails.mockReturnValue(mockNavDetails);
+
+        const { result } = renderHookWithProvider(() => useRampNavigation(), {
+          state: createMockState(),
+        });
+
+        result.current.goToRamps({
+          mode: RampMode.AGGREGATOR,
+          params: {
+            rampType: AggregatorRampType.BUY,
+          },
+        });
+
+        expect(mockCreateDepositNavigationDetails).toHaveBeenCalledWith(
+          undefined,
+        );
+        expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
+        expect(mockCreateRampNavigationDetails).not.toHaveBeenCalled();
+      });
+
+      it('navigates to deposit when routing decision is DEPOSIT and mode is AGGREGATOR and params are not present', () => {
         mockRampRoutingDecision = UnifiedRampRoutingType.DEPOSIT;
         const mockNavDetails = [Routes.DEPOSIT.ID] as const;
         mockCreateDepositNavigationDetails.mockReturnValue(mockNavDetails);
@@ -228,6 +251,29 @@ describe('useRampNavigation', () => {
         );
         expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
         expect(mockCreateRampNavigationDetails).not.toHaveBeenCalled();
+      });
+
+      it('navigates to aggregator when routing decision is DEPOSIT and params specify SELL', () => {
+        mockRampRoutingDecision = UnifiedRampRoutingType.DEPOSIT;
+        const mockNavDetails = [Routes.RAMP.BUY] as const;
+        mockCreateDepositNavigationDetails.mockReturnValue(mockNavDetails);
+
+        const { result } = renderHookWithProvider(() => useRampNavigation(), {
+          state: createMockState(),
+        });
+
+        result.current.goToRamps({
+          mode: RampMode.AGGREGATOR,
+          params: {
+            rampType: AggregatorRampType.SELL,
+          },
+        });
+
+        expect(mockCreateDepositNavigationDetails).not.toHaveBeenCalledWith(
+          undefined,
+        );
+        expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
+        expect(mockCreateRampNavigationDetails).toHaveBeenCalled();
       });
 
       it('navigates to deposit with params when routing decision is DEPOSIT and mode is DEPOSIT', () => {

--- a/app/components/UI/Ramp/hooks/useRampNavigation.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampNavigation.test.ts
@@ -2,15 +2,11 @@ import { renderHookWithProvider } from '../../../../util/test/renderWithProvider
 import { useNavigation } from '@react-navigation/native';
 import Routes from '../../../../constants/navigation/Routes';
 import { useRampNavigation, RampMode } from './useRampNavigation';
-import { createRampNavigationDetails } from '../Aggregator/routes/utils';
-import { createDepositNavigationDetails } from '../Deposit/routes/utils';
 import { RampType as AggregatorRampType } from '../Aggregator/types';
 import useRampsUnifiedV1Enabled from './useRampsUnifiedV1Enabled';
 import { UnifiedRampRoutingType } from '../../../../reducers/fiatOrders';
 
 jest.mock('@react-navigation/native');
-jest.mock('../Aggregator/routes/utils');
-jest.mock('../Deposit/routes/utils');
 jest.mock('./useRampsUnifiedV1Enabled');
 
 const mockNavigate = jest.fn();
@@ -25,15 +21,6 @@ const mockUseRampsUnifiedV1Enabled =
 let mockRampRoutingDecision: UnifiedRampRoutingType | null = null;
 
 describe('useRampNavigation', () => {
-  const mockCreateRampNavigationDetails =
-    createRampNavigationDetails as jest.MockedFunction<
-      typeof createRampNavigationDetails
-    >;
-  const mockCreateDepositNavigationDetails =
-    createDepositNavigationDetails as jest.MockedFunction<
-      typeof createDepositNavigationDetails
-    >;
-
   const createMockState = () => ({
     fiatOrders: {
       rampRoutingDecision: mockRampRoutingDecision,
@@ -50,39 +37,20 @@ describe('useRampNavigation', () => {
     } as unknown as ReturnType<typeof useNavigation>);
 
     mockUseRampsUnifiedV1Enabled.mockReturnValue(false);
-
-    mockCreateRampNavigationDetails.mockReturnValue([
-      Routes.RAMP.BUY,
-    ] as unknown as ReturnType<typeof createRampNavigationDetails>);
-
-    mockCreateDepositNavigationDetails.mockReturnValue([
-      Routes.DEPOSIT.ID,
-    ] as unknown as ReturnType<typeof createDepositNavigationDetails>);
   });
 
   describe('RampMode.AGGREGATOR', () => {
     it('navigates to buy route when mode is AGGREGATOR without params (defaults to BUY)', () => {
-      const mockNavDetails = [Routes.RAMP.BUY] as const;
-      mockCreateRampNavigationDetails.mockReturnValue(mockNavDetails);
-
       const { result } = renderHookWithProvider(() => useRampNavigation(), {
         state: createMockState(),
       });
 
       result.current.goToRamps({ mode: RampMode.AGGREGATOR });
 
-      expect(mockCreateRampNavigationDetails).toHaveBeenCalledWith(
-        AggregatorRampType.BUY,
-        undefined,
-      );
-      expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
-      expect(mockCreateDepositNavigationDetails).not.toHaveBeenCalled();
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.RAMP.BUY);
     });
 
     it('navigates to buy route when mode is AGGREGATOR with rampType BUY', () => {
-      const mockNavDetails = [Routes.RAMP.BUY] as const;
-      mockCreateRampNavigationDetails.mockReturnValue(mockNavDetails);
-
       const { result } = renderHookWithProvider(() => useRampNavigation(), {
         state: createMockState(),
       });
@@ -94,17 +62,10 @@ describe('useRampNavigation', () => {
         },
       });
 
-      expect(mockCreateRampNavigationDetails).toHaveBeenCalledWith(
-        AggregatorRampType.BUY,
-        undefined,
-      );
-      expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.RAMP.BUY);
     });
 
     it('navigates to sell route when mode is AGGREGATOR with rampType SELL', () => {
-      const mockNavDetails = [Routes.RAMP.SELL] as const;
-      mockCreateRampNavigationDetails.mockReturnValue(mockNavDetails);
-
       const { result } = renderHookWithProvider(() => useRampNavigation(), {
         state: createMockState(),
       });
@@ -116,17 +77,11 @@ describe('useRampNavigation', () => {
         },
       });
 
-      expect(mockCreateRampNavigationDetails).toHaveBeenCalledWith(
-        AggregatorRampType.SELL,
-        undefined,
-      );
-      expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.RAMP.SELL);
     });
 
-    it('passes intent to createRampNavigationDetails when provided for BUY', () => {
+    it('passes intent to navigation when provided for BUY', () => {
       const intent = { assetId: 'eip155:1/erc20:0x123' };
-      const mockNavDetails = [Routes.RAMP.BUY] as const;
-      mockCreateRampNavigationDetails.mockReturnValue(mockNavDetails);
 
       const { result } = renderHookWithProvider(() => useRampNavigation(), {
         state: createMockState(),
@@ -140,17 +95,17 @@ describe('useRampNavigation', () => {
         },
       });
 
-      expect(mockCreateRampNavigationDetails).toHaveBeenCalledWith(
-        AggregatorRampType.BUY,
-        intent,
-      );
-      expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.RAMP.BUY, {
+        screen: expect.any(String),
+        params: {
+          screen: expect.any(String),
+          params: intent,
+        },
+      });
     });
 
-    it('passes intent to createRampNavigationDetails when provided for SELL', () => {
+    it('passes intent to navigation when provided for SELL', () => {
       const intent = { assetId: 'eip155:1/erc20:0x123' };
-      const mockNavDetails = [Routes.RAMP.SELL] as const;
-      mockCreateRampNavigationDetails.mockReturnValue(mockNavDetails);
 
       const { result } = renderHookWithProvider(() => useRampNavigation(), {
         state: createMockState(),
@@ -164,36 +119,29 @@ describe('useRampNavigation', () => {
         },
       });
 
-      expect(mockCreateRampNavigationDetails).toHaveBeenCalledWith(
-        AggregatorRampType.SELL,
-        intent,
-      );
-      expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.RAMP.SELL, {
+        screen: expect.any(String),
+        params: {
+          screen: expect.any(String),
+          params: intent,
+        },
+      });
     });
   });
 
   describe('RampMode.DEPOSIT', () => {
     it('navigates to deposit route when mode is DEPOSIT without params', () => {
-      const mockNavDetails = [Routes.DEPOSIT.ID] as const;
-      mockCreateDepositNavigationDetails.mockReturnValue(mockNavDetails);
-
       const { result } = renderHookWithProvider(() => useRampNavigation(), {
         state: createMockState(),
       });
 
       result.current.goToRamps({ mode: RampMode.DEPOSIT });
 
-      expect(mockCreateDepositNavigationDetails).toHaveBeenCalledWith(
-        undefined,
-      );
-      expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
-      expect(mockCreateRampNavigationDetails).not.toHaveBeenCalled();
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.DEPOSIT.ID);
     });
 
-    it('passes params to createDepositNavigationDetails when provided', () => {
+    it('passes params to navigation when provided', () => {
       const params = { assetId: 'eip155:1/erc20:0x123', amount: '100' };
-      const mockNavDetails = [Routes.DEPOSIT.ID] as const;
-      mockCreateDepositNavigationDetails.mockReturnValue(mockNavDetails);
 
       const { result } = renderHookWithProvider(() => useRampNavigation(), {
         state: createMockState(),
@@ -201,8 +149,10 @@ describe('useRampNavigation', () => {
 
       result.current.goToRamps({ mode: RampMode.DEPOSIT, params });
 
-      expect(mockCreateDepositNavigationDetails).toHaveBeenCalledWith(params);
-      expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.DEPOSIT.ID, {
+        screen: Routes.DEPOSIT.ID,
+        params,
+      });
     });
   });
 
@@ -214,8 +164,6 @@ describe('useRampNavigation', () => {
     describe('smart routing based on routing decision', () => {
       it('navigates to deposit when routing decision is DEPOSIT and mode is AGGREGATOR and params specify BUY', () => {
         mockRampRoutingDecision = UnifiedRampRoutingType.DEPOSIT;
-        const mockNavDetails = [Routes.DEPOSIT.ID] as const;
-        mockCreateDepositNavigationDetails.mockReturnValue(mockNavDetails);
 
         const { result } = renderHookWithProvider(() => useRampNavigation(), {
           state: createMockState(),
@@ -228,17 +176,11 @@ describe('useRampNavigation', () => {
           },
         });
 
-        expect(mockCreateDepositNavigationDetails).toHaveBeenCalledWith(
-          undefined,
-        );
-        expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
-        expect(mockCreateRampNavigationDetails).not.toHaveBeenCalled();
+        expect(mockNavigate).toHaveBeenCalledWith(Routes.DEPOSIT.ID);
       });
 
       it('navigates to deposit when routing decision is DEPOSIT and mode is AGGREGATOR and params are not present', () => {
         mockRampRoutingDecision = UnifiedRampRoutingType.DEPOSIT;
-        const mockNavDetails = [Routes.DEPOSIT.ID] as const;
-        mockCreateDepositNavigationDetails.mockReturnValue(mockNavDetails);
 
         const { result } = renderHookWithProvider(() => useRampNavigation(), {
           state: createMockState(),
@@ -246,17 +188,11 @@ describe('useRampNavigation', () => {
 
         result.current.goToRamps({ mode: RampMode.AGGREGATOR });
 
-        expect(mockCreateDepositNavigationDetails).toHaveBeenCalledWith(
-          undefined,
-        );
-        expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
-        expect(mockCreateRampNavigationDetails).not.toHaveBeenCalled();
+        expect(mockNavigate).toHaveBeenCalledWith(Routes.DEPOSIT.ID);
       });
 
       it('navigates to aggregator when routing decision is DEPOSIT and params specify SELL', () => {
         mockRampRoutingDecision = UnifiedRampRoutingType.DEPOSIT;
-        const mockNavDetails = [Routes.RAMP.BUY] as const;
-        mockCreateDepositNavigationDetails.mockReturnValue(mockNavDetails);
 
         const { result } = renderHookWithProvider(() => useRampNavigation(), {
           state: createMockState(),
@@ -269,18 +205,12 @@ describe('useRampNavigation', () => {
           },
         });
 
-        expect(mockCreateDepositNavigationDetails).not.toHaveBeenCalledWith(
-          undefined,
-        );
-        expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
-        expect(mockCreateRampNavigationDetails).toHaveBeenCalled();
+        expect(mockNavigate).toHaveBeenCalledWith(Routes.RAMP.SELL);
       });
 
       it('navigates to deposit with params when routing decision is DEPOSIT and mode is DEPOSIT', () => {
         mockRampRoutingDecision = UnifiedRampRoutingType.DEPOSIT;
         const params = { assetId: 'eip155:1/erc20:0x123', amount: '100' };
-        const mockNavDetails = [Routes.DEPOSIT.ID] as const;
-        mockCreateDepositNavigationDetails.mockReturnValue(mockNavDetails);
 
         const { result } = renderHookWithProvider(() => useRampNavigation(), {
           state: createMockState(),
@@ -288,14 +218,14 @@ describe('useRampNavigation', () => {
 
         result.current.goToRamps({ mode: RampMode.DEPOSIT, params });
 
-        expect(mockCreateDepositNavigationDetails).toHaveBeenCalledWith(params);
-        expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
+        expect(mockNavigate).toHaveBeenCalledWith(Routes.DEPOSIT.ID, {
+          screen: Routes.DEPOSIT.ID,
+          params,
+        });
       });
 
       it('navigates to aggregator when routing decision is AGGREGATOR', () => {
         mockRampRoutingDecision = UnifiedRampRoutingType.AGGREGATOR;
-        const mockNavDetails = [Routes.RAMP.BUY] as const;
-        mockCreateRampNavigationDetails.mockReturnValue(mockNavDetails);
 
         const { result } = renderHookWithProvider(() => useRampNavigation(), {
           state: createMockState(),
@@ -303,18 +233,11 @@ describe('useRampNavigation', () => {
 
         result.current.goToRamps({ mode: RampMode.DEPOSIT });
 
-        expect(mockCreateRampNavigationDetails).toHaveBeenCalledWith(
-          AggregatorRampType.BUY,
-          undefined,
-        );
-        expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
-        expect(mockCreateDepositNavigationDetails).not.toHaveBeenCalled();
+        expect(mockNavigate).toHaveBeenCalledWith(Routes.RAMP.BUY);
       });
 
       it('navigates to aggregator with BUY when routing decision is AGGREGATOR and params specify BUY', () => {
         mockRampRoutingDecision = UnifiedRampRoutingType.AGGREGATOR;
-        const mockNavDetails = [Routes.RAMP.BUY] as const;
-        mockCreateRampNavigationDetails.mockReturnValue(mockNavDetails);
 
         const { result } = renderHookWithProvider(() => useRampNavigation(), {
           state: createMockState(),
@@ -327,17 +250,11 @@ describe('useRampNavigation', () => {
           },
         });
 
-        expect(mockCreateRampNavigationDetails).toHaveBeenCalledWith(
-          AggregatorRampType.BUY,
-          undefined,
-        );
-        expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
+        expect(mockNavigate).toHaveBeenCalledWith(Routes.RAMP.BUY);
       });
 
       it('navigates to aggregator with SELL when routing decision is AGGREGATOR and params specify SELL', () => {
         mockRampRoutingDecision = UnifiedRampRoutingType.AGGREGATOR;
-        const mockNavDetails = [Routes.RAMP.SELL] as const;
-        mockCreateRampNavigationDetails.mockReturnValue(mockNavDetails);
 
         const { result } = renderHookWithProvider(() => useRampNavigation(), {
           state: createMockState(),
@@ -350,18 +267,12 @@ describe('useRampNavigation', () => {
           },
         });
 
-        expect(mockCreateRampNavigationDetails).toHaveBeenCalledWith(
-          AggregatorRampType.SELL,
-          undefined,
-        );
-        expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
+        expect(mockNavigate).toHaveBeenCalledWith(Routes.RAMP.SELL);
       });
 
       it('navigates to aggregator with intent when routing decision is AGGREGATOR and intent is provided', () => {
         mockRampRoutingDecision = UnifiedRampRoutingType.AGGREGATOR;
         const intent = { assetId: 'eip155:1/erc20:0x123' };
-        const mockNavDetails = [Routes.RAMP.BUY] as const;
-        mockCreateRampNavigationDetails.mockReturnValue(mockNavDetails);
 
         const { result } = renderHookWithProvider(() => useRampNavigation(), {
           state: createMockState(),
@@ -375,17 +286,17 @@ describe('useRampNavigation', () => {
           },
         });
 
-        expect(mockCreateRampNavigationDetails).toHaveBeenCalledWith(
-          AggregatorRampType.BUY,
-          intent,
-        );
-        expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
+        expect(mockNavigate).toHaveBeenCalledWith(Routes.RAMP.BUY, {
+          screen: expect.any(String),
+          params: {
+            screen: expect.any(String),
+            params: intent,
+          },
+        });
       });
 
       it('navigates to aggregator when routing decision is UNSUPPORTED (defaults to aggregator)', () => {
         mockRampRoutingDecision = UnifiedRampRoutingType.UNSUPPORTED;
-        const mockNavDetails = [Routes.RAMP.BUY] as const;
-        mockCreateRampNavigationDetails.mockReturnValue(mockNavDetails);
 
         const { result } = renderHookWithProvider(() => useRampNavigation(), {
           state: createMockState(),
@@ -393,17 +304,11 @@ describe('useRampNavigation', () => {
 
         result.current.goToRamps({ mode: RampMode.AGGREGATOR });
 
-        expect(mockCreateRampNavigationDetails).toHaveBeenCalledWith(
-          AggregatorRampType.BUY,
-          undefined,
-        );
-        expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
+        expect(mockNavigate).toHaveBeenCalledWith(Routes.RAMP.BUY);
       });
 
       it('navigates to aggregator when routing decision is ERROR (defaults to aggregator)', () => {
         mockRampRoutingDecision = UnifiedRampRoutingType.ERROR;
-        const mockNavDetails = [Routes.RAMP.BUY] as const;
-        mockCreateRampNavigationDetails.mockReturnValue(mockNavDetails);
 
         const { result } = renderHookWithProvider(() => useRampNavigation(), {
           state: createMockState(),
@@ -411,17 +316,11 @@ describe('useRampNavigation', () => {
 
         result.current.goToRamps({ mode: RampMode.AGGREGATOR });
 
-        expect(mockCreateRampNavigationDetails).toHaveBeenCalledWith(
-          AggregatorRampType.BUY,
-          undefined,
-        );
-        expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
+        expect(mockNavigate).toHaveBeenCalledWith(Routes.RAMP.BUY);
       });
 
       it('navigates to aggregator when routing decision is null (defaults to aggregator)', () => {
         mockRampRoutingDecision = null;
-        const mockNavDetails = [Routes.RAMP.BUY] as const;
-        mockCreateRampNavigationDetails.mockReturnValue(mockNavDetails);
 
         const { result } = renderHookWithProvider(() => useRampNavigation(), {
           state: createMockState(),
@@ -429,19 +328,13 @@ describe('useRampNavigation', () => {
 
         result.current.goToRamps({ mode: RampMode.AGGREGATOR });
 
-        expect(mockCreateRampNavigationDetails).toHaveBeenCalledWith(
-          AggregatorRampType.BUY,
-          undefined,
-        );
-        expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
+        expect(mockNavigate).toHaveBeenCalledWith(Routes.RAMP.BUY);
       });
     });
 
     describe('overrideUnifiedBuyFlag', () => {
       it('uses original navigation logic when overrideUnifiedBuyFlag is true', () => {
         mockRampRoutingDecision = UnifiedRampRoutingType.DEPOSIT;
-        const mockNavDetails = [Routes.RAMP.BUY] as const;
-        mockCreateRampNavigationDetails.mockReturnValue(mockNavDetails);
 
         const { result } = renderHookWithProvider(() => useRampNavigation(), {
           state: createMockState(),
@@ -452,19 +345,12 @@ describe('useRampNavigation', () => {
           overrideUnifiedBuyFlag: true,
         });
 
-        expect(mockCreateRampNavigationDetails).toHaveBeenCalledWith(
-          AggregatorRampType.BUY,
-          undefined,
-        );
-        expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
-        expect(mockCreateDepositNavigationDetails).not.toHaveBeenCalled();
+        expect(mockNavigate).toHaveBeenCalledWith(Routes.RAMP.BUY);
       });
 
       it('uses original navigation logic for DEPOSIT mode when overrideUnifiedBuyFlag is true', () => {
         mockRampRoutingDecision = UnifiedRampRoutingType.AGGREGATOR;
         const params = { assetId: 'eip155:1/erc20:0x123', amount: '100' };
-        const mockNavDetails = [Routes.DEPOSIT.ID] as const;
-        mockCreateDepositNavigationDetails.mockReturnValue(mockNavDetails);
 
         const { result } = renderHookWithProvider(() => useRampNavigation(), {
           state: createMockState(),
@@ -476,9 +362,10 @@ describe('useRampNavigation', () => {
           overrideUnifiedBuyFlag: true,
         });
 
-        expect(mockCreateDepositNavigationDetails).toHaveBeenCalledWith(params);
-        expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
-        expect(mockCreateRampNavigationDetails).not.toHaveBeenCalled();
+        expect(mockNavigate).toHaveBeenCalledWith(Routes.DEPOSIT.ID, {
+          screen: Routes.DEPOSIT.ID,
+          params,
+        });
       });
     });
   });

--- a/app/components/UI/Ramp/hooks/useRampNavigation.ts
+++ b/app/components/UI/Ramp/hooks/useRampNavigation.ts
@@ -51,7 +51,12 @@ export const useRampNavigation = () => {
 
   const goToRamps = useCallback(
     ({ mode, params, overrideUnifiedBuyFlag }: GoToRampsParams) => {
-      if (isRampsUnifiedV1Enabled && !overrideUnifiedBuyFlag) {
+      if (
+        (mode === RampMode.DEPOSIT ||
+          params?.rampType === AggregatorRampType.BUY) &&
+        isRampsUnifiedV1Enabled &&
+        !overrideUnifiedBuyFlag
+      ) {
         if (rampRoutingDecision === UnifiedRampRoutingType.DEPOSIT) {
           navigation.navigate(
             ...createDepositNavigationDetails(

--- a/app/components/UI/Ramp/hooks/useRampNavigation.ts
+++ b/app/components/UI/Ramp/hooks/useRampNavigation.ts
@@ -51,9 +51,13 @@ export const useRampNavigation = () => {
 
   const goToRamps = useCallback(
     ({ mode, params, overrideUnifiedBuyFlag }: GoToRampsParams) => {
+      const routingParam =
+        mode === RampMode.AGGREGATOR
+          ? (params?.rampType ?? AggregatorRampType.BUY)
+          : undefined;
       if (
         (mode === RampMode.DEPOSIT ||
-          params?.rampType === AggregatorRampType.BUY) &&
+          routingParam === AggregatorRampType.BUY) &&
         isRampsUnifiedV1Enabled &&
         !overrideUnifiedBuyFlag
       ) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This pull request updates the ramp navigation logic to add an additional check before routing users to the unified deposit flow. Now, the unified ramp is only used when the user is depositing or the ramp type is set to "BUY", providing more granular control over navigation.

Navigation logic improvements:

* Updated the condition in `useRampNavigation` (in `useRampNavigation.ts`) to only route to the unified deposit flow if the mode is `DEPOSIT` or the `rampType` is `BUY`, in addition to the existing feature flag and override checks.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-2844

## **Manual testing steps**

```gherkin
Feature: Sell

  Scenario: user opens Sell
    Given unified flag v1 flag is on

    When user clicks on sell
    Then sell is opened
    And not deposit
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates ramp navigation to use unified V1 only for DEPOSIT or BUY; SELL now always routes to the aggregator, with tests revised accordingly.
> 
> - **Ramp navigation logic (`useRampNavigation.ts`)**:
>   - Apply unified V1 routing only when `mode` is `DEPOSIT` or aggregator `rampType` is `BUY` (defaults to BUY when absent).
>   - Route `SELL` directly to aggregator, bypassing unified deposit flow.
> - **Tests (`useRampNavigation.test.ts`)**:
>   - Update assertions to check direct `navigation.navigate` calls (including nested params) instead of mocking route utils.
>   - Add/refine cases for unified routing decisions: DEPOSIT vs AGGREGATOR, BUY vs SELL, intent propagation, and `overrideUnifiedBuyFlag` behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b1b8257561fa5e5255613f05fcdf60205eed6ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->