### PR TITLE
test: Fix Snaps E2E after settings changes

### DIFF
--- a/e2e/pages/Settings/SnapSettingsView.ts
+++ b/e2e/pages/Settings/SnapSettingsView.ts
@@ -1,5 +1,6 @@
 import Matchers from '../../framework/Matchers';
 import Gestures from '../../framework/Gestures';
+import { CommonSelectorsIDs } from '../../selectors/Common.selectors';
 
 class SnapSettingsView {
   get enabledToggle(): DetoxElement {
@@ -12,6 +13,10 @@ class SnapSettingsView {
 
   get snapDetailsScrollViewMatcher(): Promise<DetoxMatcher> {
     return Matchers.getIdentifier('snap-settings-scrollview');
+  }
+
+  get backButton(): DetoxElement {
+    return Matchers.getElementByID(CommonSelectorsIDs.BACK_ARROW_BUTTON);
   }
 
   async toggleEnable(): Promise<void> {
@@ -34,6 +39,12 @@ class SnapSettingsView {
     );
     await Gestures.tap(this.removeButton, {
       elemDescription: `Snap Settings - Remove Snap`,
+    });
+  }
+
+  async tapBackButton(): Promise<void> {
+    await Gestures.tapAtIndex(this.backButton, 0, {
+      elemDescription: 'Snap Settings - Back Button',
     });
   }
 }

--- a/e2e/specs/snaps/test-snap-management.spec.ts
+++ b/e2e/specs/snaps/test-snap-management.spec.ts
@@ -41,6 +41,10 @@ describe(FlaskBuildTests('Snap Management Tests'), () => {
         await SnapSettingsView.selectSnap('Dialog Example Snap');
         await SnapSettingsView.toggleEnable();
 
+        await SnapSettingsView.tapBackButton();
+        await SnapSettingsView.tapBackButton();
+        await SettingsView.tapCloseButton();
+
         await TabBarComponent.tapBrowser();
 
         await TestSnaps.tapButton('sendAlertButton');
@@ -61,9 +65,14 @@ describe(FlaskBuildTests('Snap Management Tests'), () => {
       },
       async () => {
         await TabBarComponent.tapSettings();
+        await SettingsView.tapSnaps();
 
         await SnapSettingsView.selectSnap('Dialog Example Snap');
         await SnapSettingsView.toggleEnable();
+
+        await SnapSettingsView.tapBackButton();
+        await SnapSettingsView.tapBackButton();
+        await SettingsView.tapCloseButton();
 
         await TabBarComponent.tapBrowser();
 
@@ -86,6 +95,7 @@ describe(FlaskBuildTests('Snap Management Tests'), () => {
       },
       async () => {
         await TabBarComponent.tapSettings();
+        await SettingsView.tapSnaps();
 
         await SnapSettingsView.selectSnap('Dialog Example Snap');
         await SnapSettingsView.removeSnap();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

A recent change to the settings pages broke a Snaps E2E test on main. This PR fixes that by adding additional steps to exit the settings menu.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fix Snaps E2E by adding back-navigation support and updating tests to exit Settings before proceeding.
> 
> - **E2E Page Objects**:
>   - `e2e/pages/Settings/SnapSettingsView.ts`:
>     - Add `backButton` getter using `CommonSelectorsIDs.BACK_ARROW_BUTTON`.
>     - Add `tapBackButton()` to tap the back arrow.
> - **E2E Tests**:
>   - `e2e/specs/snaps/test-snap-management.spec.ts`:
>     - After toggling Snap enablement, navigate out of Settings via two `tapBackButton()` calls and `SettingsView.tapCloseButton()` before continuing.
>     - Ensure `SettingsView.tapSnaps()` is invoked where needed before selecting a Snap.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00b8efcc9b8079cf8b705a647cfbc61bb8f362b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->