### PR TITLE
fix: cp-7.60.0 block metamask pay if submitted transaction

### DIFF
--- a/app/components/Views/confirmations/hooks/alerts/useSignedOrSubmittedAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useSignedOrSubmittedAlert.test.ts
@@ -208,4 +208,46 @@ describe('useSignedOrSubmittedAlert', () => {
       ]);
     },
   );
+
+  it.each(PAY_TYPES)(
+    'returns alert if existing transaction is submitted and current type is %s',
+    (type) => {
+      mockUseTransactionMetadataRequest.mockReturnValue({
+        ...TRANSACTION_META_MOCK,
+        id: '2',
+        status: TransactionStatus.confirmed,
+        type,
+      } as TransactionMeta);
+
+      const existingTransaction = {
+        ...TRANSACTION_META_MOCK,
+        status: TransactionStatus.submitted,
+      };
+
+      const { result } = renderHookWithProvider(
+        () => useSignedOrSubmittedAlert(),
+        {
+          state: {
+            engine: {
+              backgroundState: {
+                TransactionController: {
+                  transactions: [existingTransaction],
+                },
+              },
+            },
+          },
+        },
+      );
+
+      expect(result.current).toStrictEqual([
+        {
+          isBlocking: true,
+          key: AlertKeys.SignedOrSubmitted,
+          message: strings('alert_system.signed_or_submitted.message'),
+          title: strings('alert_system.signed_or_submitted.title'),
+          severity: Severity.Danger,
+        },
+      ]);
+    },
+  );
 });

--- a/app/components/Views/confirmations/hooks/alerts/useSignedOrSubmittedAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useSignedOrSubmittedAlert.ts
@@ -25,13 +25,20 @@ export const useSignedOrSubmittedAlert = () => {
   const { chainId, id: transactionId, txParams } = transactionMetadata || {};
   const { from } = txParams ?? {};
 
-  const existingTransaction = transactions.find(
-    (transaction) =>
-      BLOCK_STATUS.includes(transaction.status) &&
+  const existingTransaction = transactions.find((transaction) => {
+    const blockStatuses = [...BLOCK_STATUS];
+
+    if (hasTransactionType(transactionMetadata, PAY_TYPES)) {
+      blockStatuses.push(TransactionStatus.submitted);
+    }
+
+    return (
+      blockStatuses.includes(transaction.status) &&
       transaction.id !== transactionId &&
       transaction.chainId === chainId &&
-      transaction.txParams.from.toLowerCase() === from?.toLowerCase(),
-  );
+      transaction.txParams.from.toLowerCase() === from?.toLowerCase()
+    );
+  });
 
   const isTransactionPay = PAY_TYPES.some(
     (payType) =>


### PR DESCRIPTION
## **Description**

Show an alert if doing a Perps or Predict deposit and there is an existing submitted transaction on the same chain and account.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #22762 

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Alerts now trigger for Perps/Predict deposits when an existing transaction is in submitted status on the same chain/account; tests updated/added.
> 
> - **Alerts**:
>   - Update `useSignedOrSubmittedAlert` to include `TransactionStatus.submitted` as a blocking status when the current transaction is a Pay type (`perpsDeposit`, `predictDeposit`).
> - **Tests**:
>   - Add cases verifying alerts show when an existing transaction is `submitted` and current type is any in `PAY_TYPES`.
>   - Ensure existing behavior for signed/approved, chain/account checks, and Pay-type messaging remains validated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 968d2857cea425c4064f47659c8a34741457c284. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->