### PR TITLE
fix(snaps): Refactor `SnapBridge` to use `SelectedNetworkController`

### DIFF
--- a/app/core/Engine/controllers/snaps/execution-service-init.ts
+++ b/app/core/Engine/controllers/snaps/execution-service-init.ts
@@ -9,6 +9,7 @@ import Logger from '../../../../util/Logger';
 import { SnapBridge } from '../../../Snaps';
 import getRpcMethodMiddleware from '../../../RPCMethods/RPCMethodMiddleware';
 import { Duration, inMilliseconds } from '@metamask/utils';
+import { SnapId } from '@metamask/snaps-sdk';
 
 /**
  * Initialize the Snaps execution service.
@@ -38,7 +39,7 @@ export const executionServiceInit: ControllerInitFunction<
     // Consider developing an abstract class to derived custom implementations
     // for each use case.
     const bridge = new SnapBridge({
-      snapId,
+      snapId: snapId as SnapId,
       connectionStream,
       getRPCMethodMiddleware: ({ hostname, getProviderState }) =>
         getRpcMethodMiddleware({

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -1070,6 +1070,8 @@ export const getRpcMethodMiddleware = ({
 
       wallet_switchEthereumChain: () => {
         checkTabActive();
+        // eslint-disable-next-line no-console
+        console.log('RPCMethods: wallet_switchEthereumChain', req.params);
         return RPCMethods.wallet_switchEthereumChain({
           req,
           res,

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -1070,8 +1070,6 @@ export const getRpcMethodMiddleware = ({
 
       wallet_switchEthereumChain: () => {
         checkTabActive();
-        // eslint-disable-next-line no-console
-        console.log('RPCMethods: wallet_switchEthereumChain', req.params);
         return RPCMethods.wallet_switchEthereumChain({
           req,
           res,

--- a/app/core/Snaps/SnapBridge.ts
+++ b/app/core/Snaps/SnapBridge.ts
@@ -71,7 +71,7 @@ export default class SnapBridge {
   }
 
   /**
-   * Gets the provider state including unlock status and network information.
+   * Gets the provider state.
    * @returns An object containing the provider state.
    */
   async #getProviderState() {

--- a/app/core/Snaps/SnapBridge.ts
+++ b/app/core/Snaps/SnapBridge.ts
@@ -19,6 +19,7 @@ import { providerAsMiddleware } from '@metamask/eth-json-rpc-middleware';
 import { createEngineStream } from '@metamask/json-rpc-middleware-stream';
 import { SnapId } from '@metamask/snaps-sdk';
 import { Json } from '@metamask/utils';
+import { InternalAccount } from '@metamask/keyring-internal-api';
 
 import Engine from '../Engine';
 import { setupMultiplex } from '../../util/streams';
@@ -190,7 +191,7 @@ export default class SnapBridge {
           getAllEvmAccounts: () =>
             controllerMessenger
               .call('AccountsController:listAccounts')
-              .map((account) => account.address),
+              .map((account: InternalAccount) => account.address),
           grantPermissions: (approvedPermissions) =>
             controllerMessenger.call('PermissionController:grantPermissions', {
               approvedPermissions,

--- a/app/core/Snaps/SnapBridge.ts
+++ b/app/core/Snaps/SnapBridge.ts
@@ -1,172 +1,186 @@
-///: BEGIN:ONLY_INCLUDE_IF(preinstalled-snaps,external-snaps)
-/* eslint-disable import/no-commonjs */
-/* eslint-disable @typescript-eslint/no-require-imports */
-/* eslint-disable @typescript-eslint/no-var-requires */
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
 // eslint-disable-next-line import/no-nodejs-modules
 import { Duplex } from 'stream';
+// @ts-expect-error - No types declarations
+import pump from 'pump';
+
+import { JsonRpcEngine, JsonRpcMiddleware } from '@metamask/json-rpc-engine';
+// @ts-expect-error - No types declarations
+import createFilterMiddleware from '@metamask/eth-json-rpc-filters';
+// @ts-expect-error - No types declarations
+import createSubscriptionManager from '@metamask/eth-json-rpc-filters/subscriptionManager';
+import EthQuery, { JsonRpcParams } from '@metamask/eth-query';
 import {
-  createSwappableProxy,
-  createEventEmitterProxy,
-} from '@metamask/swappable-obj-proxy';
-import { JsonRpcEngine } from '@metamask/json-rpc-engine';
+  createSelectedNetworkMiddleware,
+  SelectedNetworkControllerMessenger,
+} from '@metamask/selected-network-controller';
+import { createPreinstalledSnapsMiddleware } from '@metamask/snaps-rpc-methods';
+import { SubjectType } from '@metamask/permission-controller';
+import { providerAsMiddleware } from '@metamask/eth-json-rpc-middleware';
 import { createEngineStream } from '@metamask/json-rpc-middleware-stream';
-import EthQuery from '@metamask/eth-query';
+import { SnapId } from '@metamask/snaps-sdk';
+import { Json } from '@metamask/utils';
 
 import Engine from '../Engine';
 import { setupMultiplex } from '../../util/streams';
 import Logger from '../../util/Logger';
+import { createOriginMiddleware } from '../../util/middlewares';
+import { RPCMethodsMiddleParameters } from '../RPCMethods/RPCMethodMiddleware';
 import snapMethodMiddlewareBuilder from './SnapsMethodMiddleware';
-import { SubjectType } from '@metamask/permission-controller';
-import { createPreinstalledSnapsMiddleware } from '@metamask/snaps-rpc-methods';
 import { isSnapPreinstalled } from '../SnapKeyring/utils/snaps';
 
-import ObjectMultiplex from '@metamask/object-multiplex';
-import createFilterMiddleware from '@metamask/eth-json-rpc-filters';
-import createSubscriptionManager from '@metamask/eth-json-rpc-filters/subscriptionManager';
-import { providerAsMiddleware } from '@metamask/eth-json-rpc-middleware';
-import { createOriginMiddleware } from '../../util/middlewares';
-import { createSelectedNetworkMiddleware } from '@metamask/selected-network-controller';
-const pump = require('pump');
+/**
+ * Type definition for the GetRPCMethodMiddleware function.
+ */
+type GetRPCMethodMiddleware = ({
+  hostname,
+  getProviderState,
+}: {
+  hostname: RPCMethodsMiddleParameters['hostname'];
+  getProviderState: RPCMethodsMiddleParameters['getProviderState'];
+}) => JsonRpcMiddleware<JsonRpcParams, Json>;
 
-interface ISnapBridgeProps {
-  snapId: string;
-  connectionStream: Duplex;
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getRPCMethodMiddleware: (args: any) => any;
-}
-
+/**
+ * A bridge for connecting the client Ethereum provider to a Snap's execution environment.
+ *
+ * @param params - The parameters for the SnapBridge.
+ * @param params.snapId - The ID of the Snap.
+ * @param params.connectionStream - The stream to connect to the Snap.
+ * @param params.getRPCMethodMiddleware - A function to get the RPC method middleware.
+ */
 export default class SnapBridge {
   snapId: string;
   stream: Duplex;
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getRPCMethodMiddleware: (args: any) => any;
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  provider: any;
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  blockTracker: any;
-
-  #mux: typeof ObjectMultiplex;
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  #providerProxy: any;
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  #blockTrackerProxy: any;
+  getRPCMethodMiddleware: GetRPCMethodMiddleware;
+  deprecatedNetworkVersions: Record<string, string | null> = {};
 
   constructor({
     snapId,
     connectionStream,
     getRPCMethodMiddleware,
-  }: ISnapBridgeProps) {
-    Logger.log(
-      '[SNAP BRIDGE LOG] Engine+setupSnapProvider: Setup bridge for Snap',
-      snapId,
-    );
+  }: {
+    snapId: string;
+    connectionStream: Duplex;
+    getRPCMethodMiddleware: GetRPCMethodMiddleware;
+  }) {
+    Logger.log('[SNAP BRIDGE] Initializing SnapBridge for Snap:', snapId);
 
     this.snapId = snapId;
     this.stream = connectionStream;
     this.getRPCMethodMiddleware = getRPCMethodMiddleware;
-    this.deprecatedNetworkVersions = {};
-
-    // TODO: Replace "any" with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { NetworkController } = Engine.context as any;
-
-    const { provider, blockTracker } =
-      NetworkController.getProviderAndBlockTracker();
-
-    this.#providerProxy = null;
-    this.#blockTrackerProxy = null;
-
-    this.#setProvider(provider);
-    this.#setBlockTracker(blockTracker);
-
-    this.#mux = setupMultiplex(this.stream);
   }
 
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  #setProvider = (provider: any): void => {
-    if (this.#providerProxy) {
-      this.#providerProxy.setTarget(provider);
-    } else {
-      this.#providerProxy = createSwappableProxy(provider);
-    }
-    this.provider = provider;
-  };
+  /**
+   * Checks if the wallet is unlocked.
+   * @returns A boolean indicating if the wallet is unlocked.
+   */
+  #isUnlocked() {
+    return Engine.context.KeyringController.isUnlocked();
+  }
 
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  #setBlockTracker = (blockTracker: any): void => {
-    if (this.#blockTrackerProxy) {
-      this.#blockTrackerProxy.setTarget(blockTracker);
-    } else {
-      this.#blockTrackerProxy = createEventEmitterProxy(blockTracker, {
-        eventFilter: 'skipInternal',
+  /**
+   * Gets the network state for the provider based on the origin.
+   * @param origin - The origin of the request.
+   * @returns An object containing the chain ID and network version.
+   */
+  async #getProviderNetworkState(origin: string) {
+    const { controllerMessenger } = Engine;
+
+    const networkClientId = controllerMessenger.call(
+      'SelectedNetworkController:getNetworkClientIdForDomain',
+      origin,
+    );
+
+    const networkClient = controllerMessenger.call(
+      'NetworkController:getNetworkClientById',
+      networkClientId,
+    );
+
+    const { chainId } = networkClient.configuration;
+
+    const deprecatedNetworkVersion =
+      this.deprecatedNetworkVersions[networkClientId];
+
+    if (!deprecatedNetworkVersion) {
+      const ethQuery = new EthQuery(networkClient.provider);
+
+      const networkVersion: string | null = await new Promise((resolve) => {
+        ethQuery.sendAsync({ method: 'net_version' }, (error, result) => {
+          if (error) {
+            console.error(error);
+            resolve(null);
+          } else {
+            resolve(result as string);
+          }
+        });
       });
-    }
-    this.blockTracker = blockTracker;
-  };
 
-  async getProviderState() {
+      this.deprecatedNetworkVersions[networkClientId] = networkVersion;
+
+      return {
+        chainId,
+        networkVersion: networkVersion ?? 'loading',
+      };
+    }
+
     return {
-      isUnlocked: this.isUnlocked(),
-      ...(await this.getProviderNetworkState(this.snapId)),
+      chainId,
+      networkVersion: deprecatedNetworkVersion,
     };
   }
 
-  setupProviderConnection = () => {
-    Logger.log('[SNAP BRIDGE LOG] Engine+setupProviderConnection');
-    const outStream = this.#mux.createStream('metamask-provider');
-    const engine = this.setupProviderEngine();
+  /**
+   * Gets the provider state including unlock status and network information.
+   * @returns An object containing the provider state.
+   */
+  async #getProviderState() {
+    const providerState = await this.#getProviderNetworkState(this.snapId);
 
-    const providerStream = createEngineStream({ engine });
-    // TODO: Replace "any" with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    pump(outStream, providerStream, outStream, (err: any) => {
-      engine.destroy();
-      if (err) Logger.log('Error with provider stream conn', err);
-    });
-  };
+    return {
+      isUnlocked: this.#isUnlocked(),
+      ...providerState,
+    };
+  }
 
-  setupProviderEngine = () => {
+  /**
+   * Sets up the provider engine for the Snap.
+   * @returns The configured JSON-RPC engine.
+   */
+  #setupProviderEngine() {
+    Logger.log('[SNAP BRIDGE] Setting up provider engine');
+
+    const { context, controllerMessenger } = Engine;
+    const { SelectedNetworkController, PermissionController } = context;
     const engine = new JsonRpcEngine();
 
-    // create filter polyfill middleware
-    const filterMiddleware = createFilterMiddleware({
-      provider: this.#providerProxy,
-      blockTracker: this.#blockTrackerProxy,
-    });
+    const proxy = SelectedNetworkController.getProviderAndBlockTracker(
+      this.snapId,
+    );
 
-    // create subscription polyfill middleware
-    const subscriptionManager = createSubscriptionManager({
-      provider: this.#providerProxy,
-      blockTracker: this.#blockTrackerProxy,
-    });
+    const filterMiddleware = createFilterMiddleware(proxy);
 
-    // TODO: Replace "any" with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    subscriptionManager.events.on('notification', (message: any) =>
+    const subscriptionManager = createSubscriptionManager(proxy);
+    subscriptionManager.events.on('notification', (message: Json) =>
       engine.emit('notification', message),
     );
 
-    engine.push(createOriginMiddleware({ origin: this.snapId }));
-    engine.push(createSelectedNetworkMiddleware(Engine.controllerMessenger));
+    engine.push(
+      createOriginMiddleware({ origin: this.snapId }) as JsonRpcMiddleware<
+        JsonRpcParams,
+        Json
+      >,
+    );
+
+    engine.push(
+      createSelectedNetworkMiddleware(
+        controllerMessenger as unknown as SelectedNetworkControllerMessenger,
+      ),
+    );
 
     // Filter and subscription polyfills
     engine.push(filterMiddleware);
     engine.push(subscriptionManager.middleware);
 
-    const { context, controllerMessenger } = Engine;
-    const { PermissionController } = context;
-
-    if (isSnapPreinstalled(this.snapId)) {
+    if (isSnapPreinstalled(this.snapId as SnapId)) {
       engine.push(
         createPreinstalledSnapsMiddleware({
           getPermissions: PermissionController.getPermissions.bind(
@@ -205,55 +219,35 @@ export default class SnapBridge {
     engine.push(
       this.getRPCMethodMiddleware({
         hostname: this.snapId,
-        getProviderState: this.getProviderState.bind(this),
+        getProviderState: this.#getProviderState.bind(this),
       }),
     );
 
     // Forward to metamask primary provider
-    engine.push(providerAsMiddleware(this.#providerProxy));
+    engine.push(providerAsMiddleware(proxy.provider));
+
     return engine;
-  };
+  }
 
-  isUnlocked = (): boolean => {
-    // TODO: Replace "any" with type
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { KeyringController } = Engine.context as any;
-    return KeyringController.isUnlocked();
-  };
+  /**
+   * Sets up the provider connection for the Snap.
+   */
+  setupProviderConnection() {
+    Logger.log('[SNAP BRIDGE] Setting up provider connection');
 
-  async getProviderNetworkState(origin: string) {
-    const networkClientId = Engine.controllerMessenger.call(
-      'SelectedNetworkController:getNetworkClientIdForDomain',
-      origin,
+    const stream = setupMultiplex(this.stream).createStream(
+      'metamask-provider',
     );
+    const engine = this.#setupProviderEngine();
 
-    const networkClient = Engine.controllerMessenger.call(
-      'NetworkController:getNetworkClientById',
-      networkClientId,
-    );
+    const providerStream = createEngineStream({ engine });
 
-    const { chainId } = networkClient.configuration;
+    pump(stream, providerStream, stream, (error: Error | null) => {
+      engine.destroy();
 
-    let networkVersion = this.deprecatedNetworkVersions[networkClientId];
-    if (!networkVersion) {
-      const ethQuery = new EthQuery(networkClient.provider);
-      networkVersion = await new Promise((resolve) => {
-        ethQuery.sendAsync({ method: 'net_version' }, (error, result) => {
-          if (error) {
-            console.error(error);
-            resolve(null);
-          } else {
-            resolve(result);
-          }
-        });
-      });
-      this.deprecatedNetworkVersions[networkClientId] = networkVersion;
-    }
-
-    return {
-      chainId,
-      networkVersion: networkVersion ?? 'loading',
-    };
+      if (error) {
+        Logger.log('[SNAP BRIDGE] Error with provider stream:', error);
+      }
+    });
   }
 }
-///: END:ONLY_INCLUDE_IF

--- a/app/core/Snaps/SnapBridge.ts
+++ b/app/core/Snaps/SnapBridge.ts
@@ -9,7 +9,10 @@ import createFilterMiddleware from '@metamask/eth-json-rpc-filters';
 // @ts-expect-error - No types declarations
 import createSubscriptionManager from '@metamask/eth-json-rpc-filters/subscriptionManager';
 import { JsonRpcParams } from '@metamask/eth-query';
-import { createSelectedNetworkMiddleware } from '@metamask/selected-network-controller';
+import {
+  createSelectedNetworkMiddleware,
+  SelectedNetworkControllerMessenger,
+} from '@metamask/selected-network-controller';
 import { createPreinstalledSnapsMiddleware } from '@metamask/snaps-rpc-methods';
 import { SubjectType } from '@metamask/permission-controller';
 import { providerAsMiddleware } from '@metamask/eth-json-rpc-middleware';
@@ -106,7 +109,11 @@ export default class SnapBridge {
       >,
     );
 
-    engine.push(createSelectedNetworkMiddleware(controllerMessenger));
+    engine.push(
+      createSelectedNetworkMiddleware(
+        controllerMessenger as unknown as SelectedNetworkControllerMessenger,
+      ),
+    );
 
     // Filter and subscription polyfills
     engine.push(filterMiddleware);

--- a/app/core/Snaps/SnapBridge.ts
+++ b/app/core/Snaps/SnapBridge.ts
@@ -52,7 +52,6 @@ export default class SnapBridge {
   snapId: SnapId;
   stream: Duplex;
   getRPCMethodMiddleware: GetRPCMethodMiddleware;
-  deprecatedNetworkVersions: Record<string, string | null> = {};
 
   constructor({
     snapId,

--- a/app/core/Snaps/SnapBridge.ts
+++ b/app/core/Snaps/SnapBridge.ts
@@ -9,10 +9,7 @@ import createFilterMiddleware from '@metamask/eth-json-rpc-filters';
 // @ts-expect-error - No types declarations
 import createSubscriptionManager from '@metamask/eth-json-rpc-filters/subscriptionManager';
 import EthQuery, { JsonRpcParams } from '@metamask/eth-query';
-import {
-  createSelectedNetworkMiddleware,
-  SelectedNetworkControllerMessenger,
-} from '@metamask/selected-network-controller';
+import { createSelectedNetworkMiddleware } from '@metamask/selected-network-controller';
 import { createPreinstalledSnapsMiddleware } from '@metamask/snaps-rpc-methods';
 import { SubjectType } from '@metamask/permission-controller';
 import { providerAsMiddleware } from '@metamask/eth-json-rpc-middleware';
@@ -171,11 +168,7 @@ export default class SnapBridge {
       >,
     );
 
-    engine.push(
-      createSelectedNetworkMiddleware(
-        controllerMessenger as unknown as SelectedNetworkControllerMessenger,
-      ),
-    );
+    engine.push(createSelectedNetworkMiddleware(controllerMessenger));
 
     // Filter and subscription polyfills
     engine.push(filterMiddleware);

--- a/app/core/Snaps/SnapBridge.ts
+++ b/app/core/Snaps/SnapBridge.ts
@@ -8,7 +8,7 @@ import { JsonRpcEngine, JsonRpcMiddleware } from '@metamask/json-rpc-engine';
 import createFilterMiddleware from '@metamask/eth-json-rpc-filters';
 // @ts-expect-error - No types declarations
 import createSubscriptionManager from '@metamask/eth-json-rpc-filters/subscriptionManager';
-import { JsonRpcParams } from '@metamask/eth-query';
+import { JsonRpcParams, Json } from '@metamask/utils';
 import {
   createSelectedNetworkMiddleware,
   SelectedNetworkControllerMessenger,
@@ -18,7 +18,6 @@ import { SubjectType } from '@metamask/permission-controller';
 import { providerAsMiddleware } from '@metamask/eth-json-rpc-middleware';
 import { createEngineStream } from '@metamask/json-rpc-middleware-stream';
 import { SnapId } from '@metamask/snaps-sdk';
-import { Json } from '@metamask/utils';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 
 import Engine from '../Engine';


### PR DESCRIPTION
## **Description**

This PR refactors the `SnapBridge` to use `SelectedNetworkController` to create a provider proxy. It also removes a lot of unnecessary logic. This fixes an issue where the snap couldn't switch the network.

## **Changelog**

CHANGELOG entry: Fix snap `wallet_switchEthereumChain`

## **Related issues**

Fixes: #22419

## **Manual testing steps**

1. Set the selected network to any other network than ethereum mainnet (like polygon, base,...)
2. Go to the send flow
3. Expect a valid ENS name to be resolved when trying to send ETH on mainnet

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors SnapBridge to source provider/block tracker from SelectedNetworkController, streamlines the JSON-RPC middleware stack and stream wiring, and types snapId as SnapId in init.
> 
> - **Snaps**:
>   - **`SnapBridge` refactor**:
>     - Use `SelectedNetworkController.getProviderAndBlockTracker(snapId)` and add `createSelectedNetworkMiddleware`.
>     - Rebuild JSON-RPC engine: origin middleware → selected network → filter/subscription polyfills → preinstalled snaps middleware (when applicable) → permission middleware → snaps method middleware → user RPC middleware (with `#getProviderState`) → forward via `providerAsMiddleware(proxy.provider)`.
>     - Replace custom multiplexing with `setupMultiplex` and `pump`; add concise logging; adopt strong typings (`SnapId`, `JsonRpcMiddleware`, `InternalAccount`); remove legacy proxy/network-version logic.
> - **Engine**:
>   - In `controllers/snaps/execution-service-init.ts`, pass `snapId` as `SnapId` when creating `SnapBridge`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78ef6013069b118513c923caac7e02165ebeeaea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->