### PR TITLE
fix: cp-7.60.0 hide metamask pay transaction notifications

### DIFF
--- a/app/core/NotificationManager.js
+++ b/app/core/NotificationManager.js
@@ -538,7 +538,7 @@ class NotificationManager {
     }
 
     const isRequired = transactions.some((tx) =>
-      tx.requiredTransactionIds?.includes(transactionMeta.id),
+      tx.requiredTransactionIds?.includes(transactionMeta?.id),
     );
 
     if (isRequired) {
@@ -549,7 +549,7 @@ class NotificationManager {
       (tx) =>
         hasTransactionType(tx, SKIP_NOTIFICATION_TRANSACTION_TYPES) &&
         tx.batchId &&
-        tx.batchId === transactionMeta.batchId,
+        tx.batchId === transactionMeta?.batchId,
     );
 
     return isSameBatch;

--- a/app/core/NotificationManager.js
+++ b/app/core/NotificationManager.js
@@ -519,6 +519,7 @@ class NotificationManager {
 
   #shouldSkipNotification(transactionMeta) {
     const { TransactionController } = Engine.context;
+    const { transactions } = TransactionController.state;
 
     if (
       hasTransactionType(transactionMeta, SKIP_NOTIFICATION_TRANSACTION_TYPES)
@@ -526,13 +527,32 @@ class NotificationManager {
       return true;
     }
 
-    const isSkippedInProgress = TransactionController.state.transactions.some(
+    const isSkippedInProgress = transactions.some(
       (tx) =>
         hasTransactionType(tx, SKIP_NOTIFICATION_TRANSACTION_TYPES) &&
         IN_PROGRESS_SKIP_STATUS.includes(tx.status),
     );
 
-    return isSkippedInProgress;
+    if (isSkippedInProgress) {
+      return true;
+    }
+
+    const isRequired = transactions.some((tx) =>
+      tx.requiredTransactionIds?.includes(transactionMeta.id),
+    );
+
+    if (isRequired) {
+      return true;
+    }
+
+    const isSameBatch = transactions.some(
+      (tx) =>
+        hasTransactionType(tx, SKIP_NOTIFICATION_TRANSACTION_TYPES) &&
+        tx.batchId &&
+        tx.batchId === transactionMeta.batchId,
+    );
+
+    return isSameBatch;
   }
 }
 

--- a/app/core/NotificationsManager.test.ts
+++ b/app/core/NotificationsManager.test.ts
@@ -14,6 +14,7 @@ import {
   TransactionMeta,
   TransactionType,
 } from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
 
 interface NavigationMock {
   navigate: jest.Mock;
@@ -558,5 +559,45 @@ describe('NotificationManager', () => {
         });
       },
     );
+
+    it('does not show a notification if required transaction', () => {
+      mockTransactionController.state.transactions.push({
+        type: TransactionType.perpsDeposit,
+        requiredTransactionIds: [
+          mockTransactionController.state.transactions[0].id,
+        ],
+      } as TransactionMeta);
+
+      notificationManager.watchSubmittedTransaction({
+        id: '0x123',
+        txParams: {
+          nonce: '0x1',
+        },
+        silent: false,
+      });
+
+      expect(showNotificationSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not show a notification if in batch with skipped', () => {
+      const batchId = '0x123' as Hex;
+
+      mockTransactionController.state.transactions.push({
+        type: TransactionType.perpsDeposit,
+        batchId,
+      } as TransactionMeta);
+
+      mockTransactionController.state.transactions[0].batchId = batchId;
+
+      notificationManager.watchSubmittedTransaction({
+        id: '0x123',
+        txParams: {
+          nonce: '0x1',
+        },
+        silent: false,
+      });
+
+      expect(showNotificationSpy).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## **Description**

Hide all standard transaction notifications for MetaMask Pay, including any required transactions or those in the same batch.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #22764 

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extends notification skipping to include required transactions and those in the same batch as skipped types, with tests added.
> 
> - **Core (`app/core/NotificationManager.js`)**
>   - Refines `#shouldSkipNotification` to use cached `transactions` and early returns.
>   - Skips notifications when:
>     - The transaction is required by another (`tx.requiredTransactionIds` includes `transactionMeta.id`).
>     - It shares a `batchId` with a transaction of skipped types.
> - **Tests (`app/core/NotificationsManager.test.ts`)**
>   - Adds cases verifying no notifications for required and same-batch scenarios.
>   - Minor additions (e.g., `Hex` import) to support tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ddba832836bcbbc05b704de81f766efc71ff1b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->