### PR TITLE
feat: allow add account predict flow

### DIFF
--- a/app/components/UI/Predict/components/PredictFeeSummary/PredictFeeSummary.test.tsx
+++ b/app/components/UI/Predict/components/PredictFeeSummary/PredictFeeSummary.test.tsx
@@ -10,6 +10,26 @@ jest.mock('../../utils/format', () => ({
   ),
 }));
 
+// Mock i18n strings
+jest.mock('../../../../../../locales/i18n', () => ({
+  strings: jest.fn((key: string) => {
+    const mockStrings: Record<string, string> = {
+      'predict.fee_summary.fees': 'Fees',
+      'predict.fee_summary.total': 'Total',
+      'predict.fee_summary.estimated_points': 'Est. points',
+      'predict.fee_summary.points_tooltip': 'Points',
+      'predict.fee_summary.points_tooltip_content_1':
+        'Points are how you earn MetaMask Rewards for completing transactions, like when you swap, bridge, or predict.',
+      'predict.fee_summary.points_tooltip_content_2':
+        'Keep in mind this value is an estimate and will be finalized once the transaction is complete. Points can take up to 1 hour to be confirmed in your Rewards balance.',
+      'predict.fee_summary.points_error': "We can't load points right now",
+      'predict.fee_summary.points_error_content':
+        "You'll still earn any points for this transaction. We'll notify you once they've been added to your account. You can also check your rewards tab in about an hour.",
+    };
+    return mockStrings[key] || key;
+  }),
+}));
+
 // Mock ButtonIcon
 jest.mock(
   '../../../../../component-library/components/Buttons/ButtonIcon',
@@ -52,14 +72,16 @@ jest.mock(
       field,
       value,
     }: {
-      field: { label: { text: string } };
-      value: { label: React.ReactNode };
+      field: { label: { text: string }; tooltip?: unknown };
+      value: { label: React.ReactNode; tooltip?: unknown };
     }) =>
       React.createElement(
         View,
         { testID: 'key-value-row' },
         React.createElement(RNText, null, field.label.text),
         value.label,
+        value.tooltip &&
+          React.createElement(View, { testID: 'value-tooltip' }, 'Tooltip'),
       );
   },
 );
@@ -70,10 +92,10 @@ jest.mock('../../../Rewards/components/RewardPointsAnimation', () => {
   const { Text: RNText } = jest.requireActual('react-native');
   return {
     __esModule: true,
-    default: ({ value }: { value: number }) =>
+    default: ({ value, state }: { value: number; state: string }) =>
       React.createElement(
         RNText,
-        { testID: 'rewards-animation' },
+        { testID: 'rewards-animation', 'data-state': state },
         `${value} points`,
       ),
     RewardAnimationState: {
@@ -83,6 +105,24 @@ jest.mock('../../../Rewards/components/RewardPointsAnimation', () => {
     },
   };
 });
+
+// Mock AddRewardsAccount
+jest.mock(
+  '../../../Rewards/components/AddRewardsAccount/AddRewardsAccount',
+  () => {
+    const React = jest.requireActual('react');
+    const { View } = jest.requireActual('react-native');
+    return {
+      __esModule: true,
+      default: () =>
+        React.createElement(
+          View,
+          { testID: 'add-rewards-account' },
+          'Add Rewards Account',
+        ),
+    };
+  },
+);
 
 describe('PredictFeeSummary', () => {
   const defaultProps = {
@@ -173,10 +213,10 @@ describe('PredictFeeSummary', () => {
   });
 
   describe('Rewards Row', () => {
-    it('does not display rewards row when shouldShowRewards is false', () => {
+    it('does not display rewards row when shouldShowRewardsRow is false', () => {
       const props = {
         ...defaultProps,
-        shouldShowRewards: false,
+        shouldShowRewardsRow: false,
         estimatedPoints: 100,
       };
 
@@ -186,12 +226,14 @@ describe('PredictFeeSummary', () => {
 
       expect(queryByText('Est. points')).toBeNull();
       expect(queryByTestId('rewards-animation')).toBeNull();
+      expect(queryByTestId('add-rewards-account')).toBeNull();
     });
 
-    it('displays rewards row when shouldShowRewards is true', () => {
+    it('displays rewards row when shouldShowRewardsRow is true', () => {
       const props = {
         ...defaultProps,
-        shouldShowRewards: true,
+        shouldShowRewardsRow: true,
+        accountOptedIn: true,
         estimatedPoints: 50,
       };
 
@@ -203,10 +245,11 @@ describe('PredictFeeSummary', () => {
       expect(getByTestId('rewards-animation')).toBeOnTheScreen();
     });
 
-    it('displays correct estimated points value', () => {
+    it('displays correct estimated points value when account is opted in', () => {
       const props = {
         ...defaultProps,
-        shouldShowRewards: true,
+        shouldShowRewardsRow: true,
+        accountOptedIn: true,
         estimatedPoints: 123,
       };
 
@@ -215,11 +258,134 @@ describe('PredictFeeSummary', () => {
       expect(getByText('123 points')).toBeOnTheScreen();
     });
 
-    it('displays zero points when estimatedPoints is 0', () => {
+    it('displays zero points when estimatedPoints is 0 and account is opted in', () => {
       const props = {
         ...defaultProps,
-        shouldShowRewards: true,
+        shouldShowRewardsRow: true,
+        accountOptedIn: true,
         estimatedPoints: 0,
+      };
+
+      const { getByText } = render(<PredictFeeSummary {...props} />);
+
+      expect(getByText('0 points')).toBeOnTheScreen();
+    });
+
+    it('displays AddRewardsAccount when accountOptedIn is false', () => {
+      const props = {
+        ...defaultProps,
+        shouldShowRewardsRow: true,
+        accountOptedIn: false,
+        estimatedPoints: 100,
+      };
+
+      const { getByTestId, queryByTestId } = render(
+        <PredictFeeSummary {...props} />,
+      );
+
+      expect(getByTestId('add-rewards-account')).toBeOnTheScreen();
+      expect(queryByTestId('rewards-animation')).toBeNull();
+    });
+
+    it('displays AddRewardsAccount when accountOptedIn is null', () => {
+      const props = {
+        ...defaultProps,
+        shouldShowRewardsRow: true,
+        accountOptedIn: null,
+        estimatedPoints: 100,
+      };
+
+      const { getByTestId, queryByTestId } = render(
+        <PredictFeeSummary {...props} />,
+      );
+
+      expect(getByTestId('add-rewards-account')).toBeOnTheScreen();
+      expect(queryByTestId('rewards-animation')).toBeNull();
+    });
+
+    it('displays loading state when isLoadingRewards is true', () => {
+      const props = {
+        ...defaultProps,
+        shouldShowRewardsRow: true,
+        accountOptedIn: true,
+        estimatedPoints: 50,
+        isLoadingRewards: true,
+      };
+
+      const { getByTestId } = render(<PredictFeeSummary {...props} />);
+
+      const animation = getByTestId('rewards-animation');
+      expect(animation).toBeOnTheScreen();
+      expect(animation.props['data-state']).toBe('Loading');
+    });
+
+    it('displays error state when hasRewardsError is true', () => {
+      const props = {
+        ...defaultProps,
+        shouldShowRewardsRow: true,
+        accountOptedIn: true,
+        estimatedPoints: 50,
+        hasRewardsError: true,
+      };
+
+      const { getByTestId } = render(<PredictFeeSummary {...props} />);
+
+      const animation = getByTestId('rewards-animation');
+      expect(animation).toBeOnTheScreen();
+      expect(animation.props['data-state']).toBe('ErrorState');
+    });
+
+    it('displays idle state when not loading and no error', () => {
+      const props = {
+        ...defaultProps,
+        shouldShowRewardsRow: true,
+        accountOptedIn: true,
+        estimatedPoints: 50,
+        isLoadingRewards: false,
+        hasRewardsError: false,
+      };
+
+      const { getByTestId } = render(<PredictFeeSummary {...props} />);
+
+      const animation = getByTestId('rewards-animation');
+      expect(animation).toBeOnTheScreen();
+      expect(animation.props['data-state']).toBe('Idle');
+    });
+
+    it('displays error tooltip when hasRewardsError is true', () => {
+      const props = {
+        ...defaultProps,
+        shouldShowRewardsRow: true,
+        accountOptedIn: true,
+        estimatedPoints: 50,
+        hasRewardsError: true,
+      };
+
+      const { getByTestId } = render(<PredictFeeSummary {...props} />);
+
+      expect(getByTestId('value-tooltip')).toBeOnTheScreen();
+    });
+
+    it('does not display error tooltip when hasRewardsError is false', () => {
+      const props = {
+        ...defaultProps,
+        shouldShowRewardsRow: true,
+        accountOptedIn: true,
+        estimatedPoints: 50,
+        hasRewardsError: false,
+      };
+
+      const { queryByTestId } = render(<PredictFeeSummary {...props} />);
+
+      expect(queryByTestId('value-tooltip')).toBeNull();
+    });
+
+    it('handles null estimatedPoints when account is opted in', () => {
+      const props = {
+        ...defaultProps,
+        shouldShowRewardsRow: true,
+        accountOptedIn: true,
+        estimatedPoints: null,
       };
 
       const { getByText } = render(<PredictFeeSummary {...props} />);
@@ -232,7 +398,8 @@ describe('PredictFeeSummary', () => {
     it('renders rewards row after Total row', () => {
       const props = {
         ...defaultProps,
-        shouldShowRewards: true,
+        shouldShowRewardsRow: true,
+        accountOptedIn: true,
         estimatedPoints: 50,
       };
 

--- a/app/components/UI/Predict/components/PredictFeeSummary/PredictFeeSummary.tsx
+++ b/app/components/UI/Predict/components/PredictFeeSummary/PredictFeeSummary.tsx
@@ -21,14 +21,16 @@ import RewardsAnimations, {
   RewardAnimationState,
 } from '../../../Rewards/components/RewardPointsAnimation';
 import { formatPrice } from '../../utils/format';
+import AddRewardsAccount from '../../../Rewards/components/AddRewardsAccount/AddRewardsAccount';
 
 interface PredictFeeSummaryProps {
   disabled: boolean;
   providerFee: number;
   metamaskFee: number;
   total: number;
-  shouldShowRewards?: boolean;
-  estimatedPoints?: number;
+  shouldShowRewardsRow?: boolean;
+  accountOptedIn?: boolean | null;
+  estimatedPoints?: number | null;
   isLoadingRewards?: boolean;
   hasRewardsError?: boolean;
   onFeesInfoPress?: () => void;
@@ -39,7 +41,8 @@ const PredictFeeSummary: React.FC<PredictFeeSummaryProps> = ({
   metamaskFee,
   providerFee,
   total,
-  shouldShowRewards = false,
+  shouldShowRewardsRow = false,
+  accountOptedIn = null,
   estimatedPoints = 0,
   isLoadingRewards = false,
   hasRewardsError = false,
@@ -87,7 +90,7 @@ const PredictFeeSummary: React.FC<PredictFeeSummaryProps> = ({
       </Box>
 
       {/* Estimated Points Row */}
-      {shouldShowRewards && (
+      {shouldShowRewardsRow && (
         <KeyValueRow
           field={{
             label: {
@@ -112,16 +115,20 @@ const PredictFeeSummary: React.FC<PredictFeeSummaryProps> = ({
                 justifyContent={BoxJustifyContent.Center}
                 gap={1}
               >
-                <RewardsAnimations
-                  value={estimatedPoints}
-                  state={
-                    isLoadingRewards
-                      ? RewardAnimationState.Loading
-                      : hasRewardsError
-                        ? RewardAnimationState.ErrorState
-                        : RewardAnimationState.Idle
-                  }
-                />
+                {accountOptedIn ? (
+                  <RewardsAnimations
+                    value={estimatedPoints ?? 0}
+                    state={
+                      isLoadingRewards
+                        ? RewardAnimationState.Loading
+                        : hasRewardsError
+                          ? RewardAnimationState.ErrorState
+                          : RewardAnimationState.Idle
+                    }
+                  />
+                ) : (
+                  <AddRewardsAccount />
+                )}
               </Box>
             ),
             ...(hasRewardsError && {

--- a/app/components/UI/Predict/hooks/usePredictRewards.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictRewards.test.ts
@@ -1,31 +1,37 @@
 import { renderHook, waitFor } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
 import { usePredictRewards } from './usePredictRewards';
-import bridgeController from '@metamask/bridge-controller';
-import utils, { type CaipAccountId, CaipChainId } from '@metamask/utils';
+import utils, { type CaipAccountId } from '@metamask/utils';
 import Engine from '../../../../core/Engine';
 import Logger from '../../../../util/Logger';
+import { getFormattedAddressFromInternalAccount } from '../../../../core/Multichain/utils';
+import {
+  POLYGON_MAINNET_CAIP_CHAIN_ID,
+  POLYGON_USDC_CAIP_ASSET_ID,
+} from '../providers/polymarket/constants';
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
 }));
 
-jest.mock('../../../../selectors/accountsController', () => ({
-  selectSelectedInternalAccountFormattedAddress: jest.fn(),
+jest.mock('../../../../selectors/multichainAccounts/accounts', () => ({
+  selectSelectedInternalAccountByScope: jest.fn(),
+}));
+
+jest.mock('../../../../core/Multichain/utils', () => ({
+  getFormattedAddressFromInternalAccount: jest.fn(),
 }));
 
 jest.mock('../../../../core/Engine', () => ({
   controllerMessenger: {
     call: jest.fn(),
+    subscribe: jest.fn(),
+    unsubscribe: jest.fn(),
   },
 }));
 
 jest.mock('../../../../util/Logger', () => ({
   error: jest.fn(),
-}));
-
-jest.mock('@metamask/bridge-controller', () => ({
-  formatChainIdToCaip: jest.fn(),
 }));
 
 jest.mock('@metamask/utils', () => ({
@@ -39,6 +45,13 @@ jest.mock('../constants/errors', () => ({
   },
 }));
 
+jest.mock('../providers/polymarket/constants', () => ({
+  POLYGON_MAINNET_CAIP_CHAIN_ID: 'eip155:137',
+  POLYGON_USDC_CAIP_ASSET_ID:
+    'eip155:137/erc20:0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
+  COLLATERAL_TOKEN_DECIMALS: 6,
+}));
+
 // Don't mock ensureError - use the real implementation
 jest.mock('../utils/predictErrorHandler', () => {
   const actual = jest.requireActual('../utils/predictErrorHandler');
@@ -47,35 +60,66 @@ jest.mock('../utils/predictErrorHandler', () => {
   };
 });
 
+// Mock ethers parseUnits
+jest.mock('ethers/lib/utils', () => ({
+  parseUnits: jest.fn((value: string, decimals: number) => {
+    const num = parseFloat(value);
+    const multiplier = Math.pow(10, decimals);
+    return {
+      toString: () => (num * multiplier).toString(),
+    };
+  }),
+}));
+
 describe('usePredictRewards', () => {
   const mockUseSelector = useSelector as jest.MockedFunction<
     typeof useSelector
   >;
   const mockControllerMessengerCall = Engine.controllerMessenger
     .call as jest.MockedFunction<typeof Engine.controllerMessenger.call>;
+  const mockControllerMessengerSubscribe = Engine.controllerMessenger
+    .subscribe as jest.MockedFunction<
+    typeof Engine.controllerMessenger.subscribe
+  >;
+
   const mockLoggerError = Logger.error as jest.MockedFunction<
     typeof Logger.error
   >;
-  const mockFormatChainIdToCaip =
-    bridgeController.formatChainIdToCaip as jest.MockedFunction<
-      typeof bridgeController.formatChainIdToCaip
-    >;
   const mockParseCaipChainId = utils.parseCaipChainId as jest.MockedFunction<
     typeof utils.parseCaipChainId
   >;
   const mockToCaipAccountId = utils.toCaipAccountId as jest.MockedFunction<
     typeof utils.toCaipAccountId
   >;
+  const mockGetFormattedAddressFromInternalAccount =
+    getFormattedAddressFromInternalAccount as jest.MockedFunction<
+      typeof getFormattedAddressFromInternalAccount
+    >;
 
   const mockAddress = '0x1234567890123456789012345678901234567890';
   const mockCaipAccount =
     'eip155:137:0x1234567890123456789012345678901234567890' as CaipAccountId;
+  const mockInternalAccount = {
+    id: 'account-1',
+    address: mockAddress,
+    name: 'Test Account',
+    type: 'eip155:eoa',
+    scopes: [POLYGON_MAINNET_CAIP_CHAIN_ID],
+    metadata: {},
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
 
-    mockUseSelector.mockReturnValue(mockAddress);
-    mockFormatChainIdToCaip.mockReturnValue('eip155:137' as CaipChainId);
+    // Mock selector to return a function that returns the account
+    mockUseSelector.mockReturnValue((scope: string) => {
+      if (scope === POLYGON_MAINNET_CAIP_CHAIN_ID) {
+        return mockInternalAccount;
+      }
+      return undefined;
+    });
+
+    mockGetFormattedAddressFromInternalAccount.mockReturnValue(mockAddress);
     mockParseCaipChainId.mockReturnValue({
       namespace: 'eip155',
       reference: '137',
@@ -88,32 +132,70 @@ describe('usePredictRewards', () => {
   });
 
   describe('when rewards are enabled and account has opted in', () => {
-    it('returns enabled true and isLoading transitions from true to false', async () => {
+    it('returns enabled true, estimated points, and subscribes to accountLinked event', async () => {
       // Arrange
+      const mockEstimatedPoints = 100;
       mockControllerMessengerCall
-        .mockReturnValueOnce(true)
-        .mockResolvedValueOnce(true);
+        .mockResolvedValueOnce(true) // isRewardsFeatureEnabled
+        .mockResolvedValueOnce('subscription-1') // getFirstSubscriptionId
+        .mockResolvedValueOnce(true) // getHasAccountOptedIn
+        .mockResolvedValueOnce({
+          pointsEstimate: mockEstimatedPoints,
+        }); // estimatePoints
 
       // Act
-      const { result } = renderHook(() => usePredictRewards());
+      const { result } = renderHook(() => usePredictRewards(10.5));
 
       // Assert - initial state
       expect(result.current.isLoading).toBe(true);
       expect(result.current.enabled).toBe(false);
+      expect(result.current.accountOptedIn).toBe(null);
+      expect(result.current.shouldShowRewardsRow).toBe(false);
+      expect(result.current.estimatedPoints).toBe(null);
+      expect(result.current.hasError).toBe(false);
 
       // Assert - final state
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
+        expect(result.current.estimatedPoints).toBe(mockEstimatedPoints);
       });
 
       expect(result.current.enabled).toBe(true);
-      expect(mockControllerMessengerCall).toHaveBeenCalledTimes(2);
+      expect(result.current.accountOptedIn).toBe(true);
+      expect(result.current.shouldShowRewardsRow).toBe(true);
+      expect(result.current.hasError).toBe(false);
+
+      // Verify controller calls
       expect(mockControllerMessengerCall).toHaveBeenCalledWith(
         'RewardsController:isRewardsFeatureEnabled',
       );
       expect(mockControllerMessengerCall).toHaveBeenCalledWith(
+        'RewardsController:getFirstSubscriptionId',
+      );
+      expect(mockControllerMessengerCall).toHaveBeenCalledWith(
         'RewardsController:getHasAccountOptedIn',
         mockCaipAccount,
+      );
+      expect(mockControllerMessengerCall).toHaveBeenCalledWith(
+        'RewardsController:estimatePoints',
+        expect.objectContaining({
+          activityType: 'PREDICT',
+          account: mockCaipAccount,
+          activityContext: {
+            predictContext: {
+              feeAsset: {
+                id: POLYGON_USDC_CAIP_ASSET_ID,
+                amount: expect.any(String),
+              },
+            },
+          },
+        }),
+      );
+
+      // Verify subscription
+      expect(mockControllerMessengerSubscribe).toHaveBeenCalledWith(
+        'RewardsController:accountLinked',
+        expect.any(Function),
       );
     });
   });
@@ -121,10 +203,10 @@ describe('usePredictRewards', () => {
   describe('when rewards feature is not enabled', () => {
     it('returns enabled false and stops checking', async () => {
       // Arrange
-      mockControllerMessengerCall.mockReturnValueOnce(false);
+      mockControllerMessengerCall.mockResolvedValueOnce(false);
 
       // Act
-      const { result } = renderHook(() => usePredictRewards());
+      const { result } = renderHook(() => usePredictRewards(10.5));
 
       // Assert
       await waitFor(() => {
@@ -132,6 +214,9 @@ describe('usePredictRewards', () => {
       });
 
       expect(result.current.enabled).toBe(false);
+      expect(result.current.accountOptedIn).toBe(null);
+      expect(result.current.shouldShowRewardsRow).toBe(false);
+      expect(result.current.estimatedPoints).toBe(null);
       expect(mockControllerMessengerCall).toHaveBeenCalledTimes(1);
       expect(mockControllerMessengerCall).toHaveBeenCalledWith(
         'RewardsController:isRewardsFeatureEnabled',
@@ -139,15 +224,15 @@ describe('usePredictRewards', () => {
     });
   });
 
-  describe('when account has not opted in', () => {
-    it('returns enabled false after checking opt-in status', async () => {
+  describe('when no subscription exists', () => {
+    it('returns enabled false when getFirstSubscriptionId returns null', async () => {
       // Arrange
       mockControllerMessengerCall
-        .mockReturnValueOnce(true)
-        .mockResolvedValueOnce(false);
+        .mockResolvedValueOnce(true) // isRewardsFeatureEnabled
+        .mockResolvedValueOnce(null); // getFirstSubscriptionId
 
       // Act
-      const { result } = renderHook(() => usePredictRewards());
+      const { result } = renderHook(() => usePredictRewards(10.5));
 
       // Assert
       await waitFor(() => {
@@ -155,14 +240,94 @@ describe('usePredictRewards', () => {
       });
 
       expect(result.current.enabled).toBe(false);
+      expect(result.current.accountOptedIn).toBe(null);
+      expect(result.current.shouldShowRewardsRow).toBe(false);
+      expect(result.current.estimatedPoints).toBe(null);
+      expect(result.current.hasError).toBe(false);
       expect(mockControllerMessengerCall).toHaveBeenCalledTimes(2);
     });
   });
 
-  describe('when selected address is missing', () => {
+  describe('when account has not opted in', () => {
+    it('returns enabled based on opt-in support and does not estimate points', async () => {
+      // Arrange
+      mockControllerMessengerCall
+        .mockResolvedValueOnce(true) // isRewardsFeatureEnabled
+        .mockResolvedValueOnce('subscription-1') // getFirstSubscriptionId
+        .mockResolvedValueOnce(false) // getHasAccountOptedIn
+        .mockResolvedValueOnce(true); // isOptInSupported
+
+      // Act
+      const { result } = renderHook(() => usePredictRewards(10.5));
+
+      // Assert
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.enabled).toBe(true);
+      expect(result.current.accountOptedIn).toBe(false);
+      expect(result.current.shouldShowRewardsRow).toBe(true);
+      expect(result.current.estimatedPoints).toBe(null);
+      expect(result.current.hasError).toBe(false);
+
+      expect(mockControllerMessengerCall).toHaveBeenCalledWith(
+        'RewardsController:isOptInSupported',
+        mockInternalAccount,
+      );
+      expect(mockControllerMessengerCall).not.toHaveBeenCalledWith(
+        'RewardsController:estimatePoints',
+        expect.anything(),
+      );
+    });
+
+    it('returns enabled false when opt-in is not supported', async () => {
+      // Arrange
+      mockControllerMessengerCall
+        .mockResolvedValueOnce(true) // isRewardsFeatureEnabled
+        .mockResolvedValueOnce('subscription-1') // getFirstSubscriptionId
+        .mockResolvedValueOnce(false) // getHasAccountOptedIn
+        .mockResolvedValueOnce(false); // isOptInSupported
+
+      // Act
+      const { result } = renderHook(() => usePredictRewards(10.5));
+
+      // Assert
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.enabled).toBe(false);
+      expect(result.current.accountOptedIn).toBe(false);
+      expect(result.current.shouldShowRewardsRow).toBe(false);
+      expect(result.current.estimatedPoints).toBe(null);
+    });
+  });
+
+  describe('when selected account is missing', () => {
     it('returns enabled false and isLoading false without calling controller', async () => {
       // Arrange
-      mockUseSelector.mockReturnValue(null);
+      mockUseSelector.mockReturnValue(() => undefined);
+
+      // Act
+      const { result } = renderHook(() => usePredictRewards(10.5));
+
+      // Assert
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.enabled).toBe(false);
+      expect(result.current.accountOptedIn).toBe(null);
+      expect(result.current.shouldShowRewardsRow).toBe(false);
+      expect(result.current.estimatedPoints).toBe(null);
+      expect(mockControllerMessengerCall).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when totalFeeAmountUsd is missing', () => {
+    it('returns enabled false and does not call controller when totalFeeAmountUsd is undefined', async () => {
+      // Arrange - no mocks needed since hook returns early
 
       // Act
       const { result } = renderHook(() => usePredictRewards());
@@ -173,6 +338,9 @@ describe('usePredictRewards', () => {
       });
 
       expect(result.current.enabled).toBe(false);
+      expect(result.current.accountOptedIn).toBe(null);
+      expect(result.current.shouldShowRewardsRow).toBe(false);
+      expect(result.current.estimatedPoints).toBe(null);
       expect(mockControllerMessengerCall).not.toHaveBeenCalled();
     });
   });
@@ -181,13 +349,14 @@ describe('usePredictRewards', () => {
     it('returns enabled false and logs error with proper context', async () => {
       // Arrange
       const mockError = new Error('Invalid chain ID');
-      mockFormatChainIdToCaip.mockImplementation(() => {
+      mockParseCaipChainId.mockImplementation(() => {
         throw mockError;
       });
-      mockControllerMessengerCall.mockReturnValueOnce(true);
+      mockControllerMessengerCall.mockResolvedValueOnce(true); // isRewardsFeatureEnabled
+      mockControllerMessengerCall.mockResolvedValueOnce('subscription-1'); // getFirstSubscriptionId
 
       // Act
-      const { result } = renderHook(() => usePredictRewards());
+      const { result } = renderHook(() => usePredictRewards(10.5));
 
       // Assert
       await waitFor(() => {
@@ -195,30 +364,37 @@ describe('usePredictRewards', () => {
       });
 
       expect(result.current.enabled).toBe(false);
-      expect(mockLoggerError).toHaveBeenCalledWith(mockError, {
-        tags: {
-          feature: 'Predict',
-          component: 'usePredictRewards',
-        },
-        context: {
-          name: 'usePredictRewards',
-          data: {
-            method: 'formatAccountToCaipAccountId',
-            action: 'caip_formatting',
-            operation: 'account_formatting',
+      expect(result.current.accountOptedIn).toBe(null);
+      expect(result.current.shouldShowRewardsRow).toBe(false);
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Invalid chain ID' }),
+        {
+          tags: {
+            feature: 'Predict',
+            component: 'usePredictRewards',
+          },
+          context: {
+            name: 'usePredictRewards',
+            data: {
+              method: 'formatAccountToCaipAccountId',
+              action: 'caip_formatting',
+              operation: 'account_formatting',
+            },
           },
         },
-      });
-      expect(mockControllerMessengerCall).toHaveBeenCalledTimes(1);
+      );
     });
   });
 
   describe('when RewardsController call fails', () => {
-    it('returns enabled false and logs error with proper context', async () => {
+    it('returns hasError true and logs error with proper context', async () => {
       // Arrange
       const mockError = new Error('Network error');
-      mockControllerMessengerCall.mockReturnValueOnce(true);
-      mockControllerMessengerCall.mockRejectedValueOnce(mockError);
+      mockControllerMessengerCall
+        .mockResolvedValueOnce(true) // isRewardsFeatureEnabled
+        .mockResolvedValueOnce('subscription-1') // getFirstSubscriptionId
+        .mockResolvedValueOnce(true) // getHasAccountOptedIn
+        .mockRejectedValueOnce(mockError); // estimatePoints
 
       // Suppress console.error for this test since we expect an error to be thrown
       const consoleErrorSpy = jest
@@ -228,15 +404,19 @@ describe('usePredictRewards', () => {
         });
 
       // Act
-      const { result } = renderHook(() => usePredictRewards());
+      const { result } = renderHook(() => usePredictRewards(10.5));
 
       // Assert
       await waitFor(() => {
         expect(result.current.isLoading).toBe(false);
+        expect(result.current.hasError).toBe(true);
       });
 
-      expect(result.current.enabled).toBe(false);
-      expect(mockLoggerError).toHaveBeenCalledWith(mockError, {
+      expect(result.current.enabled).toBe(true);
+      expect(result.current.accountOptedIn).toBe(true);
+      expect(result.current.shouldShowRewardsRow).toBe(true);
+      expect(result.current.estimatedPoints).toBe(null);
+      expect(mockLoggerError).toHaveBeenCalledWith(expect.any(Error), {
         tags: {
           feature: 'Predict',
           component: 'usePredictRewards',
@@ -244,57 +424,14 @@ describe('usePredictRewards', () => {
         context: {
           name: 'usePredictRewards',
           data: {
-            method: 'checkRewardsEnabled',
-            action: 'rewards_check',
-            operation: 'rewards_status',
+            method: 'estimatePoints',
+            action: 'rewards_estimation',
+            operation: 'points_estimation',
           },
         },
       });
 
       consoleErrorSpy.mockRestore();
-    });
-  });
-
-  describe('when account changes', () => {
-    it('rechecks rewards status with new account', async () => {
-      // Arrange
-      mockControllerMessengerCall
-        .mockReturnValueOnce(true)
-        .mockResolvedValueOnce(true)
-        .mockReturnValueOnce(true)
-        .mockResolvedValueOnce(false);
-
-      // Act
-      const { result, rerender } = renderHook(() => usePredictRewards());
-
-      // Assert - first account
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
-
-      expect(result.current.enabled).toBe(true);
-      expect(mockControllerMessengerCall).toHaveBeenCalledTimes(2);
-
-      // Arrange - change account
-      const newAddress = '0x9876543210987654321098765432109876543210';
-      const newCaipAccount =
-        'eip155:137:0x9876543210987654321098765432109876543210' as CaipAccountId;
-      mockUseSelector.mockReturnValue(newAddress);
-      mockToCaipAccountId.mockReturnValue(newCaipAccount);
-
-      // Act - trigger rerender
-      rerender({});
-
-      // Assert - second account
-      await waitFor(() => {
-        expect(result.current.enabled).toBe(false);
-      });
-
-      expect(mockControllerMessengerCall).toHaveBeenCalledTimes(4);
-      expect(mockControllerMessengerCall).toHaveBeenLastCalledWith(
-        'RewardsController:getHasAccountOptedIn',
-        newCaipAccount,
-      );
     });
   });
 });

--- a/app/components/UI/Predict/hooks/usePredictRewards.ts
+++ b/app/components/UI/Predict/hooks/usePredictRewards.ts
@@ -1,23 +1,35 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import Engine from '../../../../core/Engine';
-import { formatChainIdToCaip } from '@metamask/bridge-controller';
 import {
   toCaipAccountId,
   parseCaipChainId,
   type CaipAccountId,
 } from '@metamask/utils';
+import {
+  EstimatePointsDto,
+  EstimatedPointsDto,
+  EstimateAssetDto,
+} from '../../../../core/Engine/controllers/rewards-controller/types';
 import { PREDICT_CONSTANTS } from '../constants/errors';
 import { ensureError } from '../utils/predictErrorHandler';
-import { selectSelectedInternalAccountFormattedAddress } from '../../../../selectors/accountsController';
+import { selectSelectedInternalAccountByScope } from '../../../../selectors/multichainAccounts/accounts';
+import { getFormattedAddressFromInternalAccount } from '../../../../core/Multichain/utils';
+import {
+  POLYGON_MAINNET_CAIP_CHAIN_ID,
+  POLYGON_USDC_CAIP_ASSET_ID,
+  COLLATERAL_TOKEN_DECIMALS,
+} from '../providers/polymarket/constants';
+import { parseUnits } from 'ethers/lib/utils';
 import Logger from '../../../../util/Logger';
-
-// Polygon mainnet chain ID
-const POLYGON_CHAIN_ID = '0x89';
 
 interface UsePredictRewardsResult {
   enabled: boolean;
   isLoading: boolean;
+  accountOptedIn: boolean | null;
+  shouldShowRewardsRow: boolean;
+  estimatedPoints: number | null;
+  hasError: boolean;
 }
 
 /**
@@ -27,8 +39,9 @@ const formatAccountToCaipAccountId = (
   address: string,
 ): CaipAccountId | null => {
   try {
-    const caipChainId = formatChainIdToCaip(POLYGON_CHAIN_ID);
-    const { namespace, reference } = parseCaipChainId(caipChainId);
+    const { namespace, reference } = parseCaipChainId(
+      POLYGON_MAINNET_CAIP_CHAIN_ID,
+    );
     return toCaipAccountId(namespace, reference, address);
   } catch (error) {
     Logger.error(ensureError(error), {
@@ -50,45 +63,83 @@ const formatAccountToCaipAccountId = (
 };
 
 /**
- * Hook to check if rewards are enabled for the current account in Predict
- * @returns {UsePredictRewardsResult} Object containing enabled status and loading state
+ * Hook to check if rewards are enabled for the current account in Predict and estimate points
+ * @param totalFeeAmountUsd - Total fee amount in USD
+ * @returns {UsePredictRewardsResult} Object containing enabled status, loading state, and estimated points
  */
-export const usePredictRewards = (): UsePredictRewardsResult => {
+export const usePredictRewards = (
+  totalFeeAmountUsd?: number,
+): UsePredictRewardsResult => {
   const [isLoading, setIsLoading] = useState(true);
   const [enabled, setEnabled] = useState(false);
+  const [accountOptedIn, setAccountOptedIn] = useState<boolean | null>(null);
+  const [estimatedPoints, setEstimatedPoints] = useState<number | null>(null);
+  const [shouldShowRewardsRow, setShouldShowRewardsRow] = useState(false);
+  const [hasError, setHasError] = useState(false);
 
   // Selectors
-  const selectedAddress = useSelector(
-    selectSelectedInternalAccountFormattedAddress,
+  const getSelectedAccountByScope = useSelector(
+    selectSelectedInternalAccountByScope,
   );
 
-  const checkRewardsEnabled = useCallback(async () => {
+  const selectedAccount = getSelectedAccountByScope(
+    POLYGON_MAINNET_CAIP_CHAIN_ID,
+  );
+  const selectedAddress = selectedAccount
+    ? getFormattedAddressFromInternalAccount(selectedAccount)
+    : undefined;
+
+  const estimatePoints = useCallback(async () => {
     // Skip if missing required data
-    if (!selectedAddress) {
+    if (!selectedAddress || !selectedAccount || !totalFeeAmountUsd) {
+      setEstimatedPoints(null);
       setEnabled(false);
+      setAccountOptedIn(null);
+      setShouldShowRewardsRow(false);
       setIsLoading(false);
       return;
     }
 
     setIsLoading(true);
+    setHasError(false);
 
     try {
-      // Check if rewards feature is enabled globally
-      const isRewardsEnabled = Engine.controllerMessenger.call(
+      // Check if rewards feature is enabled
+      const isRewardsEnabled = await Engine.controllerMessenger.call(
         'RewardsController:isRewardsFeatureEnabled',
       );
 
       if (!isRewardsEnabled) {
+        setEstimatedPoints(null);
         setEnabled(false);
+        setShouldShowRewardsRow(false);
+        setAccountOptedIn(null);
+        setIsLoading(false);
+        return;
+      }
+
+      // Check if there's a subscription first
+      const firstSubscriptionId = await Engine.controllerMessenger.call(
+        'RewardsController:getFirstSubscriptionId',
+      );
+
+      if (!firstSubscriptionId) {
+        setEstimatedPoints(null);
+        setEnabled(false);
+        setShouldShowRewardsRow(false);
+        setAccountOptedIn(null);
+        setHasError(false);
         setIsLoading(false);
         return;
       }
 
       // Format account to CAIP-10 for Polygon
       const caipAccount = formatAccountToCaipAccountId(selectedAddress);
-
       if (!caipAccount) {
+        setEstimatedPoints(null);
         setEnabled(false);
+        setShouldShowRewardsRow(false);
+        setAccountOptedIn(null);
         setIsLoading(false);
         return;
       }
@@ -99,7 +150,67 @@ export const usePredictRewards = (): UsePredictRewardsResult => {
         caipAccount,
       );
 
-      setEnabled(hasOptedIn);
+      setAccountOptedIn(hasOptedIn);
+
+      // Determine if we should show the rewards row
+      // Show row if: opted in OR (not opted in AND opt-in is supported)
+      let shouldShow = hasOptedIn;
+
+      if (!hasOptedIn && selectedAccount) {
+        const isOptInSupported = await Engine.controllerMessenger.call(
+          'RewardsController:isOptInSupported',
+          selectedAccount,
+        );
+        shouldShow = isOptInSupported;
+      }
+
+      setShouldShowRewardsRow(shouldShow);
+      setEnabled(shouldShow);
+
+      // Only estimate points if account is opted in and fee asset info is provided
+      if (!hasOptedIn) {
+        setEstimatedPoints(null);
+        setHasError(false);
+        setIsLoading(false);
+        return;
+      }
+
+      // If fee asset information is not provided, skip estimation
+      if (!totalFeeAmountUsd) {
+        setEstimatedPoints(null);
+        setHasError(false);
+        setIsLoading(false);
+        return;
+      }
+
+      // Prepare fee asset
+      // Convert USD amount to atomic units (6 decimals for USDC)
+      const feeAsset: EstimateAssetDto = {
+        id: POLYGON_USDC_CAIP_ASSET_ID,
+        amount: parseUnits(
+          totalFeeAmountUsd.toString(),
+          COLLATERAL_TOKEN_DECIMALS,
+        ).toString(),
+      };
+
+      // Create estimate request
+      const estimateRequest: EstimatePointsDto = {
+        activityType: 'PREDICT',
+        account: caipAccount,
+        activityContext: {
+          predictContext: {
+            feeAsset,
+          },
+        },
+      };
+
+      // Call rewards controller to estimate points
+      const result: EstimatedPointsDto = await Engine.controllerMessenger.call(
+        'RewardsController:estimatePoints',
+        estimateRequest,
+      );
+
+      setEstimatedPoints(result.pointsEstimate);
     } catch (error) {
       Logger.error(ensureError(error), {
         tags: {
@@ -109,25 +220,49 @@ export const usePredictRewards = (): UsePredictRewardsResult => {
         context: {
           name: 'usePredictRewards',
           data: {
-            method: 'checkRewardsEnabled',
-            action: 'rewards_check',
-            operation: 'rewards_status',
+            method: 'estimatePoints',
+            action: 'rewards_estimation',
+            operation: 'points_estimation',
           },
         },
       });
-      setEnabled(false);
+      setEstimatedPoints(null);
+      setHasError(true);
     } finally {
       setIsLoading(false);
     }
-  }, [selectedAddress]);
+  }, [totalFeeAmountUsd, selectedAddress, selectedAccount]);
 
-  // Check rewards status when dependencies change
+  // Estimate points when dependencies change
   useEffect(() => {
-    checkRewardsEnabled();
-  }, [checkRewardsEnabled]);
+    estimatePoints();
+  }, [estimatePoints]);
+
+  // Subscribe to account linked event to retrigger estimate
+  useEffect(() => {
+    const handleAccountLinked = () => {
+      estimatePoints();
+    };
+
+    Engine.controllerMessenger.subscribe(
+      'RewardsController:accountLinked',
+      handleAccountLinked,
+    );
+
+    return () => {
+      Engine.controllerMessenger.unsubscribe(
+        'RewardsController:accountLinked',
+        handleAccountLinked,
+      );
+    };
+  }, [estimatePoints]);
 
   return {
     enabled,
     isLoading,
+    accountOptedIn,
+    shouldShowRewardsRow,
+    estimatedPoints,
+    hasError,
   };
 };

--- a/app/components/UI/Predict/providers/polymarket/constants.ts
+++ b/app/components/UI/Predict/providers/polymarket/constants.ts
@@ -75,3 +75,6 @@ export const MATIC_CONTRACTS: ContractConfig = {
   collateral: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
   conditionalTokens: '0x4D97DCd97eC945f40cF65F87097ACe5EA0476045',
 };
+
+export const POLYGON_USDC_CAIP_ASSET_ID =
+  `${POLYGON_MAINNET_CAIP_CHAIN_ID}/erc20:${MATIC_CONTRACTS.collateral}` as const;

--- a/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
+++ b/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
@@ -138,9 +138,6 @@ const PredictBuyPreview = () => {
     autoRefreshTimeout: 1000,
   });
 
-  const { enabled: isRewardsEnabled, isLoading: isRewardsLoading } =
-    usePredictRewards();
-
   // Track screen load performance (balance + initial preview)
   usePredictMeasurement({
     traceName: TraceName.PredictBuyPreviewView,
@@ -196,16 +193,6 @@ const PredictBuyPreview = () => {
   const providerFee = preview?.fees?.providerFee ?? 0;
   const total = currentValue + providerFee + metamaskFee;
 
-  // Calculate estimated rewards points: 1 point per cent spent on MM fee
-  // Formula: MM fee (in dollars) * 100 = points (rounded)
-  const estimatedPoints = useMemo(
-    () => Math.round(metamaskFee * 100),
-    [metamaskFee],
-  );
-
-  // Show rewards row if we have a valid amount
-  const shouldShowRewards = isRewardsEnabled && currentValue > 0;
-
   // Validation constants and states
   const MINIMUM_BET = 1; // $1 minimum bet
   const hasInsufficientFunds = total > balance;
@@ -216,8 +203,22 @@ const PredictBuyPreview = () => {
     preview &&
     !isLoading &&
     !isBalanceLoading &&
-    !isRewardsLoading &&
     !isRateLimited;
+
+  const {
+    enabled: isRewardsEnabled,
+    isLoading: isRewardsLoading,
+    accountOptedIn: isAccountOptedIntoRewards,
+    estimatedPoints: estimatedRewardsPoints,
+    hasError: isRewardsError,
+  } = usePredictRewards(
+    isLoading || previewError ? undefined : (preview?.fees?.totalFee ?? 0),
+  );
+
+  // Show rewards row if we have a valid amount
+  // && either active account address is opted in or not opted in but opt-in is supported
+  const shouldShowRewardsRow =
+    isRewardsEnabled && currentValue > 0 && isAccountOptedIntoRewards != null;
 
   const title = market.title;
   const outcomeGroupTitle = outcome.groupItemTitle
@@ -533,10 +534,13 @@ const PredictBuyPreview = () => {
         total={total}
         metamaskFee={metamaskFee}
         providerFee={providerFee}
-        shouldShowRewards={shouldShowRewards}
-        estimatedPoints={estimatedPoints}
-        isLoadingRewards={isCalculating && isUserInputChange}
-        hasRewardsError={false}
+        shouldShowRewardsRow={shouldShowRewardsRow}
+        accountOptedIn={isAccountOptedIntoRewards}
+        estimatedPoints={estimatedRewardsPoints}
+        isLoadingRewards={
+          (isCalculating && isUserInputChange) || isRewardsLoading
+        }
+        hasRewardsError={isRewardsError}
         onFeesInfoPress={handleFeesInfoPress}
       />
       {renderErrorMessage()}

--- a/app/components/UI/Rewards/components/RewardPointsAnimation/index.test.tsx
+++ b/app/components/UI/Rewards/components/RewardPointsAnimation/index.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import { TextVariant } from '@metamask/design-system-react-native';
 import RewardPointsAnimation, { RewardAnimationState } from './index';
+import { useRewardsAnimation } from '../../hooks/useRewardsAnimation';
 
 jest.mock('../../hooks/useRewardsAnimation', () => ({
   useRewardsAnimation: jest.fn(),
@@ -46,9 +47,9 @@ jest.mock('rive-react-native', () => ({
 jest.mock('../../../../../animations/rewards_icon_animations.riv', () => ({}));
 
 describe('RewardPointsAnimation', () => {
-  const mockUseRewardsAnimation =
-    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-commonjs, @typescript-eslint/no-var-requires
-    require('../../hooks/useRewardsAnimation').useRewardsAnimation;
+  const mockUseRewardsAnimation = useRewardsAnimation as jest.MockedFunction<
+    typeof useRewardsAnimation
+  >;
 
   const defaultProps = {
     value: 1000,
@@ -60,7 +61,7 @@ describe('RewardPointsAnimation', () => {
     rivePositionStyle: {},
     displayValue: 1000,
     displayText: null,
-    isAnimating: false,
+    hideValue: false,
   };
 
   beforeEach(() => {
@@ -281,20 +282,20 @@ describe('RewardPointsAnimation', () => {
       expect(getByTestId('info-icon')).toBeOnTheScreen();
     });
 
-    it('renders info icon when in error state with default noop callback', () => {
+    it('does not render info icon when in error state without infoOnPress', () => {
       mockUseRewardsAnimation.mockReturnValue({
         ...mockHookReturn,
         displayText: "Couldn't Load",
       });
 
-      const { getByTestId } = render(
+      const { queryByTestId } = render(
         <RewardPointsAnimation
           {...defaultProps}
           state={RewardAnimationState.ErrorState}
         />,
       );
 
-      expect(getByTestId('info-icon')).toBeOnTheScreen();
+      expect(queryByTestId('info-icon')).toBeNull();
     });
 
     it('does not render info icon when infoOnPress is explicitly null', () => {
@@ -395,6 +396,32 @@ describe('RewardPointsAnimation', () => {
       const { getByText } = render(<RewardPointsAnimation value={888} />);
 
       expect(getByText('888')).toBeOnTheScreen();
+    });
+
+    it('handles hideValue being true', () => {
+      mockUseRewardsAnimation.mockReturnValue({
+        ...mockHookReturn,
+        displayValue: 1000,
+        displayText: null,
+        hideValue: true,
+      });
+
+      const { queryByText } = render(<RewardPointsAnimation value={1000} />);
+
+      expect(queryByText('1,000')).toBeNull();
+    });
+
+    it('shows displayText when hideValue is true but displayText is provided', () => {
+      mockUseRewardsAnimation.mockReturnValue({
+        ...mockHookReturn,
+        displayValue: 1000,
+        displayText: 'Loading...',
+        hideValue: true,
+      });
+
+      const { getByText } = render(<RewardPointsAnimation value={1000} />);
+
+      expect(getByText('Loading...')).toBeOnTheScreen();
     });
   });
 

--- a/app/components/UI/Rewards/components/RewardPointsAnimation/index.tsx
+++ b/app/components/UI/Rewards/components/RewardPointsAnimation/index.tsx
@@ -51,10 +51,6 @@ interface RewardPointsAnimationProps {
   formatOptions?: Intl.NumberFormatOptions;
 }
 
-const noop = () => {
-  // do nothing
-};
-
 const RewardPointsAnimation: React.FC<RewardPointsAnimationProps> = ({
   value,
   shouldShow = true,
@@ -63,7 +59,7 @@ const RewardPointsAnimation: React.FC<RewardPointsAnimationProps> = ({
   height = 16,
   width = 16,
   state = RewardAnimationState.Idle,
-  infoOnPress = noop,
+  infoOnPress,
   locale = 'en-US',
   formatOptions,
 }) => {

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -133,6 +133,17 @@ export interface EstimatePerpsContextDto {
   coin: string;
 }
 
+export interface EstimatePredictContextDto {
+  /**
+   * Fee asset information, in caip19 format
+   * @example {
+   *   id: 'eip155:137/erc20:0x2791bca1f2de4661ed88a30c99a7a9449aa84174',
+   *   amount: '1000000'
+   * }
+   */
+  feeAsset: EstimateAssetDto;
+}
+
 export interface EstimatePointsContextDto {
   /**
    * Swap context data, must be present for SWAP activity
@@ -147,6 +158,11 @@ export interface EstimatePointsContextDto {
    * @example Batch positions: [{ type: 'CLOSE_POSITION', coin: 'USDC', usdFeeValue: '1.00' }, ...]
    */
   perpsContext?: EstimatePerpsContextDto | EstimatePerpsContextDto[];
+
+  /**
+   * Predict context data, must be present for PREDICT activity
+   */
+  predictContext?: EstimatePredictContextDto;
 }
 
 /**
@@ -156,6 +172,7 @@ export interface EstimatePointsContextDto {
 export type PointsEventEarnType =
   | 'SWAP'
   | 'PERPS'
+  | 'PREDICT'
   | 'REFERRAL'
   | 'SIGN_UP_BONUS'
   | 'LOYALTY_BONUS'


### PR DESCRIPTION
## **Description**

Switches the reward point calculation for predict from a hard coded approach to using the rewards API. It also uses the same approach recently introduced in the swaps flow, to allow add their account if it's not correctly tied to their rewards subscription.

## **Changelog**

CHANGELOG entry: Estimate reward points in predict flow

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/RWDS-801

## **Screenshots/Recordings**

### **After**

<img width="732" height="1041" alt="Screenshot-88" src="https://github.com/user-attachments/assets/9e4e27c6-2fab-4382-8d0f-69d861f4780b" />

---

<img width="701" height="823" alt="Screenshot-2025-11-18-10:30:28" src="https://github.com/user-attachments/assets/b8fd489e-610a-422c-8d23-67ae24daa4d3" />

---

<img width="500" height="600" alt="Screenshot-2025-11-18-10:31:15" src="https://github.com/user-attachments/assets/64bbfc9e-4bd2-48e7-9574-479f6299a2f5" />

---

<img width="774" height="307" alt="Screenshot-2025-11-18-10:32:21" src="https://github.com/user-attachments/assets/996f3b03-dfc2-4897-8c65-2d81b8e584a2" />

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch Predict to API-based points estimation with opt-in handling, update UI to show points/add-account, and extend rewards types/tests.
> 
> - **Predict flow**:
>   - Update `PredictBuyPreview` to use `usePredictRewards(totalFee)` and drive rewards UI; compute `shouldShowRewardsRow` and pass `accountOptedIn`, `estimatedPoints`, loading/error to `PredictFeeSummary`.
>   - `PredictFeeSummary` props renamed `shouldShowRewards` → `shouldShowRewardsRow`; add `accountOptedIn`, error tooltip; render `AddRewardsAccount` when not opted in; wire `RewardPointsAnimation` states.
> - **Hook: `usePredictRewards`**:
>   - New signature accepts `totalFeeAmountUsd`; selects multichain account by `POLYGON_MAINNET_CAIP_CHAIN_ID` and formats CAIP-10 without bridge-controller.
>   - Checks feature flag and subscription, opt-in status/support; estimates points via `RewardsController:estimatePoints` using `POLYGON_USDC_CAIP_ASSET_ID` and `parseUnits` with 6 decimals.
>   - Subscribes to `RewardsController:accountLinked`; returns `{enabled,isLoading,accountOptedIn,shouldShowRewardsRow,estimatedPoints,hasError}`.
> - **Rewards UI**:
>   - `RewardPointsAnimation`: make `infoOnPress` optional; hide info icon unless provided; support `hideValue` from hook.
> - **Types/Constants**:
>   - Extend rewards types with `EstimatePredictContextDto`, add `PREDICT` to `PointsEventEarnType`.
>   - Add `POLYGON_USDC_CAIP_ASSET_ID` constant.
> - **Tests**:
>   - Comprehensive updates for new props/flows, loading/error states, subscription/opt-in paths, and animation behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dadabd0a1d03bb0bce67e726d9a5d669085e28f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->