### PR TITLE
fix: cp-7.60.0 filter out tron staked tokens from send flow

### DIFF
--- a/app/components/Views/confirmations/hooks/send/useAccountTokens.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useAccountTokens.test.ts
@@ -6,7 +6,7 @@ import { useSendScope } from './useSendScope';
 import { getNetworkBadgeSource } from '../../utils/network';
 import { getIntlNumberFormatter } from '../../../../../util/intl';
 import { TokenStandard } from '../../types/token';
-import { selectAssetsBySelectedAccountGroup } from '../../../../../selectors/assets/assets-list';
+import { selectFilteredAssetsBySelectedAccountGroup } from '../../../../../selectors/assets/assets-list';
 import { selectCurrentCurrency } from '../../../../../selectors/currencyRateController';
 import { isTestNet } from '../../../../../util/networks';
 
@@ -36,7 +36,7 @@ jest.mock('../../../../../../locales/i18n', () => ({
 }));
 
 jest.mock('../../../../../selectors/assets/assets-list', () => ({
-  selectAssetsBySelectedAccountGroup: jest.fn(),
+  selectFilteredAssetsBySelectedAccountGroup: jest.fn(),
 }));
 
 jest.mock('../../../../../selectors/currencyRateController', () => ({
@@ -48,7 +48,7 @@ const mockUseSendScope = jest.mocked(useSendScope);
 const mockGetNetworkBadgeSource = jest.mocked(getNetworkBadgeSource);
 const mockGetIntlNumberFormatter = jest.mocked(getIntlNumberFormatter);
 const mockSelectAssetsBySelectedAccountGroup = jest.mocked(
-  selectAssetsBySelectedAccountGroup,
+  selectFilteredAssetsBySelectedAccountGroup,
 );
 const mockSelectCurrentCurrency = jest.mocked(selectCurrentCurrency);
 const mockIsTestNet = jest.mocked(isTestNet);
@@ -94,7 +94,7 @@ describe('useAccountTokens', () => {
     mockSelectCurrentCurrency.mockReturnValue('USD');
 
     mockUseSelector.mockImplementation((selector) => {
-      if (selector === selectAssetsBySelectedAccountGroup) {
+      if (selector === selectFilteredAssetsBySelectedAccountGroup) {
         return mockAssets;
       }
       if (selector === selectCurrentCurrency) {
@@ -209,7 +209,7 @@ describe('useAccountTokens', () => {
         integerAssets as any,
       );
       mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectAssetsBySelectedAccountGroup) {
+        if (selector === selectFilteredAssetsBySelectedAccountGroup) {
           return integerAssets;
         }
         if (selector === selectCurrentCurrency) {
@@ -245,7 +245,7 @@ describe('useAccountTokens', () => {
         decimalAssets as any,
       );
       mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectAssetsBySelectedAccountGroup) {
+        if (selector === selectFilteredAssetsBySelectedAccountGroup) {
           return decimalAssets;
         }
         if (selector === selectCurrentCurrency) {
@@ -297,7 +297,7 @@ describe('useAccountTokens', () => {
         sortTestAssets as any,
       );
       mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectAssetsBySelectedAccountGroup) {
+        if (selector === selectFilteredAssetsBySelectedAccountGroup) {
           return sortTestAssets;
         }
         if (selector === selectCurrentCurrency) {
@@ -318,7 +318,7 @@ describe('useAccountTokens', () => {
     it('handles empty assets object', () => {
       mockSelectAssetsBySelectedAccountGroup.mockReturnValue({});
       mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectAssetsBySelectedAccountGroup) {
+        if (selector === selectFilteredAssetsBySelectedAccountGroup) {
           return {};
         }
         if (selector === selectCurrentCurrency) {
@@ -349,7 +349,7 @@ describe('useAccountTokens', () => {
         assetsWithoutFiat as any,
       );
       mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectAssetsBySelectedAccountGroup) {
+        if (selector === selectFilteredAssetsBySelectedAccountGroup) {
           return assetsWithoutFiat;
         }
         if (selector === selectCurrentCurrency) {
@@ -380,7 +380,7 @@ describe('useAccountTokens', () => {
         assetsWithoutFiat as any,
       );
       mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectAssetsBySelectedAccountGroup) {
+        if (selector === selectFilteredAssetsBySelectedAccountGroup) {
           return assetsWithoutFiat;
         }
         if (selector === selectCurrentCurrency) {
@@ -413,7 +413,7 @@ describe('useAccountTokens', () => {
         assetsWithNullFiat as any,
       );
       mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectAssetsBySelectedAccountGroup) {
+        if (selector === selectFilteredAssetsBySelectedAccountGroup) {
           return assetsWithNullFiat;
         }
         if (selector === selectCurrentCurrency) {
@@ -445,7 +445,7 @@ describe('useAccountTokens', () => {
         assetsWithNullFiat as any,
       );
       mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectAssetsBySelectedAccountGroup) {
+        if (selector === selectFilteredAssetsBySelectedAccountGroup) {
           return assetsWithNullFiat;
         }
         if (selector === selectCurrentCurrency) {
@@ -478,7 +478,7 @@ describe('useAccountTokens', () => {
         testNetAssets as any,
       );
       mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectAssetsBySelectedAccountGroup) {
+        if (selector === selectFilteredAssetsBySelectedAccountGroup) {
           return testNetAssets;
         }
         if (selector === selectCurrentCurrency) {
@@ -512,7 +512,7 @@ describe('useAccountTokens', () => {
         testNetAssets as any,
       );
       mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectAssetsBySelectedAccountGroup) {
+        if (selector === selectFilteredAssetsBySelectedAccountGroup) {
           return testNetAssets;
         }
         if (selector === selectCurrentCurrency) {
@@ -553,7 +553,7 @@ describe('useAccountTokens', () => {
       );
 
       mockUseSelector.mockImplementation((selector) => {
-        if (selector === selectAssetsBySelectedAccountGroup) {
+        if (selector === selectFilteredAssetsBySelectedAccountGroup) {
           return assets;
         }
         if (selector === selectCurrentCurrency) {

--- a/app/components/Views/confirmations/hooks/send/useAccountTokens.ts
+++ b/app/components/Views/confirmations/hooks/send/useAccountTokens.ts
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { BigNumber } from 'bignumber.js';
 import { Hex } from '@metamask/utils';
 
-import { selectAssetsBySelectedAccountGroup } from '../../../../../selectors/assets/assets-list';
+import { selectFilteredAssetsBySelectedAccountGroup } from '../../../../../selectors/assets/assets-list';
 import { isTestNet } from '../../../../../util/networks';
 import Logger from '../../../../../util/Logger';
 import { selectCurrentCurrency } from '../../../../../selectors/currencyRateController';
@@ -16,7 +16,7 @@ import { useSendScope } from './useSendScope';
 export function useAccountTokens({
   includeNoBalance = false,
 } = {}): AssetType[] {
-  const assets = useSelector(selectAssetsBySelectedAccountGroup);
+  const assets = useSelector(selectFilteredAssetsBySelectedAccountGroup);
   const { isEvmOnly, isSolanaOnly } = useSendScope();
   const fiatCurrency = useSelector(selectCurrentCurrency);
 

--- a/app/selectors/assets/assets-list.test.ts
+++ b/app/selectors/assets/assets-list.test.ts
@@ -5,10 +5,13 @@ import {
   TrxScope,
 } from '@metamask/keyring-api';
 import { KnownCaipNamespace } from '@metamask/utils';
+// eslint-disable-next-line import/no-namespace
+import * as AssetsControllersModule from '@metamask/assets-controllers';
 import type { RootState } from '../../reducers';
 import {
   selectAsset,
   selectAssetsBySelectedAccountGroup,
+  selectFilteredAssetsBySelectedAccountGroup,
   selectSortedAssetsBySelectedAccountGroup,
   selectTronResourcesBySelectedAccountGroup,
 } from './assets-list';
@@ -351,8 +354,7 @@ const mockState = ({
 describe('selectAssetsBySelectedAccountGroup', () => {
   it('builds the initial state object', () => {
     const result = selectAssetsBySelectedAccountGroup(mockState());
-
-    expect(result).toEqual({
+    expect(result).toStrictEqual({
       '0x1': [
         {
           accountType: 'eip155:eoa',
@@ -497,6 +499,349 @@ describe('selectAssetsBySelectedAccountGroup', () => {
         },
       ],
     });
+  });
+});
+
+describe('selectFilteredAssetsBySelectedAccountGroup', () => {
+  it('filters out tron staked bandwidth and energy', () => {
+    const selectorMock = jest
+      .spyOn(AssetsControllersModule, 'selectAssetsBySelectedAccountGroup')
+      .mockReturnValue({
+        'tron:728126428': [
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:728126428/slip44:195',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Tron',
+            symbol: 'TRX',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 6,
+            rawBalance: '0x0',
+            balance: '0',
+            fiat: {
+              balance: 0,
+              currency: 'usd',
+              conversionRate: 0.28516,
+            },
+            chainId: 'tron:728126428',
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:728126428/slip44:195-staked-for-bandwidth',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Staked for Bandwidth',
+            symbol: 'sTRX-BANDWIDTH',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 6,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:728126428',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:728126428/slip44:195-staked-for-energy',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Staked for Energy',
+            symbol: 'sTRX-ENERGY',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 6,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:728126428',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:728126428/slip44:bandwidth',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Bandwidth',
+            symbol: 'BANDWIDTH',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 0,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:728126428',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:728126428/slip44:maximum-bandwidth',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Max Bandwidth',
+            symbol: 'MAX-BANDWIDTH',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 0,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:728126428',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:728126428/slip44:energy',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Energy',
+            symbol: 'ENERGY',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 0,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:728126428',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:728126428/slip44:maximum-energy',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Max Energy',
+            symbol: 'MAX-ENERGY',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 0,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:728126428',
+            fiat: undefined,
+          },
+        ],
+        'tron:3448148188': [
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:3448148188/slip44:195',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Tron',
+            symbol: 'TRX',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 6,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:3448148188',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:3448148188/slip44:195-staked-for-bandwidth',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Staked for Bandwidth',
+            symbol: 'sTRX-BANDWIDTH',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 6,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:3448148188',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:3448148188/slip44:195-staked-for-energy',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Staked for Energy',
+            symbol: 'sTRX-ENERGY',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 6,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:3448148188',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:3448148188/slip44:bandwidth',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Bandwidth',
+            symbol: 'BANDWIDTH',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 0,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:3448148188',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:3448148188/slip44:maximum-bandwidth',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Max Bandwidth',
+            symbol: 'MAX-BANDWIDTH',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 0,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:3448148188',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:3448148188/slip44:energy',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Energy',
+            symbol: 'ENERGY',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 0,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:3448148188',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:3448148188/slip44:maximum-energy',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Max Energy',
+            symbol: 'MAX-ENERGY',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 0,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:3448148188',
+            fiat: undefined,
+          },
+        ],
+        'tron:2494104990': [
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:2494104990/slip44:195',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Tron',
+            symbol: 'TRX',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 6,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:2494104990',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:2494104990/slip44:195-staked-for-bandwidth',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Staked for Bandwidth',
+            symbol: 'sTRX-BANDWIDTH',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 6,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:2494104990',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:2494104990/slip44:195-staked-for-energy',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Staked for Energy',
+            symbol: 'sTRX-ENERGY',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 6,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:2494104990',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:2494104990/slip44:bandwidth',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Bandwidth',
+            symbol: 'BANDWIDTH',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 0,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:2494104990',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:2494104990/slip44:maximum-bandwidth',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Max Bandwidth',
+            symbol: 'MAX-BANDWIDTH',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 0,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:2494104990',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:2494104990/slip44:energy',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Energy',
+            symbol: 'ENERGY',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 0,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:2494104990',
+            fiat: undefined,
+          },
+          {
+            accountType: 'tron:eoa',
+            assetId: 'tron:2494104990/slip44:maximum-energy',
+            isNative: true,
+            image:
+              'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+            name: 'Max Energy',
+            symbol: 'MAX-ENERGY',
+            accountId: 'de5c3465-d01e-4091-a219-232903e982bb',
+            decimals: 0,
+            rawBalance: '0x0',
+            balance: '0',
+            chainId: 'tron:2494104990',
+            fiat: undefined,
+          },
+        ],
+      });
+
+    const state = mockState();
+    state.engine.backgroundState.CurrencyRateController.currentCurrency = 'usd'; // force cache invalidation
+    const result = selectFilteredAssetsBySelectedAccountGroup(state);
+
+    expect(selectorMock).toHaveBeenCalled();
+    expect(result[TrxScope.Mainnet]).toHaveLength(1);
+    expect(result[TrxScope.Nile]).toHaveLength(1);
+    expect(result[TrxScope.Shasta]).toHaveLength(1);
   });
 });
 

--- a/app/selectors/assets/assets-list.ts
+++ b/app/selectors/assets/assets-list.ts
@@ -27,6 +27,7 @@ import {
   TronResourceSymbol,
 } from '../../core/Multichain/constants';
 import { sortAssetsWithPriority } from '../../components/UI/Tokens/util/sortAssetsWithPriority';
+import { TrxScope } from '@metamask/keyring-api';
 
 export const selectAssetsBySelectedAccountGroup = createDeepEqualSelector(
   (state: RootState) => {
@@ -85,6 +86,35 @@ export const selectAssetsBySelectedAccountGroup = createDeepEqualSelector(
     };
   },
   (filteredState) => _selectAssetsBySelectedAccountGroup(filteredState),
+);
+
+export const selectFilteredAssetsBySelectedAccountGroup = createSelector(
+  selectAssetsBySelectedAccountGroup,
+  (assetsByAccountGroup) => {
+    const newAssetsByAccountGroup = { ...assetsByAccountGroup };
+
+    Object.values(TrxScope).forEach((tronChainId) => {
+      if (!newAssetsByAccountGroup[tronChainId]) {
+        return;
+      }
+
+      newAssetsByAccountGroup[tronChainId] = newAssetsByAccountGroup[
+        tronChainId
+      ].filter((asset: Asset) => {
+        if (
+          asset.chainId.startsWith('tron:') &&
+          TRON_RESOURCE_SYMBOLS_SET.has(
+            asset.symbol?.toLowerCase() as TronResourceSymbol,
+          )
+        ) {
+          return false;
+        }
+        return true;
+      });
+    });
+
+    return newAssetsByAccountGroup;
+  },
 );
 
 // BIP44 MAINTENANCE: Add these items at controller level, but have them being optional on selectAssetsBySelectedAccountGroup to avoid breaking changes
@@ -192,7 +222,7 @@ const selectEnabledNetworks = createDeepEqualSelector(
 
 export const selectSortedAssetsBySelectedAccountGroup = createDeepEqualSelector(
   [
-    selectAssetsBySelectedAccountGroup,
+    selectFilteredAssetsBySelectedAccountGroup,
     selectEnabledNetworks,
     selectTokenSortConfig,
     selectStakedAssets,


### PR DESCRIPTION
## **Description**

TRON staked tokens were visible in the send flow. This PR modifies some selectors so that we filter out TRON staked tokens.

## **Changelog**

CHANGELOG entry: fix: filter out TRON staked tokens

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-1814

## **Manual testing steps**

1. Go to send flow
2. Filter TRON
3. EXPECTED: TRON staked tokens are not visible

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="316" height="720" alt="image" src="https://github.com/user-attachments/assets/d8a4656b-cf62-49e8-b6c9-1cadfb3eab4d" />

### **After**

https://www.loom.com/share/e5ca32a5434e46ab907d8832ab3af239

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Exclude Tron staked bandwidth/energy assets from token lists by introducing a filtered assets selector, wiring it into the send tokens hook and sorting selector, with accompanying tests.
> 
> - **Selectors**:
>   - Add `selectFilteredAssetsBySelectedAccountGroup` to remove Tron resource symbols (`ENERGY`, `BANDWIDTH`, and staked variants) across `TrxScope` networks.
>   - Update `selectSortedAssetsBySelectedAccountGroup` to consume the filtered selector.
> - **Hooks**:
>   - `useAccountTokens` now uses `selectFilteredAssetsBySelectedAccountGroup` to exclude Tron staked/resource tokens in the send flow.
> - **Tests**:
>   - Add coverage for `selectFilteredAssetsBySelectedAccountGroup` Tron filtering.
>   - Update `useAccountTokens` tests to use the new selector.
>   - Minor assertion tweak to `toStrictEqual` for assets shape.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f9af0efcf383d1d0f2fb2deb6ec154e1ebaa815. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->