### PR TITLE
feat(ramps): adds unsupported and error modals to ramp entrypoint

### DIFF
--- a/app/components/UI/Ramp/hooks/useRampNavigation.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampNavigation.test.ts
@@ -36,8 +36,6 @@ jest.mock('../../../../reducers/fiatOrders', () => ({
   ...jest.requireActual('../../../../reducers/fiatOrders'),
   getRampRoutingDecision: jest.fn(),
 }));
-jest.mock('../components/EligibilityFailedModal/EligibilityFailedModal');
-jest.mock('../components/RampUnsupportedModal/RampUnsupportedModal');
 
 const mockNavigate = jest.fn();
 const mockUseNavigation = useNavigation as jest.MockedFunction<
@@ -61,14 +59,6 @@ const mockCreateTokenSelectionNavigationDetails =
   >;
 const mockGetRampRoutingDecision =
   getRampRoutingDecision as jest.MockedFunction<typeof getRampRoutingDecision>;
-const mockCreateEligibilityFailedModalNavigationDetails =
-  createEligibilityFailedModalNavigationDetails as jest.MockedFunction<
-    typeof createEligibilityFailedModalNavigationDetails
-  >;
-const mockCreateRampUnsupportedModalNavigationDetails =
-  createRampUnsupportedModalNavigationDetails as jest.MockedFunction<
-    typeof createRampUnsupportedModalNavigationDetails
-  >;
 
 describe('useRampNavigation', () => {
   beforeEach(() => {
@@ -93,143 +83,9 @@ describe('useRampNavigation', () => {
     mockCreateTokenSelectionNavigationDetails.mockReturnValue([
       Routes.RAMP.TOKEN_SELECTION,
     ] as unknown as ReturnType<typeof createTokenSelectionNavDetails>);
-
-    mockCreateEligibilityFailedModalNavigationDetails.mockReturnValue([
-      Routes.MODAL.ROOT_MODAL_FLOW,
-      Routes.SHEET.ELIGIBILITY_FAILED_MODAL,
-    ] as unknown as ReturnType<
-      typeof createEligibilityFailedModalNavigationDetails
-    >);
-
-    mockCreateRampUnsupportedModalNavigationDetails.mockReturnValue([
-      Routes.MODAL.ROOT_MODAL_FLOW,
-      Routes.SHEET.UNSUPPORTED_REGION_MODAL,
-    ] as unknown as ReturnType<
-      typeof createRampUnsupportedModalNavigationDetails
-    >);
   });
 
   describe('goToBuy', () => {
-    describe('error and unsupported routing', () => {
-      it('navigates to eligibility failed modal when routing decision is ERROR', () => {
-        mockGetRampRoutingDecision.mockReturnValue(
-          UnifiedRampRoutingType.ERROR,
-        );
-        const mockNavDetails = [
-          Routes.MODAL.ROOT_MODAL_FLOW,
-          Routes.SHEET.ELIGIBILITY_FAILED_MODAL,
-        ] as unknown as ReturnType<
-          typeof createEligibilityFailedModalNavigationDetails
-        >;
-        mockCreateEligibilityFailedModalNavigationDetails.mockReturnValue(
-          mockNavDetails,
-        );
-
-        const { result } = renderHookWithProvider(() => useRampNavigation());
-
-        result.current.goToBuy();
-
-        expect(
-          mockCreateEligibilityFailedModalNavigationDetails,
-        ).toHaveBeenCalled();
-        expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
-        expect(mockCreateRampNavigationDetails).not.toHaveBeenCalled();
-        expect(mockCreateDepositNavigationDetails).not.toHaveBeenCalled();
-        expect(
-          mockCreateTokenSelectionNavigationDetails,
-        ).not.toHaveBeenCalled();
-      });
-
-      it('navigates to eligibility failed modal when routing decision is ERROR with intent', () => {
-        mockGetRampRoutingDecision.mockReturnValue(
-          UnifiedRampRoutingType.ERROR,
-        );
-        const intent = { assetId: 'eip155:1/erc20:0x123' };
-        const mockNavDetails = [
-          Routes.MODAL.ROOT_MODAL_FLOW,
-          Routes.SHEET.ELIGIBILITY_FAILED_MODAL,
-        ] as unknown as ReturnType<
-          typeof createEligibilityFailedModalNavigationDetails
-        >;
-        mockCreateEligibilityFailedModalNavigationDetails.mockReturnValue(
-          mockNavDetails,
-        );
-
-        const { result } = renderHookWithProvider(() => useRampNavigation());
-
-        result.current.goToBuy(intent);
-
-        expect(
-          mockCreateEligibilityFailedModalNavigationDetails,
-        ).toHaveBeenCalled();
-        expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
-        expect(mockCreateRampNavigationDetails).not.toHaveBeenCalled();
-        expect(mockCreateDepositNavigationDetails).not.toHaveBeenCalled();
-        expect(
-          mockCreateTokenSelectionNavigationDetails,
-        ).not.toHaveBeenCalled();
-      });
-
-      it('navigates to unsupported modal when routing decision is UNSUPPORTED', () => {
-        mockGetRampRoutingDecision.mockReturnValue(
-          UnifiedRampRoutingType.UNSUPPORTED,
-        );
-        const mockNavDetails = [
-          Routes.MODAL.ROOT_MODAL_FLOW,
-          Routes.SHEET.UNSUPPORTED_REGION_MODAL,
-        ] as unknown as ReturnType<
-          typeof createRampUnsupportedModalNavigationDetails
-        >;
-        mockCreateRampUnsupportedModalNavigationDetails.mockReturnValue(
-          mockNavDetails,
-        );
-
-        const { result } = renderHookWithProvider(() => useRampNavigation());
-
-        result.current.goToBuy();
-
-        expect(
-          mockCreateRampUnsupportedModalNavigationDetails,
-        ).toHaveBeenCalled();
-        expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
-        expect(mockCreateRampNavigationDetails).not.toHaveBeenCalled();
-        expect(mockCreateDepositNavigationDetails).not.toHaveBeenCalled();
-        expect(
-          mockCreateTokenSelectionNavigationDetails,
-        ).not.toHaveBeenCalled();
-      });
-
-      it('navigates to unsupported modal when routing decision is UNSUPPORTED with intent', () => {
-        mockGetRampRoutingDecision.mockReturnValue(
-          UnifiedRampRoutingType.UNSUPPORTED,
-        );
-        const intent = { assetId: 'eip155:1/erc20:0x123' };
-        const mockNavDetails = [
-          Routes.MODAL.ROOT_MODAL_FLOW,
-          Routes.SHEET.UNSUPPORTED_REGION_MODAL,
-        ] as unknown as ReturnType<
-          typeof createRampUnsupportedModalNavigationDetails
-        >;
-        mockCreateRampUnsupportedModalNavigationDetails.mockReturnValue(
-          mockNavDetails,
-        );
-
-        const { result } = renderHookWithProvider(() => useRampNavigation());
-
-        result.current.goToBuy(intent);
-
-        expect(
-          mockCreateRampUnsupportedModalNavigationDetails,
-        ).toHaveBeenCalled();
-        expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
-        expect(mockCreateRampNavigationDetails).not.toHaveBeenCalled();
-        expect(mockCreateDepositNavigationDetails).not.toHaveBeenCalled();
-        expect(
-          mockCreateTokenSelectionNavigationDetails,
-        ).not.toHaveBeenCalled();
-      });
-    });
-
     describe('when unified V1 is disabled', () => {
       it('navigates to aggregator BUY without intent', () => {
         const mockNavDetails = [Routes.RAMP.BUY] as const;
@@ -266,6 +122,82 @@ describe('useRampNavigation', () => {
     describe('when unified V1 is enabled', () => {
       beforeEach(() => {
         mockUseRampsUnifiedV1Enabled.mockReturnValue(true);
+      });
+
+      describe('error and unsupported routing', () => {
+        it('navigates to eligibility failed modal when routing decision is ERROR', () => {
+          mockGetRampRoutingDecision.mockReturnValue(
+            UnifiedRampRoutingType.ERROR,
+          );
+          const navDetails = createEligibilityFailedModalNavigationDetails();
+
+          const { result } = renderHookWithProvider(() => useRampNavigation());
+
+          result.current.goToBuy();
+
+          expect(mockNavigate).toHaveBeenCalledWith(...navDetails);
+          expect(mockCreateRampNavigationDetails).not.toHaveBeenCalled();
+          expect(mockCreateDepositNavigationDetails).not.toHaveBeenCalled();
+          expect(
+            mockCreateTokenSelectionNavigationDetails,
+          ).not.toHaveBeenCalled();
+        });
+
+        it('navigates to eligibility failed modal when routing decision is ERROR with intent', () => {
+          mockGetRampRoutingDecision.mockReturnValue(
+            UnifiedRampRoutingType.ERROR,
+          );
+          const intent = { assetId: 'eip155:1/erc20:0x123' };
+          const navDetails = createEligibilityFailedModalNavigationDetails();
+
+          const { result } = renderHookWithProvider(() => useRampNavigation());
+
+          result.current.goToBuy(intent);
+
+          expect(mockNavigate).toHaveBeenCalledWith(...navDetails);
+          expect(mockCreateRampNavigationDetails).not.toHaveBeenCalled();
+          expect(mockCreateDepositNavigationDetails).not.toHaveBeenCalled();
+          expect(
+            mockCreateTokenSelectionNavigationDetails,
+          ).not.toHaveBeenCalled();
+        });
+
+        it('navigates to unsupported modal when routing decision is UNSUPPORTED', () => {
+          mockGetRampRoutingDecision.mockReturnValue(
+            UnifiedRampRoutingType.UNSUPPORTED,
+          );
+          const navDetails = createRampUnsupportedModalNavigationDetails();
+
+          const { result } = renderHookWithProvider(() => useRampNavigation());
+
+          result.current.goToBuy();
+
+          expect(mockNavigate).toHaveBeenCalledWith(...navDetails);
+          expect(mockCreateRampNavigationDetails).not.toHaveBeenCalled();
+          expect(mockCreateDepositNavigationDetails).not.toHaveBeenCalled();
+          expect(
+            mockCreateTokenSelectionNavigationDetails,
+          ).not.toHaveBeenCalled();
+        });
+
+        it('navigates to unsupported modal when routing decision is UNSUPPORTED with intent', () => {
+          mockGetRampRoutingDecision.mockReturnValue(
+            UnifiedRampRoutingType.UNSUPPORTED,
+          );
+          const intent = { assetId: 'eip155:1/erc20:0x123' };
+          const navDetails = createRampUnsupportedModalNavigationDetails();
+
+          const { result } = renderHookWithProvider(() => useRampNavigation());
+
+          result.current.goToBuy(intent);
+
+          expect(mockNavigate).toHaveBeenCalledWith(...navDetails);
+          expect(mockCreateRampNavigationDetails).not.toHaveBeenCalled();
+          expect(mockCreateDepositNavigationDetails).not.toHaveBeenCalled();
+          expect(
+            mockCreateTokenSelectionNavigationDetails,
+          ).not.toHaveBeenCalled();
+        });
       });
 
       describe('token selection routing', () => {

--- a/app/components/UI/Ramp/hooks/useRampNavigation.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampNavigation.test.ts
@@ -11,6 +11,8 @@ import {
   getRampRoutingDecision,
   UnifiedRampRoutingType,
 } from '../../../../reducers/fiatOrders';
+import { createEligibilityFailedModalNavigationDetails } from '../components/EligibilityFailedModal/EligibilityFailedModal';
+import { createRampUnsupportedModalNavigationDetails } from '../components/RampUnsupportedModal/RampUnsupportedModal';
 
 jest.mock('@react-navigation/native');
 jest.mock('@react-navigation/compat', () => ({
@@ -34,6 +36,8 @@ jest.mock('../../../../reducers/fiatOrders', () => ({
   ...jest.requireActual('../../../../reducers/fiatOrders'),
   getRampRoutingDecision: jest.fn(),
 }));
+jest.mock('../components/EligibilityFailedModal/EligibilityFailedModal');
+jest.mock('../components/RampUnsupportedModal/RampUnsupportedModal');
 
 const mockNavigate = jest.fn();
 const mockUseNavigation = useNavigation as jest.MockedFunction<
@@ -57,6 +61,14 @@ const mockCreateTokenSelectionNavigationDetails =
   >;
 const mockGetRampRoutingDecision =
   getRampRoutingDecision as jest.MockedFunction<typeof getRampRoutingDecision>;
+const mockCreateEligibilityFailedModalNavigationDetails =
+  createEligibilityFailedModalNavigationDetails as jest.MockedFunction<
+    typeof createEligibilityFailedModalNavigationDetails
+  >;
+const mockCreateRampUnsupportedModalNavigationDetails =
+  createRampUnsupportedModalNavigationDetails as jest.MockedFunction<
+    typeof createRampUnsupportedModalNavigationDetails
+  >;
 
 describe('useRampNavigation', () => {
   beforeEach(() => {
@@ -81,9 +93,143 @@ describe('useRampNavigation', () => {
     mockCreateTokenSelectionNavigationDetails.mockReturnValue([
       Routes.RAMP.TOKEN_SELECTION,
     ] as unknown as ReturnType<typeof createTokenSelectionNavDetails>);
+
+    mockCreateEligibilityFailedModalNavigationDetails.mockReturnValue([
+      Routes.MODAL.ROOT_MODAL_FLOW,
+      Routes.SHEET.ELIGIBILITY_FAILED_MODAL,
+    ] as unknown as ReturnType<
+      typeof createEligibilityFailedModalNavigationDetails
+    >);
+
+    mockCreateRampUnsupportedModalNavigationDetails.mockReturnValue([
+      Routes.MODAL.ROOT_MODAL_FLOW,
+      Routes.SHEET.UNSUPPORTED_REGION_MODAL,
+    ] as unknown as ReturnType<
+      typeof createRampUnsupportedModalNavigationDetails
+    >);
   });
 
   describe('goToBuy', () => {
+    describe('error and unsupported routing', () => {
+      it('navigates to eligibility failed modal when routing decision is ERROR', () => {
+        mockGetRampRoutingDecision.mockReturnValue(
+          UnifiedRampRoutingType.ERROR,
+        );
+        const mockNavDetails = [
+          Routes.MODAL.ROOT_MODAL_FLOW,
+          Routes.SHEET.ELIGIBILITY_FAILED_MODAL,
+        ] as unknown as ReturnType<
+          typeof createEligibilityFailedModalNavigationDetails
+        >;
+        mockCreateEligibilityFailedModalNavigationDetails.mockReturnValue(
+          mockNavDetails,
+        );
+
+        const { result } = renderHookWithProvider(() => useRampNavigation());
+
+        result.current.goToBuy();
+
+        expect(
+          mockCreateEligibilityFailedModalNavigationDetails,
+        ).toHaveBeenCalled();
+        expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
+        expect(mockCreateRampNavigationDetails).not.toHaveBeenCalled();
+        expect(mockCreateDepositNavigationDetails).not.toHaveBeenCalled();
+        expect(
+          mockCreateTokenSelectionNavigationDetails,
+        ).not.toHaveBeenCalled();
+      });
+
+      it('navigates to eligibility failed modal when routing decision is ERROR with intent', () => {
+        mockGetRampRoutingDecision.mockReturnValue(
+          UnifiedRampRoutingType.ERROR,
+        );
+        const intent = { assetId: 'eip155:1/erc20:0x123' };
+        const mockNavDetails = [
+          Routes.MODAL.ROOT_MODAL_FLOW,
+          Routes.SHEET.ELIGIBILITY_FAILED_MODAL,
+        ] as unknown as ReturnType<
+          typeof createEligibilityFailedModalNavigationDetails
+        >;
+        mockCreateEligibilityFailedModalNavigationDetails.mockReturnValue(
+          mockNavDetails,
+        );
+
+        const { result } = renderHookWithProvider(() => useRampNavigation());
+
+        result.current.goToBuy(intent);
+
+        expect(
+          mockCreateEligibilityFailedModalNavigationDetails,
+        ).toHaveBeenCalled();
+        expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
+        expect(mockCreateRampNavigationDetails).not.toHaveBeenCalled();
+        expect(mockCreateDepositNavigationDetails).not.toHaveBeenCalled();
+        expect(
+          mockCreateTokenSelectionNavigationDetails,
+        ).not.toHaveBeenCalled();
+      });
+
+      it('navigates to unsupported modal when routing decision is UNSUPPORTED', () => {
+        mockGetRampRoutingDecision.mockReturnValue(
+          UnifiedRampRoutingType.UNSUPPORTED,
+        );
+        const mockNavDetails = [
+          Routes.MODAL.ROOT_MODAL_FLOW,
+          Routes.SHEET.UNSUPPORTED_REGION_MODAL,
+        ] as unknown as ReturnType<
+          typeof createRampUnsupportedModalNavigationDetails
+        >;
+        mockCreateRampUnsupportedModalNavigationDetails.mockReturnValue(
+          mockNavDetails,
+        );
+
+        const { result } = renderHookWithProvider(() => useRampNavigation());
+
+        result.current.goToBuy();
+
+        expect(
+          mockCreateRampUnsupportedModalNavigationDetails,
+        ).toHaveBeenCalled();
+        expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
+        expect(mockCreateRampNavigationDetails).not.toHaveBeenCalled();
+        expect(mockCreateDepositNavigationDetails).not.toHaveBeenCalled();
+        expect(
+          mockCreateTokenSelectionNavigationDetails,
+        ).not.toHaveBeenCalled();
+      });
+
+      it('navigates to unsupported modal when routing decision is UNSUPPORTED with intent', () => {
+        mockGetRampRoutingDecision.mockReturnValue(
+          UnifiedRampRoutingType.UNSUPPORTED,
+        );
+        const intent = { assetId: 'eip155:1/erc20:0x123' };
+        const mockNavDetails = [
+          Routes.MODAL.ROOT_MODAL_FLOW,
+          Routes.SHEET.UNSUPPORTED_REGION_MODAL,
+        ] as unknown as ReturnType<
+          typeof createRampUnsupportedModalNavigationDetails
+        >;
+        mockCreateRampUnsupportedModalNavigationDetails.mockReturnValue(
+          mockNavDetails,
+        );
+
+        const { result } = renderHookWithProvider(() => useRampNavigation());
+
+        result.current.goToBuy(intent);
+
+        expect(
+          mockCreateRampUnsupportedModalNavigationDetails,
+        ).toHaveBeenCalled();
+        expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
+        expect(mockCreateRampNavigationDetails).not.toHaveBeenCalled();
+        expect(mockCreateDepositNavigationDetails).not.toHaveBeenCalled();
+        expect(
+          mockCreateTokenSelectionNavigationDetails,
+        ).not.toHaveBeenCalled();
+      });
+    });
+
     describe('when unified V1 is disabled', () => {
       it('navigates to aggregator BUY without intent', () => {
         const mockNavDetails = [Routes.RAMP.BUY] as const;

--- a/app/components/UI/Ramp/hooks/useRampNavigation.ts
+++ b/app/components/UI/Ramp/hooks/useRampNavigation.ts
@@ -43,20 +43,22 @@ export const useRampNavigation = () => {
         overrideUnifiedRouting?: boolean;
       },
     ) => {
-      if (rampRoutingDecision === UnifiedRampRoutingType.ERROR) {
-        navigation.navigate(...createEligibilityFailedModalNavigationDetails());
-        return;
-      }
-
-      if (rampRoutingDecision === UnifiedRampRoutingType.UNSUPPORTED) {
-        navigation.navigate(...createRampUnsupportedModalNavigationDetails());
-        return;
-      }
-
       const { mode = RampMode.AGGREGATOR, overrideUnifiedRouting = false } =
         options || {};
 
       if (isRampsUnifiedV1Enabled && !overrideUnifiedRouting) {
+        if (rampRoutingDecision === UnifiedRampRoutingType.ERROR) {
+          navigation.navigate(
+            ...createEligibilityFailedModalNavigationDetails(),
+          );
+          return;
+        }
+
+        if (rampRoutingDecision === UnifiedRampRoutingType.UNSUPPORTED) {
+          navigation.navigate(...createRampUnsupportedModalNavigationDetails());
+          return;
+        }
+
         // If no assetId is provided, route to TokenSelection
         if (!intent?.assetId) {
           navigation.navigate(...createTokenSelectionNavDetails());

--- a/app/components/UI/Ramp/hooks/useRampNavigation.ts
+++ b/app/components/UI/Ramp/hooks/useRampNavigation.ts
@@ -13,6 +13,8 @@ import {
   getRampRoutingDecision,
   UnifiedRampRoutingType,
 } from '../../../../reducers/fiatOrders';
+import { createRampUnsupportedModalNavigationDetails } from '../components/RampUnsupportedModal/RampUnsupportedModal';
+import { createEligibilityFailedModalNavigationDetails } from '../components/EligibilityFailedModal/EligibilityFailedModal';
 
 enum RampMode {
   AGGREGATOR = 'AGGREGATOR',
@@ -41,6 +43,16 @@ export const useRampNavigation = () => {
         overrideUnifiedRouting?: boolean;
       },
     ) => {
+      if (rampRoutingDecision === UnifiedRampRoutingType.ERROR) {
+        navigation.navigate(...createEligibilityFailedModalNavigationDetails());
+        return;
+      }
+
+      if (rampRoutingDecision === UnifiedRampRoutingType.UNSUPPORTED) {
+        navigation.navigate(...createRampUnsupportedModalNavigationDetails());
+        return;
+      }
+
       const { mode = RampMode.AGGREGATOR, overrideUnifiedRouting = false } =
         options || {};
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds error and unsupported routing handling to the `useRampNavigation` hook. The `goToBuy` function now checks the routing decision first and navigates to the appropriate modal when the routing decision is `ERROR` or `UNSUPPORTED`, before any other routing logic executes.

**Changes:**
- Added imports for `createEligibilityFailedModalNavigationDetails` and `createRampUnsupportedModalNavigationDetails`
- Added early return checks in `goToBuy` to handle `UnifiedRampRoutingType.ERROR` and `UnifiedRampRoutingType.UNSUPPORTED` routing decisions
- When `ERROR` is detected, navigates to the eligibility failed modal
- When `UNSUPPORTED` is detected, navigates to the unsupported region modal

This ensures users see appropriate error messages when ramp services are unavailable or unsupported in their region, rather than attempting to navigate to unavailable flows.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added error and unsupported region handling to ramp navigation flow

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Ramp navigation error handling
Scenario: user attempts to buy when routing decision is ERROR
Given the app has a routing decision of ERROR
When user triggers the buy flow
Then the eligibility failed modal should be displayed
Scenario: user attempts to buy when routing decision is UNSUPPORTED
Given the app has a routing decision of UNSUPPORTED
When user triggers the buy flow
Then the unsupported region modal should be displayed
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/6eb13363-2412-481b-b268-3ef1c3a58070


https://github.com/user-attachments/assets/5ffd32ef-6798-41a0-b868-dc258bb1b294


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds early routing in `useRampNavigation.goToBuy` to show eligibility-failed or unsupported modals when unified V1 is enabled, with accompanying tests.
> 
> - **Hook updates**
>   - In `app/components/UI/Ramp/hooks/useRampNavigation.ts`:
>     - `goToBuy` now checks `UnifiedRampRoutingType` first under unified V1.
>     - Routes to `createEligibilityFailedModalNavigationDetails()` on `ERROR` and to `createRampUnsupportedModalNavigationDetails()` on `UNSUPPORTED` (early return).
>     - Preserves existing token selection and smart routing for `DEPOSIT` vs `AGGREGATOR` when an `assetId` is present.
> - **Tests**
>   - In `app/components/UI/Ramp/hooks/useRampNavigation.test.ts`:
>     - Adds test coverage for `ERROR` and `UNSUPPORTED` decisions navigating to the respective modals (with and without intent).
>     - Retains tests for token selection and smart routing behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e686bbd218dbd4dbe019f1a37596f3773ac3837. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->