### PR TITLE
ci: Enable flask tests on regular CI

### DIFF
--- a/.github/guidelines/LABELING_GUIDELINES.md
+++ b/.github/guidelines/LABELING_GUIDELINES.md
@@ -19,10 +19,6 @@ The check can be bypassed when necessary, either by setting the changelog entry 
 
 Any label can be manually added on demand depending on the PR's content. For instance, the label **QA passed** will indicate that a thorough manual testing has been performed and the PR is ready to be merged. In addition, following labels have some specific use cases.
 
-### Run Flask Android E2E tests
-
-- **run-android-flask-e2e-smoke**: The Android Flask E2E smoke tests jobs will run in the given PR. They also run on schedule on main branch.
-
 ### Bypass Quality Gates
 
 Using any of these labels should be exceptional in case of CI friction and urgencies. Please use them reasonably and verify new changes and regressions manually.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,7 +334,7 @@ jobs:
 
   e2e-smoke-tests-android-flask:
     name: 'Android Flask E2E Smoke Tests'
-    if: ${{  needs.needs_e2e_build.outputs.android_changed == 'true' }}
+    if: ${{ needs.needs_e2e_build.outputs.android_changed == 'true' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,7 +320,7 @@ jobs:
 
   build-android-flask-apks:
     name: 'Build Android Flask APKs'
-    if: ${{ github.event_name != 'merge_group' && needs.needs_e2e_build.outputs.android_changed == 'true' }}
+    if: ${{ needs.needs_e2e_build.outputs.android_changed == 'true' }}
     permissions:
       contents: read
       id-token: write
@@ -334,7 +334,7 @@ jobs:
 
   e2e-smoke-tests-android-flask:
     name: 'Android Flask E2E Smoke Tests'
-    if: ${{ github.event_name != 'merge_group' && needs.needs_e2e_build.outputs.android_changed == 'true' }}
+    if: ${{  needs.needs_e2e_build.outputs.android_changed == 'true' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,7 +320,7 @@ jobs:
 
   build-android-flask-apks:
     name: 'Build Android Flask APKs'
-    if: ${{ needs.needs_e2e_build.outputs.android_changed == 'true' }}
+    if: ${{ github.event_name != 'merge_group' && needs.needs_e2e_build.outputs.android_changed == 'true' }}
     permissions:
       contents: read
       id-token: write
@@ -334,7 +334,7 @@ jobs:
 
   e2e-smoke-tests-android-flask:
     name: 'Android Flask E2E Smoke Tests'
-    if: ${{ needs.needs_e2e_build.outputs.android_changed == 'true' }}
+    if: ${{ github.event_name != 'merge_group' && needs.needs_e2e_build.outputs.android_changed == 'true' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,8 @@ jobs:
           repository: ${{ github.repository }}
           post-comment: 'true'
 
+  # Main E2E tests
+  
   build-android-apks:
     name: 'Build Android APKs'
     if: ${{ github.event_name != 'merge_group' && needs.needs_e2e_build.outputs.android_changed == 'true' }}
@@ -310,6 +312,34 @@ jobs:
       id-token: write
     needs: [needs_e2e_build, ios-tests-ready]
     uses: ./.github/workflows/run-e2e-smoke-tests-ios.yml
+    with:
+      changed_files: ${{ needs.needs_e2e_build.outputs.changed_files }}
+    secrets: inherit
+
+  # Flask E2E tests
+
+  build-android-flask-apks:
+    name: 'Build Android Flask APKs'
+    if: ${{ github.event_name != 'merge_group' && needs.needs_e2e_build.outputs.android_changed == 'true' }}
+    permissions:
+      contents: read
+      id-token: write
+    needs: [needs_e2e_build]
+    uses: ./.github/workflows/build-android-e2e.yml
+    with:
+      build_type: 'flask'
+      metamask_environment: 'e2e'
+      keystore_target: 'flask'
+    secrets: inherit
+
+  e2e-smoke-tests-android-flask:
+    name: 'Android Flask E2E Smoke Tests'
+    if: ${{ github.event_name != 'merge_group' && needs.needs_e2e_build.outputs.android_changed == 'true' }}
+    permissions:
+      contents: read
+      id-token: write
+    needs: [needs_e2e_build, build-android-flask-apks]
+    uses: ./.github/workflows/run-e2e-smoke-tests-android-flask.yml
     with:
       changed_files: ${{ needs.needs_e2e_build.outputs.changed_files }}
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -550,6 +550,10 @@ jobs:
               echo "iOS E2E tests failed"
               exit 1
             fi
+            if [[ "${{ needs.e2e-smoke-tests-android-flask.result }}" == "failure" ]]; then
+              echo "Android Flask E2E tests failed"
+              exit 1
+            fi
           fi
 
           echo "All required jobs passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -531,6 +531,7 @@ jobs:
       - needs_e2e_build
       - e2e-smoke-tests-android
       - e2e-smoke-tests-ios
+      - e2e-smoke-tests-android-flask
     steps:
       - run: |
           # Check if all non-E2E jobs passed

--- a/.github/workflows/run-e2e-smoke-tests-android-flask.yml
+++ b/.github/workflows/run-e2e-smoke-tests-android-flask.yml
@@ -26,6 +26,7 @@ jobs:
       test_suite_tag: 'FlaskBuildTests'
       split_number: ${{ matrix.split }}
       total_splits: 3
+      changed_files: ${{ inputs.changed_files }}
       build_type: 'flask'
     secrets: inherit
 

--- a/.github/workflows/run-e2e-smoke-tests-android-flask.yml
+++ b/.github/workflows/run-e2e-smoke-tests-android-flask.yml
@@ -1,51 +1,24 @@
 name: Android Flask E2E Smoke Tests
 
 on:
-  pull_request:
-    types: [labeled, opened, synchronize]
-  schedule:
-    # Run the full suite every 3 hours
-    # This helps to identy the flaky and failed tests on main branch
-    - cron: '0 */3 * * *'
+  workflow_call:
+    inputs:
+      changed_files:
+        description: 'Changed files'
+        required: false
+        type: string
+        default: ''
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !(contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/heads/stable')) }}
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
-  needs_e2e_build:
-    name: 'Detect Mobile Build Changes'
-    # Execution rules:
-    # - schedule: always run
-    # - merge_group: never run
-    # - pull_request: run only if PR has 'run-android-flask-e2e-smoke' label
-    if: ${{ github.event_name != 'merge_group' && (github.event_name == 'schedule' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-android-flask-e2e-smoke') && github.event.pull_request.merged == false)) }}
-    uses: ./.github/workflows/needs-e2e-build.yml
-
-  build-android-flask-apps:
-    name: 'Build Android Flask Apps'
-    # Execution rules:
-    # - schedule: always run
-    # - merge_group: never run
-    # - pull_request: run only if PR has 'run-android-flask-e2e-smoke' label AND android_changed == 'true'
-    if: ${{ github.event_name != 'merge_group' && ( github.event_name == 'schedule' || ( github.event_name == 'pull_request' && needs.needs_e2e_build.outputs.android_changed == 'true' && contains(github.event.pull_request.labels.*.name, 'run-android-flask-e2e-smoke') ) ) }}
-    permissions:
-      contents: read
-      id-token: write
-    needs: [needs_e2e_build]
-    uses: ./.github/workflows/build-android-e2e.yml
-    with:
-      build_type: 'flask'
-      metamask_environment: 'e2e'
-      keystore_target: 'flask'
-    secrets: inherit
-
   flask-android-smoke:
     strategy:
       matrix:
         split: [1, 2, 3]
       fail-fast: false
-    needs: [build-android-flask-apps]
     uses: ./.github/workflows/run-e2e-workflow.yml
     with:
       test-suite-name: flask-android-smoke-${{ matrix.split }}
@@ -54,16 +27,14 @@ jobs:
       split_number: ${{ matrix.split }}
       total_splits: 3
       build_type: 'flask'
-      metamask_environment: 'e2e'
     secrets: inherit
 
   report-android-smoke-tests:
     name: Report Android Smoke Tests
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() && needs.flask-android-smoke.result != 'skipped'  }}
+    if: ${{ !cancelled() }}
     needs:
       - flask-android-smoke
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## **Description**

This PR makes the android flask E2E run alongside the other E2E tests we have in the regular CI job.

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Integrates Android Flask E2E build and smoke tests into the main CI and gates them in pass checks, refactoring the Flask E2E workflow into a reusable workflow_call and removing the obsolete label guidance.
> 
> - **CI**:
>   - Add `build-android-flask-apks` and `e2e-smoke-tests-android-flask` jobs to `ci.yml`, passing `changed_files`, and include the Flask E2E job in `check-all-jobs-pass` gating.
> - **Workflows**:
>   - Convert `run-e2e-smoke-tests-android-flask.yml` to a reusable `workflow_call` with `changed_files` input and explicit permissions; remove PR/schedule triggers, concurrency, and in-file build steps; forward `changed_files` to `run-e2e-workflow.yml`; simplify report job condition.
> - **Docs**:
>   - Remove the "Run Flask Android E2E tests" label section from `/.github/guidelines/LABELING_GUIDELINES.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9bcd5d72f31f5abcaf350544ed7311f47ea4a84c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->