### PR TITLE
perf: cp-7.60.0 reduce loading time of metamask pay confirmations

### DIFF
--- a/app/components/UI/Perps/controllers/PerpsController.test.ts
+++ b/app/components/UI/Perps/controllers/PerpsController.test.ts
@@ -2166,6 +2166,7 @@ describe('PerpsController', () => {
         networkClientId: mockNetworkClientId,
         origin: 'metamask',
         type: 'perpsDeposit',
+        skipInitialGasEstimate: true,
       });
     });
 

--- a/app/components/UI/Perps/controllers/PerpsController.ts
+++ b/app/components/UI/Perps/controllers/PerpsController.ts
@@ -1279,6 +1279,7 @@ export class PerpsController extends BaseController<
           networkClientId,
           origin: 'metamask',
           type: TransactionType.perpsDeposit,
+          skipInitialGasEstimate: true,
         });
 
       // Store the transaction ID and try to get amount from transaction

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -2605,6 +2605,8 @@ describe('PredictController', () => {
           networkClientId: 'mainnet',
           disableHook: true,
           disableSequential: true,
+          disableUpgrade: true,
+          skipInitialGasEstimate: true,
           transactions: mockTransactions,
         });
       });

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -1760,6 +1760,8 @@ export class PredictController extends BaseController<
         networkClientId,
         disableHook: true,
         disableSequential: true,
+        disableUpgrade: true,
+        skipInitialGasEstimate: true,
         transactions,
       });
 

--- a/app/components/UI/Predict/providers/polymarket/safe/utils.ts
+++ b/app/components/UI/Predict/providers/polymarket/safe/utils.ts
@@ -389,6 +389,7 @@ export const getDeployProxyWalletTransaction = async ({
         to: SAFE_FACTORY_ADDRESS as Hex,
         data: calldata,
       },
+      type: TransactionType.contractInteraction,
     };
   } catch (error) {
     console.error('Error creating proxy wallet', error);
@@ -580,6 +581,7 @@ export const getProxyWalletAllowancesTransaction = async ({
       to: safeAddress as Hex,
       data: callData as Hex,
     },
+    type: TransactionType.contractInteraction,
   };
 };
 

--- a/app/components/Views/confirmations/components/pay-token-amount/pay-token-amount.tsx
+++ b/app/components/Views/confirmations/components/pay-token-amount/pay-token-amount.tsx
@@ -44,8 +44,24 @@ export function PayTokenAmount({ amountHuman, disabled }: PayTokenAmountProps) {
 
   const fiatRates = useTokenFiatRates(fiatRequests);
 
-  const payTokenFiatRate = fiatRates[0];
-  const assetFiatRate = fiatRates[1];
+  const formattedAmount = useMemo(() => {
+    const payTokenFiatRate = fiatRates[0];
+    const assetFiatRate = fiatRates[1];
+
+    if (disabled || !payToken || !payTokenFiatRate || !assetFiatRate) {
+      return undefined;
+    }
+
+    const assetToPayTokenRate = new BigNumber(assetFiatRate).dividedBy(
+      payTokenFiatRate,
+    );
+
+    const payTokenAmount = new BigNumber(amountHuman || '0').multipliedBy(
+      assetToPayTokenRate,
+    );
+
+    return formatAmount(I18n.locale, payTokenAmount);
+  }, [amountHuman, disabled, payToken, fiatRates]);
 
   if (disabled) {
     return (
@@ -55,18 +71,7 @@ export function PayTokenAmount({ amountHuman, disabled }: PayTokenAmountProps) {
     );
   }
 
-  if (!payToken || !payTokenFiatRate || !assetFiatRate)
-    return <PayTokenAmountSkeleton />;
-
-  const assetToPayTokenRate = new BigNumber(assetFiatRate).dividedBy(
-    payTokenFiatRate,
-  );
-
-  const payTokenAmount = new BigNumber(amountHuman || '0').multipliedBy(
-    assetToPayTokenRate,
-  );
-
-  const formattedAmount = formatAmount(I18n.locale, payTokenAmount);
+  if (!formattedAmount) return <PayTokenAmountSkeleton />;
 
   return (
     <View testID="pay-token-amount">

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.test.ts
@@ -159,6 +159,39 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
       ]);
     });
 
+    it('returns alert if pay token balance shortfall is equal to total amount', () => {
+      useTransactionPayTokenMock.mockReturnValue({
+        payToken: {
+          ...PAY_TOKEN_MOCK,
+          balanceRaw: '999',
+        },
+        setPayToken: jest.fn(),
+      });
+
+      useTransactionPayRequiredTokensMock.mockReturnValue([
+        {
+          ...REQUIRED_TOKEN_MOCK,
+          amountUsd: '0.02',
+        },
+      ]);
+
+      const { result } = runHook();
+
+      expect(result.current).toStrictEqual([
+        {
+          key: AlertKeys.InsufficientPayTokenFees,
+          field: RowAlertKey.Amount,
+          isBlocking: true,
+          title: strings('alert_system.insufficient_pay_token_balance.message'),
+          message: strings(
+            'alert_system.insufficient_pay_token_balance_fees_no_target.message',
+            { amount: '$1.21' },
+          ),
+          severity: Severity.Danger,
+        },
+      ]);
+    });
+
     it('returns alert if pay token balance is less than source amount plus source network', () => {
       useTransactionPayTokenMock.mockReturnValue({
         payToken: {

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
@@ -83,7 +83,10 @@ export function useInsufficientPayTokenBalanceAlert({
 
   const targetAmountUsd = useMemo(() => {
     const shortfall = totalSourceAmountUsd.minus(balanceUsd ?? '0');
-    return formatFiat(totalAmountUsd.minus(shortfall));
+    const targetUsdValue = totalAmountUsd.minus(shortfall);
+    const targetUsd = formatFiat(targetUsdValue);
+
+    return targetUsdValue.isLessThanOrEqualTo(0) ? undefined : targetUsd;
   }, [balanceUsd, formatFiat, totalAmountUsd, totalSourceAmountUsd]);
 
   const totalSourceNetworkFeeRaw = useMemo(
@@ -141,10 +144,14 @@ export function useInsufficientPayTokenBalanceAlert({
           ...baseAlert,
           key: AlertKeys.InsufficientPayTokenFees,
           title: strings('alert_system.insufficient_pay_token_balance.message'),
-          message: strings(
-            'alert_system.insufficient_pay_token_balance_fees.message',
-            { amount: targetAmountUsd },
-          ),
+          message: targetAmountUsd
+            ? strings(
+                'alert_system.insufficient_pay_token_balance_fees.message',
+                { amount: targetAmountUsd },
+              )
+            : strings(
+                'alert_system.insufficient_pay_token_balance_fees_no_target.message',
+              ),
         },
       ];
     }

--- a/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.ts
@@ -1,33 +1,26 @@
 import { merge } from 'lodash';
 import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
-import { useTokensWithBalance } from '../../../../UI/Bridge/hooks/useTokensWithBalance';
 import { useAutomaticTransactionPayToken } from './useAutomaticTransactionPayToken';
 import { useTransactionPayToken } from './useTransactionPayToken';
 import { simpleSendTransactionControllerMock } from '../../__mocks__/controllers/transaction-controller-mock';
 import { transactionApprovalControllerMock } from '../../__mocks__/controllers/approval-controller-mock';
-import { selectEnabledSourceChains } from '../../../../../core/redux/slices/bridge';
-import { NATIVE_TOKEN_ADDRESS } from '../../constants/tokens';
 import { isHardwareAccount } from '../../../../../util/address';
 import { TransactionType } from '@metamask/transaction-controller';
 import { TransactionPayRequiredToken } from '@metamask/transaction-pay-controller';
 import { Hex } from '@metamask/utils';
 import { useTransactionPayRequiredTokens } from './useTransactionPayData';
+import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
+import { AssetType } from '../../types/token';
 
 jest.mock('./useTransactionPayToken');
-jest.mock('../../../../UI/Bridge/hooks/useTokensWithBalance');
 jest.mock('../../../../../util/address');
 jest.mock('../../../../../selectors/transactionPayController');
 jest.mock('./useTransactionPayData');
-
-jest.mock('../../../../../core/redux/slices/bridge', () => ({
-  ...jest.requireActual('../../../../../core/redux/slices/bridge'),
-  selectEnabledSourceChains: jest.fn(),
-}));
+jest.mock('./useTransactionPayAvailableTokens');
 
 const TOKEN_ADDRESS_1_MOCK = '0x1234567890abcdef1234567890abcdef12345678';
 const TOKEN_ADDRESS_2_MOCK = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
 const TOKEN_ADDRESS_3_MOCK = '0xabc1234567890abcdef1234567890abcdef12345678';
-const REQUIRED_BALANCE_MOCK = 10;
 const CHAIN_ID_1_MOCK = '0x1';
 const CHAIN_ID_2_MOCK = '0x2';
 
@@ -61,8 +54,9 @@ function runHook({ disable = false } = {}) {
 
 describe('useAutomaticTransactionPayToken', () => {
   const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
-  const useTokensWithBalanceMock = jest.mocked(useTokensWithBalance);
-  const selectEnabledSourceChainsMock = jest.mocked(selectEnabledSourceChains);
+  const useTransactionPayAvailableTokensMock = jest.mocked(
+    useTransactionPayAvailableTokens,
+  );
   const isHardwareAccountMock = jest.mocked(isHardwareAccount);
   const useTransactionPayRequiredTokensMock = jest.mocked(
     useTransactionPayRequiredTokens,
@@ -75,8 +69,6 @@ describe('useAutomaticTransactionPayToken', () => {
   beforeEach(() => {
     jest.resetAllMocks();
 
-    selectEnabledSourceChainsMock.mockReturnValue([]);
-
     useTransactionPayTokenMock.mockReturnValue({
       payToken: undefined,
       setPayToken: setPayTokenMock,
@@ -85,6 +77,7 @@ describe('useAutomaticTransactionPayToken', () => {
     useTransactionPayRequiredTokensMock.mockReturnValue([
       {
         address: TOKEN_ADDRESS_1_MOCK as Hex,
+        chainId: CHAIN_ID_1_MOCK as Hex,
       } as TransactionPayRequiredToken,
     ]);
 
@@ -92,23 +85,20 @@ describe('useAutomaticTransactionPayToken', () => {
   });
 
   it('selects target token if has balance', () => {
-    useTokensWithBalanceMock.mockReturnValue([
-      {
-        address: TOKEN_ADDRESS_1_MOCK,
-        chainId: CHAIN_ID_1_MOCK,
-        tokenFiatAmount: REQUIRED_BALANCE_MOCK,
-      },
+    useTransactionPayAvailableTokensMock.mockReturnValue([
       {
         address: TOKEN_ADDRESS_2_MOCK,
         chainId: CHAIN_ID_1_MOCK,
-        tokenFiatAmount: REQUIRED_BALANCE_MOCK + 10,
       },
       {
         address: TOKEN_ADDRESS_3_MOCK,
         chainId: CHAIN_ID_2_MOCK,
-        tokenFiatAmount: REQUIRED_BALANCE_MOCK + 20,
       },
-    ] as unknown as ReturnType<typeof useTokensWithBalance>);
+      {
+        address: TOKEN_ADDRESS_1_MOCK,
+        chainId: CHAIN_ID_1_MOCK,
+      },
+    ] as AssetType[]);
 
     runHook();
 
@@ -119,33 +109,20 @@ describe('useAutomaticTransactionPayToken', () => {
   });
 
   it('selects token with highest balance on same chain if insufficient balance on target token', () => {
-    useTokensWithBalanceMock.mockReturnValue([
-      {
-        address: TOKEN_ADDRESS_1_MOCK,
-        chainId: CHAIN_ID_1_MOCK,
-        tokenFiatAmount: 0,
-      },
-      {
-        address: TOKEN_ADDRESS_2_MOCK,
-        chainId: CHAIN_ID_1_MOCK,
-        tokenFiatAmount: REQUIRED_BALANCE_MOCK + 5,
-      },
-      {
-        address: TOKEN_ADDRESS_3_MOCK,
-        chainId: CHAIN_ID_1_MOCK,
-        tokenFiatAmount: REQUIRED_BALANCE_MOCK + 10,
-      },
+    useTransactionPayAvailableTokensMock.mockReturnValue([
       {
         address: TOKEN_ADDRESS_3_MOCK,
         chainId: CHAIN_ID_2_MOCK,
-        tokenFiatAmount: REQUIRED_BALANCE_MOCK + 20,
       },
       {
-        address: NATIVE_TOKEN_ADDRESS,
-        chainId: CHAIN_ID_1_MOCK,
-        tokenFiatAmount: 1,
+        address: TOKEN_ADDRESS_2_MOCK,
+        chainId: CHAIN_ID_2_MOCK,
       },
-    ] as unknown as ReturnType<typeof useTokensWithBalance>);
+      {
+        address: TOKEN_ADDRESS_3_MOCK,
+        chainId: CHAIN_ID_1_MOCK,
+      },
+    ] as AssetType[]);
 
     runHook();
 
@@ -156,38 +133,16 @@ describe('useAutomaticTransactionPayToken', () => {
   });
 
   it('selects token with highest balance on alternate chain if insufficient balance on same chain', () => {
-    useTokensWithBalanceMock.mockReturnValue([
-      {
-        address: TOKEN_ADDRESS_1_MOCK,
-        chainId: CHAIN_ID_1_MOCK,
-        tokenFiatAmount: 0,
-      },
-      {
-        address: TOKEN_ADDRESS_2_MOCK,
-        chainId: CHAIN_ID_1_MOCK,
-        tokenFiatAmount: 0,
-      },
-      {
-        address: TOKEN_ADDRESS_1_MOCK,
-        chainId: CHAIN_ID_2_MOCK,
-        tokenFiatAmount: REQUIRED_BALANCE_MOCK + 10,
-      },
+    useTransactionPayAvailableTokensMock.mockReturnValue([
       {
         address: TOKEN_ADDRESS_3_MOCK,
         chainId: CHAIN_ID_2_MOCK,
-        tokenFiatAmount: REQUIRED_BALANCE_MOCK + 20,
       },
       {
-        address: NATIVE_TOKEN_ADDRESS,
-        chainId: CHAIN_ID_1_MOCK,
-        tokenFiatAmount: 0,
-      },
-      {
-        address: NATIVE_TOKEN_ADDRESS,
+        address: TOKEN_ADDRESS_2_MOCK,
         chainId: CHAIN_ID_2_MOCK,
-        tokenFiatAmount: 1,
       },
-    ] as unknown as ReturnType<typeof useTokensWithBalance>);
+    ] as AssetType[]);
 
     runHook();
 
@@ -198,28 +153,7 @@ describe('useAutomaticTransactionPayToken', () => {
   });
 
   it('selects target token if insufficient balance on all chains', () => {
-    useTokensWithBalanceMock.mockReturnValue([
-      {
-        address: TOKEN_ADDRESS_1_MOCK,
-        chainId: CHAIN_ID_1_MOCK,
-        tokenFiatAmount: REQUIRED_BALANCE_MOCK - 1,
-      },
-      {
-        address: TOKEN_ADDRESS_2_MOCK,
-        chainId: CHAIN_ID_2_MOCK,
-        tokenFiatAmount: REQUIRED_BALANCE_MOCK - 1,
-      },
-      {
-        address: NATIVE_TOKEN_ADDRESS,
-        chainId: CHAIN_ID_1_MOCK,
-        tokenFiatAmount: 1,
-      },
-      {
-        address: NATIVE_TOKEN_ADDRESS,
-        chainId: CHAIN_ID_2_MOCK,
-        tokenFiatAmount: 1,
-      },
-    ] as unknown as ReturnType<typeof useTokensWithBalance>);
+    useTransactionPayAvailableTokensMock.mockReturnValue([]);
 
     runHook();
 
@@ -230,19 +164,7 @@ describe('useAutomaticTransactionPayToken', () => {
   });
 
   it('does nothing if no required tokens', () => {
-    useTokensWithBalanceMock.mockReturnValue([
-      {
-        address: TOKEN_ADDRESS_1_MOCK,
-        chainId: CHAIN_ID_1_MOCK,
-        tokenFiatAmount: REQUIRED_BALANCE_MOCK,
-      },
-      {
-        address: TOKEN_ADDRESS_2_MOCK,
-        chainId: CHAIN_ID_2_MOCK,
-        tokenFiatAmount: REQUIRED_BALANCE_MOCK,
-      },
-    ] as unknown as ReturnType<typeof useTokensWithBalance>);
-
+    useTransactionPayAvailableTokensMock.mockReturnValue([]);
     useTransactionPayRequiredTokensMock.mockReturnValue([]);
 
     runHook();
@@ -250,81 +172,21 @@ describe('useAutomaticTransactionPayToken', () => {
     expect(setPayTokenMock).not.toHaveBeenCalled();
   });
 
-  it('does not select token if no native balance on chain', () => {
-    useTokensWithBalanceMock.mockReturnValue([
-      {
-        address: TOKEN_ADDRESS_1_MOCK,
-        chainId: CHAIN_ID_1_MOCK,
-        tokenFiatAmount: REQUIRED_BALANCE_MOCK - 1,
-      },
+  it('selects target token if hardware wallet', () => {
+    useTransactionPayAvailableTokensMock.mockReturnValue([
       {
         address: TOKEN_ADDRESS_2_MOCK,
         chainId: CHAIN_ID_1_MOCK,
-        tokenFiatAmount: REQUIRED_BALANCE_MOCK + 5,
-      },
-      {
-        address: TOKEN_ADDRESS_3_MOCK,
-        chainId: CHAIN_ID_1_MOCK,
-        tokenFiatAmount: REQUIRED_BALANCE_MOCK + 10,
-      },
-      {
-        address: TOKEN_ADDRESS_3_MOCK,
-        chainId: CHAIN_ID_2_MOCK,
-        tokenFiatAmount: REQUIRED_BALANCE_MOCK + 20,
-      },
-      {
-        address: NATIVE_TOKEN_ADDRESS,
-        chainId: CHAIN_ID_1_MOCK,
-        tokenFiatAmount: 0,
-      },
-      {
-        address: NATIVE_TOKEN_ADDRESS,
-        chainId: CHAIN_ID_2_MOCK,
-        tokenFiatAmount: 1,
-      },
-    ] as unknown as ReturnType<typeof useTokensWithBalance>);
-
-    runHook();
-
-    expect(setPayTokenMock).toHaveBeenCalledWith({
-      address: TOKEN_ADDRESS_3_MOCK,
-      chainId: CHAIN_ID_2_MOCK,
-    });
-  });
-
-  it('always selects target token if hardware wallet', () => {
-    useTokensWithBalanceMock.mockReturnValue([
-      {
-        address: TOKEN_ADDRESS_1_MOCK,
-        chainId: CHAIN_ID_1_MOCK,
-        tokenFiatAmount: REQUIRED_BALANCE_MOCK - 1,
-      },
-      {
-        address: TOKEN_ADDRESS_2_MOCK,
-        chainId: CHAIN_ID_1_MOCK,
-        tokenFiatAmount: REQUIRED_BALANCE_MOCK - 2,
       },
       {
         address: TOKEN_ADDRESS_1_MOCK,
         chainId: CHAIN_ID_2_MOCK,
-        tokenFiatAmount: REQUIRED_BALANCE_MOCK + 10,
       },
       {
         address: TOKEN_ADDRESS_3_MOCK,
         chainId: CHAIN_ID_2_MOCK,
-        tokenFiatAmount: REQUIRED_BALANCE_MOCK + 20,
       },
-      {
-        address: NATIVE_TOKEN_ADDRESS,
-        chainId: CHAIN_ID_1_MOCK,
-        tokenFiatAmount: 1,
-      },
-      {
-        address: NATIVE_TOKEN_ADDRESS,
-        chainId: CHAIN_ID_2_MOCK,
-        tokenFiatAmount: 1,
-      },
-    ] as unknown as ReturnType<typeof useTokensWithBalance>);
+    ] as AssetType[]);
 
     isHardwareAccountMock.mockReturnValue(true);
 
@@ -336,53 +198,13 @@ describe('useAutomaticTransactionPayToken', () => {
     });
   });
 
-  it('returns number of tokens with balance', () => {
-    useTokensWithBalanceMock.mockReturnValue([
-      {
-        address: TOKEN_ADDRESS_1_MOCK,
-        chainId: CHAIN_ID_1_MOCK,
-        tokenFiatAmount: REQUIRED_BALANCE_MOCK - 1,
-      },
-      {
-        address: TOKEN_ADDRESS_2_MOCK,
-        chainId: CHAIN_ID_1_MOCK,
-        tokenFiatAmount: REQUIRED_BALANCE_MOCK - 2,
-      },
-      {
-        address: TOKEN_ADDRESS_1_MOCK,
-        chainId: CHAIN_ID_2_MOCK,
-        tokenFiatAmount: REQUIRED_BALANCE_MOCK + 10,
-      },
-      {
-        address: TOKEN_ADDRESS_3_MOCK,
-        chainId: CHAIN_ID_2_MOCK,
-        tokenFiatAmount: REQUIRED_BALANCE_MOCK + 20,
-      },
-      {
-        address: NATIVE_TOKEN_ADDRESS,
-        chainId: CHAIN_ID_1_MOCK,
-        tokenFiatAmount: 1,
-      },
-      {
-        address: NATIVE_TOKEN_ADDRESS,
-        chainId: CHAIN_ID_2_MOCK,
-        tokenFiatAmount: 1,
-      },
-    ] as unknown as ReturnType<typeof useTokensWithBalance>);
-
-    const { result } = runHook();
-
-    expect(result.current.count).toBe(6);
-  });
-
   it('selected nothing if disabled', () => {
-    useTokensWithBalanceMock.mockReturnValue([
+    useTransactionPayAvailableTokensMock.mockReturnValue([
       {
         address: TOKEN_ADDRESS_1_MOCK,
         chainId: CHAIN_ID_1_MOCK,
-        tokenFiatAmount: REQUIRED_BALANCE_MOCK,
       },
-    ] as unknown as ReturnType<typeof useTokensWithBalance>);
+    ] as AssetType[]);
 
     runHook({ disable: true });
 

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayMetrics.test.ts
@@ -14,7 +14,6 @@ import { useTransactionPayToken } from './useTransactionPayToken';
 import { act } from '@testing-library/react-native';
 import { updateConfirmationMetric } from '../../../../../core/redux/slices/confirmationMetrics';
 import { TransactionType } from '@metamask/transaction-controller';
-import { useAutomaticTransactionPayToken } from './useAutomaticTransactionPayToken';
 import {
   TransactionPayQuote,
   TransactionPayRequiredToken,
@@ -26,12 +25,14 @@ import {
   useTransactionPayRequiredTokens,
   useTransactionPayTotals,
 } from './useTransactionPayData';
+import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
+import { AssetType } from '../../types/token';
 
 jest.mock('./useTransactionPayToken');
-jest.mock('./useAutomaticTransactionPayToken');
 jest.mock('../useTokenAmount');
 jest.mock('../../../../../selectors/transactionPayController');
 jest.mock('../pay/useTransactionPayData');
+jest.mock('./useTransactionPayAvailableTokens');
 
 jest.mock('../../../../../core/redux/slices/confirmationMetrics', () => ({
   ...jest.requireActual('../../../../../core/redux/slices/confirmationMetrics'),
@@ -76,12 +77,13 @@ describe('useTransactionPayMetrics', () => {
   const updateConfirmationMetricMock = jest.mocked(updateConfirmationMetric);
   const useTransactionPayQuotesMock = jest.mocked(useTransactionPayQuotes);
   const useTransactionPayTotalsMock = jest.mocked(useTransactionPayTotals);
+
   const useTransactionPayRequiredTokensMock = jest.mocked(
     useTransactionPayRequiredTokens,
   );
 
-  const useAutomaticTransactionPayTokenMock = jest.mocked(
-    useAutomaticTransactionPayToken,
+  const useTransactionPayAvailableTokensMock = jest.mocked(
+    useTransactionPayAvailableTokens,
   );
 
   beforeEach(() => {
@@ -104,9 +106,13 @@ describe('useTransactionPayMetrics', () => {
 
     useTransactionPayQuotesMock.mockReturnValue([]);
 
-    useAutomaticTransactionPayTokenMock.mockReturnValue({
-      count: 5,
-    });
+    useTransactionPayAvailableTokensMock.mockReturnValue([
+      {},
+      {},
+      {},
+      {},
+      {},
+    ] as AssetType[]);
   });
 
   it('does not update metrics if no pay token selected', async () => {

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
@@ -6,6 +6,7 @@ import Engine from '../../../../../core/Engine';
 import { selectTransactionPaymentTokenByTransactionId } from '../../../../../selectors/transactionPayController';
 import { Hex } from '@metamask/utils';
 import { noop } from 'lodash';
+import EngineService from '../../../../../core/EngineService';
 
 export function useTransactionPayToken() {
   const { id: transactionId } = useTransactionMetadataRequest() || { id: '' };
@@ -33,6 +34,8 @@ export function useTransactionPayToken() {
           tokenAddress: newPayToken.address,
           chainId: newPayToken.chainId,
         });
+
+        EngineService.flushState();
       } catch (e) {
         console.error('Error updating payment token', e);
       }

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
@@ -5,6 +5,7 @@ import { RootState } from '../../../../../reducers';
 import Engine from '../../../../../core/Engine';
 import { selectTransactionPaymentTokenByTransactionId } from '../../../../../selectors/transactionPayController';
 import { Hex } from '@metamask/utils';
+import { noop } from 'lodash';
 
 export function useTransactionPayToken() {
   const { id: transactionId } = useTransactionMetadataRequest() || { id: '' };
@@ -14,7 +15,7 @@ export function useTransactionPayToken() {
   );
 
   const setPayToken = useCallback(
-    async (newPayToken: { address: Hex; chainId: Hex }) => {
+    (newPayToken: { address: Hex; chainId: Hex }) => {
       const { GasFeeController, NetworkController, TransactionPayController } =
         Engine.context;
 
@@ -22,9 +23,9 @@ export function useTransactionPayToken() {
         newPayToken.chainId,
       );
 
-      await GasFeeController.fetchGasFeeEstimates({
+      GasFeeController.fetchGasFeeEstimates({
         networkClientId,
-      });
+      }).catch(noop);
 
       try {
         TransactionPayController.updatePaymentToken({

--- a/app/components/Views/confirmations/hooks/transactions/useTransferRecipient.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransferRecipient.ts
@@ -51,10 +51,15 @@ function getRecipientByType(
   data: string,
   transactionTo: string,
 ): string | undefined {
-  const dataRecipient = getTransactionDataRecipient(data);
-  const paramsRecipient = transactionTo;
-
-  return type === TransactionType.simpleSend ? paramsRecipient : dataRecipient;
+  switch (type) {
+    case TransactionType.simpleSend:
+      return transactionTo;
+    case TransactionType.tokenMethodTransfer:
+    case TransactionType.tokenMethodTransferFrom:
+      return getTransactionDataRecipient(data);
+    default:
+      return undefined;
+  }
 }
 
 function getTransactionDataRecipient(data: string): string | undefined {

--- a/app/components/Views/confirmations/hooks/useTokenAmount.ts
+++ b/app/components/Views/confirmations/hooks/useTokenAmount.ts
@@ -32,7 +32,7 @@ import { ERC20_DEFAULT_DECIMALS, fetchErc20Decimals } from '../utils/token';
 import { parseStandardTokenTransactionData } from '../utils/transaction';
 import { useTransactionMetadataOrThrow } from './transactions/useTransactionMetadataRequest';
 import useNetworkInfo from './useNetworkInfo';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { updateEditableParams } from '../../../../util/transaction-controller';
 import { selectTokensByChainIdAndAddress } from '../../../../selectors/tokensController';
 import { getTokenTransferData } from '../utils/transaction-pay';
@@ -130,7 +130,11 @@ export const useTokenAmount = ({
     networkClientId,
   );
 
-  const transactionData = parseStandardTokenTransactionData(tokenData?.data);
+  const transactionData = useMemo(
+    () => parseStandardTokenTransactionData(tokenData?.data),
+    [tokenData?.data],
+  );
+
   const recipient = transactionData?.args?._to;
 
   const updateTokenAmount = useCallback(

--- a/app/core/EngineService/EngineService.ts
+++ b/app/core/EngineService/EngineService.ts
@@ -83,6 +83,10 @@ export class EngineService {
         Logger.log('keyringController vault missing for UPDATE_BG_STATE_KEY');
       }
       this.updateBatcher.add(controllerName);
+
+      if (controllerName === 'ApprovalController') {
+        this.updateBatcher.flush();
+      }
     };
 
     BACKGROUND_STATE_CHANGE_EVENT_NAMES.forEach((eventName) => {
@@ -176,6 +180,14 @@ export class EngineService {
     }
     endTrace({ name: TraceName.EngineInitialization });
   };
+
+  /**
+   * Flush any pending controller state updates.
+   * Only necessary in rare cases where immediate state consistency is required.
+   */
+  flushState() {
+    this.updateBatcher.flush();
+  }
 
   /**
    * Sets up persistence subscriptions for all engine controllers.

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -86,6 +86,9 @@
       "message": "Add less than {{amount}} or use a different token.",
       "title": "Insufficient funds"
     },
+    "insufficient_pay_token_balance_fees_no_target": {
+      "message": "Add less or use a different token."
+    },
     "insufficient_pay_token_native": {
       "message": "Not enough {{ticker}} to cover fees. Use a token on another network or add more {{ticker}} to continue.",
       "title": "Insufficient funds"

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "@scure/bip32": "1.7.0",
     "@metamask/snaps-sdk": "^10.0.0",
     "react-native@0.76.9": "patch:react-native@npm%3A0.76.9#./.yarn/patches/react-native-npm-0.76.9-1c25352097.patch",
-    "@metamask/transaction-controller@npm:^62.0.0": "patch:@metamask/transaction-controller@npm%3A62.0.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch"
+    "@metamask/transaction-controller@npm:^62.1.0": "patch:@metamask/transaction-controller@npm%3A62.1.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch"
   },
   "dependencies": {
     "@config-plugins/detox": "^9.0.0",
@@ -286,7 +286,7 @@
     "@metamask/swappable-obj-proxy": "^2.1.0",
     "@metamask/swaps-controller": "^15.0.0",
     "@metamask/token-search-discovery-controller": "^4.0.0",
-    "@metamask/transaction-controller": "npm:@metamask-previews/transaction-controller@62.0.0-preview-4ed214fa",
+    "@metamask/transaction-controller": "patch:@metamask/transaction-controller@npm%3A62.1.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch",
     "@metamask/transaction-pay-controller": "^10.0.0",
     "@metamask/tron-wallet-snap": "^1.9.1",
     "@metamask/utils": "^11.8.1",

--- a/package.json
+++ b/package.json
@@ -286,7 +286,7 @@
     "@metamask/swappable-obj-proxy": "^2.1.0",
     "@metamask/swaps-controller": "^15.0.0",
     "@metamask/token-search-discovery-controller": "^4.0.0",
-    "@metamask/transaction-controller": "patch:@metamask/transaction-controller@npm%3A62.0.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch",
+    "@metamask/transaction-controller": "npm:@metamask-previews/transaction-controller@62.0.0-preview-4ed214fa",
     "@metamask/transaction-pay-controller": "^10.0.0",
     "@metamask/tron-wallet-snap": "^1.9.1",
     "@metamask/utils": "^11.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9227,9 +9227,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:@metamask-previews/transaction-controller@62.0.0-preview-4ed214fa":
-  version: 62.0.0-preview-4ed214fa
-  resolution: "@metamask-previews/transaction-controller@npm:62.0.0-preview-4ed214fa"
+"@metamask/transaction-controller@npm:62.1.0":
+  version: 62.1.0
+  resolution: "@metamask/transaction-controller@npm:62.1.0"
   dependencies:
     "@ethereumjs/common": "npm:^4.4.0"
     "@ethereumjs/tx": "npm:^5.4.0"
@@ -9261,7 +9261,7 @@ __metadata:
     "@metamask/gas-fee-controller": ^26.0.0
     "@metamask/network-controller": ^26.0.0
     "@metamask/remote-feature-flag-controller": ^2.0.0
-  checksum: 10/606e0f6a4443c956c67485dca101ccc8c3216a6c125b4d4b01b0a8ebec87648c15d68b9fbb5ff2a3e2f3a9075eda0deffd4f064f4c5446ff5a6bf519a2d49a32
+  checksum: 10/2de5d4f36e2b5ddf5cee14a17484d0694fc7dd81bb568a51c712fde9eb0ab8395cae49efa66d5a9daefa86a2429e09561445e6dddc0281e9e645364a9aeeffed
   languageName: node
   linkType: hard
 
@@ -9300,6 +9300,44 @@ __metadata:
     "@metamask/network-controller": ^25.0.0
     "@metamask/remote-feature-flag-controller": ^2.0.0
   checksum: 10/99bbf130b33d0c8f241d2d79006281a2ddc5910ee0b0d6efa806339533ed191430013c1eb29de082b89f002ee0cfd33626b39fbd9cff77a5fe79731e258f47d3
+  languageName: node
+  linkType: hard
+
+"@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A62.1.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch":
+  version: 62.1.0
+  resolution: "@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A62.1.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch::version=62.1.0&hash=1a3342"
+  dependencies:
+    "@ethereumjs/common": "npm:^4.4.0"
+    "@ethereumjs/tx": "npm:^5.4.0"
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@ethersproject/wallet": "npm:^5.7.0"
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/controller-utils": "npm:^11.16.0"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/nonce-tracker": "npm:^6.0.0"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/utils": "npm:^11.8.1"
+    async-mutex: "npm:^0.5.0"
+    bignumber.js: "npm:^9.1.2"
+    bn.js: "npm:^5.2.1"
+    eth-method-registry: "npm:^4.0.0"
+    fast-json-patch: "npm:^3.1.1"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^8.3.2"
+  peerDependencies:
+    "@babel/runtime": ^7.0.0
+    "@metamask/accounts-controller": ^35.0.0
+    "@metamask/approval-controller": ^8.0.0
+    "@metamask/eth-block-tracker": ">=9"
+    "@metamask/gas-fee-controller": ^26.0.0
+    "@metamask/network-controller": ^26.0.0
+    "@metamask/remote-feature-flag-controller": ^2.0.0
+  checksum: 10/f21f02550da1230a7e0f51ebd5a828d7cbbdfbb5d5d036ecb3e5f7d903b8dff15fb5627b675fd477f158a52722ab1daa23a103bef47be08f4a96391a7fa4dcda
   languageName: node
   linkType: hard
 
@@ -35354,7 +35392,7 @@ __metadata:
     "@metamask/test-dapp-multichain": "npm:^0.17.1"
     "@metamask/test-dapp-solana": "npm:^0.3.0"
     "@metamask/token-search-discovery-controller": "npm:^4.0.0"
-    "@metamask/transaction-controller": "npm:@metamask-previews/transaction-controller@62.0.0-preview-4ed214fa"
+    "@metamask/transaction-controller": "patch:@metamask/transaction-controller@npm%3A62.1.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch"
     "@metamask/transaction-pay-controller": "npm:^10.0.0"
     "@metamask/tron-wallet-snap": "npm:^1.9.1"
     "@metamask/utils": "npm:^11.8.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9227,9 +9227,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:62.0.0":
-  version: 62.0.0
-  resolution: "@metamask/transaction-controller@npm:62.0.0"
+"@metamask/transaction-controller@npm:@metamask-previews/transaction-controller@62.0.0-preview-4ed214fa":
+  version: 62.0.0-preview-4ed214fa
+  resolution: "@metamask-previews/transaction-controller@npm:62.0.0-preview-4ed214fa"
   dependencies:
     "@ethereumjs/common": "npm:^4.4.0"
     "@ethereumjs/tx": "npm:^5.4.0"
@@ -9261,7 +9261,7 @@ __metadata:
     "@metamask/gas-fee-controller": ^26.0.0
     "@metamask/network-controller": ^26.0.0
     "@metamask/remote-feature-flag-controller": ^2.0.0
-  checksum: 10/885217c920c29e953aec06c5d9e21ecd58847d5593e9e1f60a3e8e52f7de7869a087797cdf60c5022f12f0c87822b19c860c4ec7a9df1b2a0f140c7dfdaa25e3
+  checksum: 10/606e0f6a4443c956c67485dca101ccc8c3216a6c125b4d4b01b0a8ebec87648c15d68b9fbb5ff2a3e2f3a9075eda0deffd4f064f4c5446ff5a6bf519a2d49a32
   languageName: node
   linkType: hard
 
@@ -9300,44 +9300,6 @@ __metadata:
     "@metamask/network-controller": ^25.0.0
     "@metamask/remote-feature-flag-controller": ^2.0.0
   checksum: 10/99bbf130b33d0c8f241d2d79006281a2ddc5910ee0b0d6efa806339533ed191430013c1eb29de082b89f002ee0cfd33626b39fbd9cff77a5fe79731e258f47d3
-  languageName: node
-  linkType: hard
-
-"@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A62.0.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch":
-  version: 62.0.0
-  resolution: "@metamask/transaction-controller@patch:@metamask/transaction-controller@npm%3A62.0.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch::version=62.0.0&hash=1a3342"
-  dependencies:
-    "@ethereumjs/common": "npm:^4.4.0"
-    "@ethereumjs/tx": "npm:^5.4.0"
-    "@ethereumjs/util": "npm:^9.1.0"
-    "@ethersproject/abi": "npm:^5.7.0"
-    "@ethersproject/contracts": "npm:^5.7.0"
-    "@ethersproject/providers": "npm:^5.7.0"
-    "@ethersproject/wallet": "npm:^5.7.0"
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.16.0"
-    "@metamask/eth-query": "npm:^4.0.0"
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/nonce-tracker": "npm:^6.0.0"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/utils": "npm:^11.8.1"
-    async-mutex: "npm:^0.5.0"
-    bignumber.js: "npm:^9.1.2"
-    bn.js: "npm:^5.2.1"
-    eth-method-registry: "npm:^4.0.0"
-    fast-json-patch: "npm:^3.1.1"
-    lodash: "npm:^4.17.21"
-    uuid: "npm:^8.3.2"
-  peerDependencies:
-    "@babel/runtime": ^7.0.0
-    "@metamask/accounts-controller": ^35.0.0
-    "@metamask/approval-controller": ^8.0.0
-    "@metamask/eth-block-tracker": ">=9"
-    "@metamask/gas-fee-controller": ^26.0.0
-    "@metamask/network-controller": ^26.0.0
-    "@metamask/remote-feature-flag-controller": ^2.0.0
-  checksum: 10/9caf3dfa6d88dded658f7902e42c8c20b6916c21804a8c7f593cf37b88764732738e6379443a1faefed81ea0d58f4fbac269c85fc240fa98a61f7551ec7465c9
   languageName: node
   linkType: hard
 
@@ -35392,7 +35354,7 @@ __metadata:
     "@metamask/test-dapp-multichain": "npm:^0.17.1"
     "@metamask/test-dapp-solana": "npm:^0.3.0"
     "@metamask/token-search-discovery-controller": "npm:^4.0.0"
-    "@metamask/transaction-controller": "patch:@metamask/transaction-controller@npm%3A62.0.0#~/.yarn/patches/@metamask-transaction-controller-npm-61.0.0-cccac388c7.patch"
+    "@metamask/transaction-controller": "npm:@metamask-previews/transaction-controller@62.0.0-preview-4ed214fa"
     "@metamask/transaction-pay-controller": "npm:^10.0.0"
     "@metamask/tron-wallet-snap": "npm:^1.9.1"
     "@metamask/utils": "npm:^11.8.1"


### PR DESCRIPTION
## **Description**

Reduce loading time when starting Perps and Predict deposit confirmations.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [#6162](https://github.com/MetaMask/MetaMask-planning/issues/6162) [#6165](https://github.com/MetaMask/MetaMask-planning/issues/6165)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Speeds up confirmation flows with memoization and streamlined pay-token logic, adds safer Perps/Predict transaction options, updates alerts/UI, and bumps transaction-controller.
> 
> - **Confirmations/Pay UX & Performance**:
>   - Memoize calculations in `useGasFeeToken`, `useTokenAmount`, and `pay-token-amount` with skeleton fallback; reduce recomputations and unnecessary renders.
>   - Refactor `useAutomaticTransactionPayToken` to use `useTransactionPayAvailableTokens`, simplify selection logic, and remove count-return path; update related tests.
>   - Update `useTransactionPayMetrics` to derive payment token list size from available tokens and drop dependency on automatic selector.
>   - Improve `useTransactionPayToken` by making gas estimate fetch non-blocking and flushing Engine state immediately.
>   - Tighten recipient detection in `useTransferRecipient` to explicit transfer types only.
> - **Perps/Predict Transactions**:
>   - Perps deposit: add `skipInitialGasEstimate: true` when calling `TransactionController.addTransaction`; test updated.
>   - Predict deposit: add `disableUpgrade: true` and `skipInitialGasEstimate: true` to `addTransactionBatch` options; tests updated.
>   - Safe utils: mark generated proxy/allowance/claim transactions as `TransactionType.contractInteraction`.
> - **Alerts & Localization**:
>   - `useInsufficientPayTokenBalanceAlert`: handle zero/negative target amounts with alternate copy; add `insufficient_pay_token_balance_fees_no_target` locale string.
> - **Engine**:
>   - `EngineService`: flush Redux updates immediately for `ApprovalController` and expose `flushState()`.
> - **Dependencies**:
>   - Bump `@metamask/transaction-controller` to `62.1.0` (package.json and yarn.lock).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7c039c41135cfafe54118a156f20f548e39fdfd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->