### PR TITLE
fix: add badge to bridge activity list entries cp-7.60.0

### DIFF
--- a/app/components/UI/MultichainBridgeTransactionListItem/MultichainBridgeTransactionListItem.tsx
+++ b/app/components/UI/MultichainBridgeTransactionListItem/MultichainBridgeTransactionListItem.tsx
@@ -69,6 +69,9 @@ const MultichainBridgeTransactionListItem = ({
     const chainId = parseCaipAssetType(
       bridgeHistoryItem.quote.srcAsset.assetId,
     ).chainId;
+    if (!chainId)
+      return <Image source={icon} style={style.icon} resizeMode="stretch" />;
+
     const networkImageSource = getNetworkImageSource({ chainId });
     return (
       <BadgeWrapper

--- a/app/components/UI/MultichainBridgeTransactionListItem/MultichainBridgeTransactionListItem.tsx
+++ b/app/components/UI/MultichainBridgeTransactionListItem/MultichainBridgeTransactionListItem.tsx
@@ -23,6 +23,12 @@ import {
 } from '../Bridge/utils/transaction-history';
 import { ethers } from 'ethers';
 import { formatAmountWithThreshold } from '../../../util/number';
+import BadgeWrapper from '../../../component-library/components/Badges/BadgeWrapper';
+import Badge, {
+  BadgeVariant,
+} from '../../../component-library/components/Badges/Badge';
+import { getNetworkImageSource } from '../../../util/networks';
+import { parseCaipAssetType } from '@metamask/utils';
 
 const MultichainBridgeTransactionListItem = ({
   transaction,
@@ -60,7 +66,22 @@ const MultichainBridgeTransactionListItem = ({
       appTheme,
       osColorScheme,
     );
-    return <Image source={icon} style={style.icon} resizeMode="stretch" />;
+    const chainId = parseCaipAssetType(
+      bridgeHistoryItem.quote.srcAsset.assetId,
+    ).chainId;
+    const networkImageSource = getNetworkImageSource({ chainId });
+    return (
+      <BadgeWrapper
+        badgeElement={
+          <Badge
+            variant={BadgeVariant.Network}
+            imageSource={networkImageSource}
+          />
+        }
+      >
+        <Image source={icon} style={style.icon} resizeMode="stretch" />
+      </BadgeWrapper>
+    );
   };
 
   // Does not apply to swaps


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Fixes bug where bridge transactions didn't have network badges in the activity list

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed bug where bridge transactions didn't have network badges in the activity list

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/22868

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a network badge overlay to bridge transaction icons in the activity list using the source asset’s chain ID.
> 
> - **UI**:
>   - **Bridge Activity List Item (`MultichainBridgeTransactionListItem.tsx`)**:
>     - Wraps transaction icon with `BadgeWrapper` and `Badge` (Network variant) showing the network image.
>     - Derives `chainId` from `quote.srcAsset.assetId` via `parseCaipAssetType` and fetches image with `getNetworkImageSource`.
>     - Falls back to the original icon when `chainId` is unavailable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c538bac9df4ae3a49b52fd282fe5c12d55e4ce48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->