### PR TITLE
fix(predict): Improving copy on positions that have resolved early

### DIFF
--- a/app/components/UI/Predict/components/PredictPositionResolved/PredictPositionResolved.test.tsx
+++ b/app/components/UI/Predict/components/PredictPositionResolved/PredictPositionResolved.test.tsx
@@ -6,6 +6,20 @@ import {
   type PredictPosition as PredictPositionType,
 } from '../../types';
 
+// Mock strings function from i18n
+jest.mock('../../../../../../locales/i18n', () => ({
+  strings: jest.fn((key: string, params?: Record<string, string | number>) => {
+    const translations: Record<string, string> = {
+      'predict.market_details.resolved_early': 'Resolved early',
+      'predict.market_details.ended': 'Ended',
+      'predict.market_details.amount_on_outcome': `$${params?.amount} on ${params?.outcome}`,
+      'predict.market_details.won': 'Won',
+      'predict.market_details.lost': 'Lost',
+    };
+    return translations[key] || key;
+  }),
+}));
+
 // Mock dayjs to return consistent relative time
 jest.mock('dayjs', () => {
   const originalDayjs = jest.requireActual('dayjs');

--- a/app/components/UI/Predict/components/PredictPositionResolved/PredictPositionResolved.test.tsx
+++ b/app/components/UI/Predict/components/PredictPositionResolved/PredictPositionResolved.test.tsx
@@ -11,9 +11,12 @@ jest.mock('dayjs', () => {
   const originalDayjs = jest.requireActual('dayjs');
   const mockDayjs = (date?: string | number | Date | undefined) => {
     if (date) {
+      const dayjsInstance = originalDayjs(date);
       return {
         fromNow: () => '2 days ago',
-        ...originalDayjs(date),
+        isAfter: (other: ReturnType<typeof originalDayjs>) =>
+          dayjsInstance.isAfter(other),
+        ...dayjsInstance,
       };
     }
     return originalDayjs();
@@ -42,7 +45,7 @@ const basePosition: PredictPositionType = {
   currentValue: 2345.67,
   avgPrice: 0.34,
   claimable: false,
-  endDate: '2025-12-31T00:00:00Z',
+  endDate: '2020-01-01T00:00:00Z', // Past date so it shows "Ended X ago" instead of "Resolved early"
 };
 
 const renderComponent = (overrides?: Partial<PredictPositionType>) => {
@@ -58,10 +61,9 @@ describe('PredictPositionResolved', () => {
     renderComponent();
 
     expect(screen.getByText(basePosition.title)).toBeOnTheScreen();
-    expect(
-      screen.getByText('$123.45 on Yes • Ended 2 days ago'),
-    ).toBeOnTheScreen();
-    expect(screen.getByText('Won $2,345.67')).toBeOnTheScreen();
+    expect(screen.getByText(/\$123\.45 on Yes/)).toBeOnTheScreen();
+    expect(screen.getByText(/Ended 2 days ago/)).toBeOnTheScreen();
+    expect(screen.getByText(/Won\s+\$2,345\.67/)).toBeOnTheScreen();
   });
 
   it('renders losing position correctly', () => {
@@ -71,18 +73,16 @@ describe('PredictPositionResolved', () => {
       percentPnl: -50,
     });
 
-    expect(
-      screen.getByText('$100.00 on Yes • Ended 2 days ago'),
-    ).toBeOnTheScreen();
-    expect(screen.getByText('Lost $50.00')).toBeOnTheScreen();
+    expect(screen.getByText(/\$100\.00 on Yes/)).toBeOnTheScreen();
+    expect(screen.getByText(/Ended 2 days ago/)).toBeOnTheScreen();
+    expect(screen.getByText(/Lost \$50\.00/)).toBeOnTheScreen();
   });
 
   it('renders different outcome text', () => {
     renderComponent({ outcome: 'No' });
 
-    expect(
-      screen.getByText('$123.45 on No • Ended 2 days ago'),
-    ).toBeOnTheScreen();
+    expect(screen.getByText(/\$123\.45 on No/)).toBeOnTheScreen();
+    expect(screen.getByText(/Ended 2 days ago/)).toBeOnTheScreen();
   });
 
   it('handles zero profit/loss correctly', () => {
@@ -92,7 +92,7 @@ describe('PredictPositionResolved', () => {
       percentPnl: 0,
     });
 
-    expect(screen.getByText('Lost $0.00')).toBeOnTheScreen();
+    expect(screen.getByText(/Lost \$0\.00/)).toBeOnTheScreen();
   });
 
   it('calls onPress when position is tapped', () => {

--- a/app/components/UI/Predict/components/PredictPositionResolved/PredictPositionResolved.tsx
+++ b/app/components/UI/Predict/components/PredictPositionResolved/PredictPositionResolved.tsx
@@ -11,17 +11,24 @@ import { PredictPosition as PredictPositionType } from '../../types';
 import { formatPrice } from '../../utils/format';
 import styleSheet from './PredictPositionResolved.styles';
 import { PredictPositionSelectorsIDs } from '../../../../../../e2e/selectors/Predict/Predict.selectors';
+import { strings } from '../../../../../../locales/i18n';
 
 dayjs.extend(relativeTime);
 
 /**
- * Formats a date string as relative time (e.g., "1 minute ago", "2 hours ago")
+ * Formats a market end date, showing relative time or "Resolved early" if the date is in the future
  * @param dateString - The date string to format
- * @returns Formatted relative time string
+ * @returns Formatted relative time string or "Resolved" if date is in the future
  */
-const formatRelativeTime = (dateString: string): string => {
+const formatMarketEndDate = (dateString: string): string => {
   const date = dayjs(dateString);
-  return date.fromNow();
+  const now = dayjs();
+
+  if (date.isAfter(now)) {
+    return strings('predict.market_details.resolved_early');
+  }
+
+  return strings('predict.market_details.ended') + ' ' + date.fromNow();
 };
 
 interface PredictPositionResolvedProps {
@@ -68,8 +75,11 @@ const PredictPositionResolved: React.FC<PredictPositionResolvedProps> = ({
           numberOfLines={1}
           ellipsizeMode="tail"
         >
-          ${initialValue.toFixed(2)} on {outcome} • Ended{' '}
-          {formatRelativeTime(endDate)}
+          {strings('predict.market_details.amount_on_outcome', {
+            amount: initialValue.toFixed(2),
+            outcome,
+          })}{' '}
+          • {formatMarketEndDate(endDate)}
         </Text>
       </View>
       <View>
@@ -80,7 +90,9 @@ const PredictPositionResolved: React.FC<PredictPositionResolvedProps> = ({
             numberOfLines={1}
             ellipsizeMode="tail"
           >
-            Won {formatPrice(currentValue, { maximumDecimals: 2 })}
+            {strings('predict.market_details.won')}
+            {''}
+            {formatPrice(currentValue, { maximumDecimals: 2 })}
           </Text>
         ) : (
           <Text
@@ -89,7 +101,7 @@ const PredictPositionResolved: React.FC<PredictPositionResolvedProps> = ({
             numberOfLines={1}
             ellipsizeMode="tail"
           >
-            Lost{' '}
+            {strings('predict.market_details.lost')}{' '}
             {formatPrice(initialValue - currentValue, { maximumDecimals: 2 })}
           </Text>
         )}

--- a/app/components/UI/Predict/components/PredictPositionResolved/PredictPositionResolved.tsx
+++ b/app/components/UI/Predict/components/PredictPositionResolved/PredictPositionResolved.tsx
@@ -90,8 +90,7 @@ const PredictPositionResolved: React.FC<PredictPositionResolvedProps> = ({
             numberOfLines={1}
             ellipsizeMode="tail"
           >
-            {strings('predict.market_details.won')}
-            {''}
+            {strings('predict.market_details.won')}{' '}
             {formatPrice(currentValue, { maximumDecimals: 2 })}
           </Text>
         ) : (

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1786,7 +1786,9 @@
       "market_unavailable": "Market unavailable",
       "amount_on_outcome": "${{amount}} on {{outcome}}",
       "outcome_at_price": "{{outcome}} at {{price}}¢",
-      "fee_exemption": "We don't charge any fees on this market."
+      "fee_exemption": "We don't charge any fees on this market.",
+      "ended": "Ended",
+      "resolved_early": "Resolved early"
     },
     "tab": {
       "no_predictions_description": "Your predictions will appear here, showing your stake and market movement.",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Improving copy on positions that have resolved early (so it's no long incorrectly showing things like "Ended in 14 days" and now says "Resolved early"

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: [PRED-284](https://consensyssoftware.atlassian.net/browse/PRED-284)

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="420" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-11-17 at 11 01 16" src="https://github.com/user-attachments/assets/e309867e-0fa7-46f0-a41a-a5cb14e28acc" />

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[PRED-284]: https://consensyssoftware.atlassian.net/browse/PRED-284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `PredictPositionResolved` to use i18n and display "Resolved early" when `endDate` is in the future; adjusts tests and adds locale strings.
> 
> - **Predict UI**:
>   - Replace hardcoded copy with i18n in `PredictPositionResolved` (amount/outcome, won/lost, ended/resolved-early).
>   - Add `formatMarketEndDate` using `dayjs.isAfter` to show `"Resolved early"` for future `endDate`; otherwise `"Ended" <relative time>`.
> - **Tests**:
>   - Update `PredictPositionResolved.test.tsx` to mock i18n and dayjs, and assert via regex against localized strings.
> - **Localization**:
>   - Add `predict.market_details.ended` and `predict.market_details.resolved_early` keys to `en.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2f46af5e418dfa783f484895259122e907165b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->