### PR TITLE
fix: cp-7.60.0 predict confirmation design

### DIFF
--- a/app/components/Views/confirmations/components/confirm/confirm-component.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.tsx
@@ -31,6 +31,14 @@ import { useTransactionMetadataRequest } from '../../hooks/transactions/useTrans
 import { hasTransactionType } from '../../utils/transaction';
 import { PredictClaimInfoSkeleton } from '../info/predict-claim-info';
 
+const TRANSACTION_TYPES_DISABLE_SCROLL = [TransactionType.predictClaim];
+
+const TRANSACTION_TYPES_DISABLE_ALERT_BANNER = [
+  TransactionType.perpsDeposit,
+  TransactionType.predictDeposit,
+  TransactionType.predictWithdraw,
+];
+
 export enum ConfirmationLoader {
   Default = 'default',
   CustomAmount = 'customAmount',
@@ -67,7 +75,9 @@ const ConfirmWrapped = ({
               >
                 <TouchableWithoutFeedback>
                   <>
-                    <AlertBanner ignoreTypes={[TransactionType.perpsDeposit]} />
+                    <AlertBanner
+                      ignoreTypes={TRANSACTION_TYPES_DISABLE_ALERT_BANNER}
+                    />
                     <Info route={route} />
                   </>
                 </TouchableWithoutFeedback>
@@ -210,5 +220,5 @@ function InfoLoader({
 
 function useDisableScroll() {
   const transaction = useTransactionMetadataRequest();
-  return hasTransactionType(transaction, [TransactionType.predictClaim]);
+  return hasTransactionType(transaction, TRANSACTION_TYPES_DISABLE_SCROLL);
 }

--- a/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.tsx
+++ b/app/components/Views/confirmations/components/deposit-keyboard/deposit-keyboard.tsx
@@ -103,7 +103,7 @@ export const DepositKeyboard = memo(
           {!alertMessage && hasInput && (
             <Button
               testID="deposit-keyboard-done-button"
-              label={doneLabel ?? strings('confirm.deposit_edit_amount_done')}
+              label={doneLabel ?? strings('confirm.edit_amount_done')}
               style={styles.button}
               onPress={onDonePress}
               variant={ButtonVariants.Primary}

--- a/app/components/Views/confirmations/components/edit-amount-keyboard/edit-amount-keyboard.test.tsx
+++ b/app/components/Views/confirmations/components/edit-amount-keyboard/edit-amount-keyboard.test.tsx
@@ -5,6 +5,7 @@ import { View } from 'react-native';
 
 import Text from '../../../../../component-library/components/Texts/Text';
 import { EditAmountKeyboard } from './edit-amount-keyboard';
+import { strings } from '../../../../../../locales/i18n';
 
 describe('EditAmountKeyboard', () => {
   it('calls onChange when digit pressed', () => {
@@ -37,7 +38,7 @@ describe('EditAmountKeyboard', () => {
       />,
     );
 
-    const doneButton = getByText('Done');
+    const doneButton = getByText(strings('confirm.edit_amount_done'));
     fireEvent.press(doneButton);
 
     expect(onDonePressMock).toHaveBeenCalled();
@@ -53,7 +54,7 @@ describe('EditAmountKeyboard', () => {
       />,
     );
 
-    expect(queryByText('Done')).toBeNull();
+    expect(queryByText(strings('confirm.edit_amount_done'))).toBeNull();
   });
 
   it('calls onPercentagePress when percentage button pressed', () => {
@@ -88,7 +89,7 @@ describe('EditAmountKeyboard', () => {
     );
 
     expect(getByText('Max')).toBeDefined();
-    expect(getByText('Done')).toBeDefined();
+    expect(getByText(strings('confirm.edit_amount_done'))).toBeDefined();
   });
 
   it('does not render additional buttons if showAdditionalKeyboard is false', () => {
@@ -106,7 +107,7 @@ describe('EditAmountKeyboard', () => {
 
     expect(queryByText('25%')).toBeNull();
     expect(queryByText('50%')).toBeNull();
-    expect(queryByText('Done')).toBeNull();
+    expect(queryByText(strings('confirm.edit_amount_done'))).toBeNull();
   });
 
   it('render additional rows passed in additionalRow prop', () => {

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -240,9 +240,7 @@ describe('CustomAmountInfo', () => {
     });
 
     await act(async () => {
-      fireEvent.press(
-        getByText(strings('confirm.deposit_edit_amount_predict_withdraw')),
-      );
+      fireEvent.press(getByText(strings('confirm.edit_amount_done')));
     });
 
     expect(

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -46,6 +46,7 @@ import { hasTransactionType } from '../../../utils/transaction';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
 import { TransactionType } from '@metamask/transaction-controller';
 import Button, {
+  ButtonSize,
   ButtonVariants,
   ButtonWidthTypes,
 } from '../../../../../../component-library/components/Buttons/Button';
@@ -68,7 +69,6 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     const [isKeyboardVisible, setIsKeyboardVisible] = useState(true);
     const availableTokens = useTransactionPayAvailableTokens();
     const hasTokens = availableTokens.length > 0;
-    const buttonLabel = useButtonLabel();
 
     const isResultReady = useIsResultReady({
       isKeyboardVisible,
@@ -128,7 +128,6 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
           {isKeyboardVisible && hasTokens && (
             <DepositKeyboard
               alertMessage={alertTitle}
-              doneLabel={buttonLabel}
               value={amountFiat}
               onChange={updatePendingAmount}
               onDonePress={handleDone}
@@ -234,6 +233,7 @@ function ConfirmButton({
   return (
     <Button
       style={[disabled && styles.disabledButton]}
+      size={ButtonSize.Lg}
       label={alertTitle ?? buttonLabel}
       variant={ButtonVariants.Primary}
       width={ButtonWidthTypes.Full}

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -5842,7 +5842,7 @@
     "nested_transaction_heading": "Transaction {{index}}",
     "transaction": "Transaction",
     "available_balance": "Available: ",
-    "edit_amount_done": "Done",
+    "edit_amount_done": "Continue",
     "deposit_edit_amount_done": "Add funds",
     "deposit_edit_amount_predict_withdraw": "Withdraw"
   },


### PR DESCRIPTION
## **Description**

Minor design fixes for Predict deposit confirmation.

- Increase height of confirm button.
- Update keyboard done label.
- Hide alert banner.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #22726 #22731 #22761

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Hides the alert banner for predict/perps flows, enlarges the confirm button, renames the keyboard “Done” action to “Continue,” and updates tests/i18n accordingly.
> 
> - **Confirmations UI**:
>   - Extend `AlertBanner` ignore list to `perpsDeposit`, `predictDeposit`, `predictWithdraw`.
>   - Centralize scroll disabling via `TRANSACTION_TYPES_DISABLE_SCROLL`; apply to `ScrollView`.
> - **Custom Amount / Keyboard**:
>   - Keyboard done label now uses `strings('confirm.edit_amount_done')` (text changed to “Continue”).
>   - Confirm button set to `ButtonSize.Lg`.
> - **Tests & i18n**:
>   - Update tests to reference `strings('confirm.edit_amount_done')`.
>   - Update `locales/languages/en.json`: `confirm.edit_amount_done` → "Continue".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd2677c6c53cb0f0ed75ff19909685d6fb9d6650. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->