### PR TITLE
refactor: create and reuse `onChainAnalyticProperties` utils

### DIFF
--- a/app/components/UI/Notification/List/index.tsx
+++ b/app/components/UI/Notification/List/index.tsx
@@ -16,6 +16,7 @@ import {
   useListNotifications,
   useMarkNotificationAsRead,
 } from '../../../../util/notifications/hooks/useNotifications';
+import onChainAnalyticProperties from '../../../../util/notifications/methods/notification-analytics';
 import { useMetrics } from '../../../hooks/useMetrics';
 import Empty from '../Empty';
 import { NotificationMenuItem } from '../NotificationMenuItem';
@@ -70,25 +71,13 @@ export function useNotificationOnClick(
         },
       ]);
 
-      const otherNotificationProperties = () => {
-        if (
-          'notification_type' in item &&
-          item.notification_type === 'on-chain' &&
-          item.payload?.chain_id
-        ) {
-          return { chain_id: item.payload.chain_id };
-        }
-
-        return undefined;
-      };
-
       trackEvent(
         createEventBuilder(MetaMetricsEvents.NOTIFICATION_CLICKED)
           .addProperties({
             notification_id: item.id,
             notification_type: item.type,
             previously_read: item.isRead,
-            ...otherNotificationProperties(),
+            ...onChainAnalyticProperties(item),
             data: item, // data blob for feature teams to analyse their notification shapes
           })
           .build(),

--- a/app/components/Views/Notifications/Details/Fields/NetworkFeeField.tsx
+++ b/app/components/Views/Notifications/Details/Fields/NetworkFeeField.tsx
@@ -23,6 +23,7 @@ import Icon, {
 import { NotificationDetailStyles } from '../styles';
 import { CURRENCY_SYMBOL_BY_CHAIN_ID } from '../../../../../constants/network';
 import { type INotification } from '../../../../../util/notifications';
+import onChainAnalyticProperties from '../../../../../util/notifications/methods/notification-analytics';
 import { useMetrics } from '../../../../../components/hooks/useMetrics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import NetworkFeeFieldSkeleton from './Skeletons/NetworkFeeField';
@@ -137,23 +138,12 @@ function NetworkFeeField(props: NetworkFeeFieldProps) {
   const onPress = () => {
     setIsCollapsed(!isCollapsed);
     if (!isCollapsed) {
-      const otherNotificationProperties = () => {
-        if (
-          'notification_type' in notification &&
-          notification.notification_type === 'on-chain' &&
-          notification.payload?.chain_id
-        ) {
-          return { chain_id: notification.payload.chain_id };
-        }
-
-        return undefined;
-      };
       trackEvent(
         createEventBuilder(MetaMetricsEvents.NOTIFICATION_DETAIL_CLICKED)
           .addProperties({
             notification_id: notification.id,
             notification_type: notification.type,
-            ...otherNotificationProperties(),
+            ...onChainAnalyticProperties(notification),
             clicked_item: 'fee_details',
           })
           .build(),

--- a/app/components/Views/Notifications/Details/Fields/TransactionField.tsx
+++ b/app/components/Views/Notifications/Details/Fields/TransactionField.tsx
@@ -22,6 +22,7 @@ import useStyles from '../useStyles';
 import { useMetrics } from '../../../../../components/hooks/useMetrics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import type { INotification } from '../../../../../util/notifications/types';
+import onChainAnalyticProperties from '../../../../../util/notifications/methods/notification-analytics';
 
 type TransactionFieldProps = ModalFieldTransaction & {
   notification: INotification;
@@ -55,24 +56,12 @@ function TransactionField(props: TransactionFieldProps) {
       <View style={styles.rightSection}>
         <Pressable
           onPress={() => {
-            const otherNotificationProperties = () => {
-              if (
-                'notification_type' in notification &&
-                notification.notification_type === 'on-chain' &&
-                notification.payload?.chain_id
-              ) {
-                return { chain_id: notification.payload.chain_id };
-              }
-
-              return undefined;
-            };
-
             trackEvent(
               createEventBuilder(MetaMetricsEvents.NOTIFICATION_DETAIL_CLICKED)
                 .addProperties({
                   notification_id: notification.id,
                   notification_type: notification.type,
-                  ...otherNotificationProperties(),
+                  ...onChainAnalyticProperties(notification),
                   clicked_item: 'tx_id',
                 })
                 .build(),

--- a/app/components/Views/Notifications/Details/Footers/BlockExplorerFooter.tsx
+++ b/app/components/Views/Notifications/Details/Footers/BlockExplorerFooter.tsx
@@ -14,6 +14,7 @@ import { IconName } from '../../../../../component-library/components/Icons/Icon
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { type INotification } from '../../../../../util/notifications/types';
 import { useMetrics } from '../../../../../components/hooks/useMetrics';
+import onChainAnalyticProperties from '../../../../../util/notifications/methods/notification-analytics';
 
 type BlockExplorerFooterProps = ModalFooterBlockExplorer & {
   notification: INotification;
@@ -44,25 +45,13 @@ export default function BlockExplorerFooter(props: BlockExplorerFooterProps) {
   const txHashUrl = `${url}/tx/${props.txHash}`;
 
   const onPress = () => {
-    const otherNotificationProperties = () => {
-      if (
-        'notification_type' in notification &&
-        notification.notification_type === 'on-chain' &&
-        notification.payload?.chain_id
-      ) {
-        return { chain_id: notification.payload.chain_id };
-      }
-
-      return undefined;
-    };
-
     Linking.openURL(txHashUrl);
     trackEvent(
       createEventBuilder(MetaMetricsEvents.NOTIFICATION_DETAIL_CLICKED)
         .addProperties({
           notification_id: notification.id,
           notification_type: notification.type,
-          ...otherNotificationProperties(),
+          ...onChainAnalyticProperties(notification),
           clicked_item: 'block_explorer',
         })
         .build(),

--- a/app/util/notifications/methods/notification-analytics.test.ts
+++ b/app/util/notifications/methods/notification-analytics.test.ts
@@ -1,0 +1,36 @@
+import { INotification } from '../types';
+import onChainAnalyticProperties from './notification-analytics';
+
+describe('onChainAnalyticProperties', () => {
+  it('returns undefined if notification is not on-chain', () => {
+    const notification = {
+      notification_type: 'off-chain',
+    } as unknown as INotification;
+    expect(onChainAnalyticProperties(notification)).toBeUndefined();
+  });
+
+  it('returns undefined if notification is on-chain but has no chain_id', () => {
+    const notification = {
+      notification_type: 'on-chain',
+      payload: {},
+    } as unknown as INotification;
+    expect(onChainAnalyticProperties(notification)).toBeUndefined();
+  });
+
+  it('returns chain_id if notification is on-chain and has chain_id', () => {
+    const notification = {
+      notification_type: 'on-chain',
+      payload: {
+        chain_id: '1',
+      },
+    } as unknown as INotification;
+    expect(onChainAnalyticProperties(notification)).toStrictEqual({
+      chain_id: '1',
+    });
+  });
+
+  it('returns undefined if item is not a notification', () => {
+    const notification = {} as unknown as INotification;
+    expect(onChainAnalyticProperties(notification)).toBeUndefined();
+  });
+});

--- a/app/util/notifications/methods/notification-analytics.ts
+++ b/app/util/notifications/methods/notification-analytics.ts
@@ -1,0 +1,15 @@
+import { INotification } from '../..';
+
+const onChainAnalyticProperties = (item: INotification) => {
+  if (
+    'notification_type' in item &&
+    item.notification_type === 'on-chain' &&
+    item.payload?.chain_id
+  ) {
+    return { chain_id: item.payload.chain_id };
+  }
+
+  return undefined;
+};
+
+export default onChainAnalyticProperties;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Creates a reusable `onChainAnalyticProperties` util to avoid code duplication. This util is used in four components to extract the `chain_id` for analytics events for notifications of type `on-chain`.

Also adds a test file for the new util.

test(notifications): update tests for onChainAnalyticProperties

Updates the tests for the `onChainAnalyticProperties` util to follow the project's conventions:
- Renames the tests to not start with "should".
- Replaces `.toEqual` with `.toStrictEqual`.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `onChainAnalyticProperties` to unify `chain_id` analytics for on-chain notifications, refactors four components to use it, and adds unit tests.
> 
> - **Notifications Analytics**:
>   - Replace inline analytics property builders with `onChainAnalyticProperties` in:
>     - `app/components/UI/Notification/List/index.tsx` (notification click event)
>     - `app/components/Views/Notifications/Details/Fields/NetworkFeeField.tsx` (fee details click)
>     - `app/components/Views/Notifications/Details/Fields/TransactionField.tsx` (copy tx id)
>     - `app/components/Views/Notifications/Details/Footers/BlockExplorerFooter.tsx` (open block explorer)
> - **Util**:
>   - Add `app/util/notifications/methods/notification-analytics.ts` to return `{ chain_id }` for on-chain notifications.
> - **Tests**:
>   - Add `app/util/notifications/methods/notification-analytics.test.ts` covering on/off-chain and missing `chain_id` cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86a956ea41ad2dc23ac93f5979775e25d1201617. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->