### PR TITLE
feat: track RPC update from network connection banner

### DIFF
--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.js
@@ -32,6 +32,7 @@ import sanitizeUrl, {
   compareSanitizedUrl,
 } from '../../../../../util/sanitizeUrl';
 import onlyKeepHost from '../../../../../util/onlyKeepHost';
+import { isPublicEndpointUrl } from '../../../../../core/Engine/controllers/network-controller/utils';
 import { themeAppearanceLight } from '../../../../../constants/storage';
 import CustomNetwork from './CustomNetworkView/CustomNetwork';
 import Button, {
@@ -48,6 +49,7 @@ import { selectIsRpcFailoverEnabled } from '../../../../../selectors/featureFlag
 import { regex } from '../../../../../../app/util/regex';
 import { NetworksViewSelectorsIDs } from '../../../../../../e2e/selectors/Settings/NetworksView.selectors';
 import { isSafeChainId, toHex } from '@metamask/controller-utils';
+import { hexToNumber } from '@metamask/utils';
 import { CustomDefaultNetworkIDs } from '../../../../../../e2e/selectors/Onboarding/CustomDefaultNetwork.selectors';
 import { updateIncomingTransactions } from '../../../../../util/transaction-controller';
 import { withMetricsAwareness } from '../../../../../components/hooks/useMetrics';
@@ -83,7 +85,7 @@ import Tag from '../../../../../component-library/components/Tags/Tag/Tag';
 import { CellComponentSelectorsIDs } from '../../../../../../e2e/selectors/wallet/CellComponent.selectors';
 import stripProtocol from '../../../../../util/stripProtocol';
 import stripKeyFromInfuraUrl from '../../../../../util/stripKeyFromInfuraUrl';
-import { MetaMetrics } from '../../../../../core/Analytics';
+import { MetaMetrics, MetaMetricsEvents } from '../../../../../core/Analytics';
 import {
   addItemToChainIdList,
   removeItemFromChainIdList,
@@ -532,6 +534,7 @@ export class NetworkSettings extends PureComponent {
     isCustomMainnet,
     shouldNetworkSwitchPopToWallet,
     navigation,
+    trackRpcUpdateFromBanner,
   }) => {
     const { NetworkController } = Engine.context;
 
@@ -569,6 +572,38 @@ export class NetworkSettings extends PureComponent {
             }
           : undefined,
       );
+
+      // Track RPC update from network connection banner
+      if (trackRpcUpdateFromBanner) {
+        const newRpcEndpoint =
+          networkConfig.rpcEndpoints[networkConfig.defaultRpcEndpointIndex];
+        const oldRpcEndpoint =
+          existingNetwork.rpcEndpoints?.[
+            existingNetwork.defaultRpcEndpointIndex ?? 0
+          ];
+
+        const chainIdAsDecimal = hexToNumber(chainId);
+
+        const sanitizeRpcUrl = (url) =>
+          isPublicEndpointUrl(url, infuraProjectId)
+            ? onlyKeepHost(url)
+            : 'custom';
+
+        this.props.metrics.trackEvent(
+          this.props.metrics
+            .createEventBuilder(
+              MetaMetricsEvents.NetworkConnectionBannerRpcUpdated,
+            )
+            .addProperties({
+              chain_id_caip: `eip155:${chainIdAsDecimal}`,
+              from_rpc_domain: oldRpcEndpoint?.url
+                ? sanitizeRpcUrl(oldRpcEndpoint.url)
+                : 'unknown',
+              to_rpc_domain: sanitizeRpcUrl(newRpcEndpoint.url),
+            })
+            .build(),
+        );
+      }
     } else {
       await NetworkController.addNetwork({
         ...networkConfig,
@@ -614,6 +649,9 @@ export class NetworkSettings extends PureComponent {
 
     const shouldNetworkSwitchPopToWallet =
       route.params?.shouldNetworkSwitchPopToWallet ?? true;
+
+    const trackRpcUpdateFromBanner =
+      route.params?.trackRpcUpdateFromBanner ?? false;
     // Check if CTA is disabled
     const isCtaDisabled =
       !enableAction || this.disabledByChainId() || this.disabledBySymbol();
@@ -684,6 +722,7 @@ export class NetworkSettings extends PureComponent {
       networkType,
       networkUrl,
       showNetworkOnboarding,
+      trackRpcUpdateFromBanner,
     });
   };
 

--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.test.tsx
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/index.test.tsx
@@ -24,6 +24,7 @@ import * as jsonRequest from '../../../../../util/jsonRpcRequest';
 import Logger from '../../../../../util/Logger';
 import Engine from '../../../../../core/Engine';
 import { isRemoveGlobalNetworkSelectorEnabled } from '../../../../../util/networks';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
 const { PreferencesController } = Engine.context;
 
 jest.mock(
@@ -38,14 +39,28 @@ jest.mock(
   }),
 );
 
+const mockTrackEvent = jest.fn();
+
+const mockCreateEventBuilder = jest.fn((eventName) => {
+  let properties = {};
+  return {
+    addProperties(props: Record<string, unknown>) {
+      properties = { ...properties, ...props };
+      return this;
+    },
+    build() {
+      return {
+        name: eventName,
+        properties,
+      };
+    },
+  };
+});
+
 jest.mock('../../../../../components/hooks/useMetrics', () => ({
   useMetrics: () => ({
-    trackEvent: jest.fn(),
-    createEventBuilder: jest.fn(() => ({
-      addProperties: jest.fn(() => ({
-        build: jest.fn(),
-      })),
-    })),
+    trackEvent: mockTrackEvent,
+    createEventBuilder: mockCreateEventBuilder,
   }),
   withMetricsAwareness: (Component: unknown) => Component,
 }));
@@ -1408,6 +1423,274 @@ describe('NetworkSettings', () => {
           ],
         }),
         { replacementSelectedRpcEndpointIndex: 0 },
+      );
+    });
+
+    it('tracks RPC update event when trackRpcUpdateFromBanner is true', async () => {
+      const PROPS_WITH_METRICS = {
+        ...SAMPLE_PROPS,
+        metrics: {
+          trackEvent: mockTrackEvent,
+          createEventBuilder: mockCreateEventBuilder,
+        },
+        networkConfigurations: {
+          '0x64': {
+            blockExplorerUrls: ['https://etherscan.io'],
+            defaultBlockExplorerUrlIndex: 0,
+            defaultRpcEndpointIndex: 0,
+            chainId: '0x64',
+            rpcEndpoints: [
+              {
+                networkClientId: 'custom',
+                type: 'custom',
+                url: 'https://mainnet.infura.io/v3/',
+              },
+            ],
+            name: 'Custom Network',
+            nativeCurrency: 'ETH',
+          },
+        },
+      };
+
+      const wrapper5 = shallow(
+        <Provider store={store}>
+          <NetworkSettings {...PROPS_WITH_METRICS} />
+        </Provider>,
+      )
+        .find(NetworkSettings)
+        .dive();
+
+      const instance = wrapper5.instance() as NetworkSettings;
+
+      await instance.handleNetworkUpdate({
+        rpcUrl: 'https://monad-mainnet.infura.io/v3/',
+        rpcUrls: [
+          {
+            url: 'https://monad-mainnet.infura.io/v3/',
+            type: 'custom',
+            name: 'Monad RPC',
+          },
+        ],
+        blockExplorerUrls: ['https://etherscan.io'],
+        blockExplorerUrl: 'https://etherscan.io',
+        nickname: 'Custom Network',
+        ticker: 'ETH',
+        isNetworkExists: [],
+        chainId: '0x64',
+        navigation: mockNavigation,
+        isCustomMainnet: false,
+        shouldNetworkSwitchPopToWallet: true,
+        trackRpcUpdateFromBanner: true,
+      });
+
+      expect(Engine.context.NetworkController.updateNetwork).toHaveBeenCalled();
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        mockCreateEventBuilder(
+          MetaMetricsEvents.NetworkConnectionBannerRpcUpdated,
+        )
+          .addProperties({
+            chain_id_caip: 'eip155:100',
+            from_rpc_domain: 'mainnet.infura.io',
+            to_rpc_domain: 'monad-mainnet.infura.io',
+          })
+          .build(),
+      );
+    });
+
+    it('does not track RPC update event when trackRpcUpdateFromBanner is false', async () => {
+      const PROPS_WITHOUT_TRACKING = {
+        ...SAMPLE_PROPS,
+        metrics: {
+          trackEvent: mockTrackEvent,
+          createEventBuilder: mockCreateEventBuilder,
+        },
+        networkConfigurations: {
+          '0x64': {
+            blockExplorerUrls: ['https://etherscan.io'],
+            defaultBlockExplorerUrlIndex: 0,
+            defaultRpcEndpointIndex: 0,
+            chainId: '0x64',
+            rpcEndpoints: [
+              {
+                networkClientId: 'custom',
+                type: 'custom',
+                url: 'https://mainnet.infura.io/v3/',
+              },
+            ],
+            name: 'Custom Network',
+            nativeCurrency: 'ETH',
+          },
+        },
+      };
+
+      const wrapper6 = shallow(
+        <Provider store={store}>
+          <NetworkSettings {...PROPS_WITHOUT_TRACKING} />
+        </Provider>,
+      )
+        .find(NetworkSettings)
+        .dive();
+
+      const instance = wrapper6.instance() as NetworkSettings;
+
+      await instance.handleNetworkUpdate({
+        rpcUrl: 'https://monad-mainnet.infura.io/v3/',
+        rpcUrls: [
+          {
+            url: 'https://monad-mainnet.infura.io/v3/',
+            type: 'custom',
+            name: 'Monad RPC',
+          },
+        ],
+        blockExplorerUrls: ['https://etherscan.io'],
+        blockExplorerUrl: 'https://etherscan.io',
+        nickname: 'Custom Network',
+        ticker: 'ETH',
+        isNetworkExists: [],
+        chainId: '0x64',
+        navigation: mockNavigation,
+        isCustomMainnet: false,
+        shouldNetworkSwitchPopToWallet: true,
+        trackRpcUpdateFromBanner: false,
+      });
+
+      expect(Engine.context.NetworkController.updateNetwork).toHaveBeenCalled();
+      expect(mockTrackEvent).not.toHaveBeenCalled();
+    });
+
+    it('sanitizes custom RPC URLs as "custom" in tracking event', async () => {
+      const PROPS_WITH_CUSTOM_RPC = {
+        ...SAMPLE_PROPS,
+        metrics: {
+          trackEvent: mockTrackEvent,
+          createEventBuilder: mockCreateEventBuilder,
+        },
+        networkConfigurations: {
+          '0x64': {
+            blockExplorerUrls: ['https://etherscan.io'],
+            defaultBlockExplorerUrlIndex: 0,
+            defaultRpcEndpointIndex: 0,
+            chainId: '0x64',
+            rpcEndpoints: [
+              {
+                networkClientId: 'custom',
+                type: 'custom',
+                url: 'https://my-private-rpc.com',
+              },
+            ],
+            name: 'Custom Network',
+            nativeCurrency: 'ETH',
+          },
+        },
+      };
+
+      const wrapper7 = shallow(
+        <Provider store={store}>
+          <NetworkSettings {...PROPS_WITH_CUSTOM_RPC} />
+        </Provider>,
+      )
+        .find(NetworkSettings)
+        .dive();
+
+      const instance = wrapper7.instance() as NetworkSettings;
+
+      await instance.handleNetworkUpdate({
+        rpcUrl: 'https://another-private-rpc.com',
+        rpcUrls: [
+          {
+            url: 'https://another-private-rpc.com',
+            type: 'custom',
+            name: 'Another Custom RPC',
+          },
+        ],
+        blockExplorerUrls: ['https://etherscan.io'],
+        blockExplorerUrl: 'https://etherscan.io',
+        nickname: 'Custom Network',
+        ticker: 'ETH',
+        isNetworkExists: [],
+        chainId: '0x64',
+        navigation: mockNavigation,
+        isCustomMainnet: false,
+        shouldNetworkSwitchPopToWallet: true,
+        trackRpcUpdateFromBanner: true,
+      });
+
+      expect(Engine.context.NetworkController.updateNetwork).toHaveBeenCalled();
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        mockCreateEventBuilder(
+          MetaMetricsEvents.NetworkConnectionBannerRpcUpdated,
+        )
+          .addProperties({
+            chain_id_caip: 'eip155:100',
+            from_rpc_domain: 'custom',
+            to_rpc_domain: 'custom',
+          })
+          .build(),
+      );
+    });
+
+    it('tracks unknown for missing old RPC endpoint', async () => {
+      const PROPS_WITHOUT_OLD_ENDPOINT = {
+        ...SAMPLE_PROPS,
+        metrics: {
+          trackEvent: mockTrackEvent,
+          createEventBuilder: mockCreateEventBuilder,
+        },
+        networkConfigurations: {
+          '0x64': {
+            blockExplorerUrls: ['https://etherscan.io'],
+            defaultBlockExplorerUrlIndex: 0,
+            defaultRpcEndpointIndex: undefined,
+            chainId: '0x64',
+            rpcEndpoints: [],
+            name: 'Custom Network',
+            nativeCurrency: 'ETH',
+          },
+        },
+      };
+
+      const wrapper8 = shallow(
+        <Provider store={store}>
+          <NetworkSettings {...PROPS_WITHOUT_OLD_ENDPOINT} />
+        </Provider>,
+      )
+        .find(NetworkSettings)
+        .dive();
+
+      const instance = wrapper8.instance() as NetworkSettings;
+
+      await instance.handleNetworkUpdate({
+        rpcUrl: 'https://new-rpc.infura.io/v3/',
+        rpcUrls: [
+          {
+            url: 'https://new-rpc.infura.io/v3/',
+            type: 'custom',
+            name: 'New RPC',
+          },
+        ],
+        blockExplorerUrls: ['https://etherscan.io'],
+        blockExplorerUrl: 'https://etherscan.io',
+        nickname: 'Custom Network',
+        ticker: 'ETH',
+        isNetworkExists: [],
+        chainId: '0x64',
+        navigation: mockNavigation,
+        isCustomMainnet: false,
+        shouldNetworkSwitchPopToWallet: true,
+        trackRpcUpdateFromBanner: true,
+      });
+
+      expect(Engine.context.NetworkController.updateNetwork).toHaveBeenCalled();
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        mockCreateEventBuilder(
+          MetaMetricsEvents.NetworkConnectionBannerRpcUpdated,
+        )
+          .addProperties({
+            chain_id_caip: 'eip155:100',
+            from_rpc_domain: 'unknown',
+            to_rpc_domain: 'new-rpc.infura.io',
+          })
+          .build(),
       );
     });
   });

--- a/app/components/hooks/useNetworkConnectionBanner/useNetworkConnectionBanner.test.tsx
+++ b/app/components/hooks/useNetworkConnectionBanner/useNetworkConnectionBanner.test.tsx
@@ -226,6 +226,7 @@ describe('useNetworkConnectionBanner', () => {
           network: rpcUrl,
           shouldNetworkSwitchPopToWallet: false,
           shouldShowPopularNetworks: false,
+          trackRpcUpdateFromBanner: true,
         },
       );
     });

--- a/app/components/hooks/useNetworkConnectionBanner/useNetworkConnectionBanner.ts
+++ b/app/components/hooks/useNetworkConnectionBanner/useNetworkConnectionBanner.ts
@@ -65,6 +65,7 @@ const useNetworkConnectionBanner = (): {
       network: rpcUrl,
       shouldNetworkSwitchPopToWallet: false,
       shouldShowPopularNetworks: false,
+      trackRpcUpdateFromBanner: true,
     });
 
     trackEvent(

--- a/app/core/Analytics/MetaMetrics.events.ts
+++ b/app/core/Analytics/MetaMetrics.events.ts
@@ -514,6 +514,7 @@ enum EVENT_NAME {
   // NETWORK CONNECTION BANNER
   NETWORK_CONNECTION_BANNER_SHOWN = 'Network Connection Banner Shown',
   NETWORK_CONNECTION_BANNER_UPDATE_RPC_CLICKED = 'Network Connection Banner Update RPC Clicked',
+  NetworkConnectionBannerRpcUpdated = 'Network Connection Banner RPC Updated',
 
   // Deep Link Modal Viewed
   DEEP_LINK_PRIVATE_MODAL_VIEWED = 'Deep Link Private Modal Viewed',
@@ -1331,6 +1332,9 @@ const events = {
   ),
   NETWORK_CONNECTION_BANNER_UPDATE_RPC_CLICKED: generateOpt(
     EVENT_NAME.NETWORK_CONNECTION_BANNER_UPDATE_RPC_CLICKED,
+  ),
+  NetworkConnectionBannerRpcUpdated: generateOpt(
+    EVENT_NAME.NetworkConnectionBannerRpcUpdated,
   ),
 
   // Multi SRP


### PR DESCRIPTION
## **Description**

This PR tracks when users complete the RPC update flow initiated from the network connection banner, matching the implementation in metamask-extension https://github.com/MetaMask/metamask-extension/pull/37751.

**Context**: Currently we track when users click "Update RPC" from the network connection banner (`NetworkConnectionBannerUpdateRpcClicked`), but we don't track whether they actually complete the update by saving changes in the network settings form.

**Solution**: Added the `NetworkConnectionBannerRpcUpdated` MetaMetrics event that fires when:
1. User clicks "Update RPC" from the network connection banner (sets `trackRpcUpdateFromBanner: true` in navigation params)
2. User modifies the RPC endpoint in the NetworkSettings form
3. User saves the changes

This provides complete funnel tracking for the network banner → RPC update flow.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

(Internal analytics tracking - not user-facing)

## **Related issues**

Fixes: [ttps://consensyssoftware.atlassian.net/browse/WPC-172](https://consensyssoftware.atlassian.net/browse/WPC-172)

## **Manual testing steps**

Feature: Track RPC update from network connection banner

  Scenario: user completes RPC update from network connection banner
    Given user has a network with degraded or unavailable status
    And network connection banner is shown
    
    When user clicks "Update RPC" button in the banner
    And user changes the RPC endpoint in the network settings form
    And user saves the network settings
    
    Then NetworkConnectionBannerRpcUpdated event is tracked
    And event includes chain_id_caip, from_rpc_domain, and to_rpc_domain properties

  Scenario: user saves network settings without banner tracking flag
    Given user is in network settings form
    And trackRpcUpdateFromBanner is not set
    
    When user modifies RPC endpoint
    And user saves the network settings
    
    Then NetworkConnectionBannerRpcUpdated event is not tracked

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tracks a new "Network Connection Banner RPC Updated" event when a banner-initiated RPC change is saved, with sanitized domains and CAIP chain IDs, and wires the tracking flag through navigation with comprehensive tests.
> 
> - **Analytics**
>   - Add `MetaMetricsEvents.NetworkConnectionBannerRpcUpdated` and expose in events map.
> - **Settings › NetworkSettings**
>   - On save, when `trackRpcUpdateFromBanner` is true, emit `NetworkConnectionBannerRpcUpdated` with `chain_id_caip`, `from_rpc_domain`, `to_rpc_domain`.
>   - Sanitize endpoints via `isPublicEndpointUrl`/`onlyKeepHost`; compute CAIP chain ID with `hexToNumber`.
> - **Hooks**
>   - `useNetworkConnectionBanner.updateRpc` now navigates to `Routes.EDIT_NETWORK` with `trackRpcUpdateFromBanner: true`.
> - **Tests**
>   - Add/extend tests for event emission, non-emission, URL sanitization (`custom`), `unknown` fallback, and navigation param propagation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f125ba1c7ee1ce0b682ad65ced0609960d1f759. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->