### PR TITLE
chore: rewards add account require explicit internal account

### DIFF
--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.test.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.test.tsx
@@ -75,16 +75,20 @@ jest.mock('../../hooks/useBridgeQuoteData', () => ({
       priceImpact: '-0.06%',
       slippage: '0.5%',
     },
+    shouldShowPriceImpactWarning: false,
   })),
 }));
 
-// Mock Engine for rewards functionality
-jest.mock('../../../../../core/Engine', () => ({
-  controllerMessenger: {
-    call: jest.fn(),
-    subscribe: jest.fn(),
-    unsubscribe: jest.fn(),
-  },
+// Mock useRewards hook
+jest.mock('../../hooks/useRewards', () => ({
+  useRewards: jest.fn().mockImplementation(() => ({
+    estimatedPoints: null,
+    isLoading: false,
+    shouldShowRewardsRow: false,
+    hasError: false,
+    accountOptedIn: null,
+    rewardsAccountScope: null,
+  })),
 }));
 
 // Mock formatChainIdToCaip for AddRewardsAccount component
@@ -108,6 +112,24 @@ jest.mock('../../../../UI/Rewards/hooks/useLinkAccountAddress', () => ({
     isError: false,
   })),
 }));
+
+// Mock AddRewardsAccount component
+jest.mock(
+  '../../../../UI/Rewards/components/AddRewardsAccount/AddRewardsAccount',
+  () => {
+    const React = jest.requireActual('react');
+    const { View, Text } = jest.requireActual('react-native');
+    return {
+      __esModule: true,
+      default: ({ testID }: { testID?: string }) =>
+        React.createElement(
+          View,
+          { testID },
+          React.createElement(Text, null, 'Add Rewards Account'),
+        ),
+    };
+  },
+);
 
 // Mock the bridge selectors
 jest.mock('../../../../../core/redux/slices/bridge', () => ({
@@ -505,41 +527,34 @@ describe('QuoteDetailsCard', () => {
   });
 
   describe('rewards functionality', () => {
-    const mockEngine = jest.requireMock('../../../../../core/Engine');
+    const { useRewards } = jest.requireMock('../../hooks/useRewards');
 
     beforeEach(() => {
-      // Reset Engine mocks
       jest.clearAllMocks();
       // Default to rewards disabled
-      mockEngine.controllerMessenger.call.mockImplementation(() =>
-        Promise.resolve(false),
-      );
+      (useRewards as jest.Mock).mockReturnValue({
+        estimatedPoints: null,
+        isLoading: false,
+        shouldShowRewardsRow: false,
+        hasError: false,
+        accountOptedIn: null,
+        rewardsAccountScope: null,
+      });
     });
 
     it('displays rewards row when rewards are enabled and user has opted in', async () => {
       // Given rewards feature is enabled and user has opted in
-      mockEngine.controllerMessenger.call.mockImplementation(
-        (method: string) => {
-          // Note: In the actual implementation, these are commented out as TODO
-          // But we'll mock them as if they were working
-          if (method === 'RewardsController:isRewardsFeatureEnabled') {
-            return Promise.resolve(true);
-          }
-          if (method === 'RewardsController:getFirstSubscriptionId') {
-            return Promise.resolve('subscription-id-1');
-          }
-          if (method === 'RewardsController:getHasAccountOptedIn') {
-            return Promise.resolve(true);
-          }
-          if (method === 'RewardsController:estimatePoints') {
-            return Promise.resolve({ pointsEstimate: 100 });
-          }
-          return Promise.resolve(null);
-        },
-      );
+      (useRewards as jest.Mock).mockReturnValue({
+        estimatedPoints: 100,
+        isLoading: false,
+        shouldShowRewardsRow: true,
+        hasError: false,
+        accountOptedIn: true,
+        rewardsAccountScope: null,
+      });
 
       // When rendering the component
-      const { getByText } = renderScreen(
+      const { getByText, getByTestId } = renderScreen(
         QuoteDetailsCard,
         { name: Routes.BRIDGE.ROOT },
         { state: testState },
@@ -548,29 +563,20 @@ describe('QuoteDetailsCard', () => {
       // Then the rewards row should be displayed
       await waitFor(() => {
         expect(getByText(strings('bridge.points'))).toBeOnTheScreen();
+        expect(getByTestId('mock-rive-animation')).toBeOnTheScreen();
       });
     });
 
     it('displays rewards row without points when estimation fails', async () => {
       // Given rewards estimation fails but feature is enabled and user has opted in
-      mockEngine.controllerMessenger.call.mockImplementation(
-        (method: string) => {
-          if (method === 'RewardsController:isRewardsFeatureEnabled') {
-            return Promise.resolve(true);
-          }
-          if (method === 'RewardsController:getFirstSubscriptionId') {
-            return Promise.resolve('subscription-id-1');
-          }
-          if (method === 'RewardsController:getHasAccountOptedIn') {
-            return Promise.resolve(true);
-          }
-          if (method === 'RewardsController:estimatePoints') {
-            // Throw error to simulate failure
-            throw new Error('Estimation failed');
-          }
-          return Promise.resolve(null);
-        },
-      );
+      (useRewards as jest.Mock).mockReturnValue({
+        estimatedPoints: null,
+        isLoading: false,
+        shouldShowRewardsRow: true,
+        hasError: true,
+        accountOptedIn: true,
+        rewardsAccountScope: null,
+      });
 
       // When rendering the component
       const { getByText, getByTestId } = renderScreen(
@@ -591,14 +597,14 @@ describe('QuoteDetailsCard', () => {
 
     it('does not display rewards row when rewards feature is disabled', async () => {
       // Given rewards feature is disabled
-      mockEngine.controllerMessenger.call.mockImplementation(
-        (method: string) => {
-          if (method === 'RewardsController:isRewardsFeatureEnabled') {
-            return Promise.resolve(false);
-          }
-          return Promise.resolve(null);
-        },
-      );
+      (useRewards as jest.Mock).mockReturnValue({
+        estimatedPoints: null,
+        isLoading: false,
+        shouldShowRewardsRow: false,
+        hasError: false,
+        accountOptedIn: null,
+        rewardsAccountScope: null,
+      });
 
       // When rendering the component
       const { queryByText } = renderScreen(
@@ -613,25 +619,27 @@ describe('QuoteDetailsCard', () => {
       });
     });
 
-    it('displays AddRewardsAccount when user has not opted in', async () => {
-      // Given rewards feature is enabled but user has not opted in
-      mockEngine.controllerMessenger.call.mockImplementation(
-        (method: string) => {
-          if (method === 'RewardsController:isRewardsFeatureEnabled') {
-            return Promise.resolve(true);
-          }
-          if (method === 'RewardsController:getFirstSubscriptionId') {
-            return Promise.resolve('subscription-id-1');
-          }
-          if (method === 'RewardsController:getHasAccountOptedIn') {
-            return Promise.resolve(false);
-          }
-          if (method === 'RewardsController:isOptInSupported') {
-            return Promise.resolve(true);
-          }
-          return Promise.resolve(null);
+    it('displays AddRewardsAccount when user has not opted in but has rewards account scope', async () => {
+      // Given rewards feature is enabled but user has not opted in, but has account scope
+      const mockAccount = {
+        id: 'test-account-id',
+        address: '0x1234567890123456789012345678901234567890',
+        name: 'Test Account',
+        type: 'eip155:eoa',
+        scopes: ['eip155:1'],
+        metadata: {
+          lastSelected: 0,
         },
-      );
+      };
+
+      (useRewards as jest.Mock).mockReturnValue({
+        estimatedPoints: null,
+        isLoading: false,
+        shouldShowRewardsRow: true,
+        hasError: false,
+        accountOptedIn: false,
+        rewardsAccountScope: mockAccount,
+      });
 
       // When rendering the component
       const { getByText, getByTestId, queryByTestId } = renderScreen(
@@ -652,25 +660,16 @@ describe('QuoteDetailsCard', () => {
       });
     });
 
-    it('displays rewards image when rewards row is shown', async () => {
+    it('displays rewards animation when rewards row is shown', async () => {
       // Given rewards should be shown
-      mockEngine.controllerMessenger.call.mockImplementation(
-        (method: string) => {
-          if (method === 'RewardsController:isRewardsFeatureEnabled') {
-            return Promise.resolve(true);
-          }
-          if (method === 'RewardsController:getFirstSubscriptionId') {
-            return Promise.resolve('subscription-id-1');
-          }
-          if (method === 'RewardsController:getHasAccountOptedIn') {
-            return Promise.resolve(true);
-          }
-          if (method === 'RewardsController:estimatePoints') {
-            return Promise.resolve({ pointsEstimate: 150 });
-          }
-          return Promise.resolve(null);
-        },
-      );
+      (useRewards as jest.Mock).mockReturnValue({
+        estimatedPoints: 150,
+        isLoading: false,
+        shouldShowRewardsRow: true,
+        hasError: false,
+        accountOptedIn: true,
+        rewardsAccountScope: null,
+      });
 
       // When rendering the component
       const { getByTestId } = renderScreen(
@@ -679,34 +678,22 @@ describe('QuoteDetailsCard', () => {
         { state: testState },
       );
 
-      // Then the MetaMask rewards points image should be displayed
+      // Then the MetaMask rewards points animation should be displayed
       await waitFor(() => {
         expect(getByTestId('mock-rive-animation')).toBeOnTheScreen();
       });
     });
 
     it('does not display points value when rewards are loading', async () => {
-      // Given rewards are being estimated (pending promise)
-      mockEngine.controllerMessenger.call.mockImplementation(
-        (method: string) => {
-          if (method === 'RewardsController:isRewardsFeatureEnabled') {
-            return Promise.resolve(true);
-          }
-          if (method === 'RewardsController:getFirstSubscriptionId') {
-            return Promise.resolve('subscription-id-1');
-          }
-          if (method === 'RewardsController:getHasAccountOptedIn') {
-            return Promise.resolve(true);
-          }
-          if (method === 'RewardsController:estimatePoints') {
-            // Return a pending promise to simulate loading
-            return new Promise(() => {
-              // Never resolves to simulate loading state
-            });
-          }
-          return Promise.resolve(null);
-        },
-      );
+      // Given rewards are being estimated (loading state)
+      (useRewards as jest.Mock).mockReturnValue({
+        estimatedPoints: null,
+        isLoading: true,
+        shouldShowRewardsRow: true,
+        hasError: false,
+        accountOptedIn: true,
+        rewardsAccountScope: null,
+      });
 
       // When rendering the component
       const { getByText, getByTestId } = renderScreen(
@@ -724,25 +711,16 @@ describe('QuoteDetailsCard', () => {
       expect(getByText('0')).toBeOnTheScreen();
     });
 
-    it('displays rewards row but no points when engine returns zero', async () => {
+    it('displays rewards row but no points when estimatedPoints is zero', async () => {
       // Given rewards estimation returns zero with feature enabled and user opted in
-      mockEngine.controllerMessenger.call.mockImplementation(
-        (method: string) => {
-          if (method === 'RewardsController:isRewardsFeatureEnabled') {
-            return Promise.resolve(true);
-          }
-          if (method === 'RewardsController:getFirstSubscriptionId') {
-            return Promise.resolve('subscription-id-1');
-          }
-          if (method === 'RewardsController:getHasAccountOptedIn') {
-            return Promise.resolve(true);
-          }
-          if (method === 'RewardsController:estimatePoints') {
-            return Promise.resolve({ pointsEstimate: 0 });
-          }
-          return Promise.resolve(null);
-        },
-      );
+      (useRewards as jest.Mock).mockReturnValue({
+        estimatedPoints: 0,
+        isLoading: false,
+        shouldShowRewardsRow: true,
+        hasError: false,
+        accountOptedIn: true,
+        rewardsAccountScope: null,
+      });
 
       // When rendering the component
       const { getByText, getByTestId } = renderScreen(
@@ -756,30 +734,18 @@ describe('QuoteDetailsCard', () => {
         expect(getByText(strings('bridge.points'))).toBeOnTheScreen();
         expect(getByTestId('mock-rive-animation')).toBeOnTheScreen();
       });
-
-      // When points are 0, we may show "0" or no value at all
-      // This behavior will depend on how useRewards handles the response
     });
 
     it('displays rewards tooltip when rewards row is shown', async () => {
       // Given rewards should be shown
-      mockEngine.controllerMessenger.call.mockImplementation(
-        (method: string) => {
-          if (method === 'RewardsController:isRewardsFeatureEnabled') {
-            return Promise.resolve(true);
-          }
-          if (method === 'RewardsController:getFirstSubscriptionId') {
-            return Promise.resolve('subscription-id-1');
-          }
-          if (method === 'RewardsController:getHasAccountOptedIn') {
-            return Promise.resolve(true);
-          }
-          if (method === 'RewardsController:estimatePoints') {
-            return Promise.resolve({ pointsEstimate: 100 });
-          }
-          return Promise.resolve(null);
-        },
-      );
+      (useRewards as jest.Mock).mockReturnValue({
+        estimatedPoints: 100,
+        isLoading: false,
+        shouldShowRewardsRow: true,
+        hasError: false,
+        accountOptedIn: true,
+        rewardsAccountScope: null,
+      });
 
       // When rendering the component
       const { getByLabelText } = renderScreen(
@@ -797,23 +763,14 @@ describe('QuoteDetailsCard', () => {
 
     it('displays rewards row when all conditions are met', async () => {
       // Given rewards feature is enabled, user has opted in, and estimation succeeds
-      mockEngine.controllerMessenger.call.mockImplementation(
-        (method: string) => {
-          if (method === 'RewardsController:isRewardsFeatureEnabled') {
-            return Promise.resolve(true);
-          }
-          if (method === 'RewardsController:getFirstSubscriptionId') {
-            return Promise.resolve('subscription-id-1');
-          }
-          if (method === 'RewardsController:getHasAccountOptedIn') {
-            return Promise.resolve(true);
-          }
-          if (method === 'RewardsController:estimatePoints') {
-            return Promise.resolve({ pointsEstimate: 500 });
-          }
-          return Promise.resolve(null);
-        },
-      );
+      (useRewards as jest.Mock).mockReturnValue({
+        estimatedPoints: 500,
+        isLoading: false,
+        shouldShowRewardsRow: true,
+        hasError: false,
+        accountOptedIn: true,
+        rewardsAccountScope: null,
+      });
 
       // When rendering the component
       const { getByText, getByTestId } = renderScreen(
@@ -831,23 +788,14 @@ describe('QuoteDetailsCard', () => {
 
     it('handles rewards estimation with null estimatedPoints', async () => {
       // Given rewards with null estimated points
-      mockEngine.controllerMessenger.call.mockImplementation(
-        (method: string) => {
-          if (method === 'RewardsController:isRewardsFeatureEnabled') {
-            return Promise.resolve(true);
-          }
-          if (method === 'RewardsController:getFirstSubscriptionId') {
-            return Promise.resolve('subscription-id-1');
-          }
-          if (method === 'RewardsController:getHasAccountOptedIn') {
-            return Promise.resolve(true);
-          }
-          if (method === 'RewardsController:estimatePoints') {
-            return Promise.resolve({ pointsEstimate: null });
-          }
-          return Promise.resolve(null);
-        },
-      );
+      (useRewards as jest.Mock).mockReturnValue({
+        estimatedPoints: null,
+        isLoading: false,
+        shouldShowRewardsRow: true,
+        hasError: false,
+        accountOptedIn: true,
+        rewardsAccountScope: null,
+      });
 
       // When rendering the component
       const { getByText, getByTestId } = renderScreen(
@@ -879,29 +827,18 @@ describe('QuoteDetailsCard', () => {
           priceImpact: '-0.06%',
           slippage: '0.5%',
         },
+        shouldShowPriceImpactWarning: false,
       }));
 
-      // Mock Engine to simulate rewards loading
-      mockEngine.controllerMessenger.call.mockImplementation(
-        (method: string) => {
-          if (method === 'RewardsController:isRewardsFeatureEnabled') {
-            return Promise.resolve(true);
-          }
-          if (method === 'RewardsController:getFirstSubscriptionId') {
-            return Promise.resolve('subscription-id-1');
-          }
-          if (method === 'RewardsController:getHasAccountOptedIn') {
-            return Promise.resolve(true);
-          }
-          if (method === 'RewardsController:estimatePoints') {
-            // Return a pending promise to simulate loading
-            return new Promise(() => {
-              // Never resolves to simulate loading state
-            });
-          }
-          return Promise.resolve(null);
-        },
-      );
+      // Mock useRewards to simulate rewards loading
+      (useRewards as jest.Mock).mockReturnValue({
+        estimatedPoints: null,
+        isLoading: true,
+        shouldShowRewardsRow: true,
+        hasError: false,
+        accountOptedIn: true,
+        rewardsAccountScope: null,
+      });
 
       // When rendering the component
       const { getByText, getByTestId } = renderScreen(
@@ -918,6 +855,57 @@ describe('QuoteDetailsCard', () => {
 
       // RewardPointsAnimation displays 0 while loading (estimatedPoints is null)
       expect(getByText('0')).toBeOnTheScreen();
+    });
+
+    it('displays error tooltip when rewards has error', async () => {
+      // Given rewards has an error
+      (useRewards as jest.Mock).mockReturnValue({
+        estimatedPoints: null,
+        isLoading: false,
+        shouldShowRewardsRow: true,
+        hasError: true,
+        accountOptedIn: true,
+        rewardsAccountScope: null,
+      });
+
+      // When rendering the component
+      const { getByLabelText } = renderScreen(
+        QuoteDetailsCard,
+        { name: Routes.BRIDGE.ROOT },
+        { state: testState },
+      );
+
+      // Then the error tooltip should be available
+      await waitFor(() => {
+        const errorTooltip = getByLabelText(
+          new RegExp(`${strings('bridge.points_error')} tooltip`, 'i'),
+        );
+        expect(errorTooltip).toBeOnTheScreen();
+      });
+    });
+
+    it('does not display rewards row when accountOptedIn is false and rewardsAccountScope is null', async () => {
+      // Given user has not opted in and no account scope
+      (useRewards as jest.Mock).mockReturnValue({
+        estimatedPoints: null,
+        isLoading: false,
+        shouldShowRewardsRow: true,
+        hasError: false,
+        accountOptedIn: false,
+        rewardsAccountScope: null,
+      });
+
+      // When rendering the component
+      const { queryByText } = renderScreen(
+        QuoteDetailsCard,
+        { name: Routes.BRIDGE.ROOT },
+        { state: testState },
+      );
+
+      // Then the rewards row should not be displayed (condition: shouldShowRewardsRow && (accountOptedIn || rewardsAccountScope))
+      await waitFor(() => {
+        expect(queryByText(strings('bridge.points'))).toBeNull();
+      });
     });
   });
 });

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.test.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.test.tsx
@@ -883,29 +883,5 @@ describe('QuoteDetailsCard', () => {
         expect(errorTooltip).toBeOnTheScreen();
       });
     });
-
-    it('does not display rewards row when accountOptedIn is false and rewardsAccountScope is null', async () => {
-      // Given user has not opted in and no account scope
-      (useRewards as jest.Mock).mockReturnValue({
-        estimatedPoints: null,
-        isLoading: false,
-        shouldShowRewardsRow: true,
-        hasError: false,
-        accountOptedIn: false,
-        rewardsAccountScope: null,
-      });
-
-      // When rendering the component
-      const { queryByText } = renderScreen(
-        QuoteDetailsCard,
-        { name: Routes.BRIDGE.ROOT },
-        { state: testState },
-      );
-
-      // Then the rewards row should not be displayed (condition: shouldShowRewardsRow && (accountOptedIn || rewardsAccountScope))
-      await waitFor(() => {
-        expect(queryByText(strings('bridge.points'))).toBeNull();
-      });
-    });
   });
 });

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
@@ -71,6 +71,7 @@ const QuoteDetailsCard: React.FC = () => {
     shouldShowRewardsRow,
     hasError: hasRewardsError,
     accountOptedIn,
+    rewardsAccountScope,
   } = useRewards({
     activeQuote,
     isQuoteLoading,
@@ -287,7 +288,7 @@ const QuoteDetailsCard: React.FC = () => {
         <QuoteDetailsRecipientKeyValueRow />
 
         {/* Estimated Points */}
-        {shouldShowRewardsRow && (
+        {shouldShowRewardsRow && (accountOptedIn || rewardsAccountScope) && (
           <Box testID="bridge-rewards-row">
             <KeyValueRow
               field={{
@@ -323,8 +324,13 @@ const QuoteDetailsCard: React.FC = () => {
                               : RewardAnimationState.Idle
                         }
                       />
+                    ) : rewardsAccountScope ? (
+                      <AddRewardsAccount
+                        testID="bridge-add-rewards-account"
+                        account={rewardsAccountScope}
+                      />
                     ) : (
-                      <AddRewardsAccount testID="bridge-add-rewards-account" />
+                      <></>
                     )}
                   </Box>
                 ),

--- a/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
+++ b/app/components/UI/Bridge/components/QuoteDetailsCard/QuoteDetailsCard.tsx
@@ -288,7 +288,7 @@ const QuoteDetailsCard: React.FC = () => {
         <QuoteDetailsRecipientKeyValueRow />
 
         {/* Estimated Points */}
-        {shouldShowRewardsRow && (accountOptedIn || rewardsAccountScope) && (
+        {shouldShowRewardsRow && (
           <Box testID="bridge-rewards-row">
             <KeyValueRow
               field={{

--- a/app/components/UI/Bridge/hooks/useRewards/useRewards.test.ts
+++ b/app/components/UI/Bridge/hooks/useRewards/useRewards.test.ts
@@ -171,6 +171,8 @@ const mockActiveQuote = {
 
 describe('useRewards', () => {
   const mockCall = Engine.controllerMessenger.call as jest.Mock;
+  const mockSubscribe = Engine.controllerMessenger.subscribe as jest.Mock;
+  const mockUnsubscribe = Engine.controllerMessenger.unsubscribe as jest.Mock;
 
   const defaultSourceToken = {
     address: '0x0000000000000000000000000000000000000000' as Hex,
@@ -190,6 +192,9 @@ describe('useRewards', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // Reset subscription handler storage
+    mockSubscribe.mockClear();
+    mockUnsubscribe.mockClear();
   });
 
   describe('when rewards feature is disabled', () => {
@@ -225,6 +230,7 @@ describe('useRewards', () => {
           estimatedPoints: null,
           hasError: false,
           accountOptedIn: null,
+          rewardsAccountScope: expect.any(Object),
         });
       });
 
@@ -240,7 +246,7 @@ describe('useRewards', () => {
         if (method === 'RewardsController:isRewardsFeatureEnabled') {
           return Promise.resolve(true);
         }
-        if (method === 'RewardsController:getFirstSubscriptionId') {
+        if (method === 'RewardsController:getCandidateSubscriptionId') {
           return Promise.resolve('subscription-id-1');
         }
         if (method === 'RewardsController:getHasAccountOptedIn') {
@@ -276,11 +282,12 @@ describe('useRewards', () => {
           estimatedPoints: null,
           hasError: false,
           accountOptedIn: false,
+          rewardsAccountScope: expect.any(Object),
         });
       });
 
       expect(mockCall).toHaveBeenCalledWith(
-        'RewardsController:getFirstSubscriptionId',
+        'RewardsController:getCandidateSubscriptionId',
       );
       expect(mockCall).toHaveBeenCalledWith(
         'RewardsController:getHasAccountOptedIn',
@@ -297,7 +304,7 @@ describe('useRewards', () => {
         if (method === 'RewardsController:isRewardsFeatureEnabled') {
           return Promise.resolve(true);
         }
-        if (method === 'RewardsController:getFirstSubscriptionId') {
+        if (method === 'RewardsController:getCandidateSubscriptionId') {
           return Promise.resolve('subscription-id-1');
         }
         if (method === 'RewardsController:getHasAccountOptedIn') {
@@ -333,11 +340,12 @@ describe('useRewards', () => {
           estimatedPoints: null,
           hasError: false,
           accountOptedIn: false,
+          rewardsAccountScope: expect.any(Object),
         });
       });
 
       expect(mockCall).toHaveBeenCalledWith(
-        'RewardsController:getFirstSubscriptionId',
+        'RewardsController:getCandidateSubscriptionId',
       );
       expect(mockCall).toHaveBeenCalledWith(
         'RewardsController:getHasAccountOptedIn',
@@ -356,7 +364,7 @@ describe('useRewards', () => {
         if (method === 'RewardsController:isRewardsFeatureEnabled') {
           return Promise.resolve(true);
         }
-        if (method === 'RewardsController:getFirstSubscriptionId') {
+        if (method === 'RewardsController:getCandidateSubscriptionId') {
           return Promise.resolve('subscription-id-1');
         }
         if (method === 'RewardsController:getHasAccountOptedIn') {
@@ -392,6 +400,7 @@ describe('useRewards', () => {
           estimatedPoints: 100,
           hasError: false,
           accountOptedIn: true,
+          rewardsAccountScope: expect.any(Object),
         });
       });
 
@@ -426,7 +435,7 @@ describe('useRewards', () => {
         if (method === 'RewardsController:isRewardsFeatureEnabled') {
           return Promise.resolve(true);
         }
-        if (method === 'RewardsController:getFirstSubscriptionId') {
+        if (method === 'RewardsController:getCandidateSubscriptionId') {
           return Promise.resolve('subscription-id-1');
         }
         if (method === 'RewardsController:getHasAccountOptedIn') {
@@ -499,6 +508,7 @@ describe('useRewards', () => {
         estimatedPoints: null,
         hasError: false,
         accountOptedIn: null,
+        rewardsAccountScope: expect.any(Object),
       });
 
       // Should not call Engine methods
@@ -529,6 +539,7 @@ describe('useRewards', () => {
         estimatedPoints: null,
         hasError: false,
         accountOptedIn: null,
+        rewardsAccountScope: null,
       });
     });
 
@@ -556,6 +567,7 @@ describe('useRewards', () => {
         estimatedPoints: null,
         hasError: false,
         accountOptedIn: null,
+        rewardsAccountScope: expect.any(Object),
       });
     });
 
@@ -583,6 +595,7 @@ describe('useRewards', () => {
         estimatedPoints: null,
         hasError: false,
         accountOptedIn: null,
+        rewardsAccountScope: expect.any(Object),
       });
     });
   });
@@ -593,7 +606,7 @@ describe('useRewards', () => {
         if (method === 'RewardsController:isRewardsFeatureEnabled') {
           return Promise.resolve(true);
         }
-        if (method === 'RewardsController:getFirstSubscriptionId') {
+        if (method === 'RewardsController:getCandidateSubscriptionId') {
           return Promise.resolve(null);
         }
         return Promise.resolve(null);
@@ -623,6 +636,7 @@ describe('useRewards', () => {
           estimatedPoints: null,
           hasError: false,
           accountOptedIn: null,
+          rewardsAccountScope: expect.any(Object),
         });
       });
 
@@ -630,7 +644,7 @@ describe('useRewards', () => {
         'RewardsController:isRewardsFeatureEnabled',
       );
       expect(mockCall).toHaveBeenCalledWith(
-        'RewardsController:getFirstSubscriptionId',
+        'RewardsController:getCandidateSubscriptionId',
       );
       expect(mockCall).not.toHaveBeenCalledWith(
         'RewardsController:getHasAccountOptedIn',
@@ -645,7 +659,7 @@ describe('useRewards', () => {
         if (method === 'RewardsController:isRewardsFeatureEnabled') {
           return Promise.resolve(true);
         }
-        if (method === 'RewardsController:getFirstSubscriptionId') {
+        if (method === 'RewardsController:getCandidateSubscriptionId') {
           return Promise.resolve('subscription-id-1');
         }
         if (method === 'RewardsController:getHasAccountOptedIn') {
@@ -681,6 +695,7 @@ describe('useRewards', () => {
           estimatedPoints: null,
           hasError: true,
           accountOptedIn: true,
+          rewardsAccountScope: expect.any(Object),
         });
       });
     });
@@ -717,6 +732,7 @@ describe('useRewards', () => {
           estimatedPoints: null,
           hasError: true,
           accountOptedIn: null,
+          rewardsAccountScope: expect.any(Object),
         });
       });
     });
@@ -726,7 +742,7 @@ describe('useRewards', () => {
         if (method === 'RewardsController:isRewardsFeatureEnabled') {
           return Promise.resolve(true);
         }
-        if (method === 'RewardsController:getFirstSubscriptionId') {
+        if (method === 'RewardsController:getCandidateSubscriptionId') {
           return Promise.resolve('subscription-id-1');
         }
         if (method === 'RewardsController:getHasAccountOptedIn') {
@@ -759,6 +775,7 @@ describe('useRewards', () => {
           estimatedPoints: null,
           hasError: true,
           accountOptedIn: null,
+          rewardsAccountScope: expect.any(Object),
         });
       });
     });
@@ -769,7 +786,7 @@ describe('useRewards', () => {
         if (method === 'RewardsController:isRewardsFeatureEnabled') {
           return Promise.resolve(true);
         }
-        if (method === 'RewardsController:getFirstSubscriptionId') {
+        if (method === 'RewardsController:getCandidateSubscriptionId') {
           return Promise.resolve('subscription-id-1');
         }
         if (method === 'RewardsController:getHasAccountOptedIn') {
@@ -808,7 +825,7 @@ describe('useRewards', () => {
         if (method === 'RewardsController:isRewardsFeatureEnabled') {
           return Promise.resolve(true);
         }
-        if (method === 'RewardsController:getFirstSubscriptionId') {
+        if (method === 'RewardsController:getCandidateSubscriptionId') {
           return Promise.resolve('subscription-id-1');
         }
         if (method === 'RewardsController:getHasAccountOptedIn') {
@@ -840,6 +857,7 @@ describe('useRewards', () => {
           estimatedPoints: 100,
           hasError: false,
           accountOptedIn: true,
+          rewardsAccountScope: expect.any(Object),
         });
       });
     });

--- a/app/components/UI/Bridge/hooks/useRewards/useRewards.ts
+++ b/app/components/UI/Bridge/hooks/useRewards/useRewards.ts
@@ -23,6 +23,7 @@ import {
 import { useBridgeQuoteData } from '../useBridgeQuoteData';
 import Logger from '../../../../../util/Logger';
 import usePrevious from '../../../../hooks/usePrevious';
+import { InternalAccount } from '@metamask/keyring-internal-api';
 
 /**
  *
@@ -69,6 +70,7 @@ interface UseRewardsResult {
   estimatedPoints: number | null;
   hasError: boolean;
   accountOptedIn: boolean | null;
+  rewardsAccountScope: InternalAccount | null;
 }
 
 /**
@@ -152,11 +154,11 @@ export const useRewards = ({
       }
 
       // Check if there's a subscription first
-      const firstSubscriptionId = await Engine.controllerMessenger.call(
-        'RewardsController:getFirstSubscriptionId',
+      const candidateSubscriptionId = await Engine.controllerMessenger.call(
+        'RewardsController:getCandidateSubscriptionId',
       );
 
-      if (!firstSubscriptionId) {
+      if (!candidateSubscriptionId) {
         setEstimatedPoints(null);
         setShouldShowRewardsRow(false);
         setAccountOptedIn(null);
@@ -317,5 +319,6 @@ export const useRewards = ({
     estimatedPoints,
     hasError,
     accountOptedIn,
+    rewardsAccountScope: selectedAccount ?? null,
   };
 };

--- a/app/components/UI/Bridge/hooks/useRewards/useRewards.ts
+++ b/app/components/UI/Bridge/hooks/useRewards/useRewards.ts
@@ -314,7 +314,8 @@ export const useRewards = ({
   }, [estimatePoints]);
 
   return {
-    shouldShowRewardsRow,
+    shouldShowRewardsRow:
+      shouldShowRewardsRow && (accountOptedIn || Boolean(selectedAccount)),
     isLoading: isLoading || isQuoteLoading,
     estimatedPoints,
     hasError,

--- a/app/components/UI/Predict/components/PredictFeeSummary/PredictFeeSummary.test.tsx
+++ b/app/components/UI/Predict/components/PredictFeeSummary/PredictFeeSummary.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import PredictFeeSummary from './PredictFeeSummary';
+import { InternalAccount } from '@metamask/keyring-internal-api';
 
 jest.mock('../../utils/format', () => ({
   formatPrice: jest.fn((value, options) =>
@@ -271,11 +272,21 @@ describe('PredictFeeSummary', () => {
       expect(getByText('0 points')).toBeOnTheScreen();
     });
 
-    it('displays AddRewardsAccount when accountOptedIn is false', () => {
+    it('displays AddRewardsAccount when rewardsAccountScope is provided and accountOptedIn is false', () => {
+      const mockRewardsAccountScope = {
+        id: 'account-1',
+        address: '0x1234567890123456789012345678901234567890',
+        name: 'Test Account',
+        type: 'eip155:eoa',
+        scopes: [],
+        metadata: {},
+      };
       const props = {
         ...defaultProps,
         shouldShowRewardsRow: true,
         accountOptedIn: false,
+        rewardsAccountScope:
+          mockRewardsAccountScope as unknown as InternalAccount,
         estimatedPoints: 100,
       };
 
@@ -287,11 +298,21 @@ describe('PredictFeeSummary', () => {
       expect(queryByTestId('rewards-animation')).toBeNull();
     });
 
-    it('displays AddRewardsAccount when accountOptedIn is null', () => {
+    it('displays AddRewardsAccount when rewardsAccountScope is provided and accountOptedIn is null', () => {
+      const mockRewardsAccountScope = {
+        id: 'account-1',
+        address: '0x1234567890123456789012345678901234567890',
+        name: 'Test Account',
+        type: 'eip155:eoa',
+        scopes: [],
+        metadata: {},
+      };
       const props = {
         ...defaultProps,
         shouldShowRewardsRow: true,
         accountOptedIn: null,
+        rewardsAccountScope:
+          mockRewardsAccountScope as unknown as InternalAccount,
         estimatedPoints: 100,
       };
 
@@ -301,6 +322,50 @@ describe('PredictFeeSummary', () => {
 
       expect(getByTestId('add-rewards-account')).toBeOnTheScreen();
       expect(queryByTestId('rewards-animation')).toBeNull();
+    });
+
+    it('does not display rewards row when both accountOptedIn and rewardsAccountScope are null/false', () => {
+      const props = {
+        ...defaultProps,
+        shouldShowRewardsRow: true,
+        accountOptedIn: false,
+        rewardsAccountScope: null,
+        estimatedPoints: 100,
+      };
+
+      const { queryByText, queryByTestId } = render(
+        <PredictFeeSummary {...props} />,
+      );
+
+      expect(queryByText('Est. points')).toBeNull();
+      expect(queryByTestId('rewards-animation')).toBeNull();
+      expect(queryByTestId('add-rewards-account')).toBeNull();
+    });
+
+    it('displays RewardsAnimations when accountOptedIn is true even if rewardsAccountScope is provided', () => {
+      const mockRewardsAccountScope = {
+        id: 'account-1',
+        address: '0x1234567890123456789012345678901234567890',
+        name: 'Test Account',
+        type: 'eip155:eoa',
+        scopes: [],
+        metadata: {},
+      };
+      const props = {
+        ...defaultProps,
+        shouldShowRewardsRow: true,
+        accountOptedIn: true,
+        rewardsAccountScope:
+          mockRewardsAccountScope as unknown as InternalAccount,
+        estimatedPoints: 50,
+      };
+
+      const { getByTestId, queryByTestId } = render(
+        <PredictFeeSummary {...props} />,
+      );
+
+      expect(getByTestId('rewards-animation')).toBeOnTheScreen();
+      expect(queryByTestId('add-rewards-account')).toBeNull();
     });
 
     it('displays loading state when isLoadingRewards is true', () => {

--- a/app/components/UI/Predict/components/PredictFeeSummary/PredictFeeSummary.tsx
+++ b/app/components/UI/Predict/components/PredictFeeSummary/PredictFeeSummary.tsx
@@ -22,6 +22,7 @@ import RewardsAnimations, {
 } from '../../../Rewards/components/RewardPointsAnimation';
 import { formatPrice } from '../../utils/format';
 import AddRewardsAccount from '../../../Rewards/components/AddRewardsAccount/AddRewardsAccount';
+import { InternalAccount } from '@metamask/keyring-internal-api';
 
 interface PredictFeeSummaryProps {
   disabled: boolean;
@@ -30,6 +31,7 @@ interface PredictFeeSummaryProps {
   total: number;
   shouldShowRewardsRow?: boolean;
   accountOptedIn?: boolean | null;
+  rewardsAccountScope?: InternalAccount | null;
   estimatedPoints?: number | null;
   isLoadingRewards?: boolean;
   hasRewardsError?: boolean;
@@ -43,6 +45,7 @@ const PredictFeeSummary: React.FC<PredictFeeSummaryProps> = ({
   total,
   shouldShowRewardsRow = false,
   accountOptedIn = null,
+  rewardsAccountScope = null,
   estimatedPoints = 0,
   isLoadingRewards = false,
   hasRewardsError = false,
@@ -90,7 +93,7 @@ const PredictFeeSummary: React.FC<PredictFeeSummaryProps> = ({
       </Box>
 
       {/* Estimated Points Row */}
-      {shouldShowRewardsRow && (
+      {shouldShowRewardsRow && (accountOptedIn || rewardsAccountScope) && (
         <KeyValueRow
           field={{
             label: {
@@ -126,8 +129,10 @@ const PredictFeeSummary: React.FC<PredictFeeSummaryProps> = ({
                           : RewardAnimationState.Idle
                     }
                   />
+                ) : rewardsAccountScope ? (
+                  <AddRewardsAccount account={rewardsAccountScope} />
                 ) : (
-                  <AddRewardsAccount />
+                  <></>
                 )}
               </Box>
             ),

--- a/app/components/UI/Predict/hooks/usePredictRewards.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictRewards.test.ts
@@ -137,7 +137,7 @@ describe('usePredictRewards', () => {
       const mockEstimatedPoints = 100;
       mockControllerMessengerCall
         .mockResolvedValueOnce(true) // isRewardsFeatureEnabled
-        .mockResolvedValueOnce('subscription-1') // getFirstSubscriptionId
+        .mockResolvedValueOnce('subscription-1') // getCandidateSubscriptionId
         .mockResolvedValueOnce(true) // getHasAccountOptedIn
         .mockResolvedValueOnce({
           pointsEstimate: mockEstimatedPoints,
@@ -164,13 +164,14 @@ describe('usePredictRewards', () => {
       expect(result.current.accountOptedIn).toBe(true);
       expect(result.current.shouldShowRewardsRow).toBe(true);
       expect(result.current.hasError).toBe(false);
+      expect(result.current.rewardsAccountScope).toEqual(mockInternalAccount);
 
       // Verify controller calls
       expect(mockControllerMessengerCall).toHaveBeenCalledWith(
         'RewardsController:isRewardsFeatureEnabled',
       );
       expect(mockControllerMessengerCall).toHaveBeenCalledWith(
-        'RewardsController:getFirstSubscriptionId',
+        'RewardsController:getCandidateSubscriptionId',
       );
       expect(mockControllerMessengerCall).toHaveBeenCalledWith(
         'RewardsController:getHasAccountOptedIn',
@@ -217,6 +218,7 @@ describe('usePredictRewards', () => {
       expect(result.current.accountOptedIn).toBe(null);
       expect(result.current.shouldShowRewardsRow).toBe(false);
       expect(result.current.estimatedPoints).toBe(null);
+      expect(result.current.rewardsAccountScope).toEqual(mockInternalAccount);
       expect(mockControllerMessengerCall).toHaveBeenCalledTimes(1);
       expect(mockControllerMessengerCall).toHaveBeenCalledWith(
         'RewardsController:isRewardsFeatureEnabled',
@@ -225,11 +227,11 @@ describe('usePredictRewards', () => {
   });
 
   describe('when no subscription exists', () => {
-    it('returns enabled false when getFirstSubscriptionId returns null', async () => {
+    it('returns enabled false when getCandidateSubscriptionId returns null', async () => {
       // Arrange
       mockControllerMessengerCall
         .mockResolvedValueOnce(true) // isRewardsFeatureEnabled
-        .mockResolvedValueOnce(null); // getFirstSubscriptionId
+        .mockResolvedValueOnce(null); // getCandidateSubscriptionId
 
       // Act
       const { result } = renderHook(() => usePredictRewards(10.5));
@@ -244,6 +246,7 @@ describe('usePredictRewards', () => {
       expect(result.current.shouldShowRewardsRow).toBe(false);
       expect(result.current.estimatedPoints).toBe(null);
       expect(result.current.hasError).toBe(false);
+      expect(result.current.rewardsAccountScope).toEqual(mockInternalAccount);
       expect(mockControllerMessengerCall).toHaveBeenCalledTimes(2);
     });
   });
@@ -253,7 +256,7 @@ describe('usePredictRewards', () => {
       // Arrange
       mockControllerMessengerCall
         .mockResolvedValueOnce(true) // isRewardsFeatureEnabled
-        .mockResolvedValueOnce('subscription-1') // getFirstSubscriptionId
+        .mockResolvedValueOnce('subscription-1') // getCandidateSubscriptionId
         .mockResolvedValueOnce(false) // getHasAccountOptedIn
         .mockResolvedValueOnce(true); // isOptInSupported
 
@@ -270,6 +273,7 @@ describe('usePredictRewards', () => {
       expect(result.current.shouldShowRewardsRow).toBe(true);
       expect(result.current.estimatedPoints).toBe(null);
       expect(result.current.hasError).toBe(false);
+      expect(result.current.rewardsAccountScope).toEqual(mockInternalAccount);
 
       expect(mockControllerMessengerCall).toHaveBeenCalledWith(
         'RewardsController:isOptInSupported',
@@ -285,7 +289,7 @@ describe('usePredictRewards', () => {
       // Arrange
       mockControllerMessengerCall
         .mockResolvedValueOnce(true) // isRewardsFeatureEnabled
-        .mockResolvedValueOnce('subscription-1') // getFirstSubscriptionId
+        .mockResolvedValueOnce('subscription-1') // getCandidateSubscriptionId
         .mockResolvedValueOnce(false) // getHasAccountOptedIn
         .mockResolvedValueOnce(false); // isOptInSupported
 
@@ -301,6 +305,7 @@ describe('usePredictRewards', () => {
       expect(result.current.accountOptedIn).toBe(false);
       expect(result.current.shouldShowRewardsRow).toBe(false);
       expect(result.current.estimatedPoints).toBe(null);
+      expect(result.current.rewardsAccountScope).toEqual(mockInternalAccount);
     });
   });
 
@@ -321,26 +326,7 @@ describe('usePredictRewards', () => {
       expect(result.current.accountOptedIn).toBe(null);
       expect(result.current.shouldShowRewardsRow).toBe(false);
       expect(result.current.estimatedPoints).toBe(null);
-      expect(mockControllerMessengerCall).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('when totalFeeAmountUsd is missing', () => {
-    it('returns enabled false and does not call controller when totalFeeAmountUsd is undefined', async () => {
-      // Arrange - no mocks needed since hook returns early
-
-      // Act
-      const { result } = renderHook(() => usePredictRewards());
-
-      // Assert
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
-
-      expect(result.current.enabled).toBe(false);
-      expect(result.current.accountOptedIn).toBe(null);
-      expect(result.current.shouldShowRewardsRow).toBe(false);
-      expect(result.current.estimatedPoints).toBe(null);
+      expect(result.current.rewardsAccountScope).toBe(null);
       expect(mockControllerMessengerCall).not.toHaveBeenCalled();
     });
   });
@@ -353,7 +339,7 @@ describe('usePredictRewards', () => {
         throw mockError;
       });
       mockControllerMessengerCall.mockResolvedValueOnce(true); // isRewardsFeatureEnabled
-      mockControllerMessengerCall.mockResolvedValueOnce('subscription-1'); // getFirstSubscriptionId
+      mockControllerMessengerCall.mockResolvedValueOnce('subscription-1'); // getCandidateSubscriptionId
 
       // Act
       const { result } = renderHook(() => usePredictRewards(10.5));
@@ -366,6 +352,7 @@ describe('usePredictRewards', () => {
       expect(result.current.enabled).toBe(false);
       expect(result.current.accountOptedIn).toBe(null);
       expect(result.current.shouldShowRewardsRow).toBe(false);
+      expect(result.current.rewardsAccountScope).toEqual(mockInternalAccount);
       expect(mockLoggerError).toHaveBeenCalledWith(
         expect.objectContaining({ message: 'Invalid chain ID' }),
         {
@@ -392,7 +379,7 @@ describe('usePredictRewards', () => {
       const mockError = new Error('Network error');
       mockControllerMessengerCall
         .mockResolvedValueOnce(true) // isRewardsFeatureEnabled
-        .mockResolvedValueOnce('subscription-1') // getFirstSubscriptionId
+        .mockResolvedValueOnce('subscription-1') // getCandidateSubscriptionId
         .mockResolvedValueOnce(true) // getHasAccountOptedIn
         .mockRejectedValueOnce(mockError); // estimatePoints
 
@@ -416,6 +403,7 @@ describe('usePredictRewards', () => {
       expect(result.current.accountOptedIn).toBe(true);
       expect(result.current.shouldShowRewardsRow).toBe(true);
       expect(result.current.estimatedPoints).toBe(null);
+      expect(result.current.rewardsAccountScope).toEqual(mockInternalAccount);
       expect(mockLoggerError).toHaveBeenCalledWith(expect.any(Error), {
         tags: {
           feature: 'Predict',

--- a/app/components/UI/Predict/hooks/usePredictRewards.ts
+++ b/app/components/UI/Predict/hooks/usePredictRewards.ts
@@ -22,11 +22,13 @@ import {
 } from '../providers/polymarket/constants';
 import { parseUnits } from 'ethers/lib/utils';
 import Logger from '../../../../util/Logger';
+import { InternalAccount } from '@metamask/keyring-internal-api';
 
 interface UsePredictRewardsResult {
   enabled: boolean;
   isLoading: boolean;
   accountOptedIn: boolean | null;
+  rewardsAccountScope: InternalAccount | null;
   shouldShowRewardsRow: boolean;
   estimatedPoints: number | null;
   hasError: boolean;
@@ -119,11 +121,11 @@ export const usePredictRewards = (
       }
 
       // Check if there's a subscription first
-      const firstSubscriptionId = await Engine.controllerMessenger.call(
-        'RewardsController:getFirstSubscriptionId',
+      const candidateSubscriptionId = await Engine.controllerMessenger.call(
+        'RewardsController:getCandidateSubscriptionId',
       );
 
-      if (!firstSubscriptionId) {
+      if (!candidateSubscriptionId) {
         setEstimatedPoints(null);
         setEnabled(false);
         setShouldShowRewardsRow(false);
@@ -261,6 +263,7 @@ export const usePredictRewards = (
     enabled,
     isLoading,
     accountOptedIn,
+    rewardsAccountScope: selectedAccount ?? null,
     shouldShowRewardsRow,
     estimatedPoints,
     hasError,

--- a/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
+++ b/app/components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx
@@ -209,6 +209,7 @@ const PredictBuyPreview = () => {
     enabled: isRewardsEnabled,
     isLoading: isRewardsLoading,
     accountOptedIn: isAccountOptedIntoRewards,
+    rewardsAccountScope,
     estimatedPoints: estimatedRewardsPoints,
     hasError: isRewardsError,
   } = usePredictRewards(
@@ -536,6 +537,7 @@ const PredictBuyPreview = () => {
         metamaskFee={metamaskFee}
         providerFee={providerFee}
         shouldShowRewardsRow={shouldShowRewardsRow}
+        rewardsAccountScope={rewardsAccountScope}
         accountOptedIn={isAccountOptedIntoRewards}
         estimatedPoints={estimatedRewardsPoints}
         isLoadingRewards={

--- a/app/components/UI/Rewards/components/AddRewardsAccount/AddRewardsAccount.tsx
+++ b/app/components/UI/Rewards/components/AddRewardsAccount/AddRewardsAccount.tsx
@@ -1,5 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
-import { useSelector } from 'react-redux';
+import React, { useCallback, useState } from 'react';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import {
   Button,
@@ -7,10 +6,7 @@ import {
   ButtonVariant,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { formatChainIdToCaip } from '@metamask/bridge-controller';
 import MetamaskRewardsPointsAlternativeImage from '../../../../../images/rewards/metamask-rewards-points-alternative.svg';
-import { selectSelectedInternalAccountByScope } from '../../../../../selectors/multichainAccounts/accounts';
-import { selectSourceToken } from '../../../../../core/redux/slices/bridge';
 import { useLinkAccountAddress } from '../../hooks/useLinkAccountAddress';
 import { strings } from '../../../../../../locales/i18n';
 
@@ -24,39 +20,23 @@ const AddRewardsAccount: React.FC<AddRewardsAccountProps> = ({
   testID = 'add-rewards-account',
 }) => {
   const tw = useTailwind();
-  const sourceToken = useSelector(selectSourceToken);
-  const getSelectedAccountByScope = useSelector(
-    selectSelectedInternalAccountByScope,
-  );
   const [isSuccess, setIsSuccess] = useState(false);
-  const accountScope = useMemo(() => {
-    if (account) {
-      return account;
-    }
-    const sourceChainId = sourceToken?.chainId
-      ? formatChainIdToCaip(sourceToken.chainId)
-      : undefined;
-    if (sourceChainId) {
-      return getSelectedAccountByScope(sourceChainId);
-    }
-    return undefined;
-  }, [account, sourceToken, getSelectedAccountByScope]);
 
   const { linkAccountAddress, isLoading } = useLinkAccountAddress(true);
 
   const handlePress = useCallback(async () => {
-    if (!accountScope) {
+    if (!account) {
       return;
     }
 
-    const success = await linkAccountAddress(accountScope);
+    const success = await linkAccountAddress(account);
     if (success) {
       setIsSuccess(true);
     }
-  }, [accountScope, linkAccountAddress]);
+  }, [account, linkAccountAddress]);
 
   // Don't render if no account available or if successfully linked
-  if (!accountScope || isSuccess) {
+  if (!account || isSuccess) {
     return null;
   }
 


### PR DESCRIPTION
## **Description**

- Small change in the `AddRewardsAccount`; this component shouldn't deduce an account scope but always work with the one passed in as a prop.
- Instead of using `getFirstSubscriptionId`, we are switching to `getCandidateSubscriptionId` just like in the perps implementation & in extension swap flow.

All flows were tested locally and still work.

## **Changelog**

CHANGELOG entry: null

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Require an explicit InternalAccount for AddRewardsAccount, update rewards hooks to use getCandidateSubscriptionId and expose rewardsAccountScope, and adjust UI/tests to conditionally render rewards UI based on opt-in and scope.
> 
> - **Rewards integration**:
>   - **Hooks** (`useRewards`, `usePredictRewards`):
>     - Replace `RewardsController:getFirstSubscriptionId` with `getCandidateSubscriptionId`.
>     - Return `rewardsAccountScope` and refine `shouldShowRewardsRow` (requires opted-in or available account scope).
>   - **UI**:
>     - `AddRewardsAccount`: remove account auto-derivation; now requires explicit `account` prop and hides when absent/successful.
>     - `Bridge/QuoteDetailsCard`: when rewards row is shown, display `RewardsAnimations` if `accountOptedIn`, otherwise render `AddRewardsAccount` with `rewardsAccountScope`; add error tooltip handling.
>     - `Predict/PredictFeeSummary`: show rewards row only if `accountOptedIn` or `rewardsAccountScope`; pass `rewardsAccountScope` to `AddRewardsAccount`.
>     - `PredictBuyPreview`: plumbs `rewardsAccountScope` into `PredictFeeSummary`.
> - **Tests**:
>   - Update tests to mock `useRewards`, expect `rewardsAccountScope`, new rendering conditions, and `getCandidateSubscriptionId` calls.
>   - Remove Engine-based rewards mocks; add cases for loading/error/zero-points and price impact warning flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2400cb88974f710fdcf4df2d1745f859c828a582. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->