### PR TITLE
fix: cp-7.60.0 hide monad from supported networks in boost cards

### DIFF
--- a/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/SwapSupportedNetworksSection.test.tsx
+++ b/app/components/UI/Rewards/components/Tabs/OverviewTab/WaysToEarn/SwapSupportedNetworksSection.test.tsx
@@ -20,9 +20,18 @@ jest.mock('../../../../../../../selectors/multichainNetworkController', () => ({
   selectNonEvmNetworkConfigurationsByChainId: jest.fn(),
 }));
 
+// Mock network blacklist selector
+jest.mock(
+  '../../../../../../../selectors/featureFlagController/networkBlacklist',
+  () => ({
+    selectAdditionalNetworksBlacklistFeatureFlag: jest.fn(),
+  }),
+);
+
 import { selectEvmNetworkConfigurationsByChainId } from '../../../../../../../selectors/networkController';
 import { selectNonEvmNetworkConfigurationsByChainId } from '../../../../../../../selectors/multichainNetworkController';
 import { NetworkConfiguration } from '@metamask/network-controller';
+import { selectAdditionalNetworksBlacklistFeatureFlag } from '../../../../../../../selectors/featureFlagController/networkBlacklist';
 
 const mockSelectEvmNetworkConfigurationsByChainId =
   selectEvmNetworkConfigurationsByChainId as jest.MockedFunction<
@@ -31,6 +40,10 @@ const mockSelectEvmNetworkConfigurationsByChainId =
 const mockSelectNonEvmNetworkConfigurationsByChainId =
   selectNonEvmNetworkConfigurationsByChainId as jest.MockedFunction<
     typeof selectNonEvmNetworkConfigurationsByChainId
+  >;
+const mockSelectAdditionalNetworksBlacklistFeatureFlag =
+  selectAdditionalNetworksBlacklistFeatureFlag as jest.MockedFunction<
+    typeof selectAdditionalNetworksBlacklistFeatureFlag
   >;
 
 // Mock i18n strings
@@ -107,6 +120,9 @@ describe('SwapSupportedNetworksSection', () => {
     mockSelectNonEvmNetworkConfigurationsByChainId.mockReturnValue(
       mockNonEvmNetworks as never,
     );
+    mockSelectAdditionalNetworksBlacklistFeatureFlag.mockReturnValue(
+      [] as never,
+    );
 
     // Mock useSelector to directly return the mocked data
     mockUseSelector.mockImplementation((selector) => {
@@ -115,6 +131,9 @@ describe('SwapSupportedNetworksSection', () => {
       }
       if (selector === mockSelectNonEvmNetworkConfigurationsByChainId) {
         return mockNonEvmNetworks;
+      }
+      if (selector === mockSelectAdditionalNetworksBlacklistFeatureFlag) {
+        return [];
       }
       return {};
     });
@@ -183,6 +202,9 @@ describe('SwapSupportedNetworksSection', () => {
       if (selector === mockSelectNonEvmNetworkConfigurationsByChainId) {
         return {};
       }
+      if (selector === mockSelectAdditionalNetworksBlacklistFeatureFlag) {
+        return [];
+      }
       return {};
     });
 
@@ -249,6 +271,9 @@ describe('SwapSupportedNetworksSection', () => {
         if (selector === mockSelectNonEvmNetworkConfigurationsByChainId) {
           return {};
         }
+        if (selector === mockSelectAdditionalNetworksBlacklistFeatureFlag) {
+          return [];
+        }
         return {};
       });
 
@@ -259,6 +284,60 @@ describe('SwapSupportedNetworksSection', () => {
       expect(
         getByText('Very Long Network Name That Should Be Truncated'),
       ).toBeOnTheScreen();
+    });
+  });
+
+  describe('additionalNetworksBlacklist behavior', () => {
+    it('excludes blacklisted networks from rendering', () => {
+      // Arrange - blacklist Linea
+      mockSelectAdditionalNetworksBlacklistFeatureFlag.mockReturnValue([
+        NETWORKS_CHAIN_ID.LINEA_MAINNET,
+      ] as never);
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === mockSelectEvmNetworkConfigurationsByChainId) {
+          return mockEvmNetworks;
+        }
+        if (selector === mockSelectNonEvmNetworkConfigurationsByChainId) {
+          return mockNonEvmNetworks;
+        }
+        if (selector === mockSelectAdditionalNetworksBlacklistFeatureFlag) {
+          return [NETWORKS_CHAIN_ID.LINEA_MAINNET];
+        }
+        return {};
+      });
+
+      // Act
+      const { queryByText } = render(<SwapSupportedNetworksSection />);
+
+      // Assert - Linea should be excluded and boost not shown
+      expect(queryByText('Linea Mainnet')).not.toBeOnTheScreen();
+      expect(queryByText('+100%')).not.toBeOnTheScreen();
+    });
+
+    it('does nothing when blacklist contains non-supported chain IDs', () => {
+      // Arrange - blacklist a random chainId
+      mockSelectAdditionalNetworksBlacklistFeatureFlag.mockReturnValue([
+        '0xdeadbeef',
+      ] as never);
+      mockUseSelector.mockImplementation((selector) => {
+        if (selector === mockSelectEvmNetworkConfigurationsByChainId) {
+          return mockEvmNetworks;
+        }
+        if (selector === mockSelectNonEvmNetworkConfigurationsByChainId) {
+          return mockNonEvmNetworks;
+        }
+        if (selector === mockSelectAdditionalNetworksBlacklistFeatureFlag) {
+          return ['0xdeadbeef'];
+        }
+        return {};
+      });
+
+      // Act
+      const { getByText } = render(<SwapSupportedNetworksSection />);
+
+      // Assert - Linea and others remain
+      expect(getByText('Linea Mainnet')).toBeOnTheScreen();
+      expect(getByText('Ethereum Mainnet')).toBeOnTheScreen();
     });
   });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Follow https://github.com/MetaMask/metamask-mobile/pull/21616 and use additionalNetworksBlacklist feature flag to hide Monad until ready
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/22723

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> SwapSupportedNetworksSection now excludes blacklisted networks via feature flag and tests cover blacklist behavior.
> 
> - **Rewards UI (OverviewTab → WaysToEarn → `SwapSupportedNetworksSection`)**:
>   - Integrates `selectAdditionalNetworksBlacklistFeatureFlag` and filters `SWAP_SUPPORTED_CHAIN_IDS` to exclude blacklisted networks.
>   - Updates memoization deps to include the blacklist; existing Linea boost logic remains.
> - **Tests (`SwapSupportedNetworksSection.test.tsx`)**:
>   - Mocks blacklist selector and defaults to empty list.
>   - Adds tests verifying exclusion of Linea when blacklisted and no effect for unknown chain IDs.
>   - Adjusts `useSelector` mocks accordingly across cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14ee73d23a3d800f4529eef233fbc4684579b505. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->