### PR TITLE
fix(perps): calculate weighted ROE percentage for aggregated account states cp-7.60.0

### DIFF
--- a/app/components/UI/Perps/utils/accountUtils.test.ts
+++ b/app/components/UI/Perps/utils/accountUtils.test.ts
@@ -8,7 +8,10 @@ import { createMockEngineContext } from '../__mocks__';
 const mockEngineContext = createMockEngineContext();
 jest.mock('../../../../core/Engine', () => ({ context: mockEngineContext }));
 
-import { getEvmAccountFromSelectedAccountGroup } from './accountUtils';
+import {
+  getEvmAccountFromSelectedAccountGroup,
+  calculateWeightedReturnOnEquity,
+} from './accountUtils';
 import Engine from '../../../../core/Engine';
 
 describe('accountUtils', () => {
@@ -192,6 +195,354 @@ describe('accountUtils', () => {
         type: 'eip155:eoa',
         metadata: { name: 'EVM EOA' },
       });
+    });
+  });
+
+  describe('calculateWeightedReturnOnEquity', () => {
+    it('returns "0" for empty array', () => {
+      const result = calculateWeightedReturnOnEquity([]);
+      expect(result).toBe('0');
+    });
+
+    it('calculates weighted ROE for single account with string inputs', () => {
+      const accounts = [
+        {
+          unrealizedPnl: '100',
+          returnOnEquity: '10.0',
+        },
+      ];
+
+      // marginUsed = (100 / 10.0) * 100 = 1000
+      // weightedROE = (10.0 / 100) * 1000 / 1000 = 10.0
+      const result = calculateWeightedReturnOnEquity(accounts);
+      expect(result).toBe('10.0');
+    });
+
+    it('calculates weighted ROE for single account with number inputs', () => {
+      const accounts = [
+        {
+          unrealizedPnl: 200,
+          returnOnEquity: 20,
+        },
+      ];
+
+      // marginUsed = (200 / 20.0) * 100 = 1000
+      // weightedROE = (20.0 / 100) * 1000 / 1000 = 20.0
+      const result = calculateWeightedReturnOnEquity(accounts);
+      expect(result).toBe('20.0');
+    });
+
+    it('calculates weighted ROE for multiple accounts', () => {
+      const accounts = [
+        {
+          unrealizedPnl: '100',
+          returnOnEquity: '10.0', // marginUsed = 1000
+        },
+        {
+          unrealizedPnl: '200',
+          returnOnEquity: '20.0', // marginUsed = 1000
+        },
+        {
+          unrealizedPnl: '150',
+          returnOnEquity: '15.0', // marginUsed = 1000
+        },
+      ];
+
+      // Account 1: ROE = 0.10, marginUsed = 1000, weighted = 100
+      // Account 2: ROE = 0.20, marginUsed = 1000, weighted = 200
+      // Account 3: ROE = 0.15, marginUsed = 1000, weighted = 150
+      // Total weighted = 450, total margin = 3000
+      // weightedROE = (450 / 3000) * 100 = 15.0
+      const result = calculateWeightedReturnOnEquity(accounts);
+      expect(result).toBe('15.0');
+    });
+
+    it('calculates weighted ROE with different margin amounts', () => {
+      const accounts = [
+        {
+          unrealizedPnl: '50',
+          returnOnEquity: '10.0', // marginUsed = 500
+        },
+        {
+          unrealizedPnl: '200',
+          returnOnEquity: '20.0', // marginUsed = 1000
+        },
+      ];
+
+      // Account 1: ROE = 0.10, marginUsed = 500, weighted = 50
+      // Account 2: ROE = 0.20, marginUsed = 1000, weighted = 200
+      // Total weighted = 250, total margin = 1500
+      // weightedROE = (250 / 1500) * 100 = 16.666... ≈ 16.7
+      const result = calculateWeightedReturnOnEquity(accounts);
+      expect(result).toBe('16.7');
+    });
+
+    it('handles mixed string and number inputs', () => {
+      const accounts = [
+        {
+          unrealizedPnl: '100',
+          returnOnEquity: 10,
+        },
+        {
+          unrealizedPnl: 200,
+          returnOnEquity: '20.0',
+        },
+      ];
+
+      // Account 1: ROE = 0.10, marginUsed = 1000, weighted = 100
+      // Account 2: ROE = 0.20, marginUsed = 1000, weighted = 200
+      // Total weighted = 300, total margin = 2000
+      // weightedROE = (300 / 2000) * 100 = 15.0
+      const result = calculateWeightedReturnOnEquity(accounts);
+      expect(result).toBe('15.0');
+    });
+
+    it('skips accounts with zero returnOnEquity', () => {
+      const accounts = [
+        {
+          unrealizedPnl: '100',
+          returnOnEquity: '10.0', // marginUsed = 1000
+        },
+        {
+          unrealizedPnl: '0',
+          returnOnEquity: '0', // Should be skipped
+        },
+        {
+          unrealizedPnl: '200',
+          returnOnEquity: '20.0', // marginUsed = 1000
+        },
+      ];
+
+      // Only accounts 1 and 3 are used
+      // Account 1: ROE = 0.10, marginUsed = 1000, weighted = 100
+      // Account 3: ROE = 0.20, marginUsed = 1000, weighted = 200
+      // Total weighted = 300, total margin = 2000
+      // weightedROE = (300 / 2000) * 100 = 15.0
+      const result = calculateWeightedReturnOnEquity(accounts);
+      expect(result).toBe('15.0');
+    });
+
+    it('skips accounts with NaN unrealizedPnl', () => {
+      const accounts = [
+        {
+          unrealizedPnl: '100',
+          returnOnEquity: '10.0',
+        },
+        {
+          unrealizedPnl: 'invalid',
+          returnOnEquity: '20.0',
+        },
+        {
+          unrealizedPnl: '200',
+          returnOnEquity: '20.0',
+        },
+      ];
+
+      // Only accounts 1 and 3 are used
+      // Account 1: ROE = 0.10, marginUsed = 1000, weighted = 100
+      // Account 3: ROE = 0.20, marginUsed = 1000, weighted = 200
+      // Total weighted = 300, total margin = 2000
+      // weightedROE = (300 / 2000) * 100 = 15.0
+      const result = calculateWeightedReturnOnEquity(accounts);
+      expect(result).toBe('15.0');
+    });
+
+    it('skips accounts with NaN returnOnEquity', () => {
+      const accounts = [
+        {
+          unrealizedPnl: '100',
+          returnOnEquity: '10.0',
+        },
+        {
+          unrealizedPnl: '200',
+          returnOnEquity: 'invalid',
+        },
+        {
+          unrealizedPnl: '300',
+          returnOnEquity: '30.0',
+        },
+      ];
+
+      // Only accounts 1 and 3 are used
+      const result = calculateWeightedReturnOnEquity(accounts);
+      expect(result).toBe('20.0');
+    });
+
+    it('returns "0" when all accounts are invalid', () => {
+      const accounts = [
+        {
+          unrealizedPnl: 'invalid',
+          returnOnEquity: '10.0',
+        },
+        {
+          unrealizedPnl: '200',
+          returnOnEquity: '0',
+        },
+        {
+          unrealizedPnl: '300',
+          returnOnEquity: 'invalid',
+        },
+      ];
+
+      const result = calculateWeightedReturnOnEquity(accounts);
+      expect(result).toBe('0');
+    });
+
+    it('handles negative unrealizedPnl correctly', () => {
+      const accounts = [
+        {
+          unrealizedPnl: '-100',
+          returnOnEquity: '-10.0', // marginUsed = 1000
+        },
+        {
+          unrealizedPnl: '200',
+          returnOnEquity: '20.0', // marginUsed = 1000
+        },
+      ];
+
+      // Account 1: ROE = -0.10, marginUsed = 1000, weighted = -100
+      // Account 2: ROE = 0.20, marginUsed = 1000, weighted = 200
+      // Total weighted = 100, total margin = 2000
+      // weightedROE = (100 / 2000) * 100 = 5.0
+      const result = calculateWeightedReturnOnEquity(accounts);
+      expect(result).toBe('5.0');
+    });
+
+    it('handles decimal precision correctly', () => {
+      const accounts = [
+        {
+          unrealizedPnl: '33.33',
+          returnOnEquity: '11.11', // marginUsed ≈ 300
+        },
+        {
+          unrealizedPnl: '66.67',
+          returnOnEquity: '22.22', // marginUsed ≈ 300
+        },
+      ];
+
+      const result = calculateWeightedReturnOnEquity(accounts);
+      // Should round to 1 decimal place
+      expect(result).toMatch(/^\d+\.\d$/);
+    });
+
+    it('skips accounts that result in zero or negative marginUsed', () => {
+      const accounts = [
+        {
+          unrealizedPnl: '100',
+          returnOnEquity: '10.0', // marginUsed = 1000
+        },
+        {
+          unrealizedPnl: '-50',
+          returnOnEquity: '10.0', // marginUsed = -500 (should be skipped)
+        },
+        {
+          unrealizedPnl: '0',
+          returnOnEquity: '5.0', // marginUsed = 0 (should be skipped)
+        },
+      ];
+
+      // Only account 1 is used
+      const result = calculateWeightedReturnOnEquity(accounts);
+      expect(result).toBe('10.0');
+    });
+
+    it('handles very small values correctly', () => {
+      const accounts = [
+        {
+          unrealizedPnl: '0.01',
+          returnOnEquity: '0.1', // marginUsed = 10
+        },
+        {
+          unrealizedPnl: '0.02',
+          returnOnEquity: '0.2', // marginUsed = 10
+        },
+      ];
+
+      // Account 1: ROE = 0.001, marginUsed = 10, weighted = 0.01
+      // Account 2: ROE = 0.002, marginUsed = 10, weighted = 0.02
+      // Total weighted = 0.03, total margin = 20
+      // weightedROE = (0.03 / 20) * 100 = 0.15, rounded to 0.1
+      const result = calculateWeightedReturnOnEquity(accounts);
+      expect(result).toBe('0.1');
+    });
+
+    it('handles very large values correctly', () => {
+      const accounts = [
+        {
+          unrealizedPnl: '1000000',
+          returnOnEquity: '10.0', // marginUsed = 10000000
+        },
+        {
+          unrealizedPnl: '2000000',
+          returnOnEquity: '20.0', // marginUsed = 10000000
+        },
+      ];
+
+      const result = calculateWeightedReturnOnEquity(accounts);
+      expect(result).toBe('15.0');
+    });
+
+    it('weighted ROE sign depends on total unrealizedPnl, not total returnOnEquity', () => {
+      // Example: Mixed positive and negative ROE accounts
+      // Account 1: unrealizedPnl = 100, returnOnEquity = 10%, marginUsed = 1000
+      // Account 2: unrealizedPnl = -50, returnOnEquity = -5%, marginUsed = 1000
+      // Total unrealizedPnl = 50 (positive)
+      // Total returnOnEquity = 10% + (-5%) = 5% (positive)
+      // weightedROE = (50 / 2000) * 100 = 2.5% (positive)
+      const accounts = [
+        {
+          unrealizedPnl: '100',
+          returnOnEquity: '10.0',
+        },
+        {
+          unrealizedPnl: '-50',
+          returnOnEquity: '-5.0',
+        },
+      ];
+
+      const result = calculateWeightedReturnOnEquity(accounts);
+      expect(result).toBe('2.5');
+    });
+
+    it('weighted ROE can be negative when total unrealizedPnl is negative', () => {
+      // Account 1: unrealizedPnl = -100, returnOnEquity = -10%, marginUsed = 1000
+      // Account 2: unrealizedPnl = -50, returnOnEquity = -5%, marginUsed = 1000
+      // Total unrealizedPnl = -150 (negative)
+      // weightedROE = (-150 / 2000) * 100 = -7.5% (negative)
+      const accounts = [
+        {
+          unrealizedPnl: '-100',
+          returnOnEquity: '-10.0',
+        },
+        {
+          unrealizedPnl: '-50',
+          returnOnEquity: '-5.0',
+        },
+      ];
+
+      const result = calculateWeightedReturnOnEquity(accounts);
+      expect(result).toBe('-7.5');
+    });
+
+    it('demonstrates weighted ROE sign matches total unrealizedPnl sign', () => {
+      // This test shows that weightedROE sign = sign(Σ(unrealizedPnl))
+      // not sign(Σ(returnOnEquity))
+      const accounts = [
+        {
+          unrealizedPnl: '200',
+          returnOnEquity: '20.0', // marginUsed = 1000
+        },
+        {
+          unrealizedPnl: '-100',
+          returnOnEquity: '-10.0', // marginUsed = 1000
+        },
+      ];
+
+      // Total unrealizedPnl = 200 + (-100) = 100 (positive)
+      // weightedROE = (100 / 2000) * 100 = 5.0% (positive)
+      // Even though we have both positive and negative ROE accounts
+      const result = calculateWeightedReturnOnEquity(accounts);
+      expect(result).toBe('5.0');
     });
   });
 });

--- a/app/components/UI/Perps/utils/accountUtils.ts
+++ b/app/components/UI/Perps/utils/accountUtils.ts
@@ -20,3 +20,79 @@ export const getEvmAccountFromSelectedAccountGroup = () => {
 
   return evmAccount || null;
 };
+
+/**
+ * Interface for ROE calculation input
+ */
+export interface ReturnOnEquityInput {
+  unrealizedPnl: string | number;
+  returnOnEquity: string | number;
+}
+
+/**
+ * Calculates weighted return on equity across multiple account states
+ * Weights each account's ROE by its margin used (derived from unrealizedPnl and returnOnEquity)
+ *
+ * Formula: weightedROE = Σ(ROE_i * marginUsed_i) / Σ(marginUsed_i)
+ * where marginUsed_i is derived as: (unrealizedPnl_i / returnOnEquity_i) * 100
+ *
+ * @param accounts - Array of account states with unrealizedPnl and returnOnEquity
+ * @returns Weighted return on equity as a string with 1 decimal place, or '0' if no margin used
+ */
+export function calculateWeightedReturnOnEquity(
+  accounts: ReturnOnEquityInput[],
+): string {
+  if (accounts.length === 0) {
+    return '0';
+  }
+
+  let totalWeightedROE = 0;
+  let totalMarginUsed = 0;
+
+  for (const account of accounts) {
+    const unrealizedPnl =
+      typeof account.unrealizedPnl === 'string'
+        ? Number.parseFloat(account.unrealizedPnl)
+        : account.unrealizedPnl;
+    const returnOnEquity =
+      typeof account.returnOnEquity === 'string'
+        ? Number.parseFloat(account.returnOnEquity)
+        : account.returnOnEquity;
+
+    // Skip invalid values
+    if (Number.isNaN(unrealizedPnl) || Number.isNaN(returnOnEquity)) {
+      continue;
+    }
+
+    // Derive marginUsed from unrealizedPnl and returnOnEquity
+    // If returnOnEquity is 0, we can't derive marginUsed, so skip this account
+    if (returnOnEquity === 0) {
+      // If both are 0, marginUsed could be anything, so we skip it
+      // If unrealizedPnl != 0 but returnOnEquity == 0, this is an error case, skip it
+      continue;
+    }
+
+    // marginUsed = (unrealizedPnl / returnOnEquity) * 100
+    const marginUsed = (unrealizedPnl / returnOnEquity) * 100;
+
+    // Skip invalid or zero margin accounts
+    if (Number.isNaN(marginUsed) || marginUsed <= 0) {
+      continue;
+    }
+
+    // Convert ROE from percentage to decimal for calculation
+    const roeDecimal = returnOnEquity / 100;
+
+    // Weight the ROE by margin used
+    totalWeightedROE += roeDecimal * marginUsed;
+    totalMarginUsed += marginUsed;
+  }
+
+  if (totalMarginUsed <= 0) {
+    return '0';
+  }
+
+  // Calculate weighted average and convert back to percentage
+  const weightedROE = (totalWeightedROE / totalMarginUsed) * 100;
+  return weightedROE.toFixed(1);
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes the calculation of return on equity (ROE) percentage for aggregated account states across multiple DEX accounts in the Perps feature. Previously, the ROE was calculated using a simple formula that didn't account for the different margin amounts across accounts, which could lead to inaccurate percentage values.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed return on equity percentage calculation for aggregated Perps positions across multiple DEX accounts

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2086

## **Manual testing steps**

```gherkin
Feature: Perps aggregated account ROE calculation

  Scenario: user views aggregated account state with multiple DEX positions
    Given user has multiple Perps positions across different DEX accounts with varying margin amounts
    And each position has different unrealized PnL and ROE values
    
    When user views the aggregated account state
    Then the displayed ROE percentage should be a weighted average based on margin used
    And the calculation should correctly handle accounts with zero or negative values
    And invalid or NaN values should be skipped in the calculation
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
![Screenshot_20251121_104805_MetaMask (1)](https://github.com/user-attachments/assets/17e6528f-981d-4b36-a83b-4fa43762645d)


### **After**

<!-- [screenshots/recordings] -->
<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2025-11-21 at 11 23 26" src="https://github.com/user-attachments/assets/23a33e94-e8b2-4b63-b57a-031fc5276653" />


## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces aggregate ROE with a margin-weighted calculation and adds comprehensive unit tests.
> 
> - **Perps utils**:
>   - **Weighted ROE**: Add `calculateWeightedReturnOnEquity` (and `ReturnOnEquityInput`) in `app/components/UI/Perps/utils/accountUtils.ts` to compute margin-weighted ROE across accounts.
>   - Integrate weighted ROE in `HyperLiquidSubscriptionService.aggregateAccountStates()` by using `calculateWeightedReturnOnEquity` instead of the previous simple ratio.
> - **Tests**:
>   - Add extensive unit tests in `app/components/UI/Perps/utils/accountUtils.test.ts` covering mixed types, edge cases (zero/negative/NaN), precision, and multi-account scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 334fcd627a1c300c67faae8abcdc0eee4635e03b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->