### PR TITLE
fix(perps): use static filter tab values to match FilterTab type cp-7.60.0

### DIFF
--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx
@@ -343,15 +343,7 @@ const PerpsTransactionsView: React.FC<PerpsTransactionsViewProps> = () => {
     </View>
   );
 
-  const filterTabs: FilterTab[] = useMemo(
-    () => [
-      strings('perps.transactions.tabs.trades'),
-      strings('perps.transactions.tabs.orders'),
-      strings('perps.transactions.tabs.funding'),
-      strings('perps.transactions.tabs.deposits'),
-    ],
-    [],
-  );
+  const filterTabs: FilterTab[] = ['Trades', 'Orders', 'Funding', 'Deposits'];
 
   const filterTabDescription = useMemo(() => {
     if (activeFilter === 'Funding') {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixed an issue where the `filterTabs` array in `PerpsTransactionsView` was using translated strings, which could cause mismatches with the filter logic that expects hardcoded values ('Trades', 'Orders', 'Funding', 'Deposits').

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an issue where orders, and deposits would not show if the user is not using english locale

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2093

## **Manual testing steps**

```gherkin
Feature: Perps Transactions View Filter Tabs

  Scenario: user switches between transaction filter tabs
    Given the user is on the Perps Transactions screen
    And the user uses French language
    And the user has transaction history data

    When user taps on the "Orders" tab
    Then the Orders filter should be active
    And only order transactions should be displayed

    When user taps on the "Funding" tab
    Then the Funding filter should be active
    And only funding transactions should be displayed

    When user taps on the "Deposits" tab
    Then the Deposits filter should be active
    And only deposit/withdrawal transactions should be displayed

    When user taps on the "Trades" tab
    Then the Trades filter should be active
    And only trade transactions should be displayed
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/53fd37db-a03c-4b68-985b-68d3beab20a7



### **After**

<!-- [screenshots/recordings] -->
<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2025-11-21 at 13 02 25" src="https://github.com/user-attachments/assets/aaa03b7f-746c-46ab-b471-87c2e176ed70" />

## **Pre-merge author checklist**

- [ ] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use static `['Trades','Orders','Funding','Deposits']` for `filterTabs` in `PerpsTransactionsView` to align with `FilterTab` and avoid locale mismatches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22cf93de09b2214442803ad02461965840300a10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->