### PR TITLE
feat(test): add user based ignore for jest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ temp/
 .reassure/
 
 tests/coverage-systems/
+
+# Personal Jest ignore patterns config (user-specific, not to be committed)
+jest.config.personal-*.js

--- a/jest.config.js
+++ b/jest.config.js
@@ -80,5 +80,41 @@ const config = {
   cache: false,
 };
 
+/**
+ * Personal Jest Ignore Patterns Configuration (Optional)
+ *
+ * This section automatically loads and merges a personal ignore config file if it exists.
+ * This allows developers to add personal ignore patterns (e.g., IDE history folders,
+ * personal test directories) without committing them to the repository.
+ *
+ * IMPORTANT: This file is ONLY for ignore patterns. Other Jest configuration
+ * customizations should not be added here.
+ *
+ * To use:
+ * 1. Copy `jest.config.personal-ignore.js.example` to `jest.config.personal-ignore.js`
+ * 2. Add your personal ignore patterns to the file
+ * 3. The patterns will be automatically merged with the base config
+ *
+ * Note: The personal config file is gitignored and will not be committed to the repository.
+ */
+try {
+  // eslint-disable-next-line import/no-dynamic-require -- Loading optional personal config file
+  const personalConfig = require('./jest.config.personal-ignore.js');
+  if (personalConfig.coveragePathIgnorePatterns) {
+    config.coveragePathIgnorePatterns = [
+      ...config.coveragePathIgnorePatterns,
+      ...personalConfig.coveragePathIgnorePatterns,
+    ];
+  }
+  if (personalConfig.testPathIgnorePatterns) {
+    config.testPathIgnorePatterns = [
+      ...config.testPathIgnorePatterns,
+      ...personalConfig.testPathIgnorePatterns,
+    ];
+  }
+} catch {
+  // Personal config file doesn't exist, which is fine - it's optional
+}
+
 // eslint-disable-next-line import/no-commonjs
 module.exports = config;

--- a/jest.config.personal-ignore.js.example
+++ b/jest.config.personal-ignore.js.example
@@ -1,0 +1,36 @@
+/**
+ * Personal Jest Ignore Patterns Configuration
+ *
+ * This file is gitignored and automatically loaded by jest.config.js if it exists.
+ * Use this file ONLY to add personal ignore patterns (e.g., IDE history folders,
+ * personal test directories) without committing them to the repository.
+ *
+ * IMPORTANT: This file is ONLY for ignore patterns. Other Jest configuration
+ * customizations should not be added here.
+ *
+ * To use:
+ * 1. Copy this file to `jest.config.personal-ignore.js` (remove the .example extension)
+ * 2. Add your personal ignore patterns below
+ * 3. The patterns will be automatically merged with the base config
+ *
+ * Supported properties:
+ * - coveragePathIgnorePatterns: Patterns to ignore when collecting coverage
+ * - testPathIgnorePatterns: Patterns to ignore when discovering test files
+ *
+ * Note: These patterns are regular expressions (not glob patterns). Use:
+ * - `.*` to match any characters (instead of `**` for glob)
+ * - `\\.` to match a literal dot (instead of `.` in glob)
+ * - Example: `.*\\.my-custom-global-git-ignored-folder/` matches `.my-custom-global-git-ignored-folder` folders at any depth
+ */
+
+module.exports = {
+  coveragePathIgnorePatterns: [
+    '<rootDir>/.history/',
+    '.*\\.my-custom-global-git-ignored-folder/',
+  ],
+  testPathIgnorePatterns: [
+    '<rootDir>/.history/',
+    '.*\\.my-custom-global-git-ignored-folder/',
+  ],
+};
+


### PR DESCRIPTION
## **Description**

Adds support for personal Jest ignore patterns via an optional `jest.config.personal-ignore.js` file that is gitignored. 

**Context:**
- Developers increasingly use custom ignored folders (e.g., `.my-custom-AI-ignored-folder/`) to store AI plans, feature work, and progress tracking without committing these files
- IDE history plugins (e.g., `.history/`) create snapshot files that Jest incorrectly treats as test snapshots
- These personal folders are globally gitignored but Jest still discovers them, causing confusion

**Changes:**
- Auto-loads `jest.config.personal-ignore.js` if it exists
- Added `jest.config.personal-ignore.js.example` template
- Updated `.gitignore` to ignore `jest.config.personal-*.js` files
- Only supports ignore patterns (not other Jest config options)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

```gherkin
Feature: Personal Jest ignore patterns

  Scenario: Developer adds personal ignore patterns
    Given a developer has personal folders like .history/ that Jest discovers
    When the developer copies jest.config.personal-ignore.js.example to jest.config.personal-ignore.js
    And adds their ignore patterns using regex syntax
    And runs Jest tests
    Then Jest ignores files in the specified personal folders
    And the personal config file is not committed to git
```

**Screenshots/Recordings**

N/A - Developer tooling change

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional personal Jest ignore config that auto-merges ignore patterns into Jest and ignores user-specific config files in git, with an example template.
> 
> - **Jest configuration**:
>   - Auto-loads optional `jest.config.personal-ignore.js` and merges `coveragePathIgnorePatterns` and `testPathIgnorePatterns` into base `jest.config.js`.
>   - Adds example template `jest.config.personal-ignore.js.example` with sample regex patterns and usage notes.
> - **Repo config**:
>   - Updates `.gitignore` to ignore `jest.config.personal-*.js` files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d90bbb3175cbbfb22bc47e8a9cebdb82c3bf5a97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->