### PR TITLE
fix: scrolling issue in asset list prevents rendering bottom assets

### DIFF
--- a/app/components/UI/Bridge/components/BridgeDestTokenSelector/__snapshots__/BridgeDestTokenSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeDestTokenSelector/__snapshots__/BridgeDestTokenSelector.test.tsx.snap
@@ -884,7 +884,13 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                               </View>
                             </View>
                           </View>
-                          <View>
+                          <View
+                            style={
+                              {
+                                "flex": 1,
+                              }
+                            }
+                          >
                             <RCTScrollView
                               ListEmptyComponent={
                                 {
@@ -895,6 +901,11 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                               }
                               bounces={true}
                               collapsable={false}
+                              contentContainerStyle={
+                                {
+                                  "paddingBottom": 0,
+                                }
+                              }
                               data={
                                 [
                                   {
@@ -962,6 +973,7 @@ exports[`BridgeDestTokenSelector renders with initial state and displays tokens 
                               stickyHeaderIndices={[]}
                               style={
                                 {
+                                  "flex": 1,
                                   "marginTop": 10,
                                 }
                               }

--- a/app/components/UI/Bridge/components/BridgeSourceTokenSelector/__snapshots__/BridgeSourceTokenSelector.test.tsx.snap
+++ b/app/components/UI/Bridge/components/BridgeSourceTokenSelector/__snapshots__/BridgeSourceTokenSelector.test.tsx.snap
@@ -889,7 +889,13 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                               </View>
                             </View>
                           </View>
-                          <View>
+                          <View
+                            style={
+                              {
+                                "flex": 1,
+                              }
+                            }
+                          >
                             <RCTScrollView
                               ListEmptyComponent={
                                 {
@@ -900,6 +906,11 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                               }
                               bounces={true}
                               collapsable={false}
+                              contentContainerStyle={
+                                {
+                                  "paddingBottom": 0,
+                                }
+                              }
                               data={
                                 [
                                   {
@@ -1027,6 +1038,7 @@ exports[`BridgeSourceTokenSelector renders with initial state and displays token
                               stickyHeaderIndices={[]}
                               style={
                                 {
+                                  "flex": 1,
                                   "marginTop": 10,
                                 }
                               }

--- a/app/components/UI/Bridge/components/BridgeTokenSelectorBase.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelectorBase.tsx
@@ -54,6 +54,13 @@ const createStyles = (params: { theme: Theme }) => {
     },
     tokensList: {
       marginTop: 10,
+      flex: 1,
+    },
+    tokensListContent: {
+      paddingBottom: 0,
+    },
+    tokensListContainer: {
+      flex: 1,
     },
     searchInput: {
       borderRadius: 12,
@@ -242,9 +249,10 @@ export const BridgeTokenSelectorBase: React.FC<BridgeTokenSelectorBaseProps> =
           </Box>
 
           {/* Need this extra View to fix tokens not being reliably pressable on Android hardware, no idea why */}
-          <View>
+          <View style={styles.tokensListContainer}>
             <ListComponent
               style={styles.tokensList}
+              contentContainerStyle={styles.tokensListContent}
               key={scrollResetKey}
               data={
                 shouldRenderOverallLoading


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The scrollable section in the select assets list stops scrolling prematurely, preventing some assets at the bottom from being displayed. Users are unable to select these assets as the list snaps back to a previous position when trying to scroll to the end. This issue needs to be resolved before the new asset picker goes live.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog** 

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixes scrolling issue in asset list that prevents rendering bottom assets

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-3453

## **Manual testing steps**

```gherkin
Ensure that assets that appear at the bottom of the asset list in both src and dest asset selector are visible in both android and ios.
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/31ccef83-f961-4785-b763-4151c9c8f229

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/8d1bbe3c-ef73-41c0-9732-2f7f7e687530


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make bridge token lists occupy full height and remove extra bottom padding to prevent premature scroll stops.
> 
> - **Bridge token selectors (`BridgeTokenSelectorBase`)**:
>   - Add `tokensListContainer` with `flex: 1` and set `tokensList` `flex: 1` to ensure the list fills available space.
>   - Add `tokensListContent` with `paddingBottom: 0` and pass via `contentContainerStyle` to avoid extra bottom space.
> - **Tests**:
>   - Update snapshots for `BridgeSourceTokenSelector` and `BridgeDestTokenSelector` to reflect new layout and list content container styles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e45658765c45aedfe8129bef31d8933f7659ba8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->