### PR TITLE
fix(perps): use centralized ROE calculation in live positions cp-7.59.0

### DIFF
--- a/app/components/UI/Perps/hooks/stream/useLivePositions.test.ts
+++ b/app/components/UI/Perps/hooks/stream/useLivePositions.test.ts
@@ -383,7 +383,7 @@ describe('usePerpsLivePositions', () => {
       });
     });
 
-    it('uses mark price over mid price when available', async () => {
+    it('uses price price over mark price when available', async () => {
       let positionsCallback: (positions: Position[]) => void = jest.fn();
       let pricesCallback: (prices: Record<string, PriceUpdate>) => void =
         jest.fn();
@@ -428,7 +428,7 @@ describe('usePerpsLivePositions', () => {
 
       await waitFor(() => {
         const updatedPosition = result.current.positions[0];
-        expect(updatedPosition.unrealizedPnl).toBe('1500');
+        expect(updatedPosition.unrealizedPnl).toBe('1000');
       });
     });
 

--- a/app/components/UI/Perps/hooks/stream/useLivePositions.test.ts
+++ b/app/components/UI/Perps/hooks/stream/useLivePositions.test.ts
@@ -709,16 +709,22 @@ describe('usePerpsLivePositions', () => {
       expect(enriched[0]).toEqual(position);
     });
 
-    it('returns position unchanged when margin is NaN', () => {
+    it('calculates PnL even when margin is NaN (uses leverage instead)', () => {
       const position: Position = {
         ...mockPosition,
+        entryPrice: '50000',
+        size: '1.0',
         marginUsed: 'invalid',
-        unrealizedPnl: '500',
+        leverage: {
+          type: 'isolated',
+          value: 10,
+        },
       };
 
       const enriched = enrichPositionsWithLivePnL([position], basePriceData);
 
-      expect(enriched[0]).toEqual(position);
+      expect(enriched[0].unrealizedPnl).toBe('2000');
+      expect(enriched[0].returnOnEquity).toBe('0.4');
     });
 
     it('handles multiple positions with mixed price availability', () => {

--- a/app/components/UI/Perps/hooks/stream/useLivePositions.test.ts
+++ b/app/components/UI/Perps/hooks/stream/useLivePositions.test.ts
@@ -383,7 +383,7 @@ describe('usePerpsLivePositions', () => {
       });
     });
 
-    it('uses price price over mark price when available', async () => {
+    it('uses price over mark price when available', async () => {
       let positionsCallback: (positions: Position[]) => void = jest.fn();
       let pricesCallback: (prices: Record<string, PriceUpdate>) => void =
         jest.fn();

--- a/app/components/UI/Perps/hooks/stream/usePerpsLivePositions.ts
+++ b/app/components/UI/Perps/hooks/stream/usePerpsLivePositions.ts
@@ -40,11 +40,11 @@ export function enrichPositionsWithLivePnL(
     }
 
     // Use mark price if available, fallback to mid price
-    const markPrice = priceUpdate.markPrice
-      ? Number.parseFloat(priceUpdate.markPrice)
-      : Number.parseFloat(priceUpdate.price);
+    const currentPrice = Number.parseFloat(
+      priceUpdate.price ?? priceUpdate.markPrice,
+    );
 
-    if (!markPrice || Number.isNaN(markPrice) || markPrice <= 0) {
+    if (!currentPrice || Number.isNaN(currentPrice) || currentPrice <= 0) {
       return position;
     }
 
@@ -58,14 +58,14 @@ export function enrichPositionsWithLivePnL(
 
     const direction = size >= 0 ? 'long' : 'short';
 
-    const calculatedUnrealizedPnl = (markPrice - entryPrice) * size;
+    const calculatedUnrealizedPnl = (currentPrice - entryPrice) * size;
 
     const roePercentage = calculateRoEForPrice(
-      markPrice.toString(),
+      currentPrice.toString(),
       calculatedUnrealizedPnl >= 0, // isProfit
       true, // isForPositionBoundTpsl - true for existing positions
       {
-        currentPrice: markPrice,
+        currentPrice,
         direction,
         leverage,
         entryPrice,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR refactors the Return on Equity (ROE) calculation logic in the usePerpsLivePositions hook to use the centralized calculateRoEForPrice utility function instead of the previous manual calculation.


## **Changelog**

CHANGELOG entry: Fixed a bug where the PnL was showing incorrect values in the position card

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2080
Fixes https://github.com/MetaMask/metamask-mobile/issues/22790

## **Manual testing steps**

```gherkin
Feature: Live ROE calculation for Perps positions

  Scenario: user views live positions with updated ROE
    Given user has open perpetual positions
    And the positions are being streamed with live price updates

    When the market price changes
    Then the ROE percentage should update in real-time
    And the ROE should be calculated consistently with TP/SL ROE calculations
    And the ROE should properly reflect the position direction (long/short)
    And the ROE should account for the position's leverage
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

PnL on the list is not matching the PnL on the position card 
https://github.com/user-attachments/assets/72729f8d-080f-45a5-bcd0-ce3776f2efde



### **After**
PnL in the position card is matching the PnL from the list

<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2025-11-17 at 13 14 10" src="https://github.com/user-attachments/assets/bc82bdff-3579-4bc0-91f4-a6ceb8518b5e" />
<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2025-11-17 at 13 14 02" src="https://github.com/user-attachments/assets/4dd7c44b-8b58-4389-b083-0110e2af6007" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reworks live PnL/ROE to use centralized ROE utility, prefer `price` over `markPrice`, and handle leverage when margin is invalid, with corresponding test updates.
> 
> - **Perps Live Positions Hook (`usePerpsLivePositions.ts`)**:
>   - Use centralized `calculateRoEForPrice` for `returnOnEquity`.
>   - Prefer `price` over `markPrice` for live calculations; validate positive numeric `currentPrice`.
>   - Compute PnL as `(currentPrice - entryPrice) * size`; infer direction from `size` (supports shorts).
>   - Derive ROE from leverage (fallback when `marginUsed` invalid); ignore invalid `entryPrice`/`size`/price.
> - **Tests (`useLivePositions.test.ts`)**:
>   - Update expectations to reflect `price` precedence and centralized ROE calc.
>   - Add coverage for short positions and leverage-based ROE when `marginUsed` is NaN.
>   - Maintain behavior when price data missing/empty and multiple position scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75a749fbe640d70c562b869a983f6e7c70ef74d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->