### PR TITLE
Analyze and resolve metamask issue

### DIFF
--- a/app/components/Views/confirmations/components/rows/transactions/advanced-details-row/advanced-details-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/advanced-details-row/advanced-details-row.test.tsx
@@ -155,6 +155,51 @@ describe('AdvancedDetailsRow', () => {
       expect(mockSetShowNonceModal).toHaveBeenCalledTimes(1);
       expect(mockSetShowNonceModal).toHaveBeenCalledWith(true);
     });
+
+    it('nonce is not editable if showCustomNonce setting is false', () => {
+      const stateWithCustomNonceDisabled = merge(
+        {},
+        generateContractInteractionState,
+        {
+          settings: {
+            showCustomNonce: false,
+          },
+        },
+      );
+
+      const { getByText } = renderWithProvider(
+        <AdvancedDetailsRow />,
+        { state: stateWithCustomNonceDisabled },
+        false,
+      );
+
+      fireEvent.press(getByText('Advanced details'));
+      fireEvent.press(getByText('42'));
+      expect(mockSetShowNonceModal).toHaveBeenCalledTimes(0);
+    });
+
+    it('nonce is editable if showCustomNonce setting is true', () => {
+      const stateWithCustomNonceEnabled = merge(
+        {},
+        generateContractInteractionState,
+        {
+          settings: {
+            showCustomNonce: true,
+          },
+        },
+      );
+
+      const { getByText } = renderWithProvider(
+        <AdvancedDetailsRow />,
+        { state: stateWithCustomNonceEnabled },
+        false,
+      );
+
+      fireEvent.press(getByText('Advanced details'));
+      fireEvent.press(getByText('42'));
+      expect(mockSetShowNonceModal).toHaveBeenCalledTimes(1);
+      expect(mockSetShowNonceModal).toHaveBeenCalledWith(true);
+    });
   });
 
   it('display correct information for downgrade confirmation', () => {

--- a/app/components/Views/confirmations/components/rows/transactions/advanced-details-row/advanced-details-row.tsx
+++ b/app/components/Views/confirmations/components/rows/transactions/advanced-details-row/advanced-details-row.tsx
@@ -19,6 +19,7 @@ import { NameType } from '../../../../../../UI/Name/Name.types';
 import { selectSmartTransactionsEnabled } from '../../../../../../../selectors/smartTransactionsController';
 import { RootState } from '../../../../../../../reducers';
 import { selectSmartTransactionsOptInStatus } from '../../../../../../../selectors/preferencesController';
+import { selectShowCustomNonce } from '../../../../../../../selectors/settings';
 import { useTransactionMetadataRequest } from '../../../../hooks/transactions/useTransactionMetadataRequest';
 import CustomNonceModal from '../../../../legacy/SendFlow/components/CustomNonceModal';
 import { use7702TransactionType } from '../../../../hooks/7702/use7702TransactionType';
@@ -48,7 +49,8 @@ const AdvancedDetailsRow = () => {
   const isSTXOptIn = useSelector((state: RootState) =>
     selectSmartTransactionsOptInStatus(state),
   );
-  const isNonceChangeDisabled = isSTXEnabledForChain && isSTXOptIn;
+  const showCustomNonce = useSelector(selectShowCustomNonce);
+  const isNonceChangeDisabled = !showCustomNonce || (isSTXEnabledForChain && isSTXOptIn);
 
   const { styles } = useStyles(styleSheet, {
     isNonceChangeDisabled,


### PR DESCRIPTION
Disable nonce editing in the Advanced Details section when the "Custom Nonce" setting is disabled or Smart Transactions are active.

Previously, the new confirmation flow's `advanced-details-row.tsx` component only considered Smart Transactions status to disable nonce editing, ignoring the user's `showCustomNonce` preference. This led to an inconsistency where the nonce was editable despite the setting being off, unlike the legacy flow.

---
<a href="https://cursor.com/background-agent?bcId=bc-07a3e91a-c550-4792-89d2-2fd00c2c85dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-07a3e91a-c550-4792-89d2-2fd00c2c85dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

