### PR TITLE
fix(predict): cp-7.60.0 claimable positions logic

### DIFF
--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -101,7 +101,7 @@ export type PredictControllerState = {
   // Account balances
   balances: { [providerId: string]: { [address: string]: PredictBalance } };
 
-  // Claim management
+  // Claim management (this should always be ALL claimable positions)
   claimablePositions: { [address: string]: PredictPosition[] };
 
   // Deposit management

--- a/app/components/UI/Predict/hooks/usePredictPositions.ts
+++ b/app/components/UI/Predict/hooks/usePredictPositions.ts
@@ -1,5 +1,5 @@
 import { useFocusEffect } from '@react-navigation/native';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
 import Logger from '../../../../util/Logger';
 import type { PredictPosition } from '../types';
@@ -32,7 +32,8 @@ interface UsePredictPositionsOptions {
   marketId?: string;
 
   /**
-   * The parameters to load positions for
+   * Only load claimable positions. When this is set to true, marketId is ignored when fetching positions.
+   * However, the positions returned will be filtered to only include the specific market positions.
    */
   claimable?: boolean;
   /**
@@ -70,7 +71,9 @@ export function usePredictPositions(
   const { getPositions } = usePredictTrading();
   const { ensurePolygonNetworkExists } = usePredictNetworkManagement();
 
+  // `positions` state only stores active positions
   const [positions, setPositions] = useState<PredictPosition[]>([]);
+
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -83,6 +86,13 @@ export function usePredictPositions(
       address: selectedInternalAccountAddress,
     }),
   );
+
+  const filteredClaimablePositions = useMemo(() => {
+    if (!marketId) return claimablePositions;
+    return claimablePositions.filter(
+      (position) => position.marketId === marketId,
+    );
+  }, [claimablePositions, marketId]);
 
   const loadPositions = useCallback(
     async (loadOptions?: { isRefresh?: boolean }) => {
@@ -114,11 +124,15 @@ export function usePredictPositions(
           address: selectedInternalAccountAddress,
           providerId,
           claimable,
-          marketId,
+          // Always load ALL positions when claimable is true
+          marketId: claimable ? undefined : marketId,
         });
         const validPositions = positionsData ?? [];
 
-        setPositions(validPositions);
+        if (!claimable) {
+          // `positions` state only stores active positions
+          setPositions(validPositions);
+        }
 
         DevLogger.log('usePredictPositions: Loaded positions', {
           originalCount: validPositions.length,
@@ -211,7 +225,7 @@ export function usePredictPositions(
     // Get claimable positions from controller state if claimable is true.
     // This will ensure that we can refresh claimable positions when the user
     // performs a claim operation.
-    positions: claimable ? [...claimablePositions] : positions,
+    positions: claimable ? filteredClaimablePositions : positions,
     isLoading,
     isRefreshing,
     error,

--- a/app/components/UI/Predict/hooks/usePredictPositions.ts
+++ b/app/components/UI/Predict/hooks/usePredictPositions.ts
@@ -88,7 +88,7 @@ export function usePredictPositions(
   );
 
   const filteredClaimablePositions = useMemo(() => {
-    if (!marketId) return claimablePositions;
+    if (!marketId) return [...claimablePositions];
     return claimablePositions.filter(
       (position) => position.marketId === marketId,
     );


### PR DESCRIPTION
## **Description**

This PR fixes the claimable positions logic in the Predict feature to ensure we always fetch **ALL** claimable positions and filter them afterward, rather than fetching only positions for a specific market.

### Why this change?

1. The claim operation works at the account level - users can only claim **all** positions at once, never individual market positions
2. We need to keep all claimable positions in the `PredictController` state to support the global claim functionality
3. Previously, when viewing a specific market's details, we would fetch only that market's claimable positions, which caused the controller state to be incomplete

### What was fixed?
1. **Always fetch ALL claimable positions**: Modified `usePredictPositions` to ignore the `marketId` parameter when `claimable=true`, ensuring we always fetch all claimable positions for the account
2. **Filter at display time**: Introduced `filteredClaimablePositions` using `useMemo` to filter positions by `marketId` when displaying them in market-specific screens
3. **State management**: Clarified that `claimablePositions` in the controller should always contain ALL claimable positions, and `positions` state only stores active positions
4. **Fixed display bug**: Market details screens now correctly show only the claimable positions for that specific market, rather than incorrectly showing positions from other markets

## **Changelog**

CHANGELOG entry: Fixed claimable positions logic to always fetch all positions and filter correctly by market

## **Related issues**

Fixes: [PRED-318](https://consensyssoftware.atlassian.net/browse/PRED-318)

## **Manual testing steps**

```gherkin
Feature: Claimable positions management

  Scenario: user views claimable positions in market details
    Given user has claimable positions in multiple markets
    And user is viewing a specific market's details screen

    When the market details screen loads
    Then only claimable positions for that specific market should be displayed
    And all claimable positions should be stored in the PredictController state

  Scenario: user claims all positions
    Given user has multiple claimable positions across different markets
    And user is on any market details screen

    When user initiates a claim operation
    Then all claimable positions from all markets should be claimed
    And the controller state should correctly reflect all claimable positions

  Scenario: user switches between markets with claimable positions
    Given user has claimable positions in Market A and Market B
    And user is viewing Market A details

    When user navigates to Market B details
    Then only Market B's claimable positions should be displayed
    And the controller state should still contain all claimable positions from both markets
```

## **Screenshots/Recordings**

### **Before**

<!-- Market details screen incorrectly showing claimable positions from other markets -->

### **After**

<!-- Market details screen correctly showing only positions for the current market -->

https://github.com/user-attachments/assets/52255fb4-dcd0-48a9-ac1d-29eca1c09d0e




## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure claimable positions always load globally and are filtered per-market in the hook, with local state storing only active positions.
> 
> - **PredictController**:
>   - Clarifies `claimablePositions` should always contain ALL claimable positions.
> - **Hook `usePredictPositions`**:
>   - Always fetches all positions when `claimable=true` (ignores `marketId`) and filters by `marketId` via `useMemo`.
>   - Returns filtered claimable positions; only stores active (non-claimable) positions in local `positions` state.
>   - Updates option docs; adds `useMemo` import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c00940ccbd4cf39a0d84641efb3bc630cd6927e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



[PRED-318]: https://consensyssoftware.atlassian.net/browse/PRED-318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ