### PR TITLE
fix: validate selected internal account address format in Asset component cp-7.60.0

### DIFF
--- a/app/components/Views/Asset/index.js
+++ b/app/components/Views/Asset/index.js
@@ -30,6 +30,7 @@ import {
 } from '../../../selectors/networkController';
 import { selectTokens } from '../../../selectors/tokensController';
 import { sortTransactions } from '../../../util/activity';
+import { isHexAddress } from '@metamask/utils';
 import {
   areAddressesEqual,
   safeToChecksumAddress,
@@ -65,7 +66,6 @@ import { selectSelectedInternalAccount } from '../../../selectors/accountsContro
 import { updateIncomingTransactions } from '../../../util/transaction-controller';
 import { withMetricsAwareness } from '../../../components/hooks/useMetrics';
 import { store } from '../../../store';
-import { toChecksumHexAddress } from '@metamask/controller-utils';
 import {
   selectSwapsTransactions,
   selectTransactions,
@@ -216,9 +216,9 @@ class Asset extends PureComponent {
   filter = undefined;
   navSymbol = undefined;
   navAddress = undefined;
-  selectedAddress = toChecksumHexAddress(
-    this.props.selectedInternalAccount?.address,
-  );
+  selectedAddress = isHexAddress(this.props.selectedInternalAccount?.address)
+    ? safeToChecksumAddress(this.props.selectedInternalAccount?.address)
+    : this.props.selectedInternalAccount?.address;
 
   updateNavBar = (contentOffset = 0) => {
     const {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR fixes non-evm address transformation on asset page, used for generating blockexplorer link.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug that was causing redirect to incorrect url when viewing all transactions on blockexplorer from asset page

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/22858

## **Manual testing steps**

```gherkin
Feature: View full history on Solscan

  Scenario: user views full history on Solscan
    Given user has transacted with some solana assets

    When user opens individual solana asset page and clicks "View full history on Solscan"
    Then correct solscan link is opened
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/ccf486ec-3bf9-44c6-bbca-3ed4d8582aaa


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/14882761-c8ae-4bd5-8b3e-4fb4eea65472


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Only checksum EVM (hex) addresses in Asset view, leaving non-EVM addresses intact to produce correct block explorer links.
> 
> - **Asset View (`app/components/Views/Asset/index.js`)**:
>   - Validate address with `isHexAddress` and only apply `safeToChecksumAddress` to EVM addresses; leave non-EVM addresses unchanged for downstream usage (e.g., block explorer links).
>   - Update imports: add `isHexAddress`; remove `toChecksumHexAddress` usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d1b03f93c71ea76c548af878f6d7e7364615806. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->