### PR TITLE
fix(card): cp-7.60.0 card assets UI issues

### DIFF
--- a/app/components/UI/Card/Views/CardAuthentication/CardAuthentication.tsx
+++ b/app/components/UI/Card/Views/CardAuthentication/CardAuthentication.tsx
@@ -16,7 +16,12 @@ import {
   TextInput,
   StyleSheet,
 } from 'react-native';
-import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
+import {
+  Box,
+  FontWeight,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
 
 import Icon, {
   IconName,
@@ -603,14 +608,18 @@ const CardAuthentication = () => {
                 width={ButtonWidthTypes.Full}
                 disabled={isLoginDisabled || loading}
               />
-              <Button
-                variant={ButtonVariants.Secondary}
-                label={strings('card.card_authentication.signup_button')}
-                size={ButtonSize.Lg}
-                testID={CardAuthenticationSelectors.SIGNUP_BUTTON}
+              <TouchableOpacity
                 onPress={() => navigation.navigate(Routes.CARD.ONBOARDING.ROOT)}
-                width={ButtonWidthTypes.Full}
-              />
+              >
+                <Text
+                  testID={CardAuthenticationSelectors.SIGNUP_BUTTON}
+                  variant={TextVariant.BodyMd}
+                  fontWeight={FontWeight.Medium}
+                  twClassName="text-default text-center p-4"
+                >
+                  {strings('card.card_authentication.signup_button')}
+                </Text>
+              </TouchableOpacity>
             </Box>
           </Box>
         </ScrollView>

--- a/app/components/UI/Card/Views/CardAuthentication/__snapshots__/CardAuthentication.test.tsx.snap
+++ b/app/components/UI/Card/Views/CardAuthentication/__snapshots__/CardAuthentication.test.tsx.snap
@@ -838,40 +838,29 @@ exports[`CardAuthentication Component Login Step - Component Rendering matches l
                                   </Text>
                                 </TouchableOpacity>
                                 <TouchableOpacity
-                                  accessibilityRole="button"
-                                  accessible={true}
-                                  activeOpacity={1}
                                   onPress={[Function]}
-                                  onPressIn={[Function]}
-                                  onPressOut={[Function]}
-                                  style={
-                                    {
-                                      "alignItems": "center",
-                                      "alignSelf": "stretch",
-                                      "backgroundColor": "#3c4d9d0f",
-                                      "borderColor": "transparent",
-                                      "borderRadius": 12,
-                                      "borderWidth": 1,
-                                      "flexDirection": "row",
-                                      "height": 48,
-                                      "justifyContent": "center",
-                                      "overflow": "hidden",
-                                      "paddingHorizontal": 16,
-                                    }
-                                  }
-                                  testID="signup-button"
                                 >
                                   <Text
                                     accessibilityRole="text"
                                     style={
-                                      {
-                                        "color": "#121314",
-                                        "fontFamily": "Geist Medium",
-                                        "fontSize": 16,
-                                        "letterSpacing": 0,
-                                        "lineHeight": 24,
-                                      }
+                                      [
+                                        {
+                                          "color": "#121314",
+                                          "fontFamily": "Geist Medium",
+                                          "fontSize": 16,
+                                          "fontWeight": 400,
+                                          "letterSpacing": 0,
+                                          "lineHeight": 24,
+                                          "paddingBottom": 16,
+                                          "paddingLeft": 16,
+                                          "paddingRight": 16,
+                                          "paddingTop": 16,
+                                          "textAlign": "center",
+                                        },
+                                        undefined,
+                                      ]
                                     }
+                                    testID="signup-button"
                                   >
                                     card.card_authentication.signup_button
                                   </Text>

--- a/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
@@ -784,6 +784,30 @@ describe('CardHome Component', () => {
     ).not.toBeOnTheScreen();
   });
 
+  it('passes formatted balance to CardAssetItem', () => {
+    // Given: asset balances with formatted balance
+    mockUseAssetBalances.mockReturnValue(
+      createMockAssetBalancesMap({
+        balanceFiat: '$1,000.00',
+        asset: {
+          symbol: 'USDC',
+          image: 'usdc-image-url',
+        },
+        balanceFormatted: '1000.000000 USDC',
+        rawTokenBalance: 1000,
+        rawFiatNumber: 1000,
+      }),
+    );
+
+    // When: component renders
+    render();
+
+    // Then: CardAssetItem should be rendered with formatted balance
+    expect(
+      screen.queryByTestId(CardHomeSelectors.CARD_ASSET_ITEM_SKELETON),
+    ).not.toBeOnTheScreen();
+  });
+
   it('displays manage card section', () => {
     // Given: default state
     // When: component renders

--- a/app/components/UI/Card/Views/CardHome/CardHome.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.tsx
@@ -784,7 +784,11 @@ const CardHome = () => {
               testID={CardHomeSelectors.CARD_ASSET_ITEM_SKELETON}
             />
           ) : (
-            <CardAssetItem asset={asset} privacyMode={privacyMode} />
+            <CardAssetItem
+              asset={asset}
+              privacyMode={privacyMode}
+              balanceFormatted={balanceFormatted}
+            />
           )}
         </View>
 

--- a/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.tsx
+++ b/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.tsx
@@ -136,7 +136,6 @@ const SpendingLimit = ({
         // If not loading or we're explicitly allowing navigation, allow it
         return;
       }
-      Logger.log('Blocking back navigation while loading');
 
       // Prevent default navigation behavior
       e.preventDefault();

--- a/app/components/UI/Card/components/AssetSelectionBottomSheet/AssetSelectionBottomSheet.tsx
+++ b/app/components/UI/Card/components/AssetSelectionBottomSheet/AssetSelectionBottomSheet.tsx
@@ -194,12 +194,23 @@ const AssetSelectionBottomSheet: React.FC = () => {
       userToken: CardTokenAllowance,
     ): CardTokenAllowance & { chainName: string } => {
       const chainName = mapCaipChainIdToChainName(userToken.caipChainId);
+      const supportedToken = sdk
+        ?.getSupportedTokensByChainId(userToken.caipChainId)
+        ?.find(
+          (token) =>
+            token.address?.toLowerCase() === userToken.address?.toLowerCase() &&
+            token.symbol?.toLowerCase() === userToken.symbol?.toLowerCase(),
+        );
 
       return {
         ...userToken,
         address: userToken.address ?? '',
-        symbol: userToken.symbol?.toUpperCase() ?? '',
-        name: userToken.name ?? userToken.symbol?.toUpperCase() ?? '',
+        symbol: supportedToken?.symbol ?? userToken.symbol?.toUpperCase() ?? '',
+        name:
+          supportedToken?.name ??
+          userToken.name ??
+          userToken.symbol?.toUpperCase() ??
+          '',
         decimals: userToken.decimals ?? 0,
         chainName,
         allowance: userToken.allowance || '0',
@@ -207,7 +218,7 @@ const AssetSelectionBottomSheet: React.FC = () => {
         stagingTokenAddress: userToken.stagingTokenAddress ?? undefined,
       } as CardTokenAllowance & { chainName: string };
     },
-    [],
+    [sdk],
   );
 
   // Helper: Check if token exists in user tokens
@@ -411,11 +422,20 @@ const AssetSelectionBottomSheet: React.FC = () => {
 
           const tokenAddress = getTokenAddress(tokenConfig, network);
           const isNonProduction = network.environment !== 'production';
+          const supportedToken = sdk
+            ?.getSupportedTokensByChainId(caipChainId)
+            ?.find(
+              (token) =>
+                token.address?.toLowerCase() ===
+                  tokenConfig.address?.toLowerCase() &&
+                token.symbol?.toLowerCase() ===
+                  tokenConfig.symbol?.toLowerCase(),
+            );
 
           supportedFromSettings.push({
             address: tokenAddress,
-            symbol: tokenConfig.symbol.toUpperCase(),
-            name: tokenConfig.symbol.toUpperCase(),
+            symbol: supportedToken?.symbol ?? tokenConfig.symbol,
+            name: supportedToken?.name ?? tokenConfig.symbol,
             decimals: tokenConfig.decimals,
             caipChainId,
             walletAddress: undefined,

--- a/app/components/UI/Card/components/CardAssetItem/CardAssetItem.test.tsx
+++ b/app/components/UI/Card/components/CardAssetItem/CardAssetItem.test.tsx
@@ -180,4 +180,26 @@ describe('CardAssetItem Component', () => {
 
     expect(getByText('ETH')).toBeOnTheScreen();
   });
+
+  it('uses balanceFormatted when provided', () => {
+    const balanceFormatted = '1.234567 ETH';
+
+    renderWithProvider(() => (
+      <CardAssetItem
+        asset={mockAsset}
+        privacyMode={false}
+        balanceFormatted={balanceFormatted}
+      />
+    ));
+
+    expect(mockAsset.balance).toBe('1000000000000000000');
+  });
+
+  it('falls back to asset balance when balanceFormatted is not provided', () => {
+    renderWithProvider(() => (
+      <CardAssetItem asset={mockAsset} privacyMode={false} />
+    ));
+
+    expect(mockAsset.balance).toBe('1000000000000000000');
+  });
 });

--- a/app/components/UI/Card/components/CardAssetItem/CardAssetItem.tsx
+++ b/app/components/UI/Card/components/CardAssetItem/CardAssetItem.tsx
@@ -21,12 +21,14 @@ interface CardAssetItemProps {
   asset: TokenI | undefined;
   privacyMode: boolean;
   onPress?: (asset: TokenI) => void;
+  balanceFormatted?: string;
 }
 
 const CardAssetItem: React.FC<CardAssetItemProps> = ({
   asset,
   onPress,
   privacyMode,
+  balanceFormatted,
 }) => {
   const { styles } = useStyles(styleSheet, {});
   const chainId = asset?.chainId as Hex;
@@ -46,7 +48,7 @@ const CardAssetItem: React.FC<CardAssetItemProps> = ({
       disabled
       asset={asset}
       balance={asset.balanceFiat}
-      secondaryBalance={`${asset.balance} ${asset.symbol}`}
+      secondaryBalance={balanceFormatted ?? `${asset.balance} ${asset.symbol}`}
       privacyMode={privacyMode}
     >
       <BadgeWrapper

--- a/app/components/UI/Card/components/Onboarding/SignUp.tsx
+++ b/app/components/UI/Card/components/Onboarding/SignUp.tsx
@@ -343,7 +343,7 @@ const SignUp = () => {
           testID="signup-i-already-have-an-account-text"
           variant={TextVariant.BodyMd}
           fontWeight={FontWeight.Medium}
-          twClassName="text-primary-default text-center p-4 underline"
+          twClassName="text-default text-center p-4"
         >
           {strings('card.card_onboarding.sign_up.i_already_have_an_account')}
         </Text>

--- a/app/components/UI/Card/hooks/useOpenSwaps.test.ts
+++ b/app/components/UI/Card/hooks/useOpenSwaps.test.ts
@@ -3,7 +3,10 @@ import { useSelector, useDispatch } from 'react-redux';
 import { useOpenSwaps } from './useOpenSwaps';
 import { buildTokenIconUrl } from '../util/buildTokenIconUrl';
 import { getHighestFiatToken } from '../util/getHighestFiatToken';
-import { setDestToken } from '../../../../core/redux/slices/bridge';
+import {
+  setDestToken,
+  selectSelectedSourceChainIds,
+} from '../../../../core/redux/slices/bridge';
 import { SwapBridgeNavigationLocation } from '../../Bridge/hooks/useSwapBridgeNavigation';
 import { CardTokenAllowance } from '../types';
 import { selectAllPopularNetworkConfigurations } from '../../../../selectors/networkController';
@@ -33,6 +36,7 @@ jest.mock('../util/getHighestFiatToken', () => ({
 
 jest.mock('../../../../core/redux/slices/bridge', () => ({
   setDestToken: jest.fn(),
+  selectSelectedSourceChainIds: jest.fn(),
 }));
 
 jest.mock('../../../../selectors/multichain', () => ({
@@ -60,6 +64,8 @@ describe('useOpenSwaps', () => {
   const mockGoToSwaps = jest.fn();
   const mockTrackEvent = jest.fn();
   const mockCreateEventBuilder = jest.fn();
+
+  const mockChainIds = ['0xe708'];
 
   const mockTokensWithBalance = [
     {
@@ -115,6 +121,9 @@ describe('useOpenSwaps', () => {
     (
       selectAllPopularNetworkConfigurations as unknown as jest.Mock
     ).mockReturnValue(mockPopularNetworks);
+    (selectSelectedSourceChainIds as unknown as jest.Mock).mockReturnValue(
+      mockChainIds,
+    );
     (useTokensWithBalance as jest.Mock).mockReturnValue(mockTokensWithBalance);
 
     (useSelector as jest.Mock).mockImplementation((selector) => selector());
@@ -310,5 +319,13 @@ describe('useOpenSwaps', () => {
     // The hook should use useTokensWithBalance hook
     expect(result.current).toBeDefined();
     expect(typeof result.current.openSwaps).toBe('function');
+  });
+
+  it('calls useTokensWithBalance with chain IDs from selector', () => {
+    renderHook(() => useOpenSwaps());
+
+    expect(useTokensWithBalance).toHaveBeenCalledWith({
+      chainIds: mockChainIds,
+    });
   });
 });

--- a/app/components/UI/Card/hooks/useOpenSwaps.ts
+++ b/app/components/UI/Card/hooks/useOpenSwaps.ts
@@ -11,9 +11,11 @@ import { BridgeToken } from '../../Bridge/types';
 import { CardTokenAllowance } from '../types';
 import { buildTokenIconUrl } from '../util/buildTokenIconUrl';
 import { getHighestFiatToken } from '../util/getHighestFiatToken';
-import { setDestToken } from '../../../../core/redux/slices/bridge';
+import {
+  selectSelectedSourceChainIds,
+  setDestToken,
+} from '../../../../core/redux/slices/bridge';
 import { MetaMetricsEvents, useMetrics } from '../../../hooks/useMetrics';
-import { selectAllPopularNetworkConfigurations } from '../../../../selectors/networkController';
 import { useTokensWithBalance } from '../../Bridge/hooks/useTokensWithBalance';
 
 export interface OpenSwapsParams {
@@ -32,10 +34,7 @@ export const useOpenSwaps = ({
   priorityToken,
 }: UseOpenSwapsOptions = {}) => {
   const dispatch = useDispatch();
-  const popularNetworks = useSelector(selectAllPopularNetworkConfigurations);
-  const chainIds = Object.entries(popularNetworks).map(
-    (network) => network[1].chainId,
-  );
+  const chainIds = useSelector(selectSelectedSourceChainIds);
   const tokensWithBalance = useTokensWithBalance({
     chainIds,
   });

--- a/app/components/UI/Card/sdk/CardSDK.ts
+++ b/app/components/UI/Card/sdk/CardSDK.ts
@@ -1008,7 +1008,7 @@ export class CardSDK {
 
     if (delegationSettingNetwork.environment === 'staging') {
       return {
-        symbol: delegationSettingToken.symbol.toUpperCase(),
+        symbol: tokenDetails.symbol,
         address: tokenDetails.address,
         decimals: delegationSettingToken.decimals,
         decimalChainId: delegationSettingNetwork.chainId,
@@ -1020,7 +1020,7 @@ export class CardSDK {
     }
 
     return {
-      symbol: delegationSettingToken.symbol.toUpperCase(),
+      symbol: tokenDetails.symbol,
       address: delegationSettingToken.address,
       decimals: delegationSettingToken.decimals,
       decimalChainId: delegationSettingNetwork.chainId,

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6475,7 +6475,7 @@
       "email_placeholder": "Enter your email address",
       "password_placeholder": "Enter your password",
       "login_button": "Log in",
-      "signup_button": "Create account",
+      "signup_button": "I don't have an account",
       "errors": {
         "invalid_credentials": "Invalid login details",
         "unknown_error": "Unknown error, please try again later",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -6475,7 +6475,7 @@
       "email_placeholder": "Enter your email address",
       "password_placeholder": "Enter your password",
       "login_button": "Log in",
-      "signup_button": "Sign up",
+      "signup_button": "Create account",
       "errors": {
         "invalid_credentials": "Invalid login details",
         "unknown_error": "Unknown error, please try again later",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR addresses several UI problems and inconsistencies. 
It updates the sign up button so it no longer uses a unique layout on the sign in page, resolves a crash related to useOpenSwaps, corrects an issue where the WETH balance caused the UI to break and also fixes cases where asset symbols were shown in lowercase.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fix UI inconsistency for the sign up button on the sign in page
CHANGELOG entry: Fix crash caused by useOpenSwaps
CHANGELOG entry: Fix UI break caused by WETH balance display
CHANGELOG entry: Fix asset symbols being shown in lowercase

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes auth/signup buttons and copy, fixes token symbol/name casing via SDK, passes formatted balances to asset item, updates swap chain source, and enhances asset selection behavior with navigation and metadata.
> 
> - **UI/Copy**:
>   - Replace `Secondary` signup button in `CardAuthentication` with text link; adjust styling; update copy to `"I don't have an account"`.
>   - Tweak Sign Up screen “I already have an account” link styling.
> - **Balances**:
>   - `CardHome` now passes `balanceFormatted` to `CardAssetItem`.
>   - `CardAssetItem` supports optional `balanceFormatted` for `secondaryBalance`.
> - **Asset Selection**:
>   - Normalize token `symbol`/`name` using SDK in `mapUserToken` and when merging tokens from delegation settings.
>   - Add navigation-based selection return, wallet address display, token merging (avoid duplicates), and priority token highlighting.
> - **Swaps Hook**:
>   - `useOpenSwaps` now sources chain IDs from `selectSelectedSourceChainIds` selector.
> - **SDK**:
>   - Use SDK-provided token `symbol`/`name` (no forced uppercasing) when mapping delegation settings tokens.
> - **Tests**:
>   - Extensive updates/additions for CardHome, CardAssetItem, AssetSelectionBottomSheet, and useOpenSwaps snapshots/behaviors.
> - **Misc**:
>   - Remove extraneous log in SpendingLimit back-navigation guard.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb485908c7340a616baefb8a7c31f8e0720e77d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->