### PR TITLE
fix(predict): cp-7.60.0 fade in gtm modal after image loads

### DIFF
--- a/app/components/UI/Predict/components/PredictGTMModal/PredictGTMModal.tsx
+++ b/app/components/UI/Predict/components/PredictGTMModal/PredictGTMModal.tsx
@@ -1,6 +1,11 @@
 import { useNavigation } from '@react-navigation/native';
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Image, View } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+} from 'react-native-reanimated';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { strings } from '../../../../../../locales/i18n';
 import ButtonBase from '../../../../../component-library/components/Buttons/Button/foundation/ButtonBase';
@@ -33,11 +38,24 @@ const PredictGTMModal = () => {
   const { trackEvent, createEventBuilder } = useMetrics();
   const { navigate } = useNavigation();
   const theme = useTheme();
+  const [imageLoaded, setImageLoaded] = useState(false);
+  const opacity = useSharedValue(0);
 
   const titleText = strings('predict.gtm_content.title');
   const subtitleText = strings('predict.gtm_content.title_description');
 
   const styles = createStyles(theme);
+
+  // Animate content fade-in when image loads
+  useEffect(() => {
+    if (imageLoaded) {
+      opacity.value = withTiming(1, { duration: 500 });
+    }
+  }, [imageLoaded, opacity]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+  }));
 
   const handleClose = async () => {
     await StorageWrapper.setItem(PREDICT_GTM_MODAL_SHOWN, 'true');
@@ -81,9 +99,16 @@ const PredictGTMModal = () => {
   };
 
   return (
-    <View style={styles.pageContainer} testID="predict-gtm-modal-container">
+    <Animated.View
+      style={[styles.pageContainer, animatedStyle]}
+      testID="predict-gtm-modal-container"
+    >
       {/* Background Image - Full Screen */}
-      <Image source={PredictMarketingImage} style={styles.backgroundImage} />
+      <Image
+        source={PredictMarketingImage}
+        style={styles.backgroundImage}
+        onLoad={() => setImageLoaded(true)}
+      />
 
       {/* Content Overlay */}
       <SafeAreaView style={styles.contentContainer}>
@@ -142,7 +167,7 @@ const PredictGTMModal = () => {
           />
         </View>
       </SafeAreaView>
-    </View>
+    </Animated.View>
   );
 };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Currently the GTM modal for Predict looks funky as it seems to render different pieces at different times.
This PR attempts to fix this by introducing two main changes:
- Animate opacity for the whole modals 0 -> 1
- Only start animation when the background image finishes loading

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/a8b61805-9f8a-4518-b37c-7cedf56d806b




### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/41d44fed-56ff-4ec6-b800-867d5530e15f



## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a reanimated opacity fade-in for the Predict GTM modal that starts once the background image finishes loading.
> 
> - **UI/Animation**:
>   - Wraps modal root in `Animated.View` and animates `opacity` from 0→1 with `withTiming`.
>   - Starts animation on background image `onLoad` via `useState` + `useEffect` and `useSharedValue`/`useAnimatedStyle`.
>   - Ensures content appears only after image loads for smoother reveal.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae4bba0357e78420cc51aafb395c893331b76228. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->