### PR TITLE
feat: Add skeleton loading for the Send flow

### DIFF
--- a/app/components/Views/confirmations/components/confirm/confirm-component.styles.ts
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.styles.ts
@@ -34,18 +34,6 @@ const styleSheet = (params: {
       justifyContent: 'center',
       alignItems: 'center',
     },
-    footerSkeletonContainer: {
-      flexDirection: 'row',
-      paddingHorizontal: 16,
-      paddingTop: 16,
-      paddingBottom: 32,
-      backgroundColor: theme.colors.background.alternative,
-      gap: 16,
-    },
-    footerButtonSkeleton: {
-      flex: 1,
-      borderRadius: 99,
-    },
   });
 };
 

--- a/app/components/Views/confirmations/components/confirm/confirm-component.styles.ts
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.styles.ts
@@ -34,6 +34,18 @@ const styleSheet = (params: {
       justifyContent: 'center',
       alignItems: 'center',
     },
+    footerSkeletonContainer: {
+      flexDirection: 'row',
+      paddingHorizontal: 16,
+      paddingTop: 16,
+      paddingBottom: 32,
+      backgroundColor: theme.colors.background.alternative,
+      gap: 16,
+    },
+    footerButtonSkeleton: {
+      flex: 1,
+      borderRadius: 99,
+    },
   });
 };
 

--- a/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.test.tsx
@@ -1,6 +1,7 @@
 import { act } from '@testing-library/react-native';
 import React from 'react';
 import { cloneDeep } from 'lodash';
+import { ScrollView } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import {
   generateContractInteractionState,
@@ -359,6 +360,165 @@ describe('Confirm', () => {
     });
 
     expect(getByTestId('confirm-loader-custom-amount')).toBeDefined();
+  });
+
+  it('displays PredictClaim loader when specified', () => {
+    useParamsMock.mockReturnValue({
+      loader: ConfirmationLoader.PredictClaim,
+    });
+
+    const stateWithoutRequest = cloneDeep(typedSignV1ConfirmationState);
+    stateWithoutRequest.engine.backgroundState.ApprovalController = {
+      pendingApprovals: {},
+      pendingApprovalCount: 0,
+      approvalFlows: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const { getByTestId } = renderWithProvider(<Confirm />, {
+      state: stateWithoutRequest,
+    });
+
+    expect(getByTestId('confirm-loader-predict-claim')).toBeDefined();
+  });
+
+  it('displays Transfer loader when specified', () => {
+    useParamsMock.mockReturnValue({
+      loader: ConfirmationLoader.Transfer,
+    });
+
+    const stateWithoutRequest = cloneDeep(typedSignV1ConfirmationState);
+    stateWithoutRequest.engine.backgroundState.ApprovalController = {
+      pendingApprovals: {},
+      pendingApprovalCount: 0,
+      approvalFlows: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const { getByTestId } = renderWithProvider(<Confirm />, {
+      state: stateWithoutRequest,
+    });
+
+    expect(getByTestId('confirm-loader-transfer')).toBeDefined();
+  });
+
+  it('renders InfoLoader with SafeAreaView for CustomAmount loader', () => {
+    useParamsMock.mockReturnValue({
+      loader: ConfirmationLoader.CustomAmount,
+    });
+
+    const stateWithoutRequest = cloneDeep(typedSignV1ConfirmationState);
+    stateWithoutRequest.engine.backgroundState.ApprovalController = {
+      pendingApprovals: {},
+      pendingApprovalCount: 0,
+      approvalFlows: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const { getByTestId, UNSAFE_queryAllByType } = renderWithProvider(
+      <Confirm />,
+      {
+        state: stateWithoutRequest,
+      },
+    );
+
+    const loaderContainer = getByTestId('confirm-loader-custom-amount');
+    const scrollViews = UNSAFE_queryAllByType(ScrollView);
+
+    expect(loaderContainer).toBeDefined();
+    expect(scrollViews.length).toBeGreaterThan(0);
+  });
+
+  it('renders InfoLoader with SafeAreaView for PredictClaim loader', () => {
+    useParamsMock.mockReturnValue({
+      loader: ConfirmationLoader.PredictClaim,
+    });
+
+    const stateWithoutRequest = cloneDeep(typedSignV1ConfirmationState);
+    stateWithoutRequest.engine.backgroundState.ApprovalController = {
+      pendingApprovals: {},
+      pendingApprovalCount: 0,
+      approvalFlows: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const { getByTestId, UNSAFE_queryAllByType } = renderWithProvider(
+      <Confirm />,
+      {
+        state: stateWithoutRequest,
+      },
+    );
+
+    const loaderContainer = getByTestId('confirm-loader-predict-claim');
+    const scrollViews = UNSAFE_queryAllByType(ScrollView);
+
+    expect(loaderContainer).toBeDefined();
+    expect(scrollViews.length).toBeGreaterThan(0);
+  });
+
+  it('renders InfoLoader with SafeAreaView for Transfer loader', () => {
+    useParamsMock.mockReturnValue({
+      loader: ConfirmationLoader.Transfer,
+    });
+
+    const stateWithoutRequest = cloneDeep(typedSignV1ConfirmationState);
+    stateWithoutRequest.engine.backgroundState.ApprovalController = {
+      pendingApprovals: {},
+      pendingApprovalCount: 0,
+      approvalFlows: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const { getByTestId, UNSAFE_queryAllByType } = renderWithProvider(
+      <Confirm />,
+      {
+        state: stateWithoutRequest,
+      },
+    );
+
+    const loaderContainer = getByTestId('confirm-loader-transfer');
+    const scrollViews = UNSAFE_queryAllByType(ScrollView);
+
+    expect(loaderContainer).toBeDefined();
+    expect(scrollViews.length).toBeGreaterThan(0);
+  });
+
+  it('defaults to Default loader when no loader param is provided', () => {
+    useParamsMock.mockReturnValue({});
+
+    const stateWithoutRequest = cloneDeep(typedSignV1ConfirmationState);
+    stateWithoutRequest.engine.backgroundState.ApprovalController = {
+      pendingApprovals: {},
+      pendingApprovalCount: 0,
+      approvalFlows: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const { getByTestId } = renderWithProvider(<Confirm />, {
+      state: stateWithoutRequest,
+    });
+
+    expect(getByTestId('confirm-loader-default')).toBeDefined();
+  });
+
+  it('defaults to Default loader when loader param is undefined', () => {
+    useParamsMock.mockReturnValue({
+      loader: undefined,
+    });
+
+    const stateWithoutRequest = cloneDeep(typedSignV1ConfirmationState);
+    stateWithoutRequest.engine.backgroundState.ApprovalController = {
+      pendingApprovals: {},
+      pendingApprovalCount: 0,
+      approvalFlows: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const { getByTestId } = renderWithProvider(<Confirm />, {
+      state: stateWithoutRequest,
+    });
+
+    expect(getByTestId('confirm-loader-default')).toBeDefined();
   });
 
   it('sets navigation options with header hidden for modal confirmations', () => {

--- a/app/components/Views/confirmations/components/confirm/confirm-component.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.tsx
@@ -19,7 +19,7 @@ import { ConfirmationAssetPollingProvider } from '../confirmation-asset-polling-
 import AlertBanner from '../alert-banner';
 import Info from '../info-root';
 import Title from '../title';
-import { Footer } from '../footer';
+import { Footer, FooterSkeleton } from '../footer';
 import { Splash } from '../splash';
 import styleSheet from './confirm-component.styles';
 import { TransactionType } from '@metamask/transaction-controller';
@@ -31,7 +31,6 @@ import { useTransactionMetadataRequest } from '../../hooks/transactions/useTrans
 import { hasTransactionType } from '../../utils/transaction';
 import { PredictClaimInfoSkeleton } from '../info/predict-claim-info';
 import { TransferInfoSkeleton } from '../info/transfer/transfer';
-import { Skeleton } from '../../../../../component-library/components/Skeleton';
 
 const TRANSACTION_TYPES_DISABLE_SCROLL = [TransactionType.predictClaim];
 
@@ -175,7 +174,7 @@ function Loader() {
 
   if (loader === ConfirmationLoader.CustomAmount) {
     return (
-      <InfoLoader testId="confirm-loader-custom-amount">
+      <InfoLoader testId="confirm-loader-custom-amount" loader={loader}>
         <CustomAmountInfoSkeleton />
       </InfoLoader>
     );
@@ -183,7 +182,7 @@ function Loader() {
 
   if (loader === ConfirmationLoader.PredictClaim) {
     return (
-      <InfoLoader testId="confirm-loader-predict-claim">
+      <InfoLoader testId="confirm-loader-predict-claim" loader={loader}>
         <PredictClaimInfoSkeleton />
       </InfoLoader>
     );
@@ -191,7 +190,7 @@ function Loader() {
 
   if (loader === ConfirmationLoader.Transfer) {
     return (
-      <InfoLoader testId="confirm-loader-transfer">
+      <InfoLoader testId="confirm-loader-transfer" loader={loader}>
         <TransferInfoSkeleton />
       </InfoLoader>
     );
@@ -207,9 +206,11 @@ function Loader() {
 function InfoLoader({
   children,
   testId,
+  loader,
 }: {
   children: ReactNode;
   testId?: string;
+  loader: ConfirmationLoader;
 }) {
   const { styles } = useStyles(styleSheet, { isFullScreenConfirmation: true });
 
@@ -225,19 +226,8 @@ function InfoLoader({
       >
         {children}
       </ScrollView>
-      <FooterSkeleton />
+      {loader === ConfirmationLoader.Transfer && <FooterSkeleton />}
     </SafeAreaView>
-  );
-}
-
-function FooterSkeleton() {
-  const { styles } = useStyles(styleSheet, { isFullScreenConfirmation: true });
-
-  return (
-    <View style={styles.footerSkeletonContainer}>
-      <Skeleton height={48} style={styles.footerButtonSkeleton} />
-      <Skeleton height={48} style={styles.footerButtonSkeleton} />
-    </View>
   );
 }
 

--- a/app/components/Views/confirmations/components/confirm/confirm-component.tsx
+++ b/app/components/Views/confirmations/components/confirm/confirm-component.tsx
@@ -30,6 +30,8 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTransactionMetadataRequest } from '../../hooks/transactions/useTransactionMetadataRequest';
 import { hasTransactionType } from '../../utils/transaction';
 import { PredictClaimInfoSkeleton } from '../info/predict-claim-info';
+import { TransferInfoSkeleton } from '../info/transfer/transfer';
+import { Skeleton } from '../../../../../component-library/components/Skeleton';
 
 const TRANSACTION_TYPES_DISABLE_SCROLL = [TransactionType.predictClaim];
 
@@ -43,6 +45,7 @@ export enum ConfirmationLoader {
   Default = 'default',
   CustomAmount = 'customAmount',
   PredictClaim = 'predictClaim',
+  Transfer = 'transfer',
 }
 
 export interface ConfirmationParams {
@@ -186,6 +189,14 @@ function Loader() {
     );
   }
 
+  if (loader === ConfirmationLoader.Transfer) {
+    return (
+      <InfoLoader testId="confirm-loader-transfer">
+        <TransferInfoSkeleton />
+      </InfoLoader>
+    );
+  }
+
   return (
     <View style={styles.spinnerContainer} testID="confirm-loader-default">
       <AnimatedSpinner size={SpinnerSize.MD} />
@@ -214,7 +225,19 @@ function InfoLoader({
       >
         {children}
       </ScrollView>
+      <FooterSkeleton />
     </SafeAreaView>
+  );
+}
+
+function FooterSkeleton() {
+  const { styles } = useStyles(styleSheet, { isFullScreenConfirmation: true });
+
+  return (
+    <View style={styles.footerSkeletonContainer}>
+      <Skeleton height={48} style={styles.footerButtonSkeleton} />
+      <Skeleton height={48} style={styles.footerButtonSkeleton} />
+    </View>
   );
 }
 

--- a/app/components/Views/confirmations/components/footer/footer.styles.ts
+++ b/app/components/Views/confirmations/components/footer/footer.styles.ts
@@ -60,6 +60,18 @@ const styleSheet = (params: {
       flexDirection: 'row',
       justifyContent: 'center',
     },
+    footerSkeletonContainer: {
+      flexDirection: 'row',
+      paddingHorizontal: 16,
+      paddingTop: 16,
+      paddingBottom: 32,
+      backgroundColor: colors.background.alternative,
+      gap: 16,
+    },
+    footerButtonSkeleton: {
+      flex: 1,
+      borderRadius: 99,
+    },
   });
 };
 

--- a/app/components/Views/confirmations/components/footer/footer.styles.ts
+++ b/app/components/Views/confirmations/components/footer/footer.styles.ts
@@ -41,11 +41,15 @@ const styleSheet = (params: {
         isFullScreenConfirmation,
       );
 
+  const baseFooterStyle = {
+    backgroundColor: colors.background.alternative,
+    paddingHorizontal: 16,
+    paddingTop: 16,
+  };
+
   return StyleSheet.create({
     base: {
-      backgroundColor: colors.background.alternative,
-      paddingHorizontal: 16,
-      paddingTop: 16,
+      ...baseFooterStyle,
       paddingBottom: basePaddingBottom,
     },
     linkText: {
@@ -61,11 +65,9 @@ const styleSheet = (params: {
       justifyContent: 'center',
     },
     footerSkeletonContainer: {
+      ...baseFooterStyle,
       flexDirection: 'row',
-      paddingHorizontal: 16,
-      paddingTop: 16,
       paddingBottom: 32,
-      backgroundColor: colors.background.alternative,
       gap: 16,
     },
     footerButtonSkeleton: {

--- a/app/components/Views/confirmations/components/footer/footer.tsx
+++ b/app/components/Views/confirmations/components/footer/footer.tsx
@@ -38,6 +38,7 @@ import {
 import { hasTransactionType } from '../../utils/transaction';
 import { PredictClaimFooter } from '../predict-confirmations/predict-claim-footer/predict-claim-footer';
 import { useIsTransactionPayLoading } from '../../hooks/pay/useTransactionPayData';
+import { Skeleton } from '../../../../../component-library/components/Skeleton';
 
 const HIDE_FOOTER_BY_DEFAULT_TYPES = [
   TransactionType.perpsDeposit,
@@ -246,3 +247,19 @@ export const Footer = () => {
     </>
   );
 };
+
+export function FooterSkeleton() {
+  const { isFullScreenConfirmation } = useFullScreenConfirmation();
+  const { styles } = useStyles(styleSheet, {
+    confirmDisabled: false,
+    isStakingConfirmationBool: false,
+    isFullScreenConfirmation,
+  });
+
+  return (
+    <View style={styles.footerSkeletonContainer}>
+      <Skeleton height={48} style={styles.footerButtonSkeleton} />
+      <Skeleton height={48} style={styles.footerButtonSkeleton} />
+    </View>
+  );
+}

--- a/app/components/Views/confirmations/components/footer/index.ts
+++ b/app/components/Views/confirmations/components/footer/index.ts
@@ -1,1 +1,1 @@
-export { Footer } from './footer';
+export { Footer, FooterSkeleton } from './footer';

--- a/app/components/Views/confirmations/components/info/transfer/transfer.tsx
+++ b/app/components/Views/confirmations/components/info/transfer/transfer.tsx
@@ -12,11 +12,11 @@ import useNavbar from '../../../hooks/ui/useNavbar';
 import { useMaxValueRefresher } from '../../../hooks/useMaxValueRefresher';
 import { useTokenAmount } from '../../../hooks/useTokenAmount';
 import { useTransferAssetType } from '../../../hooks/useTransferAssetType';
-import { HeroRow } from '../../rows/transactions/hero-row';
-import { NetworkAndOriginRow } from '../../rows/transactions/network-and-origin-row';
-import FromToRow from '../../rows/transactions/from-to-row';
-import GasFeesDetailsRow from '../../rows/transactions/gas-fee-details-row';
-import AdvancedDetailsRow from '../../rows/transactions/advanced-details-row';
+import { HeroRow, HeroRowSkeleton } from '../../rows/transactions/hero-row';
+import { NetworkAndOriginRow, NetworkAndOriginRowSkeleton } from '../../rows/transactions/network-and-origin-row';
+import FromToRow, { FromToRowSkeleton } from '../../rows/transactions/from-to-row';
+import GasFeesDetailsRow, { GasFeesDetailsRowSkeleton } from '../../rows/transactions/gas-fee-details-row';
+import AdvancedDetailsRow, { AdvancedDetailsRowSkeleton } from '../../rows/transactions/advanced-details-row';
 
 const Transfer = () => {
   // Set navbar as first to prevent Android navigation flickering
@@ -54,5 +54,20 @@ const Transfer = () => {
     </View>
   );
 };
+
+export function TransferInfoSkeleton() {
+  // Set navbar for loading state
+  useNavbar(strings('confirm.review'));
+
+  return (
+    <View testID="transfer-info-skeleton">
+      <HeroRowSkeleton />
+      <FromToRowSkeleton />
+      <NetworkAndOriginRowSkeleton />
+      <GasFeesDetailsRowSkeleton />
+      <AdvancedDetailsRowSkeleton />
+    </View>
+  );
+}
 
 export default Transfer;

--- a/app/components/Views/confirmations/components/info/transfer/transfer.tsx
+++ b/app/components/Views/confirmations/components/info/transfer/transfer.tsx
@@ -13,10 +13,19 @@ import { useMaxValueRefresher } from '../../../hooks/useMaxValueRefresher';
 import { useTokenAmount } from '../../../hooks/useTokenAmount';
 import { useTransferAssetType } from '../../../hooks/useTransferAssetType';
 import { HeroRow, HeroRowSkeleton } from '../../rows/transactions/hero-row';
-import { NetworkAndOriginRow, NetworkAndOriginRowSkeleton } from '../../rows/transactions/network-and-origin-row';
-import FromToRow, { FromToRowSkeleton } from '../../rows/transactions/from-to-row';
-import GasFeesDetailsRow, { GasFeesDetailsRowSkeleton } from '../../rows/transactions/gas-fee-details-row';
-import AdvancedDetailsRow, { AdvancedDetailsRowSkeleton } from '../../rows/transactions/advanced-details-row';
+import {
+  NetworkAndOriginRow,
+  NetworkAndOriginRowSkeleton,
+} from '../../rows/transactions/network-and-origin-row';
+import FromToRow, {
+  FromToRowSkeleton,
+} from '../../rows/transactions/from-to-row';
+import GasFeesDetailsRow, {
+  GasFeesDetailsRowSkeleton,
+} from '../../rows/transactions/gas-fee-details-row';
+import AdvancedDetailsRow, {
+  AdvancedDetailsRowSkeleton,
+} from '../../rows/transactions/advanced-details-row';
 
 const Transfer = () => {
   // Set navbar as first to prevent Android navigation flickering

--- a/app/components/Views/confirmations/components/rows/transactions/advanced-details-row/advanced-details-row.styles.ts
+++ b/app/components/Views/confirmations/components/rows/transactions/advanced-details-row/advanced-details-row.styles.ts
@@ -26,6 +26,16 @@ const styleSheet = (params: {
     dataScrollContainer: {
       height: 200,
     },
+    skeletonContainer: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      paddingBottom: 8,
+      paddingHorizontal: 8,
+    },
+    skeletonBorderRadius: {
+      borderRadius: 4,
+    },
   });
 };
 

--- a/app/components/Views/confirmations/components/rows/transactions/advanced-details-row/advanced-details-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/advanced-details-row/advanced-details-row.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import { View } from 'react-native';
 import { Hex } from '@metamask/utils';
 import { useSelector } from 'react-redux';
 import { ScrollView } from 'react-native-gesture-handler';
@@ -27,6 +28,7 @@ import InfoRow from '../../../UI/info-row';
 import InfoSection from '../../../UI/info-row/info-section';
 import NestedTransactionData from '../../../nested-transaction-data/nested-transaction-data';
 import SmartContractWithLogo from '../../../smart-contract-with-logo';
+import { Skeleton } from '../../../../../../../component-library/components/Skeleton';
 import styleSheet from './advanced-details-row.styles';
 
 const MAX_DATA_LENGTH_FOR_SCROLL = 200;
@@ -160,5 +162,24 @@ const AdvancedDetailsRow = () => {
     </>
   );
 };
+
+export function AdvancedDetailsRowSkeleton() {
+  return (
+    <InfoSection>
+      <View
+        style={{
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          paddingBottom: 8,
+          paddingHorizontal: 8,
+        }}
+      >
+        <Skeleton width={130} height={20} style={{ borderRadius: 4 }} />
+        <Skeleton width={16} height={16} style={{ borderRadius: 4 }} />
+      </View>
+    </InfoSection>
+  );
+}
 
 export default AdvancedDetailsRow;

--- a/app/components/Views/confirmations/components/rows/transactions/advanced-details-row/advanced-details-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/advanced-details-row/advanced-details-row.tsx
@@ -164,19 +164,15 @@ const AdvancedDetailsRow = () => {
 };
 
 export function AdvancedDetailsRowSkeleton() {
+  const { styles } = useStyles(styleSheet, {
+    isNonceChangeDisabled: false,
+  });
+
   return (
     <InfoSection>
-      <View
-        style={{
-          flexDirection: 'row',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          paddingBottom: 8,
-          paddingHorizontal: 8,
-        }}
-      >
-        <Skeleton width={130} height={20} style={{ borderRadius: 4 }} />
-        <Skeleton width={16} height={16} style={{ borderRadius: 4 }} />
+      <View style={styles.skeletonContainer}>
+        <Skeleton width={130} height={20} style={styles.skeletonBorderRadius} />
+        <Skeleton width={16} height={16} style={styles.skeletonBorderRadius} />
       </View>
     </InfoSection>
   );

--- a/app/components/Views/confirmations/components/rows/transactions/advanced-details-row/index.ts
+++ b/app/components/Views/confirmations/components/rows/transactions/advanced-details-row/index.ts
@@ -1,1 +1,1 @@
-export { default } from './advanced-details-row';
+export { default, AdvancedDetailsRowSkeleton } from './advanced-details-row';

--- a/app/components/Views/confirmations/components/rows/transactions/from-to-row/from-to-row.styles.ts
+++ b/app/components/Views/confirmations/components/rows/transactions/from-to-row/from-to-row.styles.ts
@@ -23,6 +23,12 @@ const styleSheet = () =>
     iconContainer: {
       paddingHorizontal: 8,
     },
+    skeletonBorderRadiusLarge: {
+      borderRadius: 18,
+    },
+    skeletonBorderRadiusSmall: {
+      borderRadius: 4,
+    },
   });
 
 export default styleSheet;

--- a/app/components/Views/confirmations/components/rows/transactions/from-to-row/from-to-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/from-to-row/from-to-row.tsx
@@ -79,13 +79,25 @@ export function FromToRowSkeleton() {
     <InfoSection>
       <View style={styles.container}>
         <View style={[styles.nameContainer, styles.leftNameContainer]}>
-          <Skeleton width={110} height={36} style={{ borderRadius: 18 }} />
+          <Skeleton
+            width={110}
+            height={36}
+            style={styles.skeletonBorderRadiusLarge}
+          />
         </View>
         <View style={styles.iconContainer}>
-          <Skeleton width={16} height={16} style={{ borderRadius: 4 }} />
+          <Skeleton
+            width={16}
+            height={16}
+            style={styles.skeletonBorderRadiusSmall}
+          />
         </View>
         <View style={[styles.nameContainer, styles.rightNameContainer]}>
-          <Skeleton width={110} height={36} style={{ borderRadius: 18 }} />
+          <Skeleton
+            width={110}
+            height={36}
+            style={styles.skeletonBorderRadiusLarge}
+          />
         </View>
       </View>
     </InfoSection>

--- a/app/components/Views/confirmations/components/rows/transactions/from-to-row/from-to-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/from-to-row/from-to-row.tsx
@@ -15,6 +15,7 @@ import { useTransferRecipient } from '../../../../hooks/transactions/useTransfer
 import { RowAlertKey } from '../../../UI/info-row/alert-row/constants';
 import InfoSection from '../../../UI/info-row/info-section';
 import AlertRow from '../../../UI/info-row/alert-row';
+import { Skeleton } from '../../../../../../../component-library/components/Skeleton';
 import styleSheet from './from-to-row.styles';
 
 const FromToRow = () => {
@@ -70,5 +71,25 @@ const FromToRow = () => {
     </InfoSection>
   );
 };
+
+export function FromToRowSkeleton() {
+  const { styles } = useStyles(styleSheet, {});
+
+  return (
+    <InfoSection>
+      <View style={styles.container}>
+        <View style={[styles.nameContainer, styles.leftNameContainer]}>
+          <Skeleton width={110} height={36} style={{ borderRadius: 18 }} />
+        </View>
+        <View style={styles.iconContainer}>
+          <Skeleton width={16} height={16} style={{ borderRadius: 4 }} />
+        </View>
+        <View style={[styles.nameContainer, styles.rightNameContainer]}>
+          <Skeleton width={110} height={36} style={{ borderRadius: 18 }} />
+        </View>
+      </View>
+    </InfoSection>
+  );
+}
 
 export default FromToRow;

--- a/app/components/Views/confirmations/components/rows/transactions/from-to-row/index.ts
+++ b/app/components/Views/confirmations/components/rows/transactions/from-to-row/index.ts
@@ -1,1 +1,1 @@
-export { default } from './from-to-row';
+export { default, FromToRowSkeleton } from './from-to-row';

--- a/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.styles.ts
+++ b/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.styles.ts
@@ -42,6 +42,9 @@ const styleSheet = (params: { theme: Theme }) => {
       textAlign: 'left',
       flex: 1,
     },
+    skeletonBorderRadius: {
+      borderRadius: 4,
+    },
   });
 };
 

--- a/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.styles.ts
+++ b/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.styles.ts
@@ -45,6 +45,14 @@ const styleSheet = (params: { theme: Theme }) => {
     skeletonBorderRadius: {
       borderRadius: 4,
     },
+    skeletonRowContainer: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      minHeight: 24,
+      paddingBottom: 8,
+      paddingHorizontal: 8,
+    },
   });
 };
 

--- a/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.tsx
@@ -329,33 +329,17 @@ const GasFeesDetailsRow = ({
 };
 
 export function GasFeesDetailsRowSkeleton() {
+  const { styles } = useStyles(styleSheet, {});
+
   return (
     <InfoSection>
-      <View
-        style={{
-          flexDirection: 'row',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          minHeight: 24,
-          paddingBottom: 8,
-          paddingHorizontal: 8,
-        }}
-      >
-        <Skeleton width={105} height={20} style={{ borderRadius: 4 }} />
-        <Skeleton width={140} height={20} style={{ borderRadius: 4 }} />
+      <View style={styles.skeletonRowContainer}>
+        <Skeleton width={105} height={20} style={styles.skeletonBorderRadius} />
+        <Skeleton width={140} height={20} style={styles.skeletonBorderRadius} />
       </View>
-      <View
-        style={{
-          flexDirection: 'row',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          minHeight: 24,
-          paddingBottom: 8,
-          paddingHorizontal: 8,
-        }}
-      >
-        <Skeleton width={50} height={20} style={{ borderRadius: 4 }} />
-        <Skeleton width={140} height={20} style={{ borderRadius: 4 }} />
+      <View style={styles.skeletonRowContainer}>
+        <Skeleton width={50} height={20} style={styles.skeletonBorderRadius} />
+        <Skeleton width={140} height={20} style={styles.skeletonBorderRadius} />
       </View>
     </InfoSection>
   );

--- a/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.tsx
@@ -4,7 +4,6 @@ import {
 } from '@metamask/transaction-controller';
 import React, { useState } from 'react';
 import { TouchableOpacity, View } from 'react-native';
-import SkeletonPlaceholder from 'react-native-skeleton-placeholder';
 import { ConfirmationRowComponentIDs } from '../../../../../../../../e2e/selectors/Confirmation/ConfirmationView.selectors';
 import { strings } from '../../../../../../../../locales/i18n';
 import Icon, {
@@ -35,6 +34,7 @@ import { GasFeeModal } from '../../../modals/gas-fee-modal';
 import AlertRow from '../../../UI/info-row/alert-row';
 import { RowAlertKey } from '../../../UI/info-row/alert-row/constants';
 import InfoSection from '../../../UI/info-row/info-section';
+import { Skeleton } from '../../../../../../../component-library/components/Skeleton';
 import styleSheet from './gas-fee-details-row.styles';
 
 const PaidByMetaMask = () => (
@@ -44,14 +44,7 @@ const PaidByMetaMask = () => (
 );
 
 const SkeletonEstimationInfo = () => (
-  <SkeletonPlaceholder>
-    <SkeletonPlaceholder.Item
-      width={120}
-      height={24}
-      borderRadius={8}
-      marginTop={2}
-    />
-  </SkeletonPlaceholder>
+  <Skeleton width={140} height={20} style={{ borderRadius: 4 }} />
 );
 
 const EstimationInfo = ({
@@ -330,5 +323,38 @@ const GasFeesDetailsRow = ({
     </>
   );
 };
+
+export function GasFeesDetailsRowSkeleton() {
+  return (
+    <InfoSection>
+      <View
+        style={{
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          minHeight: 24,
+          paddingBottom: 8,
+          paddingHorizontal: 8,
+        }}
+      >
+        <Skeleton width={105} height={20} style={{ borderRadius: 4 }} />
+        <Skeleton width={140} height={20} style={{ borderRadius: 4 }} />
+      </View>
+      <View
+        style={{
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          minHeight: 24,
+          paddingBottom: 8,
+          paddingHorizontal: 8,
+        }}
+      >
+        <Skeleton width={50} height={20} style={{ borderRadius: 4 }} />
+        <Skeleton width={140} height={20} style={{ borderRadius: 4 }} />
+      </View>
+    </InfoSection>
+  );
+}
 
 export default GasFeesDetailsRow;

--- a/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/gas-fee-details-row.tsx
@@ -43,9 +43,13 @@ const PaidByMetaMask = () => (
   </Text>
 );
 
-const SkeletonEstimationInfo = () => (
-  <Skeleton width={140} height={20} style={{ borderRadius: 4 }} />
-);
+const SkeletonEstimationInfo = () => {
+  const { styles } = useStyles(styleSheet, {});
+
+  return (
+    <Skeleton width={140} height={20} style={styles.skeletonBorderRadius} />
+  );
+};
 
 const EstimationInfo = ({
   hideFiatForTestnet,

--- a/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/index.ts
+++ b/app/components/Views/confirmations/components/rows/transactions/gas-fee-details-row/index.ts
@@ -1,1 +1,1 @@
-export { default } from './gas-fee-details-row';
+export { default, GasFeesDetailsRowSkeleton } from './gas-fee-details-row';

--- a/app/components/Views/confirmations/components/rows/transactions/hero-row/hero-row.styles.ts
+++ b/app/components/Views/confirmations/components/rows/transactions/hero-row/hero-row.styles.ts
@@ -16,6 +16,18 @@ const styleSheet = (params: { theme: Theme }) => {
       borderRadius: 39,
       backgroundColor: theme.colors.background.alternativePressed,
     },
+    skeletonBorderRadiusLarge: {
+      borderRadius: 32,
+    },
+    skeletonBorderRadiusMedium: {
+      borderRadius: 6,
+      marginTop: 16,
+    },
+    skeletonBorderRadiusSmall: {
+      borderRadius: 4,
+      marginTop: 8,
+      marginBottom: 14,
+    },
   });
 };
 

--- a/app/components/Views/confirmations/components/rows/transactions/hero-row/hero-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/hero-row/hero-row.tsx
@@ -6,12 +6,20 @@ import { useIsNft } from '../../../../hooks/nft/useIsNft';
 import { HeroNft } from '../../../hero-nft';
 import { HeroToken } from '../../../hero-token';
 import { useStyles } from '../../../../../../../component-library/hooks';
+import { Skeleton } from '../../../../../../../component-library/components/Skeleton';
 import styleSheet from './hero-row.styles';
 
-const LoadingHeroRow = () => {
+export function HeroRowSkeleton() {
   const { styles } = useStyles(styleSheet, {});
-  return <View style={styles.loadingWrapper} />;
-};
+
+  return (
+    <View style={styles.wrapper}>
+      <Skeleton width={64} height={64} style={{ borderRadius: 32 }} />
+      <Skeleton width={150} height={24} style={{ borderRadius: 6, marginTop: 16 }} />
+      <Skeleton width={80} height={18} style={{ borderRadius: 4, marginTop: 8, marginBottom: 14 }} />
+    </View>
+  );
+}
 
 export const HeroRow = ({ amountWei }: { amountWei?: string }) => {
   const { isNft, isPending } = useIsNft();
@@ -22,9 +30,11 @@ export const HeroRow = ({ amountWei }: { amountWei?: string }) => {
       style={styles.wrapper}
       testID={ConfirmationRowComponentIDs.TOKEN_HERO}
     >
-      {isPending && <LoadingHeroRow />}
+      {isPending && <HeroRowSkeleton />}
       {!isPending &&
         (isNft ? <HeroNft /> : <HeroToken amountWei={amountWei} />)}
     </View>
   );
 };
+
+

--- a/app/components/Views/confirmations/components/rows/transactions/hero-row/hero-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/hero-row/hero-row.tsx
@@ -15,8 +15,16 @@ export function HeroRowSkeleton() {
   return (
     <View style={styles.wrapper}>
       <Skeleton width={64} height={64} style={{ borderRadius: 32 }} />
-      <Skeleton width={150} height={24} style={{ borderRadius: 6, marginTop: 16 }} />
-      <Skeleton width={80} height={18} style={{ borderRadius: 4, marginTop: 8, marginBottom: 14 }} />
+      <Skeleton
+        width={150}
+        height={24}
+        style={{ borderRadius: 6, marginTop: 16 }}
+      />
+      <Skeleton
+        width={80}
+        height={18}
+        style={{ borderRadius: 4, marginTop: 8, marginBottom: 14 }}
+      />
     </View>
   );
 }

--- a/app/components/Views/confirmations/components/rows/transactions/hero-row/hero-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/hero-row/hero-row.tsx
@@ -14,16 +14,20 @@ export function HeroRowSkeleton() {
 
   return (
     <View style={styles.wrapper}>
-      <Skeleton width={64} height={64} style={{ borderRadius: 32 }} />
+      <Skeleton
+        width={64}
+        height={64}
+        style={styles.skeletonBorderRadiusLarge}
+      />
       <Skeleton
         width={150}
         height={24}
-        style={{ borderRadius: 6, marginTop: 16 }}
+        style={styles.skeletonBorderRadiusMedium}
       />
       <Skeleton
         width={80}
         height={18}
-        style={{ borderRadius: 4, marginTop: 8, marginBottom: 14 }}
+        style={styles.skeletonBorderRadiusSmall}
       />
     </View>
   );

--- a/app/components/Views/confirmations/components/rows/transactions/hero-row/hero-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/hero-row/hero-row.tsx
@@ -36,5 +36,3 @@ export const HeroRow = ({ amountWei }: { amountWei?: string }) => {
     </View>
   );
 };
-
-

--- a/app/components/Views/confirmations/components/rows/transactions/hero-row/index.ts
+++ b/app/components/Views/confirmations/components/rows/transactions/hero-row/index.ts
@@ -1,1 +1,1 @@
-export { HeroRow } from './hero-row';
+export { HeroRow, HeroRowSkeleton } from './hero-row';

--- a/app/components/Views/confirmations/components/rows/transactions/network-and-origin-row/network-and-origin-row.styles.ts
+++ b/app/components/Views/confirmations/components/rows/transactions/network-and-origin-row/network-and-origin-row.styles.ts
@@ -12,6 +12,16 @@ const styleSheet = () =>
     avatarNetwork: {
       marginRight: 4,
     },
+    skeletonContainer: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      paddingBottom: 8,
+      paddingHorizontal: 8,
+    },
+    skeletonBorderRadius: {
+      borderRadius: 4,
+    },
   });
 
 export default styleSheet;

--- a/app/components/Views/confirmations/components/rows/transactions/network-and-origin-row/network-and-origin-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/network-and-origin-row/network-and-origin-row.tsx
@@ -22,6 +22,7 @@ import { MMM_ORIGIN } from '../../../../constants/confirmations';
 import InfoSection from '../../../UI/info-row/info-section';
 import InfoRow from '../../../UI/info-row/info-row';
 import Address from '../../../UI/info-row/info-value/address';
+import { Skeleton } from '../../../../../../../component-library/components/Skeleton';
 import styleSheet from './network-and-origin-row.styles';
 import { RowAlertKey } from '../../../UI/info-row/alert-row/constants';
 import AlertRow from '../../../UI/info-row/alert-row';
@@ -89,3 +90,22 @@ export const NetworkAndOriginRow = () => {
     </InfoSection>
   );
 };
+
+export function NetworkAndOriginRowSkeleton() {
+  return (
+    <InfoSection>
+      <View
+        style={{
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          paddingBottom: 8,
+          paddingHorizontal: 8,
+        }}
+      >
+        <Skeleton width={70} height={20} style={{ borderRadius: 4 }} />
+        <Skeleton width={100} height={20} style={{ borderRadius: 4 }} />
+      </View>
+    </InfoSection>
+  );
+}

--- a/app/components/Views/confirmations/components/rows/transactions/network-and-origin-row/network-and-origin-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/network-and-origin-row/network-and-origin-row.tsx
@@ -92,19 +92,13 @@ export const NetworkAndOriginRow = () => {
 };
 
 export function NetworkAndOriginRowSkeleton() {
+  const { styles } = useStyles(styleSheet, {});
+
   return (
     <InfoSection>
-      <View
-        style={{
-          flexDirection: 'row',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          paddingBottom: 8,
-          paddingHorizontal: 8,
-        }}
-      >
-        <Skeleton width={70} height={20} style={{ borderRadius: 4 }} />
-        <Skeleton width={100} height={20} style={{ borderRadius: 4 }} />
+      <View style={styles.skeletonContainer}>
+        <Skeleton width={70} height={20} style={styles.skeletonBorderRadius} />
+        <Skeleton width={100} height={20} style={styles.skeletonBorderRadius} />
       </View>
     </InfoSection>
   );

--- a/app/components/Views/confirmations/hooks/send/useSendActions.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useSendActions.test.ts
@@ -73,6 +73,7 @@ describe('useSendActions', () => {
     result.current.handleSubmitPress();
     expect(mockNavigate).toHaveBeenCalledWith('RedesignedConfirmations', {
       params: { maxValueMode: undefined },
+      loader: 'transfer',
     });
   });
 

--- a/app/components/Views/confirmations/hooks/send/useSendActions.ts
+++ b/app/components/Views/confirmations/hooks/send/useSendActions.ts
@@ -11,6 +11,7 @@ import { addLeadingZeroIfNeeded, submitEvmTransaction } from '../../utils/send';
 import { useSendContext } from '../../context/send-context';
 import { useSendType } from './useSendType';
 import { useSendExitMetrics } from './metrics/useSendExitMetrics';
+import { ConfirmationLoader } from '../../components/confirm/confirm-component';
 
 export const useSendActions = () => {
   const { asset, chainId, fromAccount, from, maxValueMode, to, value } =
@@ -41,6 +42,7 @@ export const useSendActions = () => {
             params: {
               maxValueMode,
             },
+            loader: ConfirmationLoader.Transfer,
           },
         );
       } else {


### PR DESCRIPTION
## **Description**
Replaces blank page with a loader for the Send flow with skeleton loading

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Replaces blank page with a loader for the Send flow with skeleton loading

## **Related issues**

Fixes: 
https://github.com/MetaMask/metamask-mobile/issues/19676 
https://github.com/MetaMask/metamask-mobile/issues/22763
https://github.com/MetaMask/metamask-mobile/issues/17838

## **Manual testing steps**
1. Click Send on the main page
2. Fill in the form, submit it
3. You will see skeleton loading now

## **Screenshots/Recordings**

### **Before**
<img width="654" height="1334" alt="image" src="https://github.com/user-attachments/assets/866ddc22-c26f-4e1e-838f-942958fffe56" />

### **After**
<img width="637" height="1389" alt="image" src="https://github.com/user-attachments/assets/e0224b0e-5747-45d4-ac05-072aacfd6b42" />
 
<img width="637" height="1377" alt="image" src="https://github.com/user-attachments/assets/11ab4928-5322-4dc8-b134-fbe8c27480e7" />

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Transfer-specific skeleton loader (including footer skeleton) to the confirmation screen and routes Send flow to use it, plus skeletons across key info rows.
> 
> - **Confirmations UI**
>   - Adds `ConfirmationLoader.Transfer` and renders `TransferInfoSkeleton` in `confirm-component.tsx`.
>   - Extends `InfoLoader` to accept `loader` and shows `FooterSkeleton` when `loader === 'transfer'`.
>   - Keeps default spinner; retains existing loaders (`customAmount`, `predictClaim`).
> - **Footer**
>   - Introduces `FooterSkeleton` with styles (`footerSkeletonContainer`, `footerButtonSkeleton`).
>   - Refactors base footer styles for reuse.
> - **Transfer Info Skeletons**
>   - Adds skeleton components for rows: `HeroRowSkeleton`, `FromToRowSkeleton`, `NetworkAndOriginRowSkeleton`, `GasFeesDetailsRowSkeleton`, `AdvancedDetailsRowSkeleton` with corresponding style additions.
>   - Replaces `react-native-skeleton-placeholder` usage with shared `Skeleton` component in gas fee row.
> - **Navigation/Send Flow**
>   - `useSendActions`: navigates to `RedesignedConfirmations` with `{ loader: 'transfer', params: { maxValueMode } }`.
> - **Tests**
>   - Updates `confirm-component.test.tsx` and `useSendActions.test.ts` to cover new loaders, SafeArea + `ScrollView`, defaults, and navigation params.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f5656ebe3cdb2502465c2c997deb8fd75723d4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->