### PR TITLE
SL-309: fix: add delay before revoke tokens cp-7.60.0

### DIFF
--- a/app/core/OAuthService/SeedlessControllerHelper.ts
+++ b/app/core/OAuthService/SeedlessControllerHelper.ts
@@ -1,9 +1,20 @@
 import Engine from '../Engine';
 
+// delay function
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Renews the refresh tokens for the seedless onboarding controller and revokes the pending revoke tokens.
+ * @param password - The password to use to unlock seedless controller in order to renew the refresh tokens.
+ * @returns A promise that resolves when the refresh tokens have been renewed.
+ */
 export const renewSeedlessControllerRefreshTokens = async (
   password: string,
 ) => {
   const { SeedlessOnboardingController } = Engine.context;
   await SeedlessOnboardingController.renewRefreshToken(password);
+
+  // delay to allow new refresh token to be persisted
+  await delay(15_000);
   await SeedlessOnboardingController.revokePendingRefreshTokens();
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
app is using revoked tokens to refresh token.
That should not be the case, as we only revoke token after successful renew refresh token.
We are speculating that user might closed the app before the redux state are persisted on the files

This PR add a delay of 15 seconds after successful renew refresh token before call revoke token

Jira Link
https://consensyssoftware.atlassian.net/browse/SL-297
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:
https://github.com/MetaMask/metamask-mobile/issues/21950
https://github.com/MetaMask/metamask-mobile/issues/20591

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wait 15s after renewing the Seedless refresh token before revoking pending tokens to ensure persistence.
> 
> - **OAuth service** (`app/core/OAuthService/SeedlessControllerHelper.ts`):
>   - Add `delay` utility.
>   - Update `renewSeedlessControllerRefreshTokens` to wait 15s after `renewRefreshToken` before calling `revokePendingRefreshTokens`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1effb311ee8ba44a9d4d8af667de3e123987bbd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->