### PR TITLE
feat: Add predefined recipient support to send flow

### DIFF
--- a/app/components/UI/AssetOverview/AssetOverview.tsx
+++ b/app/components/UI/AssetOverview/AssetOverview.tsx
@@ -314,7 +314,7 @@ const AssetOverview: React.FC<AssetOverviewProps> = ({
       dispatch(newAssetTransaction(asset));
     }
 
-    navigateToSendPage(InitSendLocation.AssetOverview, asset);
+    navigateToSendPage({ location: InitSendLocation.AssetOverview, asset });
   };
 
   const onBuy = () => {

--- a/app/components/UI/CollectibleModal/CollectibleModal.tsx
+++ b/app/components/UI/CollectibleModal/CollectibleModal.tsx
@@ -83,7 +83,10 @@ const CollectibleModal = () => {
 
   const onSend = useCallback(async () => {
     dispatch(newAssetTransaction({ contractName, ...collectible }));
-    navigateToSendPage(InitSendLocation.CollectibleModal, collectible);
+    navigateToSendPage({
+      location: InitSendLocation.CollectibleModal,
+      asset: collectible,
+    });
   }, [contractName, collectible, dispatch, navigateToSendPage]);
 
   const isTradable = useCallback(

--- a/app/components/Views/NftDetails/NftDetails.tsx
+++ b/app/components/Views/NftDetails/NftDetails.tsx
@@ -189,7 +189,10 @@ const NftDetails = () => {
     dispatch(
       newAssetTransaction({ contractName: collectible.name, ...collectible }),
     );
-    navigateToSendPage(InitSendLocation.NftDetails, collectible);
+    navigateToSendPage({
+      location: InitSendLocation.NftDetails,
+      asset: collectible,
+    });
   }, [collectible, chainId, dispatch, navigateToSendPage]);
 
   const isTradable = useCallback(

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -695,14 +695,14 @@ const Wallet = ({
       }
 
       // Navigate to send flow after successful transaction initialization
-      navigateToSendPage(InitSendLocation.HomePage);
+      navigateToSendPage({ location: InitSendLocation.HomePage });
     } catch (error) {
       // Handle any errors that occur during the send flow initiation
       console.error('Error initiating send flow:', error);
 
       // Still attempt to navigate to maintain user flow, but without transaction initialization
       // The SendFlow view should handle the lack of initialized transaction gracefully
-      navigateToSendPage(InitSendLocation.HomePage);
+      navigateToSendPage({ location: InitSendLocation.HomePage });
     }
   }, [
     trackEvent,

--- a/app/components/Views/confirmations/__mocks__/send.mock.ts
+++ b/app/components/Views/confirmations/__mocks__/send.mock.ts
@@ -34,6 +34,8 @@ export const EVM_NATIVE_ASSET = {
   decimals: 18,
   isNative: true,
   isETH: true,
+  image:
+    'https://upload.wikimedia.org/wikipedia/commons/0/05/Ethereum_logo_2014.svg',
   logo: 'https://upload.wikimedia.org/wikipedia/commons/0/05/Ethereum_logo_2014.svg',
   name: 'Ethereum',
   symbol: 'ETH',

--- a/app/components/Views/confirmations/components/send/amount/amount-keyboard/amount-keyboard.test.tsx
+++ b/app/components/Views/confirmations/components/send/amount/amount-keyboard/amount-keyboard.test.tsx
@@ -203,10 +203,7 @@ describe('Amount', () => {
     mockUseParams.mockReturnValue({
       predefinedRecipient: {
         address: predefinedRecipientAddress,
-        isEvm: true,
-        isBitcoin: false,
-        isSolana: false,
-        isTron: false,
+        chainType: 'evm',
       },
     });
     mockUseSendContext.mockReturnValue({

--- a/app/components/Views/confirmations/components/send/amount/amount-keyboard/amount-keyboard.test.tsx
+++ b/app/components/Views/confirmations/components/send/amount/amount-keyboard/amount-keyboard.test.tsx
@@ -197,7 +197,8 @@ describe('Amount', () => {
 
   it('calls updateTo and handleSubmitPress when predefinedRecipient is provided', () => {
     const mockUpdateTo = jest.fn();
-    const predefinedRecipientAddress = '0x1234567890123456789012345678901234567890';
+    const predefinedRecipientAddress =
+      '0x1234567890123456789012345678901234567890';
 
     mockUseParams.mockReturnValue({
       predefinedRecipient: {

--- a/app/components/Views/confirmations/components/send/amount/amount-keyboard/amount-keyboard.test.tsx
+++ b/app/components/Views/confirmations/components/send/amount/amount-keyboard/amount-keyboard.test.tsx
@@ -16,6 +16,8 @@ import { usePercentageAmount } from '../../../../hooks/send/usePercentageAmount'
 import { useSendContext } from '../../../../context/send-context';
 import { useRouteParams } from '../../../../hooks/send/useRouteParams';
 import { useSendType } from '../../../../hooks/send/useSendType';
+import { useParams } from '../../../../../../../util/navigation/navUtils';
+import { useSendActions } from '../../../../hooks/send/useSendActions';
 // eslint-disable-next-line import/no-namespace
 import * as AmountValidation from '../../../../hooks/send/useAmountValidation';
 import { getBackgroundColor } from './amount-keyboard.styles';
@@ -53,6 +55,14 @@ jest.mock('../../../../hooks/send/useSendType', () => ({
   useSendType: jest.fn(),
 }));
 
+jest.mock('../../../../../../../util/navigation/navUtils', () => ({
+  useParams: jest.fn(),
+}));
+
+jest.mock('../../../../hooks/send/useSendActions', () => ({
+  useSendActions: jest.fn(),
+}));
+
 const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();
 jest.mock('@react-navigation/native', () => ({
@@ -87,6 +97,9 @@ const mockUsePercentageAmount = usePercentageAmount as jest.MockedFunction<
   typeof usePercentageAmount
 >;
 
+const mockUseParams = jest.mocked(useParams);
+const mockUseSendActions = jest.mocked(useSendActions);
+
 const renderComponent = (
   mockState?: ProviderValues['state'],
   amount = '100',
@@ -113,7 +126,10 @@ const renderComponent = (
 
 describe('Amount', () => {
   const mockUseSendType = jest.mocked(useSendType);
+  const mockHandleSubmitPress = jest.fn();
+
   beforeEach(() => {
+    jest.clearAllMocks();
     mockUseSendType.mockReturnValue({
       isNonEvmSendType: false,
     } as unknown as ReturnType<typeof useSendType>);
@@ -121,6 +137,10 @@ describe('Amount', () => {
       getPercentageAmount: () => 10,
       isMaxAmountSupported: true,
     } as unknown as ReturnType<typeof usePercentageAmount>);
+    mockUseParams.mockReturnValue({});
+    mockUseSendActions.mockReturnValue({
+      handleSubmitPress: mockHandleSubmitPress,
+    } as unknown as ReturnType<typeof useSendActions>);
   });
 
   it('renders correctly', () => {
@@ -173,6 +193,35 @@ describe('Amount', () => {
     const { getByText } = renderComponent();
     fireEvent.press(getByText('Continue'));
     expect(mockValidateNonEvmAmountAsync).toHaveBeenCalled();
+  });
+
+  it('calls updateTo and handleSubmitPress when predefinedRecipient is provided', () => {
+    const mockUpdateTo = jest.fn();
+    const predefinedRecipientAddress = '0x1234567890123456789012345678901234567890';
+
+    mockUseParams.mockReturnValue({
+      predefinedRecipient: {
+        address: predefinedRecipientAddress,
+        isEvm: true,
+        isBitcoin: false,
+        isSolana: false,
+        isTron: false,
+      },
+    });
+    mockUseSendContext.mockReturnValue({
+      asset: MOCK_EVM_ASSET,
+      updateAsset: jest.fn(),
+      updateTo: mockUpdateTo,
+    } as unknown as ReturnType<typeof useSendContext>);
+
+    const { getByText } = renderComponent();
+    fireEvent.press(getByText('Continue'));
+
+    expect(mockUpdateTo).toHaveBeenCalledWith(predefinedRecipientAddress);
+    expect(mockHandleSubmitPress).toHaveBeenCalledWith(
+      predefinedRecipientAddress,
+    );
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 });
 

--- a/app/components/Views/confirmations/components/send/amount/amount-keyboard/amount-keyboard.tsx
+++ b/app/components/Views/confirmations/components/send/amount/amount-keyboard/amount-keyboard.tsx
@@ -17,6 +17,7 @@ import { useCurrencyConversions } from '../../../../hooks/send/useCurrencyConver
 import { usePercentageAmount } from '../../../../hooks/send/usePercentageAmount';
 import { useSendType } from '../../../../hooks/send/useSendType';
 import { useSendContext } from '../../../../context/send-context';
+import { type PredefinedRecipient } from '../../../../utils/send';
 import { useSendScreenNavigation } from '../../../../hooks/send/useSendScreenNavigation';
 import { useSendActions } from '../../../../hooks/send/useSendActions';
 import { EditAmountKeyboard } from '../../../edit-amount-keyboard';
@@ -58,9 +59,7 @@ export const AmountKeyboard = ({
     useAmountSelectionMetrics();
 
   const { predefinedRecipient } = useParams<{
-    predefinedRecipient: {
-      address: string;
-    };
+    predefinedRecipient: PredefinedRecipient;
   }>();
 
   const updateToPercentageAmount = useCallback(

--- a/app/components/Views/confirmations/components/send/amount/amount-keyboard/amount-keyboard.tsx
+++ b/app/components/Views/confirmations/components/send/amount/amount-keyboard/amount-keyboard.tsx
@@ -7,6 +7,7 @@ import Button, {
   ButtonVariants,
   ButtonWidthTypes,
 } from '../../../../../../../component-library/components/Buttons/Button';
+import { useParams } from '../../../../../../../util/navigation/navUtils.ts';
 import { useStyles } from '../../../../../../hooks/useStyles';
 import { AssetType, TokenStandard } from '../../../../types/token';
 import { getFractionLength } from '../../../../utils/send.ts';
@@ -17,6 +18,7 @@ import { usePercentageAmount } from '../../../../hooks/send/usePercentageAmount'
 import { useSendType } from '../../../../hooks/send/useSendType';
 import { useSendContext } from '../../../../context/send-context';
 import { useSendScreenNavigation } from '../../../../hooks/send/useSendScreenNavigation';
+import { useSendActions } from '../../../../hooks/send/useSendActions';
 import { EditAmountKeyboard } from '../../../edit-amount-keyboard';
 import { styleSheet } from './amount-keyboard.styles';
 
@@ -44,7 +46,8 @@ export const AmountKeyboard = ({
   const { gotToSendScreen } = useSendScreenNavigation();
   const { isMaxAmountSupported, getPercentageAmount } = usePercentageAmount();
   const { amountError, validateNonEvmAmountAsync } = useAmountValidation();
-  const { asset, updateValue } = useSendContext();
+  const { asset, updateValue, updateTo } = useSendContext();
+  const { handleSubmitPress } = useSendActions();
   const { isNonEvmSendType } = useSendType();
   const isNFT = asset?.standard === TokenStandard.ERC1155;
   const { styles } = useStyles(styleSheet, {
@@ -53,6 +56,12 @@ export const AmountKeyboard = ({
   });
   const { captureAmountSelected, setAmountInputMethodPressedMax } =
     useAmountSelectionMetrics();
+
+  const { predefinedRecipient } = useParams<{
+    predefinedRecipient: {
+      address: string;
+    };
+  }>();
 
   const updateToPercentageAmount = useCallback(
     (percentage: number) => {
@@ -100,12 +109,21 @@ export const AmountKeyboard = ({
       }
     }
     captureAmountSelected();
+    // Skip the recipient screen if a predefined recipient is provided
+    if (predefinedRecipient) {
+      updateTo(predefinedRecipient.address);
+      handleSubmitPress(predefinedRecipient.address);
+      return;
+    }
     gotToSendScreen(Routes.SEND.RECIPIENT);
   }, [
     captureAmountSelected,
     gotToSendScreen,
     isNonEvmSendType,
     validateNonEvmAmountAsync,
+    handleSubmitPress,
+    updateTo,
+    predefinedRecipient,
   ]);
 
   return (

--- a/app/components/Views/confirmations/components/send/amount/amount.test.tsx
+++ b/app/components/Views/confirmations/components/send/amount/amount.test.tsx
@@ -76,7 +76,9 @@ jest.mock('@react-navigation/native', () => ({
     goBack: jest.fn(),
     navigate: jest.fn(),
   }),
-  useRoute: jest.fn(),
+  useRoute: () => ({
+    params: {},
+  }),
 }));
 
 const mockedUseAmountSelectionMetrics = jest.mocked(useAmountSelectionMetrics);

--- a/app/components/Views/confirmations/components/send/asset/asset.test.tsx
+++ b/app/components/Views/confirmations/components/send/asset/asset.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react-native';
 
 import { AssetType, Nft } from '../../../types/token';
-import { useAccountTokens } from '../../../hooks/send/useAccountTokens';
+import { useSendTokens } from '../../../hooks/send/useSendTokens';
 import { useTokenSearch } from '../../../hooks/send/useTokenSearch';
 import { useEVMNfts } from '../../../hooks/send/useNfts';
 import { useAssetSelectionMetrics } from '../../../hooks/send/metrics/useAssetSelectionMetrics';
@@ -66,8 +66,8 @@ const mockNfts: Nft[] = [
   },
 ];
 
-jest.mock('../../../hooks/send/useAccountTokens', () => ({
-  useAccountTokens: jest.fn(),
+jest.mock('../../../hooks/send/useSendTokens', () => ({
+  useSendTokens: jest.fn(),
 }));
 
 jest.mock('../../../hooks/send/useTokenSearch', () => ({
@@ -198,7 +198,7 @@ jest.mock('../../../../../../../locales/i18n', () => ({
   }),
 }));
 
-const mockUseAccountTokens = jest.mocked(useAccountTokens);
+const mockUseSendTokens = jest.mocked(useSendTokens);
 const mockUseTokenSearch = jest.mocked(useTokenSearch);
 const mockUseEVMNfts = jest.mocked(useEVMNfts);
 const mockUseAssetSelectionMetrics = jest.mocked(useAssetSelectionMetrics);
@@ -212,7 +212,7 @@ describe('Asset', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    mockUseAccountTokens.mockReturnValue(mockTokens);
+    mockUseSendTokens.mockReturnValue(mockTokens);
     mockUseEVMNfts.mockReturnValue(mockNfts);
 
     mockUseTokenSearch.mockReturnValue({

--- a/app/components/Views/confirmations/components/send/asset/asset.tsx
+++ b/app/components/Views/confirmations/components/send/asset/asset.tsx
@@ -21,7 +21,7 @@ import { NftList } from '../../nft-list';
 import { AssetType } from '../../../types/token';
 import { NetworkFilter } from '../../network-filter';
 import { useEVMNfts } from '../../../hooks/send/useNfts';
-import { useAccountTokens } from '../../../hooks/send/useAccountTokens';
+import { useSendTokens } from '../../../hooks/send/useSendTokens';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { ScrollView } from 'react-native-gesture-handler';
 
@@ -40,7 +40,7 @@ export const Asset: React.FC<AssetProps> = (props = {}) => {
     tokenFilter,
   } = props;
 
-  const originalTokens = useAccountTokens({ includeNoBalance });
+  const originalTokens = useSendTokens({ includeNoBalance });
 
   const tokens = useMemo(
     () => (tokenFilter ? tokenFilter(originalTokens) : originalTokens),

--- a/app/components/Views/confirmations/hooks/send/useAccountTokens.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useAccountTokens.test.ts
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import { useSelector } from 'react-redux';
 
 import { useAccountTokens } from './useAccountTokens';
-import { useSendScope } from './useSendScope';
+import { useSendType } from './useSendType';
 import { getNetworkBadgeSource } from '../../utils/network';
 import { getIntlNumberFormatter } from '../../../../../util/intl';
 import { TokenStandard } from '../../types/token';
@@ -14,8 +14,8 @@ jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
 }));
 
-jest.mock('./useSendScope', () => ({
-  useSendScope: jest.fn(),
+jest.mock('./useSendType', () => ({
+  useSendType: jest.fn(),
 }));
 
 jest.mock('../../utils/network', () => ({
@@ -44,7 +44,7 @@ jest.mock('../../../../../selectors/currencyRateController', () => ({
 }));
 
 const mockUseSelector = jest.mocked(useSelector);
-const mockUseSendScope = jest.mocked(useSendScope);
+const mockUseSendType = jest.mocked(useSendType);
 const mockGetNetworkBadgeSource = jest.mocked(getNetworkBadgeSource);
 const mockGetIntlNumberFormatter = jest.mocked(getIntlNumberFormatter);
 const mockSelectAssetsBySelectedAccountGroup = jest.mocked(
@@ -103,9 +103,14 @@ describe('useAccountTokens', () => {
       return undefined;
     });
 
-    mockUseSendScope.mockReturnValue({
-      isEvmOnly: false,
-      isSolanaOnly: false,
+    mockUseSendType.mockReturnValue({
+      isEvmSendType: undefined,
+      isEvmNativeSendType: undefined,
+      isNonEvmSendType: undefined,
+      isNonEvmNativeSendType: undefined,
+      isSolanaSendType: undefined,
+      isBitcoinSendType: undefined,
+      isTronSendType: undefined,
     });
     mockGetNetworkBadgeSource.mockReturnValue('network-badge-source');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -133,9 +138,14 @@ describe('useAccountTokens', () => {
 
   describe('when EVM only scope is applied', () => {
     beforeEach(() => {
-      mockUseSendScope.mockReturnValue({
-        isEvmOnly: true,
-        isSolanaOnly: false,
+      mockUseSendType.mockReturnValue({
+        isEvmSendType: true,
+        isEvmNativeSendType: undefined,
+        isNonEvmSendType: undefined,
+        isNonEvmNativeSendType: undefined,
+        isSolanaSendType: undefined,
+        isBitcoinSendType: undefined,
+        isTronSendType: undefined,
       });
     });
 
@@ -150,9 +160,14 @@ describe('useAccountTokens', () => {
 
   describe('when Solana only scope is applied', () => {
     beforeEach(() => {
-      mockUseSendScope.mockReturnValue({
-        isEvmOnly: false,
-        isSolanaOnly: true,
+      mockUseSendType.mockReturnValue({
+        isEvmSendType: undefined,
+        isEvmNativeSendType: undefined,
+        isNonEvmSendType: true,
+        isNonEvmNativeSendType: undefined,
+        isSolanaSendType: true,
+        isBitcoinSendType: undefined,
+        isTronSendType: undefined,
       });
     });
 

--- a/app/components/Views/confirmations/hooks/send/useAccountTokens.ts
+++ b/app/components/Views/confirmations/hooks/send/useAccountTokens.ts
@@ -11,13 +11,13 @@ import I18n from '../../../../../../locales/i18n';
 import { getIntlNumberFormatter } from '../../../../../util/intl';
 import { getNetworkBadgeSource } from '../../utils/network';
 import { AssetType, TokenStandard } from '../../types/token';
-import { useSendScope } from './useSendScope';
+import { useSendType } from './useSendType';
 
 export function useAccountTokens({
   includeNoBalance = false,
 } = {}): AssetType[] {
   const assets = useSelector(selectFilteredAssetsBySelectedAccountGroup);
-  const { isEvmOnly, isSolanaOnly } = useSendScope();
+  const { isEvmSendType, isSolanaSendType } = useSendType();
   const fiatCurrency = useSelector(selectCurrentCurrency);
 
   return useMemo(() => {
@@ -25,11 +25,11 @@ export function useAccountTokens({
 
     let filteredAssets;
 
-    if (isEvmOnly) {
+    if (isEvmSendType) {
       filteredAssets = flatAssets.filter((asset) =>
         asset.accountType.includes('eip155'),
       );
-    } else if (isSolanaOnly) {
+    } else if (isSolanaSendType) {
       filteredAssets = flatAssets.filter((asset) =>
         asset.accountType.includes('solana'),
       );
@@ -88,8 +88,8 @@ export function useAccountTokens({
   }, [
     assets,
     includeNoBalance,
-    isEvmOnly,
-    isSolanaOnly,
+    isEvmSendType,
+    isSolanaSendType,
     fiatCurrency,
   ]) as unknown as AssetType[];
 }

--- a/app/components/Views/confirmations/hooks/send/useAccountTokens.ts
+++ b/app/components/Views/confirmations/hooks/send/useAccountTokens.ts
@@ -11,37 +11,19 @@ import I18n from '../../../../../../locales/i18n';
 import { getIntlNumberFormatter } from '../../../../../util/intl';
 import { getNetworkBadgeSource } from '../../utils/network';
 import { AssetType, TokenStandard } from '../../types/token';
-import { useSendType } from './useSendType';
 
 export function useAccountTokens({
   includeNoBalance = false,
+}: {
+  includeNoBalance?: boolean;
 } = {}): AssetType[] {
   const assets = useSelector(selectFilteredAssetsBySelectedAccountGroup);
-  const { isEvmSendType, isSolanaSendType, isTronSendType, isBitcoinSendType } =
-    useSendType();
   const fiatCurrency = useSelector(selectCurrentCurrency);
 
   return useMemo(() => {
     const flatAssets = Object.values(assets).flat();
 
-    const accountTypeMap: Record<string, boolean> = {
-      eip155: !!isEvmSendType,
-      solana: !!isSolanaSendType,
-      tron: !!isTronSendType,
-      bip122: !!isBitcoinSendType,
-    };
-
-    const matchedAccountType = Object.entries(accountTypeMap).find(
-      ([, isType]) => isType,
-    )?.[0];
-
-    const filteredAssets = matchedAccountType
-      ? flatAssets.filter((asset) =>
-          asset.accountType.includes(matchedAccountType),
-        )
-      : flatAssets;
-
-    const assetsWithBalance = filteredAssets.filter((asset) => {
+    const assetsWithBalance = flatAssets.filter((asset) => {
       if (includeNoBalance) {
         return true;
       }
@@ -89,13 +71,5 @@ export function useAccountTokens({
           new BigNumber(a.fiat?.balance || 0),
         ) || 0,
     );
-  }, [
-    assets,
-    includeNoBalance,
-    isEvmSendType,
-    isSolanaSendType,
-    isTronSendType,
-    isBitcoinSendType,
-    fiatCurrency,
-  ]) as unknown as AssetType[];
+  }, [assets, includeNoBalance, fiatCurrency]) as unknown as AssetType[];
 }

--- a/app/components/Views/confirmations/hooks/send/useAccountTokens.ts
+++ b/app/components/Views/confirmations/hooks/send/useAccountTokens.ts
@@ -17,25 +17,29 @@ export function useAccountTokens({
   includeNoBalance = false,
 } = {}): AssetType[] {
   const assets = useSelector(selectFilteredAssetsBySelectedAccountGroup);
-  const { isEvmSendType, isSolanaSendType } = useSendType();
+  const { isEvmSendType, isSolanaSendType, isTronSendType, isBitcoinSendType } =
+    useSendType();
   const fiatCurrency = useSelector(selectCurrentCurrency);
 
   return useMemo(() => {
     const flatAssets = Object.values(assets).flat();
 
-    let filteredAssets;
+    const accountTypeMap: Record<string, boolean> = {
+      eip155: !!isEvmSendType,
+      solana: !!isSolanaSendType,
+      tron: !!isTronSendType,
+      bip122: !!isBitcoinSendType,
+    };
 
-    if (isEvmSendType) {
-      filteredAssets = flatAssets.filter((asset) =>
-        asset.accountType.includes('eip155'),
-      );
-    } else if (isSolanaSendType) {
-      filteredAssets = flatAssets.filter((asset) =>
-        asset.accountType.includes('solana'),
-      );
-    } else {
-      filteredAssets = flatAssets;
-    }
+    const matchedAccountType = Object.entries(accountTypeMap).find(
+      ([, isType]) => isType,
+    )?.[0];
+
+    const filteredAssets = matchedAccountType
+      ? flatAssets.filter((asset) =>
+          asset.accountType.includes(matchedAccountType),
+        )
+      : flatAssets;
 
     const assetsWithBalance = filteredAssets.filter((asset) => {
       if (includeNoBalance) {
@@ -90,6 +94,8 @@ export function useAccountTokens({
     includeNoBalance,
     isEvmSendType,
     isSolanaSendType,
+    isTronSendType,
+    isBitcoinSendType,
     fiatCurrency,
   ]) as unknown as AssetType[];
 }

--- a/app/components/Views/confirmations/hooks/send/useAmountValidation.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useAmountValidation.test.ts
@@ -19,6 +19,10 @@ import { AssetType, TokenStandard } from '../../types/token';
 import * as SendContext from '../../context/send-context/send-context';
 const MOCK_ADDRESS_1 = '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc';
 
+jest.mock('../../../../../util/navigation/navUtils', () => ({
+  useParams: () => ({}),
+}));
+
 describe('validateERC1155Balance', () => {
   it('return error if amount is greater than balance and not otherwise', () => {
     expect(

--- a/app/components/Views/confirmations/hooks/send/useAmountValidation.ts
+++ b/app/components/Views/confirmations/hooks/send/useAmountValidation.ts
@@ -132,6 +132,7 @@ export function validatePositiveNumericString(
   value: string,
 ): string | undefined {
   if (!isValidPositiveNumericString(value)) {
+    console.log('OGP - value', value);
     return strings('send.invalid_value');
   }
   return undefined;

--- a/app/components/Views/confirmations/hooks/send/useAmountValidation.ts
+++ b/app/components/Views/confirmations/hooks/send/useAmountValidation.ts
@@ -132,7 +132,6 @@ export function validatePositiveNumericString(
   value: string,
 ): string | undefined {
   if (!isValidPositiveNumericString(value)) {
-    console.log('OGP - value', value);
     return strings('send.invalid_value');
   }
   return undefined;

--- a/app/components/Views/confirmations/hooks/send/useGasFeeEstimatesForSend.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useGasFeeEstimatesForSend.test.ts
@@ -8,16 +8,21 @@ jest.mock('../gas/useGasFeeEstimates', () => ({
   }),
 }));
 
+jest.mock('../../../../../util/navigation/navUtils', () => ({
+  useParams: () => ({}),
+}));
+
 const mockState = {
   state: evmSendStateMock,
 };
 
 describe('useGasFeeEstimatesForSend', () => {
-  it('return gas estimates', () => {
+  it('returns gas estimates', () => {
     const { result } = renderHookWithProvider(
       () => useGasFeeEstimatesForSend(),
       mockState,
     );
+
     expect(result.current.gasFeeEstimates).toBeDefined();
   });
 });

--- a/app/components/Views/confirmations/hooks/send/usePercentageAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/send/usePercentageAmount.test.ts
@@ -12,6 +12,7 @@ import { useSendContext } from '../../context/send-context';
 import * as SendUtils from '../../utils/send';
 import { usePercentageAmount } from './usePercentageAmount';
 import { useBalance } from './useBalance';
+import { useParams } from '../../../../../util/navigation/navUtils';
 
 jest.mock('@metamask/assets-controllers', () => ({
   getNativeTokenAddress: () => '0xeDd1935e28b253C7905Cf5a944f0B5830FFA916a',
@@ -31,6 +32,10 @@ jest.mock('./useBalance', () => ({
   useBalance: jest.fn(),
 }));
 
+jest.mock('../../../../../util/navigation/navUtils', () => ({
+  useParams: jest.fn(),
+}));
+
 const mockState = {
   state: evmSendStateMock,
 };
@@ -41,7 +46,14 @@ const mockUseSendContext = useSendContext as jest.MockedFunction<
 
 const mockUseBalance = useBalance as jest.MockedFunction<typeof useBalance>;
 
+const mockUseParams = useParams as jest.MockedFunction<typeof useParams>;
+
 describe('usePercentageAmount', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseParams.mockReturnValue(undefined);
+  });
+
   it('return required fields', () => {
     mockUseSendContext.mockReturnValue({
       asset: {},

--- a/app/components/Views/confirmations/hooks/send/useSendTokens.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useSendTokens.test.ts
@@ -1,0 +1,262 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useSendTokens } from './useSendTokens';
+import { useAccountTokens } from './useAccountTokens';
+import { useSendType } from './useSendType';
+import { AssetType, TokenStandard } from '../../types/token';
+
+jest.mock('./useAccountTokens');
+jest.mock('./useSendType');
+
+const mockUseAccountTokens = jest.mocked(useAccountTokens);
+const mockUseSendType = jest.mocked(useSendType);
+
+const mockEvmToken = {
+  address: '0x1234567890123456789012345678901234567890',
+  chainId: '0x1',
+  symbol: 'ETH',
+  ticker: 'ETH',
+  decimals: 18,
+  balance: '1.5',
+  balanceFiat: '$3000.00',
+  image: 'https://example.com/eth.png',
+  aggregators: [],
+  logo: 'https://example.com/eth.png',
+  isETH: true,
+  isNative: true,
+  accountType: 'eip155:1/erc20:0xtoken1',
+  networkBadgeSource: 'network-badge-source',
+  balanceInSelectedCurrency: '$3000.00',
+  standard: TokenStandard.ERC20,
+  fiat: { balance: '3000' },
+  rawBalance: '0x1234',
+} as unknown as AssetType;
+
+const mockSolanaToken: AssetType = {
+  address: '0xsolanatoken',
+  chainId: 'solana:mainnet',
+  symbol: 'SOL',
+  ticker: 'SOL',
+  decimals: 9,
+  balance: '10.5',
+  balanceFiat: '$500.00',
+  image: 'https://example.com/sol.png',
+  aggregators: [],
+  logo: 'https://example.com/sol.png',
+  isNative: true,
+  accountType: 'solana:mainnet/spl:0xsoltoken1',
+  networkBadgeSource: 'network-badge-source',
+  balanceInSelectedCurrency: '$500.00',
+  standard: TokenStandard.ERC20,
+  fiat: { balance: '500' },
+  rawBalance: '0x5678',
+} as unknown as AssetType;
+
+const mockTronToken: AssetType = {
+  address: '0xtrontoken',
+  chainId: 'tron:mainnet',
+  symbol: 'TRX',
+  ticker: 'TRX',
+  decimals: 6,
+  balance: '100',
+  balanceFiat: '$200.00',
+  image: 'https://example.com/trx.png',
+  aggregators: [],
+  logo: 'https://example.com/trx.png',
+  isNative: true,
+  accountType: 'tron:mainnet/trc20:0xtrontoken1',
+  networkBadgeSource: 'network-badge-source',
+  balanceInSelectedCurrency: '$200.00',
+  standard: TokenStandard.ERC20,
+  fiat: { balance: '200' },
+  rawBalance: '0x9abc',
+} as unknown as AssetType;
+
+const mockBitcoinToken: AssetType = {
+  address: '0xbtctoken',
+  chainId: 'bip122:000000000019d6689c085ae165831e93',
+  symbol: 'BTC',
+  ticker: 'BTC',
+  decimals: 8,
+  balance: '0.5',
+  balanceFiat: '$25000.00',
+  image: 'https://example.com/btc.png',
+  aggregators: [],
+  logo: 'https://example.com/btc.png',
+  isNative: true,
+  accountType: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
+  networkBadgeSource: 'network-badge-source',
+  balanceInSelectedCurrency: '$25000.00',
+  standard: TokenStandard.ERC20,
+  fiat: { balance: '25000' },
+  rawBalance: '0xdef0',
+} as unknown as AssetType;
+
+describe('useSendTokens', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseSendType.mockReturnValue({
+      isEvmSendType: undefined,
+      isEvmNativeSendType: undefined,
+      isNonEvmSendType: undefined,
+      isNonEvmNativeSendType: undefined,
+      isSolanaSendType: undefined,
+      isBitcoinSendType: undefined,
+      isTronSendType: undefined,
+    });
+  });
+
+  it('returns all tokens when no send type is set', () => {
+    mockUseAccountTokens.mockReturnValue([
+      mockEvmToken,
+      mockSolanaToken,
+      mockTronToken,
+      mockBitcoinToken,
+    ]);
+
+    const { result } = renderHook(() => useSendTokens());
+
+    expect(mockUseAccountTokens).toHaveBeenCalledWith({
+      includeNoBalance: false,
+    });
+    expect(result.current).toHaveLength(4);
+  });
+
+  it('filters to EVM tokens when isEvmSendType is true', () => {
+    mockUseSendType.mockReturnValue({
+      isEvmSendType: true,
+      isEvmNativeSendType: undefined,
+      isNonEvmSendType: undefined,
+      isNonEvmNativeSendType: undefined,
+      isSolanaSendType: undefined,
+      isBitcoinSendType: undefined,
+      isTronSendType: undefined,
+    });
+    mockUseAccountTokens.mockReturnValue([
+      mockEvmToken,
+      mockSolanaToken,
+      mockTronToken,
+      mockBitcoinToken,
+    ]);
+
+    const { result } = renderHook(() => useSendTokens());
+
+    expect(mockUseAccountTokens).toHaveBeenCalledWith({
+      includeNoBalance: false,
+    });
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]).toEqual(mockEvmToken);
+  });
+
+  it('filters to Solana tokens when isSolanaSendType is true', () => {
+    mockUseSendType.mockReturnValue({
+      isEvmSendType: undefined,
+      isEvmNativeSendType: undefined,
+      isNonEvmSendType: true,
+      isNonEvmNativeSendType: undefined,
+      isSolanaSendType: true,
+      isBitcoinSendType: undefined,
+      isTronSendType: undefined,
+    });
+    mockUseAccountTokens.mockReturnValue([
+      mockEvmToken,
+      mockSolanaToken,
+      mockTronToken,
+      mockBitcoinToken,
+    ]);
+
+    const { result } = renderHook(() => useSendTokens());
+
+    expect(mockUseAccountTokens).toHaveBeenCalledWith({
+      includeNoBalance: false,
+    });
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]).toEqual(mockSolanaToken);
+  });
+
+  it('filters to Tron tokens when isTronSendType is true', () => {
+    mockUseSendType.mockReturnValue({
+      isEvmSendType: undefined,
+      isEvmNativeSendType: undefined,
+      isNonEvmSendType: true,
+      isNonEvmNativeSendType: undefined,
+      isSolanaSendType: undefined,
+      isBitcoinSendType: undefined,
+      isTronSendType: true,
+    });
+    mockUseAccountTokens.mockReturnValue([
+      mockEvmToken,
+      mockSolanaToken,
+      mockTronToken,
+      mockBitcoinToken,
+    ]);
+
+    const { result } = renderHook(() => useSendTokens());
+
+    expect(mockUseAccountTokens).toHaveBeenCalledWith({
+      includeNoBalance: false,
+    });
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]).toEqual(mockTronToken);
+  });
+
+  it('filters to Bitcoin tokens when isBitcoinSendType is true', () => {
+    mockUseSendType.mockReturnValue({
+      isEvmSendType: undefined,
+      isEvmNativeSendType: undefined,
+      isNonEvmSendType: true,
+      isNonEvmNativeSendType: undefined,
+      isSolanaSendType: undefined,
+      isBitcoinSendType: true,
+      isTronSendType: undefined,
+    });
+    mockUseAccountTokens.mockReturnValue([
+      mockEvmToken,
+      mockSolanaToken,
+      mockTronToken,
+      mockBitcoinToken,
+    ]);
+
+    const { result } = renderHook(() => useSendTokens());
+
+    expect(mockUseAccountTokens).toHaveBeenCalledWith({
+      includeNoBalance: false,
+    });
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]).toEqual(mockBitcoinToken);
+  });
+
+  it('passes includeNoBalance option to useAccountTokens', () => {
+    mockUseAccountTokens.mockReturnValue([mockEvmToken]);
+
+    renderHook(() => useSendTokens({ includeNoBalance: true }));
+
+    expect(mockUseAccountTokens).toHaveBeenCalledWith({
+      includeNoBalance: true,
+    });
+  });
+
+  it('prioritizes first matching account type when multiple are true', () => {
+    mockUseSendType.mockReturnValue({
+      isEvmSendType: true,
+      isEvmNativeSendType: undefined,
+      isNonEvmSendType: true,
+      isNonEvmNativeSendType: undefined,
+      isSolanaSendType: true,
+      isBitcoinSendType: undefined,
+      isTronSendType: undefined,
+    });
+    mockUseAccountTokens.mockReturnValue([
+      mockEvmToken,
+      mockSolanaToken,
+      mockTronToken,
+      mockBitcoinToken,
+    ]);
+
+    const { result } = renderHook(() => useSendTokens());
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]).toEqual(mockEvmToken);
+  });
+});

--- a/app/components/Views/confirmations/hooks/send/useSendTokens.ts
+++ b/app/components/Views/confirmations/hooks/send/useSendTokens.ts
@@ -1,0 +1,41 @@
+import { useMemo } from 'react';
+import { AssetType } from '../../types/token';
+import { useAccountTokens } from './useAccountTokens';
+import { useSendType } from './useSendType';
+
+export function useSendTokens({
+  includeNoBalance = false,
+}: {
+  includeNoBalance?: boolean;
+} = {}): AssetType[] {
+  const { isEvmSendType, isSolanaSendType, isTronSendType, isBitcoinSendType } =
+    useSendType();
+  const allTokens = useAccountTokens({ includeNoBalance });
+
+  return useMemo(() => {
+    const accountTypeMap: Record<string, boolean> = {
+      eip155: !!isEvmSendType,
+      solana: !!isSolanaSendType,
+      tron: !!isTronSendType,
+      bip122: !!isBitcoinSendType,
+    };
+
+    const matchedAccountType = Object.entries(accountTypeMap).find(
+      ([, isType]) => isType,
+    )?.[0];
+
+    if (!matchedAccountType) {
+      return allTokens;
+    }
+
+    return allTokens.filter((token) =>
+      token.accountType?.includes(matchedAccountType),
+    );
+  }, [
+    allTokens,
+    isEvmSendType,
+    isSolanaSendType,
+    isTronSendType,
+    isBitcoinSendType,
+  ]);
+}

--- a/app/components/Views/confirmations/hooks/send/useSendType.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useSendType.test.ts
@@ -1,20 +1,350 @@
 import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
-import { evmSendStateMock } from '../../__mocks__/send.mock';
+import {
+  evmSendStateMock,
+  EVM_NATIVE_ASSET,
+  SOLANA_ASSET,
+} from '../../__mocks__/send.mock';
 import { useSendType } from './useSendType';
+import { useParams } from '../../../../../util/navigation/navUtils';
+import { useSendContext } from '../../context/send-context';
+import { AssetType } from '../../types/token';
 
 const mockState = {
   state: evmSendStateMock,
 };
 
+jest.mock('../../../../../util/navigation/navUtils', () => ({
+  useParams: jest.fn(),
+}));
+
+jest.mock('../../context/send-context', () => ({
+  useSendContext: jest.fn(),
+}));
+
 describe('useSendType', () => {
-  it('return types of send', () => {
-    const { result } = renderHookWithProvider(() => useSendType(), mockState);
-    expect(result.current).toEqual({
-      isEvmNativeSendType: undefined,
-      isEvmSendType: undefined,
-      isNonEvmNativeSendType: undefined,
-      isNonEvmSendType: undefined,
-      isSolanaSendType: undefined,
+  const mockUseParams = jest.mocked(useParams);
+  const mockUseSendContext = jest.mocked(useSendContext);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseParams.mockReturnValue(undefined);
+    mockUseSendContext.mockReturnValue({
+      asset: undefined,
+      chainId: undefined,
+      fromAccount: undefined,
+      from: '',
+      maxValueMode: false,
+      to: undefined,
+      updateAsset: jest.fn(),
+      updateTo: jest.fn(),
+      updateValue: jest.fn(),
+      value: undefined,
+    });
+  });
+
+  describe('with no asset or predefined recipient', () => {
+    it('returns undefined for all send types', () => {
+      const { result } = renderHookWithProvider(() => useSendType(), mockState);
+
+      expect(result.current).toEqual({
+        isEvmNativeSendType: undefined,
+        isEvmSendType: undefined,
+        isNonEvmNativeSendType: undefined,
+        isNonEvmSendType: undefined,
+        isSolanaSendType: undefined,
+      });
+    });
+  });
+
+  describe('EVM assets', () => {
+    it('identifies EVM address as EVM send type', () => {
+      mockUseSendContext.mockReturnValue({
+        asset: {
+          ...EVM_NATIVE_ASSET,
+          address: '0x1234567890123456789012345678901234567890',
+        } as unknown as AssetType,
+        chainId: undefined,
+        fromAccount: undefined,
+        from: '',
+        maxValueMode: false,
+        to: undefined,
+        updateAsset: jest.fn(),
+        updateTo: jest.fn(),
+        updateValue: jest.fn(),
+        value: undefined,
+      });
+
+      const { result } = renderHookWithProvider(() => useSendType(), mockState);
+
+      expect(result.current.isEvmSendType).toBe(true);
+    });
+
+    it('identifies EVM native asset as EVM native send type', () => {
+      mockUseSendContext.mockReturnValue({
+        asset: EVM_NATIVE_ASSET as unknown as AssetType,
+        chainId: undefined,
+        fromAccount: undefined,
+        from: '',
+        maxValueMode: false,
+        to: undefined,
+        updateAsset: jest.fn(),
+        updateTo: jest.fn(),
+        updateValue: jest.fn(),
+        value: undefined,
+      });
+
+      const { result } = renderHookWithProvider(() => useSendType(), mockState);
+
+      expect(result.current.isEvmSendType).toBe(true);
+      expect(result.current.isEvmNativeSendType).toBe(true);
+    });
+
+    it('identifies EVM token as EVM send type but not native', () => {
+      mockUseSendContext.mockReturnValue({
+        asset: {
+          ...EVM_NATIVE_ASSET,
+          image: '',
+          isNative: false,
+        },
+        chainId: undefined,
+        fromAccount: undefined,
+        from: '',
+        maxValueMode: false,
+        to: undefined,
+        updateAsset: jest.fn(),
+        updateTo: jest.fn(),
+        updateValue: jest.fn(),
+        value: undefined,
+      });
+
+      const { result } = renderHookWithProvider(() => useSendType(), mockState);
+
+      expect(result.current.isEvmSendType).toBe(true);
+      expect(result.current.isEvmNativeSendType).toBe(false);
+    });
+  });
+
+  describe('Solana assets', () => {
+    it('identifies Solana chain ID as Solana send type', () => {
+      mockUseSendContext.mockReturnValue({
+        asset: SOLANA_ASSET,
+        chainId: undefined,
+        fromAccount: undefined,
+        from: '',
+        maxValueMode: false,
+        to: undefined,
+        updateAsset: jest.fn(),
+        updateTo: jest.fn(),
+        updateValue: jest.fn(),
+        value: undefined,
+      });
+
+      const { result } = renderHookWithProvider(() => useSendType(), mockState);
+
+      expect(result.current.isSolanaSendType).toBe(true);
+      expect(result.current.isNonEvmSendType).toBe(true);
+    });
+
+    it('identifies Solana native asset as non-EVM native send type', () => {
+      mockUseSendContext.mockReturnValue({
+        asset: SOLANA_ASSET,
+        chainId: undefined,
+        fromAccount: undefined,
+        from: '',
+        maxValueMode: false,
+        to: undefined,
+        updateAsset: jest.fn(),
+        updateTo: jest.fn(),
+        updateValue: jest.fn(),
+        value: undefined,
+      });
+
+      const { result } = renderHookWithProvider(() => useSendType(), mockState);
+
+      expect(result.current.isNonEvmNativeSendType).toBe(true);
+      expect(result.current.isSolanaSendType).toBe(true);
+    });
+  });
+
+  describe('predefined recipients', () => {
+    it('identifies predefined EVM recipient as EVM send type', () => {
+      mockUseParams.mockReturnValue({
+        predefinedRecipient: {
+          isEvm: true,
+          isBitcoin: false,
+          isSolana: false,
+          isTron: false,
+        },
+      });
+
+      const { result } = renderHookWithProvider(() => useSendType(), mockState);
+
+      expect(result.current.isEvmSendType).toBe(true);
+    });
+
+    it('identifies predefined Solana recipient as Solana send type', () => {
+      mockUseParams.mockReturnValue({
+        predefinedRecipient: {
+          isEvm: false,
+          isBitcoin: false,
+          isSolana: true,
+          isTron: false,
+        },
+      });
+
+      const { result } = renderHookWithProvider(() => useSendType(), mockState);
+
+      expect(result.current.isSolanaSendType).toBe(true);
+      expect(result.current.isNonEvmSendType).toBe(true);
+    });
+  });
+
+  describe('EVM vs non-EVM detection', () => {
+    it('returns undefined for EVM when asset has no address', () => {
+      mockUseSendContext.mockReturnValue({
+        asset: {
+          ...EVM_NATIVE_ASSET,
+          address: undefined as unknown as string,
+        },
+        chainId: undefined,
+        fromAccount: undefined,
+        from: '',
+        maxValueMode: false,
+        to: undefined,
+        updateAsset: jest.fn(),
+        updateTo: jest.fn(),
+        updateValue: jest.fn(),
+        value: undefined,
+      });
+
+      const { result } = renderHookWithProvider(() => useSendType(), mockState);
+
+      expect(result.current.isEvmSendType).toBeUndefined();
+    });
+
+    it('returns undefined for non-EVM when asset has no chainId', () => {
+      mockUseSendContext.mockReturnValue({
+        asset: {
+          ...SOLANA_ASSET,
+          chainId: undefined as unknown as string,
+        },
+        chainId: undefined,
+        fromAccount: undefined,
+        from: '',
+        maxValueMode: false,
+        to: undefined,
+        updateAsset: jest.fn(),
+        updateTo: jest.fn(),
+        updateValue: jest.fn(),
+        value: undefined,
+      });
+
+      const { result } = renderHookWithProvider(() => useSendType(), mockState);
+
+      expect(result.current.isNonEvmSendType).toBeUndefined();
+    });
+  });
+
+  describe('native asset detection', () => {
+    it('returns undefined for native status when asset has no isNative property', () => {
+      mockUseSendContext.mockReturnValue({
+        asset: {
+          address: '0x1234567890123456789012345678901234567890',
+        } as unknown as typeof EVM_NATIVE_ASSET,
+        chainId: undefined,
+        fromAccount: undefined,
+        from: '',
+        maxValueMode: false,
+        to: undefined,
+        updateAsset: jest.fn(),
+        updateTo: jest.fn(),
+        updateValue: jest.fn(),
+        value: undefined,
+      });
+
+      const { result } = renderHookWithProvider(() => useSendType(), mockState);
+
+      expect(result.current.isEvmNativeSendType).toBeUndefined();
+      expect(result.current.isNonEvmNativeSendType).toBeUndefined();
+    });
+
+    it('handles false native status correctly', () => {
+      mockUseSendContext.mockReturnValue({
+        asset: {
+          ...EVM_NATIVE_ASSET,
+          isNative: false,
+          image: '',
+        },
+        chainId: undefined,
+        fromAccount: undefined,
+        from: '',
+        maxValueMode: false,
+        to: undefined,
+        updateAsset: jest.fn(),
+        updateTo: jest.fn(),
+        updateValue: jest.fn(),
+        value: undefined,
+      });
+
+      const { result } = renderHookWithProvider(() => useSendType(), mockState);
+
+      expect(result.current.isEvmNativeSendType).toBe(false);
+    });
+  });
+
+  describe('predefined recipient priority', () => {
+    it('prioritizes predefined EVM over asset address', () => {
+      mockUseParams.mockReturnValue({
+        predefinedRecipient: {
+          isEvm: true,
+          isBitcoin: false,
+          isSolana: false,
+          isTron: false,
+        },
+      });
+      mockUseSendContext.mockReturnValue({
+        asset: SOLANA_ASSET,
+        chainId: undefined,
+        fromAccount: undefined,
+        from: '',
+        maxValueMode: false,
+        to: undefined,
+        updateAsset: jest.fn(),
+        updateTo: jest.fn(),
+        updateValue: jest.fn(),
+        value: undefined,
+      });
+
+      const { result } = renderHookWithProvider(() => useSendType(), mockState);
+
+      expect(result.current.isEvmSendType).toBe(true);
+    });
+
+    it('prioritizes predefined Solana over asset chainId', () => {
+      mockUseParams.mockReturnValue({
+        predefinedRecipient: {
+          isEvm: false,
+          isBitcoin: false,
+          isSolana: true,
+          isTron: false,
+        },
+      });
+      mockUseSendContext.mockReturnValue({
+        asset: EVM_NATIVE_ASSET,
+        chainId: undefined,
+        fromAccount: undefined,
+        from: '',
+        maxValueMode: false,
+        to: undefined,
+        updateAsset: jest.fn(),
+        updateTo: jest.fn(),
+        updateValue: jest.fn(),
+        value: undefined,
+      });
+
+      const { result } = renderHookWithProvider(() => useSendType(), mockState);
+
+      expect(result.current.isSolanaSendType).toBe(true);
     });
   });
 });

--- a/app/components/Views/confirmations/hooks/send/useSendType.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useSendType.test.ts
@@ -170,10 +170,8 @@ describe('useSendType', () => {
     it('identifies predefined EVM recipient as EVM send type', () => {
       mockUseParams.mockReturnValue({
         predefinedRecipient: {
-          isEvm: true,
-          isBitcoin: false,
-          isSolana: false,
-          isTron: false,
+          address: '0x1234567890123456789012345678901234567890',
+          chainType: 'evm',
         },
       });
 
@@ -185,10 +183,8 @@ describe('useSendType', () => {
     it('identifies predefined Solana recipient as Solana send type', () => {
       mockUseParams.mockReturnValue({
         predefinedRecipient: {
-          isEvm: false,
-          isBitcoin: false,
-          isSolana: true,
-          isTron: false,
+          address: '7W54AwGDYRF7Xmoi6phjTnrQhruYtoUdCKJMYAXP7VWC',
+          chainType: 'solana',
         },
       });
 
@@ -296,10 +292,8 @@ describe('useSendType', () => {
     it('prioritizes predefined EVM over asset address', () => {
       mockUseParams.mockReturnValue({
         predefinedRecipient: {
-          isEvm: true,
-          isBitcoin: false,
-          isSolana: false,
-          isTron: false,
+          address: '0x1234567890123456789012345678901234567890',
+          chainType: 'evm',
         },
       });
       mockUseSendContext.mockReturnValue({
@@ -323,10 +317,8 @@ describe('useSendType', () => {
     it('prioritizes predefined Solana over asset chainId', () => {
       mockUseParams.mockReturnValue({
         predefinedRecipient: {
-          isEvm: false,
-          isBitcoin: false,
-          isSolana: true,
-          isTron: false,
+          address: '7W54AwGDYRF7Xmoi6phjTnrQhruYtoUdCKJMYAXP7VWC',
+          chainType: 'solana',
         },
       });
       mockUseSendContext.mockReturnValue({

--- a/app/components/Views/confirmations/hooks/send/useSendType.ts
+++ b/app/components/Views/confirmations/hooks/send/useSendType.ts
@@ -14,34 +14,76 @@ import {
   isTronChainId,
   /// END:ONLY_INCLUDE_IF
 } from '../../../../../core/Multichain/utils';
+import { useParams } from '../../../../../util/navigation/navUtils';
 
 export const useSendType = () => {
   const { asset } = useSendContext();
+  const { predefinedRecipient } = useParams<{
+    predefinedRecipient: {
+      address: string;
+      isEvm: boolean;
+      isBitcoin: boolean;
+      isSolana: boolean;
+      isTron: boolean;
+    };
+  }>();
+
+  const {
+    isEvm: isPredefinedEvm,
+    isBitcoin: isPredefinedBitcoin,
+    isSolana: isPredefinedSolana,
+    isTron: isPredefinedTron,
+  } = predefinedRecipient || {};
+
+  const isPredefinedNonEvm = useMemo(
+    () =>
+      isPredefinedEvm ||
+      isPredefinedSolana ||
+      isPredefinedBitcoin ||
+      isPredefinedTron,
+    [
+      isPredefinedEvm,
+      isPredefinedSolana,
+      isPredefinedBitcoin,
+      isPredefinedTron,
+    ],
+  );
+
   const isEvmSendType = useMemo(
-    () => (asset?.address ? isEvmAddress(asset.address) : undefined),
-    [asset?.address],
+    () =>
+      isPredefinedEvm ||
+      (asset?.address ? isEvmAddress(asset.address) : undefined),
+    [asset?.address, isPredefinedEvm],
   );
   const isNonEvmSendType = useMemo(
-    () => (asset?.chainId ? isNonEvmChainId(asset.chainId) : undefined),
-    [asset?.chainId],
+    () =>
+      isPredefinedNonEvm ||
+      (asset?.chainId ? isNonEvmChainId(asset.chainId) : undefined),
+    [asset?.chainId, isPredefinedNonEvm],
   );
 
   const isSolanaSendType = useMemo(
-    () => (asset?.chainId ? isSolanaChainId(asset.chainId) : undefined),
-    [asset?.chainId],
+    () =>
+      isPredefinedSolana ||
+      (asset?.chainId ? isSolanaChainId(asset.chainId) : undefined),
+    [asset?.chainId, isPredefinedSolana],
   );
 
   /// BEGIN:ONLY_INCLUDE_IF(bitcoin)
   const isBitcoinSendType = useMemo(
-    () => (asset?.chainId ? isBitcoinChainId(asset.chainId) : undefined),
-    [asset?.chainId],
+    () =>
+      isPredefinedBitcoin ||
+      (asset?.chainId ? isBitcoinChainId(asset.chainId) : undefined),
+    [asset?.chainId, isPredefinedBitcoin],
   );
   /// END:ONLY_INCLUDE_IF
 
   /// BEGIN:ONLY_INCLUDE_IF(tron)
   const isTronSendType = useMemo(
-    () => (asset?.chainId ? isTronChainId(asset.chainId) : undefined),
-    [asset?.chainId],
+    () =>
+      isPredefinedTron ||
+      (asset?.chainId ? isTronChainId(asset.chainId) : undefined),
+    [asset?.chainId, isPredefinedTron],
   );
   /// END:ONLY_INCLUDE_IF
 

--- a/app/components/Views/confirmations/hooks/send/useSendType.ts
+++ b/app/components/Views/confirmations/hooks/send/useSendType.ts
@@ -24,15 +24,13 @@ export const useSendType = () => {
       predefinedRecipient: PredefinedRecipient;
     }>() || {};
 
-  const {
-    isEvm: isPredefinedEvm,
-    isBitcoin: isPredefinedBitcoin,
-    isSolana: isPredefinedSolana,
-    isTron: isPredefinedTron,
-  } = predefinedRecipient || {};
+  const isPredefinedEvm = predefinedRecipient?.chainType === 'evm';
+  const isPredefinedBitcoin = predefinedRecipient?.chainType === 'bitcoin';
+  const isPredefinedSolana = predefinedRecipient?.chainType === 'solana';
+  const isPredefinedTron = predefinedRecipient?.chainType === 'tron';
 
   const isPredefinedNonEvm =
-    isPredefinedSolana || isPredefinedBitcoin || isPredefinedTron;
+    predefinedRecipient?.chainType && predefinedRecipient.chainType !== 'evm';
 
   const isEvmSendType = useMemo(
     () =>

--- a/app/components/Views/confirmations/hooks/send/useSendType.ts
+++ b/app/components/Views/confirmations/hooks/send/useSendType.ts
@@ -19,9 +19,10 @@ import { PredefinedRecipient } from '../../utils/send';
 
 export const useSendType = () => {
   const { asset } = useSendContext();
-  const { predefinedRecipient } = useParams<{
-    predefinedRecipient: PredefinedRecipient;
-  }>();
+  const { predefinedRecipient } =
+    useParams<{
+      predefinedRecipient: PredefinedRecipient;
+    }>() || {};
 
   const {
     isEvm: isPredefinedEvm,

--- a/app/components/Views/confirmations/hooks/send/useSendType.ts
+++ b/app/components/Views/confirmations/hooks/send/useSendType.ts
@@ -36,17 +36,8 @@ export const useSendType = () => {
   } = predefinedRecipient || {};
 
   const isPredefinedNonEvm = useMemo(
-    () =>
-      isPredefinedEvm ||
-      isPredefinedSolana ||
-      isPredefinedBitcoin ||
-      isPredefinedTron,
-    [
-      isPredefinedEvm,
-      isPredefinedSolana,
-      isPredefinedBitcoin,
-      isPredefinedTron,
-    ],
+    () => isPredefinedSolana || isPredefinedBitcoin || isPredefinedTron,
+    [isPredefinedSolana, isPredefinedBitcoin, isPredefinedTron],
   );
 
   const isEvmSendType = useMemo(

--- a/app/components/Views/confirmations/hooks/send/useSendType.ts
+++ b/app/components/Views/confirmations/hooks/send/useSendType.ts
@@ -15,17 +15,12 @@ import {
   /// END:ONLY_INCLUDE_IF
 } from '../../../../../core/Multichain/utils';
 import { useParams } from '../../../../../util/navigation/navUtils';
+import { PredefinedRecipient } from '../../utils/send';
 
 export const useSendType = () => {
   const { asset } = useSendContext();
   const { predefinedRecipient } = useParams<{
-    predefinedRecipient: {
-      address: string;
-      isEvm: boolean;
-      isBitcoin: boolean;
-      isSolana: boolean;
-      isTron: boolean;
-    };
+    predefinedRecipient: PredefinedRecipient;
   }>();
 
   const {

--- a/app/components/Views/confirmations/hooks/send/useSendType.ts
+++ b/app/components/Views/confirmations/hooks/send/useSendType.ts
@@ -5,7 +5,7 @@ import {
   /// END:ONLY_INCLUDE_IF
   isSolanaChainId,
 } from '@metamask/bridge-controller';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { useSendContext } from '../../context/send-context';
 import {
@@ -35,10 +35,8 @@ export const useSendType = () => {
     isTron: isPredefinedTron,
   } = predefinedRecipient || {};
 
-  const isPredefinedNonEvm = useMemo(
-    () => isPredefinedSolana || isPredefinedBitcoin || isPredefinedTron,
-    [isPredefinedSolana, isPredefinedBitcoin, isPredefinedTron],
-  );
+  const isPredefinedNonEvm =
+    isPredefinedSolana || isPredefinedBitcoin || isPredefinedTron;
 
   const isEvmSendType = useMemo(
     () =>
@@ -46,6 +44,7 @@ export const useSendType = () => {
       (asset?.address ? isEvmAddress(asset.address) : undefined),
     [asset?.address, isPredefinedEvm],
   );
+
   const isNonEvmSendType = useMemo(
     () =>
       isPredefinedNonEvm ||
@@ -53,28 +52,32 @@ export const useSendType = () => {
     [asset?.chainId, isPredefinedNonEvm],
   );
 
+  const createChainTypeCheck = useCallback(
+    (
+      isPredefined: boolean | undefined,
+      chainChecker: (chainId: string) => boolean,
+    ) =>
+      isPredefined ||
+      (asset?.chainId ? chainChecker(asset.chainId) : undefined),
+    [asset?.chainId],
+  );
+
   const isSolanaSendType = useMemo(
-    () =>
-      isPredefinedSolana ||
-      (asset?.chainId ? isSolanaChainId(asset.chainId) : undefined),
-    [asset?.chainId, isPredefinedSolana],
+    () => createChainTypeCheck(isPredefinedSolana, isSolanaChainId),
+    [createChainTypeCheck, isPredefinedSolana],
   );
 
   /// BEGIN:ONLY_INCLUDE_IF(bitcoin)
   const isBitcoinSendType = useMemo(
-    () =>
-      isPredefinedBitcoin ||
-      (asset?.chainId ? isBitcoinChainId(asset.chainId) : undefined),
-    [asset?.chainId, isPredefinedBitcoin],
+    () => createChainTypeCheck(isPredefinedBitcoin, isBitcoinChainId),
+    [createChainTypeCheck, isPredefinedBitcoin],
   );
   /// END:ONLY_INCLUDE_IF
 
   /// BEGIN:ONLY_INCLUDE_IF(tron)
   const isTronSendType = useMemo(
-    () =>
-      isPredefinedTron ||
-      (asset?.chainId ? isTronChainId(asset.chainId) : undefined),
-    [asset?.chainId, isPredefinedTron],
+    () => createChainTypeCheck(isPredefinedTron, isTronChainId),
+    [createChainTypeCheck, isPredefinedTron],
   );
   /// END:ONLY_INCLUDE_IF
 

--- a/app/components/Views/confirmations/hooks/send/useToAddressValidation.test.ts
+++ b/app/components/Views/confirmations/hooks/send/useToAddressValidation.test.ts
@@ -8,9 +8,14 @@ import {
 } from '../../__mocks__/send.mock';
 import { useSendContext } from '../../context/send-context';
 import { useToAddressValidation } from './useToAddressValidation';
+import { useParams } from '../../../../../util/navigation/navUtils';
 
 jest.mock('../../context/send-context', () => ({
   useSendContext: jest.fn(),
+}));
+
+jest.mock('../../../../../util/navigation/navUtils', () => ({
+  useParams: jest.fn(),
 }));
 
 const mockState = {
@@ -21,7 +26,14 @@ const mockUseSendContext = useSendContext as jest.MockedFunction<
   typeof useSendContext
 >;
 
+const mockUseParams = jest.mocked(useParams);
+
 describe('useToAddressValidation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseParams.mockReturnValue(undefined);
+  });
+
   it('return fields for to address error and warning', () => {
     mockUseSendContext.mockReturnValue(
       {} as unknown as ReturnType<typeof useSendContext>,

--- a/app/components/Views/confirmations/hooks/useSendNavigation.test.ts
+++ b/app/components/Views/confirmations/hooks/useSendNavigation.test.ts
@@ -35,9 +35,10 @@ describe('useSendNavigation', () => {
       const { result } = renderHookWithProvider(() => useSendNavigation(), {
         state: mockState,
       });
-      result.current.navigateToSendPage(InitSendLocation.AssetOverview, {
-        name: 'ETHEREUM',
-      } as AssetType);
+      result.current.navigateToSendPage({
+        location: InitSendLocation.AssetOverview,
+        asset: { name: 'ETHEREUM' } as AssetType,
+      });
       expect(mockNavigate).toHaveBeenCalledWith('SendFlowView');
     });
 
@@ -45,9 +46,10 @@ describe('useSendNavigation', () => {
       const { result } = renderHookWithProvider(() => useSendNavigation(), {
         state: rffSendRedesignEnabledMock,
       });
-      result.current.navigateToSendPage(InitSendLocation.AssetOverview, {
-        name: 'ETHEREUM',
-      } as AssetType);
+      result.current.navigateToSendPage({
+        location: InitSendLocation.AssetOverview,
+        asset: { name: 'ETHEREUM' } as AssetType,
+      });
       expect(mockNavigate.mock.calls[0][0]).toEqual('Send');
     });
   });

--- a/app/components/Views/confirmations/hooks/useSendNavigation.ts
+++ b/app/components/Views/confirmations/hooks/useSendNavigation.ts
@@ -1,11 +1,9 @@
-import { Nft } from '@metamask/assets-controllers';
 import { useCallback } from 'react';
 import { useNavigation } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
 
 import { selectSendRedesignFlags } from '../../../../selectors/featureFlagController/confirmations';
-import { handleSendPageNavigation } from '../utils/send';
-import { AssetType } from '../types/token';
+import { handleSendPageNavigation, SendNavigationParams } from '../utils/send';
 
 export const useSendNavigation = () => {
   const { navigate } = useNavigation();
@@ -14,13 +12,11 @@ export const useSendNavigation = () => {
   );
 
   const navigateToSendPage = useCallback(
-    (location: string, asset?: AssetType | Nft) => {
-      handleSendPageNavigation(
-        navigate,
-        location,
+    (params: Omit<SendNavigationParams, 'isSendRedesignEnabled'>) => {
+      handleSendPageNavigation(navigate, {
+        ...params,
         isSendRedesignEnabled,
-        asset,
-      );
+      });
     },
     [navigate, isSendRedesignEnabled],
   );

--- a/app/components/Views/confirmations/utils/address.test.ts
+++ b/app/components/Views/confirmations/utils/address.test.ts
@@ -1,0 +1,130 @@
+import { derivePredefinedRecipientParams } from './address';
+import { ChainType } from './send';
+
+describe('derivePredefinedRecipientParams', () => {
+  describe('EVM addresses', () => {
+    it('returns EVM chain type for valid EVM address', () => {
+      const address = '0xC4955C0d639D99699Bfd7Ec54d9FaFEe40e4D272';
+
+      const result = derivePredefinedRecipientParams(address);
+
+      expect(result).toEqual({
+        address,
+        chainType: ChainType.EVM,
+      });
+    });
+  });
+
+  describe('Solana addresses', () => {
+    it('returns Solana chain type for valid Solana address', () => {
+      const address = '7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV';
+
+      const result = derivePredefinedRecipientParams(address);
+
+      expect(result).toEqual({
+        address,
+        chainType: ChainType.SOLANA,
+      });
+    });
+  });
+
+  describe('Bitcoin addresses', () => {
+    it('returns Bitcoin chain type for valid P2WPKH mainnet address', () => {
+      const address = 'bc1qwl8399fz829uqvqly9tcatgrgtwp3udnhxfq4k';
+
+      const result = derivePredefinedRecipientParams(address);
+
+      expect(result).toEqual({
+        address,
+        chainType: ChainType.BITCOIN,
+      });
+    });
+
+    it('returns Bitcoin chain type for valid P2PKH mainnet address', () => {
+      const address = '1P5ZEDWTKTFGxQjZphgWPQUpe554WKDfHQ';
+
+      const result = derivePredefinedRecipientParams(address);
+
+      expect(result).toEqual({
+        address,
+        chainType: ChainType.BITCOIN,
+      });
+    });
+  });
+
+  describe('Tron addresses', () => {
+    it('returns Tron chain type for valid Tron address', () => {
+      const address = 'TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7';
+
+      const result = derivePredefinedRecipientParams(address);
+
+      expect(result).toEqual({
+        address,
+        chainType: ChainType.TRON,
+      });
+    });
+
+    it('returns Tron chain type for another valid Tron address', () => {
+      const address = 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t';
+
+      const result = derivePredefinedRecipientParams(address);
+
+      expect(result).toEqual({
+        address,
+        chainType: ChainType.TRON,
+      });
+    });
+  });
+
+  describe('Invalid addresses', () => {
+    it('returns undefined for invalid address', () => {
+      const address = 'invalid-address';
+
+      const result = derivePredefinedRecipientParams(address);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined for empty string', () => {
+      const address = '';
+
+      const result = derivePredefinedRecipientParams(address);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined for address with wrong prefix', () => {
+      const address = 'ANPeeaaFhwdYaBjwE6tz8N6Vp1y66i5NjE';
+
+      const result = derivePredefinedRecipientParams(address);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('Priority order', () => {
+    it('checks EVM address first', () => {
+      const evmAddress = '0xC4955C0d639D99699Bfd7Ec54d9FaFEe40e4D272';
+      const result = derivePredefinedRecipientParams(evmAddress);
+      expect(result?.chainType).toBe(ChainType.EVM);
+    });
+
+    it('checks Solana address after EVM', () => {
+      const solanaAddress = '7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV';
+      const result = derivePredefinedRecipientParams(solanaAddress);
+      expect(result?.chainType).toBe(ChainType.SOLANA);
+    });
+
+    it('checks Bitcoin address after Solana', () => {
+      const btcAddress = 'bc1qwl8399fz829uqvqly9tcatgrgtwp3udnhxfq4k';
+      const result = derivePredefinedRecipientParams(btcAddress);
+      expect(result?.chainType).toBe(ChainType.BITCOIN);
+    });
+
+    it('checks Tron address last', () => {
+      const tronAddress = 'TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7';
+      const result = derivePredefinedRecipientParams(tronAddress);
+      expect(result?.chainType).toBe(ChainType.TRON);
+    });
+  });
+});

--- a/app/components/Views/confirmations/utils/address.ts
+++ b/app/components/Views/confirmations/utils/address.ts
@@ -1,0 +1,39 @@
+import { ChainType } from './send';
+import { isAddress as isSolanaAddress } from '@solana/addresses';
+import { isAddress as isEvmAddress } from 'ethers/lib/utils';
+import {
+  isBtcMainnetAddress,
+  isTronAddress,
+} from '../../../../core/Multichain/utils';
+
+export const derivePredefinedRecipientParams = (address: string) => {
+  if (isEvmAddress(address)) {
+    return {
+      address,
+      chainType: ChainType.EVM,
+    };
+  }
+
+  if (isSolanaAddress(address)) {
+    return {
+      address,
+      chainType: ChainType.SOLANA,
+    };
+  }
+
+  if (isBtcMainnetAddress(address)) {
+    return {
+      address,
+      chainType: ChainType.BITCOIN,
+    };
+  }
+
+  if (isTronAddress(address)) {
+    return {
+      address,
+      chainType: ChainType.TRON,
+    };
+  }
+
+  return undefined;
+};

--- a/app/components/Views/confirmations/utils/send.test.ts
+++ b/app/components/Views/confirmations/utils/send.test.ts
@@ -44,26 +44,24 @@ jest.mock('../../../../lib/ppom/ppom-util', () => ({
 describe('handleSendPageNavigation', () => {
   it('navigates to legacy send page', () => {
     const mockNavigate = jest.fn();
-    handleSendPageNavigation(
-      mockNavigate,
-      InitSendLocation.WalletActions,
-      false,
-      {
+    handleSendPageNavigation(mockNavigate, {
+      location: InitSendLocation.WalletActions,
+      isSendRedesignEnabled: false,
+      asset: {
         name: 'ETHEREUM',
       } as AssetType,
-    );
+    });
     expect(mockNavigate).toHaveBeenCalledWith('SendFlowView');
   });
   it('navigates to send redesign page', () => {
     const mockNavigate = jest.fn();
-    handleSendPageNavigation(
-      mockNavigate,
-      InitSendLocation.WalletActions,
-      true,
-      {
+    handleSendPageNavigation(mockNavigate, {
+      location: InitSendLocation.WalletActions,
+      isSendRedesignEnabled: true,
+      asset: {
         name: 'ETHEREUM',
       } as AssetType,
-    );
+    });
     expect(mockNavigate.mock.calls[0][0]).toEqual('Send');
   });
 });

--- a/app/components/Views/confirmations/utils/send.ts
+++ b/app/components/Views/confirmations/utils/send.ts
@@ -30,6 +30,21 @@ import { AssetType, TokenStandard } from '../types/token';
 import { MMM_ORIGIN } from '../constants/confirmations';
 import { isNativeToken } from '../utils/generic';
 
+type OneOf<T, Keys extends keyof T = keyof T> = Keys extends keyof T
+  ? { [K in Keys]: T[K] } & { [K in Exclude<keyof T, Keys>]?: never }
+  : never;
+
+interface ChainType {
+  isEvm: true;
+  isSolana: true;
+  isBitcoin: true;
+  isTron: true;
+}
+
+export type PredefinedRecipient = {
+  address: string;
+} & OneOf<ChainType>;
+
 const captureSendStartedEvent = (location: string) => {
   const { trackEvent } = MetaMetrics.getInstance();
   trackEvent(
@@ -60,13 +75,7 @@ export const handleSendPageNavigation = (
   location: string,
   isSendRedesignEnabled: boolean,
   asset?: AssetType | Nft,
-  predefinedRecipient?: {
-    address: string;
-    isEvm?: boolean;
-    isSolana?: boolean;
-    isBitcoin?: boolean;
-    isTron?: boolean;
-  },
+  predefinedRecipient?: PredefinedRecipient,
 ) => {
   if (isSendRedesignEnabled) {
     captureSendStartedEvent(location);

--- a/app/components/Views/confirmations/utils/send.ts
+++ b/app/components/Views/confirmations/utils/send.ts
@@ -66,7 +66,47 @@ export function isValidPositiveNumericString(str: string) {
     return false;
   }
 }
-
+/**
+ * Navigates to the appropriate send flow screen based on the redesign flag and asset type.
+ *
+ * This function handles navigation for both the legacy and redesigned send flows. In the redesigned flow,
+ * it intelligently determines the starting screen based on whether an asset is provided:
+ * - No asset: starts at asset selection screen
+ * - ERC721 NFT: starts at recipient screen (since NFTs are non-divisible)
+ * - Other assets: starts at amount screen
+ *
+ * @param navigate - Navigation function that accepts a screen name and optional params object
+ * @param location - Analytics identifier for where the send flow was initiated (e.g., 'wallet', 'token_details')
+ * @param isSendRedesignEnabled - Feature flag indicating whether to use the new send flow or legacy SendFlowView
+ * @param asset - Optional preselected asset (token or NFT) to send. When provided, skips the asset selection screen.
+ * @param predefinedRecipient - Optional recipient with chain information. Should be an object containing:
+ * - `address`: The recipient's address string
+ * - Exactly ONE of the following chain type flags set to `true`: `isEvm`, `isSolana`, `isBitcoin`, or `isTron`
+ *
+ * Example usage:
+ * ```typescript
+ * const recipient = {
+ *   address: '0x1234...',
+ *   isEvm: true,
+ * };
+ * handleSendPageNavigation(navigate, 'QRCode', true, undefined, recipient);
+ * ```
+ *
+ * @remarks
+ * The predefinedRecipient is passed through navigation params and can be used by downstream screens
+ * to pre-populate the recipient field and determine the appropriate chain context for the transaction.
+ *
+ * @example
+ * ```typescript
+ * handleSendPageNavigation(
+ *   navigation.navigate,
+ *   'QRCode',
+ *   true,
+ *   undefined,
+ *   { address: '7W54AwGDYRF7X...', isSolana: true }
+ * );
+ * ```
+ */
 export const handleSendPageNavigation = (
   navigate: <RouteName extends string>(
     screenName: RouteName,

--- a/app/components/Views/confirmations/utils/send.ts
+++ b/app/components/Views/confirmations/utils/send.ts
@@ -60,6 +60,13 @@ export const handleSendPageNavigation = (
   location: string,
   isSendRedesignEnabled: boolean,
   asset?: AssetType | Nft,
+  predefinedRecipient?: {
+    address: string;
+    isEvm?: boolean;
+    isSolana?: boolean;
+    isBitcoin?: boolean;
+    isTron?: boolean;
+  },
 ) => {
   if (isSendRedesignEnabled) {
     captureSendStartedEvent(location);
@@ -71,10 +78,12 @@ export const handleSendPageNavigation = (
         screen = Routes.SEND.AMOUNT;
       }
     }
+
     navigate(Routes.SEND.DEFAULT, {
       screen,
       params: {
         asset,
+        predefinedRecipient,
       },
     });
   } else {

--- a/app/components/hooks/useSendNonEvmAsset.ts
+++ b/app/components/hooks/useSendNonEvmAsset.ts
@@ -40,12 +40,11 @@ export function useSendNonEvmAsset({
   const sendNonEvmAsset = useCallback(
     async (location: string): Promise<boolean> => {
       if (isSendRedesignEnabled) {
-        handleSendPageNavigation(
-          navigation.navigate,
+        handleSendPageNavigation(navigation.navigate, {
           location,
-          true,
-          asset.address ? (asset as TokenI) : undefined,
-        );
+          isSendRedesignEnabled: true,
+          asset: asset.address ? (asset as TokenI) : undefined,
+        });
         return true;
       }
 

--- a/app/components/hooks/useSendNonEvmAsset.ts
+++ b/app/components/hooks/useSendNonEvmAsset.ts
@@ -45,13 +45,6 @@ export function useSendNonEvmAsset({
           location,
           true,
           asset.address ? (asset as TokenI) : undefined,
-          {
-            address: '0x1231231231231231231231231231231231231231',
-            isEvm: true,
-            // isSolana: true,
-            // isTron: true,
-            // isBitcoin: true,
-          },
         );
         return true;
       }

--- a/app/components/hooks/useSendNonEvmAsset.ts
+++ b/app/components/hooks/useSendNonEvmAsset.ts
@@ -40,11 +40,17 @@ export function useSendNonEvmAsset({
   const sendNonEvmAsset = useCallback(
     async (location: string): Promise<boolean> => {
       if (isSendRedesignEnabled) {
+        console.log('OGP - 44444');
         handleSendPageNavigation(
           navigation.navigate,
           location,
           true,
           asset.address ? (asset as TokenI) : undefined,
+          // {
+          //   address: '0x12345',
+          //   // isEvm: true,
+          //   isSolana: true,
+          // },
         );
         return true;
       }

--- a/app/components/hooks/useSendNonEvmAsset.ts
+++ b/app/components/hooks/useSendNonEvmAsset.ts
@@ -40,17 +40,18 @@ export function useSendNonEvmAsset({
   const sendNonEvmAsset = useCallback(
     async (location: string): Promise<boolean> => {
       if (isSendRedesignEnabled) {
-        console.log('OGP - 44444');
         handleSendPageNavigation(
           navigation.navigate,
           location,
           true,
           asset.address ? (asset as TokenI) : undefined,
-          // {
-          //   address: '0x12345',
-          //   // isEvm: true,
-          //   isSolana: true,
-          // },
+          {
+            address: '0x1231231231231231231231231231231231231231',
+            isEvm: true,
+            // isSolana: true,
+            // isTron: true,
+            // isBitcoin: true,
+          },
         );
         return true;
       }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to add a support for predefined recipient into send flow navigation. It mainly aims to support opening send flow through QR scanner. 

In order to send predefined recipient flows should call `navigateToSendPage` callback from `app/components/Views/confirmations/hooks/useSendNavigation.ts` hook.

Let's assume we already validated the QR address is Solana address. In that scenario a call like 

```
navigateToSendPage({
   location: "QRScanner",
   predefinedRecipient: {
       address: '7W54AwGDYRF7Xmoi6phjTnrQhruYtoUdCKJMYAXP7VWC',
       chainType: "solana",
   },
})
```
will open assets page in the send flow and it will skip recipient page as user already wants to send into that address.

All the navigations that will come from QR scanner have to fill validated recipient address and the flag for the type. For more information please see `handleSendPageNavigation` jsdoc or `SendNavigationParams.PredefinedRecipient`

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/21758

## **Manual testing steps**

Adds predefined recipient navigation to send flow - so this is currently a technical feature which doesn't have any usage for now.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/f7327bf1-ec0a-4255-a441-b98e2cf20aa2



## **Pre-merge author checklist**

- [X] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds predefined recipient handling to the new send flow, refactors navigation to a param object API, updates amount/asset selection logic, and expands tests.
> 
> - **Send flow & navigation**:
>   - Introduce `ChainType`, `PredefinedRecipient`, and `SendNavigationParams`; refactor `handleSendPageNavigation` to accept a params object and pass `predefinedRecipient` to routes.
>   - Update `useSendNavigation` to accept params and propagate `isSendRedesignEnabled` internally; migrate callers (`AssetOverview`, `CollectibleModal`, `NftDetails`, `Wallet`).
>   - Amount screen (`AmountKeyboard`) now reads `predefinedRecipient` from route params and skips the recipient step, calling `updateTo`/`handleSubmitPress` directly.
> - **Asset selection & tokens**:
>   - Add `useSendTokens` to filter tokens by chain type based on `useSendType`; switch `Asset` component to use it.
>   - Simplify `useAccountTokens` (remove scope filtering) and keep balance-based filtering/formatting.
> - **Utilities**:
>   - Add `derivePredefinedRecipientParams` to infer chain type from an address.
> - **Tests**:
>   - Add/adjust tests for navigation, amount flow, send type detection, token filtering, gas/amount validation, and address utils; update mocks to new APIs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acda5985857eb144e111b0498cd1af273c895d37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->