### PR TITLE
fix(perps): increase bottom padding in PerpsTabView for navigation cl…

### DIFF
--- a/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.styles.ts
@@ -7,7 +7,10 @@ const styleSheet = (params: { theme: Theme }) => {
 
   return StyleSheet.create({
     tradeInfoContainer: {
-      paddingBottom: 12,
+      paddingBottom: 20,
+    },
+    emptyStateContainer: {
+      paddingBottom: 20,
     },
     wrapper: {
       flex: 1,

--- a/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.styles.ts
@@ -7,10 +7,10 @@ const styleSheet = (params: { theme: Theme }) => {
 
   return StyleSheet.create({
     tradeInfoContainer: {
-      paddingBottom: 20,
+      paddingBottom: 30,
     },
     emptyStateContainer: {
-      paddingBottom: 20,
+      paddingBottom: 30,
     },
     wrapper: {
       flex: 1,

--- a/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx
@@ -255,11 +255,13 @@ const PerpsTabView: React.FC<PerpsTabViewProps> = () => {
           }}
         >
           {!isInitialLoading && hasNoPositionsOrOrders ? (
-            <PerpsEmptyState
-              onAction={handleNewTrade}
-              testID="perps-empty-state"
-              twClassName="mx-auto"
-            />
+            <View style={styles.emptyStateContainer}>
+              <PerpsEmptyState
+                onAction={handleNewTrade}
+                testID="perps-empty-state"
+                twClassName="mx-auto"
+              />
+            </View>
           ) : (
             <View style={styles.tradeInfoContainer}>
               <View>{renderPositionsSection()}</View>


### PR DESCRIPTION
## **Description**

Fixed bottom padding in the Perps tab view where the "Start trading" button was overlapping with the bottom navigation's "+" action button, particularly noticeable on Android. Increased bottom padding from 12px to 20px for both the positions/orders view and empty state to provide adequate clearance.

**Changes:**
- Updated `tradeInfoContainer` style: paddingBottom from 12 to 30
- Added `emptyStateContainer` style with paddingBottom: 30
- Wrapped `PerpsEmptyState` component with styled View to apply consistent padding

## **Changelog**

CHANGELOG entry: Fixed bottom padding in Perps tab to prevent overlap with bottom navigation button

## **Related issues**

Fixes: <!-- Add issue number if applicable -->

## **Manual testing steps**

```gherkin
Feature: Perps tab bottom padding

  Scenario: user views Perps tab with positions/orders
    Given user has open positions or orders in the Perps tab

    When user navigates to the Perps tab
    Then the "Start trading" button should have adequate clearance from the bottom navigation
    And the button should not overlap with the "+" action button

  Scenario: user views empty Perps tab
    Given user has no positions or orders

    When user navigates to the Perps tab
    Then the empty state should have adequate clearance from the bottom navigation
    And content should not overlap with the "+" action button
```

## **Screenshots/Recordings**

### **Before**

<!-- Android: Start trading button overlapping with + button -->
<img width="397" height="376" alt="image" src="https://github.com/user-attachments/assets/1df51259-b43f-4f5f-99ec-e415e7fbad17" />

<!-- iOS: Tight spacing with + button -->
<img width="412" height="476" alt="image" src="https://github.com/user-attachments/assets/3e2ae99e-ec12-4a9d-967a-b7e5b815c243" />

### **After**

<!-- Android: 20px clearance from + button -->
<!-- iOS: 20px clearance from + button (consistent with Android) -->
<img width="397" height="432" alt="image" src="https://github.com/user-attachments/assets/221fe494-181a-4122-924b-0107ee8b7f8c" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase bottom padding for trade info and empty states in `PerpsTabView` and wrap empty state in a padded container to avoid overlap with bottom navigation.
> 
> - **UI (PerpsTabView)**:
>   - **Padding adjustments**:
>     - `tradeInfoContainer` `paddingBottom`: `12` -> `30` in `app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.styles.ts`.
>     - Add `emptyStateContainer` with `paddingBottom: 30`.
>   - **Empty state layout**:
>     - Wrap `PerpsEmptyState` in a `View` using `styles.emptyStateContainer` in `app/components/UI/Perps/Views/PerpsTabView/PerpsTabView.tsx` to apply consistent bottom spacing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5dc7adcbc9acaf7146e338e965ae7e0c194a908. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->